### PR TITLE
Revert "fix(votor): only add vote to vote_history if voting (#12713)"

### DIFF
--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -238,6 +238,11 @@ fn insert_vote_and_create_bls_message(
     is_refresh: bool,
     context: &mut VotingContext,
 ) -> Result<BLSOp, VoteError> {
+    // Update and save the vote history
+    if !is_refresh {
+        context.vote_history.add_vote(vote);
+    }
+
     let bank = context.sharable_banks.root();
     let message = match generate_vote_tx(
         vote,
@@ -257,15 +262,6 @@ fn insert_vote_and_create_bls_message(
             }
         }
     };
-
-    // Only record after generate_vote_tx has produced a signed message.
-    // Recording before would leave vote_history claiming we voted for the
-    // slot when HotSpare/NonVoting/NoRankFound short-circuited the broadcast,
-    // permanently blocking us from voting for that slot.
-    if !is_refresh {
-        context.vote_history.add_vote(vote);
-    }
-
     context
         .own_vote_sender
         .send(vec![message.clone()])


### PR DESCRIPTION
This reverts commit 0aeb9c2e51e452f53409a7367c0cda9307b5d835.

#### Problem
https://github.com/anza-xyz/agave/pull/12713 breaks unstaked nodes. By design unstaked nodes do not generate or broadcast consensus messages however it is imperative they have an accurate `vote_history` for use the in the event loop.

Without an accurate `vote_history` they are unable to root / report confirmation etc. Also at any point an unstaked node could become staked.

#### Summary of Changes
Revert the commit
