### PR TITLE
ci: check actor in dependabot-pr.yml

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -9,7 +9,7 @@ jobs:
   dependabot:
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Create github app token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1


### PR DESCRIPTION
#### Problem

`pull_request.user.login` always refers to the original PR author. however, we might push a follow-up update. The update shouldn't trigger this pipeline.

(btw, we can't restrict the workflow to `pull_request: [opened]` because we will break `dependabot recreate`)

#### Summary of Changes

check `actor` instead