### PR TITLE
ci: use github app token in dependabot pr pipeline

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -8,14 +8,33 @@ on:
 jobs:
   dependabot:
     timeout-minutes: 10
+    environment: dependency-update
     runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Create github app token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ vars.CLIENT_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        run: |
+          git config --global user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_ID: ${{ vars.APP_ID }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: update code
         env:
@@ -45,8 +64,6 @@ jobs:
           if [ -z "$(git status --porcelain)" ]; then
             echo "✅ Nothing to update"
           else
-            git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
-            git config user.name "dependabot[bot]"
             git add **/Cargo.toml
             git add **/Cargo.lock
             git commit -am "Update all workspaces"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   dependabot:
     timeout-minutes: 10
-    environment: dependency-update
     runs-on: ubuntu-24.04
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
@@ -16,18 +15,16 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          client-id: ${{ vars.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Set git config
         run: |
-          git config --global user.email "${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git config --global user.name "dependabot[bot]"
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_ID: ${{ vars.APP_ID }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
#### Problem

I reverted my previous env based solution (https://github.com/anza-xyz/agave/pull/12975) because dependabot can only read secrets from its dedicated secrets.

#### Summary of Changes

moved all required fields to dependabot secrets and let's try to use github app token in this workflow again