### PR TITLE
net: add alpenglow mode to net scripts

### DIFF
--- a/net/net.sh
+++ b/net/net.sh
@@ -297,6 +297,7 @@ startBootstrapLeader() {
   declare ipAddress=$1
   declare nodeIndex="$2"
   declare logFile="$3"
+  declare alpenglow="$4"
   echo "--- Starting bootstrap validator: $ipAddress"
   echo "start log: $logFile"
 
@@ -332,6 +333,7 @@ startBootstrapLeader() {
          \"$TMPFS_ACCOUNTS\" \
          \"$disableQuic\" \
          \"$enableUdp\" \
+         \"$alpenglow\" \
       "
 
   ) >> "$logFile" 2>&1 || {
@@ -345,6 +347,7 @@ startNode() {
   declare ipAddress=$1
   declare nodeType=$2
   declare nodeIndex="$3"
+  declare alpenglow="$4"
 
   initLogDir
   declare logFile="$netLogDir/validator-$ipAddress.log"
@@ -405,6 +408,7 @@ startNode() {
          \"$TMPFS_ACCOUNTS\" \
          \"$disableQuic\" \
          \"$enableUdp\" \
+         \"$alpenglow\" \
       "
   ) >> "$logFile" 2>&1 &
   declare pid=$!
@@ -585,7 +589,7 @@ deploy() {
     if $bootstrapLeader; then
       SECONDS=0
       declare bootstrapNodeDeployTime=
-      startBootstrapLeader "$nodeAddress" "$nodeIndex" "$netLogDir/bootstrap-validator-$ipAddress.log"
+      startBootstrapLeader "$nodeAddress" "$nodeIndex" "$netLogDir/bootstrap-validator-$ipAddress.log" "$alpenglow"
       bootstrapNodeDeployTime=$SECONDS
       $metricsWriteDatapoint "testnet-deploy net-bootnode-leader-started=1"
 
@@ -593,7 +597,7 @@ deploy() {
       SECONDS=0
       pids=()
     else
-      startNode "$ipAddress" "$nodeType" "$nodeIndex"
+      startNode "$ipAddress" "$nodeType" "$nodeIndex" "$alpenglow"
 
       # Stagger additional node start time. If too many nodes start simultaneously
       # the bootstrap node gets more rsync requests from the additional nodes than
@@ -789,6 +793,7 @@ disableQuic=false
 enableUdp=false
 clientType=tpu-client
 maybeUseUnstakedConnection=""
+alpenglow=false
 
 command=$1
 [[ -n $command ]] || usage
@@ -917,6 +922,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --use-unstaked-connection ]]; then
       maybeUseUnstakedConnection="$1"
       shift 1
+    elif [[ $1 = --alpenglow ]]; then
+      alpenglow=true
+      shift 1
     else
       usage "Unknown long option: $1"
     fi
@@ -1026,7 +1034,7 @@ if [[ "$numClientsRequested" -eq 0 ]]; then
   numClientsRequested=$numClients
 else
   if [[ "$numClientsRequested" -gt "$numClients" ]]; then
-    echo "Error: More clients requested ($numClientsRequested) then available ($numClients)"
+    echo "Error: More clients requested ($numClientsRequested) than available ($numClients)"
     exit 1
   fi
 fi
@@ -1099,7 +1107,7 @@ startnode)
   nodeType=
   nodeIndex=
   getNodeType
-  startNode "$nodeAddress" "$nodeType" "$nodeIndex"
+  startNode "$nodeAddress" "$nodeType" "$nodeIndex" "$alpenglow"
   ;;
 startclients)
   startClients

--- a/net/remote/remote-node.sh
+++ b/net/remote/remote-node.sh
@@ -29,6 +29,7 @@ extraPrimordialStakes="${20:=0}"
 tmpfsAccounts="${21:false}"
 disableQuic="${22}"
 enableUdp="${23}"
+alpenglow="${24:-false}"
 
 set +x
 
@@ -203,7 +204,15 @@ EOF
                                        "$(solana-keygen pubkey "config/validator-vote-$i.json")"
                                        "$(solana-keygen pubkey "config/validator-stake-$i.json")"
           )
+          args+=(--bootstrap-validator-bls-pubkey "$(solana-keygen bls_pubkey "config/validator-identity-$i.json")")
         done
+      fi
+
+      if $alpenglow; then
+        echo "Consensus method: Alpenglow"
+        args+=(--alpenglow)
+      else
+        echo "Consensus method: TowerBFT"
       fi
 
       multinode-demo/setup.sh "${args[@]}"


### PR DESCRIPTION
Split from #11814 

#### Problem
When using the `net` scripts to start a cluster we have no way of turning on Alpenglow

#### Summary of Changes
Expose a `--alpenglow` flag which passes to `solana-genesis`. Also update the `bootstrap` validator to set a BLS pubkey