### PR TITLE
Move flush on upsert to cache drop

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -205,8 +205,9 @@ impl AccountsCacheIndex {
 
     /// Decrement the reference count for each pubkey in `pubkeys`. Removes an entry entirely if
     /// the count reaches zero. `max_slot` is not updated; it will become stale if the removed slot
-    /// is the highest slot
-    fn remove(&self, pubkeys: impl IntoIterator<Item = Pubkey>) {
+    /// is the highest slot. Returns a vec of pubkeys removed from the index.
+    fn remove(&self, pubkeys: impl IntoIterator<Item = Pubkey>) -> Vec<Pubkey> {
+        let mut removed_pubkeys = Vec::new();
         for pubkey in pubkeys {
             let Entry::Occupied(mut occupied_entry) = self.entries.entry(pubkey) else {
                 // If this has happened the index is corrupted
@@ -217,8 +218,10 @@ impl AccountsCacheIndex {
             if *ref_count == 0 {
                 occupied_entry.remove_entry();
                 self.num_unique_pubkeys.fetch_sub(1, Ordering::Relaxed);
+                removed_pubkeys.push(pubkey);
             }
         }
+        removed_pubkeys
     }
 
     /// Returns the recorded max slot for `pubkey`, or `None` if the pubkey is not present in the
@@ -313,14 +316,16 @@ impl AccountsCache {
             .and_then(|slot_cache| slot_cache.get_cloned(pubkey))
     }
 
-    pub fn remove_slot(&self, slot: Slot) -> Option<Arc<SlotCache>> {
+    /// Removes a slot from the accounts cache and returns the set of pubkeys removed from the index.
+    #[must_use]
+    pub fn remove_slot(&self, slot: Slot) -> Option<Vec<Pubkey>> {
         let result = self.cache.remove(&slot).map(|(_, slot_cache)| slot_cache);
-        if let Some(slot_cache) = &result {
-            self.index.remove(slot_cache.iter().map(|item| *item.key()));
-        }
         // If this slot was a root, it has now left the cache, so stop tracking it as unflushed.
         self.unflushed_roots.write().unwrap().remove(&slot);
+
         result
+            .as_ref()
+            .map(|slot_cache| self.index.remove(slot_cache.iter().map(|item| *item.key())))
     }
 
     /// Finds the newest write-cache entry for `pubkey` visible from `ancestors`. Searches
@@ -628,12 +633,14 @@ mod tests {
         assert!(cache.index.max_slot_for_pubkey(&pk2).is_some());
 
         // Remove slot 1 — pk2 should disappear, pk1 still present (in slot 3)
-        cache.remove_slot(1);
+        let pubkeys_removed = cache.remove_slot(1);
+        assert_eq!(pubkeys_removed, Some(vec![pk2]));
         assert!(cache.index.max_slot_for_pubkey(&pk1).is_some());
         assert!(cache.index.max_slot_for_pubkey(&pk2).is_none());
 
         // Remove slot 3 — pk1 should also disappear
-        cache.remove_slot(3);
+        let pubkeys_removed = cache.remove_slot(3);
+        assert_eq!(pubkeys_removed, Some(vec![pk1]));
         assert!(cache.index.max_slot_for_pubkey(&pk1).is_none());
     }
 
@@ -711,7 +718,7 @@ mod tests {
         cache.add_root(10);
         // A flush finishes a slot with `remove_slot`, which drops both its cache and its
         // unflushed-root tracking; call it directly here to stand in for that flush.
-        cache.remove_slot(10);
+        let _ = cache.remove_slot(10);
 
         // With the slot gone from the cache and untracked as a root, it is not visible.
         let empty = Ancestors::default();
@@ -765,7 +772,7 @@ mod tests {
         cache.add_root(2);
 
         // remove_slot drops slot 1 from both the cache and the tracked roots, leaving slot 2.
-        cache.remove_slot(1);
+        let _ = cache.remove_slot(1);
         assert_eq!(*cache.unflushed_roots.read().unwrap(), BTreeSet::from([2]));
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4272,7 +4272,11 @@ impl AccountsDb {
                 remove_cache_elapsed.stop();
                 remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
                 // Nobody else should have removed the slot cache entry yet
-                assert!(self.accounts_cache.remove_slot(*remove_slot).is_some());
+                let pubkeys_removed = self
+                    .accounts_cache
+                    .remove_slot(*remove_slot)
+                    .expect("slot cache entry must still be present");
+                self.accounts_index.write_through_pubkeys(pubkeys_removed);
             } else {
                 self.purge_slot_storage(*remove_slot, purge_stats);
             }
@@ -4652,6 +4656,11 @@ impl AccountsDb {
                 i64
             ),
             ("select_pubkeys_us", flush_stats.select_pubkeys_us.0, i64),
+            (
+                "disk_index_write_through_us",
+                flush_stats.disk_index_write_through_us.0,
+                i64
+            ),
         );
     }
 
@@ -4860,8 +4869,17 @@ impl AccountsDb {
         // atomic switch from the cache to storage.
         // There is some racy condition for existing readers who just has read exactly while
         // flushing. That case is handled by retry_to_get_account_accessor()
-        assert!(self.accounts_cache.remove_slot(slot).is_some());
+        let pubkeys_removed = self
+            .accounts_cache
+            .remove_slot(slot)
+            .expect("slot must be in the cache when flushing");
 
+        // Now that this slot has left the cache, any pubkey that no longer appears
+        // in any cached slot is eligible to be written through so its in-mem entry
+        // becomes clean and can be evicted.
+        let (_, disk_index_write_through_us) =
+            measure_us!(self.accounts_index.write_through_pubkeys(pubkeys_removed));
+        flush_stats.disk_index_write_through_us = Saturating(disk_index_write_through_us);
         // Add `accounts` to uncleaned_pubkeys since they were written to storage
         // and should be visited by `clean`.
         // If old slots were reclaimed, accounts were already cleaned,

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -354,6 +354,7 @@ pub struct FlushStats {
     pub store_accounts_timing: StoreAccountsTiming,
     pub store_accounts_total_us: Saturating<u64>,
     pub select_pubkeys_us: Saturating<u64>,
+    pub disk_index_write_through_us: Saturating<u64>,
 }
 
 impl FlushStats {
@@ -366,6 +367,7 @@ impl FlushStats {
             .accumulate(&other.store_accounts_timing);
         self.store_accounts_total_us += other.store_accounts_total_us;
         self.select_pubkeys_us += other.select_pubkeys_us;
+        self.disk_index_write_through_us += other.disk_index_write_through_us;
     }
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3,7 +3,10 @@ use {
     super::*,
     crate::{
         accounts_file::AccountsFileProvider,
-        accounts_index::{AccountSecondaryIndexesIncludeExclude, test_utils::*},
+        accounts_index::{
+            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountSecondaryIndexesIncludeExclude,
+            AccountsIndexConfig, IndexLimit, IndexLimitThreshold, test_utils::*,
+        },
         append_vec::{AppendVec, test_utils::TempFile},
         storable_accounts::AccountForStorage,
     },
@@ -630,6 +633,159 @@ fn test_flush_slots_with_reclaim_old_slots() {
         );
     }
     assert!(accounts.storage.get_slot_storage_entry(new_slot).is_some());
+}
+
+/// With write-through enabled, a pubkey that is hot-written across multiple cached
+/// slots must not be written through to disk until the *last* cached slot leaves the
+/// cache.
+#[test]
+fn test_flush_defers_write_through_until_all_cached_slots_drop() {
+    // Build an AccountsDb whose index has IndexLimit::Threshold so write-through is enabled.
+    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
+        AccountsFileProvider::AppendVec,
+        AccountsDbConfig {
+            index: Some(AccountsIndexConfig {
+                index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                    num_bytes: 25_000_000_000,
+                    num_entries_overhead: 1,
+                    num_entries_to_evict: 1,
+                }),
+                ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
+            }),
+            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+        },
+    );
+
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // Cache the same pubkey at three consecutive slots without flushing in between.
+    db.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+    db.store_for_tests((1, [(&pubkey, &account)].as_slice()));
+    db.store_for_tests((2, [(&pubkey, &account)].as_slice()));
+
+    let immediate_disk_writes = || {
+        db.accounts_index
+            .stats()
+            .flush_entries_updated_on_disk_immediate
+            .load(Ordering::Relaxed)
+    };
+
+    let baseline_writes = immediate_disk_writes();
+
+    // Flush slot 0. Pubkey is still cached at slots 1 and 2, so remove_slot does
+    // not return it and try_write_through is never called, so no immediate disk
+    // write must fire.
+    db.add_root_and_flush_write_cache(0);
+    assert_eq!(immediate_disk_writes(), baseline_writes);
+
+    // Flush slot 1. Pubkey is still cached at slot 2, same story.
+    db.add_root_and_flush_write_cache(1);
+    assert_eq!(immediate_disk_writes(), baseline_writes);
+
+    // Flush slot 2. The pubkey is no longer in any cached slot, so the cache-drop
+    // loop in flush_slot_cache calls try_write_through. ReclaimOldSlots has
+    // collapsed the slot list to a single storage entry with ref_count == 1, so
+    // write-through fires and bumps the counter by exactly one.
+    db.add_root_and_flush_write_cache(2);
+    assert_eq!(
+        immediate_disk_writes(),
+        baseline_writes + 1,
+        "exactly one immediate disk write should have fired across all flushes",
+    );
+}
+
+/// With write-through disabled (the default, non-threshold index config) the cache-drop path
+/// must be a pure no-op: flushing a slot leaves the in-mem entry dirty and writes nothing
+/// through to disk. Guards the "disabled => old behavior preserved" contract for the most
+/// common production configuration.
+#[test]
+fn test_flush_does_not_write_through_when_write_through_disabled() {
+    // new_single_for_tests uses IndexLimit::InMemOnly, so write-through is disabled. The
+    // behavioral assertions below (entry stays dirty, no disk write) would fail if that default
+    // ever changed to a threshold config.
+    let db = AccountsDb::new_single_for_tests();
+
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+    db.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+
+    let immediate_disk_writes = || {
+        db.accounts_index
+            .stats()
+            .flush_entries_updated_on_disk_immediate
+            .load(Ordering::Relaxed)
+    };
+    let baseline_writes = immediate_disk_writes();
+
+    // Flush slot 0. The pubkey leaves the cache, but write-through is disabled, so
+    // write_through_pubkeys short-circuits and no immediate disk write fires.
+    db.add_root_and_flush_write_cache(0);
+    assert_eq!(immediate_disk_writes(), baseline_writes);
+}
+
+/// The dead-slot purge path removes only the purged slot's index entries, so a pubkey with
+/// a surviving dirty single-ref entry at another slot must be written through when the purge
+/// drops its last cached slot.
+#[test]
+fn test_purge_unrooted_slot_writes_through_surviving_entry() {
+    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
+        AccountsFileProvider::AppendVec,
+        AccountsDbConfig {
+            index: Some(AccountsIndexConfig {
+                index_limit: IndexLimit::Threshold(IndexLimitThreshold {
+                    num_bytes: 25_000_000_000,
+                    num_entries_overhead: 1,
+                    num_entries_to_evict: 1,
+                }),
+                ..ACCOUNTS_INDEX_CONFIG_FOR_TESTING
+            }),
+            ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+        },
+    );
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // Cache the pubkey at slot 0 (will be rooted + flushed) and slot 1 (stays unrooted/cached).
+    db.store_for_tests((0, [(&pubkey, &account)].as_slice()));
+    db.store_for_tests((1, [(&pubkey, &account)].as_slice()));
+
+    let is_dirty_in_mem = |pubkey: &Pubkey| -> bool {
+        db.accounts_index.get_and_then(pubkey, |entry| {
+            (false, entry.expect("entry should be in the index").dirty())
+        })
+    };
+    let immediate_disk_writes = || {
+        db.accounts_index
+            .stats()
+            .flush_entries_updated_on_disk_immediate
+            .load(Ordering::Relaxed)
+    };
+
+    // Flush slot 0. The pubkey is still cached at slot 1, so it does not leave the cache and
+    // write-through does not fire; its slot-0 storage entry is left dirty (slot list now has the
+    // uncached slot-0 entry plus the cached slot-1 entry).
+    let baseline_writes = immediate_disk_writes();
+    db.add_root_and_flush_write_cache(0);
+    assert!(
+        is_dirty_in_mem(&pubkey),
+        "dirty after flushing slot 0 while still cached at slot 1"
+    );
+    assert_eq!(immediate_disk_writes(), baseline_writes);
+
+    // Purge the unrooted slot 1 from the cache. `purge_slot_cache` removes only the slot-1
+    // entry, leaving the slot-0 entry as a single-ref dirty entry; the pubkey leaves the cache
+    // entirely, so the purge path's write-through fires on that surviving entry exactly once.
+    db.remove_unrooted_slots(&[(1, 1)]);
+    assert!(
+        !is_dirty_in_mem(&pubkey),
+        "should be clean after purge writes through the surviving entry"
+    );
+    assert_eq!(
+        immediate_disk_writes(),
+        baseline_writes + 1,
+        "purge path must write through the surviving single-ref entry exactly once"
+    );
 }
 
 define_accounts_db_test!(test_remove_unrooted_slot_cached, |db| {
@@ -3894,7 +4050,7 @@ fn setup_accounts_db_cache_clean(
         }
     }
 
-    accounts_db.accounts_cache.remove_slot(stall_slot);
+    let _ = accounts_db.accounts_cache.remove_slot(stall_slot);
 
     // If there's <= max_cache_slots(), no slots should be flushed
     if accounts_db.accounts_cache.num_slots() <= max_cache_slots() {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -797,6 +797,18 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.account_maps.len()
     }
 
+    /// Write through to disk the in-mem entries for `pubkeys`. Each entry is only persisted if it
+    /// is dirty, `slot_list.len() == 1`, and `ref_count == 1`. Persisting an entry clears its
+    /// dirty flag so it becomes eligible for eviction. No-op when disk index is disabled.
+    pub fn write_through_pubkeys(&self, pubkeys: Vec<Pubkey>) {
+        if !self.storage.storage.should_write_through() {
+            return;
+        }
+        for pubkey in pubkeys {
+            self.get_bin(&pubkey).try_write_through(&pubkey);
+        }
+    }
+
     /// Same functionally to upsert, but:
     /// 1. operates on a batch of items in reusable Vec, draining all elements
     /// 2. holds the write lock for the duration of adding the items

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -93,6 +93,10 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     /// Precomputed thresholds per bin for flushing and eviction
     /// None for Minimal/InMemOnly, Some(threshold_entries_per_bin) for Threshold
     pub(super) threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
+
+    /// If true, flush dirty entries to disk once `slot_list.len() == 1` and
+    /// `ref_count == 1`, making it evictable
+    should_write_through: bool,
 }
 
 impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> Debug for BucketMapHolder<T, U> {
@@ -106,6 +110,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     /// is the accounts index using disk as a backing store
     pub fn is_disk_index_enabled(&self) -> bool {
         self.disk.is_some()
+    }
+
+    /// If true, flush dirty entries to disk once `slot_list.len() == 1` and
+    /// `ref_count == 1`, making it evictable
+    pub(crate) fn should_write_through(&self) -> bool {
+        self.should_write_through
     }
 
     /// Returns true when a bin's entry count is high enough that eviction should begin.
@@ -315,6 +325,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             }
         };
 
+        // Write through is currently only used with a memory threshold, to ensure
+        // the memory threshold is not exceeded
+        let should_write_through = match config.index_limit {
+            IndexLimit::InMemOnly | IndexLimit::Minimal => false,
+            IndexLimit::Threshold(_) => true,
+        };
+
         // The age interval, `age_ms`, varies depending on `config.index_limit`
         let age_ms = match config.index_limit {
             IndexLimit::Minimal => {
@@ -359,6 +376,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
             _phantom: PhantomData,
             startup_stats: Arc::default(),
             threshold_entries_per_bin,
+            should_write_through,
         }
     }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -60,7 +60,8 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     /// stats related to starting up
     pub(crate) startup_stats: Arc<StartupStats>,
 
-    /// Whether to write through to disk on upsert (true when threshold-based bin management is active)
+    /// If true, flush dirty entries to disk once `slot_list.len() == 1` and
+    /// `ref_count == 1`, making it evictable
     should_write_through: bool,
 }
 
@@ -147,8 +148,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             ),
             num_ages_to_distribute_flushes,
             startup_stats: Arc::clone(&storage.startup_stats),
-            // should_write_through: write through on every upsert so inline eviction can fire immediately
-            should_write_through: storage.threshold_entries_per_bin.is_some(),
+            should_write_through: storage.should_write_through(),
         }
     }
 
@@ -400,7 +400,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// The entry is always marked dirty after `user_fn` returns, regardless of whether
     /// `user_fn` modifies the slot list — callers should ideally know they will modify it.
     /// When write-through is active and the resulting slot list has exactly one entry with
-    /// ref_count=1, the entry is additionally flushed to disk immediately and the dirty
+    /// `ref_count == 1`, the entry is additionally flushed to disk immediately and the dirty
     /// flag may be cleared.
     pub(crate) fn slot_list_mut_with_entry<RT>(
         &self,
@@ -481,6 +481,31 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         });
     }
 
+    /// If the in-mem entry for pubkey is `slot_list.len() == 1` with `ref_count == 1` and
+    /// currently dirty, write it through to disk
+    pub fn try_write_through(&self, pubkey: &Pubkey) {
+        let to_write = self.get_only_in_mem(pubkey, false, |entry| {
+            entry.and_then(|entry| {
+                if !entry.dirty() {
+                    return None;
+                }
+
+                let slot_list = entry.slot_list_read_lock();
+                match (entry.ref_count(), &slot_list[..]) {
+                    (1, [info]) => Some(*info),
+                    _ => None,
+                }
+            })
+        });
+        if let Some((slot, info)) = to_write {
+            debug_assert!(
+                !info.is_cached(),
+                "Cached entries should not be written through"
+            );
+            self.write_through(pubkey, slot, info);
+        }
+    }
+
     /// Clean the slot list by removing all slot_list items older than the max_slot.
     /// Decrease the reference count of the entry by the number of removed accounts.
     /// Note: This must only be called on startup, and reclaims must be reclaimed.
@@ -548,7 +573,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) {
         let (slot, account_info) = new_value.into();
         let is_cached = account_info.is_cached();
-        let mut should_write_through = false;
 
         self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {
             if is_cached {
@@ -562,14 +586,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     reclaims,
                     reclaim,
                 );
-                should_write_through =
-                    self.should_write_through && slot_list_length == 1 && entry.ref_count() == 1;
                 self.set_age_to_future(entry, slot_list_length > 1);
             }
         });
-        if should_write_through {
-            self.write_through(pubkey, slot, account_info);
-        }
     }
 
     /// Replaces the slot list entry at `old_slot` with `new_item`.
@@ -3010,7 +3029,7 @@ mod tests {
         );
     }
 
-    /// `slot_list_mut` write-through fires only for single-slot, ref_count=1 entries.
+    /// `slot_list_mut` write-through fires only for `slot_list.len() == 1`, `ref_count == 1` entries.
     #[test_case(SlotList::from([(1, 0)]), 1, true  ; "writes_through")]
     #[test_case(SlotList::from(vec![(1, 10), (2, 20)]),  1, false ; "multi_slot")]
     #[test_case(SlotList::from([(1, 0)]), 2, false ; "multi_ref")]
@@ -3043,9 +3062,9 @@ mod tests {
         );
     }
 
-    /// `upsert` with `should_write_through=true` writes through to disk and clears the dirty flag.
+    /// `upsert` then `try_write_through` clears the dirty flag.
     #[test]
-    fn test_upsert_write_through_clears_dirty() {
+    fn test_try_write_through_clears_dirty() {
         let index = new_should_write_through_for_test(None);
         let pubkey = solana_pubkey::new_rand();
         let slot = 1;
@@ -3061,6 +3080,7 @@ mod tests {
             &mut ReclaimsSlotList::new(),
             UpsertReclaim::IgnoreReclaims,
         );
+        index.try_write_through(&pubkey);
 
         index.get_only_in_mem(&pubkey, false, |entry| {
             let entry = entry.expect("entry should be in memory");
@@ -3072,6 +3092,66 @@ mod tests {
             .expect("upsert should have written entry to disk");
         assert_eq!(slot_list, SlotList::from([(slot, info)]));
         assert_eq!(ref_count, 1);
+    }
+
+    /// `try_write_through` must leave a multi-ref entry alone: if the pubkey still has more
+    /// than one slot-list entry (ref_count > 1), persisting just one of them to disk would let a
+    /// later eviction drop the fresher in-mem entry in favor of an incomplete disk entry. The
+    /// entry must stay dirty and nothing must be written to disk.
+    #[test]
+    fn test_try_write_through_skips_multi_ref_entry() {
+        let index = new_should_write_through_for_test(None);
+        let pubkey = solana_pubkey::new_rand();
+        let info = 10;
+
+        assert!(index.load_from_disk(&pubkey).is_none(), "not on disk yet");
+
+        // Upsert the same pubkey at two different (uncached) slots so its slot list has two
+        // entries and ref_count == 2
+        for slot in [1, 2] {
+            let new_value = PreAllocatedAccountMapEntry::new(slot, info, &index.storage, true);
+            index.upsert(
+                &pubkey,
+                new_value,
+                None,
+                &mut ReclaimsSlotList::new(),
+                UpsertReclaim::IgnoreReclaims,
+            );
+        }
+        index.get_only_in_mem(&pubkey, false, |entry| {
+            let entry = entry.expect("entry should be in memory");
+            assert_eq!(
+                entry.slot_list_read_lock().len(),
+                2,
+                "two-version slot list"
+            );
+            assert_eq!(entry.ref_count(), 2);
+            assert!(entry.dirty(), "dirty before write-through attempt");
+        });
+
+        let immediate_writes_before = index
+            .stats()
+            .flush_entries_updated_on_disk_immediate
+            .load(Ordering::Relaxed);
+
+        index.try_write_through(&pubkey);
+
+        index.get_only_in_mem(&pubkey, false, |entry| {
+            let entry = entry.expect("entry should still be in memory");
+            assert!(entry.dirty(), "multi-version entry must stay dirty");
+        });
+        assert!(
+            index.load_from_disk(&pubkey).is_none(),
+            "multi-version entry must not be written through to disk"
+        );
+        assert_eq!(
+            index
+                .stats()
+                .flush_entries_updated_on_disk_immediate
+                .load(Ordering::Relaxed),
+            immediate_writes_before,
+            "no immediate disk write should have fired"
+        );
     }
 
     /// When the bin exceeds the threshold and a new pubkey is inserted in `should_write_through`
@@ -3094,6 +3174,7 @@ mod tests {
                 &mut ReclaimsSlotList::new(),
                 UpsertReclaim::IgnoreReclaims,
             );
+            index.try_write_through(pubkey);
         }
         assert_eq!(index.map_internal.read().unwrap().len(), 3);
 


### PR DESCRIPTION
#### Problem
When cached accounts are removed from the index, with the disk index enabled, the current flush algorithm will flush every entry during upsert asevery entry would be a single ref account, single slot list length account, which would lead to excessive index writes.

#### Summary of Changes
- Move the flush to when entries are evicted from the cache

Fixes #

Memory Usage for two nodes. Until the second restart RoryP (Purple) is running this code, and Dbsa is running master. I'm not sure why memory jumps on RoryP during index generation (which is why I switched them in the first place to verify), but it is not related to this change. need to spend some time digging on why separately

<img width="1820" height="475" alt="image" src="https://github.com/user-attachments/assets/8e0094c3-9568-4913-b2d1-f3cea4fc38bf" />
 
Disk Usage:
Disk usage is the same for both nodes
<img width="1820" height="475" alt="image" src="https://github.com/user-attachments/assets/3c093884-77c7-4c03-ba8f-8eb1cd1de7ce" />


Flush time is a little worse with this change, but not terribly worse.
RoryP starts with master + disk_index, while DbSa starts with this change + disk_index.
At around 945 they switch. I'm not sure why DbSA is so much slower in general. 

<img width="1820" height="505" alt="image" src="https://github.com/user-attachments/assets/e70ba9c3-c356-4c51-8120-9a01ab9fd7a6" />

The slowdown is calling because of all the extra index lookups: 
<img width="1820" height="505" alt="image" src="https://github.com/user-attachments/assets/5ba133eb-8df8-4f62-9b9b-187434401bd0" />

But this is slow path, and should allow us to speed up the fast path. 
