### PR TITLE
clippy: allow new_without_default for workspaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,10 +156,14 @@ check-cfg = [
 
 # Clippy lint configuration that can not be applied in clippy.toml
 [workspace.lints.clippy]
+# Denied lints
 arithmetic_side_effects = "deny"
 default_trait_access = "deny"
 manual_let_else = "deny"
 used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -21,10 +21,14 @@ check-cfg = [
 
 # Clippy lint configuration that can not be applied in clippy.toml
 [workspace.lints.clippy]
+# Denied lints
 arithmetic_side_effects = "deny"
 default_trait_access = "deny"
 manual_let_else = "deny"
 used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
 
 [workspace.dependencies]
 agave-feature-set = { path = "../feature-set", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/fs/src/buffered_reader.rs
+++ b/fs/src/buffered_reader.rs
@@ -146,7 +146,6 @@ pub struct BufferedReader<'a, const N: usize> {
 }
 
 impl<'a, const N: usize> BufferedReader<'a, N> {
-    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Self {
             file_offset_of_next_read: 0,

--- a/fs/src/io_uring/sequential_file_reader.rs
+++ b/fs/src/io_uring/sequential_file_reader.rs
@@ -48,7 +48,6 @@ pub struct SequentialFileReaderBuilder<'sp> {
 }
 
 impl<'sp> SequentialFileReaderBuilder<'sp> {
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             read_capacity: DEFAULT_READ_SIZE,

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -74,7 +74,6 @@ pub struct ValidatorKeys {
 }
 
 impl ValidatorKeys {
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             node_keypair: Arc::new(Keypair::new()),


### PR DESCRIPTION
#### Problem
Since we do not like Default, we should disable lint `clippy::new-without-default`

#### Summary of Changes
Add allows on main and dev-bins workspace level.
You are still allowed to implement `Default`, just not forced to when you declare `fn new() -> Self`.

Note: `programs/sbf/Cargo.toml` and `ci/xtask/Cargo.toml` do not have clippy lint blocks right now, probably worth synchronizing, but let's do it as follow up, since it should also accommodate changes from https://github.com/anza-xyz/agave/pull/12680 and include `perf` crate, which is unable to inherit workspace clippy lints