### PR TITLE
ci: rename crate-check to Crate Check

### DIFF
--- a/.github/workflows/crate-check.yml
+++ b/.github/workflows/crate-check.yml
@@ -1,4 +1,4 @@
-name: crate-check
+name: Crate Check
 
 on:
   push:


### PR DESCRIPTION
#### Problem

most of our GitHub Actions use Title Case

#### Summary of Changes

rename crate-check to Crate Check