### PR TITLE
SIMD-0525: Dynamic VAT

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1530,19 +1530,19 @@ pub mod set_lamports_per_byte_to_6960 {
 }
 
 pub mod reduce_slot_time_to_350ms {
-    solana_pubkey::declare_id!("iBRL2iJvhLssJveF1utbmmQGmjonmNYZALcJFEHTbUF");
+    solana_pubkey::declare_id!("iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ");
 }
 
 pub mod reduce_slot_time_to_300ms {
-    solana_pubkey::declare_id!("iBRLA3zvd6x9445cK1vS7xt8n6Y7DS3otfRcDdW8JRW");
+    solana_pubkey::declare_id!("iBRLL3k18HST852F1Mf3Lv83waTNQmmqvKDxvYGwQFL");
 }
 
 pub mod reduce_slot_time_to_250ms {
-    solana_pubkey::declare_id!("iBRLR6nG3fDi8YD4mpPTUVTgo5NaiYfZgrzokCfADP2");
+    solana_pubkey::declare_id!("iBRLMc81UjRa8fn8A6eE8bJTnRbgQoPTynM51akENCV");
 }
 
 pub mod reduce_slot_time_to_200ms {
-    solana_pubkey::declare_id!("iBRLypKvvj9VEvwoTeRpbLhbW55NFR4T3GE9BUR8A16");
+    solana_pubkey::declare_id!("iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW");
 }
 
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -42,7 +42,7 @@ use {
     solana_rpc_client::rpc_client::RpcClient,
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
     solana_runtime::{
-        bank::VAT_TO_BURN_PER_EPOCH,
+        bank::DEFAULT_VAT_TO_BURN_PER_EPOCH,
         genesis_utils::{add_genesis_epoch_rewards_account, add_genesis_stake_config_account},
         stake_utils,
     },
@@ -66,7 +66,7 @@ use {
 
 /// In order to satisfy the VAT we need to fund all vote accounts
 /// This corresponds to 100 epochs worth of VAT
-const VAT_MINIMUM_LAMPORTS: u64 = VAT_TO_BURN_PER_EPOCH * 100;
+const DEFAULT_VAT_MINIMUM_LAMPORTS: u64 = DEFAULT_VAT_TO_BURN_PER_EPOCH * 100;
 
 pub enum AccountFileFormat {
     Pubkey,
@@ -279,7 +279,7 @@ fn add_validator_accounts(
             .unwrap_or([0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE]);
         // Vote account needs enough lamports for rent exemption plus VAT
         let vote_account_lamports =
-            rent.minimum_balance(VoteStateV4::size_of()) + VAT_MINIMUM_LAMPORTS;
+            rent.minimum_balance(VoteStateV4::size_of()) + DEFAULT_VAT_MINIMUM_LAMPORTS;
         let vote_account = vote_state::create_v4_account_with_authorized(
             identity_pubkey,
             identity_pubkey,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -251,9 +251,12 @@ pub const MAX_LEADER_SCHEDULE_STAKES: Epoch = 5;
 /// only the top 2000 validators by stake will be present in vote account structures.
 pub const MAX_ALPENGLOW_VOTE_ACCOUNTS: usize = 2000;
 
-/// The admission cost in lamports that is burned from the vote account of
-/// validators that are a part of the voting set
-pub const VAT_TO_BURN_PER_EPOCH: u64 = 1_600_000_000; // 1.6 SOL
+/// Default 400ms-slot Validator Admission Ticket burn amount.
+///
+/// Use this for conservative genesis/test funding defaults. Runtime VAT
+/// filtering and burns must use the bank's effective slot params instead.
+pub const DEFAULT_VAT_TO_BURN_PER_EPOCH: u64 =
+    crate::slot_params::LEGACY_SLOT_PARAMS.vat_to_burn_per_epoch();
 
 /// The off-curve account where we store the Alpenglow clock. The clock sysvar has seconds
 /// resolution while the Alpenglow clock has nanosecond resolution.
@@ -2615,6 +2618,7 @@ impl Bank {
             return;
         }
 
+        let vat_to_burn_per_epoch = self.vat_to_burn_per_epoch();
         let vote_accounts = epoch_stakes.stakes().vote_accounts();
         debug_assert!(vote_accounts.len() <= 2000);
         // +1 for the incinerator account
@@ -2626,11 +2630,11 @@ impl Bank {
         // accounts with non-zero stake and sufficient balance.
         for (vote_pubkey, _stake) in vote_accounts.delegated_stakes() {
             let mut account = self.get_account(vote_pubkey).unwrap();
-            total_vat += VAT_TO_BURN_PER_EPOCH;
+            total_vat += vat_to_burn_per_epoch;
             account.set_lamports(
                 account
                     .lamports()
-                    .checked_sub(VAT_TO_BURN_PER_EPOCH)
+                    .checked_sub(vat_to_burn_per_epoch)
                     .expect(
                         "Vote accounts should have already been filtered to contain enough \
                          balance for the VAT",
@@ -2790,6 +2794,11 @@ impl Bank {
     /// Returns the slot params that should be effective for this bank's slot.
     fn current_slot_params(&self) -> SlotParams {
         self.slot_params_at_slot(self.slot)
+    }
+
+    /// Returns the Validator Admission Ticket burn for this bank's slot params.
+    pub(crate) fn vat_to_burn_per_epoch(&self) -> u64 {
+        self.current_slot_params().vat_to_burn_per_epoch()
     }
 
     /// Returns the effective slot duration for `slot`.
@@ -6501,7 +6510,7 @@ impl Bank {
             .rent
             .minimum_balance(VoteStateV4::size_of());
         if self.feature_set.snapshot().alpenglow {
-            vote_account_rent_exempt_minimum + VAT_TO_BURN_PER_EPOCH
+            vote_account_rent_exempt_minimum + self.vat_to_burn_per_epoch()
         } else {
             vote_account_rent_exempt_minimum
         }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -3014,7 +3014,7 @@ mod tests {
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let pubkey = solana_pubkey::new_rand();
 
-        let pre_burn_balance = 10 * crate::bank::VAT_TO_BURN_PER_EPOCH;
+        let pre_burn_balance = 10 * crate::bank::DEFAULT_VAT_TO_BURN_PER_EPOCH;
         let commission_lamports = 12_345;
 
         // Commission is planned against the pre-burn account state.
@@ -3034,7 +3034,7 @@ mod tests {
 
         // Simulate the VAT burn that would run in `update_epoch_stakes`
         // between reward calculation and distribution.
-        let post_burn_balance = pre_burn_balance - crate::bank::VAT_TO_BURN_PER_EPOCH;
+        let post_burn_balance = pre_burn_balance - crate::bank::DEFAULT_VAT_TO_BURN_PER_EPOCH;
         let mut burned_account = commission_account.clone();
         burned_account.set_lamports(post_burn_balance);
         bank.store_account_and_update_capitalization(&pubkey, &burned_account);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6321,6 +6321,7 @@ fn assert_slot_time_bank_state(bank: &Bank, params: SlotParams) {
         bank.partitioned_rewards_stake_account_stores_per_block,
         params.partitioned_epoch_rewards_stake_account_stores_per_block()
     );
+    assert_eq!(bank.vat_to_burn_per_epoch(), params.vat_to_burn_per_epoch());
     assert_eq!(
         bank.entry_bytes_budget().slot_limit(),
         params.max_entry_bytes_per_slot()
@@ -6379,6 +6380,63 @@ fn test_reduce_slot_time_features() {
         );
         assert!(bank.slot_time_reduction_active());
         assert_slot_time_bank_state(&bank, params);
+    }
+}
+
+#[test]
+fn test_vat_burn_slot_params() {
+    let voting_keypair = ValidatorVoteKeypairs::new_rand();
+    let validator_keypairs = [&voting_keypair];
+    let vote_pubkey = voting_keypair.vote_keypair.pubkey();
+
+    // Loop through slot reduction features one at a time.
+    for (slot_time_feature_id, params) in std::iter::once((None, LEGACY_SLOT_PARAMS))
+        .chain(slot_time_feature_gates().map(|(feature_id, params)| (Some(feature_id), params)))
+    {
+        // Genesis with slot reduction feature active (if applicable).
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_vote_accounts_and_cluster_type(
+            1_000 * LAMPORTS_PER_SOL,
+            &validator_keypairs,
+            vec![minimum_vote_account_balance_for_vat(100)],
+            ClusterType::Development,
+            &FeatureSet::default(),
+            false,
+        );
+        activate_feature(&mut genesis_config, feature_set::alpenglow::id());
+        activate_feature(
+            &mut genesis_config,
+            feature_set::validator_admission_ticket::id(),
+        );
+        if let Some(feature_id) = slot_time_feature_id {
+            activate_feature(&mut genesis_config, feature_id);
+        }
+
+        // Advance forward such that feature goes effective.
+        let (parent_bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let bank_slot = if slot_time_feature_id.is_some() {
+            parent_bank.epoch_schedule().get_first_slot_in_epoch(1)
+        } else {
+            parent_bank.slot().saturating_add(1)
+        };
+        let mut bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), bank_slot);
+        assert_eq!(bank.vat_to_burn_per_epoch(), params.vat_to_burn_per_epoch());
+
+        // Verify correct VAT amount is burned.
+        let vote_lamports_before = bank.get_balance(&vote_pubkey);
+        let incinerator_lamports_before = bank.get_balance(&incinerator::id());
+        let stakes = SerdeStakesToStakeFormat::from(bank.get_top_epoch_stakes());
+        let epoch_stakes = VersionedEpochStakes::new(stakes, bank.epoch());
+        bank.maybe_burn_vat_from_staked_accounts(&epoch_stakes);
+        assert_eq!(
+            bank.get_balance(&vote_pubkey),
+            vote_lamports_before - params.vat_to_burn_per_epoch()
+        );
+        assert_eq!(
+            bank.get_balance(&incinerator::id()),
+            incinerator_lamports_before + params.vat_to_burn_per_epoch()
+        );
     }
 }
 
@@ -6944,6 +7002,10 @@ fn test_slot_params_use_genesis_baseline_without_features() {
     assert_eq!(
         baseline_params.partitioned_epoch_rewards_stake_account_stores_per_block(),
         stake_account_stores_per_block
+    );
+    assert_eq!(
+        baseline_params.vat_to_burn_per_epoch(),
+        DEFAULT_VAT_TO_BURN_PER_EPOCH
     );
     assert_eq!(
         bank.max_data_shreds_per_slot(),

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -602,7 +602,6 @@ mod tests {
     use {
         super::*,
         crate::{
-            bank::VAT_TO_BURN_PER_EPOCH,
             bank_forks::BankForks,
             genesis_utils::{
                 ValidatorVoteKeypairs, activate_all_features_alpenglow,
@@ -1304,11 +1303,11 @@ mod tests {
 
             let (initial_validator_lamports, final_validator_lamports) =
                 self.get_initial_and_final_lamports(reward_bank, payout_bank, voter_pubkey);
+            let vat_burn =
+                payout_bank.vat_to_burn_per_epoch() * (payout_bank.epoch() - reward_bank.epoch());
             assert_eq!(
                 expected_validator_reward,
-                final_validator_lamports
-                    + VAT_TO_BURN_PER_EPOCH * (payout_bank.epoch() - reward_bank.epoch())
-                    - initial_validator_lamports
+                final_validator_lamports + vat_burn - initial_validator_lamports
             );
             leader_reward
         }
@@ -1336,11 +1335,11 @@ mod tests {
 
             let (initial_validator_lamports, final_validator_lamports) =
                 self.get_initial_and_final_lamports(reward_bank, payout_bank, &leader);
+            let vat_burn =
+                payout_bank.vat_to_burn_per_epoch() * (payout_bank.epoch() - reward_bank.epoch());
             assert_eq!(
                 expected_validator_reward,
-                final_validator_lamports
-                    + VAT_TO_BURN_PER_EPOCH * (payout_bank.epoch() - reward_bank.epoch())
-                    - initial_validator_lamports
+                final_validator_lamports + vat_burn - initial_validator_lamports
             );
         }
 

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use {
         crate::{
-            bank::{Bank, VAT_TO_BURN_PER_EPOCH},
+            bank::Bank,
             block_component_processor::vote_reward::{
                 VoteState, increment_credits,
                 tests::{new_bank_from_parent, set_commission},
@@ -388,10 +388,12 @@ mod tests {
 
             let (initial_lamports, final_lamports) =
                 self.get_initial_and_final_lamports(reward_bank, payout_bank, &vote_pubkey);
-            let diff = final_lamports
-                + VAT_TO_BURN_PER_EPOCH * (payout_bank.epoch() - reward_bank.epoch())
-                - initial_lamports;
-            assert_eq!(expected_validator_reward, diff);
+            let vat_burn =
+                payout_bank.vat_to_burn_per_epoch() * (payout_bank.epoch() - reward_bank.epoch());
+            assert_eq!(
+                expected_validator_reward,
+                final_lamports + vat_burn - initial_lamports
+            );
         }
 
         fn validate_rewards(&self, reward_bank: &Bank, payout_bank: &Bank) {

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -2,7 +2,7 @@
 use solana_stake_interface::config::Config as StakeConfig;
 use {
     crate::{
-        bank::VAT_TO_BURN_PER_EPOCH,
+        bank::DEFAULT_VAT_TO_BURN_PER_EPOCH,
         block_component_processor::vote_reward::epoch_inflation_account_state::EpochInflationAccountState,
         stake_utils,
     },
@@ -50,10 +50,11 @@ use {
 // Default amount received by the validator
 const VALIDATOR_LAMPORTS: u64 = 890_880;
 
-// Minimum vote account balance required for VAT (SIMD-0357).
-// Vote accounts need this minimum to pass VAT filtering.
+// Default minimum vote account balance used by tests/genesis helpers. This is
+// conservative once shorter slot-time regimes lower the live bank VAT burn.
 pub fn minimum_vote_account_balance_for_vat(num_epochs: Epoch) -> u64 {
-    VAT_TO_BURN_PER_EPOCH * num_epochs + Rent::default().minimum_balance(VoteStateV4::size_of())
+    DEFAULT_VAT_TO_BURN_PER_EPOCH * num_epochs
+        + Rent::default().minimum_balance(VoteStateV4::size_of())
 }
 
 // Minimum stake lamports required for a valid stake account with non-zero stake.
@@ -449,7 +450,9 @@ pub fn create_genesis_config_with_leader_ex_no_features(
     mut initial_accounts: Vec<(Pubkey, AccountSharedData)>,
 ) -> GenesisConfig {
     // Ensure minimum lamports for VAT filtering, but only when stake > 0.
-    // VAT requires: non-zero stake, BLS pubkey, and lamports >= VAT_TO_BURN_PER_EPOCH + rent_exempt_minimum.
+    // VAT requires non-zero stake, a BLS pubkey, and lamports >= the bank's
+    // current VAT burn plus rent-exempt minimum. This helper funds with the
+    // conservative default burn amount.
     let (vote_account_lamports, stake_lamports) = if validator_stake_lamports > 0 {
         (
             validator_stake_lamports.max(minimum_vote_account_balance_for_vat(100)),

--- a/runtime/src/slot_params.rs
+++ b/runtime/src/slot_params.rs
@@ -27,6 +27,7 @@ pub struct SlotParams {
     pub(crate) max_code_shreds_per_slot: u32,
     pub(crate) max_entry_bytes_per_slot: u64,
     pub(crate) partitioned_epoch_rewards_stake_account_stores_per_block: u64,
+    pub(crate) vat_to_burn_per_epoch: u64,
 }
 
 impl SlotParams {
@@ -85,6 +86,11 @@ impl SlotParams {
         self.partitioned_epoch_rewards_stake_account_stores_per_block
     }
 
+    /// Validator Admission Ticket burn amount for one epoch.
+    pub const fn vat_to_burn_per_epoch(&self) -> u64 {
+        self.vat_to_burn_per_epoch
+    }
+
     /// Returns the per-bank cost limits for these params.
     pub(crate) const fn cost_limits(self, raise_block_limits_to_100m: bool) -> (u64, u64, u64) {
         let (max_writable_account_units, max_block_units) = if raise_block_limits_to_100m {
@@ -118,6 +124,7 @@ pub(crate) const LEGACY_SLOT_PARAMS: SlotParams = SlotParams {
     max_code_shreds_per_slot: 32_768,
     max_entry_bytes_per_slot: 20 * 1024 * 1024,
     partitioned_epoch_rewards_stake_account_stores_per_block: 4096,
+    vat_to_burn_per_epoch: 1_600_000_000,
 };
 
 pub(crate) const SLOT_PARAMS_350MS: SlotParams = SlotParams {
@@ -131,6 +138,7 @@ pub(crate) const SLOT_PARAMS_350MS: SlotParams = SlotParams {
     max_code_shreds_per_slot: 28_672,
     max_entry_bytes_per_slot: 18_350_080,
     partitioned_epoch_rewards_stake_account_stores_per_block: 3_584,
+    vat_to_burn_per_epoch: 1_400_000_000,
 };
 
 pub(crate) const SLOT_PARAMS_300MS: SlotParams = SlotParams {
@@ -144,6 +152,7 @@ pub(crate) const SLOT_PARAMS_300MS: SlotParams = SlotParams {
     max_code_shreds_per_slot: 24_576,
     max_entry_bytes_per_slot: 15_728_640,
     partitioned_epoch_rewards_stake_account_stores_per_block: 3_072,
+    vat_to_burn_per_epoch: 1_200_000_000,
 };
 
 pub(crate) const SLOT_PARAMS_250MS: SlotParams = SlotParams {
@@ -157,6 +166,7 @@ pub(crate) const SLOT_PARAMS_250MS: SlotParams = SlotParams {
     max_code_shreds_per_slot: 20_480,
     max_entry_bytes_per_slot: 13_107_200,
     partitioned_epoch_rewards_stake_account_stores_per_block: 2_560,
+    vat_to_burn_per_epoch: 1_000_000_000,
 };
 
 pub(crate) const SLOT_PARAMS_200MS: SlotParams = SlotParams {
@@ -170,6 +180,7 @@ pub(crate) const SLOT_PARAMS_200MS: SlotParams = SlotParams {
     max_code_shreds_per_slot: 16_384,
     max_entry_bytes_per_slot: 10_485_760,
     partitioned_epoch_rewards_stake_account_stores_per_block: 2_048,
+    vat_to_burn_per_epoch: 800_000_000,
 };
 
 /// Slot-time reduction gates in the intended activation order.

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -8,7 +8,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::{MAX_ALPENGLOW_VOTE_ACCOUNTS, VAT_TO_BURN_PER_EPOCH},
+        bank::{DEFAULT_VAT_TO_BURN_PER_EPOCH, MAX_ALPENGLOW_VOTE_ACCOUNTS},
         test_utils::{
             new_rand_vote_account, new_rand_vote_accounts, new_staked_vote_accounts, staked_nodes,
         },
@@ -445,14 +445,14 @@ fn test_clone_and_filter_for_vat_not_enough_lamports() {
         MAX_STAKE_FOR_STAKED_ACCOUNT,
         |index| {
             if index < entries_to_modify {
-                VAT_TO_BURN_PER_EPOCH - 1
+                DEFAULT_VAT_TO_BURN_PER_EPOCH - 1
             } else {
                 10_000_000_000
             }
         },
     );
-    let filtered =
-        vote_accounts.clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, VAT_TO_BURN_PER_EPOCH);
+    let filtered = vote_accounts
+        .clone_and_filter_for_vat(MAX_ALPENGLOW_VOTE_ACCOUNTS, DEFAULT_VAT_TO_BURN_PER_EPOCH);
     assert!(filtered.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS - entries_to_modify);
 }
 


### PR DESCRIPTION
Blocked on SIMD amendment approval https://github.com/solana-foundation/solana-improvement-documents/pull/556

## Summary

Scales Validator Admission Ticket (VAT) burn with the active slot-time regime.

With shorter slots, validators vote more frequently. Keeping VAT fixed at `1.6 SOL` per epoch would make the admission cost disproportionately high relative to the reduced slot duration. Scaling VAT with slot time keeps the epoch-level burn aligned with the staged slot-time reductions.

The live VAT burn amount now comes from `SlotParams`, matching the staged slot-time reductions:

- `400ms`: `1.6 SOL`
- `350ms`: `1.4 SOL`
- `300ms`: `1.2 SOL`
- `250ms`: `1.0 SOL`
- `200ms`: `0.8 SOL`

## What Changed

- Added `vat_to_burn_per_epoch` to `SlotParams`
- Updated `Bank` VAT filtering and burn logic to use the bank’s effective slot params
- Renamed the flat legacy constant to `DEFAULT_VAT_TO_BURN_PER_EPOCH`
- Kept `DEFAULT_VAT_TO_BURN_PER_EPOCH` only for conservative genesis/test funding defaults
- Updated VAT/reward tests to account for the bank’s effective VAT burn amount instead of assuming the default `1.6 SOL`
- Added coverage that verifies VAT burn scaling across all slot-time regimes
- Changed feature gate keys to reflect feature behavior change