### PR TITLE
local-cluster: time-bound wait_for_duplicate_fork_frozen

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5225,11 +5225,16 @@ fn test_duplicate_shreds_switch_failure() {
         // Ensure all the slots <= dup_slot are also full so we know we can replay up to dup_slot
         // on restart
         info!("Waiting to receive and replay entire duplicate fork with tip {dup_slot}");
+        let start = Instant::now();
         loop {
             let duplicate_fork_validator_blockstore = open_blockstore(ledger_path);
             if let Some(frozen_hash) = duplicate_fork_validator_blockstore.get_bank_hash(dup_slot) {
                 return frozen_hash;
             }
+            assert!(
+                start.elapsed() < Duration::from_secs(60),
+                "Timed out waiting to receive and replay duplicate fork with tip {dup_slot}",
+            );
             sleep(Duration::from_millis(1000));
         }
     }


### PR DESCRIPTION
`wait_for_duplicate_fork_frozen` in `test_duplicate_shreds_switch_failure` (`local-cluster/tests/local_cluster.rs:5224`) loops with no timeout. If the duplicate fork validator never freezes `dup_slot` the test just hangs forever. Hit it locally on `cargo test --ignored --test-threads=1`.

Add a 60s `assert!` matching what `:992` / `:1585` / `:1686` / `:1724` / `:2832` already do. cf. #5431.

`cargo check --release -p solana-local-cluster --tests` clean.
