### PR TITLE
consensus_pool: Use `NonZero` to represent total stake

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -29,7 +29,7 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
-    std::{cmp::Ordering, collections::BTreeMap, num::NonZeroU64, sync::Arc},
+    std::{cmp::Ordering, collections::BTreeMap, num::NonZero, sync::Arc},
     thiserror::Error,
 };
 
@@ -76,7 +76,7 @@ fn get_key_and_stakes(
     root_bank: &Bank,
     slot: Slot,
     rank: u16,
-) -> Result<(Pubkey, Stake, Stake), AddVoteError> {
+) -> Result<(Pubkey, NonZero<Stake>, NonZero<Stake>), AddVoteError> {
     let epoch_stakes = root_bank.epoch_stakes_from_slot(slot).ok_or_else(|| {
         AddVoteError::EpochStakesNotFound(root_bank.epoch_schedule().get_epoch(slot))
     })?;
@@ -86,17 +86,15 @@ fn get_key_and_stakes(
     else {
         return Err(AddVoteError::InvalidRank(rank));
     };
-    if entry.stake == 0 {
-        // Since we have a valid rank, this should never happen, there is no rank for zero stake.
-        panic!(
-            "Validator stake is zero for pubkey: {}",
-            entry.vote_account_pubkey
-        );
-    }
     Ok((
         entry.vote_account_pubkey,
-        entry.stake,
-        epoch_stakes.total_stake(),
+        NonZero::new(entry.stake).unwrap_or_else(|| {
+            panic!(
+                "Validator stake is zero for pubkey: {}",
+                entry.vote_account_pubkey,
+            )
+        }),
+        NonZero::new(epoch_stakes.total_stake()).expect("expect total stakes to not be 0"),
     ))
 }
 
@@ -176,7 +174,7 @@ impl ConsensusPool {
         &mut self,
         vote: VoteMessage,
         validator_vote_key: Pubkey,
-        validator_stake: Stake,
+        validator_stake: NonZero<Stake>,
     ) -> Option<Stake> {
         let vote_type = vote.vote.get_type();
         let pool = self
@@ -206,7 +204,7 @@ impl ConsensusPool {
         vote: &Vote,
         block_id: Option<Hash>,
         events: &mut Vec<VotorEvent>,
-        total_stake: Stake,
+        total_stake: NonZero<Stake>,
     ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
         let slot = vote.slot();
         let mut new_certificates_to_send = Vec::new();
@@ -233,7 +231,6 @@ impl ConsensusPool {
                     })
                 })
                 .sum::<Stake>();
-            let total_stake = NonZeroU64::new(total_stake).unwrap();
             if Fraction::new(accumulated_stake, total_stake) < limit {
                 continue;
             }
@@ -413,12 +410,6 @@ impl ConsensusPool {
         let vote_slot = vote.slot();
         let (validator_vote_key, validator_stake, total_stake) =
             get_key_and_stakes(root_bank, vote_slot, rank)?;
-
-        // Since we have a valid rank, this should never happen, there is no rank for zero stake.
-        assert_ne!(
-            validator_stake, 0,
-            "Validator stake is zero for pubkey: {validator_vote_key}"
-        );
 
         self.stats.incoming_votes = self.stats.incoming_votes.saturating_add(1);
         if vote_slot < root_bank.slot() {

--- a/votor/src/consensus_pool/slot_stake_counters.rs
+++ b/votor/src/consensus_pool/slot_stake_counters.rs
@@ -11,13 +11,13 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
-    std::{collections::BTreeMap, num::NonZeroU64},
+    std::{collections::BTreeMap, num::NonZero},
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct SlotStakeCounters {
     my_first_vote: Option<Vote>,
-    total_stake: Stake,
+    total_stake: NonZero<Stake>,
     skip_total: Stake,
     notarize_total: Stake,
     notarize_entry_total: BTreeMap<Hash, Stake>,
@@ -27,10 +27,16 @@ pub(crate) struct SlotStakeCounters {
 }
 
 impl SlotStakeCounters {
-    pub fn new(total_stake: Stake) -> Self {
+    pub fn new(total_stake: NonZero<Stake>) -> Self {
         Self {
+            my_first_vote: None,
             total_stake,
-            ..Default::default()
+            skip_total: 0,
+            notarize_total: 0,
+            notarize_entry_total: BTreeMap::new(),
+            top_notarized_stake: 0,
+            safe_to_notar_sent: vec![],
+            safe_to_skip_sent: false,
         }
     }
 
@@ -110,14 +116,15 @@ impl SlotStakeCounters {
         }
         trace!(
             "safe_to_notar {block_id:?} skip_ratio={} notarized_ratio={}",
-            self.skip_total as f64 / self.total_stake as f64,
-            *stake as f64 / self.total_stake as f64
+            self.skip_total as f64 / self.total_stake.get() as f64,
+            *stake as f64 / self.total_stake.get() as f64
         );
         // Check if the block fits condition (i) 40% of stake holders voted notarize
-        let total_stake = NonZeroU64::new(self.total_stake).unwrap();
-        let notarized_ratio = Fraction::new(*stake, total_stake);
-        let notarized_plus_skip_ratio =
-            Fraction::new(self.skip_total.checked_add(*stake).unwrap(), total_stake);
+        let notarized_ratio = Fraction::new(*stake, self.total_stake);
+        let notarized_plus_skip_ratio = Fraction::new(
+            self.skip_total.checked_add(*stake).unwrap(),
+            self.total_stake,
+        );
         notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY
             // Check if the block fits condition (ii) 20% notarized, and 60% notarized or skip
             || (notarized_ratio >= SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP
@@ -141,9 +148,8 @@ impl SlotStakeCounters {
             let num_stake = self
                 .skip_total
                 .saturating_add(self.notarize_total.saturating_sub(self.top_notarized_stake));
-            let total_stake = NonZeroU64::new(self.total_stake).unwrap();
 
-            Fraction::new(num_stake, total_stake) >= SAFE_TO_SKIP_THRESHOLD
+            Fraction::new(num_stake, self.total_stake) >= SAFE_TO_SKIP_THRESHOLD
         } else {
             false
         }
@@ -156,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_safe_to_notar_first_in_leader_window() {
-        let mut counters = SlotStakeCounters::new(100);
+        let mut counters = SlotStakeCounters::new(NonZero::new(100).unwrap());
 
         let mut events = vec![];
         let mut pending_safe_to_notar = vec![];
@@ -208,7 +214,7 @@ mod tests {
         assert_eq!(stats.event_safe_to_notarize, 1);
 
         // Reset counters with slot 4 (first in next leader window)
-        counters = SlotStakeCounters::new(100);
+        counters = SlotStakeCounters::new(NonZero::new(100).unwrap());
         events.clear();
         pending_safe_to_notar.clear();
         stats = ConsensusPoolStats::default();
@@ -261,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_safe_to_notar_intrawindow_block() {
-        let mut counters = SlotStakeCounters::new(100);
+        let mut counters = SlotStakeCounters::new(NonZero::new(100).unwrap());
 
         let mut events = vec![];
         let mut pending_safe_to_notar = vec![];
@@ -300,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_safe_to_skip() {
-        let mut counters = SlotStakeCounters::new(100);
+        let mut counters = SlotStakeCounters::new(NonZero::new(100).unwrap());
 
         let mut events = vec![];
         let mut pending_safe_to_notar = vec![];
@@ -345,7 +351,7 @@ mod tests {
         assert_eq!(stats.event_safe_to_skip, 1);
 
         // Reset counters
-        counters = SlotStakeCounters::new(100);
+        counters = SlotStakeCounters::new(NonZero::new(100).unwrap());
         events.clear();
         pending_safe_to_notar.clear();
         stats = ConsensusPoolStats::default();

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -3,7 +3,10 @@ use {
     agave_votor_messages::consensus_message::VoteMessage,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    std::collections::{BTreeMap, BTreeSet},
+    std::{
+        collections::{BTreeMap, BTreeSet},
+        num::NonZero,
+    },
 };
 
 /// There are two types of vote pools:
@@ -27,14 +30,14 @@ impl SimpleVotePool {
     pub(super) fn add_vote(
         &mut self,
         validator_vote_key: Pubkey,
-        validator_stake: Stake,
+        validator_stake: NonZero<Stake>,
         vote: VoteMessage,
     ) -> Option<Stake> {
         if !self.prev_voted_validators.insert(validator_vote_key) {
             return None;
         }
         self.votes.push(vote);
-        self.total_stake = self.total_stake.saturating_add(validator_stake);
+        self.total_stake = self.total_stake.saturating_add(validator_stake.get());
         Some(self.total_stake)
     }
 
@@ -75,7 +78,7 @@ impl DuplicateBlockVotePool {
     pub(super) fn add_vote(
         &mut self,
         validator_vote_key: Pubkey,
-        validator_stake: Stake,
+        validator_stake: NonZero<Stake>,
         vote: VoteMessage,
     ) -> Option<Stake> {
         let block_id = *vote.vote.block_id().unwrap();
@@ -96,7 +99,7 @@ impl DuplicateBlockVotePool {
         vote_entry.votes.push(vote);
         vote_entry.total_stake_by_key = vote_entry
             .total_stake_by_key
-            .saturating_add(validator_stake);
+            .saturating_add(validator_stake.get());
         Some(vote_entry.total_stake_by_key)
     }
 
@@ -146,16 +149,25 @@ mod test {
         };
         let my_pubkey = Pubkey::new_unique();
 
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), Some(10));
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message),
+            Some(10)
+        );
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote_message), None);
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message),
+            None
+        );
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote_message), Some(70));
+        assert_eq!(
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), vote_message),
+            Some(70)
+        );
         assert_eq!(vote_pool.total_stake(), 70);
     }
 
@@ -170,18 +182,30 @@ mod test {
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
         };
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            Some(10)
+        );
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 10);
 
         // Adding the same key again should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            None
+        );
 
         // Adding a different bankhash should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), None);
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            None
+        );
 
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
+        assert_eq!(
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), vote),
+            Some(70)
+        );
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 70);
     }
 
@@ -204,14 +228,20 @@ mod test {
 
         // Adding the first 3 votes should succeed, but total_stake should remain at 10
         for vote in votes.iter().take(3).cloned() {
-            assert_eq!(vote_pool.add_vote(my_pubkey, 10, vote), Some(10));
+            assert_eq!(
+                vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+                Some(10)
+            );
             assert_eq!(
                 vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 10
             );
         }
         // Adding the 4th vote should fail
-        assert_eq!(vote_pool.add_vote(my_pubkey, 10, votes[3]), None);
+        assert_eq!(
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), votes[3]),
+            None
+        );
         assert_eq!(
             vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             0
@@ -220,7 +250,10 @@ mod test {
         // Adding a different key should succeed
         let new_pubkey = Pubkey::new_unique();
         for vote in votes.iter().skip(1).take(2).cloned() {
-            assert_eq!(vote_pool.add_vote(new_pubkey, 60, vote), Some(70));
+            assert_eq!(
+                vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), vote),
+                Some(70)
+            );
             assert_eq!(
                 vote_pool.total_stake_by_block_id(vote.vote.block_id().unwrap()),
                 70
@@ -228,13 +261,19 @@ mod test {
         }
 
         // The new key only added 2 votes, so adding block_ids[3] should succeed
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[3]), Some(60));
+        assert_eq!(
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[3]),
+            Some(60)
+        );
         assert_eq!(
             vote_pool.total_stake_by_block_id(votes[3].vote.block_id().unwrap()),
             60
         );
 
         // Now if adding the same key again, it should fail
-        assert_eq!(vote_pool.add_vote(new_pubkey, 60, votes[0]), None);
+        assert_eq!(
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[0]),
+            None
+        );
     }
 }


### PR DESCRIPTION
#### Problem

There are unnecessary `unwrap` to assert that total_stake is not 0 in the consensus_pool module.  We already assert (implicitly) that is not 0 when we retrieve it initially.  


#### Summary of Changes

Uses `NonZero` to reduce unwraps 