### PR TITLE
Socket stuff: Non-blocking I/O for retransmit sockets, socket buffer sizing, resend on EGAIN/ENOBUFS, non-blocking I/O

### DIFF
--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -10,10 +10,10 @@ use {
         find_available_ports_in_range,
         multihomed_sockets::BindIpAddrs,
         sockets::{
-            SocketConfiguration as SocketConfig, bind_gossip_port_in_range_with_config,
-            bind_in_range_with_config, bind_more_with_config, bind_to_with_config,
-            get_max_recv_buffer_size, get_max_send_buffer_size, localhost_port_range_for_tests,
-            multi_bind_in_range_with_config,
+            bind_gossip_port_in_range_with_config, bind_in_range_with_config,
+            bind_more_with_config, bind_to_with_config, get_max_udp_recv_buffer_size,
+            get_max_udp_send_buffer_size, localhost_port_range_for_tests,
+            multi_bind_in_range_with_config, SocketConfiguration as SocketConfig,
         },
     },
     solana_pubkey::Pubkey,
@@ -66,66 +66,79 @@ impl Node {
     /// sockets nor receive on primarily_write_udp sockets. Setting the unused
     /// side to 1 avoids increasing it; Linux still enforces a minimum. Note
     /// unlike Linux, MacOS and FreeBSD will not accept a buffer size of zero.
+    /// Furthermore as UDP socket sends on MacOS and FreeBSD are unbuffered,
+    /// there is no point increasing UDP socket send buffers on those platforms.
     ///
     /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
     /// and the minimum receive buffer size (SO_RCVBUF) is 256 bytes
     /// See: https://man7.org/linux/man-pages/man7/socket.7.html
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     fn create_socket_configs() -> SocketConfigs {
-        if cfg!(any(
-            target_os = "linux",
-            target_os = "freebsd",
-            target_os = "macos"
-        )) {
-            const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
-            let recv_buffer_size = get_max_recv_buffer_size()
-                .map_err(|err| {
-                    error!(
-                        "Maximum socket receive buffer size could not be determined: {}",
-                        err
-                    )
-                })
-                .ok();
-            let send_buffer_size = get_max_send_buffer_size()
-                .map_err(|err| {
-                    error!(
-                        "Maximum socket send buffer size could not be determined: {}",
-                        err
-                    )
-                })
-                .ok();
-            if let Some(sz) = recv_buffer_size {
-                info!("Maximum socket receive buffer size is {}", sz)
-            }
-            if let Some(sz) = send_buffer_size {
-                info!("Maximum socket send buffer size is {}", sz)
-            }
-            let maybe_set_recv_buffer_size = move |c: SocketConfig| {
-                let Some(sz) = recv_buffer_size else { return c };
-                c.recv_buffer_size(sz)
+        const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+
+        let max_recv_buffer_size = get_max_udp_recv_buffer_size()
+            .map(|sz| {
+                info!("Maximum UDP socket receive buffer size is {}", sz);
+                sz
+            })
+            .map_err(|err| {
+                error!(
+                    "Maximum UDP socket receive buffer size could not be determined: {}",
+                    err
+                )
+            })
+            .ok();
+        let max_send_buffer_size = get_max_udp_send_buffer_size()
+            .map(|sz| {
+                info!("Maximum UDP socket send buffer size is {}", sz);
+                sz
+            })
+            .map_err(|err| {
+                error!(
+                    "Maximum UDP socket send buffer size could not be determined: {}",
+                    err
+                )
+            })
+            .ok();
+        let set_max_recv_send_buffer_size =
+            move |c: &mut SocketConfig, recv_size: Option<usize>, send_size: Option<usize>| {
+                let recv_size = match (recv_size, max_recv_buffer_size) {
+                    (Some(sz), Some(max_sz)) => std::cmp::min(sz, max_sz),
+                    (Some(sz), _) | (_, Some(sz)) => sz,
+                    _ => return,
+                };
+                *c = c.recv_buffer_size(recv_size);
+                // As UDP socket sends on freebsd & macos are always
+                // unbuffered, do not change the send buffer size.
+                if cfg!(not(any(target_os = "freebsd", target_os = "macos"))) {
+                    let send_size = match (send_size, max_send_buffer_size) {
+                        (Some(sz), Some(max_sz)) => std::cmp::min(sz, max_sz),
+                        (Some(sz), _) | (_, Some(sz)) => sz,
+                        _ => return,
+                    };
+                    *c = c.send_buffer_size(send_size);
+                }
             };
-            let maybe_set_send_buffer_size = move |c: SocketConfig| {
-                let Some(sz) = send_buffer_size else { return c };
-                c.send_buffer_size(sz)
-            };
-            let maybe_set_recv_and_send_buffer_sizes = move |c| {
-                let c = maybe_set_recv_buffer_size(c);
-                let c = maybe_set_send_buffer_size(c);
-                c
-            };
-            SocketConfigs {
-                read_write: maybe_set_recv_and_send_buffer_sizes(SocketConfig::default()),
-                primarily_read_quic: maybe_set_recv_buffer_size(SocketConfig::default())
-                    .send_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_write_quic: maybe_set_send_buffer_size(SocketConfig::default())
-                    .recv_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_read_udp: maybe_set_recv_buffer_size(SocketConfig::default())
-                    .send_buffer_size(1),
-                primarily_write_udp: maybe_set_send_buffer_size(SocketConfig::default())
-                    .recv_buffer_size(1),
-            }
-        } else {
-            SocketConfigs::default()
-        }
+        let mut c = SocketConfigs::default();
+        set_max_recv_send_buffer_size(&mut c.read_write, None, None);
+        set_max_recv_send_buffer_size(
+            &mut c.primarily_read_quic,
+            None,
+            Some(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+        );
+        set_max_recv_send_buffer_size(
+            &mut c.primarily_write_quic,
+            Some(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+            None,
+        );
+        set_max_recv_send_buffer_size(&mut c.primarily_read_udp, None, Some(1));
+        set_max_recv_send_buffer_size(&mut c.primarily_write_udp, Some(1), None);
+        c
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
+    fn create_socket_configs() -> SocketConfigs {
+        SocketConfigs::default()
     }
 
     /// create localhost node for tests

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -10,9 +10,10 @@ use {
         find_available_ports_in_range,
         multihomed_sockets::BindIpAddrs,
         sockets::{
-            SocketConfiguration as SocketConfig, bind_gossip_port_in_range,
+            SocketConfiguration as SocketConfig, bind_gossip_port_in_range_with_config,
             bind_in_range_with_config, bind_more_with_config, bind_to_with_config,
-            localhost_port_range_for_tests, multi_bind_in_range_with_config,
+            get_max_recv_buffer_size, get_max_send_buffer_size, localhost_port_range_for_tests,
+            multi_bind_in_range_with_config,
         },
     },
     solana_pubkey::Pubkey,
@@ -63,22 +64,64 @@ impl Node {
     /// (handshakes, ACKs, connection management). For UDP, "read/write" only
     /// describes buffer tuning: Agave does not send from primarily_read_udp
     /// sockets nor receive on primarily_write_udp sockets. Setting the unused
-    /// side to 0 avoids increasing it; Linux still enforces a minimum.
+    /// side to 1 avoids increasing it; Linux still enforces a minimum. Note
+    /// unlike Linux, MacOS and FreeBSD will not accept a buffer size of zero.
     ///
     /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
     /// and the minimum receive buffer size (SO_RCVBUF) is 256 bytes
     /// See: https://man7.org/linux/man-pages/man7/socket.7.html
     fn create_socket_configs() -> SocketConfigs {
-        if cfg!(target_os = "linux") {
+        if cfg!(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "macos"
+        )) {
             const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+            let recv_buffer_size = get_max_recv_buffer_size()
+                .map_err(|err| {
+                    error!(
+                        "Maximum socket receive buffer size could not be determined: {}",
+                        err
+                    )
+                })
+                .ok();
+            let send_buffer_size = get_max_send_buffer_size()
+                .map_err(|err| {
+                    error!(
+                        "Maximum socket send buffer size could not be determined: {}",
+                        err
+                    )
+                })
+                .ok();
+            if let Some(sz) = recv_buffer_size {
+                info!("Maximum socket receive buffer size is {}", sz)
+            }
+            if let Some(sz) = send_buffer_size {
+                info!("Maximum socket send buffer size is {}", sz)
+            }
+            let maybe_set_recv_buffer_size = move |c: SocketConfig| {
+                let Some(sz) = recv_buffer_size else { return c };
+                c.recv_buffer_size(sz)
+            };
+            let maybe_set_send_buffer_size = move |c: SocketConfig| {
+                let Some(sz) = send_buffer_size else { return c };
+                c.send_buffer_size(sz)
+            };
+            let maybe_set_recv_and_send_buffer_sizes = move |c| {
+                let c = maybe_set_recv_buffer_size(c);
+                let c = maybe_set_send_buffer_size(c);
+                c
+            };
             SocketConfigs {
-                read_write: SocketConfig::default(),
-                primarily_read_quic: SocketConfig::default()
+                read_write: maybe_set_recv_and_send_buffer_sizes(SocketConfig::default()),
+                primarily_read_quic: maybe_set_recv_buffer_size(SocketConfig::default())
                     .send_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_write_quic: SocketConfig::default()
+                primarily_write_quic: maybe_set_send_buffer_size(SocketConfig::default())
                     .recv_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_read_udp: SocketConfig::default().send_buffer_size(0),
-                primarily_write_udp: SocketConfig::default().recv_buffer_size(0),
+                primarily_read_udp: maybe_set_recv_buffer_size(SocketConfig::default())
+                    .send_buffer_size(1),
+                primarily_write_udp: maybe_set_send_buffer_size(SocketConfig::default())
+                    .recv_buffer_size(1),
             }
         } else {
             SocketConfigs::default()
@@ -136,16 +179,21 @@ impl Node {
         let mut gossip_sockets = Vec::with_capacity(bind_ip_addrs.len());
         let mut gossip_ports = Vec::with_capacity(bind_ip_addrs.len());
         let mut ip_echo_sockets = Vec::with_capacity(bind_ip_addrs.len());
+
+        let socket_configs = Self::create_socket_configs();
+
         for ip in bind_ip_addrs.iter() {
             let gossip_addr = SocketAddr::new(*ip, gossip_port);
-            let (port, (gossip, ip_echo)) =
-                bind_gossip_port_in_range(&gossip_addr, port_range, *ip);
+            let (port, (gossip, ip_echo)) = bind_gossip_port_in_range_with_config(
+                &gossip_addr,
+                port_range,
+                *ip,
+                socket_configs.read_write,
+            );
             gossip_sockets.push(gossip);
             gossip_ports.push(port);
             ip_echo_sockets.push(ip_echo);
         }
-
-        let socket_configs = Self::create_socket_configs();
 
         let (tvu_port, mut tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -46,6 +46,15 @@ pub fn bind_gossip_port_in_range(
     bind_ip_addr: IpAddr,
 ) -> (u16, (UdpSocket, TcpListener)) {
     let config = SocketConfiguration::default();
+    bind_gossip_port_in_range_with_config(gossip_addr, port_range, bind_ip_addr, config)
+}
+
+pub fn bind_gossip_port_in_range_with_config(
+    gossip_addr: &SocketAddr,
+    port_range: PortRange,
+    bind_ip_addr: IpAddr,
+    config: SocketConfiguration,
+) -> (u16, (UdpSocket, TcpListener)) {
     if gossip_addr.port() != 0 {
         (
             gossip_addr.port(),
@@ -138,6 +147,77 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
     }
     sock.set_nonblocking(non_blocking)?;
     Ok(sock)
+}
+
+/// The get_max_recv/send_buffer_size functions below will probe buffer sizes
+/// up to this limit which should both be sufficiently large and within the
+/// allowable ranges for the platforms below.
+const MAX_BUF_SIZ: usize = 0x7fff_ffff;
+
+// Linux normally always succeeds, clamping the size to the system limit.
+// A quirk of Linux is that it doubles buffer size internally hence the
+// division by two below.
+#[cfg(target_os = "linux")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    sock.set_recv_buffer_size(MAX_BUF_SIZ)?;
+    sock.recv_buffer_size().map(|sz| sz / 2)
+}
+#[cfg(target_os = "linux")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    sock.set_send_buffer_size(MAX_BUF_SIZ)?;
+    sock.send_buffer_size().map(|sz| sz / 2)
+}
+
+// MacOS will clamp the size to the system limit but will succeed the
+// first time if the clamped size is larger than the current value.
+// Subsequent attempts to increase a buffer that is already at max will
+// fail. Hence we intentionally disregard any error when requesting the
+// maximum buffer size.
+#[cfg(target_os = "macos")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let _ = sock.set_recv_buffer_size(MAX_BUF_SIZ);
+    sock.recv_buffer_size()
+}
+#[cfg(target_os = "macos")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let _ = sock.set_send_buffer_size(MAX_BUF_SIZ);
+    sock.send_buffer_size()
+}
+
+// FreeBSD will not clamp the requested size but rather will return an
+// error if the size requested exceeds the system limit. Thus a binary
+// search algorithm is employed to determine the maximum available size.
+#[cfg(target_os = "freebsd")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
+    while lo <= hi {
+        let mid = (lo + hi) / 2;
+        if sock.set_recv_buffer_size(mid).is_ok() {
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    Ok(hi)
+}
+#[cfg(target_os = "freebsd")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
+    while lo <= hi {
+        let mid = (lo + hi) / 2;
+        if sock.set_send_buffer_size(mid).is_ok() {
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    Ok(hi)
 }
 
 /// Find a port in the given range with a socket config that is available for both TCP and UDP

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -154,18 +154,31 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
 /// allowable ranges for the platforms below.
 const MAX_BUF_SIZ: usize = 0x7fff_ffff;
 
+pub fn get_max_tcp_recv_buffer_size() -> io::Result<usize> {
+    get_max_recv_buffer_size(Type::STREAM)
+}
+pub fn get_max_tcp_send_buffer_size() -> io::Result<usize> {
+    get_max_send_buffer_size(Type::STREAM)
+}
+pub fn get_max_udp_recv_buffer_size() -> io::Result<usize> {
+    get_max_recv_buffer_size(Type::DGRAM)
+}
+pub fn get_max_udp_send_buffer_size() -> io::Result<usize> {
+    get_max_send_buffer_size(Type::DGRAM)
+}
+
 // Linux normally always succeeds, clamping the size to the system limit.
 // A quirk of Linux is that it doubles buffer size internally hence the
 // division by two below.
 #[cfg(target_os = "linux")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     sock.set_recv_buffer_size(MAX_BUF_SIZ)?;
     sock.recv_buffer_size().map(|sz| sz / 2)
 }
 #[cfg(target_os = "linux")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     sock.set_send_buffer_size(MAX_BUF_SIZ)?;
     sock.send_buffer_size().map(|sz| sz / 2)
 }
@@ -176,14 +189,14 @@ pub fn get_max_send_buffer_size() -> io::Result<usize> {
 // fail. Hence we intentionally disregard any error when requesting the
 // maximum buffer size.
 #[cfg(target_os = "macos")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let _ = sock.set_recv_buffer_size(MAX_BUF_SIZ);
     sock.recv_buffer_size()
 }
 #[cfg(target_os = "macos")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let _ = sock.set_send_buffer_size(MAX_BUF_SIZ);
     sock.send_buffer_size()
 }
@@ -192,8 +205,8 @@ pub fn get_max_send_buffer_size() -> io::Result<usize> {
 // error if the size requested exceeds the system limit. Thus a binary
 // search algorithm is employed to determine the maximum available size.
 #[cfg(target_os = "freebsd")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
     while lo <= hi {
         let mid = (lo + hi) / 2;
@@ -206,8 +219,8 @@ pub fn get_max_recv_buffer_size() -> io::Result<usize> {
     Ok(hi)
 }
 #[cfg(target_os = "freebsd")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
     while lo <= hi {
         let mid = (lo + hi) / 2;

--- a/streamer/src/msghdr.rs
+++ b/streamer/src/msghdr.rs
@@ -1,5 +1,4 @@
-#![cfg(target_os = "linux")]
-
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use {
     libc::{iovec, msghdr, sockaddr_storage, socklen_t},
     std::{
@@ -8,6 +7,7 @@ use {
     },
 };
 
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub(crate) fn create_msghdr(
     msg_name: &mut MaybeUninit<sockaddr_storage>,
     msg_namelen: socklen_t,

--- a/streamer/src/recvmmsg.rs
+++ b/streamer/src/recvmmsg.rs
@@ -1,11 +1,11 @@
 //! The `recvmmsg` module provides recvmmsg() API implementation
 
 pub use solana_perf::packet::PACKETS_PER_BATCH;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use {
     crate::msghdr::create_msghdr,
     itertools::izip,
-    libc::{AF_INET, AF_INET6, MSG_WAITFORONE, iovec, mmsghdr, sockaddr_storage, socklen_t},
+    libc::{AF_INET, AF_INET6, iovec, mmsghdr, sockaddr_storage, socklen_t},
     std::{
         mem::{self, MaybeUninit},
         net::{SocketAddr, SocketAddrV4, SocketAddrV6},
@@ -17,7 +17,7 @@ use {
     std::{cmp, io, net::UdpSocket},
 };
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
 pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num packets:*/ usize> {
     debug_assert!(packets.iter().all(|pkt| pkt.meta() == &Meta::default()));
     let mut i = 0;
@@ -44,7 +44,7 @@ pub fn recv_mmsg(socket: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num
     Ok(i)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn cast_socket_addr(addr: &sockaddr_storage, hdr: &mmsghdr) -> Option<SocketAddr> {
     use libc::{sa_family_t, sockaddr_in, sockaddr_in6};
     const SOCKADDR_IN_SIZE: usize = std::mem::size_of::<sockaddr_in>();
@@ -90,7 +90,7 @@ this function
  You may want to call `sock.set_read_timeout(Some(Duration::from_secs(1)));` or similar
  prior to calling this function if you require this to actually time out after 1 second.
 */
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num packets:*/ usize> {
     // Should never hit this, but bail if the caller didn't provide any Packets
     // to receive into
@@ -129,14 +129,21 @@ pub fn recv_mmsg(sock: &UdpSocket, packets: &mut [Packet]) -> io::Result</*num p
         tv_sec: 1,
         tv_nsec: 0,
     };
-    // TODO: remove .try_into().unwrap() once rust libc fixes recvmmsg types for musl
-    #[allow(clippy::useless_conversion)]
     let nrecv = unsafe {
+        #[cfg(target_os = "linux")]
+        let count = count as u32;
+
+        #[cfg(not(target_env = "musl"))]
+        use libc::MSG_WAITFORONE;
+
+        #[cfg(target_env = "musl")]
+        const MSG_WAITFORONE: u32 = libc::MSG_WAITFORONE as u32;
+
         libc::recvmmsg(
             sock_fd,
             hdrs[0].assume_init_mut(),
-            count as u32,
-            MSG_WAITFORONE.try_into().unwrap(),
+            count,
+            MSG_WAITFORONE,
             &mut ts,
         )
     };

--- a/streamer/src/sendmmsg.rs
+++ b/streamer/src/sendmmsg.rs
@@ -1,6 +1,6 @@
 //! The `sendmmsg` module provides sendmmsg() API implementation
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use {
     crate::msghdr::create_msghdr,
     itertools::izip,
@@ -35,7 +35,7 @@ impl From<SendPktsError> for TransportError {
 }
 
 // The type and lifetime constraints are overspecified to match 'linux' code.
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
 pub fn batch_send<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,
@@ -62,7 +62,7 @@ where
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn mmsghdr_for_packet(
     packet: &[u8],
     dest: &SocketAddr,
@@ -124,6 +124,70 @@ fn mmsghdr_for_packet(
     });
 }
 
+#[cfg(target_os = "freebsd")]
+fn single_sendmsg_retry(sock_fd: libc::c_int, msg: &libc::msghdr) -> io::Result<(usize, i64)> {
+    let mut retries = 0;
+
+    loop {
+        // use sendmsg as sendmmsg is implemented in libc, not a
+        // dedicated syscall so is of little benefit.
+        let n = unsafe { libc::sendmsg(sock_fd, msg, libc::MSG_DONTWAIT) };
+        if n >= 0 {
+            return Ok((n as usize, retries));
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error().is_none_or(|e| e != libc::ENOBUFS) {
+            // return immediately on any error other than ENOBUFS
+            return Err(error);
+        }
+        retries += 1;
+        if retries > 52 {
+            // give up after 52 retries which is roughly 500ms
+            return Err(error);
+        }
+        // given 1.25kb packet is 10k bits so transmission time
+        // at 1G is 0.01ms or 0.001ms at 10G, so 1ms delay should
+        // allow roughly 100 (1,000) tx descriptors to free up at
+        // 1G (10G) speeds.
+        // sleep for periods of 1.25ms, 2.5ms, 5ms and then 10ms
+        let shift = std::cmp::max(1, std::cmp::min(4, retries)) - 1;
+        let rqtp = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 1_250_000 << shift,
+        };
+        unsafe {
+            libc::clock_nanosleep(libc::CLOCK_MONOTONIC_FAST, 0, &rqtp, ptr::null_mut());
+        }
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+fn sendmmsg_retry(sock: &UdpSocket, hdrs: &mut [mmsghdr]) -> Result<(), SendPktsError> {
+    let sock_fd = sock.as_raw_fd();
+    let mut total_sent = 0;
+    let mut erropt = None;
+
+    for hdr in hdrs.iter_mut() {
+        match single_sendmsg_retry(sock_fd, &hdr.msg_hdr) {
+            Ok((n, _retries)) => {
+                hdr.msg_len = n as isize;
+                total_sent += 1;
+            }
+            Err(err) => {
+                if erropt.is_none() {
+                    erropt = Some(err)
+                }
+            }
+        }
+    }
+
+    if let Some(err) = erropt {
+        return Err(SendPktsError::IoError(err, hdrs.len() - total_sent));
+    }
+
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn sendmmsg_retry(sock: &UdpSocket, hdrs: &mut [mmsghdr]) -> Result<(), SendPktsError> {
     let sock_fd = sock.as_raw_fd();
@@ -157,10 +221,13 @@ fn sendmmsg_retry(sock: &UdpSocket, hdrs: &mut [mmsghdr]) -> Result<(), SendPkts
     }
 }
 
+#[cfg(target_os = "freebsd")]
+const MAX_IOV: usize = libc::IOV_MAX as usize;
+
 #[cfg(target_os = "linux")]
 const MAX_IOV: usize = libc::UIO_MAXIOV as usize;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn batch_send_max_iov<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,
@@ -204,7 +271,7 @@ where
 
 // Need &'a to ensure that raw packet pointers obtained in mmsghdr_for_packet
 // stay valid.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub fn batch_send<'a, S, T: 'a + ?Sized>(
     sock: &UdpSocket,
     packets: impl IntoIterator<Item = (&'a T, S), IntoIter: ExactSizeIterator>,


### PR DESCRIPTION
#### Problems
- Currently socket uses default buffer sizes for the most part requiring not just the maximum size to be increased in systctl but also the default size, which means every socket created by any program on the server uses more memory. It is better to set only a high maximum in sysctl and have the validator increase the socket buffer sizes for its own sockets, so ntp and other daemons do not needlessly waste memory.
- Blocking I/O with send/sendmsg/sendmmsg on udp sockets on freebsd will return ENOBUFS when hardware is busy and no buffers are available rather than block (which linux appears to do). As the current code does not retry these sends, significant transmit packet drops can occur, particularly with 1G NICs.

#### Summary of Changes

- use recvmmsg & sendmmsg syscalls on freebsd
- support setting SO_RCVBUF and SO_SNDBUF on freebsd and macos
- probe and set maximum socket buffer sizes on linux, freebsd and macosx
- set socket buffer sizes on gossip ports
- wait for retransmit sockets to be writable and retry on EAGAIN and ENOBUFS
- use non-blocking I/O for retransmit sockets

Although I am currently running this I am leaving this as a draft PR for now pending comment as this is not strictly a freebsd/macosx supoprt and there are some changes on the linux side which I believe are beneficial.