### PR TITLE
votor: preserve peer identity in fanout targets

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4,7 +4,9 @@ use {
         SnapshotArchiveKind, SnapshotInterval, paths as snapshot_paths,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
     },
-    agave_votor::voting_service::{AlpenglowPortOverride, VotingServiceOverride},
+    agave_votor::voting_service::{
+        AdditionalListener, AlpenglowPortOverride, VotingServiceOverride,
+    },
     agave_votor_messages::migration::MIGRATION_SLOT_OFFSET,
     assert_matches::assert_matches,
     crossbeam_channel::{Receiver, unbounded},
@@ -5990,7 +5992,10 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.fixed_leader_schedule = Some(leader_schedule);
     validator_config.voting_service_test_override = Some(VotingServiceOverride {
-        additional_listeners: vec![vote_listener_addr.local_addr().unwrap()],
+        additional_listeners: vec![AdditionalListener {
+            pubkey: Pubkey::new_unique(),
+            addr: vote_listener_addr.local_addr().unwrap(),
+        }],
         alpenglow_port_override: AlpenglowPortOverride::default(),
     });
     validator_config.wait_for_supermajority = Some(0);
@@ -6177,7 +6182,10 @@ fn test_alpenglow_migration(
     let vote_listener_addr = vote_listener_socket.try_clone().unwrap();
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.voting_service_test_override = Some(VotingServiceOverride {
-        additional_listeners: vec![vote_listener_addr.local_addr().unwrap()],
+        additional_listeners: vec![AdditionalListener {
+            pubkey: Pubkey::new_unique(),
+            addr: vote_listener_addr.local_addr().unwrap(),
+        }],
         alpenglow_port_override: AlpenglowPortOverride::default(),
     });
     validator_config.wait_for_supermajority = Some(0);

--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -14,15 +14,14 @@ use {
 };
 
 struct StakedValidatorsCacheEntry {
-    /// Alpenglow Sockets associated with the staked validators
-    alpenglow_sockets: Vec<SocketAddr>,
+    /// (Pubkey, Alpenglow socket) pairs for the staked validators.
+    peers: Vec<(Pubkey, SocketAddr)>,
 
     /// The time at which this entry was created
     creation_time: Instant,
 }
 
-/// Maintain `SocketAddr`s associated with all staked validators for a particular protocol (e.g.,
-/// UDP, QUIC) over number of epochs.
+/// Maintain `SocketAddr`s associated with all staked validators over a number of epochs.
 ///
 /// We employ an LRU cache with a target size, mapping Epoch to cache entries that store the socket
 /// information. We also track cache entry times, forcing recalculations of cache entries that are
@@ -123,10 +122,14 @@ impl StakedValidatorsCache {
             })
             .collect();
 
+        // Collapse nodes that advertise the same Alpenglow socket so we never send a duplicate
+        // datagram to one destination. `dedup_by_key` only removes consecutive duplicates, so
+        // sort by socket first, then restore stake ordering.
+        nodes.sort_unstable_by_key(|node| node.alpenglow_socket);
         nodes.dedup_by_key(|node| node.alpenglow_socket);
         nodes.sort_unstable_by_key(|a| a.stake);
 
-        let mut alpenglow_sockets = Vec::with_capacity(nodes.len());
+        let mut peers = Vec::with_capacity(nodes.len());
         let override_map = self
             .alpenglow_port_override
             .as_ref()
@@ -142,12 +145,12 @@ impl StakedValidatorsCache {
             } else {
                 alpenglow_socket
             };
-            alpenglow_sockets.push(socket);
+            peers.push((node.pubkey, socket));
         }
         self.cache.put(
             epoch,
             StakedValidatorsCacheEntry {
-                alpenglow_sockets,
+                peers,
                 creation_time: update_time,
             },
         );
@@ -158,7 +161,7 @@ impl StakedValidatorsCache {
         slot: Slot,
         cluster_info: &ClusterInfo,
         access_time: Instant,
-    ) -> (&[SocketAddr], bool) {
+    ) -> (&[(Pubkey, SocketAddr)], bool) {
         // Check if self.alpenglow_port_override has a different last_modified.
         // Immediately refresh the cache if it does.
         if let Some(alpenglow_port_override) = &self.alpenglow_port_override {
@@ -183,7 +186,7 @@ impl StakedValidatorsCache {
         epoch: Epoch,
         cluster_info: &ClusterInfo,
         access_time: Instant,
-    ) -> (&[SocketAddr], bool) {
+    ) -> (&[(Pubkey, SocketAddr)], bool) {
         // For a given epoch, if we either:
         //
         // (1) have a cache entry that has expired
@@ -203,10 +206,7 @@ impl StakedValidatorsCache {
         (
             // Unwrapping is fine here, since update_cache guarantees that we push a cache entry to
             // self.cache[epoch].
-            self.cache
-                .get(&epoch)
-                .map(|v| &*v.alpenglow_sockets)
-                .unwrap(),
+            self.cache.get(&epoch).map(|v| &*v.peers).unwrap(),
             refresh_cache,
         )
     }
@@ -552,7 +552,7 @@ mod tests {
         let (sockets, _) =
             svc.get_staked_validators_by_slot(slot_num, &cluster_info, Instant::now());
         assert_eq!(sockets.len(), num_nodes);
-        assert!(sockets.contains(&my_socket_addr));
+        assert!(sockets.iter().any(|(_, socket)| socket == &my_socket_addr));
 
         // Create our staked validators cache - set include_self to false
         let mut svc =
@@ -562,7 +562,7 @@ mod tests {
             svc.get_staked_validators_by_slot(slot_num, &cluster_info, Instant::now());
         // We should have num_nodes - 1 sockets, since we exclude our own socket address.
         assert_eq!(sockets.len(), num_nodes.checked_sub(1).unwrap());
-        assert!(!sockets.contains(&my_socket_addr));
+        assert!(!sockets.iter().any(|(_, socket)| socket == &my_socket_addr));
     }
 
     #[test]
@@ -585,14 +585,14 @@ mod tests {
         // Nothing in the override, so we should get the original socket addresses.
         let (sockets, _) = svc.get_staked_validators_by_slot(0, &cluster_info, Instant::now());
         assert_eq!(sockets.len(), 2);
-        assert!(!sockets.contains(&blackhole_addr));
+        assert!(!sockets.iter().any(|(_, socket)| socket == &blackhole_addr));
 
         // Add an override for pubkey_B, and check that we get the overridden socket address.
         alpenglow_port_override.update_override(HashMap::from([(pubkey_b, blackhole_addr)]));
         let (sockets, _) = svc.get_staked_validators_by_slot(0, &cluster_info, Instant::now());
         assert_eq!(sockets.len(), 2);
         // Sort sockets to ensure the blackhole address is at index 0.
-        let mut sockets: Vec<_> = sockets.to_vec();
+        let mut sockets: Vec<_> = sockets.iter().map(|(_, socket)| *socket).collect();
         sockets.sort();
         assert_eq!(sockets[0], blackhole_addr);
         assert_ne!(sockets[1], blackhole_addr);
@@ -601,6 +601,6 @@ mod tests {
         alpenglow_port_override.clear();
         let (sockets, _) = svc.get_staked_validators_by_slot(0, &cluster_info, Instant::now());
         assert_eq!(sockets.len(), 2);
-        assert!(!sockets.contains(&blackhole_addr));
+        assert!(!sockets.iter().any(|(_, socket)| socket == &blackhole_addr));
     }
 }

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -109,9 +109,20 @@ impl AlpenglowPortOverride {
     }
 }
 
+/// Test-only additional listener: the voting service will fan out every
+/// consensus message to this `(pubkey, addr)` peer alongside the live
+/// staked-validators list. The stream-mode sender only uses `addr`; the
+/// pubkey is carried here so the later datagram path can target authenticated
+/// peers without changing the fanout API again.
+#[derive(Clone, Debug)]
+pub struct AdditionalListener {
+    pub pubkey: Pubkey,
+    pub addr: SocketAddr,
+}
+
 #[derive(Clone)]
 pub struct VotingServiceOverride {
-    pub additional_listeners: Vec<SocketAddr>,
+    pub additional_listeners: Vec<AdditionalListener>,
     pub alpenglow_port_override: AlpenglowPortOverride,
 }
 
@@ -165,7 +176,7 @@ impl VotingService {
         cluster_info: &ClusterInfo,
         message: &ConsensusMessage,
         connection_cache: Arc<ConnectionCache>,
-        additional_listeners: &[SocketAddr],
+        additional_listeners: &[AdditionalListener],
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         let buf = match wincode::serialize(message) {
@@ -180,7 +191,12 @@ impl VotingService {
             .get_staked_validators_by_slot(slot, cluster_info, Instant::now());
         let sockets = additional_listeners
             .iter()
-            .chain(staked_validator_alpenglow_sockets.iter());
+            .map(|listener| &listener.addr)
+            .chain(
+                staked_validator_alpenglow_sockets
+                    .iter()
+                    .map(|(_, socket)| socket),
+            );
 
         // We use send_message in a loop right now because we worry that sending packets too fast
         // will cause a packet spike and overwhelm the network. If we later find out that this is
@@ -197,7 +213,7 @@ impl VotingService {
         vote_history_storage: &dyn VoteHistoryStorage,
         bls_op: BLSOp,
         connection_cache: Arc<ConnectionCache>,
-        additional_listeners: &[SocketAddr],
+        additional_listeners: &[AdditionalListener],
         staked_validators_cache: &mut StakedValidatorsCache,
     ) {
         match bls_op {
@@ -272,17 +288,14 @@ mod tests {
             quic::{QuicStreamerConfig, SpawnServerResult, spawn_stake_weighted_qos_server},
             streamer::StakedNodes,
         },
-        std::{
-            net::SocketAddr,
-            sync::{Arc, RwLock},
-        },
+        std::sync::{Arc, RwLock},
         test_case::test_case,
         tokio_util::sync::CancellationToken,
     };
 
     fn create_voting_service(
         bls_receiver: Receiver<BLSOp>,
-        listener: SocketAddr,
+        listener: AdditionalListener,
     ) -> (VotingService, Vec<ValidatorVoteKeypairs>) {
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
@@ -354,9 +367,13 @@ mod tests {
         // Bind to a random UDP port
         let socket = bind_to_localhost_unique().unwrap();
         let listener_addr = socket.local_addr().unwrap();
+        let listener = AdditionalListener {
+            pubkey: Pubkey::new_unique(),
+            addr: listener_addr,
+        };
 
         // Create VotingService with the listener address
-        let (_, validator_keypairs) = create_voting_service(bls_receiver, listener_addr);
+        let (_, validator_keypairs) = create_voting_service(bls_receiver, listener);
 
         // Send a BLS message via the VotingService
         assert!(bls_sender.send(bls_op).is_ok());


### PR DESCRIPTION
#### Problem

Split off from  #12572 

#### Summary of Changes

Adds ability to track down also pubkeys of peers to whom we send votor messages so authenticated transport can verify that targeted peer matches the pubkey.