### PR TITLE
override vote transaction requested cu limit config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10093,6 +10093,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-vote-program",
  "wincode",
 ]
 

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -35,6 +35,7 @@ solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-vote-program = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -59,9 +59,16 @@ impl<T> TransactionMeta for RuntimeTransaction<T> {
         &self,
         feature_set: &FeatureSet,
     ) -> Result<TransactionConfiguration, TransactionError> {
-        self.meta
+        let mut config = self
+            .meta
             .versioned_transaction_config
-            .try_into_config(feature_set)
+            .try_into_config(feature_set)?;
+        if self.meta.is_simple_vote_transaction {
+            config.compute_unit_limit =
+                u32::try_from(solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS)
+                    .expect("vote default compute units fit in u32");
+        }
+        Ok(config)
     }
     fn instruction_data_len(&self) -> u16 {
         self.meta.instruction_data_len

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -256,11 +256,15 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
 mod tests {
     use {
         super::*,
+        agave_feature_set::FeatureSet,
         agave_reserved_account_keys::ReservedAccountKeys,
         solana_hash::Hash,
+        solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_message::{AddressLookupTableAccount, SimpleAddressLoader, v0},
+        solana_sdk_ids::vote,
         solana_signature::Signature,
+        solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_system_transaction as system_transaction,
     };
@@ -302,6 +306,56 @@ mod tests {
 
         assert_eq!(hash, *dynamic_runtime_transaction.message_hash());
         assert!(!dynamic_runtime_transaction.is_simple_vote_transaction());
+    }
+
+    #[test]
+    fn test_simple_vote_transaction_configuration_uses_vote_default_compute_unit_limit() {
+        let block_hash = Hash::new_unique();
+        let vote_keypair = Keypair::new();
+        let node_keypair = Keypair::new();
+        let auth_keypair = Keypair::new();
+        let vote_ix = Instruction::new_with_bytes(
+            vote::id(),
+            &[],
+            vec![
+                AccountMeta::new(vote_keypair.pubkey(), false),
+                AccountMeta::new_readonly(auth_keypair.pubkey(), true),
+            ],
+        );
+        let mut vote_tx = solana_transaction::Transaction::new_with_payer(
+            &[vote_ix],
+            Some(&node_keypair.pubkey()),
+        );
+        vote_tx.partial_sign(&[&node_keypair], block_hash);
+        vote_tx.partial_sign(&[&auth_keypair], block_hash);
+
+        let serialized_transaction =
+            wincode::serialize(&VersionedTransaction::from(vote_tx)).unwrap();
+        let transaction =
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+        let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            transaction,
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+
+        assert!(runtime_transaction.is_simple_vote_transaction());
+
+        let runtime_transaction = RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+            runtime_transaction,
+            None,
+            &ReservedAccountKeys::empty_key_set(),
+        )
+        .unwrap();
+        let config = runtime_transaction
+            .transaction_configuration(&FeatureSet::all_enabled())
+            .unwrap();
+
+        assert_eq!(
+            config.compute_unit_limit,
+            u32::try_from(solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem


#### Summary of Changes
- RuntimeTransaction overrides vote transaction's `config.compute_unit_limit` to const value

Fixes #
