### PR TITLE
Revert "SIMD-0525: Slot Time Reductions (#12264)"

### DIFF
--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -1,22 +1,16 @@
 //! Code related to partitioned rewards distribution
 
-/// Baseline number of stake accounts to store in one 400ms block during the
-/// partitioned reward interval.
-///
-/// The target is 64 rewards per entry/tick. A block has a minimum of 64
-/// entries/ticks, giving 4096 total rewards to store in one 400ms block. This
-/// constant affects consensus; shorter slot-time targets scale this value down
-/// in `Bank` state.
-pub const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
+/// # stake accounts to store in one block during partitioned reward interval
+/// Target to store 64 rewards per entry/tick in a block. A block has a minimum of 64
+/// entries/tick. This gives 4096 total rewards to store in one block.
+/// This constant affects consensus.
+const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
 
-/// Configuration options for partitioned epoch rewards.
 #[derive(Debug, Clone, Copy)]
+/// Configuration options for partitioned epoch rewards.
 pub struct PartitionedEpochRewardsConfig {
-    /// Baseline number of stake accounts to store in one block during the
-    /// partitioned reward interval.
-    ///
-    /// This value is stored as the 400ms-slot baseline. Runtime `Bank` state
-    /// derives the effective per-bank value from the active slot-time target.
+    /// number of stake accounts to store in one block during partitioned reward interval
+    /// normally, this is a number tuned for reasonable performance, such as 4096 accounts/block
     pub stake_account_stores_per_block: u64,
 }
 
@@ -36,8 +30,7 @@ impl Default for PartitionedEpochRewardsConfig {
 }
 
 impl PartitionedEpochRewardsConfig {
-    /// Constructs a config with an explicit 400ms-slot baseline for tests and
-    /// benchmarks.
+    /// Only for tests and benchmarks
     pub fn new_for_test(stake_account_stores_per_block: u64) -> Self {
         Self {
             stake_account_stores_per_block,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1525,22 +1525,6 @@ pub mod set_lamports_per_byte_to_6960 {
     pub const LAMPORTS_PER_BYTE: u64 = 6960;
 }
 
-pub mod reduce_slot_time_to_350ms {
-    solana_pubkey::declare_id!("iBRL2iJvhLssJveF1utbmmQGmjonmNYZALcJFEHTbUF");
-}
-
-pub mod reduce_slot_time_to_300ms {
-    solana_pubkey::declare_id!("iBRLA3zvd6x9445cK1vS7xt8n6Y7DS3otfRcDdW8JRW");
-}
-
-pub mod reduce_slot_time_to_250ms {
-    solana_pubkey::declare_id!("iBRLR6nG3fDi8YD4mpPTUVTgo5NaiYfZgrzokCfADP2");
-}
-
-pub mod reduce_slot_time_to_200ms {
-    solana_pubkey::declare_id!("iBRLypKvvj9VEvwoTeRpbLhbW55NFR4T3GE9BUR8A16");
-}
-
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2430,22 +2414,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             alpenglow::id(),
             "SIMD-0326: Alpenglow: new consensus algorithm",
-        ),
-        (
-            reduce_slot_time_to_350ms::id(),
-            "SIMD-0525: Reduce slot time to 350ms",
-        ),
-        (
-            reduce_slot_time_to_300ms::id(),
-            "SIMD-0525: Reduce slot time to 300ms",
-        ),
-        (
-            reduce_slot_time_to_250ms::id(),
-            "SIMD-0525: Reduce slot time to 250ms",
-        ),
-        (
-            reduce_slot_time_to_200ms::id(),
-            "SIMD-0525: Reduce slot time to 200ms",
         ),
         (
             disable_zk_elgamal_proof_program::id(),

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -595,10 +595,7 @@ mod tests {
         itertools::Itertools,
         solana_leader_schedule::SlotLeader,
         solana_perf::packet::{Packet, PacketFlags},
-        solana_runtime::{
-            bank::Bank,
-            slot_params::{slot_time_feature_gates, slot_time_feature_ids},
-        },
+        solana_runtime::bank::Bank,
         std::{
             io::{Cursor, Seek, SeekFrom, Write},
             sync::Arc,
@@ -621,26 +618,6 @@ mod tests {
         } else {
             Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot)
         }
-    }
-
-    fn deactivate_slot_time_features(bank: &mut Bank) {
-        for feature_id in slot_time_feature_ids() {
-            bank.deactivate_feature(&feature_id);
-        }
-    }
-
-    fn shred_filter_for_tests(
-        feature_ids: impl IntoIterator<Item = Pubkey>,
-    ) -> (ShredFilterContext, Slot) {
-        let genesis_config = create_genesis_config(1).genesis_config;
-        let mut root_bank = Bank::new_for_tests(&genesis_config);
-        deactivate_slot_time_features(&mut root_bank);
-        for feature_id in feature_ids {
-            root_bank.activate_feature(&feature_id);
-        }
-        let first_epoch_slot = root_bank.epoch_schedule().get_first_slot_in_epoch(1);
-        let (root_bank, _) = root_bank.wrap_with_bank_forks_for_tests();
-        (ShredFilterContext::new(root_bank, 0), first_epoch_slot)
     }
 
     #[test_case(true ; "last_in_slot")]
@@ -1067,36 +1044,6 @@ mod tests {
             );
             assert_eq!(shred_filter_context.stats.index_out_of_bounds, 1);
         }
-    }
-
-    #[test]
-    fn test_shred_limit_for_slot_times() {
-        for (features, shred_limits) in std::iter::once((vec![], ShredLimits::DEFAULT)).chain(
-            slot_time_feature_gates().map(|(feature_id, params)| {
-                (
-                    vec![feature_id],
-                    ShredLimits::new(
-                        params.max_data_shreds_per_slot(),
-                        params.max_code_shreds_per_slot(),
-                    ),
-                )
-            }),
-        ) {
-            let (shred_filter, effective_slot) = shred_filter_for_tests(features);
-            assert_eq!(
-                shred_filter.shred_limits(effective_slot.saturating_sub(1)),
-                ShredLimits::DEFAULT
-            );
-            assert_eq!(shred_filter.shred_limits(effective_slot), shred_limits);
-        }
-
-        let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
-        let (shred_filter, effective_slot) =
-            shred_filter_for_tests([reduce_to_350ms, reduce_to_200ms]);
-        assert_eq!(
-            shred_filter.shred_limits(effective_slot),
-            ShredLimits::new(16_384, 16_384)
-        );
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -112,7 +112,7 @@ use {
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_cost_model::cost_tracker::CostTracker,
+    solana_cost_model::{block_cost_limits::simd_0286_block_limit, cost_tracker::CostTracker},
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_gate_interface as feature,
@@ -179,6 +179,7 @@ use {
     solana_system_transaction as system_transaction,
     solana_sysvar::{self as sysvar, SysvarSerialize, last_restart_slot::LastRestartSlot},
     solana_sysvar_id::SysvarId,
+    solana_time_utils::years_as_slots,
     solana_transaction::{
         Transaction, TransactionVerificationMode,
         sanitized::{MAX_TX_ACCOUNT_LOCKS, MessageHash, SanitizedTransaction},
@@ -2179,7 +2180,20 @@ impl Bank {
              snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
+        assert_eq!(
+            bank.ns_per_slot,
+            genesis_config.poh_config.target_tick_duration.as_nanos()
+                * genesis_config.ticks_per_slot as u128
+        );
         assert_eq!(bank.max_tick_height, (bank.slot + 1) * bank.ticks_per_slot);
+        assert_eq!(
+            bank.slots_per_year,
+            years_as_slots(
+                1.0,
+                &genesis_config.poh_config.target_tick_duration,
+                bank.ticks_per_slot,
+            )
+        );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
 
         bank.refresh_slot_params_with_baseline(Self::genesis_config_slot_params(
@@ -2696,18 +2710,12 @@ impl Bank {
         });
     }
 
-    /// Rebuilds slot-param state from the current feature set.
-    fn refresh_slot_params(&mut self) {
-        self.refresh_slot_params_with_baseline(self.slot_params.baseline_params());
-    }
-
     /// Rebuilds cached slot params while preserving the supplied slot-0 baseline.
     ///
     /// The cache is not serialized into snapshots; it is reconstructed from
     /// existing Bank fields during genesis and snapshot restore.
     fn refresh_slot_params_with_baseline(&mut self, baseline_params: SlotParams) {
-        self.slot_params =
-            SlotParamsArchive::new(&self.feature_set, &self.epoch_schedule, baseline_params);
+        self.slot_params = SlotParamsArchive::new(&self.epoch_schedule, baseline_params);
     }
 
     /// Builds slot-0 params from the genesis config.
@@ -2726,11 +2734,6 @@ impl Bank {
     /// Returns the slot params effective at `slot`.
     fn slot_params_at_slot(&self, slot: Slot) -> SlotParams {
         self.slot_params.params_at_slot(slot)
-    }
-
-    /// Returns the slot params that should be effective for this bank's slot.
-    fn current_slot_params(&self) -> SlotParams {
-        self.slot_params_at_slot(self.slot)
     }
 
     /// Returns the effective slot duration for `slot`.
@@ -4673,81 +4676,22 @@ impl Bank {
         self.rc.accounts.clone()
     }
 
-    /// Recomputes cost tracker limits from active feature state.
     fn apply_cost_tracker_limits_for_active_features(&mut self) {
-        let params = self.current_slot_params();
-        let (account_cost_limit, block_cost_limit, vote_cost_limit, data_size_limit) =
-            params.cost_limits(self.feature_set.snapshot().raise_block_limits_to_100m);
-
         let mut cost_tracker = self.write_cost_tracker().unwrap();
+        let block_cost_limit = if self.feature_set.snapshot().raise_block_limits_to_100m {
+            simd_0286_block_limit()
+        } else {
+            cost_tracker.get_block_limit()
+        };
+        let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
+        let vote_cost_limit = cost_tracker.get_vote_limit();
+        let allocated_data_size_limit = cost_tracker.get_allocated_data_size_limit();
         cost_tracker.set_limits(
             account_cost_limit,
             block_cost_limit,
             vote_cost_limit,
-            data_size_limit,
+            allocated_data_size_limit,
         );
-    }
-
-    /// Recomputes this bank's effective partitioned-reward write budget.
-    fn apply_partitioned_epoch_rewards_config_for_active_features(&mut self) {
-        self.partitioned_rewards_stake_account_stores_per_block = self
-            .current_slot_params()
-            .partitioned_epoch_rewards_stake_account_stores_per_block();
-    }
-
-    /// Applies slot-time changes for fields serialized into snapshots.
-    fn apply_slot_time_persistent_changes(&mut self) {
-        let params = self.current_slot_params();
-        self.ns_per_slot = params.ns_per_slot();
-        self.slots_per_year = params.slots_per_year();
-        self.rent_collector.slots_per_year = params.slots_per_year();
-        if !self.feature_set.is_active(&feature_set::alpenglow::id())
-            && self.hashes_per_tick().is_some()
-        {
-            self.set_hashes_per_tick(params.hashes_per_tick());
-        }
-    }
-
-    /// Verifies bank fields are consistent with current slot params.
-    fn assert_bank_matches_slot_params(&self) {
-        let params = self.current_slot_params();
-        assert_eq!(
-            self.ns_per_slot,
-            params.ns_per_slot(),
-            "snapshot slot-time ns_per_slot mismatch"
-        );
-        assert_eq!(
-            self.slots_per_year.to_bits(),
-            params.slots_per_year().to_bits(),
-            "snapshot slot-time slots_per_year mismatch"
-        );
-        assert_eq!(
-            self.rent_collector.slots_per_year.to_bits(),
-            params.slots_per_year().to_bits(),
-            "snapshot slot-time rent_collector.slots_per_year mismatch"
-        );
-        let hashes_per_tick = self.hashes_per_tick();
-        if !self.feature_set.is_active(&feature_set::alpenglow::id()) && hashes_per_tick.is_some() {
-            assert_eq!(
-                hashes_per_tick,
-                params.hashes_per_tick(),
-                "snapshot slot-time hashes_per_tick mismatch"
-            );
-        }
-        assert_eq!(
-            self.entry_bytes_budget().slot_limit(),
-            params.max_entry_bytes_per_slot(),
-            "snapshot slot-time entry byte budget mismatch"
-        );
-    }
-
-    /// Applies slot-time changes for runtime-only fields. This function is
-    /// expected to be idempotent.
-    fn apply_slot_time_runtime_changes(&mut self) {
-        self.entry_bytes_consumed =
-            EntryBytesBudget::new(self.current_slot_params().max_entry_bytes_per_slot());
-        self.apply_cost_tracker_limits_for_active_features();
-        self.apply_partitioned_epoch_rewards_config_for_active_features();
     }
 
     fn apply_simd_0339_invoke_cost_changes(&mut self) {
@@ -4771,10 +4715,11 @@ impl Bank {
             Arc::new(reserved_keys)
         };
 
-        // Many fields are not serialized in snapshot or any configs. Rebuild
-        // them from the feature set so the initial bank state is consistent.
-        self.refresh_slot_params();
-        self.apply_slot_time_runtime_changes();
+        // Cost-Tracker is not serialized in snapshot or any configs.
+        // We must apply previously activated features related to limits here
+        // so that the initial bank state is consistent with the feature set.
+        // Cost-tracker limits are propagated through children banks.
+        self.apply_cost_tracker_limits_for_active_features();
         self.apply_simd_0339_invoke_cost_changes();
 
         let program_runtime_environment =
@@ -5869,14 +5814,12 @@ impl Bank {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
         feature_set.deactivate(id);
         self.feature_set = Arc::new(feature_set);
-        self.refresh_slot_params();
     }
 
     pub fn activate_feature(&mut self, id: &Pubkey) {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
         feature_set.activate(id, 0);
         self.feature_set = Arc::new(feature_set);
-        self.refresh_slot_params();
     }
 
     pub fn fill_bank_with_ticks_for_tests(&self) {
@@ -5952,7 +5895,6 @@ impl Bank {
         self.feature_set = Arc::new(feature_set);
 
         self.apply_activated_features();
-        self.assert_bank_matches_slot_params();
     }
 
     /// This is called from each epoch boundary
@@ -5961,7 +5903,6 @@ impl Bank {
         let (feature_set, new_feature_activations) =
             self.compute_active_feature_set(include_pending);
         self.feature_set = Arc::new(feature_set);
-        self.refresh_slot_params();
 
         // Update activation slot of features in `new_feature_activations`
         for feature_id in new_feature_activations.iter() {
@@ -6044,11 +5985,10 @@ impl Bank {
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT;
         }
 
-        // Apply unconditionally: this is relatively cheap and idempotent.
-        self.apply_slot_time_persistent_changes();
-        self.apply_slot_time_runtime_changes();
-
         self.apply_new_builtin_program_feature_transitions(&new_feature_activations);
+        if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
+            self.apply_cost_tracker_limits_for_active_features();
+        }
 
         if new_feature_activations.contains(&feature_set::replace_spl_token_with_p_token::id()) {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(
@@ -7002,11 +6942,6 @@ impl Bank {
             .for_each(|(pubkey, _)| {
                 minimized_account_set.insert(*pubkey);
             });
-    }
-
-    /// Returns true when this bank is using slot params beyond its genesis baseline.
-    pub fn slot_time_reduction_active(&self) -> bool {
-        self.ns_per_slot != self.slot_params.baseline_params().ns_per_slot()
     }
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -417,7 +417,6 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
-                deactivate_features,
             },
             runtime_config::RuntimeConfig,
             stake_utils,
@@ -575,9 +574,6 @@ mod tests {
         stake_account_stores_per_block: u64,
         advance_num_slots: u64,
     ) -> (RewardBank, Arc<RwLock<BankForks>>) {
-        // Disable slot time reduction features as they will override the custom
-        // stores per block provided in this test helper.
-        let features_to_deactivate = crate::slot_params::slot_time_feature_ids().to_vec();
         let validator_keypairs = (0..stakes.len())
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -586,7 +582,6 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
-        deactivate_features(&mut genesis_config, &features_to_deactivate);
 
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING;
         accounts_db_config.partitioned_epoch_rewards_config =

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -19,11 +19,7 @@ use {
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
-        slot_params::{
-            DEFAULT_MAX_ENTRY_BYTES_PER_SLOT, LEGACY_HASHES_PER_TICK, LEGACY_SLOT_PARAMS,
-            SLOT_PARAMS_200MS, SLOT_PARAMS_250MS, SLOT_PARAMS_300MS, SLOT_PARAMS_350MS, SlotParams,
-            slot_time_feature_gates, slot_time_feature_ids,
-        },
+        slot_params::{DEFAULT_MAX_ENTRY_BYTES_PER_SLOT, LEGACY_SLOT_PARAMS},
         stake_history::StakeHistory,
         stake_utils,
         stakes::{DeserializableStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat, Stakes},
@@ -182,12 +178,6 @@ fn create_genesis_config_no_tx_fee(lamports: u64) -> (GenesisConfig, Keypair) {
 
 pub(in crate::bank) fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
     solana_genesis_config::create_genesis_config(lamports)
-}
-
-fn create_genesis_config_with_legacy_hashes(lamports: u64) -> (GenesisConfig, Keypair) {
-    let (mut genesis_config, mint_keypair) = create_genesis_config(lamports);
-    genesis_config.poh_config.hashes_per_tick = Some(LEGACY_HASHES_PER_TICK);
-    (genesis_config, mint_keypair)
 }
 
 pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessage {
@@ -5267,9 +5257,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "9ycftRwjpQ17PrhnwhGPbVzDKd3Q9BybmLYU8UD1Pg1T"
+                    "F4ns41hFn3ignVHqaVehaTZ8LMUxPaELAgvN8iTcowDD"
                 } else {
-                    "4XzjZMjhP9s8iBeFQsnHFwaQ991dpiBGHEkzj1ifAcpS"
+                    "FyxeAqHjieaKMA6mLK3yfSD46Xcw2U6hzKfyeu1qVuCD"
                 },
             );
         }
@@ -5278,9 +5268,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "7sbqfkN4W3PkBREyduDc3R2eiKu68JKYRXZt6gCWNt4N"
+                    "sF1tuUv3r5JCr9smYyhm9Qv27f5jcoJ75LnoLGV5Scd"
                 } else {
-                    "ArB3XNVLJsyV7AtrG3C3Bj4akb8s7AzpS5rHJnqGW5sw"
+                    "DrpEs59czmKpLQvR9kBjSmWJUYMNKDdQ4Zsyu4WjfoPb"
                 },
             );
             break;
@@ -6303,272 +6293,6 @@ fn test_block_limits() {
         bank.read_cost_tracker().unwrap().get_account_limit(),
         MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_ENABLED,
         "bank created from genesis config should have new limit"
-    );
-}
-
-fn assert_slot_time_bank_state(bank: &Bank, params: SlotParams) {
-    assert_eq!(bank.ns_per_slot, params.ns_per_slot());
-    assert_eq!(bank.hashes_per_tick(), params.hashes_per_tick());
-    assert_eq!(
-        bank.slots_per_year.to_bits(),
-        params.slots_per_year().to_bits()
-    );
-    assert_eq!(
-        bank.rent_collector.slots_per_year.to_bits(),
-        bank.slots_per_year.to_bits()
-    );
-    assert_eq!(
-        bank.partitioned_rewards_stake_account_stores_per_block,
-        params.partitioned_epoch_rewards_stake_account_stores_per_block()
-    );
-    assert_eq!(
-        bank.entry_bytes_budget().slot_limit(),
-        params.max_entry_bytes_per_slot()
-    );
-    let cost_tracker = bank.read_cost_tracker().unwrap();
-    let (account_limit, block_limit, vote_limit, data_size_limit) = params.cost_limits(
-        bank.feature_set
-            .is_active(&feature_set::raise_block_limits_to_100m::id()),
-    );
-    assert_eq!(cost_tracker.get_account_limit(), account_limit);
-    assert_eq!(cost_tracker.get_block_limit(), block_limit);
-    assert_eq!(cost_tracker.get_vote_limit(), vote_limit);
-    assert_eq!(
-        cost_tracker.get_allocated_data_size_limit(),
-        data_size_limit
-    );
-}
-
-#[test]
-fn test_reduce_slot_time_features() {
-    let (genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-    let feature_account_balance = genesis_config.rent.minimum_balance(Feature::size_of());
-
-    let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    assert!(!bank.slot_time_reduction_active());
-    assert_eq!(bank.hashes_per_tick(), Some(LEGACY_HASHES_PER_TICK));
-
-    for (feature_id, params) in slot_time_feature_gates() {
-        let previous_params = bank.current_slot_params();
-        bank.store_account(
-            &feature_id,
-            &feature::create_account(&Feature::default(), feature_account_balance),
-        );
-
-        let activation_slot = bank
-            .epoch_schedule()
-            .get_first_slot_in_epoch(bank.epoch().saturating_add(1));
-        let activation_bank = Bank::new_from_parent_with_bank_forks(
-            &bank_forks,
-            bank,
-            SlotLeader::default(),
-            activation_slot,
-        );
-
-        assert!(activation_bank.feature_set.is_active(&feature_id));
-        assert_eq!(activation_bank.current_slot_params(), previous_params);
-        assert_slot_time_bank_state(&activation_bank, previous_params);
-
-        let effective_slot = activation_bank
-            .epoch_schedule()
-            .get_first_slot_in_epoch(activation_bank.epoch().saturating_add(1));
-        bank = Bank::new_from_parent_with_bank_forks(
-            &bank_forks,
-            activation_bank,
-            SlotLeader::default(),
-            effective_slot,
-        );
-        assert!(bank.slot_time_reduction_active());
-        assert_slot_time_bank_state(&bank, params);
-    }
-}
-
-#[test]
-fn test_reduce_slot_time_features_active_at_genesis() {
-    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-    for feature_id in slot_time_feature_ids() {
-        activate_feature(&mut genesis_config, feature_id);
-    }
-    activate_feature(
-        &mut genesis_config,
-        feature_set::raise_block_limits_to_100m::id(),
-    );
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    assert!(!bank.slot_time_reduction_active());
-    assert_slot_time_bank_state(&bank, LEGACY_SLOT_PARAMS);
-
-    let effective_slot = bank.epoch_schedule().get_first_slot_in_epoch(1);
-    let bank = Bank::new_from_parent_with_bank_forks(
-        &bank_forks,
-        bank,
-        SlotLeader::default(),
-        effective_slot,
-    );
-    assert_slot_time_bank_state(&bank, SLOT_PARAMS_200MS);
-}
-
-#[test]
-fn test_reduce_slot_time_hashes_per_tick() {
-    let assert_reduced_slot_time_hashes_per_tick =
-        |genesis_config, expected_initial_hashes_per_tick, expected_effective_hashes_per_tick| {
-            let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-            assert_eq!(bank.ns_per_slot, LEGACY_SLOT_PARAMS.ns_per_slot());
-            assert_eq!(bank.hashes_per_tick(), expected_initial_hashes_per_tick);
-
-            let effective_slot = bank.epoch_schedule().get_first_slot_in_epoch(1);
-            let bank = Bank::new_from_parent_with_bank_forks(
-                &bank_forks,
-                bank,
-                SlotLeader::default(),
-                effective_slot,
-            );
-            assert_eq!(bank.ns_per_slot, SLOT_PARAMS_200MS.ns_per_slot());
-            assert_eq!(bank.hashes_per_tick(), expected_effective_hashes_per_tick);
-        };
-
-    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-    activate_feature(
-        &mut genesis_config,
-        feature_set::reduce_slot_time_to_200ms::id(),
-    );
-    assert_reduced_slot_time_hashes_per_tick(
-        genesis_config,
-        Some(LEGACY_HASHES_PER_TICK),
-        SLOT_PARAMS_200MS.hashes_per_tick(),
-    );
-
-    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-    genesis_utils::activate_all_features_alpenglow(&mut genesis_config);
-    assert_eq!(genesis_config.poh_config.hashes_per_tick, None);
-    assert_reduced_slot_time_hashes_per_tick(genesis_config, None, None);
-}
-
-#[test]
-fn test_reduce_slot_time_range_duration() {
-    const SLOTS_PER_EPOCH: Slot = 32;
-    let bank_for_activations = |activations: &[(Pubkey, Slot)]| {
-        let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
-        genesis_config.epoch_schedule =
-            EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
-        let mut bank = Bank::new_for_tests(&genesis_config);
-        let mut feature_set = FeatureSet::default();
-        for (feature_id, activation_slot) in activations {
-            feature_set.activate(feature_id, *activation_slot);
-        }
-        bank.feature_set = Arc::new(feature_set);
-        bank.refresh_slot_params();
-        bank
-    };
-
-    let ordered_activations = slot_time_feature_gates()
-        .into_iter()
-        .zip([1, 33, 65, 97])
-        .map(|((feature_id, _), activation_slot)| (feature_id, activation_slot))
-        .collect::<Vec<_>>();
-    let bank = bank_for_activations(&ordered_activations);
-
-    let expected_duration = [
-        (SLOTS_PER_EPOCH, LEGACY_SLOT_PARAMS),
-        (SLOTS_PER_EPOCH, SLOT_PARAMS_350MS),
-        (SLOTS_PER_EPOCH, SLOT_PARAMS_300MS),
-        (SLOTS_PER_EPOCH, SLOT_PARAMS_250MS),
-        (SLOTS_PER_EPOCH, SLOT_PARAMS_200MS),
-    ]
-    .into_iter()
-    .map(|(slots, params)| slots as f64 / params.slots_per_year())
-    .sum::<f64>();
-
-    assert_eq!(
-        bank.slot_range_duration_in_years(0, SLOTS_PER_EPOCH * 5)
-            .to_bits(),
-        expected_duration.to_bits()
-    );
-    assert_eq!(
-        bank.slot_range_duration_nanos(0, SLOTS_PER_EPOCH * 5 - 1),
-        [
-            (SLOTS_PER_EPOCH, LEGACY_SLOT_PARAMS),
-            (SLOTS_PER_EPOCH, SLOT_PARAMS_350MS),
-            (SLOTS_PER_EPOCH, SLOT_PARAMS_300MS),
-            (SLOTS_PER_EPOCH, SLOT_PARAMS_250MS),
-            (SLOTS_PER_EPOCH, SLOT_PARAMS_200MS),
-        ]
-        .into_iter()
-        .map(|(slots, params)| u128::from(slots) * params.ns_per_slot())
-        .sum::<u128>()
-    );
-
-    let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
-    let bank =
-        bank_for_activations(&[(reduce_to_200ms, 1), (reduce_to_350ms, SLOTS_PER_EPOCH + 1)]);
-    assert_eq!(
-        bank.slot_params_at_slot(SLOTS_PER_EPOCH - 1),
-        LEGACY_SLOT_PARAMS
-    );
-    assert_eq!(bank.slot_params_at_slot(SLOTS_PER_EPOCH), SLOT_PARAMS_200MS);
-    assert_eq!(
-        bank.slot_params_at_slot(SLOTS_PER_EPOCH * 2),
-        SLOT_PARAMS_200MS
-    );
-    assert_eq!(
-        bank.slot_range_duration_in_years(0, SLOTS_PER_EPOCH * 3)
-            .to_bits(),
-        (SLOTS_PER_EPOCH as f64 / LEGACY_SLOT_PARAMS.slots_per_year()
-            + (SLOTS_PER_EPOCH * 2) as f64 / SLOT_PARAMS_200MS.slots_per_year())
-        .to_bits()
-    );
-    assert_eq!(
-        bank.slot_range_duration_nanos(0, SLOTS_PER_EPOCH * 3 - 1),
-        u128::from(SLOTS_PER_EPOCH) * LEGACY_SLOT_PARAMS.ns_per_slot()
-            + u128::from(SLOTS_PER_EPOCH * 2) * SLOT_PARAMS_200MS.ns_per_slot()
-    );
-}
-
-#[test]
-fn test_update_clock_slot_range_duration() {
-    const SLOTS_PER_EPOCH: Slot = 32;
-
-    let leader_pubkey = solana_pubkey::new_rand();
-    let GenesisConfigInfo {
-        mut genesis_config,
-        voting_keypair,
-        ..
-    } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
-    genesis_config.epoch_schedule = EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
-    activate_feature(
-        &mut genesis_config,
-        feature_set::reduce_slot_time_to_200ms::id(),
-    );
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let vote_timestamp_slot = 4;
-    let vote_timestamp = bank.unix_timestamp_from_genesis();
-    update_vote_account_timestamp(
-        BlockTimestamp {
-            slot: vote_timestamp_slot,
-            timestamp: vote_timestamp,
-        },
-        &bank,
-        &voting_keypair.pubkey(),
-    );
-
-    let current_slot = SLOTS_PER_EPOCH + 3;
-    let bank = Bank::new_from_parent_with_bank_forks(
-        &bank_forks,
-        bank,
-        SlotLeader::default(),
-        current_slot,
-    );
-    let expected_elapsed = Duration::from_nanos_u128(
-        bank.slot_range_duration_nanos(vote_timestamp_slot + 1, current_slot),
-    );
-    let scalar_elapsed =
-        Duration::from_nanos(bank.ns_per_slot as u64) * (current_slot - vote_timestamp_slot) as u32;
-
-    assert_ne!(expected_elapsed.as_secs(), scalar_elapsed.as_secs());
-    assert_eq!(
-        bank.clock().unix_timestamp,
-        vote_timestamp + expected_elapsed.as_secs() as i64
     );
 }
 

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -155,11 +155,9 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config,
-                create_genesis_config_with_alpenglow_vote_accounts, deactivate_features,
+                create_genesis_config_with_alpenglow_vote_accounts,
             },
-            slot_params::slot_time_feature_ids,
         },
-        agave_feature_set as feature_set,
         rand::Rng,
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
@@ -233,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn new_epoch_update_account_uses_current_epoch_rewards() {
+    fn new_epoch_update_account_use_current_reward_budget() {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(1_000_000_000);
@@ -241,71 +239,46 @@ mod tests {
         // Warmup is necessary here to give epoch 0 and epoch 1 different reward
         // budgets.
         genesis_config.epoch_schedule = EpochSchedule::custom(64, 64, true);
-        deactivate_features(&mut genesis_config, &slot_time_feature_ids().to_vec());
 
-        for (case, genesis_config, activate_slot_time_feature) in [
-            ("current reward budget", genesis_config, false),
-            (
-                "current epoch slot params",
-                GenesisConfig {
-                    inflation: Inflation::full(),
-                    ..GenesisConfig::default()
-                },
-                true,
-            ),
-        ] {
-            let mut bank_epoch_0 = Bank::new_for_tests(&genesis_config);
-            if activate_slot_time_feature {
-                bank_epoch_0.activate_feature(&feature_set::reduce_slot_time_to_350ms::id());
-            }
-            let bank_forks = BankForks::new_rw_arc(bank_epoch_0);
-            let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
-            let epoch_1_first_slot = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
-            let bank_epoch_1 = Bank::new_from_parent_with_bank_forks(
-                bank_forks.as_ref(),
-                bank_epoch_0.clone(),
-                SlotLeader::new_unique(),
-                epoch_1_first_slot,
-            );
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
+        let epoch_1_first_slot = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
+        let bank_epoch_1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank_epoch_0.clone(),
+            SlotLeader::new_unique(),
+            epoch_1_first_slot,
+        );
 
-            assert_eq!(bank_epoch_0.epoch(), 0, "{case}");
-            assert_eq!(bank_epoch_1.epoch(), 1, "{case}");
-            if activate_slot_time_feature {
-                assert_ne!(bank_epoch_0.ns_per_slot, bank_epoch_1.ns_per_slot, "{case}");
-            } else {
-                assert_ne!(
-                    bank_epoch_1.epoch_schedule().get_slots_in_epoch(0),
-                    bank_epoch_1.epoch_schedule().get_slots_in_epoch(1),
-                    "{case}",
-                );
-            }
+        assert_eq!(bank_epoch_0.epoch(), 0);
+        assert_eq!(bank_epoch_1.epoch(), 1);
+        assert_ne!(
+            bank_epoch_1.epoch_schedule().get_slots_in_epoch(0),
+            bank_epoch_1.epoch_schedule().get_slots_in_epoch(1)
+        );
 
-            let epoch_start_capitalization = bank_epoch_0.capitalization();
-            let expected_current_epoch_rewards = bank_epoch_1.calculate_epoch_inflation_rewards(
+        let epoch_start_capitalization = bank_epoch_0.capitalization();
+        let expected_current_epoch_rewards = bank_epoch_1
+            .calculate_epoch_inflation_rewards(epoch_start_capitalization, bank_epoch_1.epoch());
+        assert_ne!(
+            expected_current_epoch_rewards,
+            bank_epoch_1.calculate_epoch_inflation_rewards(
                 epoch_start_capitalization,
-                bank_epoch_1.epoch(),
-            );
-            assert_ne!(
-                expected_current_epoch_rewards,
-                bank_epoch_1.calculate_epoch_inflation_rewards(
-                    epoch_start_capitalization,
-                    bank_epoch_0.epoch()
-                ),
-                "{case}",
-            );
+                bank_epoch_0.epoch()
+            )
+        );
 
-            EpochInflationAccountState::new_epoch_update_account(
-                &bank_epoch_1,
-                epoch_start_capitalization,
-                0,
-            );
-            let state = EpochInflationAccountState::new_from_bank(&bank_epoch_1).unwrap();
-            assert_eq!(state.current.epoch, bank_epoch_1.epoch(), "{case}");
-            assert_eq!(
-                state.current.max_possible_validator_reward, expected_current_epoch_rewards,
-                "{case}",
-            );
-        }
+        EpochInflationAccountState::new_epoch_update_account(
+            &bank_epoch_1,
+            epoch_start_capitalization,
+            0,
+        );
+        let state = EpochInflationAccountState::new_from_bank(&bank_epoch_1).unwrap();
+        assert_eq!(state.current.epoch, bank_epoch_1.epoch());
+        assert_eq!(
+            state.current.max_possible_validator_reward,
+            expected_current_epoch_rewards
+        );
     }
 
     #[test]

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -1,8 +1,6 @@
 use {
-    agave_feature_set::{self as feature_set, FeatureSet},
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
-    solana_pubkey::Pubkey,
     std::{
         collections::BTreeMap,
         ops::Bound::{Excluded, Included},
@@ -13,8 +11,10 @@ pub const DEFAULT_MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
 
 /// Runtime parameters tied to a slot-time regime.
 ///
-/// Slot-time reduction features select explicit table values instead of
-/// deriving ratios at runtime, which avoids rounding drift in consensus paths.
+/// This intentionally groups values that need to move together when slot time
+/// changes. For now, only the legacy baseline exists, so routing through this
+/// type preserves current behavior while giving future feature-gated changes a
+/// single table-shaped home.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SlotParams {
     pub(crate) ns_per_slot: u128,
@@ -87,35 +87,20 @@ impl SlotParams {
     }
 
     /// Returns the per-bank cost limits for these params.
-    pub(crate) const fn cost_limits(
-        self,
-        raise_block_limits_to_100m: bool,
-    ) -> (u64, u64, u64, u64) {
-        let (max_writable_account_units, max_block_units) = if raise_block_limits_to_100m {
-            (
-                self.max_writable_account_units
-                    .saturating_mul(100)
-                    .saturating_div(60),
-                self.max_block_units.saturating_mul(100).saturating_div(60),
-            )
-        } else {
-            (self.max_writable_account_units, self.max_block_units)
-        };
-
+    pub const fn cost_limits(self) -> (u64, u64, u64, u64) {
         (
-            max_writable_account_units,
-            max_block_units,
+            self.max_writable_account_units,
+            self.max_block_units,
             self.max_vote_units,
             self.max_block_accounts_data_size_delta,
         )
     }
 }
 
-pub const LEGACY_HASHES_PER_TICK: u64 = 62_500;
 pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
     ns_per_slot: 400_000_000,
     slots_per_year: 78_892_314.984,
-    hashes_per_tick: Some(LEGACY_HASHES_PER_TICK),
+    hashes_per_tick: Some(62_500),
     max_block_units: 60_000_000,
     max_writable_account_units: 24_000_000,
     max_vote_units: 36_000_000,
@@ -125,92 +110,6 @@ pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
     max_entry_bytes_per_slot: 20 * 1024 * 1024,
     partitioned_epoch_rewards_stake_account_stores_per_block: 4096,
 };
-
-pub(crate) const SLOT_PARAMS_350MS: SlotParams = SlotParams {
-    ns_per_slot: 350_000_000,
-    slots_per_year: 90_162_645.696,
-    hashes_per_tick: Some(54_687),
-    max_block_units: 52_500_000,
-    max_writable_account_units: 21_000_000,
-    max_vote_units: 31_500_000,
-    max_block_accounts_data_size_delta: 87_500_000,
-    max_data_shreds_per_slot: 28_672,
-    max_code_shreds_per_slot: 28_672,
-    max_entry_bytes_per_slot: 18_350_080,
-    partitioned_epoch_rewards_stake_account_stores_per_block: 3_584,
-};
-
-pub(crate) const SLOT_PARAMS_300MS: SlotParams = SlotParams {
-    ns_per_slot: 300_000_000,
-    slots_per_year: 105_189_753.312,
-    hashes_per_tick: Some(46_875),
-    max_block_units: 45_000_000,
-    max_writable_account_units: 18_000_000,
-    max_vote_units: 27_000_000,
-    max_block_accounts_data_size_delta: 75_000_000,
-    max_data_shreds_per_slot: 24_576,
-    max_code_shreds_per_slot: 24_576,
-    max_entry_bytes_per_slot: 15_728_640,
-    partitioned_epoch_rewards_stake_account_stores_per_block: 3_072,
-};
-
-pub(crate) const SLOT_PARAMS_250MS: SlotParams = SlotParams {
-    ns_per_slot: 250_000_000,
-    slots_per_year: 126_227_703.974,
-    hashes_per_tick: Some(39_062),
-    max_block_units: 37_500_000,
-    max_writable_account_units: 15_000_000,
-    max_vote_units: 22_500_000,
-    max_block_accounts_data_size_delta: 62_500_000,
-    max_data_shreds_per_slot: 20_480,
-    max_code_shreds_per_slot: 20_480,
-    max_entry_bytes_per_slot: 13_107_200,
-    partitioned_epoch_rewards_stake_account_stores_per_block: 2_560,
-};
-
-pub(crate) const SLOT_PARAMS_200MS: SlotParams = SlotParams {
-    ns_per_slot: 200_000_000,
-    slots_per_year: 157_784_629.968,
-    hashes_per_tick: Some(31_250),
-    max_block_units: 30_000_000,
-    max_writable_account_units: 12_000_000,
-    max_vote_units: 18_000_000,
-    max_block_accounts_data_size_delta: 50_000_000,
-    max_data_shreds_per_slot: 16_384,
-    max_code_shreds_per_slot: 16_384,
-    max_entry_bytes_per_slot: 10_485_760,
-    partitioned_epoch_rewards_stake_account_stores_per_block: 2_048,
-};
-
-/// Slot-time reduction gates in the intended activation order.
-const SLOT_TIME_REDUCTION_PARAMS: [(Pubkey, SlotParams); 4] = [
-    (
-        feature_set::reduce_slot_time_to_350ms::ID,
-        SLOT_PARAMS_350MS,
-    ),
-    (
-        feature_set::reduce_slot_time_to_300ms::ID,
-        SLOT_PARAMS_300MS,
-    ),
-    (
-        feature_set::reduce_slot_time_to_250ms::ID,
-        SLOT_PARAMS_250MS,
-    ),
-    (
-        feature_set::reduce_slot_time_to_200ms::ID,
-        SLOT_PARAMS_200MS,
-    ),
-];
-
-/// Returns slot-time feature gates mapped to runtime slot parameters.
-pub fn slot_time_feature_gates() -> [(Pubkey, SlotParams); 4] {
-    SLOT_TIME_REDUCTION_PARAMS
-}
-
-/// Returns all slot-time reduction feature IDs in activation order.
-pub fn slot_time_feature_ids() -> [Pubkey; 4] {
-    SLOT_TIME_REDUCTION_PARAMS.map(|(feature_id, _)| feature_id)
-}
 
 /// Bank-local archive of slot-parameter transitions.
 ///
@@ -225,49 +124,25 @@ pub(crate) struct SlotParamsArchive {
     /// This is used when a bank, usually the root bank, must answer "which
     /// parameters apply to some other slot?" Examples include shred filtering
     /// for incoming shreds and inflation calculations that span historical slot
-    /// ranges. The transitions are normalized so slot duration never increases
-    /// as slots advance, even if slot-time features activate out of order.
+    /// ranges.
     param_transitions: BTreeMap<Slot, SlotParams>,
 }
 
 impl Default for SlotParamsArchive {
     fn default() -> Self {
-        Self::new(
-            &FeatureSet::default(),
-            &EpochSchedule::default(),
-            LEGACY_SLOT_PARAMS,
-        )
+        Self::new(&EpochSchedule::default(), LEGACY_SLOT_PARAMS)
     }
 }
 
 impl SlotParamsArchive {
-    /// Rebuilds slot-parameter transitions from the active feature set.
-    pub(crate) fn new(
-        feature_set: &FeatureSet,
-        epoch_schedule: &EpochSchedule,
-        baseline_params: SlotParams,
-    ) -> Self {
-        let mut param_transitions = BTreeMap::from([(0, baseline_params)]);
-        let mut earliest_same_or_shorter_slot = Slot::MAX;
-
-        // The feature table is ordered longest-to-shortest. Walk it in reverse
-        // so once a same-or-shorter target is effective at slot S, any longer
-        // target effective at S or later is known to be redundant.
-        for (feature_id, params) in slot_time_feature_gates().into_iter().rev() {
-            if params.ns_per_slot > baseline_params.ns_per_slot {
-                continue;
-            }
-            let Some(activation_slot) = feature_set.activated_slot(&feature_id) else {
-                continue;
-            };
-            let effective_slot = Self::feature_effective_slot(epoch_schedule, activation_slot);
-            if effective_slot < earliest_same_or_shorter_slot {
-                param_transitions.insert(effective_slot, params);
-                earliest_same_or_shorter_slot = effective_slot;
-            }
+    /// Rebuilds slot-parameter transitions from the supplied baseline.
+    ///
+    /// `_epoch_schedule` is accepted now so the call sites already have the
+    /// right shape for delayed, epoch-boundary-effective feature transitions.
+    pub(crate) fn new(_epoch_schedule: &EpochSchedule, baseline_params: SlotParams) -> Self {
+        Self {
+            param_transitions: BTreeMap::from([(0, baseline_params)]),
         }
-
-        Self { param_transitions }
     }
 
     /// Returns the baseline params supplied at genesis or snapshot restore.
@@ -319,42 +194,5 @@ impl SlotParamsArchive {
 
         let remaining_slots = u128::from(end_slot.saturating_sub(cursor)) + 1;
         duration.saturating_add(remaining_slots.saturating_mul(params.ns_per_slot()))
-    }
-
-    /// Returns the first slot where a slot-time feature may affect bank state.
-    ///
-    /// A gate that activates in epoch E is effective starting at the first slot
-    /// of epoch E + 1, giving shred filters a full epoch of advance notice
-    /// before enforcing lower shred limits.
-    fn feature_effective_slot(epoch_schedule: &EpochSchedule, activation_slot: Slot) -> Slot {
-        let activation_epoch = epoch_schedule.get_epoch(activation_slot);
-        epoch_schedule.get_first_slot_in_epoch(activation_epoch.saturating_add(1))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_cost_limits_scaling_matches_simd_0525() {
-        for (params, expected_account_limit, expected_block_limit) in [
-            (LEGACY_SLOT_PARAMS, 40_000_000, 100_000_000),
-            (SLOT_PARAMS_350MS, 35_000_000, 87_500_000),
-            (SLOT_PARAMS_300MS, 30_000_000, 75_000_000),
-            (SLOT_PARAMS_250MS, 25_000_000, 62_500_000),
-            (SLOT_PARAMS_200MS, 20_000_000, 50_000_000),
-        ] {
-            let (_, _, vote_limit, data_size_limit) = params.cost_limits(false);
-            assert_eq!(
-                params.cost_limits(true),
-                (
-                    expected_account_limit,
-                    expected_block_limit,
-                    vote_limit,
-                    data_size_limit
-                )
-            );
-        }
     }
 }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -676,12 +676,7 @@ mod test {
             shred::{DATA_SHREDS_PER_FEC_BLOCK, max_ticks_per_n_shreds},
         },
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
-        solana_pubkey::Pubkey,
-        solana_runtime::{
-            bank::{Bank, SlotLeader},
-            genesis_utils::{activate_feature, deactivate_features},
-            slot_params::{slot_time_feature_gates, slot_time_feature_ids},
-        },
+        solana_runtime::bank::Bank,
         solana_signer::Signer,
         std::{ops::Deref, sync::Arc, time::Duration},
         test_case::test_case,
@@ -743,65 +738,6 @@ mod test {
 
     fn test_leader_schedule_cache(bank: &Bank) -> Arc<LeaderScheduleCache> {
         Arc::new(LeaderScheduleCache::new_from_bank(bank))
-    }
-
-    fn broadcast_shred_limits_for_slot_time_features(
-        feature_ids: impl IntoIterator<Item = Pubkey>,
-    ) -> (u32, u32) {
-        let ledger_path = get_tmp_ledger_path!();
-        let blockstore = Arc::new(
-            Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
-        );
-        let mut genesis_config = create_genesis_config(10_000).genesis_config;
-        let slot_time_features = slot_time_feature_ids().to_vec();
-        deactivate_features(&mut genesis_config, &slot_time_features);
-        for feature_id in feature_ids {
-            activate_feature(&mut genesis_config, feature_id);
-        }
-
-        let (parent_bank, bank_forks) =
-            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-        parent_bank.set_tick_height(parent_bank.max_tick_height());
-        Bank::calculate_and_set_block_id_for_dcou(&parent_bank);
-
-        let effective_slot = parent_bank.epoch_schedule().get_first_slot_in_epoch(1);
-        let bank = Bank::new_from_parent_with_bank_forks(
-            &bank_forks,
-            parent_bank,
-            SlotLeader::default(),
-            effective_slot,
-        );
-        let ticks = create_ticks(1, 0, genesis_config.hash());
-        let receive_results = ReceiveResults {
-            component: BlockComponent::EntryBatch(ticks.clone()),
-            bank: bank.clone(),
-            last_tick_height: bank.tick_height() + ticks.len() as u64,
-        };
-        let (socket_sender, _socket_receiver) = unbounded();
-        let (blockstore_sender, _blockstore_receiver) = unbounded();
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
-        let mut standard_broadcast_run = StandardBroadcastRun::new(
-            0,
-            Arc::new(MigrationStatus::default()),
-            votor_event_sender,
-            test_leader_schedule_cache(&bank),
-        );
-
-        standard_broadcast_run
-            .process_receive_results(
-                &Keypair::new(),
-                &blockstore,
-                &socket_sender,
-                &blockstore_sender,
-                receive_results,
-                &mut ProcessShredsStats::default(),
-            )
-            .unwrap();
-
-        (
-            standard_broadcast_run.max_data_shreds_per_slot,
-            standard_broadcast_run.max_code_shreds_per_slot,
-        )
     }
 
     #[test]
@@ -1222,28 +1158,52 @@ mod test {
 
     #[test]
     fn test_update_shred_limits_from_bank() {
-        assert_eq!(
-            broadcast_shred_limits_for_slot_time_features(std::iter::empty()),
-            (
-                DEFAULT_MAX_DATA_SHREDS_PER_SLOT,
-                DEFAULT_MAX_CODE_SHREDS_PER_SLOT
-            )
+        agave_logger::setup();
+        let num_shreds_per_slot = 2;
+        let (
+            blockstore,
+            genesis_config,
+            cluster_info,
+            parent_bank,
+            leader_keypair,
+            socket,
+            bank_forks,
+        ) = setup(num_shreds_per_slot);
+        let bank = new_child_bank(&parent_bank, 1);
+        let ticks = create_ticks(1, 0, genesis_config.hash());
+        let receive_results = ReceiveResults {
+            component: BlockComponent::EntryBatch(ticks),
+            bank: bank.clone(),
+            last_tick_height: bank.tick_height() + 1,
+        };
+
+        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let mut standard_broadcast_run = StandardBroadcastRun::new(
+            0,
+            Arc::new(MigrationStatus::default()),
+            votor_event_sender,
+            test_leader_schedule_cache(&bank),
         );
+        standard_broadcast_run.max_data_shreds_per_slot = 1;
+        standard_broadcast_run.max_code_shreds_per_slot = 1;
+        standard_broadcast_run
+            .test_process_receive_results(
+                &leader_keypair,
+                &cluster_info,
+                &socket,
+                &blockstore,
+                receive_results,
+                &bank_forks,
+            )
+            .unwrap();
 
-        for ((feature_id, _), expected_shreds_per_slot) in slot_time_feature_gates()
-            .into_iter()
-            .zip([28_672, 24_576, 20_480, 16_384])
-        {
-            assert_eq!(
-                broadcast_shred_limits_for_slot_time_features([feature_id]),
-                (expected_shreds_per_slot, expected_shreds_per_slot)
-            );
-        }
-
-        let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
         assert_eq!(
-            broadcast_shred_limits_for_slot_time_features([reduce_to_350ms, reduce_to_200ms]),
-            (16_384, 16_384)
+            standard_broadcast_run.max_data_shreds_per_slot,
+            bank.max_data_shreds_per_slot()
+        );
+        assert_eq!(
+            standard_broadcast_run.max_code_shreds_per_slot,
+            bank.max_code_shreds_per_slot()
         );
     }
 


### PR DESCRIPTION
#### Problem
I had a node encounter a panic while unpacking snapshot. The node had been running master from a couple days ago. I then stopped the node and restarted with a branch that was rebased to the tip of master at the time (8cff9b26b2e1f231465b75ab986c563bdb3029aa). I needed to restart from snapshot archives for a different reason and encountered the following panic at startup:
```
[2026-06-04T01:56:57.676884570Z INFO  solana_runtime::snapshot_bank_utils] Loading bank from
full snapshot archive: /home/sol/ledger-snapshots/snapshot-424116877-52S9671eW6yPbei1YW5wrCjfSqZksnHxMRYGPtc6N5Wb.tar.zst,
and incremental snapshot archive: Some("/home/sol/ledger-snapshots/incremental-snapshot-424116877-424146771-YTB5gT2i8V4uE4NGk47Z7zRG4Yp17sX52uicCHpW4HV.tar.zst")
...
[2026-06-04T01:59:04.803082378Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="solBnkFrkSnap" one=1i message="panicked at runtime/src/bank.rs:4731:13:
    assertion `left == right` failed: snapshot slot-time hashes_per_tick mismatch
      left: Some(62500)
     right: Some(12500)" location="runtime/src/bank.rs:4731:13" version="4.2.0-alpha.0 (src:b5c9616a; feat:2d304fc4, client:Agave)"
```
I checked `git blame` for that line number:
```
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4730)         if !self.feature_set.is_active(&feature_set::alpenglow::id()) && hashes_per_tick.is_some() {
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4731)             assert_eq!(
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4732)                 hashes_per_tick,
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4733)                 params.hashes_per_tick(),
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4734)                 "snapshot slot-time hashes_per_tick mismatch"
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4735)             );
90f279a50d7 runtime/src/bank.rs (Brennan                 2026-06-03 14:32:22 -0700 4736)         }
```
And seeing that 90f279a50d73c2cf4a269d75c4ccbf6732d655fa was freshly landed, I decided to try to restart the node with 7a542eac95f0be75f8f229e94e32ad1eb255e276 (one commit earlier). I was able to successfully unpack the snapshot on this restart:
```
[2026-06-04T02:06:16.656470929Z INFO  solana_runtime::snapshot_bank_utils] Loading bank from
full snapshot archive: /home/sol/ledger-snapshots/snapshot-424116877-52S9671eW6yPbei1YW5wrCjfSqZksnHxMRYGPtc6N5Wb.tar.zst,
and incremental snapshot archive: Some("/home/sol/ledger-snapshots/incremental-snapshot-424116877-424146771-YTB5gT2i8V4uE4NGk47Z7zRG4Yp17sX52uicCHpW4HV.tar.zst")
...
[2026-06-04T02:08:24.759656024Z INFO  solana_runtime::bank] bank frozen: 424146771 hash: 5t6P74sCqR8UPiZm9r11EgCQu5Ur4vJUDWWgHTh8tcXH ...
```

#### Summary of Changes
This reverts commit 90f279a50d73c2cf4a269d75c4ccbf6732d655fa.
