### PR TITLE
votor: commitment cache update on rooted not finalization certificate

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -193,9 +193,9 @@ impl AggregateCommitmentService {
                 // Notarize (our first round vote in favor of a block) satisfies the Processed commitment level
                 w_block_commitment_cache.set_slot(slot);
             }
-            AlpenglowCommitmentType::Finalized => {
+            AlpenglowCommitmentType::Rooted => {
                 // There is no distinction of OC, root, or finalized in Alpengow commitment.
-                // When receiving a finalilzation certificate we set all of these values.
+                // Once votor selects a finalized bank as root, set all of these values.
                 w_block_commitment_cache.set_highest_confirmed_slot(slot);
                 w_block_commitment_cache.set_root(slot);
                 w_block_commitment_cache.set_highest_super_majority_root(slot);

--- a/votor/src/commitment.rs
+++ b/votor/src/commitment.rs
@@ -14,8 +14,8 @@ pub enum CommitmentError {
 pub enum CommitmentType {
     /// Our node has voted notarize for the slot
     Notarize,
-    /// We have observed a finalization certificate for the slot
-    Finalized,
+    /// Votor has selected the slot as root
+    Rooted,
 }
 
 #[derive(Debug, PartialEq)]
@@ -65,7 +65,7 @@ mod tests {
             }
         );
         let slot = 5;
-        let commitment_type = CommitmentType::Finalized;
+        let commitment_type = CommitmentType::Rooted;
         update_commitment_cache(commitment_type, slot, &commitment_sender)
             .expect("Failed to send commitment data");
         let received_data = commitment_receiver
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(
             received_data,
             CommitmentAggregationData {
-                commitment_type: CommitmentType::Finalized,
+                commitment_type: CommitmentType::Rooted,
                 slot,
             }
         );

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -5,7 +5,6 @@ mod stats;
 
 use {
     crate::{
-        commitment::{CommitmentAggregationData, CommitmentType, update_commitment_cache},
         common::DELTA_STANDSTILL,
         consensus_pool::{
             AddVoteError, ConsensusPool,
@@ -59,7 +58,6 @@ pub(crate) struct ConsensusPoolContext {
 
     pub(crate) bls_sender: Sender<BLSOp>,
     pub(crate) event_sender: VotorEventSender,
-    pub(crate) commitment_sender: Sender<CommitmentAggregationData>,
     pub(crate) repair_event_sender: RepairEventSender,
 
     /// Used to communicate the highest finalization cert the pool has observed to the block creation loop.
@@ -189,17 +187,15 @@ impl ConsensusPoolService {
             }
         }
         let root_bank = ctx.sharable_banks.root();
-        let (new_finalized_slot, new_certificates_to_send) =
-            Self::add_message_and_maybe_update_commitment(
-                &root_bank,
-                &ctx.cluster_info.id(),
-                &ctx.my_vote_pubkey,
-                message,
-                consensus_pool,
-                events,
-                &ctx.commitment_sender,
-                stats,
-            )?;
+        let (new_finalized_slot, new_certificates_to_send) = Self::add_message(
+            &root_bank,
+            &ctx.cluster_info.id(),
+            &ctx.my_vote_pubkey,
+            message,
+            consensus_pool,
+            events,
+            stats,
+        )?;
         Self::maybe_update_root_and_send_new_certificates(
             consensus_pool,
             &ctx.sharable_banks,
@@ -419,17 +415,16 @@ impl ConsensusPoolService {
         Ok(())
     }
 
-    /// Adds a vote to the certificate pool and updates the commitment cache if necessary
+    /// Adds a vote to the certificate pool.
     ///
     /// If a new finalization slot was recognized, returns the slot
-    fn add_message_and_maybe_update_commitment(
+    fn add_message(
         root_bank: &Bank,
         my_pubkey: &Pubkey,
         my_vote_pubkey: &Pubkey,
         message: ConsensusMessage,
         consensus_pool: &mut ConsensusPool,
         votor_events: &mut Vec<VotorEvent>,
-        commitment_sender: &Sender<CommitmentAggregationData>,
         stats: &mut ConsensusPoolServiceStats,
     ) -> Result<(Option<Slot>, Vec<Arc<Certificate>>), AddVoteError> {
         let (new_finalized_slot, new_certificates_to_send) =
@@ -438,11 +433,7 @@ impl ConsensusPoolService {
             return Ok((None, new_certificates_to_send));
         };
         trace!("{my_pubkey}: new finalization certificate for {new_finalized_slot}");
-        update_commitment_cache(
-            CommitmentType::Finalized,
-            new_finalized_slot,
-            commitment_sender,
-        )?;
+        // RPC-facing finalized commitment is updated after votor selects a root.
         stats.standstill = false;
         Ok((Some(new_finalized_slot), new_certificates_to_send))
     }
@@ -646,8 +637,6 @@ mod tests {
         consensus_pool: ConsensusPool,
         bls_sender: Sender<BLSOp>,
         bls_receiver: Receiver<BLSOp>,
-        commitment_sender: Sender<CommitmentAggregationData>,
-        commitment_receiver: Receiver<CommitmentAggregationData>,
         validator_keypairs: Vec<ValidatorVoteKeypairs>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         sharable_banks: SharableBanks,
@@ -662,8 +651,6 @@ mod tests {
     impl Default for TestContext {
         fn default() -> Self {
             let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
-            let (commitment_sender, commitment_receiver) = crossbeam_channel::unbounded();
-
             // Create 10 node validatorvotekeypairs vec
             let validator_keypairs = (0..10)
                 .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -706,8 +693,6 @@ mod tests {
                 consensus_pool,
                 bls_sender,
                 bls_receiver,
-                commitment_sender,
-                commitment_receiver,
                 validator_keypairs,
                 leader_schedule_cache,
                 sharable_banks,
@@ -724,8 +709,7 @@ mod tests {
     /// Test the full consensus message flow:
     /// 1. Validators 0-7 send notarize votes for slot 2. After processing all
     ///    votes, we expect a notarize/finalize certificate to be produced and
-    ///    forwarded via the BLS channel, a finalized event to be emitted, and a
-    ///    commitment update to be sent.
+    ///    forwarded via the BLS channel and a finalized event to be emitted.
     /// 2. A skip certificate is then sent for slot 3 and we verify it is
     ///    immediately forwarded via the BLS channel.
     #[test]
@@ -754,14 +738,13 @@ mod tests {
             });
 
             let mut stats = ConsensusPoolServiceStats::new();
-            let result = ConsensusPoolService::add_message_and_maybe_update_commitment(
+            let result = ConsensusPoolService::add_message(
                 &root_bank,
                 &ctx.my_pubkey,
                 &ctx.my_vote_pubkey,
                 message,
                 &mut ctx.consensus_pool,
                 &mut events,
-                &ctx.commitment_sender,
                 &mut stats,
             );
             assert!(result.is_ok());
@@ -817,17 +800,6 @@ mod tests {
             "Should have received a finalized event"
         );
 
-        // Verify that we received a commitment update
-        let commitment = ctx.commitment_receiver.try_recv();
-        assert!(commitment.is_ok());
-        let CommitmentAggregationData {
-            commitment_type,
-            slot,
-            ..
-        } = commitment.unwrap();
-        assert_eq!(commitment_type, CommitmentType::Finalized);
-        assert_eq!(slot, target_slot);
-
         // Now send a Skip certificate on slot 3, should be forwarded immediately
         let target_slot = 3;
         let skip_certificate = Certificate {
@@ -838,14 +810,13 @@ mod tests {
         events.clear();
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result = ConsensusPoolService::add_message_and_maybe_update_commitment(
+        let result = ConsensusPoolService::add_message(
             &root_bank,
             &ctx.my_pubkey,
             &ctx.my_vote_pubkey,
             ConsensusMessage::Certificate(skip_certificate),
             &mut ctx.consensus_pool,
             &mut events,
-            &ctx.commitment_sender,
             &mut stats,
         );
         assert!(result.is_ok());
@@ -902,14 +873,13 @@ mod tests {
                 bitmap: vec![],
             };
 
-            let result = ConsensusPoolService::add_message_and_maybe_update_commitment(
+            let result = ConsensusPoolService::add_message(
                 &root_bank,
                 &ctx.my_pubkey,
                 &ctx.my_vote_pubkey,
                 ConsensusMessage::Certificate(skip_certificate),
                 &mut ctx.consensus_pool,
                 &mut events,
-                &ctx.commitment_sender,
                 &mut stats,
             );
             assert!(result.is_ok());
@@ -930,7 +900,6 @@ mod tests {
             consensus_message_receiver: crossbeam_channel::unbounded().1,
             bls_sender: ctx.bls_sender.clone(),
             event_sender: crossbeam_channel::unbounded().0,
-            commitment_sender: ctx.commitment_sender.clone(),
             highest_finalized: ctx.highest_finalized.clone(),
             repair_event_sender,
         };
@@ -995,7 +964,6 @@ mod tests {
             consensus_message_receiver,
             bls_sender: ctx.bls_sender.clone(),
             event_sender,
-            commitment_sender: ctx.commitment_sender.clone(),
             highest_finalized: ctx.highest_finalized.clone(),
             repair_event_sender,
         };

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -1,5 +1,10 @@
 use {
-    crate::{event_handler::PendingBlocks, voting_utils::VotingContext, votor::SharedContext},
+    crate::{
+        commitment::{CommitmentType, update_commitment_cache},
+        event_handler::PendingBlocks,
+        voting_utils::VotingContext,
+        votor::SharedContext,
+    },
     agave_votor_messages::consensus_message::Block,
     crossbeam_channel::Sender,
     solana_clock::Slot,
@@ -59,6 +64,12 @@ pub(crate) fn set_root(
             "failed to record optimistic slot in blockstore: slot={}: {:?}",
             new_root, &e
         );
+    }
+
+    if let Err(err) =
+        update_commitment_cache(CommitmentType::Rooted, new_root, &vctx.commitment_sender)
+    {
+        warn!("failed to update Alpenglow rooted commitment for root {new_root}: {err}");
     }
 
     // It is critical to send the OC notification in order to keep compatibility with

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -240,7 +240,6 @@ impl Votor {
             consensus_message_receiver,
             bls_sender,
             event_sender,
-            commitment_sender,
             repair_event_sender,
             highest_finalized,
         };


### PR DESCRIPTION
#### Problem
In Alpenglow we currently update the root & highest super majority root for RPC when we receive a finalization certificate.

The issue is that we might receive the finalization certificate before we have the bank frozen.
This then becomes a problem when RPC tries to serve out of the finalized commitment as the bank is missing.
It also leads to false reporting where the values in ledger monitor are increasing, however the node is not actually making progress.

#### Summary of Changes
Instead plug this into rooting as then we know that the RPC will have the bank available.