### PR TITLE
fix(transaction-status): fix Reward binary deserialization

### DIFF
--- a/transaction-status-client-types/src/lib.rs
+++ b/transaction-status-client-types/src/lib.rs
@@ -202,7 +202,10 @@ pub struct EncodedTransactionWithStatusMeta {
     pub version: Option<TransactionVersion>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead, SchemaWrite)]
+// `Reward` derives `SchemaRead` only (not `SchemaWrite`): rewards are persisted as protobuf, so
+// the only wincode use is the read-only `get_protobuf_or_wincode::<Rewards>` blockstore fallback
+// for legacy rows.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead)]
 #[serde(rename_all = "camelCase")]
 pub struct Reward {
     pub pubkey: String,
@@ -210,7 +213,14 @@ pub struct Reward {
     pub post_balance: u64, // Account balance in lamports after `lamports` was applied
     pub reward_type: Option<RewardType>,
     pub commission: Option<u8>, // Vote account commission when the reward was credited, only present for voting and staking rewards
-    #[serde(skip_serializing_if = "Option::is_none")]
+    // Excluded from the wincode wire format entirely (always deserialized as `None`).
+    // The wincode reader is only used as a fallback for legacy blockstore rows, which predate this
+    // field and never contained it. We can't second-guess with tolerant "default on EOF" reader
+    // because `Reward` is read as part of a `Rewards` (`Vec<Reward>`) sequence: every element except
+    // the last is followed by more bytes. New values are written as protobuf, where `commission_bps`
+    // is carried normally; it is likewise preserved over serde/JSON.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[wincode(skip)]
     pub commission_bps: Option<u16>, // Vote account commission in basis points (SIMD-0291)
 }
 


### PR DESCRIPTION
#### Problem
https://github.com/buffalojoec/solana/commit/a8edefc00a9611bfeefdfa39c9e7a33cfb51ed54 added a field `Reward::commission_bps`. This isn't a compatible change for legacy binary deserialization still happening as fallback in
```
    --> ledger/src/blockstore.rs:4747:40
     |
4747 |             .get_protobuf_or_wincode::<Rewards>(index)
     |                                        ^^^^^^^
```

Since `Reward` is deserialized in a `Rewards` sequence (`Vec<Reward>`), there isn't any way to support this field being populated, the only compatible way to deserialize legacy values is to `skip` them for binary deserialization.

#### Summary of Changes
* add `wincode(skip)` - currently we use wincode to deserialize those values, there is still a benchmark that uses bincode, but it actually fails to run because of this bug here and the benchmark itself might be fine to remove or strip of legacy format testing, since it's unlikely we will get back to it.
* add `default` to serde, seems like some serializers (json) can still parse the values without it, but this way it's more explicit and matches other structs in the file
* remove `SchemaWrite`, we don't use wincode for serialization anyway now, and given this compatibility quirk maybe it's better to keep it this way
