### PR TITLE
rpc-client: Make it work with v1 transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9806,6 +9806,7 @@ dependencies = [
  "solana-rpc-client-api",
  "solana-signature",
  "solana-signer",
+ "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9815,6 +9815,7 @@ dependencies = [
  "static_assertions",
  "test-case",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8264,6 +8264,7 @@ dependencies = [
  "solana-version",
  "solana-vote-interface",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8087,6 +8087,7 @@ dependencies = [
  "solana-version",
  "solana-vote-interface",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -54,6 +54,7 @@ solana-transaction-status-client-types = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-interface = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -67,6 +67,7 @@ solana-hash = { workspace = true, features = ["atomic"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
+solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-system-transaction = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -34,7 +34,7 @@ use {
         },
     },
     solana_signature::Signature,
-    solana_transaction::{Transaction, versioned::TransactionVersion},
+    solana_transaction::versioned::{TransactionVersion, VersionedTransaction},
     solana_transaction_error::{TransactionError, TransactionResult},
     solana_transaction_status_client_types::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, EncodedTransaction,
@@ -364,7 +364,7 @@ impl RpcSender for MockSender {
                 } else {
                     let tx_str = params.as_array().unwrap()[0].as_str().unwrap().to_string();
                     let data = BASE64_STANDARD.decode(tx_str).unwrap();
-                    let tx: Transaction = wincode::deserialize(&data).unwrap();
+                    let tx: VersionedTransaction = wincode::deserialize(&data).unwrap();
                     tx.signatures[0].to_string()
                 };
                 Value::String(signature)

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -364,7 +364,7 @@ impl RpcSender for MockSender {
                 } else {
                     let tx_str = params.as_array().unwrap()[0].as_str().unwrap().to_string();
                     let data = BASE64_STANDARD.decode(tx_str).unwrap();
-                    let tx: Transaction = bincode::deserialize(&data).unwrap();
+                    let tx: Transaction = wincode::deserialize(&data).unwrap();
                     tx.signatures[0].to_string()
                 };
                 Value::String(signature)

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -21,7 +21,6 @@ use {
     },
     agave_votor_messages::certificate::Certificate,
     base64::{Engine, prelude::BASE64_STANDARD},
-    bincode::serialize,
     futures::join,
     log::*,
     serde_json::{Value, json},
@@ -57,6 +56,7 @@ use {
         time::{Duration, Instant},
     },
     tokio::time::sleep,
+    wincode::{SchemaWrite, config::DefaultConfig},
 };
 
 /// A client of a remote Solana node.
@@ -5111,9 +5111,9 @@ impl RpcClient {
 
 fn serialize_and_encode<T>(input: &T, encoding: UiTransactionEncoding) -> ClientResult<String>
 where
-    T: serde::ser::Serialize,
+    T: SchemaWrite<DefaultConfig, Src = T>,
 {
-    let serialized = serialize(input)
+    let serialized = wincode::serialize(input)
         .map_err(|e| ClientErrorKind::Custom(format!("Serialization failed: {e}")))?;
     let encoded = match encoding {
         UiTransactionEncoding::Base58 => bs58::encode(serialized).into_string(),

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -4372,9 +4372,12 @@ mod tests {
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
         solana_keypair::Keypair,
-        solana_message::{MessageHeader, compiled_instruction::CompiledInstruction},
+        solana_message::{
+            MessageHeader, VersionedMessage, compiled_instruction::CompiledInstruction, v1,
+        },
         solana_rpc_client_api::client_error::ErrorKind,
         solana_signer::Signer,
+        solana_system_interface::instruction as system_instruction,
         solana_system_transaction as system_transaction,
         solana_transaction_error::TransactionError,
         std::{io, thread},
@@ -5181,5 +5184,35 @@ mod tests {
             .get_latest_blockhash_with_commitment(CommitmentConfig::default())
             .unwrap();
         assert_eq!(value, response.value);
+    }
+
+    #[test]
+    fn test_send_transaction_v1() {
+        let rpc_client = RpcClient::new_mock("succeeds".to_string());
+
+        let key = Keypair::new();
+        let to = Pubkey::new_unique();
+        let blockhash = Hash::default();
+        let ix = system_instruction::transfer(&key.pubkey(), &to, 50);
+        let tx = VersionedTransaction::try_new(
+            VersionedMessage::V1(
+                v1::Message::try_compile(&key.pubkey(), &[ix], blockhash).unwrap(),
+            ),
+            &[key],
+        )
+        .unwrap();
+
+        let signature = rpc_client.send_transaction(&tx);
+        assert_eq!(signature.unwrap(), tx.signatures[0]);
+
+        let rpc_client = RpcClient::new_mock("fails".to_string());
+
+        let signature = rpc_client.send_transaction(&tx);
+        assert!(signature.is_err());
+
+        // Test bad signature returned from rpc node
+        let rpc_client = RpcClient::new_mock("malicious".to_string());
+        let signature = rpc_client.send_transaction(&tx);
+        assert!(signature.is_err());
     }
 }

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -18,7 +18,6 @@ use {
         rpc_sender::*,
     },
     agave_votor_messages::certificate::Certificate,
-    serde::Serialize,
     serde_json::Value,
     solana_account::{Account, ReadableAccount},
     solana_account_decoder::UiAccount,
@@ -46,6 +45,7 @@ use {
     },
     solana_vote_interface::state::MAX_LOCKOUT_HISTORY,
     std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration},
+    wincode::{SchemaWrite, config::DefaultConfig},
 };
 
 #[derive(Default)]
@@ -95,7 +95,7 @@ impl SerializableMessage for v0::Message {
 
 /// Trait used to add support for versioned transactions to RPC APIs while
 /// retaining backwards compatibility
-pub trait SerializableTransaction: Serialize {
+pub trait SerializableTransaction: SchemaWrite<DefaultConfig, Src = Self> {
     fn get_signature(&self) -> &Signature;
     fn get_recent_blockhash(&self) -> &Hash;
     fn uses_durable_nonce(&self) -> bool;


### PR DESCRIPTION
#### Problem

v1 transactions don't work with RPC client, since it's always using bincode to serialize the transaction.

#### Summary of changes

Parametrize everything via wincode instead.

Note: I'm not sure if I got the wincode trait parameters right, so please correct me there!