### PR TITLE
solana-keygen: display the compressed BLS pubkey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7319,6 +7319,7 @@ name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
  "assert_matches",
+ "bs58",
  "chrono",
  "clap 2.33.3",
  "rpassword",
@@ -8332,6 +8333,7 @@ dependencies = [
  "agave-snapshots",
  "base64 0.22.1",
  "bincode",
+ "bs58",
  "clap 2.33.3",
  "itertools 0.14.0",
  "serde",

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -19,6 +19,7 @@ name = "solana_clap_utils"
 agave-unstable-api = []
 
 [dependencies]
+bs58 = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["default"] }
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
 rpassword = { workspace = true }

--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -5,7 +5,10 @@ use {
     },
     chrono::DateTime,
     clap::ArgMatches,
-    solana_bls_signatures::{Pubkey as BLSPubkey, PubkeyCompressed as BLSPubkeyCompressed},
+    solana_bls_signatures::{
+        BLS_PUBLIC_KEY_COMPRESSED_SIZE, Pubkey as BLSPubkey,
+        PubkeyCompressed as BLSPubkeyCompressed,
+    },
     solana_clock::UnixTimestamp,
     solana_cluster_type::ClusterType,
     solana_commitment_config::CommitmentConfig,
@@ -105,19 +108,45 @@ pub fn pubkeys_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Pubkey>> {
     })
 }
 
+fn bls_pubkey_compressed_from_base58(value: &str) -> Result<BLSPubkeyCompressed, String> {
+    let bytes = bs58::decode(value)
+        .into_vec()
+        .map_err(|err| err.to_string())?;
+    let bytes: [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE] =
+        bytes.try_into().map_err(|bytes: Vec<u8>| {
+            format!(
+                "expected {BLS_PUBLIC_KEY_COMPRESSED_SIZE} decoded bytes, got {}",
+                bytes.len()
+            )
+        })?;
+    Ok(BLSPubkeyCompressed(bytes))
+}
+
+pub fn bls_pubkey_compressed_from_str(value: &str) -> Result<BLSPubkeyCompressed, String> {
+    if let Ok(bls_pubkey) = BLSPubkeyCompressed::from_str(value) {
+        return Ok(bls_pubkey);
+    }
+
+    if let Ok(bls_pubkey) = BLSPubkey::from_str(value) {
+        return bls_pubkey
+            .try_into()
+            .map_err(|err| format!("failed to convert BLS pubkey to compressed form: {err}"));
+    }
+
+    bls_pubkey_compressed_from_base58(value).map_err(|err| {
+        format!(
+            "Failed to parse BLS pubkey as compressed string, uncompressed string, or base58 \
+             compressed bytes: {err}"
+        )
+    })
+}
+
 pub fn bls_pubkeys_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<BLSPubkeyCompressed>> {
     matches.values_of(name).map(|values| {
         values
             .map(|value| {
-                // Most of the case it is just a compressed BLS pubkey string
-                // If the conversion fails, we try to read it as uncompressed BLS pubkey string
-                BLSPubkeyCompressed::from_str(value).unwrap_or_else(|_| {
-                    let bls_pubkey = BLSPubkey::from_str(value)
-                        .expect("Failed to parse BLS pubkey or compressed BLS pubkey from string");
-                    bls_pubkey
-                        .try_into()
-                        .expect("Failed to convert to compressed BLS pubkey")
-                })
+                bls_pubkey_compressed_from_str(value)
+                    .expect("Failed to parse BLS pubkey or compressed BLS pubkey from string")
             })
             .collect()
     })
@@ -461,6 +490,22 @@ mod tests {
             &bls_pubkey1_compressed.to_string(),
             "--multiple",
             &bls_pubkey2_compressed.to_string(),
+        ]);
+        assert_eq!(
+            bls_pubkeys_of(&matches, "multiple"),
+            Some(vec![bls_pubkey1_compressed, bls_pubkey2_compressed])
+        );
+
+        // Test that base58-encoded compressed BLS pubkey bytes also work, matching
+        // the vote-account display format.
+        let bls_pubkey1_base58 = bs58::encode(bls_pubkey1_compressed.0).into_string();
+        let bls_pubkey2_base58 = bs58::encode(bls_pubkey2_compressed.0).into_string();
+        let matches = app().get_matches_from(vec![
+            "test",
+            "--multiple",
+            &bls_pubkey1_base58,
+            "--multiple",
+            &bls_pubkey2_base58,
         ]);
         assert_eq!(
             bls_pubkeys_of(&matches, "multiple"),

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6378,6 +6378,7 @@ dependencies = [
 name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "bs58",
  "chrono",
  "clap",
  "rpassword",

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -68,6 +68,7 @@ solana-vote-program = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
+bs58 = { workspace = true, features = ["std"] }
 solana-borsh = { workspace = true }
 solana-genesis = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -7,10 +7,10 @@ use {
     clap::{App, Arg, ArgMatches, crate_description, crate_name, value_t, value_t_or_exit},
     itertools::Itertools,
     solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
-    solana_bls_signatures::{Pubkey as BLSPubkey, PubkeyCompressed as BLSPubkeyCompressed},
+    solana_bls_signatures::PubkeyCompressed as BLSPubkeyCompressed,
     solana_clap_utils::{
         input_parsers::{
-            bls_pubkeys_of, cluster_type_of, pubkey_of, pubkeys_of,
+            bls_pubkey_compressed_from_str, bls_pubkeys_of, cluster_type_of, pubkey_of, pubkeys_of,
             unix_timestamp_from_rfc3339_datetime,
         },
         input_validators::{
@@ -83,13 +83,7 @@ fn pubkey_from_str(key_str: &str) -> Result<Pubkey, Box<dyn error::Error>> {
 }
 
 fn bls_pubkey_from_str(key_str: &str) -> Result<BLSPubkeyCompressed, Box<dyn error::Error>> {
-    match BLSPubkeyCompressed::from_str(key_str) {
-        Ok(bls_pubkey) => Ok(bls_pubkey),
-        Err(_) => {
-            let bls_pubkey = BLSPubkey::from_str(key_str)?;
-            Ok(bls_pubkey.try_into()?)
-        }
-    }
+    bls_pubkey_compressed_from_str(key_str).map_err(Into::into)
 }
 
 pub fn load_genesis_accounts(file: &str, genesis_config: &mut GenesisConfig) -> io::Result<u64> {
@@ -1001,7 +995,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 mod tests {
     use {
         super::*,
-        solana_bls_signatures::keypair::Keypair as BLSKeypair,
+        solana_bls_signatures::{Pubkey as BLSPubkey, keypair::Keypair as BLSKeypair},
         solana_borsh::v1 as borsh1,
         solana_genesis_config::GenesisConfig,
         solana_stake_interface as stake,
@@ -1357,12 +1351,14 @@ mod tests {
         assert_eq!(genesis_config.accounts.len(), 3);
     }
 
-    #[test_case(true, true; "add bls compressed pubkey")]
-    #[test_case(true, false; "add bls pubkey")]
-    #[test_case(false, false; "no bls pubkey")]
+    #[test_case(true, true, false; "add bls compressed pubkey")]
+    #[test_case(true, true, true; "add bls base58 compressed pubkey")]
+    #[test_case(true, false, false; "add bls pubkey")]
+    #[test_case(false, false, false; "no bls pubkey")]
     fn test_append_validator_accounts_to_genesis(
         add_bls_pubkey: bool,
         use_compressed_pubkey: bool,
+        use_base58_pubkey: bool,
     ) {
         // Test invalid file returns error
         assert!(
@@ -1382,7 +1378,11 @@ mod tests {
                 let bls_pubkey: BLSPubkey = BLSKeypair::new().public.into_inner().into();
                 if use_compressed_pubkey {
                     let bls_pubkey_compressed: BLSPubkeyCompressed = bls_pubkey.try_into().unwrap();
-                    Some(bls_pubkey_compressed.to_string())
+                    if use_base58_pubkey {
+                        Some(bs58::encode(bls_pubkey_compressed.0).into_string())
+                    } else {
+                        Some(bls_pubkey_compressed.to_string())
+                    }
                 } else {
                     Some(bls_pubkey.to_string())
                 }
@@ -1423,7 +1423,9 @@ mod tests {
         let filename = format!(
             "test_append_validator_accounts_to_genesis_{}_{}_bls.yml",
             if add_bls_pubkey { "with" } else { "without" },
-            if use_compressed_pubkey {
+            if use_base58_pubkey {
+                "base58_compressed"
+            } else if use_compressed_pubkey {
                 "compressed"
             } else {
                 "uncompressed"
@@ -1466,15 +1468,9 @@ mod tests {
                 let authorized_voters = &vote_state.authorized_voters;
                 assert_eq!(authorized_voters.first().unwrap().1, &identity_pk);
                 if add_bls_pubkey {
-                    let bls_pubkey_compressed_from_input = if use_compressed_pubkey {
-                        BLSPubkeyCompressed::from_str(b64_account.bls_pubkey.as_ref().unwrap())
-                            .expect("failed to parse BLS pubkey from input")
-                    } else {
-                        BLSPubkey::from_str(b64_account.bls_pubkey.as_ref().unwrap())
-                            .expect("failed to parse BLS pubkey from input")
-                            .try_into()
-                            .expect("failed to convert BLS pubkey to compressed form")
-                    };
+                    let bls_pubkey_compressed_from_input =
+                        bls_pubkey_from_str(b64_account.bls_pubkey.as_ref().unwrap())
+                            .expect("failed to parse BLS pubkey from input");
                     let bls_pubkey_compressed_from_account = BLSPubkeyCompressed(
                         vote_state
                             .bls_pubkey_compressed

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -6,7 +6,7 @@ use {
         Arg, ArgAction, ArgMatches, Command, builder::ValueParser, crate_description, crate_name,
         value_parser,
     },
-    solana_bls_signatures::{Pubkey as BLSPubkey, keypair::Keypair as BLSKeypair},
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clap_v3_utils::{
         DisplayError,
         input_parsers::{
@@ -394,7 +394,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
         )
         .subcommand(
             Command::new("bls_pubkey")
-                .about("Display the BLS pubkey derived from given ed25519 keypair file")
+                .about("Display the compressed BLS pubkey derived from given ed25519 keypair file")
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("keypair")
@@ -485,13 +485,17 @@ fn write_pubkey_file(outfile: &str, pubkey: Pubkey) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
+fn format_bls_pubkey_compressed(bls_pubkey_compressed: &[u8]) -> String {
+    bs58::encode(bls_pubkey_compressed).into_string()
+}
+
 fn write_bls_pubkey_file(
     outfile: &str,
-    bls_pubkey: BLSPubkey,
+    bls_pubkey_compressed: &[u8],
 ) -> Result<(), Box<dyn std::error::Error>> {
     use std::io::Write;
 
-    let printable = format!("{bls_pubkey}");
+    let printable = format_bls_pubkey_compressed(bls_pubkey_compressed);
     let serialized = serde_json::to_string(&printable)?;
 
     if let Some(outdir) = std::path::Path::new(&outfile).parent() {
@@ -538,14 +542,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
         ("bls_pubkey", matches) => {
             let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
             let bls_keypair = BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?;
-            let bls_pubkey: BLSPubkey = bls_keypair.public.into_inner().into();
+            let bls_pubkey_compressed = bls_keypair.public.to_bytes_compressed();
 
             if matches.try_contains_id("outfile")? {
                 let outfile = matches.get_one::<String>("outfile").unwrap();
                 check_for_overwrite(outfile, matches)?;
-                write_bls_pubkey_file(outfile, bls_pubkey)?;
+                write_bls_pubkey_file(outfile, &bls_pubkey_compressed)?;
             } else {
-                println!("{bls_pubkey}");
+                println!("{}", format_bls_pubkey_compressed(&bls_pubkey_compressed));
             }
         }
         ("new", matches) => {
@@ -907,12 +911,11 @@ mod tests {
         Ok(Pubkey::from_str(&printable)?)
     }
 
-    fn read_bls_pubkey_file(infile: &str) -> Result<BLSPubkey, Box<dyn std::error::Error>> {
+    fn read_bls_pubkey_file(infile: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         let f = std::fs::File::open(infile)?;
         let printable: String = serde_json::from_reader(f)?;
 
-        use std::str::FromStr;
-        Ok(BLSPubkey::from_str(&printable)?)
+        Ok(bs58::decode(printable).into_vec()?)
     }
 
     fn process_test_command(args: &[&str]) -> Result<(), Box<dyn error::Error>> {
@@ -1292,8 +1295,8 @@ mod tests {
     fn test_read_write_bls_pubkey() -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         let filename = "test_bls_pubkey.json";
         let bls_keypair = BLSKeypair::new();
-        let bls_pubkey: BLSPubkey = bls_keypair.public.into_inner().into();
-        write_bls_pubkey_file(filename, bls_pubkey)?;
+        let bls_pubkey = bls_keypair.public.to_bytes_compressed();
+        write_bls_pubkey_file(filename, &bls_pubkey)?;
         let read = read_bls_pubkey_file(filename)?;
         assert_eq!(read, bls_pubkey);
         std::fs::remove_file(filename)?;
@@ -1323,7 +1326,7 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(&my_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
         let read_bls_pubkey = read_bls_pubkey_file(&outfile_path).unwrap();
-        assert_eq!(read_bls_pubkey, bls_keypair.public.into_inner().into());
+        assert_eq!(read_bls_pubkey, bls_keypair.public.to_bytes_compressed());
     }
 
     #[test]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6225,6 +6225,7 @@ dependencies = [
 name = "solana-clap-utils"
 version = "4.2.0-alpha.0"
 dependencies = [
+ "bs58",
  "chrono",
  "clap",
  "rpassword",


### PR DESCRIPTION
#### Problem
`solana vote-account` displays the BLS pubkey on the vote account in the compressed format, whereas `solana-keygen bls_pubkey` displays it as uncompressed.

This caused confusion when operators set their BLS pubkey on testnet as the two commands showed different outputs.

#### Summary of Changes
In agave we only use the compressed format, so display it as compressed in `solana-keygen bls_pubkey`
Update `solana-genesis` to be able to accept the b58 format

#### Testing
```sh
~ solana -ul vote-account ~/community-cluster/keys/priv/vote.json | grep "BLS Public Key:"
BLS Public Key: 6wikmE4oPuhqqL4mUT3nx47NcB7WWZySMdWe5dWHJ5q4HejGYZppm1aX95bsDsFqM5
```

Without this change
```sh
~ solana-keygen bls_pubkey ~/community-cluster/keys/priv/id.json
AgYqghVtyigxQDAsQ1H0l2HfJsTn8hRL3H9+37BR5bU6B5zv0LmaTidDAZTZPwucGDjbCS1P7LAYqAMp/uUMAC2K5CdBDjTCyzhD+PqgptOYk9PwjBofVSiQqV/0hz4u
```

With the change
```sh
~ solana-keygen bls_pubkey ~/community-cluster/keys/priv/id.json
6wikmE4oPuhqqL4mUT3nx47NcB7WWZySMdWe5dWHJ5q4HejGYZppm1aX95bsDsFqM5
```