### PR TITLE
Add trusted snapshot server bootstrap option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8286,10 +8286,12 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-snapshots",
  "log",
+ "reqwest 0.12.28",
  "solana-clock",
  "solana-file-download",
  "solana-genesis-config",
  "solana-runtime",
+ "tempfile",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6624,6 +6624,7 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-snapshots",
  "log",
+ "reqwest 0.12.28",
  "solana-clock",
  "solana-file-download",
  "solana-genesis-config",

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -24,6 +24,7 @@ agave-unstable-api = []
 [dependencies]
 agave-snapshots = { workspace = true }
 log = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 solana-clock = { workspace = true }
 solana-file-download = { workspace = true }
 solana-genesis-config = { workspace = true }
@@ -31,6 +32,7 @@ solana-runtime = { workspace = true }
 
 [dev-dependencies]
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -19,7 +19,7 @@ use {
 };
 
 pub fn download_genesis_if_missing(
-    rpc_addr: &SocketAddr,
+    snapshot_server_url: &str,
     genesis_package: &Path,
     use_progress_bar: bool,
 ) -> Result<PathBuf, String> {
@@ -29,7 +29,10 @@ pub fn download_genesis_if_missing(
 
         let _ignored = fs::remove_dir_all(&tmp_genesis_path);
         download_file(
-            &format!("http://{rpc_addr}/{DEFAULT_GENESIS_ARCHIVE}"),
+            &format!(
+                "{}/{DEFAULT_GENESIS_ARCHIVE}",
+                snapshot_server_url.trim_end_matches('/'),
+            ),
             &tmp_genesis_package,
             use_progress_bar,
             &mut None,
@@ -41,7 +44,7 @@ pub fn download_genesis_if_missing(
     }
 }
 
-/// Download a snapshot archive from `rpc_addr`.  Use `snapshot_kind` to specify downloading either
+/// Download a snapshot archive from `rpc_addr`. Use `snapshot_kind` to specify downloading either
 /// a full snapshot or an incremental snapshot.
 pub fn download_snapshot_archive(
     rpc_addr: &SocketAddr,
@@ -98,8 +101,7 @@ pub fn download_snapshot_archive(
 
         match download_file(
             &format!(
-                "http://{}/{}",
-                rpc_addr,
+                "http://{rpc_addr}/{}",
                 destination_path.file_name().unwrap().to_str().unwrap()
             ),
             &destination_path,
@@ -111,7 +113,204 @@ pub fn download_snapshot_archive(
         }
     }
     Err(format!(
-        "Failed to download a snapshot archive for slot {} from {}",
-        desired_snapshot_hash.0, rpc_addr
+        "Failed to download a snapshot archive for slot {} from {rpc_addr}",
+        desired_snapshot_hash.0
     ))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn download_latest_snapshot_archive_from_snapshot_server(
+    snapshot_server_url: &str,
+    full_snapshot_archives_dir: &Path,
+    incremental_snapshot_archives_dir: &Path,
+    maximum_full_snapshot_archives_to_retain: NonZeroUsize,
+    maximum_incremental_snapshot_archives_to_retain: NonZeroUsize,
+    use_progress_bar: bool,
+    progress_notify_callback: &mut DownloadProgressCallbackOption<'_>,
+    snapshot_kind: SnapshotArchiveKind,
+) -> Result<PathBuf, String> {
+    snapshot_utils::purge_old_snapshot_archives(
+        full_snapshot_archives_dir,
+        incremental_snapshot_archives_dir,
+        maximum_full_snapshot_archives_to_retain,
+        maximum_incremental_snapshot_archives_to_retain,
+    );
+
+    let snapshot_url = format!(
+        "{}/{}",
+        snapshot_server_url.trim_end_matches('/'),
+        match snapshot_kind {
+            SnapshotArchiveKind::Full => "snapshot.tar.bz2",
+            SnapshotArchiveKind::Incremental(_) => "incremental-snapshot.tar.bz2",
+        }
+    );
+    let response = reqwest::blocking::Client::new()
+        .get(&snapshot_url)
+        .send()
+        .and_then(|response| response.error_for_status())
+        .map_err(|err| err.to_string())?;
+
+    let trusted_filename = response
+        .url()
+        .path_segments()
+        .and_then(|mut path_segments| path_segments.next_back())
+        .filter(|filename| !filename.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| format!("Unable to determine trusted filename for {snapshot_url}"))?;
+    let trusted_url = response.url().to_string();
+    drop(response);
+
+    let snapshot_archives_remote_dir =
+        snapshot_paths::build_snapshot_archives_remote_dir(match snapshot_kind {
+            SnapshotArchiveKind::Full => {
+                snapshot_paths::parse_full_snapshot_archive_filename(&trusted_filename)
+                    .map_err(|err| format!("Invalid redirected full snapshot filename: {err}"))?;
+                full_snapshot_archives_dir
+            }
+            SnapshotArchiveKind::Incremental(_) => {
+                snapshot_paths::parse_incremental_snapshot_archive_filename(&trusted_filename)
+                    .map_err(|err| {
+                        format!("Invalid redirected incremental snapshot filename: {err}")
+                    })?;
+                incremental_snapshot_archives_dir
+            }
+        });
+    fs::create_dir_all(&snapshot_archives_remote_dir).unwrap();
+    let destination_path = snapshot_archives_remote_dir.join(trusted_filename);
+
+    if destination_path.is_file() {
+        return Ok(destination_path);
+    }
+
+    download_file(
+        &trusted_url,
+        &destination_path,
+        use_progress_bar,
+        progress_notify_callback,
+    )?;
+
+    Ok(destination_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::{
+            io::{BufRead, BufReader, Write},
+            net::TcpListener,
+            thread::{self, JoinHandle},
+        },
+        tempfile::TempDir,
+    };
+
+    const HASH: &str = "AvFf9oS8A8U78HdjT9YG2sTTThLHJZmhaMn2g8vkWYnr";
+
+    fn start_redirect_server(
+        request_path: &'static str,
+        redirected_filename: String,
+        request_count: usize,
+    ) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let snapshot_server_url = format!("http://{}", listener.local_addr().unwrap());
+        let handle = thread::spawn(move || {
+            for _ in 0..request_count {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream.try_clone().unwrap());
+                let mut request_line = String::new();
+                reader.read_line(&mut request_line).unwrap();
+                loop {
+                    let mut header = String::new();
+                    reader.read_line(&mut header).unwrap();
+                    if header == "\r\n" || header.is_empty() {
+                        break;
+                    }
+                }
+
+                let path = request_line.split_whitespace().nth(1).unwrap();
+                if path == request_path {
+                    write!(
+                        stream,
+                        "HTTP/1.1 303 See Other\r\nLocation: \
+                         /{redirected_filename}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .unwrap();
+                } else if path == format!("/{redirected_filename}") {
+                    write!(
+                        stream,
+                        "HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: close\r\n\r\nsnapshot"
+                    )
+                    .unwrap();
+                } else {
+                    write!(
+                        stream,
+                        "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .unwrap();
+                }
+            }
+        });
+
+        (snapshot_server_url, handle)
+    }
+
+    #[test]
+    fn test_trusted_snapshot_archive_filename() {
+        for (request_path, filename, snapshot_kind, expected_remote_dir, expected_success) in [
+            (
+                "/snapshot.tar.bz2",
+                format!("snapshot-100-{HASH}.tar.zst"),
+                SnapshotArchiveKind::Full,
+                SnapshotArchiveKind::Full,
+                true,
+            ),
+            (
+                "/incremental-snapshot.tar.bz2",
+                format!("incremental-snapshot-100-200-{HASH}.tar.lz4"),
+                SnapshotArchiveKind::Incremental(100),
+                SnapshotArchiveKind::Incremental(100),
+                true,
+            ),
+            (
+                "/snapshot.tar.bz2",
+                "not-a-snapshot.txt".to_string(),
+                SnapshotArchiveKind::Full,
+                SnapshotArchiveKind::Full,
+                false,
+            ),
+        ] {
+            let full_snapshot_archives_dir = TempDir::new().unwrap();
+            let incremental_snapshot_archives_dir = TempDir::new().unwrap();
+            let (snapshot_server_url, server) = start_redirect_server(
+                request_path,
+                filename.clone(),
+                expected_success as usize + 2,
+            );
+
+            let result = download_latest_snapshot_archive_from_snapshot_server(
+                &snapshot_server_url,
+                full_snapshot_archives_dir.path(),
+                incremental_snapshot_archives_dir.path(),
+                NonZeroUsize::new(usize::MAX).unwrap(),
+                NonZeroUsize::new(usize::MAX).unwrap(),
+                false,
+                &mut None,
+                snapshot_kind,
+            );
+            server.join().unwrap();
+
+            if expected_success {
+                let expected_dir = match expected_remote_dir {
+                    SnapshotArchiveKind::Full => full_snapshot_archives_dir.path(),
+                    SnapshotArchiveKind::Incremental(_) => incremental_snapshot_archives_dir.path(),
+                };
+                assert_eq!(
+                    result.unwrap(),
+                    snapshot_paths::build_snapshot_archives_remote_dir(expected_dir).join(filename)
+                );
+            } else {
+                assert!(result.is_err());
+            }
+        }
+    }
 }

--- a/genesis-utils/src/lib.rs
+++ b/genesis-utils/src/lib.rs
@@ -6,7 +6,6 @@ use {
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, GenesisConfig},
     solana_hash::Hash,
     solana_rpc_client::rpc_client::RpcClient,
-    std::net::SocketAddr,
 };
 
 mod open;
@@ -41,7 +40,7 @@ fn load_local_genesis(
 }
 
 fn get_genesis_config(
-    rpc_addr: &SocketAddr,
+    genesis_source_url: &str,
     ledger_path: &std::path::Path,
     expected_genesis_hash: Option<Hash>,
     max_genesis_archive_unpacked_size: u64,
@@ -54,7 +53,7 @@ fn get_genesis_config(
 
     let genesis_package = ledger_path.join(DEFAULT_GENESIS_ARCHIVE);
     if let Ok(tmp_genesis_package) =
-        download_genesis_if_missing(rpc_addr, &genesis_package, use_progress_bar)
+        download_genesis_if_missing(genesis_source_url, &genesis_package, use_progress_bar)
     {
         unpack_genesis_archive(
             &tmp_genesis_package,
@@ -76,45 +75,17 @@ fn get_genesis_config(
     }
 }
 
-fn set_and_verify_expected_genesis_hash(
-    genesis_config: GenesisConfig,
-    expected_genesis_hash: &mut Option<Hash>,
-    rpc_client: &RpcClient,
-) -> Result<(), String> {
-    let genesis_hash = genesis_config.hash();
-    if expected_genesis_hash.is_none() {
-        info!("Expected genesis hash set to {genesis_hash}");
-        *expected_genesis_hash = Some(genesis_hash);
-    }
-    let expected_genesis_hash = expected_genesis_hash.unwrap();
-
-    // Sanity check that the RPC node is using the expected genesis hash before
-    // downloading a snapshot from it
-    let rpc_genesis_hash = rpc_client
-        .get_genesis_hash()
-        .map_err(|err| format!("Failed to get genesis hash: {err}"))?;
-
-    if expected_genesis_hash != rpc_genesis_hash {
-        return Err(format!(
-            "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis hash is \
-             {rpc_genesis_hash}"
-        ));
-    }
-
-    Ok(())
-}
-
 pub fn download_then_check_genesis_hash(
-    rpc_addr: &SocketAddr,
+    genesis_source_url: &str,
     ledger_path: &std::path::Path,
     expected_genesis_hash: &mut Option<Hash>,
     max_genesis_archive_unpacked_size: u64,
     no_genesis_fetch: bool,
     use_progress_bar: bool,
-    rpc_client: &RpcClient,
+    rpc_client: Option<&RpcClient>,
 ) -> Result<(), String> {
     let genesis_config = get_genesis_config(
-        rpc_addr,
+        genesis_source_url,
         ledger_path,
         *expected_genesis_hash,
         max_genesis_archive_unpacked_size,
@@ -122,7 +93,29 @@ pub fn download_then_check_genesis_hash(
         use_progress_bar,
     )?;
 
-    set_and_verify_expected_genesis_hash(genesis_config, expected_genesis_hash, rpc_client)
+    if expected_genesis_hash.is_none() {
+        let genesis_hash = genesis_config.hash();
+        info!("Expected genesis hash set to {genesis_hash}");
+        *expected_genesis_hash = Some(genesis_hash);
+    }
+    let expected_genesis_hash = expected_genesis_hash.unwrap();
+
+    if let Some(rpc_client) = rpc_client {
+        // Sanity check that the RPC node is using the expected genesis hash before
+        // downloading a snapshot from it
+        let rpc_genesis_hash = rpc_client
+            .get_genesis_hash()
+            .map_err(|err| format!("Failed to get genesis hash: {err}"))?;
+
+        if expected_genesis_hash != rpc_genesis_hash {
+            return Err(format!(
+                "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis \
+                 hash is {rpc_genesis_hash}"
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 pub use open::{MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, OpenGenesisConfigError, open_genesis_config};

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6736,6 +6736,7 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "agave-snapshots",
  "log",
+ "reqwest 0.12.28",
  "solana-clock",
  "solana-file-download",
  "solana-genesis-config",

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -11,7 +11,10 @@ use {
     solana_clock::Slot,
     solana_commitment_config::CommitmentConfig,
     solana_core::validator::{ValidatorConfig, ValidatorStartProgress},
-    solana_download_utils::{DownloadProgressRecord, download_snapshot_archive},
+    solana_download_utils::{
+        DownloadProgressRecord, download_latest_snapshot_archive_from_snapshot_server,
+        download_snapshot_archive,
+    },
     solana_genesis_utils::download_then_check_genesis_hash,
     solana_gossip::{
         cluster_info::ClusterInfo,
@@ -63,6 +66,7 @@ pub const PING_TIMEOUT: Duration = Duration::from_secs(2);
 pub struct RpcBootstrapConfig {
     pub no_genesis_fetch: bool,
     pub no_snapshot_fetch: bool,
+    pub snapshot_servers: Vec<String>,
     pub only_known_rpc: bool,
     pub max_genesis_archive_unpacked_size: u64,
     pub check_vote_account: Option<String>,
@@ -359,7 +363,8 @@ fn shutdown_gossip_service(gossip: (Arc<ClusterInfo>, Arc<AtomicBool>, GossipSer
 
 #[allow(clippy::too_many_arguments)]
 pub fn attempt_download_genesis_and_snapshot(
-    rpc_contact_info: &ContactInfo,
+    snapshot_source_url: &str,
+    rpc_contact_info: Option<&ContactInfo>,
     ledger_path: &Path,
     validator_config: &mut ValidatorConfig,
     bootstrap_config: &RpcBootstrapConfig,
@@ -372,20 +377,15 @@ pub fn attempt_download_genesis_and_snapshot(
     maximum_snapshot_download_abort: u64,
     download_abort_count: &mut u64,
     snapshot_hash: Option<SnapshotHash>,
-    identity_keypair: &Arc<Keypair>,
-    vote_account: &Pubkey,
-    authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
 ) -> Result<(), String> {
     download_then_check_genesis_hash(
-        &rpc_contact_info
-            .rpc()
-            .ok_or_else(|| String::from("Invalid RPC address"))?,
+        snapshot_source_url,
         ledger_path,
         &mut validator_config.expected_genesis_hash,
         bootstrap_config.max_genesis_archive_unpacked_size,
         bootstrap_config.no_genesis_fetch,
         use_progress_bar,
-        rpc_client,
+        Some(rpc_client),
     )?;
 
     if let Some(gossip) = gossip.take() {
@@ -407,33 +407,10 @@ pub fn attempt_download_genesis_and_snapshot(
         maximum_snapshot_download_abort,
         download_abort_count,
         snapshot_hash,
+        snapshot_source_url,
         rpc_contact_info,
     )?;
 
-    if let Some(url) = bootstrap_config.check_vote_account.as_ref() {
-        let rpc_client = RpcClient::new(url);
-        check_vote_account(
-            &rpc_client,
-            &identity_keypair.pubkey(),
-            vote_account,
-            &authorized_voter_keypairs
-                .read()
-                .unwrap()
-                .iter()
-                .map(|k| k.pubkey())
-                .collect::<Vec<_>>(),
-        )
-        .unwrap_or_else(|err| {
-            // Consider failures here to be more likely due to user error (eg,
-            // incorrect `agave-validator` command-line arguments) rather than the
-            // RPC node failing.
-            //
-            // Power users can always use the `--no-check-vote-account` option to
-            // bypass this check entirely
-            error!("{err}");
-            exit(1);
-        });
-    }
     Ok(())
 }
 
@@ -592,75 +569,145 @@ pub fn rpc_bootstrap(
     let mut gossip = None;
     let mut vetted_rpc_nodes = vec![];
     let mut download_abort_count = 0;
-    loop {
-        if gossip.is_none() {
-            *start_progress.write().unwrap() = ValidatorStartProgress::SearchingForRpcService;
-
-            gossip = Some(start_gossip_node(
-                identity_keypair.clone(),
-                cluster_entrypoints,
-                validator_config.known_validators.clone(),
+    'bootstrap: {
+        for snapshot_server_url in &bootstrap_config.snapshot_servers {
+            info!("Trying snapshot server for bootstrap: {snapshot_server_url}");
+            let snapshot_download_start = Instant::now();
+            let download_result = download_then_check_genesis_hash(
+                snapshot_server_url,
                 ledger_path,
-                &node
-                    .info
-                    .gossip()
-                    .expect("Operator must spin up node with valid gossip address"),
-                node.sockets.gossip.clone(),
-                validator_config
-                    .expected_shred_version
-                    .expect("expected_shred_version should not be None"),
-                validator_config.gossip_validators.clone(),
-                validator_config.should_check_duplicate_instance,
-                socket_addr_space,
-            ));
+                &mut validator_config.expected_genesis_hash,
+                bootstrap_config.max_genesis_archive_unpacked_size,
+                bootstrap_config.no_genesis_fetch,
+                use_progress_bar,
+                None,
+            )
+            .and_then(|()| {
+                download_snapshots(
+                    validator_config,
+                    &bootstrap_config,
+                    use_progress_bar,
+                    maximum_local_snapshot_age,
+                    start_progress,
+                    minimal_snapshot_download_speed,
+                    maximum_snapshot_download_abort,
+                    &mut download_abort_count,
+                    None,
+                    snapshot_server_url,
+                    None,
+                )
+            });
+            snapshot_download_time += snapshot_download_start.elapsed();
+            match download_result {
+                Ok(()) => break 'bootstrap,
+                Err(err) => {
+                    warn!(
+                        "Failed to bootstrap from snapshot server {snapshot_server_url}: {err}. \
+                         Trying next snapshot server or falling back to gossip-discovered RPC \
+                         nodes"
+                    );
+                }
+            }
         }
 
-        let get_rpc_nodes_start = Instant::now();
-        get_vetted_rpc_nodes(
-            &mut vetted_rpc_nodes,
-            &gossip.as_ref().unwrap().0,
-            validator_config,
-            &mut blacklisted_rpc_nodes,
-            &bootstrap_config,
-        );
-        let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.pop().unwrap();
-        get_rpc_nodes_time += get_rpc_nodes_start.elapsed();
+        loop {
+            if gossip.is_none() {
+                *start_progress.write().unwrap() = ValidatorStartProgress::SearchingForRpcService;
 
-        let snapshot_download_start = Instant::now();
-        let download_result = attempt_download_genesis_and_snapshot(
-            &rpc_contact_info,
-            ledger_path,
-            validator_config,
-            &bootstrap_config,
-            use_progress_bar,
-            &mut gossip,
-            &rpc_client,
-            maximum_local_snapshot_age,
-            start_progress,
-            minimal_snapshot_download_speed,
-            maximum_snapshot_download_abort,
-            &mut download_abort_count,
-            snapshot_hash,
-            identity_keypair,
-            vote_account,
-            authorized_voter_keypairs.clone(),
-        );
-        snapshot_download_time += snapshot_download_start.elapsed();
-        match download_result {
-            Ok(()) => break,
-            Err(err) => {
-                fail_rpc_node(
-                    err,
-                    &validator_config.known_validators,
-                    rpc_contact_info.pubkey(),
-                    &mut blacklisted_rpc_nodes,
-                );
+                gossip = Some(start_gossip_node(
+                    identity_keypair.clone(),
+                    cluster_entrypoints,
+                    validator_config.known_validators.clone(),
+                    ledger_path,
+                    &node
+                        .info
+                        .gossip()
+                        .expect("Operator must spin up node with valid gossip address"),
+                    node.sockets.gossip.clone(),
+                    validator_config
+                        .expected_shred_version
+                        .expect("expected_shred_version should not be None"),
+                    validator_config.gossip_validators.clone(),
+                    validator_config.should_check_duplicate_instance,
+                    socket_addr_space,
+                ));
+            }
+
+            let get_rpc_nodes_start = Instant::now();
+            get_vetted_rpc_nodes(
+                &mut vetted_rpc_nodes,
+                &gossip.as_ref().unwrap().0,
+                validator_config,
+                &mut blacklisted_rpc_nodes,
+                &bootstrap_config,
+            );
+            let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.pop().unwrap();
+            get_rpc_nodes_time += get_rpc_nodes_start.elapsed();
+
+            let snapshot_download_start = Instant::now();
+            let download_result = attempt_download_genesis_and_snapshot(
+                &format!(
+                    "http://{}",
+                    rpc_contact_info
+                        .rpc()
+                        .expect("vetted RPC node must have an RPC address")
+                ),
+                Some(&rpc_contact_info),
+                ledger_path,
+                validator_config,
+                &bootstrap_config,
+                use_progress_bar,
+                &mut gossip,
+                &rpc_client,
+                maximum_local_snapshot_age,
+                start_progress,
+                minimal_snapshot_download_speed,
+                maximum_snapshot_download_abort,
+                &mut download_abort_count,
+                snapshot_hash,
+            );
+            snapshot_download_time += snapshot_download_start.elapsed();
+            match download_result {
+                Ok(()) => break,
+                Err(err) => {
+                    fail_rpc_node(
+                        err,
+                        &validator_config.known_validators,
+                        rpc_contact_info.pubkey(),
+                        &mut blacklisted_rpc_nodes,
+                    );
+                }
             }
         }
     }
 
     if let Some(gossip) = gossip.take() {
         shutdown_gossip_service(gossip);
+    }
+
+    if let Some(url) = bootstrap_config.check_vote_account.as_ref() {
+        let rpc_client = RpcClient::new(url);
+        check_vote_account(
+            &rpc_client,
+            &identity_keypair.pubkey(),
+            vote_account,
+            &authorized_voter_keypairs
+                .read()
+                .unwrap()
+                .iter()
+                .map(|k| k.pubkey())
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_else(|err| {
+            // Consider failures here to be more likely due to user error (eg,
+            // incorrect `agave-validator` command-line arguments) rather than the
+            // RPC node failing.
+            //
+            // Power users can always use the `--no-check-vote-account` option to
+            // bypass this check entirely
+            error!("{err}");
+            exit(1);
+        });
     }
 
     datapoint_info!(
@@ -1103,15 +1150,65 @@ fn download_snapshots(
     maximum_snapshot_download_abort: u64,
     download_abort_count: &mut u64,
     snapshot_hash: Option<SnapshotHash>,
-    rpc_contact_info: &ContactInfo,
+    snapshot_source_url: &str,
+    rpc_contact_info: Option<&ContactInfo>,
 ) -> Result<(), String> {
     if snapshot_hash.is_none() {
+        if bootstrap_config.no_snapshot_fetch {
+            return Ok(());
+        }
+
+        let maximum_full_snapshot_archives_to_retain = validator_config
+            .snapshot_config
+            .maximum_full_snapshot_archives_to_retain;
+        let maximum_incremental_snapshot_archives_to_retain = validator_config
+            .snapshot_config
+            .maximum_incremental_snapshot_archives_to_retain;
+        let full_snapshot_archives_dir =
+            &validator_config.snapshot_config.full_snapshot_archives_dir;
+        let incremental_snapshot_archives_dir = &validator_config
+            .snapshot_config
+            .incremental_snapshot_archives_dir;
+
+        for (snapshot_type, snapshot_kind) in std::iter::once(("full", SnapshotArchiveKind::Full))
+            .chain(
+                bootstrap_config
+                    .incremental_snapshot_fetch
+                    .then_some(("incremental", SnapshotArchiveKind::Incremental(0))),
+            )
+        {
+            let mut progress_notify_callback = Some(new_snapshot_download_progress_callback(
+                validator_config,
+                bootstrap_config,
+                minimal_snapshot_download_speed,
+                maximum_snapshot_download_abort,
+                download_abort_count,
+                rpc_contact_info.map(|rpc_contact_info| rpc_contact_info.pubkey()),
+            ));
+            info!(
+                "Downloaded {snapshot_type} snapshot archive from {snapshot_source_url} to {}",
+                download_latest_snapshot_archive_from_snapshot_server(
+                    snapshot_source_url,
+                    full_snapshot_archives_dir,
+                    incremental_snapshot_archives_dir,
+                    maximum_full_snapshot_archives_to_retain,
+                    maximum_incremental_snapshot_archives_to_retain,
+                    use_progress_bar,
+                    &mut progress_notify_callback,
+                    snapshot_kind,
+                )?
+                .display()
+            );
+        }
+
         return Ok(());
     }
     let SnapshotHash {
         full: full_snapshot_hash,
         incr: incremental_snapshot_hash,
     } = snapshot_hash.unwrap();
+    let rpc_contact_info =
+        rpc_contact_info.ok_or_else(|| String::from("Missing RPC contact info"))?;
     let full_snapshot_archives_dir = &validator_config.snapshot_config.full_snapshot_archives_dir;
     let incremental_snapshot_archives_dir = &validator_config
         .snapshot_config
@@ -1190,6 +1287,52 @@ fn download_snapshots(
     Ok(())
 }
 
+fn new_snapshot_download_progress_callback<'a>(
+    validator_config: &'a ValidatorConfig,
+    bootstrap_config: &'a RpcBootstrapConfig,
+    minimal_snapshot_download_speed: f32,
+    maximum_snapshot_download_abort: u64,
+    download_abort_count: &'a mut u64,
+    rpc_pubkey: Option<&'a Pubkey>,
+) -> Box<dyn FnMut(&DownloadProgressRecord) -> bool + 'a> {
+    Box::new(move |download_progress: &DownloadProgressRecord| {
+        debug!("Download progress: {download_progress:?}");
+        if download_progress.last_throughput < minimal_snapshot_download_speed
+            && download_progress.notification_count <= 1
+            && download_progress.percentage_done <= 2_f32
+            && download_progress.estimated_remaining_time > 60_f32
+            && *download_abort_count < maximum_snapshot_download_abort
+        {
+            if let (Some(known_validators), Some(rpc_pubkey)) =
+                (&validator_config.known_validators, rpc_pubkey)
+                && known_validators.contains(rpc_pubkey)
+                && known_validators.len() == 1
+                && bootstrap_config.only_known_rpc
+            {
+                warn!(
+                    "The snapshot download is too slow, throughput: {} < min speed \
+                     {minimal_snapshot_download_speed} bytes/sec, but will NOT abort and try a \
+                     different node as it is the only known validator and the --only-known-rpc \
+                     flag is set. Abort count: {download_abort_count}, Progress detail: \
+                     {download_progress:?}",
+                    download_progress.last_throughput,
+                );
+                return true; // Do not abort download from the one-and-only known validator
+            }
+            warn!(
+                "The snapshot download is too slow, throughput: {} < min speed \
+                 {minimal_snapshot_download_speed} bytes/sec, will abort and try a different \
+                 node. Abort count: {download_abort_count}, Progress detail: {download_progress:?}",
+                download_progress.last_throughput,
+            );
+            *download_abort_count += 1;
+            false
+        } else {
+            true
+        }
+    })
+}
+
 /// Download a snapshot
 #[allow(clippy::too_many_arguments)]
 fn download_snapshot(
@@ -1214,21 +1357,28 @@ fn download_snapshot(
     let incremental_snapshot_archives_dir = &validator_config
         .snapshot_config
         .incremental_snapshot_archives_dir;
+    let rpc_addr = rpc_contact_info
+        .rpc()
+        .ok_or_else(|| String::from("Invalid RPC address"))?;
 
     *start_progress.write().unwrap() = ValidatorStartProgress::DownloadingSnapshot {
         slot: desired_snapshot_hash.0,
-        rpc_addr: rpc_contact_info
-            .rpc()
-            .ok_or_else(|| String::from("Invalid RPC address"))?,
+        rpc_addr,
     };
     let desired_snapshot_hash = (
         desired_snapshot_hash.0,
         agave_snapshots::snapshot_hash::SnapshotHash(desired_snapshot_hash.1),
     );
+    let mut progress_notify_callback = Some(new_snapshot_download_progress_callback(
+        validator_config,
+        bootstrap_config,
+        minimal_snapshot_download_speed,
+        maximum_snapshot_download_abort,
+        download_abort_count,
+        Some(rpc_contact_info.pubkey()),
+    ));
     download_snapshot_archive(
-        &rpc_contact_info
-            .rpc()
-            .ok_or_else(|| String::from("Invalid RPC address"))?,
+        &rpc_addr,
         full_snapshot_archives_dir,
         incremental_snapshot_archives_dir,
         desired_snapshot_hash,
@@ -1236,45 +1386,7 @@ fn download_snapshot(
         maximum_full_snapshot_archives_to_retain,
         maximum_incremental_snapshot_archives_to_retain,
         use_progress_bar,
-        &mut Some(Box::new(|download_progress: &DownloadProgressRecord| {
-            debug!("Download progress: {download_progress:?}");
-            if download_progress.last_throughput < minimal_snapshot_download_speed
-                && download_progress.notification_count <= 1
-                && download_progress.percentage_done <= 2_f32
-                && download_progress.estimated_remaining_time > 60_f32
-                && *download_abort_count < maximum_snapshot_download_abort
-            {
-                if let Some(ref known_validators) = validator_config.known_validators
-                    && known_validators.contains(rpc_contact_info.pubkey())
-                    && known_validators.len() == 1
-                    && bootstrap_config.only_known_rpc
-                {
-                    warn!(
-                        "The snapshot download is too slow, throughput: {} < min speed {} \
-                         bytes/sec, but will NOT abort and try a different node as it is the only \
-                         known validator and the --only-known-rpc flag is set. Abort count: {}, \
-                         Progress detail: {:?}",
-                        download_progress.last_throughput,
-                        minimal_snapshot_download_speed,
-                        download_abort_count,
-                        download_progress,
-                    );
-                    return true; // Do not abort download from the one-and-only known validator
-                }
-                warn!(
-                    "The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, \
-                     will abort and try a different node. Abort count: {}, Progress detail: {:?}",
-                    download_progress.last_throughput,
-                    minimal_snapshot_download_speed,
-                    download_abort_count,
-                    download_progress,
-                );
-                *download_abort_count += 1;
-                false
-            } else {
-                true
-            }
-        })),
+        &mut progress_notify_callback,
     )
 }
 
@@ -1361,6 +1473,38 @@ mod tests {
 
     fn default_contact_info_for_tests() -> ContactInfo {
         ContactInfo::new_localhost(&Pubkey::default(), /*now:*/ 1_681_834_947_321)
+    }
+
+    #[test]
+    fn test_no_snapshot_fetch_skips_snapshot_server_download() {
+        let validator_config = ValidatorConfig::default_for_test();
+        let bootstrap_config = RpcBootstrapConfig {
+            no_snapshot_fetch: true,
+            ..RpcBootstrapConfig::default()
+        };
+        let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
+        let mut download_abort_count = 0;
+
+        download_snapshots(
+            &validator_config,
+            &bootstrap_config,
+            false,
+            0,
+            &start_progress,
+            0.0,
+            0,
+            &mut download_abort_count,
+            None,
+            "http://127.0.0.1:9",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(download_abort_count, 0);
+        assert_eq!(
+            *start_progress.read().unwrap(),
+            ValidatorStartProgress::default()
+        );
     }
 
     #[test]

--- a/validator/src/commands/run/args/rpc_bootstrap_config.rs
+++ b/validator/src/commands/run/args/rpc_bootstrap_config.rs
@@ -17,6 +17,7 @@ impl Default for RpcBootstrapConfig {
         Self {
             no_genesis_fetch: false,
             no_snapshot_fetch: false,
+            snapshot_servers: vec![],
             check_vote_account: None,
             only_known_rpc: false,
             max_genesis_archive_unpacked_size: 10485760,
@@ -30,6 +31,17 @@ impl FromClapArgMatches for RpcBootstrapConfig {
         let no_genesis_fetch = matches.is_present("no_genesis_fetch");
 
         let no_snapshot_fetch = matches.is_present("no_snapshot_fetch");
+
+        let snapshot_servers = matches
+            .values_of("snapshot_servers")
+            .map(|values| {
+                values
+                    .map(str::trim)
+                    .filter(|server| !server.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let check_vote_account = matches
             .value_of("check_vote_account")
@@ -49,6 +61,7 @@ impl FromClapArgMatches for RpcBootstrapConfig {
         Ok(Self {
             no_genesis_fetch,
             no_snapshot_fetch,
+            snapshot_servers,
             check_vote_account,
             only_known_rpc,
             max_genesis_archive_unpacked_size,
@@ -69,6 +82,19 @@ pub(crate) fn args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .help(
                 "Do not attempt to fetch a snapshot from the cluster, start from a local snapshot \
                  if present",
+            ),
+        Arg::with_name("snapshot_servers")
+            .long("snapshots-server")
+            .aliases(&["snapshot-server", "snapshots-servers", "snapshot-servers"])
+            .takes_value(true)
+            .number_of_values(1)
+            .multiple(true)
+            .use_delimiter(true)
+            .value_name("URL")
+            .help(
+                "Try this trusted snapshot server URL for genesis and latest snapshot downloads \
+                 before using gossip. May be specified multiple times or as a comma-separated \
+                 list. No snapshot path is required; fixed snapshot paths are probed",
             ),
         Arg::with_name("check_vote_account")
             .long("check-vote-account")
@@ -181,6 +207,32 @@ mod tests {
                 expected_args,
             );
         }
+    }
+
+    #[test]
+    fn verify_args_struct_by_command_run_with_snapshot_servers() {
+        let default_run_args = RunArgs::default();
+        let expected_args = RunArgs {
+            rpc_bootstrap_config: RpcBootstrapConfig {
+                snapshot_servers: vec![
+                    "https://snapshots-1.example.com".to_string(),
+                    "https://snapshots-2.example.com".to_string(),
+                    "https://snapshots-3.example.com".to_string(),
+                ],
+                ..RpcBootstrapConfig::default()
+            },
+            ..default_run_args.clone()
+        };
+        verify_args_struct_by_command_run_with_identity_setup(
+            default_run_args,
+            vec![
+                "--snapshots-server",
+                "https://snapshots-1.example.com,https://snapshots-2.example.com",
+                "--snapshot-server",
+                "https://snapshots-3.example.com",
+            ],
+            expected_args,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Background:
Firedancer models trusted snapshot sources as a list of base server URLs:

```toml
[snapshots.sources]
# Trusted snapshot server you operate or explicitly trust.
# No path; Firedancer probes fixed snapshot paths.
servers = [
  "https://snapshots.example.com:443",
]
```

This PR follows that shape for Agave bootstrap: operators can provide trusted snapshot server base URLs, without embedding archive paths, and the validator probes the fixed genesis/full/incremental snapshot paths before falling back to gossip-discovered RPC nodes.

Summary:
- add repeatable/comma-separated `--snapshots-server <URL>` support, to try trusted snapshot servers before gossip discovery
- make trusted snapshot-server bootstrap download genesis and latest full/incremental snapshots from fixed base-URL paths
- support redirected latest snapshot filenames with snapshot archive filename validation
- keep gossip-discovered RPC snapshot downloads as fallback, including RPC genesis-hash checks for RPC-backed bootstrap
