### PR TITLE
CertBuilder: unify handling of skip and notarfallback certs

### DIFF
--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -98,20 +98,9 @@ enum BuilderType {
         signature: SignatureProjective,
         bitmap: BitVec<u8, Lsb0>,
     },
-    /// A [`Certificate`] of type Skip will be produced.
-    ///
-    /// It can require two types of [`VoteMessage`]s.
-    /// In order to be able to produce certificates for reward purposes, signature aggregates for the two types are tracked separately.
-    Skip {
-        signature0: SignatureProjective,
-        bitmap0: BitVec<u8, Lsb0>,
-        sig_and_bitmap1: Option<(SignatureProjective, BitVec<u8, Lsb0>)>,
-    },
-    /// A [`Certificate`] of type NotarFallback will be produced.
-    ///
-    /// It can require two types of [`VoteMessage`]s.
-    /// This certificate is not used for rewards so its signature can be aggregated in a single container.
-    NotarFallback {
+
+    /// The produced [`Certificate`] will require two types of [`VoteMessage`]s.
+    DoubleVote {
         signature: SignatureProjective,
         bitmap0: BitVec<u8, Lsb0>,
         bitmap1: Option<BitVec<u8, Lsb0>>,
@@ -122,16 +111,13 @@ impl BuilderType {
     /// Creates a new instance of [`BuilderType`].
     fn new(cert_type: &CertificateType) -> Self {
         match cert_type {
-            CertificateType::Skip(_) => Self::Skip {
-                signature0: SignatureProjective::identity(),
-                bitmap0: default_bitvec(),
-                sig_and_bitmap1: None,
-            },
-            CertificateType::NotarizeFallback(_, _) => Self::NotarFallback {
-                signature: SignatureProjective::identity(),
-                bitmap0: default_bitvec(),
-                bitmap1: None,
-            },
+            CertificateType::Skip(_) | CertificateType::NotarizeFallback(_, _) => {
+                Self::DoubleVote {
+                    signature: SignatureProjective::identity(),
+                    bitmap0: default_bitvec(),
+                    bitmap1: None,
+                }
+            }
             _ => Self::SingleVote {
                 signature: SignatureProjective::identity(),
                 bitmap: default_bitvec(),
@@ -147,39 +133,7 @@ impl BuilderType {
     ) -> Result<(), AggregateError> {
         let vote_types = cert_type.limits_and_vote_types().1;
         match self {
-            Self::Skip {
-                signature0,
-                bitmap0,
-                sig_and_bitmap1,
-            } => {
-                assert_eq!(vote_types.len(), 2);
-                for msg in msgs {
-                    let vote_type = msg.vote.get_type();
-                    if vote_type == vote_types[0] {
-                        try_set_bitmap(bitmap0, msg.rank)?;
-                    } else {
-                        assert_eq!(vote_type, vote_types[1]);
-                        let (_, bitmap) = sig_and_bitmap1.get_or_insert_with(|| {
-                            (SignatureProjective::identity(), default_bitvec())
-                        });
-                        try_set_bitmap(bitmap, msg.rank)?;
-                    }
-                }
-                signature0.aggregate_with(msgs.iter().filter_map(|msg| {
-                    (msg.vote.get_type() == vote_types[0]).then_some(&msg.signature)
-                }))?;
-                sig_and_bitmap1
-                    .as_mut()
-                    .map(|(signature, _)| {
-                        signature.aggregate_with(msgs.iter().filter_map(|msg| {
-                            (msg.vote.get_type() == vote_types[1]).then_some(&msg.signature)
-                        }))
-                    })
-                    .unwrap_or(Ok(()))?;
-                Ok(())
-            }
-
-            Self::NotarFallback {
+            Self::DoubleVote {
                 signature,
                 bitmap0,
                 bitmap1,
@@ -215,20 +169,7 @@ impl BuilderType {
             Self::SingleVote { signature, bitmap } => {
                 build_cert_from_bitmap(cert_type, signature, bitmap).map_err(BuildError::Encode)
             }
-            Self::Skip {
-                mut signature0,
-                bitmap0,
-                sig_and_bitmap1,
-            } => match sig_and_bitmap1 {
-                None => build_cert_from_bitmap(cert_type, signature0, bitmap0)
-                    .map_err(BuildError::Encode),
-                Some((signature1, bitmap1)) => {
-                    signature0.aggregate_with([signature1].iter())?;
-                    build_cert_from_bitmaps(cert_type, signature0, bitmap0, bitmap1)
-                        .map_err(BuildError::Encode)
-                }
-            },
-            Self::NotarFallback {
+            Self::DoubleVote {
                 signature,
                 bitmap0,
                 bitmap1,


### PR DESCRIPTION
#### Problem

We had previously separated their handling as we thought we would use the skip cert builder for rewards.  But now we have a separate rewards cert builder.


#### Summary of Changes

Unifies the handling of skip and notarfallback cert building