### PR TITLE
SIMD-0525: Slot Time Reductions

### DIFF
--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -1,16 +1,22 @@
 //! Code related to partitioned rewards distribution
 
-/// # stake accounts to store in one block during partitioned reward interval
-/// Target to store 64 rewards per entry/tick in a block. A block has a minimum of 64
-/// entries/tick. This gives 4096 total rewards to store in one block.
-/// This constant affects consensus.
-const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
+/// Baseline number of stake accounts to store in one 400ms block during the
+/// partitioned reward interval.
+///
+/// The target is 64 rewards per entry/tick. A block has a minimum of 64
+/// entries/ticks, giving 4096 total rewards to store in one 400ms block. This
+/// constant affects consensus; shorter slot-time targets scale this value down
+/// in `Bank` state.
+pub const MAX_PARTITIONED_REWARDS_PER_BLOCK: u64 = 4096;
 
-#[derive(Debug, Clone, Copy)]
 /// Configuration options for partitioned epoch rewards.
+#[derive(Debug, Clone, Copy)]
 pub struct PartitionedEpochRewardsConfig {
-    /// number of stake accounts to store in one block during partitioned reward interval
-    /// normally, this is a number tuned for reasonable performance, such as 4096 accounts/block
+    /// Baseline number of stake accounts to store in one block during the
+    /// partitioned reward interval.
+    ///
+    /// This value is stored as the 400ms-slot baseline. Runtime `Bank` state
+    /// derives the effective per-bank value from the active slot-time target.
     pub stake_account_stores_per_block: u64,
 }
 
@@ -30,7 +36,8 @@ impl Default for PartitionedEpochRewardsConfig {
 }
 
 impl PartitionedEpochRewardsConfig {
-    /// Only for tests and benchmarks
+    /// Constructs a config with an explicit 400ms-slot baseline for tests and
+    /// benchmarks.
     pub fn new_for_test(stake_account_stores_per_block: u64) -> Self {
         Self {
             stake_account_stores_per_block,

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1529,6 +1529,22 @@ pub mod set_lamports_per_byte_to_6960 {
     pub const LAMPORTS_PER_BYTE: u64 = 6960;
 }
 
+pub mod reduce_slot_time_to_350ms {
+    solana_pubkey::declare_id!("iBRL2iJvhLssJveF1utbmmQGmjonmNYZALcJFEHTbUF");
+}
+
+pub mod reduce_slot_time_to_300ms {
+    solana_pubkey::declare_id!("iBRLA3zvd6x9445cK1vS7xt8n6Y7DS3otfRcDdW8JRW");
+}
+
+pub mod reduce_slot_time_to_250ms {
+    solana_pubkey::declare_id!("iBRLR6nG3fDi8YD4mpPTUVTgo5NaiYfZgrzokCfADP2");
+}
+
+pub mod reduce_slot_time_to_200ms {
+    solana_pubkey::declare_id!("iBRLypKvvj9VEvwoTeRpbLhbW55NFR4T3GE9BUR8A16");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2418,6 +2434,22 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             alpenglow::id(),
             "SIMD-0326: Alpenglow: new consensus algorithm",
+        ),
+        (
+            reduce_slot_time_to_350ms::id(),
+            "SIMD-0525: Reduce slot time to 350ms",
+        ),
+        (
+            reduce_slot_time_to_300ms::id(),
+            "SIMD-0525: Reduce slot time to 300ms",
+        ),
+        (
+            reduce_slot_time_to_250ms::id(),
+            "SIMD-0525: Reduce slot time to 250ms",
+        ),
+        (
+            reduce_slot_time_to_200ms::id(),
+            "SIMD-0525: Reduce slot time to 200ms",
         ),
         (
             disable_zk_elgamal_proof_program::id(),

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -595,7 +595,10 @@ mod tests {
         itertools::Itertools,
         solana_leader_schedule::SlotLeader,
         solana_perf::packet::{Packet, PacketFlags},
-        solana_runtime::bank::Bank,
+        solana_runtime::{
+            bank::Bank,
+            slot_params::{slot_time_feature_gates, slot_time_feature_ids},
+        },
         std::{
             io::{Cursor, Seek, SeekFrom, Write},
             sync::Arc,
@@ -618,6 +621,26 @@ mod tests {
         } else {
             Bank::new_from_parent_with_bank_forks(&bank_forks, bank, SlotLeader::default(), slot)
         }
+    }
+
+    fn deactivate_slot_time_features(bank: &mut Bank) {
+        for feature_id in slot_time_feature_ids() {
+            bank.deactivate_feature(&feature_id);
+        }
+    }
+
+    fn shred_filter_for_tests(
+        feature_ids: impl IntoIterator<Item = Pubkey>,
+    ) -> (ShredFilterContext, Slot) {
+        let genesis_config = create_genesis_config(1).genesis_config;
+        let mut root_bank = Bank::new_for_tests(&genesis_config);
+        deactivate_slot_time_features(&mut root_bank);
+        for feature_id in feature_ids {
+            root_bank.activate_feature(&feature_id);
+        }
+        let first_epoch_slot = root_bank.epoch_schedule().get_first_slot_in_epoch(1);
+        let (root_bank, _) = root_bank.wrap_with_bank_forks_for_tests();
+        (ShredFilterContext::new(root_bank, 0), first_epoch_slot)
     }
 
     #[test_case(true ; "last_in_slot")]
@@ -1044,6 +1067,36 @@ mod tests {
             );
             assert_eq!(shred_filter_context.stats.index_out_of_bounds, 1);
         }
+    }
+
+    #[test]
+    fn test_shred_limit_for_slot_times() {
+        for (features, shred_limits) in std::iter::once((vec![], ShredLimits::DEFAULT)).chain(
+            slot_time_feature_gates().map(|(feature_id, params)| {
+                (
+                    vec![feature_id],
+                    ShredLimits::new(
+                        params.max_data_shreds_per_slot(),
+                        params.max_code_shreds_per_slot(),
+                    ),
+                )
+            }),
+        ) {
+            let (shred_filter, effective_slot) = shred_filter_for_tests(features);
+            assert_eq!(
+                shred_filter.shred_limits(effective_slot.saturating_sub(1)),
+                ShredLimits::DEFAULT
+            );
+            assert_eq!(shred_filter.shred_limits(effective_slot), shred_limits);
+        }
+
+        let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
+        let (shred_filter, effective_slot) =
+            shred_filter_for_tests([reduce_to_350ms, reduce_to_200ms]);
+        assert_eq!(
+            shred_filter.shred_limits(effective_slot),
+            ShredLimits::new(16_384, 16_384)
+        );
     }
 
     #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -112,7 +112,7 @@ use {
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
-    solana_cost_model::{block_cost_limits::simd_0286_block_limit, cost_tracker::CostTracker},
+    solana_cost_model::cost_tracker::CostTracker,
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
     solana_feature_gate_interface as feature,
@@ -179,7 +179,6 @@ use {
     solana_system_transaction as system_transaction,
     solana_sysvar::{self as sysvar, SysvarSerialize, last_restart_slot::LastRestartSlot},
     solana_sysvar_id::SysvarId,
-    solana_time_utils::years_as_slots,
     solana_transaction::{
         Transaction, TransactionVerificationMode,
         sanitized::{MAX_TX_ACCOUNT_LOCKS, MessageHash, SanitizedTransaction},
@@ -2180,27 +2179,10 @@ impl Bank {
              snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
-        assert_eq!(
-            bank.ns_per_slot,
-            genesis_config.poh_config.target_tick_duration.as_nanos()
-                * genesis_config.ticks_per_slot as u128
-        );
         assert_eq!(bank.max_tick_height, (bank.slot + 1) * bank.ticks_per_slot);
-        assert_eq!(
-            bank.slots_per_year,
-            years_as_slots(
-                1.0,
-                &genesis_config.poh_config.target_tick_duration,
-                bank.ticks_per_slot,
-            )
-        );
         assert_eq!(bank.epoch_schedule, genesis_config.epoch_schedule);
 
-        bank.refresh_slot_params_with_baseline(Self::genesis_config_slot_params(
-            genesis_config,
-            bank.partitioned_rewards_stake_account_stores_per_block,
-        ));
-
+        bank.refresh_slot_params_from_snapshot(genesis_config);
         bank.initialize_after_snapshot_restore(|| rewards_calculation_thread_pool);
 
         datapoint_info!(
@@ -2710,12 +2692,25 @@ impl Bank {
         });
     }
 
+    /// Rebuilds slot-param state from the current feature set.
+    fn refresh_slot_params(&mut self) {
+        self.refresh_slot_params_with_baseline(self.slot_params.baseline_params());
+    }
+
+    fn refresh_slot_params_from_snapshot(&mut self, genesis_config: &GenesisConfig) {
+        let (feature_set, _) = self.compute_active_feature_set(false);
+        self.refresh_slot_params_with_baseline(
+            self.snapshot_restore_slot_params_baseline(genesis_config, &feature_set),
+        );
+    }
+
     /// Rebuilds cached slot params while preserving the supplied slot-0 baseline.
     ///
     /// The cache is not serialized into snapshots; it is reconstructed from
     /// existing Bank fields during genesis and snapshot restore.
     fn refresh_slot_params_with_baseline(&mut self, baseline_params: SlotParams) {
-        self.slot_params = SlotParamsArchive::new(&self.epoch_schedule, baseline_params);
+        self.slot_params =
+            SlotParamsArchive::new(&self.feature_set, &self.epoch_schedule, baseline_params);
     }
 
     /// Builds slot-0 params from the genesis config.
@@ -2731,9 +2726,70 @@ impl Bank {
         )
     }
 
+    /// Builds the slot-param baseline from the restored bank fields.
+    ///
+    /// Snapshot fields represent the cluster's current reality. This can
+    /// differ from genesis for values, such as `hashes_per_tick`, that were
+    /// changed by older feature gates before slot-time reductions existed.
+    fn restored_bank_slot_params(&self) -> SlotParams {
+        SlotParams::genesis_baseline(
+            self.ns_per_slot,
+            self.slots_per_year,
+            self.hashes_per_tick(),
+            self.partitioned_rewards_stake_account_stores_per_block,
+        )
+    }
+
+    /// Returns true if any slot-time reduction has taken effect by this bank.
+    ///
+    /// Feature activation happens in one epoch, but slot params become effective
+    /// at the start of the following epoch.
+    fn any_slot_time_reduction_effective(
+        &self,
+        feature_set: &FeatureSet,
+        ns_per_slot: u128,
+    ) -> bool {
+        SlotParamsArchive::any_slot_time_reduction_effective(
+            &self.epoch_schedule,
+            self.slot,
+            feature_set,
+            ns_per_slot,
+        )
+    }
+
+    /// Selects the slot-param baseline to use when reconstructing from snapshot.
+    ///
+    /// Before any slot-time reduction is effective, the baseline should match
+    /// restored bank fields because historical non-slot-time feature gates may
+    /// have already changed some values away from genesis. Once a slot-time
+    /// reduction is effective, keep the genesis baseline so historical lookups
+    /// for pre-reduction slots remain correct.
+    fn snapshot_restore_slot_params_baseline(
+        &self,
+        genesis_config: &GenesisConfig,
+        feature_set: &FeatureSet,
+    ) -> SlotParams {
+        if self.any_slot_time_reduction_effective(feature_set, genesis_config.ns_per_slot()) {
+            Self::genesis_config_slot_params(
+                genesis_config,
+                self.partitioned_rewards_stake_account_stores_per_block,
+            )
+        } else {
+            // Default to whatever is in the bank if we've never enabled any
+            // slot time reductions. This prevents resetting any slot params
+            // that may have been changed previously back to genesis.
+            self.restored_bank_slot_params()
+        }
+    }
+
     /// Returns the slot params effective at `slot`.
     fn slot_params_at_slot(&self, slot: Slot) -> SlotParams {
         self.slot_params.params_at_slot(slot)
+    }
+
+    /// Returns the slot params that should be effective for this bank's slot.
+    fn current_slot_params(&self) -> SlotParams {
+        self.slot_params_at_slot(self.slot)
     }
 
     /// Returns the effective slot duration for `slot`.
@@ -4676,20 +4732,76 @@ impl Bank {
         self.rc.accounts.clone()
     }
 
+    /// Recomputes cost tracker limits from active feature state.
     fn apply_cost_tracker_limits_for_active_features(&mut self) {
+        let params = self.current_slot_params();
+        let (account_cost_limit, block_cost_limit, data_size_limit) =
+            params.cost_limits(self.feature_set.snapshot().raise_block_limits_to_100m);
+
         let mut cost_tracker = self.write_cost_tracker().unwrap();
-        let block_cost_limit = if self.feature_set.snapshot().raise_block_limits_to_100m {
-            simd_0286_block_limit()
-        } else {
-            cost_tracker.get_block_limit()
-        };
-        let account_cost_limit = block_cost_limit.saturating_mul(40).saturating_div(100);
-        let allocated_data_size_limit = cost_tracker.get_allocated_data_size_limit();
-        cost_tracker.set_limits(
-            account_cost_limit,
-            block_cost_limit,
-            allocated_data_size_limit,
+        cost_tracker.set_limits(account_cost_limit, block_cost_limit, data_size_limit);
+    }
+
+    /// Recomputes this bank's effective partitioned-reward write budget.
+    fn apply_partitioned_epoch_rewards_config_for_active_features(&mut self) {
+        self.partitioned_rewards_stake_account_stores_per_block = self
+            .current_slot_params()
+            .partitioned_epoch_rewards_stake_account_stores_per_block();
+    }
+
+    /// Applies slot-time changes for fields serialized into snapshots.
+    fn apply_slot_time_persistent_changes(&mut self) {
+        let params = self.current_slot_params();
+        self.ns_per_slot = params.ns_per_slot();
+        self.slots_per_year = params.slots_per_year();
+        self.rent_collector.slots_per_year = params.slots_per_year();
+        if !self.feature_set.is_active(&feature_set::alpenglow::id())
+            && self.hashes_per_tick().is_some()
+        {
+            self.set_hashes_per_tick(params.hashes_per_tick());
+        }
+    }
+
+    /// Verifies bank fields are consistent with current slot params.
+    fn assert_bank_matches_slot_params(&self) {
+        let params = self.current_slot_params();
+        assert_eq!(
+            self.ns_per_slot,
+            params.ns_per_slot(),
+            "snapshot slot-time ns_per_slot mismatch"
         );
+        assert_eq!(
+            self.slots_per_year.to_bits(),
+            params.slots_per_year().to_bits(),
+            "snapshot slot-time slots_per_year mismatch"
+        );
+        assert_eq!(
+            self.rent_collector.slots_per_year.to_bits(),
+            params.slots_per_year().to_bits(),
+            "snapshot slot-time rent_collector.slots_per_year mismatch"
+        );
+        let hashes_per_tick = self.hashes_per_tick();
+        if !self.feature_set.is_active(&feature_set::alpenglow::id()) && hashes_per_tick.is_some() {
+            assert_eq!(
+                hashes_per_tick,
+                params.hashes_per_tick(),
+                "snapshot slot-time hashes_per_tick mismatch"
+            );
+        }
+        assert_eq!(
+            self.entry_bytes_budget().slot_limit(),
+            params.max_entry_bytes_per_slot(),
+            "snapshot slot-time entry byte budget mismatch"
+        );
+    }
+
+    /// Applies slot-time changes for runtime-only fields. This function is
+    /// expected to be idempotent.
+    fn apply_slot_time_runtime_changes(&mut self) {
+        self.entry_bytes_consumed =
+            EntryBytesBudget::new(self.current_slot_params().max_entry_bytes_per_slot());
+        self.apply_cost_tracker_limits_for_active_features();
+        self.apply_partitioned_epoch_rewards_config_for_active_features();
     }
 
     fn apply_simd_0339_invoke_cost_changes(&mut self) {
@@ -4713,11 +4825,10 @@ impl Bank {
             Arc::new(reserved_keys)
         };
 
-        // Cost-Tracker is not serialized in snapshot or any configs.
-        // We must apply previously activated features related to limits here
-        // so that the initial bank state is consistent with the feature set.
-        // Cost-tracker limits are propagated through children banks.
-        self.apply_cost_tracker_limits_for_active_features();
+        // Many fields are not serialized in snapshot or any configs. Rebuild
+        // them from the feature set so the initial bank state is consistent.
+        self.refresh_slot_params();
+        self.apply_slot_time_runtime_changes();
         self.apply_simd_0339_invoke_cost_changes();
 
         let program_runtime_environment =
@@ -5812,12 +5923,14 @@ impl Bank {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
         feature_set.deactivate(id);
         self.feature_set = Arc::new(feature_set);
+        self.refresh_slot_params();
     }
 
     pub fn activate_feature(&mut self, id: &Pubkey) {
         let mut feature_set = Arc::make_mut(&mut self.feature_set).clone();
         feature_set.activate(id, 0);
         self.feature_set = Arc::new(feature_set);
+        self.refresh_slot_params();
     }
 
     pub fn fill_bank_with_ticks_for_tests(&self) {
@@ -5893,6 +6006,7 @@ impl Bank {
         self.feature_set = Arc::new(feature_set);
 
         self.apply_activated_features();
+        self.assert_bank_matches_slot_params();
     }
 
     /// This is called from each epoch boundary
@@ -5901,6 +6015,7 @@ impl Bank {
         let (feature_set, new_feature_activations) =
             self.compute_active_feature_set(include_pending);
         self.feature_set = Arc::new(feature_set);
+        self.refresh_slot_params();
 
         // Update activation slot of features in `new_feature_activations`
         for feature_id in new_feature_activations.iter() {
@@ -5983,10 +6098,11 @@ impl Bank {
             self.fee_rate_governor.burn_percent = solana_fee_calculator::DEFAULT_BURN_PERCENT;
         }
 
+        // Apply unconditionally: this is relatively cheap and idempotent.
+        self.apply_slot_time_persistent_changes();
+        self.apply_slot_time_runtime_changes();
+
         self.apply_new_builtin_program_feature_transitions(&new_feature_activations);
-        if new_feature_activations.contains(&feature_set::raise_block_limits_to_100m::id()) {
-            self.apply_cost_tracker_limits_for_active_features();
-        }
 
         if new_feature_activations.contains(&feature_set::replace_spl_token_with_p_token::id()) {
             if let Err(e) = self.upgrade_loader_v2_program_with_loader_v3_program(
@@ -6940,6 +7056,11 @@ impl Bank {
             .for_each(|(pubkey, _)| {
                 minimized_account_set.insert(*pubkey);
             });
+    }
+
+    /// Returns true when this bank is using slot params beyond its genesis baseline.
+    pub fn slot_time_reduction_active(&self) -> bool {
+        self.ns_per_slot != self.slot_params.baseline_params().ns_per_slot()
     }
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -417,6 +417,7 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config_with_vote_accounts,
+                deactivate_features,
             },
             runtime_config::RuntimeConfig,
             stake_utils,
@@ -574,6 +575,9 @@ mod tests {
         stake_account_stores_per_block: u64,
         advance_num_slots: u64,
     ) -> (RewardBank, Arc<RwLock<BankForks>>) {
+        // Disable slot time reduction features as they will override the custom
+        // stores per block provided in this test helper.
+        let features_to_deactivate = crate::slot_params::slot_time_feature_ids().to_vec();
         let validator_keypairs = (0..stakes.len())
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -582,6 +586,7 @@ mod tests {
             mut genesis_config, ..
         } = create_genesis_config_with_vote_accounts(1_000_000_000, &validator_keypairs, stakes);
         genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        deactivate_features(&mut genesis_config, &features_to_deactivate);
 
         let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING;
         accounts_db_config.partitioned_epoch_rewards_config =

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -19,7 +19,11 @@ use {
         },
         runtime_config::RuntimeConfig,
         serde_snapshot::fields_from_stream,
-        slot_params::{DEFAULT_MAX_ENTRY_BYTES_PER_SLOT, LEGACY_SLOT_PARAMS},
+        slot_params::{
+            DEFAULT_MAX_ENTRY_BYTES_PER_SLOT, LEGACY_HASHES_PER_TICK, LEGACY_SLOT_PARAMS,
+            SLOT_PARAMS_200MS, SLOT_PARAMS_250MS, SLOT_PARAMS_300MS, SLOT_PARAMS_350MS, SlotParams,
+            slot_time_feature_gates, slot_time_feature_ids,
+        },
         stake_history::StakeHistory,
         stake_utils,
         stakes::{DeserializableStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat, Stakes},
@@ -178,6 +182,12 @@ fn create_genesis_config_no_tx_fee(lamports: u64) -> (GenesisConfig, Keypair) {
 
 pub(in crate::bank) fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
     solana_genesis_config::create_genesis_config(lamports)
+}
+
+fn create_genesis_config_with_legacy_hashes(lamports: u64) -> (GenesisConfig, Keypair) {
+    let (mut genesis_config, mint_keypair) = create_genesis_config(lamports);
+    genesis_config.poh_config.hashes_per_tick = Some(LEGACY_HASHES_PER_TICK);
+    (genesis_config, mint_keypair)
 }
 
 pub(in crate::bank) fn new_sanitized_message(message: Message) -> SanitizedMessage {
@@ -5257,9 +5267,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "F4ns41hFn3ignVHqaVehaTZ8LMUxPaELAgvN8iTcowDD"
+                    "9ycftRwjpQ17PrhnwhGPbVzDKd3Q9BybmLYU8UD1Pg1T"
                 } else {
-                    "FyxeAqHjieaKMA6mLK3yfSD46Xcw2U6hzKfyeu1qVuCD"
+                    "4XzjZMjhP9s8iBeFQsnHFwaQ991dpiBGHEkzj1ifAcpS"
                 },
             );
         }
@@ -5268,9 +5278,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "sF1tuUv3r5JCr9smYyhm9Qv27f5jcoJ75LnoLGV5Scd"
+                    "7sbqfkN4W3PkBREyduDc3R2eiKu68JKYRXZt6gCWNt4N"
                 } else {
-                    "DrpEs59czmKpLQvR9kBjSmWJUYMNKDdQ4Zsyu4WjfoPb"
+                    "ArB3XNVLJsyV7AtrG3C3Bj4akb8s7AzpS5rHJnqGW5sw"
                 },
             );
             break;
@@ -6293,6 +6303,271 @@ fn test_block_limits() {
         bank.read_cost_tracker().unwrap().get_account_limit(),
         MAX_WRITABLE_ACCOUNT_UNITS_SIMD_0306_ENABLED,
         "bank created from genesis config should have new limit"
+    );
+}
+
+fn assert_slot_time_bank_state(bank: &Bank, params: SlotParams) {
+    assert_eq!(bank.ns_per_slot, params.ns_per_slot());
+    assert_eq!(bank.hashes_per_tick(), params.hashes_per_tick());
+    assert_eq!(
+        bank.slots_per_year.to_bits(),
+        params.slots_per_year().to_bits()
+    );
+    assert_eq!(
+        bank.rent_collector.slots_per_year.to_bits(),
+        bank.slots_per_year.to_bits()
+    );
+    assert_eq!(
+        bank.partitioned_rewards_stake_account_stores_per_block,
+        params.partitioned_epoch_rewards_stake_account_stores_per_block()
+    );
+    assert_eq!(
+        bank.entry_bytes_budget().slot_limit(),
+        params.max_entry_bytes_per_slot()
+    );
+    let cost_tracker = bank.read_cost_tracker().unwrap();
+    let (account_limit, block_limit, data_size_limit) = params.cost_limits(
+        bank.feature_set
+            .is_active(&feature_set::raise_block_limits_to_100m::id()),
+    );
+    assert_eq!(cost_tracker.get_account_limit(), account_limit);
+    assert_eq!(cost_tracker.get_block_limit(), block_limit);
+    assert_eq!(
+        cost_tracker.get_allocated_data_size_limit(),
+        data_size_limit
+    );
+}
+
+#[test]
+fn test_reduce_slot_time_features() {
+    let (genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
+    let feature_account_balance = genesis_config.rent.minimum_balance(Feature::size_of());
+
+    let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    assert!(!bank.slot_time_reduction_active());
+    assert_eq!(bank.hashes_per_tick(), Some(LEGACY_HASHES_PER_TICK));
+
+    for (feature_id, params) in slot_time_feature_gates() {
+        let previous_params = bank.current_slot_params();
+        bank.store_account(
+            &feature_id,
+            &feature::create_account(&Feature::default(), feature_account_balance),
+        );
+
+        let activation_slot = bank
+            .epoch_schedule()
+            .get_first_slot_in_epoch(bank.epoch().saturating_add(1));
+        let activation_bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            bank,
+            SlotLeader::default(),
+            activation_slot,
+        );
+
+        assert!(activation_bank.feature_set.is_active(&feature_id));
+        assert_eq!(activation_bank.current_slot_params(), previous_params);
+        assert_slot_time_bank_state(&activation_bank, previous_params);
+
+        let effective_slot = activation_bank
+            .epoch_schedule()
+            .get_first_slot_in_epoch(activation_bank.epoch().saturating_add(1));
+        bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            activation_bank,
+            SlotLeader::default(),
+            effective_slot,
+        );
+        assert!(bank.slot_time_reduction_active());
+        assert_slot_time_bank_state(&bank, params);
+    }
+}
+
+#[test]
+fn test_reduce_slot_time_features_active_at_genesis() {
+    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
+    for feature_id in slot_time_feature_ids() {
+        activate_feature(&mut genesis_config, feature_id);
+    }
+    activate_feature(
+        &mut genesis_config,
+        feature_set::raise_block_limits_to_100m::id(),
+    );
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    assert!(!bank.slot_time_reduction_active());
+    assert_slot_time_bank_state(&bank, LEGACY_SLOT_PARAMS);
+
+    let effective_slot = bank.epoch_schedule().get_first_slot_in_epoch(1);
+    let bank = Bank::new_from_parent_with_bank_forks(
+        &bank_forks,
+        bank,
+        SlotLeader::default(),
+        effective_slot,
+    );
+    assert_slot_time_bank_state(&bank, SLOT_PARAMS_200MS);
+}
+
+#[test]
+fn test_reduce_slot_time_hashes_per_tick() {
+    let assert_reduced_slot_time_hashes_per_tick =
+        |genesis_config, expected_initial_hashes_per_tick, expected_effective_hashes_per_tick| {
+            let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+            assert_eq!(bank.ns_per_slot, LEGACY_SLOT_PARAMS.ns_per_slot());
+            assert_eq!(bank.hashes_per_tick(), expected_initial_hashes_per_tick);
+
+            let effective_slot = bank.epoch_schedule().get_first_slot_in_epoch(1);
+            let bank = Bank::new_from_parent_with_bank_forks(
+                &bank_forks,
+                bank,
+                SlotLeader::default(),
+                effective_slot,
+            );
+            assert_eq!(bank.ns_per_slot, SLOT_PARAMS_200MS.ns_per_slot());
+            assert_eq!(bank.hashes_per_tick(), expected_effective_hashes_per_tick);
+        };
+
+    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
+    activate_feature(
+        &mut genesis_config,
+        feature_set::reduce_slot_time_to_200ms::id(),
+    );
+    assert_reduced_slot_time_hashes_per_tick(
+        genesis_config,
+        Some(LEGACY_HASHES_PER_TICK),
+        SLOT_PARAMS_200MS.hashes_per_tick(),
+    );
+
+    let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
+    genesis_utils::activate_all_features_alpenglow(&mut genesis_config);
+    assert_eq!(genesis_config.poh_config.hashes_per_tick, None);
+    assert_reduced_slot_time_hashes_per_tick(genesis_config, None, None);
+}
+
+#[test]
+fn test_reduce_slot_time_range_duration() {
+    const SLOTS_PER_EPOCH: Slot = 32;
+    let bank_for_activations = |activations: &[(Pubkey, Slot)]| {
+        let (mut genesis_config, _) = create_genesis_config_with_legacy_hashes(1_000_000);
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let mut feature_set = FeatureSet::default();
+        for (feature_id, activation_slot) in activations {
+            feature_set.activate(feature_id, *activation_slot);
+        }
+        bank.feature_set = Arc::new(feature_set);
+        bank.refresh_slot_params();
+        bank
+    };
+
+    let ordered_activations = slot_time_feature_gates()
+        .into_iter()
+        .zip([1, 33, 65, 97])
+        .map(|((feature_id, _), activation_slot)| (feature_id, activation_slot))
+        .collect::<Vec<_>>();
+    let bank = bank_for_activations(&ordered_activations);
+
+    let expected_duration = [
+        (SLOTS_PER_EPOCH, LEGACY_SLOT_PARAMS),
+        (SLOTS_PER_EPOCH, SLOT_PARAMS_350MS),
+        (SLOTS_PER_EPOCH, SLOT_PARAMS_300MS),
+        (SLOTS_PER_EPOCH, SLOT_PARAMS_250MS),
+        (SLOTS_PER_EPOCH, SLOT_PARAMS_200MS),
+    ]
+    .into_iter()
+    .map(|(slots, params)| slots as f64 / params.slots_per_year())
+    .sum::<f64>();
+
+    assert_eq!(
+        bank.slot_range_duration_in_years(0, SLOTS_PER_EPOCH * 5)
+            .to_bits(),
+        expected_duration.to_bits()
+    );
+    assert_eq!(
+        bank.slot_range_duration_nanos(0, SLOTS_PER_EPOCH * 5 - 1),
+        [
+            (SLOTS_PER_EPOCH, LEGACY_SLOT_PARAMS),
+            (SLOTS_PER_EPOCH, SLOT_PARAMS_350MS),
+            (SLOTS_PER_EPOCH, SLOT_PARAMS_300MS),
+            (SLOTS_PER_EPOCH, SLOT_PARAMS_250MS),
+            (SLOTS_PER_EPOCH, SLOT_PARAMS_200MS),
+        ]
+        .into_iter()
+        .map(|(slots, params)| u128::from(slots) * params.ns_per_slot())
+        .sum::<u128>()
+    );
+
+    let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
+    let bank =
+        bank_for_activations(&[(reduce_to_200ms, 1), (reduce_to_350ms, SLOTS_PER_EPOCH + 1)]);
+    assert_eq!(
+        bank.slot_params_at_slot(SLOTS_PER_EPOCH - 1),
+        LEGACY_SLOT_PARAMS
+    );
+    assert_eq!(bank.slot_params_at_slot(SLOTS_PER_EPOCH), SLOT_PARAMS_200MS);
+    assert_eq!(
+        bank.slot_params_at_slot(SLOTS_PER_EPOCH * 2),
+        SLOT_PARAMS_200MS
+    );
+    assert_eq!(
+        bank.slot_range_duration_in_years(0, SLOTS_PER_EPOCH * 3)
+            .to_bits(),
+        (SLOTS_PER_EPOCH as f64 / LEGACY_SLOT_PARAMS.slots_per_year()
+            + (SLOTS_PER_EPOCH * 2) as f64 / SLOT_PARAMS_200MS.slots_per_year())
+        .to_bits()
+    );
+    assert_eq!(
+        bank.slot_range_duration_nanos(0, SLOTS_PER_EPOCH * 3 - 1),
+        u128::from(SLOTS_PER_EPOCH) * LEGACY_SLOT_PARAMS.ns_per_slot()
+            + u128::from(SLOTS_PER_EPOCH * 2) * SLOT_PARAMS_200MS.ns_per_slot()
+    );
+}
+
+#[test]
+fn test_update_clock_slot_range_duration() {
+    const SLOTS_PER_EPOCH: Slot = 32;
+
+    let leader_pubkey = solana_pubkey::new_rand();
+    let GenesisConfigInfo {
+        mut genesis_config,
+        voting_keypair,
+        ..
+    } = create_genesis_config_with_leader(5, &leader_pubkey, 3);
+    genesis_config.epoch_schedule = EpochSchedule::custom(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH, false);
+    activate_feature(
+        &mut genesis_config,
+        feature_set::reduce_slot_time_to_200ms::id(),
+    );
+
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let vote_timestamp_slot = 4;
+    let vote_timestamp = bank.unix_timestamp_from_genesis();
+    update_vote_account_timestamp(
+        BlockTimestamp {
+            slot: vote_timestamp_slot,
+            timestamp: vote_timestamp,
+        },
+        &bank,
+        &voting_keypair.pubkey(),
+    );
+
+    let current_slot = SLOTS_PER_EPOCH + 3;
+    let bank = Bank::new_from_parent_with_bank_forks(
+        &bank_forks,
+        bank,
+        SlotLeader::default(),
+        current_slot,
+    );
+    let expected_elapsed = Duration::from_nanos_u128(
+        bank.slot_range_duration_nanos(vote_timestamp_slot + 1, current_slot),
+    );
+    let scalar_elapsed =
+        Duration::from_nanos(bank.ns_per_slot as u64) * (current_slot - vote_timestamp_slot) as u32;
+
+    assert_ne!(expected_elapsed.as_secs(), scalar_elapsed.as_secs());
+    assert_eq!(
+        bank.clock().unix_timestamp,
+        vote_timestamp + expected_elapsed.as_secs() as i64
     );
 }
 
@@ -11913,6 +12188,57 @@ fn test_new_from_snapshot_uses_rent_from_sysvar() {
     // Verify the bank's rent matches the sysvar, NOT the corrupted fields
     assert_eq!(new_bank.rent_collector.rent, expected_rent);
     assert_ne!(new_bank.rent_collector.rent, wrong_rent);
+}
+
+#[test]
+fn test_new_from_snapshot_hashes_per_tick_changed() {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = create_genesis_config_with_leader(100_000, &Pubkey::new_unique(), 3);
+    genesis_config.poh_config.hashes_per_tick = Some(12_500);
+
+    let bank = Bank::new_for_tests(&genesis_config);
+    bank.set_hashes_per_tick(Some(LEGACY_HASHES_PER_TICK));
+    bank.set_block_id(Some(Hash::default()));
+
+    let snapshot_storages = bank.get_snapshot_storages(None);
+    let mut buf = vec![];
+    crate::serde_snapshot::bank_to_stream(
+        &mut std::io::BufWriter::new(Cursor::new(&mut buf)),
+        &bank,
+        &snapshot_storages,
+    )
+    .unwrap();
+
+    let mut reader = std::io::BufReader::new(Cursor::new(&buf));
+    let (mut fields, _accounts_db_fields) = fields_from_stream(&mut reader).unwrap();
+    let epoch_stakes = std::mem::take(&mut fields.versioned_epoch_stakes)
+        .into_iter()
+        .map(|(epoch, stakes)| (epoch, stakes.into()))
+        .collect();
+
+    let new_bank = Bank::new_from_snapshot(
+        BankRc {
+            accounts: Arc::clone(&bank.rc.accounts),
+            parent: RwLock::new(None),
+            bank_id_generator: Arc::clone(&bank.rc.bank_id_generator),
+        },
+        &genesis_config,
+        Arc::new(RuntimeConfig::default()),
+        fields,
+        None,
+        None,
+        bank.load_accounts_data_size(),
+        epoch_stakes,
+    );
+
+    assert_eq!(genesis_config.hashes_per_tick(), Some(12_500));
+    assert_eq!(new_bank.hashes_per_tick(), Some(LEGACY_HASHES_PER_TICK));
+    assert_eq!(
+        new_bank.slot_params.baseline_params().hashes_per_tick(),
+        Some(LEGACY_HASHES_PER_TICK)
+    );
+    new_bank.assert_bank_matches_slot_params();
 }
 
 #[test]

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -155,9 +155,11 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{
                 GenesisConfigInfo, ValidatorVoteKeypairs, create_genesis_config,
-                create_genesis_config_with_alpenglow_vote_accounts,
+                create_genesis_config_with_alpenglow_vote_accounts, deactivate_features,
             },
+            slot_params::slot_time_feature_ids,
         },
+        agave_feature_set as feature_set,
         rand::Rng,
         solana_epoch_schedule::EpochSchedule,
         solana_genesis_config::GenesisConfig,
@@ -231,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn new_epoch_update_account_use_current_reward_budget() {
+    fn new_epoch_update_account_uses_current_epoch_rewards() {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(1_000_000_000);
@@ -239,46 +241,71 @@ mod tests {
         // Warmup is necessary here to give epoch 0 and epoch 1 different reward
         // budgets.
         genesis_config.epoch_schedule = EpochSchedule::custom(64, 64, true);
+        deactivate_features(&mut genesis_config, &slot_time_feature_ids().to_vec());
 
-        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
-        let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
-        let epoch_1_first_slot = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
-        let bank_epoch_1 = Bank::new_from_parent_with_bank_forks(
-            bank_forks.as_ref(),
-            bank_epoch_0.clone(),
-            SlotLeader::new_unique(),
-            epoch_1_first_slot,
-        );
+        for (case, genesis_config, activate_slot_time_feature) in [
+            ("current reward budget", genesis_config, false),
+            (
+                "current epoch slot params",
+                GenesisConfig {
+                    inflation: Inflation::full(),
+                    ..GenesisConfig::default()
+                },
+                true,
+            ),
+        ] {
+            let mut bank_epoch_0 = Bank::new_for_tests(&genesis_config);
+            if activate_slot_time_feature {
+                bank_epoch_0.activate_feature(&feature_set::reduce_slot_time_to_350ms::id());
+            }
+            let bank_forks = BankForks::new_rw_arc(bank_epoch_0);
+            let bank_epoch_0 = bank_forks.read().unwrap().root_bank();
+            let epoch_1_first_slot = bank_epoch_0.epoch_schedule().get_first_slot_in_epoch(1);
+            let bank_epoch_1 = Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank_epoch_0.clone(),
+                SlotLeader::new_unique(),
+                epoch_1_first_slot,
+            );
 
-        assert_eq!(bank_epoch_0.epoch(), 0);
-        assert_eq!(bank_epoch_1.epoch(), 1);
-        assert_ne!(
-            bank_epoch_1.epoch_schedule().get_slots_in_epoch(0),
-            bank_epoch_1.epoch_schedule().get_slots_in_epoch(1)
-        );
+            assert_eq!(bank_epoch_0.epoch(), 0, "{case}");
+            assert_eq!(bank_epoch_1.epoch(), 1, "{case}");
+            if activate_slot_time_feature {
+                assert_ne!(bank_epoch_0.ns_per_slot, bank_epoch_1.ns_per_slot, "{case}");
+            } else {
+                assert_ne!(
+                    bank_epoch_1.epoch_schedule().get_slots_in_epoch(0),
+                    bank_epoch_1.epoch_schedule().get_slots_in_epoch(1),
+                    "{case}",
+                );
+            }
 
-        let epoch_start_capitalization = bank_epoch_0.capitalization();
-        let expected_current_epoch_rewards = bank_epoch_1
-            .calculate_epoch_inflation_rewards(epoch_start_capitalization, bank_epoch_1.epoch());
-        assert_ne!(
-            expected_current_epoch_rewards,
-            bank_epoch_1.calculate_epoch_inflation_rewards(
+            let epoch_start_capitalization = bank_epoch_0.capitalization();
+            let expected_current_epoch_rewards = bank_epoch_1.calculate_epoch_inflation_rewards(
                 epoch_start_capitalization,
-                bank_epoch_0.epoch()
-            )
-        );
+                bank_epoch_1.epoch(),
+            );
+            assert_ne!(
+                expected_current_epoch_rewards,
+                bank_epoch_1.calculate_epoch_inflation_rewards(
+                    epoch_start_capitalization,
+                    bank_epoch_0.epoch()
+                ),
+                "{case}",
+            );
 
-        EpochInflationAccountState::new_epoch_update_account(
-            &bank_epoch_1,
-            epoch_start_capitalization,
-            0,
-        );
-        let state = EpochInflationAccountState::new_from_bank(&bank_epoch_1).unwrap();
-        assert_eq!(state.current.epoch, bank_epoch_1.epoch());
-        assert_eq!(
-            state.current.max_possible_validator_reward,
-            expected_current_epoch_rewards
-        );
+            EpochInflationAccountState::new_epoch_update_account(
+                &bank_epoch_1,
+                epoch_start_capitalization,
+                0,
+            );
+            let state = EpochInflationAccountState::new_from_bank(&bank_epoch_1).unwrap();
+            assert_eq!(state.current.epoch, bank_epoch_1.epoch(), "{case}");
+            assert_eq!(
+                state.current.max_possible_validator_reward, expected_current_epoch_rewards,
+                "{case}",
+            );
+        }
     }
 
     #[test]

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -1,6 +1,8 @@
 use {
+    agave_feature_set::{self as feature_set, FeatureSet},
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
+    solana_pubkey::Pubkey,
     std::{
         collections::BTreeMap,
         ops::Bound::{Excluded, Included},
@@ -11,10 +13,8 @@ pub const DEFAULT_MAX_ENTRY_BYTES_PER_SLOT: u64 = 20 * 1024 * 1024; // 20 MiB
 
 /// Runtime parameters tied to a slot-time regime.
 ///
-/// This intentionally groups values that need to move together when slot time
-/// changes. For now, only the legacy baseline exists, so routing through this
-/// type preserves current behavior while giving future feature-gated changes a
-/// single table-shaped home.
+/// Slot-time reduction features select explicit table values instead of
+/// deriving ratios at runtime, which avoids rounding drift in consensus paths.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct SlotParams {
     pub(crate) ns_per_slot: u128,
@@ -22,7 +22,6 @@ pub struct SlotParams {
     pub(crate) hashes_per_tick: Option<u64>,
     pub(crate) max_block_units: u64,
     pub(crate) max_writable_account_units: u64,
-    pub(crate) max_vote_units: u64,
     pub(crate) max_block_accounts_data_size_delta: u64,
     pub(crate) max_data_shreds_per_slot: u32,
     pub(crate) max_code_shreds_per_slot: u32,
@@ -87,29 +86,121 @@ impl SlotParams {
     }
 
     /// Returns the per-bank cost limits for these params.
-    pub const fn cost_limits(self) -> (u64, u64, u64, u64) {
+    pub(crate) const fn cost_limits(self, raise_block_limits_to_100m: bool) -> (u64, u64, u64) {
+        let (max_writable_account_units, max_block_units) = if raise_block_limits_to_100m {
+            (
+                self.max_writable_account_units
+                    .saturating_mul(100)
+                    .saturating_div(60),
+                self.max_block_units.saturating_mul(100).saturating_div(60),
+            )
+        } else {
+            (self.max_writable_account_units, self.max_block_units)
+        };
+
         (
-            self.max_writable_account_units,
-            self.max_block_units,
-            self.max_vote_units,
+            max_writable_account_units,
+            max_block_units,
             self.max_block_accounts_data_size_delta,
         )
     }
 }
 
+pub const LEGACY_HASHES_PER_TICK: u64 = 62_500;
 pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
     ns_per_slot: 400_000_000,
     slots_per_year: 78_892_314.984,
-    hashes_per_tick: Some(62_500),
+    hashes_per_tick: Some(LEGACY_HASHES_PER_TICK),
     max_block_units: 60_000_000,
     max_writable_account_units: 24_000_000,
-    max_vote_units: 36_000_000,
     max_block_accounts_data_size_delta: 100_000_000,
     max_data_shreds_per_slot: 32_768,
     max_code_shreds_per_slot: 32_768,
     max_entry_bytes_per_slot: 20 * 1024 * 1024,
     partitioned_epoch_rewards_stake_account_stores_per_block: 4096,
 };
+
+pub(crate) const SLOT_PARAMS_350MS: SlotParams = SlotParams {
+    ns_per_slot: 350_000_000,
+    slots_per_year: 90_162_645.696,
+    hashes_per_tick: Some(54_687),
+    max_block_units: 52_500_000,
+    max_writable_account_units: 21_000_000,
+    max_block_accounts_data_size_delta: 87_500_000,
+    max_data_shreds_per_slot: 28_672,
+    max_code_shreds_per_slot: 28_672,
+    max_entry_bytes_per_slot: 18_350_080,
+    partitioned_epoch_rewards_stake_account_stores_per_block: 3_584,
+};
+
+pub(crate) const SLOT_PARAMS_300MS: SlotParams = SlotParams {
+    ns_per_slot: 300_000_000,
+    slots_per_year: 105_189_753.312,
+    hashes_per_tick: Some(46_875),
+    max_block_units: 45_000_000,
+    max_writable_account_units: 18_000_000,
+    max_block_accounts_data_size_delta: 75_000_000,
+    max_data_shreds_per_slot: 24_576,
+    max_code_shreds_per_slot: 24_576,
+    max_entry_bytes_per_slot: 15_728_640,
+    partitioned_epoch_rewards_stake_account_stores_per_block: 3_072,
+};
+
+pub(crate) const SLOT_PARAMS_250MS: SlotParams = SlotParams {
+    ns_per_slot: 250_000_000,
+    slots_per_year: 126_227_703.974,
+    hashes_per_tick: Some(39_062),
+    max_block_units: 37_500_000,
+    max_writable_account_units: 15_000_000,
+    max_block_accounts_data_size_delta: 62_500_000,
+    max_data_shreds_per_slot: 20_480,
+    max_code_shreds_per_slot: 20_480,
+    max_entry_bytes_per_slot: 13_107_200,
+    partitioned_epoch_rewards_stake_account_stores_per_block: 2_560,
+};
+
+pub(crate) const SLOT_PARAMS_200MS: SlotParams = SlotParams {
+    ns_per_slot: 200_000_000,
+    slots_per_year: 157_784_629.968,
+    hashes_per_tick: Some(31_250),
+    max_block_units: 30_000_000,
+    max_writable_account_units: 12_000_000,
+    max_block_accounts_data_size_delta: 50_000_000,
+    max_data_shreds_per_slot: 16_384,
+    max_code_shreds_per_slot: 16_384,
+    max_entry_bytes_per_slot: 10_485_760,
+    partitioned_epoch_rewards_stake_account_stores_per_block: 2_048,
+};
+
+/// Slot-time reduction gates in the intended activation order.
+const SLOT_TIME_REDUCTION_PARAMS: [(Pubkey, SlotParams); 4] = [
+    (
+        feature_set::reduce_slot_time_to_350ms::ID,
+        SLOT_PARAMS_350MS,
+    ),
+    (
+        feature_set::reduce_slot_time_to_300ms::ID,
+        SLOT_PARAMS_300MS,
+    ),
+    (
+        feature_set::reduce_slot_time_to_250ms::ID,
+        SLOT_PARAMS_250MS,
+    ),
+    (
+        feature_set::reduce_slot_time_to_200ms::ID,
+        SLOT_PARAMS_200MS,
+    ),
+];
+
+/// Returns slot-time feature gates mapped to runtime slot parameters.
+pub fn slot_time_feature_gates() -> [(Pubkey, SlotParams); 4] {
+    SLOT_TIME_REDUCTION_PARAMS
+}
+
+/// Returns all slot-time reduction feature IDs in activation order.
+pub fn slot_time_feature_ids() -> [Pubkey; 4] {
+    SLOT_TIME_REDUCTION_PARAMS.map(|(feature_id, _)| feature_id)
+}
 
 /// Bank-local archive of slot-parameter transitions.
 ///
@@ -124,25 +215,49 @@ pub(crate) struct SlotParamsArchive {
     /// This is used when a bank, usually the root bank, must answer "which
     /// parameters apply to some other slot?" Examples include shred filtering
     /// for incoming shreds and inflation calculations that span historical slot
-    /// ranges.
+    /// ranges. The transitions are normalized so slot duration never increases
+    /// as slots advance, even if slot-time features activate out of order.
     param_transitions: BTreeMap<Slot, SlotParams>,
 }
 
 impl Default for SlotParamsArchive {
     fn default() -> Self {
-        Self::new(&EpochSchedule::default(), LEGACY_SLOT_PARAMS)
+        Self::new(
+            &FeatureSet::default(),
+            &EpochSchedule::default(),
+            LEGACY_SLOT_PARAMS,
+        )
     }
 }
 
 impl SlotParamsArchive {
-    /// Rebuilds slot-parameter transitions from the supplied baseline.
-    ///
-    /// `_epoch_schedule` is accepted now so the call sites already have the
-    /// right shape for delayed, epoch-boundary-effective feature transitions.
-    pub(crate) fn new(_epoch_schedule: &EpochSchedule, baseline_params: SlotParams) -> Self {
-        Self {
-            param_transitions: BTreeMap::from([(0, baseline_params)]),
+    /// Rebuilds slot-parameter transitions from the active feature set.
+    pub(crate) fn new(
+        feature_set: &FeatureSet,
+        epoch_schedule: &EpochSchedule,
+        baseline_params: SlotParams,
+    ) -> Self {
+        let mut param_transitions = BTreeMap::from([(0, baseline_params)]);
+        let mut earliest_same_or_shorter_slot = Slot::MAX;
+
+        // The feature table is ordered longest-to-shortest. Walk it in reverse
+        // so once a same-or-shorter target is effective at slot S, any longer
+        // target effective at S or later is known to be redundant.
+        for (feature_id, params) in slot_time_feature_gates().into_iter().rev() {
+            if params.ns_per_slot > baseline_params.ns_per_slot {
+                continue;
+            }
+            let Some(activation_slot) = feature_set.activated_slot(&feature_id) else {
+                continue;
+            };
+            let effective_slot = Self::feature_effective_slot(epoch_schedule, activation_slot);
+            if effective_slot < earliest_same_or_shorter_slot {
+                param_transitions.insert(effective_slot, params);
+                earliest_same_or_shorter_slot = effective_slot;
+            }
         }
+
+        Self { param_transitions }
     }
 
     /// Returns the baseline params supplied at genesis or snapshot restore.
@@ -194,5 +309,60 @@ impl SlotParamsArchive {
 
         let remaining_slots = u128::from(end_slot.saturating_sub(cursor)) + 1;
         duration.saturating_add(remaining_slots.saturating_mul(params.ns_per_slot()))
+    }
+
+    /// Returns the first slot where a slot-time feature may affect bank state.
+    ///
+    /// A gate that activates in epoch E is effective starting at the first slot
+    /// of epoch E + 1, giving shred filters a full epoch of advance notice
+    /// before enforcing lower shred limits.
+    fn feature_effective_slot(epoch_schedule: &EpochSchedule, activation_slot: Slot) -> Slot {
+        let activation_epoch = epoch_schedule.get_epoch(activation_slot);
+        epoch_schedule.get_first_slot_in_epoch(activation_epoch.saturating_add(1))
+    }
+
+    /// Returns true if any slot-time reduction has taken effect by this bank.
+    ///
+    /// Feature activation happens in one epoch, but slot params become effective
+    /// at the start of the following epoch.
+    pub(crate) fn any_slot_time_reduction_effective(
+        epoch_schedule: &EpochSchedule,
+        slot: Slot,
+        feature_set: &FeatureSet,
+        ns_per_slot: u128,
+    ) -> bool {
+        slot_time_feature_gates()
+            .into_iter()
+            .filter(|(_, params)| params.ns_per_slot() <= ns_per_slot)
+            .filter_map(|(feature_id, _)| feature_set.activated_slot(&feature_id))
+            .any(|activation_slot| {
+                Self::feature_effective_slot(epoch_schedule, activation_slot) <= slot
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cost_limits_scaling_matches_simd_0525() {
+        for (params, expected_account_limit, expected_block_limit) in [
+            (LEGACY_SLOT_PARAMS, 40_000_000, 100_000_000),
+            (SLOT_PARAMS_350MS, 35_000_000, 87_500_000),
+            (SLOT_PARAMS_300MS, 30_000_000, 75_000_000),
+            (SLOT_PARAMS_250MS, 25_000_000, 62_500_000),
+            (SLOT_PARAMS_200MS, 20_000_000, 50_000_000),
+        ] {
+            let (_, _, data_size_limit) = params.cost_limits(false);
+            assert_eq!(
+                params.cost_limits(true),
+                (
+                    expected_account_limit,
+                    expected_block_limit,
+                    data_size_limit
+                )
+            );
+        }
     }
 }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -682,7 +682,12 @@ mod test {
             shred::{DATA_SHREDS_PER_FEC_BLOCK, max_ticks_per_n_shreds},
         },
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
-        solana_runtime::bank::Bank,
+        solana_pubkey::Pubkey,
+        solana_runtime::{
+            bank::{Bank, SlotLeader},
+            genesis_utils::{activate_feature, deactivate_features},
+            slot_params::{slot_time_feature_gates, slot_time_feature_ids},
+        },
         solana_signer::Signer,
         std::{ops::Deref, sync::Arc, time::Duration},
         test_case::test_case,
@@ -744,6 +749,65 @@ mod test {
 
     fn test_leader_schedule_cache(bank: &Bank) -> Arc<LeaderScheduleCache> {
         Arc::new(LeaderScheduleCache::new_from_bank(bank))
+    }
+
+    fn broadcast_shred_limits_for_slot_time_features(
+        feature_ids: impl IntoIterator<Item = Pubkey>,
+    ) -> (u32, u32) {
+        let ledger_path = get_tmp_ledger_path!();
+        let blockstore = Arc::new(
+            Blockstore::open(&ledger_path).expect("Expected to be able to open database ledger"),
+        );
+        let mut genesis_config = create_genesis_config(10_000).genesis_config;
+        let slot_time_features = slot_time_feature_ids().to_vec();
+        deactivate_features(&mut genesis_config, &slot_time_features);
+        for feature_id in feature_ids {
+            activate_feature(&mut genesis_config, feature_id);
+        }
+
+        let (parent_bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        parent_bank.set_tick_height(parent_bank.max_tick_height());
+        Bank::calculate_and_set_block_id_for_dcou(&parent_bank);
+
+        let effective_slot = parent_bank.epoch_schedule().get_first_slot_in_epoch(1);
+        let bank = Bank::new_from_parent_with_bank_forks(
+            &bank_forks,
+            parent_bank,
+            SlotLeader::default(),
+            effective_slot,
+        );
+        let ticks = create_ticks(1, 0, genesis_config.hash());
+        let receive_results = ReceiveResults {
+            component: BlockComponent::EntryBatch(ticks.clone()),
+            bank: bank.clone(),
+            last_tick_height: bank.tick_height() + ticks.len() as u64,
+        };
+        let (socket_sender, _socket_receiver) = unbounded();
+        let (blockstore_sender, _blockstore_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let mut standard_broadcast_run = StandardBroadcastRun::new(
+            0,
+            Arc::new(MigrationStatus::default()),
+            votor_event_sender,
+            test_leader_schedule_cache(&bank),
+        );
+
+        standard_broadcast_run
+            .process_receive_results(
+                &Keypair::new(),
+                &blockstore,
+                &socket_sender,
+                &blockstore_sender,
+                receive_results,
+                &mut ProcessShredsStats::default(),
+            )
+            .unwrap();
+
+        (
+            standard_broadcast_run.max_data_shreds_per_slot,
+            standard_broadcast_run.max_code_shreds_per_slot,
+        )
     }
 
     #[test]
@@ -1164,52 +1228,28 @@ mod test {
 
     #[test]
     fn test_update_shred_limits_from_bank() {
-        agave_logger::setup();
-        let num_shreds_per_slot = 2;
-        let (
-            blockstore,
-            genesis_config,
-            cluster_info,
-            parent_bank,
-            leader_keypair,
-            socket,
-            bank_forks,
-        ) = setup(num_shreds_per_slot);
-        let bank = new_child_bank(&parent_bank, 1);
-        let ticks = create_ticks(1, 0, genesis_config.hash());
-        let receive_results = ReceiveResults {
-            component: BlockComponent::EntryBatch(ticks),
-            bank: bank.clone(),
-            last_tick_height: bank.tick_height() + 1,
-        };
-
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
-        let mut standard_broadcast_run = StandardBroadcastRun::new(
-            0,
-            Arc::new(MigrationStatus::default()),
-            votor_event_sender,
-            test_leader_schedule_cache(&bank),
-        );
-        standard_broadcast_run.max_data_shreds_per_slot = 1;
-        standard_broadcast_run.max_code_shreds_per_slot = 1;
-        standard_broadcast_run
-            .test_process_receive_results(
-                &leader_keypair,
-                &cluster_info,
-                &socket,
-                &blockstore,
-                receive_results,
-                &bank_forks,
+        assert_eq!(
+            broadcast_shred_limits_for_slot_time_features(std::iter::empty()),
+            (
+                DEFAULT_MAX_DATA_SHREDS_PER_SLOT,
+                DEFAULT_MAX_CODE_SHREDS_PER_SLOT
             )
-            .unwrap();
-
-        assert_eq!(
-            standard_broadcast_run.max_data_shreds_per_slot,
-            bank.max_data_shreds_per_slot()
         );
+
+        for ((feature_id, _), expected_shreds_per_slot) in slot_time_feature_gates()
+            .into_iter()
+            .zip([28_672, 24_576, 20_480, 16_384])
+        {
+            assert_eq!(
+                broadcast_shred_limits_for_slot_time_features([feature_id]),
+                (expected_shreds_per_slot, expected_shreds_per_slot)
+            );
+        }
+
+        let [reduce_to_350ms, _, _, reduce_to_200ms] = slot_time_feature_ids();
         assert_eq!(
-            standard_broadcast_run.max_code_shreds_per_slot,
-            bank.max_code_shreds_per_slot()
+            broadcast_shred_limits_for_slot_time_features([reduce_to_350ms, reduce_to_200ms]),
+            (16_384, 16_384)
         );
     }
 


### PR DESCRIPTION
#### Problem
#12264 was backed out due to a panic during restart from snapshot. See #12940 for details.

#### Summary of Changes

- Reintroduce SIMD-0525 changes
- w/ a fix for the issue uncovered (see 9f2da7b060274bfecb41ea5852c154314a5468ea)
- and a unit test to confirm this works (`fn test_new_from_snapshot_hashes_per_tick_changed`)

We default to using the current bank params as the initial entry in the slot params archive if we haven't activated any slot time reduction features yet

Confirmed I am able to successfully start from snapshot on mainnet:
```bash
⠤ Validator startup: LoadingLedger...                                                                                                                       
Genesis Hash: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
⠄ 00:06:14 | Processed Slot: 424163281 | Confirmed Slot: 424163281 | Finalized Slot: 424163249 | Full Snapshot Slot: 424116877 | Incremental Snapshot Slot:
```