### PR TITLE
CostTrackerLimits struct

### DIFF
--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -211,6 +211,7 @@ mod tests {
     use {
         super::*,
         itertools::Itertools,
+        solana_cost_model::cost_tracker::CostTrackerLimits,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_runtime::genesis_utils::{GenesisConfigInfo, create_genesis_config},
@@ -300,7 +301,7 @@ mod tests {
         let cost_limit = transfer_tx_cost + vote_tx_cost;
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(cost_limit, cost_limit, 0);
+            .set_limits(CostTrackerLimits::new(cost_limit, cost_limit, 0));
         let (results, num_selected) =
             QosService::select_transactions_per_cost(txs.iter(), txs_costs.into_iter(), &bank);
         assert_eq!(num_selected, 2);

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -64,12 +64,41 @@ pub struct UpdatedCosts {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CostTrackerLimits {
+    pub account_cost: u64,
+    pub block_cost: u64,
+    // Maximum new account allocation data per block in bytes.
+    pub allocated_data_size: u64,
+}
+
+impl CostTrackerLimits {
+    const MAX: Self = Self::new(u64::MAX, u64::MAX, u64::MAX);
+
+    pub const fn new(account_cost: u64, block_cost: u64, allocated_data_size: u64) -> Self {
+        Self {
+            account_cost,
+            block_cost,
+            allocated_data_size,
+        }
+    }
+}
+
+impl Default for CostTrackerLimits {
+    fn default() -> Self {
+        const _: () = assert!(MAX_WRITABLE_ACCOUNT_UNITS <= MAX_BLOCK_UNITS);
+        Self {
+            account_cost: MAX_WRITABLE_ACCOUNT_UNITS,
+            block_cost: MAX_BLOCK_UNITS,
+            allocated_data_size: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug)]
 pub struct CostTracker {
-    account_cost_limit: u64,
-    block_cost_limit: u64,
-    // Maximum new account allocation data per block in bytes.
-    allocated_data_size_limit: u64,
+    limits: CostTrackerLimits,
     cost_by_writable_accounts: HashMap<Pubkey, u64, ahash::RandomState>,
     block_cost: SharedBlockCost,
     transaction_count: Saturating<u64>,
@@ -86,12 +115,8 @@ pub struct CostTracker {
 
 impl Default for CostTracker {
     fn default() -> Self {
-        const _: () = assert!(MAX_WRITABLE_ACCOUNT_UNITS <= MAX_BLOCK_UNITS);
-
         Self {
-            account_cost_limit: MAX_WRITABLE_ACCOUNT_UNITS,
-            block_cost_limit: MAX_BLOCK_UNITS,
-            allocated_data_size_limit: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
+            limits: CostTrackerLimits::default(),
             cost_by_writable_accounts: HashMap::with_capacity_and_hasher(
                 WRITABLE_ACCOUNTS_PER_BLOCK,
                 ahash::RandomState::new(),
@@ -111,43 +136,37 @@ impl Default for CostTracker {
 impl CostTracker {
     pub fn new_from_parent_limits(&self) -> Self {
         let mut new = Self::default();
-        new.set_limits(
-            self.account_cost_limit,
-            self.block_cost_limit,
-            self.allocated_data_size_limit,
-        );
+        new.set_limits(self.limits);
         new
+    }
+
+    /// Get the cost tracker limits.
+    pub fn get_limits(&self) -> CostTrackerLimits {
+        self.limits
     }
 
     /// Get the overall account limit.
     pub fn get_account_limit(&self) -> u64 {
-        self.account_cost_limit
+        self.limits.account_cost
     }
 
     /// Get the overall block limit.
     pub fn get_block_limit(&self) -> u64 {
-        self.block_cost_limit
+        self.limits.block_cost
     }
 
     /// Get the overall allocated account data size limit.
     pub fn get_allocated_data_size_limit(&self) -> u64 {
-        self.allocated_data_size_limit
+        self.limits.allocated_data_size
     }
 
     /// allows to adjust limits initiated during construction
-    pub fn set_limits(
-        &mut self,
-        account_cost_limit: u64,
-        block_cost_limit: u64,
-        allocated_data_size_limit: u64,
-    ) {
-        self.account_cost_limit = account_cost_limit;
-        self.block_cost_limit = block_cost_limit;
-        self.allocated_data_size_limit = allocated_data_size_limit;
+    pub fn set_limits(&mut self, limits: CostTrackerLimits) {
+        self.limits = limits;
     }
 
     pub fn set_limits_max(&mut self) {
-        self.set_limits(u64::MAX, u64::MAX, u64::MAX);
+        self.set_limits(CostTrackerLimits::MAX);
     }
 
     pub fn in_flight_transaction_count(&self) -> usize {
@@ -289,7 +308,8 @@ impl CostTracker {
     fn find_number_of_contended_accounts(&self) -> usize {
         // accounts has more than 95% of account_cu_limit is considered as highly contended
         let contended_cost_mark: u64 = self
-            .account_cost_limit
+            .limits
+            .account_cost
             .saturating_mul(95)
             .saturating_div(100);
 
@@ -305,20 +325,20 @@ impl CostTracker {
     ) -> Result<(), CostTrackerError> {
         let cost: u64 = tx_cost.sum();
 
-        if self.block_cost().saturating_add(cost) > self.block_cost_limit {
+        if self.block_cost().saturating_add(cost) > self.limits.block_cost {
             // check against the total package cost
             return Err(CostTrackerError::WouldExceedBlockMaxLimit);
         }
 
         // check if the transaction itself is more costly than the account_cost_limit
-        if cost > self.account_cost_limit {
+        if cost > self.limits.account_cost {
             return Err(CostTrackerError::WouldExceedAccountMaxLimit);
         }
 
         let allocated_accounts_data_size =
             self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
 
-        if allocated_accounts_data_size.0 > self.allocated_data_size_limit {
+        if allocated_accounts_data_size.0 > self.limits.allocated_data_size {
             return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
         }
 
@@ -326,7 +346,7 @@ impl CostTracker {
         for account_key in tx_cost.writable_accounts() {
             match self.cost_by_writable_accounts.get(account_key) {
                 Some(chained_cost) => {
-                    if chained_cost.saturating_add(cost) > self.account_cost_limit {
+                    if chained_cost.saturating_add(cost) > self.limits.account_cost {
                         return Err(CostTrackerError::WouldExceedAccountMaxLimit);
                     } else {
                         continue;
@@ -456,11 +476,13 @@ mod tests {
     impl CostTracker {
         fn new(account_cost_limit: u64, block_cost_limit: u64) -> Self {
             assert!(account_cost_limit <= block_cost_limit);
-            Self {
-                account_cost_limit,
-                block_cost_limit,
-                ..Self::default()
-            }
+            let mut cost_tracker = Self::default();
+            cost_tracker.set_limits(CostTrackerLimits {
+                account_cost: account_cost_limit,
+                block_cost: block_cost_limit,
+                ..CostTrackerLimits::default()
+            });
+            cost_tracker
         }
     }
 
@@ -522,8 +544,8 @@ mod tests {
     #[test]
     fn test_cost_tracker_initialization() {
         let testee = CostTracker::new(10, 11);
-        assert_eq!(10, testee.account_cost_limit);
-        assert_eq!(11, testee.block_cost_limit);
+        assert_eq!(10, testee.limits.account_cost);
+        assert_eq!(11, testee.limits.block_cost);
         assert_eq!(0, testee.cost_by_writable_accounts.len());
         assert_eq!(0, testee.block_cost());
     }
@@ -748,7 +770,10 @@ mod tests {
         assert_eq!(testee.would_fit(&tx_cost), Ok(()),);
 
         // Transaction does not fit with 1B limit.
-        testee.allocated_data_size_limit = 1;
+        testee.set_limits(CostTrackerLimits {
+            allocated_data_size: 1,
+            ..testee.get_limits()
+        });
         assert_eq!(
             testee.would_fit(&tx_cost),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2976,6 +2976,7 @@ pub mod tests {
         rayon::ThreadPoolBuilder,
         solana_account::{AccountSharedData, WritableAccount},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_cost_model::cost_tracker::CostTrackerLimits,
         solana_entry::{
             block_component::{BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker},
             entry::{create_ticks, next_entry, next_entry_mut},
@@ -6293,7 +6294,7 @@ pub mod tests {
         let block_limit = tx_cost.sum();
         bank.write_cost_tracker()
             .unwrap()
-            .set_limits(u64::MAX, block_limit, u64::MAX);
+            .set_limits(CostTrackerLimits::new(u64::MAX, block_limit, u64::MAX));
 
         let tx_costs = vec![None, Some(tx_cost), None];
         // The transaction will fit when added the first time

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4735,11 +4735,11 @@ impl Bank {
     /// Recomputes cost tracker limits from active feature state.
     fn apply_cost_tracker_limits_for_active_features(&mut self) {
         let params = self.current_slot_params();
-        let (account_cost_limit, block_cost_limit, data_size_limit) =
+        let cost_limits =
             params.cost_limits(self.feature_set.snapshot().raise_block_limits_to_100m);
 
         let mut cost_tracker = self.write_cost_tracker().unwrap();
-        cost_tracker.set_limits(account_cost_limit, block_cost_limit, data_size_limit);
+        cost_tracker.set_limits(cost_limits);
     }
 
     /// Recomputes this bank's effective partitioned-reward write budget.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6326,16 +6326,11 @@ fn assert_slot_time_bank_state(bank: &Bank, params: SlotParams) {
         params.max_entry_bytes_per_slot()
     );
     let cost_tracker = bank.read_cost_tracker().unwrap();
-    let (account_limit, block_limit, data_size_limit) = params.cost_limits(
+    let cost_limits = params.cost_limits(
         bank.feature_set
             .is_active(&feature_set::raise_block_limits_to_100m::id()),
     );
-    assert_eq!(cost_tracker.get_account_limit(), account_limit);
-    assert_eq!(cost_tracker.get_block_limit(), block_limit);
-    assert_eq!(
-        cost_tracker.get_allocated_data_size_limit(),
-        data_size_limit
-    );
+    assert_eq!(cost_tracker.get_limits(), cost_limits);
 }
 
 #[test]

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -1,6 +1,7 @@
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
     solana_clock::Slot,
+    solana_cost_model::cost_tracker::CostTrackerLimits,
     solana_epoch_schedule::EpochSchedule,
     solana_pubkey::Pubkey,
     std::{
@@ -20,9 +21,7 @@ pub struct SlotParams {
     pub(crate) ns_per_slot: u128,
     pub(crate) slots_per_year: f64,
     pub(crate) hashes_per_tick: Option<u64>,
-    pub(crate) max_block_units: u64,
-    pub(crate) max_writable_account_units: u64,
-    pub(crate) max_block_accounts_data_size_delta: u64,
+    pub(crate) cost_tracker_limits: CostTrackerLimits,
     pub(crate) max_data_shreds_per_slot: u32,
     pub(crate) max_code_shreds_per_slot: u32,
     pub(crate) max_entry_bytes_per_slot: u64,
@@ -86,22 +85,30 @@ impl SlotParams {
     }
 
     /// Returns the per-bank cost limits for these params.
-    pub(crate) const fn cost_limits(self, raise_block_limits_to_100m: bool) -> (u64, u64, u64) {
-        let (max_writable_account_units, max_block_units) = if raise_block_limits_to_100m {
+    pub(crate) const fn cost_limits(self, raise_block_limits_to_100m: bool) -> CostTrackerLimits {
+        let cost_tracker_limits = self.cost_tracker_limits;
+        let (account_cost, block_cost) = if raise_block_limits_to_100m {
             (
-                self.max_writable_account_units
+                cost_tracker_limits
+                    .account_cost
                     .saturating_mul(100)
                     .saturating_div(60),
-                self.max_block_units.saturating_mul(100).saturating_div(60),
+                cost_tracker_limits
+                    .block_cost
+                    .saturating_mul(100)
+                    .saturating_div(60),
             )
         } else {
-            (self.max_writable_account_units, self.max_block_units)
+            (
+                cost_tracker_limits.account_cost,
+                cost_tracker_limits.block_cost,
+            )
         };
 
-        (
-            max_writable_account_units,
-            max_block_units,
-            self.max_block_accounts_data_size_delta,
+        CostTrackerLimits::new(
+            account_cost,
+            block_cost,
+            cost_tracker_limits.allocated_data_size,
         )
     }
 }
@@ -111,9 +118,7 @@ pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
     ns_per_slot: 400_000_000,
     slots_per_year: 78_892_314.984,
     hashes_per_tick: Some(LEGACY_HASHES_PER_TICK),
-    max_block_units: 60_000_000,
-    max_writable_account_units: 24_000_000,
-    max_block_accounts_data_size_delta: 100_000_000,
+    cost_tracker_limits: CostTrackerLimits::new(24_000_000, 60_000_000, 100_000_000),
     max_data_shreds_per_slot: 32_768,
     max_code_shreds_per_slot: 32_768,
     max_entry_bytes_per_slot: 20 * 1024 * 1024,
@@ -124,9 +129,7 @@ pub(crate) const SLOT_PARAMS_350MS: SlotParams = SlotParams {
     ns_per_slot: 350_000_000,
     slots_per_year: 90_162_645.696,
     hashes_per_tick: Some(54_687),
-    max_block_units: 52_500_000,
-    max_writable_account_units: 21_000_000,
-    max_block_accounts_data_size_delta: 87_500_000,
+    cost_tracker_limits: CostTrackerLimits::new(21_000_000, 52_500_000, 87_500_000),
     max_data_shreds_per_slot: 28_672,
     max_code_shreds_per_slot: 28_672,
     max_entry_bytes_per_slot: 18_350_080,
@@ -137,9 +140,7 @@ pub(crate) const SLOT_PARAMS_300MS: SlotParams = SlotParams {
     ns_per_slot: 300_000_000,
     slots_per_year: 105_189_753.312,
     hashes_per_tick: Some(46_875),
-    max_block_units: 45_000_000,
-    max_writable_account_units: 18_000_000,
-    max_block_accounts_data_size_delta: 75_000_000,
+    cost_tracker_limits: CostTrackerLimits::new(18_000_000, 45_000_000, 75_000_000),
     max_data_shreds_per_slot: 24_576,
     max_code_shreds_per_slot: 24_576,
     max_entry_bytes_per_slot: 15_728_640,
@@ -150,9 +151,7 @@ pub(crate) const SLOT_PARAMS_250MS: SlotParams = SlotParams {
     ns_per_slot: 250_000_000,
     slots_per_year: 126_227_703.974,
     hashes_per_tick: Some(39_062),
-    max_block_units: 37_500_000,
-    max_writable_account_units: 15_000_000,
-    max_block_accounts_data_size_delta: 62_500_000,
+    cost_tracker_limits: CostTrackerLimits::new(15_000_000, 37_500_000, 62_500_000),
     max_data_shreds_per_slot: 20_480,
     max_code_shreds_per_slot: 20_480,
     max_entry_bytes_per_slot: 13_107_200,
@@ -163,9 +162,7 @@ pub(crate) const SLOT_PARAMS_200MS: SlotParams = SlotParams {
     ns_per_slot: 200_000_000,
     slots_per_year: 157_784_629.968,
     hashes_per_tick: Some(31_250),
-    max_block_units: 30_000_000,
-    max_writable_account_units: 12_000_000,
-    max_block_accounts_data_size_delta: 50_000_000,
+    cost_tracker_limits: CostTrackerLimits::new(12_000_000, 30_000_000, 50_000_000),
     max_data_shreds_per_slot: 16_384,
     max_code_shreds_per_slot: 16_384,
     max_entry_bytes_per_slot: 10_485_760,
@@ -354,10 +351,10 @@ mod tests {
             (SLOT_PARAMS_250MS, 25_000_000, 62_500_000),
             (SLOT_PARAMS_200MS, 20_000_000, 50_000_000),
         ] {
-            let (_, _, data_size_limit) = params.cost_limits(false);
+            let data_size_limit = params.cost_limits(false).allocated_data_size;
             assert_eq!(
                 params.cost_limits(true),
-                (
+                CostTrackerLimits::new(
                     expected_account_limit,
                     expected_block_limit,
                     data_size_limit


### PR DESCRIPTION
#### Problem
Passing around large tuples to bundle cost tracker limits can be hard to parse and easy to mix up.

This came up in Andrew's review of slot time changes

#### Summary of Changes

Add `struct CostTrackerLimits` to hold this block limit information