### PR TITLE
Cleans up `BLSOp` and removes `Copy` derivation on `VoteMessage`

### DIFF
--- a/core/src/bls_sigverify/bls_vote_sigverify.rs
+++ b/core/src/bls_sigverify/bls_vote_sigverify.rs
@@ -90,7 +90,7 @@ pub(super) fn verify_and_send_votes(
     stats.sig_verified_votes += verified_votes.len() as u64;
 
     let (votes_for_pool, msgs_for_repair, msg_for_reward, msg_for_metrics) =
-        process_verified_votes(&verified_votes, root_bank, cluster_info, leader_schedule);
+        process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
 
     send_votes_to_pool(votes_for_pool, &channels.channel_to_pool, &mut stats)?;
     send_votes_to_repair(msgs_for_repair, &channels.channel_to_repair, &mut stats)?;
@@ -124,7 +124,7 @@ fn inspect_for_repair(vote: &VotePayload, msgs_for_repair: &mut HashMap<Pubkey, 
 /// In particular, collects and returns the relevant messages for the consensus pool; rewards;
 /// repair; and metrics;
 fn process_verified_votes(
-    verified_votes: &[VotePayload],
+    verified_votes: Vec<VotePayload>,
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
@@ -138,25 +138,23 @@ fn process_verified_votes(
     let mut msgs_for_repair = HashMap::new();
     let mut votes_for_pool = Vec::with_capacity(verified_votes.len());
     let mut votes_for_metrics = Vec::with_capacity(verified_votes.len());
-    for vote in verified_votes {
-        let vote_message = vote.vote_message;
+    for payload in verified_votes {
         if crate::block_creation_loop::rewards::certs_builder::wants_vote(
             cluster_info,
             leader_schedule,
             root_bank.slot(),
-            &vote_message,
+            &payload.vote_message,
         ) {
-            votes_for_reward.push(vote_message);
+            votes_for_reward.push(payload.vote_message.clone());
         }
 
-        inspect_for_repair(vote, &mut msgs_for_repair);
-
-        votes_for_pool.push(ConsensusMessage::Vote(vote_message));
+        inspect_for_repair(&payload, &mut msgs_for_repair);
 
         votes_for_metrics.push(ConsensusMetricsEvent::Vote {
-            id: vote.pubkey,
-            vote: vote.vote_message.vote,
+            id: payload.pubkey,
+            vote: payload.vote_message.vote,
         });
+        votes_for_pool.push(ConsensusMessage::Vote(payload.vote_message));
     }
     let msgs_for_repair = msgs_for_repair
         .into_iter()

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1748,17 +1748,16 @@ impl ReplayStage {
             None,
             &mut HashMap::new(),
         ) {
-            GenerateVoteTxResult::ConsensusMessage(message) => {
+            GenerateVoteTxResult::Vote(vote_msg) => {
                 // Send vote to ConsensusPool and rest of cluster
                 warn!(
                     "{} Alpenglow migration: Casting genesis vote for ({block:?})",
                     identity_keypair.pubkey()
                 );
                 // If sending fails that means the channel is disconnected and we are shutting down
-                let _ = own_vote_sender.send(vec![message.clone()]);
+                let _ = own_vote_sender.send(vec![ConsensusMessage::Vote(vote_msg.clone())]);
                 let _ = bls_sender.send(BLSOp::PushVote {
-                    message: Arc::new(message),
-                    slot: block.slot,
+                    vote: Arc::new(vote_msg),
                     saved_vote_history:
                         agave_votor::vote_history_storage::SavedVoteHistoryVersions::Current(
                             SavedVoteHistory::default(),

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -54,7 +54,7 @@ pub struct Block {
     derive(AbiExample),
     frozen_abi(digest = "CTiXEk2aQbpf6TS6PNKcaTsGkLruDvAYsTLFhHKW2vsm")
 )]
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -408,7 +408,7 @@ impl ConsensusPool {
         vote_message: VoteMessage,
         events: &mut Vec<VotorEvent>,
     ) -> Result<Vec<Arc<Certificate>>, AddVoteError> {
-        let vote = &vote_message.vote;
+        let vote = vote_message.vote;
         let rank = vote_message.rank;
         let vote_slot = vote.slot();
         let (validator_vote_key, validator_stake, total_stake) =
@@ -452,7 +452,7 @@ impl ConsensusPool {
                     .entry(vote_slot)
                     .or_insert_with(|| SlotStakeCounters::new(total_stake));
                 fallback_vote_counters.add_vote(
-                    vote,
+                    &vote,
                     entry_stake,
                     my_vote_pubkey == &validator_vote_key,
                     events,
@@ -463,7 +463,7 @@ impl ConsensusPool {
         }
         self.stats.incr_ingested_vote_type(vote_type);
 
-        self.update_certificates(root_bank, vote, block_id, events, total_stake)
+        self.update_certificates(root_bank, &vote, block_id, events, total_stake)
     }
 
     fn add_certificate(

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -153,14 +153,14 @@ mod test {
         let my_pubkey = Pubkey::new_unique();
 
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message.clone()),
             Some(10)
         );
         assert_eq!(vote_pool.total_stake(), 10);
 
         // Adding the same key again should fail
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote_message.clone()),
             None
         );
         assert_eq!(vote_pool.total_stake(), 10);
@@ -186,20 +186,20 @@ mod test {
             rank: 1,
         };
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote.clone()),
             Some(10)
         );
         assert_eq!(vote_pool.total_stake_by_block_id(&block_id), 10);
 
         // Adding the same key again should fail
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote.clone()),
             None
         );
 
         // Adding a different bankhash should fail
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote.clone()),
             None
         );
 
@@ -235,7 +235,7 @@ mod test {
         // Adding the first 3 votes should succeed, but total_stake should remain at 10
         for vote in votes.iter().take(3).cloned() {
             assert_eq!(
-                vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote),
+                vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), vote.clone()),
                 Some(10)
             );
             assert_eq!(
@@ -245,7 +245,7 @@ mod test {
         }
         // Adding the 4th vote should fail
         assert_eq!(
-            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), votes[3]),
+            vote_pool.add_vote(my_pubkey, NonZero::new(10).unwrap(), votes[3].clone()),
             None
         );
         assert_eq!(
@@ -257,7 +257,7 @@ mod test {
         let new_pubkey = Pubkey::new_unique();
         for vote in votes.iter().skip(1).take(2).cloned() {
             assert_eq!(
-                vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), vote),
+                vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), vote.clone()),
                 Some(70)
             );
             assert_eq!(
@@ -268,7 +268,7 @@ mod test {
 
         // The new key only added 2 votes, so adding block_ids[3] should succeed
         assert_eq!(
-            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[3]),
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[3].clone()),
             Some(60)
         );
         assert_eq!(
@@ -278,7 +278,7 @@ mod test {
 
         // Now if adding the same key again, it should fail
         assert_eq!(
-            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[0]),
+            vote_pool.add_vote(new_pubkey, NonZero::new(60).unwrap(), votes[0].clone()),
             None
         );
     }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1348,15 +1348,15 @@ mod tests {
                 let expected_vote_serialized = wincode::serialize(v).unwrap();
                 let signature: BLSSignature =
                     self.my_bls_keypair.sign(&expected_vote_serialized).into();
-                let expected_message = ConsensusMessage::Vote(VoteMessage {
+                let expected_message = VoteMessage {
                     vote: *v,
                     rank: 0,
                     signature,
-                });
+                };
                 let prev_length = self.bls_ops.len();
-                self.bls_ops.retain(|bls_op| {
-                    !matches!(bls_op, BLSOp::PushVote { message, .. } if **message == expected_message)
-                });
+                self.bls_ops.retain(
+                    |bls_op| !matches!(bls_op, BLSOp::PushVote{ vote, .. } if **vote == expected_message),
+                );
                 assert!(
                     self.bls_ops.len() < prev_length,
                     "Did not find expected vote: {expected_message:?}",
@@ -1368,22 +1368,22 @@ mod tests {
             let expected_vote_serialized = wincode::serialize(expected_vote).unwrap();
             let signature: BLSSignature =
                 self.my_bls_keypair.sign(&expected_vote_serialized).into();
-            let expected_message = ConsensusMessage::Vote(VoteMessage {
+            let expected_message = VoteMessage {
                 vote: *expected_vote,
                 rank: 0,
                 signature,
-            });
+            };
             let prev_length = self.bls_ops.len();
-            self.bls_ops.retain(|bls_op| {
-                !matches!(bls_op, BLSOp::PushVote { message, .. } if **message == expected_message)
-            });
+            self.bls_ops.retain(
+                |bls_op| !matches!(bls_op, BLSOp::PushVote { vote, .. } if **vote == expected_message),
+            );
             assert!(
                 self.bls_ops.len() < prev_length,
                 "Did not find expected vote: {expected_message:?}",
             );
             // Also check own_vote_receiver
             let own_vote = self.own_vote_receiver.try_recv().unwrap();
-            assert_eq!(own_vote, vec![expected_message]);
+            assert_eq!(own_vote, vec![ConsensusMessage::Vote(expected_message)]);
         }
 
         fn check_for_commitment(&mut self, expected_type: CommitmentType, expected_slot: Slot) {

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -1,6 +1,6 @@
 use {
     crate::{event::VotorEvent, voting_service::BLSOp},
-    agave_votor_messages::{consensus_message::ConsensusMessage, vote::VoteType},
+    agave_votor_messages::vote::VoteType,
     solana_clock::Slot,
     solana_metrics::datapoint_info,
     std::{
@@ -185,11 +185,7 @@ impl EventHandlerStats {
     }
 
     pub fn incr_vote(&mut self, bls_op: &BLSOp) {
-        if let BLSOp::PushVote { message, .. } = bls_op {
-            let ConsensusMessage::Vote(vote) = **message else {
-                warn!("Unexpected BLS message type: {message:?}");
-                return;
-            };
+        if let BLSOp::PushVote { vote, .. } = bls_op {
             let vote_type = vote.vote.get_type();
             let entry = self.sent_votes.entry(vote_type).or_insert(0);
             *entry = entry.saturating_add(1);

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -3,7 +3,10 @@ use {
         staked_validators_cache::StakedValidatorsCache,
         vote_history_storage::{SavedVoteHistoryVersions, VoteHistoryStorage},
     },
-    agave_votor_messages::{certificate::Certificate, consensus_message::ConsensusMessage},
+    agave_votor_messages::{
+        certificate::Certificate,
+        consensus_message::{ConsensusMessage, VoteMessage},
+    },
     crossbeam_channel::Receiver,
     solana_client::connection_cache::ConnectionCache,
     solana_clock::Slot,
@@ -31,8 +34,7 @@ const STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET: usize = 3;
 #[derive(Debug)]
 pub enum BLSOp {
     PushVote {
-        message: Arc<ConsensusMessage>,
-        slot: Slot,
+        vote: Arc<VoteMessage>,
         saved_vote_history: SavedVoteHistoryVersions,
     },
     PushCertificate {
@@ -202,8 +204,7 @@ impl VotingService {
     ) {
         match bls_op {
             BLSOp::PushVote {
-                message,
-                slot,
+                vote,
                 saved_vote_history,
             } => {
                 let mut measure = Measure::start("alpenglow vote history save");
@@ -213,21 +214,22 @@ impl VotingService {
                 }
                 measure.stop();
                 trace!("{measure}");
-
+                let slot = vote.vote.slot();
+                let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
                 Self::broadcast_consensus_message(
                     slot,
                     cluster_info,
-                    &message,
+                    &msg,
                     connection_cache,
                     additional_listeners,
                     staked_validators_cache,
                 );
             }
             BLSOp::PushCertificate { certificate } => {
-                let vote_slot = certificate.cert_type.slot();
-                let message = ConsensusMessage::Certificate((*certificate).clone());
+                let slot = certificate.cert_type.slot();
+                let message = ConsensusMessage::Certificate(Arc::unwrap_or_clone(certificate));
                 Self::broadcast_consensus_message(
-                    vote_slot,
+                    slot,
                     cluster_info,
                     &message,
                     connection_cache,
@@ -323,12 +325,11 @@ mod tests {
     }
 
     #[test_case(BLSOp::PushVote {
-        message: Arc::new(ConsensusMessage::Vote(VoteMessage {
+        vote: Arc::new(VoteMessage {
             vote: Vote::new_skip_vote(5),
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
-        })),
-        slot: 5,
+        }),
         saved_vote_history: SavedVoteHistoryVersions::Current(SavedVoteHistory::default()),
     }, ConsensusMessage::Vote(VoteMessage {
         vote: Vote::new_skip_vote(5),

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -53,8 +53,8 @@ pub enum GenerateVoteTxResult {
     // The following are the successful cases
     // Generated a vote transaction
     Tx(Transaction),
-    // Generated a ConsensusMessage
-    ConsensusMessage(ConsensusMessage),
+    // Generated a VoteMessage
+    Vote(VoteMessage),
 }
 
 impl GenerateVoteTxResult {
@@ -74,7 +74,7 @@ impl GenerateVoteTxResult {
             | Self::WaitForStartupVerification
             | Self::WaitToVoteSlot(_)
             | Self::NoRankFound => false,
-            Self::Tx(_) | Self::ConsensusMessage(_) => false,
+            Self::Tx(_) | Self::Vote(_) => false,
         }
     }
 
@@ -86,7 +86,7 @@ impl GenerateVoteTxResult {
             | Self::WaitForStartupVerification
             | Self::WaitToVoteSlot(_)
             | Self::NoRankFound => true,
-            Self::Tx(_) | Self::ConsensusMessage(_) => false,
+            Self::Tx(_) | Self::Vote(_) => false,
         }
     }
 }
@@ -216,11 +216,11 @@ pub fn generate_vote_tx(
     };
 
     let vote_serialized = wincode::serialize(&vote).unwrap();
-    GenerateVoteTxResult::ConsensusMessage(ConsensusMessage::Vote(VoteMessage {
+    GenerateVoteTxResult::Vote(VoteMessage {
         vote,
         signature: bls_keypair.sign(&vote_serialized).into(),
         rank: my_rank,
-    }))
+    })
 }
 
 /// Send an alpenglow vote as a BLSMessage
@@ -244,7 +244,7 @@ fn insert_vote_and_create_bls_message(
     }
 
     let bank = context.sharable_banks.root();
-    let message = match generate_vote_tx(
+    let vote_msg = match generate_vote_tx(
         vote,
         &bank,
         context.vote_account_pubkey,
@@ -253,7 +253,7 @@ fn insert_vote_and_create_bls_message(
         context.wait_to_vote_slot,
         &mut context.derived_bls_keypairs,
     ) {
-        GenerateVoteTxResult::ConsensusMessage(m) => m,
+        GenerateVoteTxResult::Vote(vote) => vote,
         e => {
             if e.is_transient_error() {
                 return Err(VoteError::TransientError(Box::new(e)));
@@ -264,7 +264,7 @@ fn insert_vote_and_create_bls_message(
     };
     context
         .own_vote_sender
-        .send(vec![message.clone()])
+        .send(vec![ConsensusMessage::Vote(vote_msg.clone())])
         .map_err(|_| SendError(()))?;
 
     // TODO: for refresh votes use a different BLSOp so we don't have to rewrite the same vote history to file
@@ -273,8 +273,7 @@ fn insert_vote_and_create_bls_message(
 
     // Return vote for sending
     Ok(BLSOp::PushVote {
-        message: Arc::new(message),
-        slot: vote.slot(),
+        vote: Arc::new(vote_msg),
         saved_vote_history: SavedVoteHistoryVersions::from(saved_vote_history),
     })
 }
@@ -413,16 +412,15 @@ mod tests {
             .unwrap();
         let expected_message = generate_expected_consensus_message(vote, &my_bls_keypair);
         if let BLSOp::PushVote {
-            message,
-            slot,
+            vote,
             saved_vote_history,
-        } = &result
+        } = result
         {
-            assert_eq!(slot, &vote_slot);
-            assert_eq!(**message, expected_message);
+            let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
+            assert_eq!(msg, expected_message);
             assert_eq!(
                 saved_vote_history,
-                &SavedVoteHistoryVersions::from(
+                SavedVoteHistoryVersions::from(
                     SavedVoteHistory::new(
                         &voting_context.vote_history,
                         &voting_context.identity_keypair
@@ -431,7 +429,7 @@ mod tests {
                 )
             );
         } else {
-            panic!("Expected BLSOp::PushVote, got {result:?}");
+            panic!("Expected BLSOp::VotePush, got {result:?}");
         }
 
         // Check that own vote sender receives the vote


### PR DESCRIPTION
#### Problem

Two seemingly unrelated problems that I hit at the same time while working on https://github.com/anza-xyz/agave/issues/12760.

BLSOp:
- `BLSOp` is not very well defined.  When it wants to send a vote, it is sending the vote inside a `Arc<ConsensusMessage>` which does not make sense.
- The `PushVote` variant includes slot which can be looked up from the vote being sent.

`VoteMessage` is deriving `Copy` and it is a potentially expensive struct to copy so we should be using `clone` on it instead.  Neither `ConsensusMessage` and `Certificate` which are of similar sizes derive `Copy`.


#### Summary of Changes

- Cleans up `BLSOp`.  I am also open to feedback on a better name for the struct.
- Removes the `Copy` derivation on `VoteMessage`