### PR TITLE
repair: switch to wincode

### DIFF
--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -454,7 +454,7 @@ impl AncestorHashesService {
                 }
                 stats.ping_count += 1;
                 let pong = RepairProtocol::Pong(Pong::new(&ping, keypair));
-                if let Ok(pong) = bincode::serialize(&pong) {
+                if let Ok(pong) = wincode::serialize(&pong) {
                     let _ = ancestor_socket.send_to(&pong, from_addr);
                 }
                 None

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -689,7 +689,7 @@ impl BlockIdRepairService {
             return;
         }
         let pong = RepairProtocol::Pong(Pong::new(ping, keypair));
-        let pong_bytes = bincode::serialize(&pong).expect("Pong serialization should not fail");
+        let pong_bytes = wincode::serialize(&pong).expect("Pong serialization should not fail");
 
         match block_id_repair_socket.send_to(&pong_bytes, addr) {
             Ok(bytes_sent) if bytes_sent == pong_bytes.len() => {
@@ -1066,7 +1066,6 @@ impl BlockIdRepairService {
 mod tests {
     use {
         super::*,
-        bincode::Options,
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo, ping_pong::Ping},
         solana_hash::Hash,
         solana_keypair::{Keypair, Signer},
@@ -1103,11 +1102,7 @@ mod tests {
 
     /// Serialize a response and nonce into packet format
     fn serialize_response(response: &BlockIdRepairResponse, nonce: u32) -> Vec<u8> {
-        bincode::options()
-            .with_fixint_encoding()
-            .allow_trailing_bytes()
-            .serialize(&(response, nonce))
-            .unwrap()
+        wincode::serialize(&(response, nonce)).unwrap()
     }
 
     /// Create a packet from serialized data
@@ -1238,7 +1233,7 @@ mod tests {
             parent_proof: parent_proof.clone(),
         };
 
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let packet = make_packet(&data);
         let packet_data = packet.data(..).unwrap();
 
@@ -1270,7 +1265,7 @@ mod tests {
             fec_set_proof: fec_set_proof.clone(),
         };
 
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let packet = make_packet(&data);
         let packet_data = packet.data(..).unwrap();
 
@@ -1612,7 +1607,7 @@ mod tests {
         let ping = Ping::new([7u8; 32], &ping_keypair);
         state.expect_ping_response(ping_keypair.pubkey(), from_addr, timestamp());
         let response = BlockIdRepairResponse::Ping { ping };
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let mut packet = make_packet(&data);
         packet.meta_mut().set_socket_addr(&from_addr);
 
@@ -1634,7 +1629,7 @@ mod tests {
             .unwrap();
         let mut buffer = vec![0; 2048];
         let (size, _) = pong_receiver.recv_from(&mut buffer).unwrap();
-        match bincode::deserialize(&buffer[..size]).unwrap() {
+        match wincode::deserialize(&buffer[..size]).unwrap() {
             RepairProtocol::Pong(pong) => assert!(pong.verify()),
             request => panic!("Expected Pong response, got {request:?}"),
         }
@@ -1652,7 +1647,7 @@ mod tests {
 
         let first_ping = Ping::new([1u8; 32], &ping_keypair);
         let response = BlockIdRepairResponse::Ping { ping: first_ping };
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let mut packet = make_packet(&data);
         packet.meta_mut().set_socket_addr(&from_addr);
         BlockIdRepairService::process_block_id_repair_response(
@@ -1665,7 +1660,7 @@ mod tests {
 
         let second_ping = Ping::new([2u8; 32], &ping_keypair);
         let response = BlockIdRepairResponse::Ping { ping: second_ping };
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let mut packet = make_packet(&data);
         packet.meta_mut().set_socket_addr(&from_addr);
         BlockIdRepairService::process_block_id_repair_response(
@@ -1690,7 +1685,7 @@ mod tests {
         let from_addr = SocketAddr::from(([127, 0, 0, 1], 1234));
         let ping = Ping::new([7u8; 32], &ping_keypair);
         let response = BlockIdRepairResponse::Ping { ping };
-        let data = bincode::serialize(&response).unwrap();
+        let data = wincode::serialize(&response).unwrap();
         let mut packet = make_packet(&data);
         packet.meta_mut().set_socket_addr(&from_addr);
 

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -10,7 +10,6 @@ use {
         serve_repair::{AncestorHashesResponse, BlockIdRepairResponse, MAX_ANCESTOR_RESPONSES},
     },
     agave_votor_messages::migration::MigrationStatus,
-    bincode::serialize,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
@@ -30,16 +29,20 @@ use {
         net::SocketAddr,
         sync::{Arc, RwLock},
     },
+    wincode::{SchemaWrite, serialize},
 };
 
 /// Helper function to create a PacketBatch from a serializable response
-fn create_response_packet_batch<T: serde::Serialize>(
+fn create_response_packet_batch<T>(
     recycler: &PacketBatchRecycler,
     response: &T,
     from_addr: &SocketAddr,
     nonce: Nonce,
     debug_label: &'static str,
-) -> Option<PacketBatch> {
+) -> Option<PacketBatch>
+where
+    T: SchemaWrite<wincode::config::DefaultConfig, Src = T>,
+{
     let serialized_response = serialize(response).ok()?;
     let packet =
         repair_response::repair_response_packet_from_bytes(serialized_response, from_addr, nonce)?;
@@ -421,7 +424,7 @@ mod tests {
 
             let packet = packet_batch.iter().next().unwrap();
             let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
-                bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+                wincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
 
             assert_eq!(response_nonce, nonce);
             match response {
@@ -488,7 +491,7 @@ mod tests {
 
         let packet = packet_batch.iter().next().unwrap();
         let (response, response_nonce): (BlockIdRepairResponse, Nonce) =
-            bincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
+            wincode::deserialize(packet.data(..packet.meta().size).unwrap()).unwrap();
 
         assert_eq!(response_nonce, nonce);
         match response {

--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -38,7 +38,7 @@ pub fn repair_response_packet_from_bytes(
     packet.meta_mut().set_socket_addr(dest);
     packet.buffer_mut()[..bytes.len()].copy_from_slice(bytes);
     let mut wr = io::Cursor::new(&mut packet.buffer_mut()[bytes.len()..]);
-    bincode::serialize_into(&mut wr, &nonce).expect("Buffer not large enough to fit nonce");
+    wincode::serialize_into(&mut wr, &nonce).expect("Buffer not large enough to fit nonce");
     Some(packet)
 }
 

--- a/core/src/repair/result.rs
+++ b/core/src/repair/result.rs
@@ -30,7 +30,9 @@ pub enum Error {
     #[error("Send Error")]
     SendError,
     #[error(transparent)]
-    Serialize(#[from] std::boxed::Box<bincode::ErrorKind>),
+    Serialize(#[from] wincode::WriteError),
+    #[error(transparent)]
+    Deserialize(#[from] wincode::ReadError),
     #[error(transparent)]
     WeightedIndex(#[from] rand::distr::weighted::Error),
 }

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "frozen-abi")]
+use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use {
     crate::repair::standard_repair_handler::StandardRepairHandler,
@@ -17,7 +19,6 @@ use {
         },
     },
     agave_votor_messages::{consensus_message::Block, migration::MigrationStatus},
-    bincode::{Options, serialize},
     crossbeam_channel::{Receiver, RecvTimeoutError},
     lazy_lru::LruCache,
     rand::{
@@ -27,7 +28,6 @@ use {
             weighted::{Error as WeightedError, WeightedIndex},
         },
     },
-    serde::{Deserialize, Serialize},
     solana_clock::Slot,
     solana_gossip::{
         cluster_info::{ClusterInfo, ClusterInfoError},
@@ -47,7 +47,8 @@ use {
     solana_net_utils::{SocketAddrSpace, token_bucket::TokenBucket},
     solana_packet::PACKET_DATA_SIZE,
     solana_perf::packet::{
-        BytesPacket, Packet, PacketBatch, PacketBatchRecycler, PacketRef, RecycledPacketBatch,
+        BytesPacket, Packet, PacketBatch, PacketBatchRecycler, PacketConfig, PacketRef,
+        RecycledPacketBatch, packet_from_data,
     },
     solana_poh::poh_recorder::SharedLeaderState,
     solana_pubkey::{PUBKEY_BYTES, Pubkey},
@@ -71,7 +72,7 @@ use {
         thread::{Builder, JoinHandle},
         time::{Duration, Instant},
     },
-    wincode::{SchemaRead, SchemaWrite},
+    wincode::{SchemaRead, SchemaWrite, serialize},
 };
 
 /// the number of slots to respond with when responding to `Orphan` requests
@@ -103,7 +104,7 @@ const SIGNED_REPAIR_TIME_WINDOW: Duration = Duration::from_secs(60 * 10); // 10 
 #[cfg(test)]
 static_assertions::const_assert_eq!(MAX_ANCESTOR_RESPONSES, 30);
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum ShredRepairType {
     /// Requesting `MAX_ORPHAN_REPAIR_RESPONSES ` parent shreds
     Orphan(Slot),
@@ -190,7 +191,16 @@ impl AncestorHashesRepairType {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi, StableAbiSample, Deserialize, Serialize, PartialEq),
+    frozen_abi(
+        abi_digest = "DhEfFPRMwZSyPVCX3wqoK3u7LvrWaK6SE7q6uLXSJ5ph",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Debug, SchemaRead, SchemaWrite)]
 pub enum AncestorHashesResponse {
     Hashes(Vec<(Slot, Hash)>),
     Ping(Ping),
@@ -236,7 +246,16 @@ impl BlockIdRepairType {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi, StableAbiSample, Deserialize, Serialize, PartialEq),
+    frozen_abi(
+        abi_digest = "4UwjM1HevzQRxGkh6L9vXhf1db7y2ioQYTXRUaKZ4iNo",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Debug, SchemaRead, SchemaWrite)]
 pub enum BlockIdRepairResponse {
     ParentFecSetCount {
         fec_set_count: u32,
@@ -371,8 +390,11 @@ struct ServeRepairStats {
     err_id_mismatch: usize,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi))]
-#[derive(Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, Deserialize, Serialize, PartialEq)
+)]
+#[derive(Debug, SchemaRead, SchemaWrite)]
 pub struct RepairRequestHeader {
     signature: Signature,
     sender: Pubkey,
@@ -423,13 +445,17 @@ type PingCache = ping_pong::PingCache<REPAIR_PING_TOKEN_SIZE>;
 /// The message can then be removed once the feature gate is active and there are no responders.
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiEnumVisitor, AbiExample, StableAbi),
+    derive(
+        AbiEnumVisitor, AbiExample, StableAbi, Deserialize, Serialize, PartialEq,
+    ),
     frozen_abi(
         api_digest = "2j14Ywc3jWmohnXsEuMUQRPLf7JmxAVKvXKeKpYuzg7S",
-        abi_digest = "D5RRQygn3D6ux1TYxeyXdksWD2KGA8PYi315hXP3JJ7c"
+        abi_digest = "D5RRQygn3D6ux1TYxeyXdksWD2KGA8PYi315hXP3JJ7c",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
     )
 )]
-#[derive(Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[derive(Debug, SchemaRead, SchemaWrite)]
 pub enum RepairProtocol {
     LegacyWindowIndex,
     LegacyHighestWindowIndex,
@@ -546,7 +572,19 @@ fn is_well_formed_repair_request(packet: &PacketRef, stats: &mut ServeRepairStat
     well_formed
 }
 
-#[derive(Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(
+        AbiEnumVisitor, AbiExample, StableAbi, StableAbiSample, Deserialize, Serialize, PartialEq,
+    ),
+    frozen_abi(
+        api_digest = "2atc1j4n5MjGtmAYoL157stGow5ajeDtqAyMhwcniy5b",
+        abi_digest = "5qmbs9MjvFrMQ2DYmre88SLLjLLDx3pdEW37cKUEQKMK",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Debug, SchemaRead, SchemaWrite)]
 pub(crate) enum RepairResponse {
     Ping(Ping),
 }
@@ -1467,15 +1505,15 @@ impl ServeRepair {
                 | RepairProtocol::Orphan { .. }
                 | RepairProtocol::WindowIndexForBlockId { .. } => {
                     let ping = RepairResponse::Ping(ping);
-                    Packet::from_data(Some(from_addr), ping).ok()
+                    packet_from_data(Some(from_addr), ping).ok()
                 }
                 RepairProtocol::ParentAndFecSetCount { .. } | RepairProtocol::FecSetRoot { .. } => {
                     let ping = BlockIdRepairResponse::Ping { ping };
-                    Packet::from_data(Some(from_addr), ping).ok()
+                    packet_from_data(Some(from_addr), ping).ok()
                 }
                 RepairProtocol::AncestorHashes { .. } => {
                     let ping = AncestorHashesResponse::Ping(ping);
-                    Packet::from_data(Some(from_addr), ping).ok()
+                    packet_from_data(Some(from_addr), ping).ok()
                 }
                 RepairProtocol::Pong(_) => None,
                 RepairProtocol::LegacyWindowIndex
@@ -1871,7 +1909,7 @@ impl ServeRepair {
                 packet.meta_mut().set_discard(true);
                 stats.ping_count += 1;
                 let pong = RepairProtocol::Pong(Pong::new(&ping, keypair));
-                if let Ok(pong) = bincode::serialize(&pong) {
+                if let Ok(pong) = wincode::serialize(&pong) {
                     let from_addr = packet.meta().socket_addr();
                     pending_pongs.push((pong, from_addr));
                 }
@@ -1926,15 +1964,11 @@ impl ServeRepair {
 
 pub(crate) fn deserialize_request<T>(
     request: &BytesPacket,
-) -> std::result::Result<T, bincode::Error>
+) -> std::result::Result<T, wincode::ReadError>
 where
-    T: serde::de::DeserializeOwned,
+    T: for<'de> SchemaRead<'de, PacketConfig, Dst = T>,
 {
-    bincode::options()
-        .with_limit(request.buffer().len() as u64)
-        .with_fixint_encoding()
-        .reject_trailing_bytes()
-        .deserialize(request.buffer())
+    wincode::config::deserialize_exact(request.buffer(), PacketConfig::new())
 }
 
 #[cfg(test)]
@@ -1957,7 +1991,9 @@ mod tests {
             },
         },
         solana_net_utils::SocketAddrSpace,
-        solana_perf::packet::{Packet, PacketFlags, PacketRef},
+        solana_perf::packet::{
+            Packet, PacketFlags, PacketRef, RecycledPacketBatch, deserialize_slice_from_packet,
+        },
         solana_pubkey::Pubkey,
         solana_runtime::bank::Bank,
         solana_time_utils::timestamp,
@@ -1981,7 +2017,7 @@ mod tests {
         let keypair = Keypair::new();
         let ping = Ping::new(rng.random(), &keypair);
         let ping = RepairResponse::Ping(ping);
-        let pkt = Packet::from_data(None, ping).unwrap();
+        let pkt = packet_from_data(None, ping).unwrap();
         assert_eq!(pkt.meta().size, REPAIR_RESPONSE_SERIALIZED_PING_BYTES);
     }
 
@@ -1992,7 +2028,7 @@ mod tests {
         let mut pkt = Packet::default();
         shred.copy_to_packet(&mut pkt);
         pkt.meta_mut().size = REPAIR_RESPONSE_SERIALIZED_PING_BYTES;
-        let res = pkt.deserialize_slice::<RepairResponse, _>(..);
+        let res = deserialize_slice_from_packet::<RepairResponse, _>(&pkt, ..);
         if let Ok(RepairResponse::Ping(ping)) = res {
             assert!(!ping.verify());
         } else {
@@ -2029,7 +2065,8 @@ mod tests {
         let (check, ping_pkt) =
             ServeRepair::check_ping_cache(&mut ping_cache, &request, &from_addr, &identity_keypair);
         assert!(!check);
-        let response: BlockIdRepairResponse = ping_pkt.unwrap().deserialize_slice(..).unwrap();
+        let response: BlockIdRepairResponse =
+            deserialize_slice_from_packet(&ping_pkt.unwrap(), ..).unwrap();
         match response {
             BlockIdRepairResponse::Ping { ping } => assert!(ping.verify()),
             response => panic!("Expected Ping challenge, got {response:?}"),
@@ -2068,7 +2105,7 @@ mod tests {
         let ping = Ping::new(rng.random(), &keypair);
         let pong = Pong::new(&ping, &keypair);
         let request = RepairProtocol::Pong(pong);
-        let mut pkt = Packet::from_data(None, request).unwrap();
+        let mut pkt = packet_from_data(None, request).unwrap();
         let mut batch = vec![make_remote_request(&pkt)];
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -2085,7 +2122,7 @@ mod tests {
             slot: 123,
             shred_index: 456,
         };
-        let mut pkt = Packet::from_data(None, request).unwrap();
+        let mut pkt = packet_from_data(None, request).unwrap();
         let mut batch = vec![make_remote_request(&pkt)];
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -2101,7 +2138,7 @@ mod tests {
             header: repair_request_header_for_tests(),
             slot: 123,
         };
-        let mut pkt = Packet::from_data(None, request).unwrap();
+        let mut pkt = packet_from_data(None, request).unwrap();
         let mut batch = vec![make_remote_request(&pkt)];
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -2117,7 +2154,7 @@ mod tests {
             header: repair_request_header_for_tests(),
             slot: 262_547_696,
         };
-        let mut pkt = Packet::from_data(None, request).unwrap();
+        let mut pkt = packet_from_data(None, request).unwrap();
         let mut batch = vec![make_remote_request(&pkt)];
         let mut stats = ServeRepairStats::default();
         let num_well_formed = discard_malformed_repair_requests(&mut batch, &mut stats);
@@ -2332,11 +2369,11 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, request).unwrap();
+            let mut packet = packet_from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
-        let request: RepairProtocol = packet.deserialize_slice(..).unwrap();
+        let request: RepairProtocol = deserialize_slice_from_packet(&packet, ..).unwrap();
         assert_matches!(
             ServeRepair::verify_signed_packet(
                 &other_keypair.pubkey(),
@@ -2356,11 +2393,11 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, request).unwrap();
+            let mut packet = packet_from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
-        let request: RepairProtocol = packet.deserialize_slice(..).unwrap();
+        let request: RepairProtocol = deserialize_slice_from_packet(&packet, ..).unwrap();
         assert_matches!(
             ServeRepair::verify_signed_packet(
                 &my_keypair.pubkey(),
@@ -2382,11 +2419,11 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, request).unwrap();
+            let mut packet = packet_from_data(None, request).unwrap();
             sign_packet(&mut packet, &my_keypair);
             packet
         };
-        let request: RepairProtocol = packet.deserialize_slice(..).unwrap();
+        let request: RepairProtocol = deserialize_slice_from_packet(&packet, ..).unwrap();
         assert_matches!(
             ServeRepair::verify_signed_packet(
                 &other_keypair.pubkey(),
@@ -2406,11 +2443,11 @@ mod tests {
             );
             let slot = 239847;
             let request = RepairProtocol::Orphan { header, slot };
-            let mut packet = Packet::from_data(None, request).unwrap();
+            let mut packet = packet_from_data(None, request).unwrap();
             sign_packet(&mut packet, &other_keypair);
             packet
         };
-        let request: RepairProtocol = packet.deserialize_slice(..).unwrap();
+        let request: RepairProtocol = deserialize_slice_from_packet(&packet, ..).unwrap();
         assert_matches!(
             ServeRepair::verify_signed_packet(
                 &other_keypair.pubkey(),

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -1,6 +1,6 @@
 //! The `packet` module defines data structures and methods to pull data from the network.
 #[cfg(feature = "dev-context-only-utils")]
-use wincode::{SchemaWrite, WriteResult, config::DefaultConfig};
+use wincode::{ReadError, ReadResult, SchemaRead, config::DefaultConfig};
 use {
     crate::{recycled_vec::RecycledVec, recycler::Recycler},
     bytes::Bytes,
@@ -11,11 +11,15 @@ use {
     serde::{Deserialize, Serialize},
     std::{
         borrow::Borrow,
+        io::Cursor,
         net::SocketAddr,
         ops::{Deref, DerefMut, Index, IndexMut},
         slice::{Iter, SliceIndex},
     },
-    wincode::config::{Config, Configuration},
+    wincode::{
+        SchemaWrite, WriteResult,
+        config::{Config, Configuration},
+    },
 };
 pub use {
     bytes,
@@ -27,12 +31,45 @@ pub const NUM_PACKETS: usize = 1024 * 8;
 pub const PACKETS_PER_BATCH: usize = 64;
 pub const NUM_RCVMMSGS: usize = 64;
 
+pub type PacketConfig = Configuration<true, PACKET_DATA_SIZE>;
+
 /// wincode configuration setup to use for deserializing a Packet.
 /// - Zero-copy alignment check is enabled.
 /// - Preallocation size limit is PACKET_DATA_SIZE.
 #[inline]
-pub const fn packet_config() -> impl Config {
+const fn packet_config_inner() -> PacketConfig {
     Configuration::default().with_preallocation_size_limit::<{ solana_packet::PACKET_DATA_SIZE }>()
+}
+
+#[inline]
+pub const fn packet_config() -> impl Config {
+    packet_config_inner()
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+pub fn deserialize_slice_from_packet<'de, T, I>(packet: &'de Packet, index: I) -> ReadResult<T>
+where
+    T: SchemaRead<'de, PacketConfig, Dst = T>,
+    I: SliceIndex<[u8], Output = [u8]>,
+{
+    let data = packet
+        .data(index)
+        .ok_or(ReadError::Custom("packet discarded"))?;
+    wincode::config::deserialize(data, packet_config_inner())
+}
+
+pub fn packet_from_data<T>(dest: Option<&SocketAddr>, data: T) -> WriteResult<Packet>
+where
+    T: SchemaWrite<PacketConfig, Src = T>,
+{
+    let mut packet = Packet::default();
+    let mut wr = Cursor::new(packet.buffer_mut());
+    wincode::config::serialize_into(&mut wr, &data, packet_config_inner())?;
+    packet.meta_mut().size = wr.position() as usize;
+    if let Some(dest) = dest {
+        packet.meta_mut().set_socket_addr(dest);
+    }
+    Ok(packet)
 }
 
 /// Representation of a packet used in TPU.


### PR DESCRIPTION
#### Problem
Repair crate still uses bincode

#### Summary of Changes
* Switch repair crate to use wincode
* Retained serialize and deserialize derives for frozen-abi compatibility purposes.
* Added stableAbi for BlockIdRepairResponse.
* Added stableAbi bincode and wincode serializers for BlockIdRepairResponse and RepairProtocol.
* Added stableAbi round-trip equivalence and wire tests for BlockIdRepairResponse and RepairProtocol.
* bincode::options().with_fixint_encoding().allow_trailing_bytes().serialize() -> wincode::serialize()
* bincode::options().with_limit().with_fixint_encoding().reject_trailing_bytes().deserialize() -> 
wincode::config::deserialize_exact()
* Some changes previously in this PR were addressed by Akhi in #13175 specifically around solana_perf::packet:: deserialize_from_with_limit use in repair. 
* bincode-bound Packet::deserialize_slice() and perf::packet::from_data() with new wincode equivalents.

### Testing
cargo test, CI, and new test coverage from stableAbi round trip equivalence and wire testing.

