### PR TITLE
replay: if leader aborts a block in alpenglow, do not emit Error log

### DIFF
--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -15,7 +15,8 @@ use {
     agave_votor_messages::migration::MigrationStatus,
     solana_clock::Slot,
     solana_ledger::{
-        block_error::BlockError, blockstore::Blockstore,
+        block_error::BlockError,
+        blockstore::{Blockstore, BlockstoreError},
         blockstore_processor::BlockstoreProcessorError,
     },
     solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
@@ -44,6 +45,9 @@ impl DeadSlotLogLevel {
     pub(super) fn for_replay_error(err: &BlockstoreProcessorError) -> Self {
         match err {
             BlockstoreProcessorError::InvalidBlock(BlockError::TooFewTicks) => Self::Info,
+            BlockstoreProcessorError::FailedToLoadEntries(BlockstoreError::BlockAborted(_)) => {
+                Self::Info
+            }
             _ => Self::Error,
         }
     }

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -472,6 +472,7 @@ pub enum BlockComponent {
 impl BlockComponent {
     const MAX_ENTRIES: usize = u32::MAX as usize;
     const ENTRY_COUNT_SIZE: usize = 8;
+    const EMPTY_ENTRY_BATCH: [u8; Self::ENTRY_COUNT_SIZE] = 0u64.to_le_bytes();
 
     pub fn new_entry_batch(entries: Vec<Entry>) -> Result<Self, BlockComponentError> {
         if entries.is_empty() {
@@ -516,6 +517,13 @@ impl BlockComponent {
 
     pub fn infer_is_block_marker(data: &[u8]) -> Option<bool> {
         Self::infer_is_entry_batch(data).map(|is_entry_batch| !is_entry_batch)
+    }
+
+    /// In Alpenglow an empty entry batch will fail to deserialize
+    /// Leader's should only use an empty entry batch to indicate that they
+    /// are aborting the block
+    pub fn infer_is_empty_entry_batch(data: &[u8]) -> bool {
+        *data == Self::EMPTY_ENTRY_BATCH
     }
 }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5003,9 +5003,13 @@ impl Blockstore {
             wincode::deserialize(&payload)
                 .map(|component| vec![component])
                 .map_err(|e| {
-                    BlockstoreError::InvalidShredData(format!(
-                        "could not reconstruct block component: {e}"
-                    ))
+                    if BlockComponent::infer_is_empty_entry_batch(&payload) {
+                        BlockstoreError::BlockAborted(slot)
+                    } else {
+                        BlockstoreError::InvalidShredData(format!(
+                            "could not reconstruct block component: {e}"
+                        ))
+                    }
                 })
         })
     }

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -113,6 +113,8 @@ pub enum BlockstoreError {
         block_header_parent_slot: Slot,
         shred_parent_slot: Slot,
     },
+    #[error("Block in slot {0} was aborted as leader sent an empty entry batch")]
+    BlockAborted(Slot),
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
#### Problem
In both TowerBFT and Alpenglow if the leader wants to abort a block (another fork becomes heavier in Tower, or window has moved on in Alpenglow), they emit an empty entry batch.

https://github.com/anza-xyz/agave/blob/dd3bfb3ab43fa2856e49322be8cb45aa1779be79/turbine/src/broadcast_stage/standard_broadcast_run.rs#L192

In Tower this translates to `TooFewTicks` which replay logs as an info log.

#### Summary of Changes
In Alpenglow this leads to a block component deserialization error which replay logs as an error log.
This caused alarm in the community cluster.

Update to log as info instead
