### PR TITLE
bench(ledger): convert protobuf bench from libtest to criterion

### DIFF
--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -155,5 +155,9 @@ name = "blockstore"
 name = "make_shreds_from_entries"
 harness = false
 
+[[bench]]
+name = "protobuf"
+harness = false
+
 [lints]
 workspace = true

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -1,13 +1,12 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![feature(test)]
-extern crate test;
 
 use {
     bincode::{deserialize, serialize},
+    criterion::{Criterion, criterion_group, criterion_main},
     prost::Message,
     solana_runtime::bank::RewardType,
     solana_transaction_status::{Reward, Rewards},
-    test::Bencher,
+    std::hint::black_box,
 };
 
 fn create_rewards() -> Rewards {
@@ -18,7 +17,9 @@ fn create_rewards() -> Rewards {
             post_balance: u64::MAX,
             reward_type: Some(RewardType::Fee),
             commission: None,
-            commission_bps: None,
+            // `Reward::commission_bps` is `skip_serializing_if` without a serde
+            // `default`, so it must be `Some` to round-trip through bincode.
+            commission_bps: Some(i as u16),
         })
         .collect()
 }
@@ -44,52 +45,67 @@ fn protobuf_deserialize_rewards(bytes: &[u8]) -> Rewards {
         .into()
 }
 
-fn bench_serialize_rewards<S>(bench: &mut Bencher, serialize_method: S)
+fn bench_serialize_rewards<S>(name: &str, c: &mut Criterion, serialize_method: S)
 where
     S: Fn(Rewards) -> Vec<u8>,
 {
     let rewards = create_rewards();
-    bench.iter(move || {
-        let _ = serialize_method(rewards.clone());
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            black_box(serialize_method(rewards.clone()));
+        })
     });
 }
 
-fn bench_deserialize_rewards<S, D>(bench: &mut Bencher, serialize_method: S, deserialize_method: D)
-where
+fn bench_deserialize_rewards<S, D>(
+    name: &str,
+    c: &mut Criterion,
+    serialize_method: S,
+    deserialize_method: D,
+) where
     S: Fn(Rewards) -> Vec<u8>,
     D: Fn(&[u8]) -> Rewards,
 {
     let rewards = create_rewards();
     let rewards_bytes = serialize_method(rewards);
-    bench.iter(move || {
-        let _ = deserialize_method(&rewards_bytes);
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            black_box(deserialize_method(&rewards_bytes));
+        })
     });
 }
 
-#[bench]
-fn bench_serialize_bincode(bencher: &mut Bencher) {
-    bench_serialize_rewards(bencher, bincode_serialize_rewards);
+fn bench_serialize_bincode(c: &mut Criterion) {
+    bench_serialize_rewards("bench_serialize_bincode", c, bincode_serialize_rewards);
 }
 
-#[bench]
-fn bench_serialize_protobuf(bencher: &mut Bencher) {
-    bench_serialize_rewards(bencher, protobuf_serialize_rewards);
+fn bench_serialize_protobuf(c: &mut Criterion) {
+    bench_serialize_rewards("bench_serialize_protobuf", c, protobuf_serialize_rewards);
 }
 
-#[bench]
-fn bench_deserialize_bincode(bencher: &mut Bencher) {
+fn bench_deserialize_bincode(c: &mut Criterion) {
     bench_deserialize_rewards(
-        bencher,
+        "bench_deserialize_bincode",
+        c,
         bincode_serialize_rewards,
         bincode_deserialize_rewards,
     );
 }
 
-#[bench]
-fn bench_deserialize_protobuf(bencher: &mut Bencher) {
+fn bench_deserialize_protobuf(c: &mut Criterion) {
     bench_deserialize_rewards(
-        bencher,
+        "bench_deserialize_protobuf",
+        c,
         protobuf_serialize_rewards,
         protobuf_deserialize_rewards,
     );
 }
+
+criterion_group!(
+    benches,
+    bench_serialize_bincode,
+    bench_serialize_protobuf,
+    bench_deserialize_bincode,
+    bench_deserialize_protobuf
+);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem
`ledger/benches/protobuf.rs` uses unstable libtest `#![feature(test)]` / `#[bench]` harness

#### Summary of Changes
- `benches/protobuf.rs`: drop `#![feature(test)]`/`extern crate test`; helpers now take `(&str, &mut Criterion, …)` and use `c.bench_function(name, |b| b.iter(…))` with `std::hint::black_box`; wired up via `criterion_group!`/`criterion_main!`.
- `Cargo.toml`: register the bench with `harness = false`.
- Fix the benchmark's test data so it actually runs: `Reward.commission_bps` has `#[serde(skip_serializing_if = "Option::is_none")]` with no `#[serde(default)]` (this seems like an actual bug, will fix in separate PR)
 
**Verification:** all four benchmarks run. The bincode-vs-protobuf comparison (the point of this bench) is unchanged vs the old `#[bench]` baseline — serialize ~3.5× and deserialize ~2.7× in favor of bincode in both harnesses. Absolute timings are ~1.3–1.6× higher than the old numbers purely due to criterion (stable) vs libtest (nightly) measurement/toolchain differences, not a code change.

| Benchmark | old `#[bench]` (nightly) | criterion (stable) |
|---|---|---|
| `serialize_bincode` | 4,012 ns | 5,531 ns |
| `serialize_protobuf` | 15,703 ns | 19,602 ns |
| `deserialize_bincode` | 5,783 ns | 9,153 ns |
| `deserialize_protobuf` | 16,043 ns | 24,459 ns |

