### PR TITLE
replay: reword alpenglow bank hash mismatch log message

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3913,12 +3913,12 @@ impl ReplayStage {
                 );
 
                 if let Err((expected_hash, computed_hash)) = verify_result {
-                    error!(
-                        "Bank hash mismatch for slot {bank_slot} expected: {expected_hash} \
-                         computed: {computed_hash}",
+                    warn!(
+                        "For slot {bank_slot} the leader said the bank hash should be: \
+                         {expected_hash} however we computed: {computed_hash}",
                     );
 
-                    datapoint_error!(
+                    datapoint_warn!(
                         "bank_hash_mismatch",
                         ("slot", bank_slot, i64),
                         ("expected", expected_hash.to_string(), String),


### PR DESCRIPTION
#### Problem
Now that we have #12776 , we panic if we bank hash mismatch on a finalized block.
However we still `error!` log if we bank hash mismatch but the block was not finalized.

This caused alarm in the community cluster when a leader with an outdated version produced a block

#### Summary of Changes
Reword the log and demote to a warn
