### PR TITLE
blockstore: Replace and improve purge_from_next_slots

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -716,9 +716,8 @@ impl BankingSimulator {
             .last()
         {
             info!("purging slots {}, {}", self.first_simulated_slot, end_slot);
-            blockstore.purge_from_next_slots(self.first_simulated_slot, end_slot);
             blockstore
-                .purge_slots(self.first_simulated_slot, end_slot, PurgeType::Exact)
+                .purge_slots_cleanup_chaining(self.first_simulated_slot, end_slot, PurgeType::Exact)
                 .unwrap();
             info!("done: purging");
         } else {

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -725,9 +725,8 @@ impl BankingSimulator {
             .last()
         {
             info!("purging slots {}, {}", self.first_simulated_slot, end_slot);
-            blockstore.purge_from_next_slots(self.first_simulated_slot, end_slot);
             blockstore
-                .purge_slots(self.first_simulated_slot, end_slot, PurgeType::Exact)
+                .purge_slots_cleanup_chaining(self.first_simulated_slot, end_slot, PurgeType::Exact)
                 .unwrap();
             info!("done: purging");
         } else {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2879,8 +2879,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
 
     info!("Purging slots {start_slot} to {end_slot} from blockstore");
     let mut timer = Measure::start("blockstore purge");
-    blockstore.purge_from_next_slots(start_slot, end_slot);
-    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)?;
+    blockstore.purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)?;
     timer.stop();
     info!("Purging slots done. {timer}");
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2821,8 +2821,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
 
     info!("Purging slots {start_slot} to {end_slot} from blockstore");
     let mut timer = Measure::start("blockstore purge");
-    blockstore.purge_from_next_slots(start_slot, end_slot);
-    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)?;
+    blockstore.purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)?;
     timer.stop();
     info!("Purging slots done. {timer}");
 

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -11,7 +11,6 @@ use {
     clap::{
         App, AppSettings, Arg, ArgMatches, SubCommand, value_t, value_t_or_exit, values_t_or_exit,
     },
-    itertools::Itertools,
     log::*,
     regex::Regex,
     serde_json::json,
@@ -22,7 +21,7 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{
-            Blockstore, BlockstoreError, PurgeType,
+            Blockstore, PurgeType,
             column::{Column, ColumnName},
         },
         blockstore_options::AccessType,
@@ -457,14 +456,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                  ledger]",
             ))
             .arg(
-                Arg::with_name("batch_size")
-                    .long("batch-size")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .default_value("1000")
-                    .help("Removes at most BATCH_SIZE slots while purging in loop"),
-            )
-            .arg(
                 Arg::with_name("dead_slots_only")
                     .long("dead-slots-only")
                     .required(false)
@@ -810,7 +801,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let start_slot = value_t_or_exit!(arg_matches, "start_slot", Slot);
             let end_slot = value_t!(arg_matches, "end_slot", Slot).ok();
             let dead_slots_only = arg_matches.is_present("dead_slots_only");
-            let batch_size = value_t_or_exit!(arg_matches, "batch_size", usize);
 
             let blockstore = crate::open_blockstore(
                 &ledger_path,
@@ -836,41 +826,23 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 )));
             }
 
-            info!(
-                "Purging data from slots {} to {} ({} slots) (dead slot only: {})",
-                start_slot,
-                end_slot,
-                end_slot - start_slot,
-                dead_slots_only,
-            );
-            let purge_from_blockstore =
-                |start_slot, end_slot| -> std::result::Result<(), BlockstoreError> {
-                    blockstore.purge_from_next_slots(start_slot, end_slot);
-                    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)
-                };
             if !dead_slots_only {
-                let slots_iter = &(start_slot..=end_slot).chunks(batch_size);
-                for slots in slots_iter {
-                    let slots = slots.collect::<Vec<_>>();
-                    assert!(!slots.is_empty());
-
-                    let start_slot = *slots.first().unwrap();
-                    let end_slot = *slots.last().unwrap();
-                    info!(
-                        "Purging chunked slots from {} to {} ({} slots)",
-                        start_slot,
-                        end_slot,
-                        end_slot - start_slot
-                    );
-                    purge_from_blockstore(start_slot, end_slot)?;
-                }
+                blockstore.purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)?;
             } else {
-                let dead_slots_iter = blockstore
+                let dead_slots: Vec<_> = blockstore
                     .dead_slots_iterator(start_slot)?
-                    .take_while(|s| *s <= end_slot);
-                for dead_slot in dead_slots_iter {
+                    .take_while(|s| *s <= end_slot)
+                    .collect();
+                // Iterate the slots in reverse order so that purging does not
+                // retain an empty `SlotMeta` for dead slots that are chained to
+                // each other
+                for dead_slot in dead_slots.into_iter().rev() {
                     info!("Purging dead slot {dead_slot}");
-                    purge_from_blockstore(dead_slot, dead_slot)?;
+                    blockstore.purge_slots_cleanup_chaining(
+                        dead_slot,
+                        dead_slot,
+                        PurgeType::Exact,
+                    )?;
                 }
             }
         }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -11,7 +11,6 @@ use {
     clap::{
         App, AppSettings, Arg, ArgMatches, SubCommand, value_t, value_t_or_exit, values_t_or_exit,
     },
-    itertools::Itertools,
     log::*,
     regex::Regex,
     serde_json::json,
@@ -22,7 +21,7 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{
-            Blockstore, BlockstoreError, PurgeType,
+            Blockstore, PurgeType,
             column::{Column, ColumnName},
         },
         blockstore_options::AccessType,
@@ -457,14 +456,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                  ledger]",
             ))
             .arg(
-                Arg::with_name("batch_size")
-                    .long("batch-size")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .default_value("1000")
-                    .help("Removes at most BATCH_SIZE slots while purging in loop"),
-            )
-            .arg(
                 Arg::with_name("dead_slots_only")
                     .long("dead-slots-only")
                     .required(false)
@@ -810,7 +801,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let start_slot = value_t_or_exit!(arg_matches, "start_slot", Slot);
             let end_slot = value_t!(arg_matches, "end_slot", Slot).ok();
             let dead_slots_only = arg_matches.is_present("dead_slots_only");
-            let batch_size = value_t_or_exit!(arg_matches, "batch_size", usize);
 
             let blockstore = crate::open_blockstore(
                 &ledger_path,
@@ -836,41 +826,19 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 )));
             }
 
-            info!(
-                "Purging data from slots {} to {} ({} slots) (dead slot only: {})",
-                start_slot,
-                end_slot,
-                end_slot - start_slot,
-                dead_slots_only,
-            );
-            let purge_from_blockstore =
-                |start_slot, end_slot| -> std::result::Result<(), BlockstoreError> {
-                    blockstore.purge_from_next_slots(start_slot, end_slot);
-                    blockstore.purge_slots(start_slot, end_slot, PurgeType::Exact)
-                };
             if !dead_slots_only {
-                let slots_iter = &(start_slot..=end_slot).chunks(batch_size);
-                for slots in slots_iter {
-                    let slots = slots.collect::<Vec<_>>();
-                    assert!(!slots.is_empty());
-
-                    let start_slot = *slots.first().unwrap();
-                    let end_slot = *slots.last().unwrap();
-                    info!(
-                        "Purging chunked slots from {} to {} ({} slots)",
-                        start_slot,
-                        end_slot,
-                        end_slot - start_slot
-                    );
-                    purge_from_blockstore(start_slot, end_slot)?;
-                }
+                blockstore.purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)?;
             } else {
                 let dead_slots_iter = blockstore
                     .dead_slots_iterator(start_slot)?
                     .take_while(|s| *s <= end_slot);
                 for dead_slot in dead_slots_iter {
                     info!("Purging dead slot {dead_slot}");
-                    purge_from_blockstore(dead_slot, dead_slot)?;
+                    blockstore.purge_slots_cleanup_chaining(
+                        dead_slot,
+                        dead_slot,
+                        PurgeType::Exact,
+                    )?;
                 }
             }
         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2444,9 +2444,8 @@ fn main() {
 
                             // Purge modifies state so use rw_blockstore
                             info!("Purging slot {slot} from Blockstore");
-                            rw_blockstore.purge_from_next_slots(slot, slot);
                             rw_blockstore
-                                .purge_slots(slot, slot, PurgeType::Exact)
+                                .purge_slots_cleanup_chaining(slot, slot, PurgeType::Exact)
                                 .expect("Blockstore operation must succeed");
                         }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1,6 +1,6 @@
 use {
     super::*, crate::blockstore::error::BlockstoreManualPurgeError, crossbeam_channel::Sender,
-    solana_message::AccountKeys, std::time::Instant,
+    solana_message::AccountKeys,
 };
 
 #[derive(Default)]
@@ -8,6 +8,23 @@ pub struct PurgeStats {
     delete_range: u64,
     write_batch: u64,
     delete_file_in_range: u64,
+}
+
+impl PurgeStats {
+    fn report(&self, from_slot: Slot, to_slot: Slot) {
+        datapoint_info!(
+            "blockstore-purge",
+            ("from_slot", from_slot as i64, i64),
+            ("to_slot", to_slot as i64, i64),
+            ("delete_range_us", self.delete_range as i64, i64),
+            ("write_batch_us", self.write_batch as i64, i64),
+            (
+                "delete_file_in_range_us",
+                self.delete_file_in_range as i64,
+                i64
+            )
+        );
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -39,28 +56,51 @@ impl Blockstore {
     /// based on the `purge_type` setting.
     pub fn purge_slots(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) -> Result<()> {
         let mut purge_stats = PurgeStats::default();
-        let purge_result =
-            self.run_purge_with_stats(from_slot, to_slot, purge_type, &mut purge_stats);
-
-        datapoint_info!(
-            "blockstore-purge",
-            ("from_slot", from_slot as i64, i64),
-            ("to_slot", to_slot as i64, i64),
-            ("delete_range_us", purge_stats.delete_range as i64, i64),
-            ("write_batch_us", purge_stats.write_batch as i64, i64),
-            (
-                "delete_file_in_range_us",
-                purge_stats.delete_file_in_range as i64,
-                i64
+        let purge_result = self
+            .run_purge_with_stats(
+                from_slot,
+                to_slot,
+                purge_type,
+                /*cleanup_chaining:*/ false,
+                &mut purge_stats,
             )
-        );
-        purge_result.map_err(|e| BlockstoreError::PurgeFailed {
-            from_slot,
-            to_slot,
-            purge_type,
-            inner: Box::new(e),
-        })?;
-        Ok(())
+            .map_err(|e| BlockstoreError::PurgeFailed {
+                from_slot,
+                to_slot,
+                purge_type,
+                inner: Box::new(e),
+            });
+        purge_stats.report(from_slot, to_slot);
+
+        purge_result
+    }
+
+    /// Similar to `Blockstore::purge_slots()` with the addition of cleaning up
+    /// chaining for slots outside of the purge range that chain to purged slots
+    pub fn purge_slots_cleanup_chaining(
+        &self,
+        from_slot: Slot,
+        to_slot: Slot,
+        purge_type: PurgeType,
+    ) -> Result<()> {
+        let mut purge_stats = PurgeStats::default();
+        let purge_result = self
+            .run_purge_with_stats(
+                from_slot,
+                to_slot,
+                purge_type,
+                /*cleanup_chaining:*/ true,
+                &mut purge_stats,
+            )
+            .map_err(|e| BlockstoreError::PurgeFailed {
+                from_slot,
+                to_slot,
+                purge_type,
+                inner: Box::new(e),
+            });
+        purge_stats.report(from_slot, to_slot);
+
+        purge_result
     }
 
     /// Usually this is paired with .purge_slots() but we can't internally call this in
@@ -74,51 +114,6 @@ impl Blockstore {
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
         self.db.set_oldest_slot(to_slot);
-    }
-
-    /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
-    /// \[from_slot,to_slot\] range
-    ///
-    /// Dangerous; Use with care
-    pub fn purge_from_next_slots(&self, from_slot: Slot, to_slot: Slot) {
-        let mut count = 0;
-        let mut rewritten = 0;
-        let mut last_print = Instant::now();
-        let mut total_retain_us = 0;
-        for (slot, mut meta) in self
-            .slot_meta_iterator(0)
-            .expect("unable to iterate over meta")
-        {
-            if slot > to_slot {
-                break;
-            }
-
-            count += 1;
-            if last_print.elapsed().as_millis() > 2000 {
-                info!(
-                    "purged: {count} slots rewritten: {rewritten} retain_time: {total_retain_us}us"
-                );
-                count = 0;
-                rewritten = 0;
-                total_retain_us = 0;
-                last_print = Instant::now();
-            }
-            let mut time = Measure::start("retain");
-            let original_len = meta.next_slots.len();
-            meta.next_slots
-                .retain(|slot| *slot < from_slot || *slot > to_slot);
-            if meta.next_slots.len() != original_len {
-                rewritten += 1;
-                info!(
-                    "purge_from_next_slots: meta for slot {} no longer refers to slots {:?}",
-                    slot,
-                    from_slot..=to_slot
-                );
-                self.put_meta(slot, &meta).expect("couldn't update meta");
-            }
-            time.stop();
-            total_retain_us += time.as_us();
-        }
     }
 
     /// Purges all columns relating to `slot`.
@@ -190,11 +185,12 @@ impl Blockstore {
     /// Note: slots > `to_slot` that chained to a purged slot are not properly
     /// cleaned up. This function is not intended to be used if such slots need
     /// to be replayed.
-    pub(crate) fn run_purge_with_stats(
+    fn run_purge_with_stats(
         &self,
         from_slot: Slot,
         to_slot: Slot,
         purge_type: PurgeType,
+        cleanup_chaining: bool,
         purge_stats: &mut PurgeStats,
     ) -> Result<()> {
         let mut write_batch = self.get_write_batch()?;
@@ -207,6 +203,9 @@ impl Blockstore {
             purge_type,
             /* purge_alt_columns */ true,
         )?;
+        if cleanup_chaining {
+            self.cleanup_chaining_for_nonpurged_slots(&mut write_batch, from_slot, to_slot)?;
+        }
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
@@ -354,6 +353,73 @@ impl Blockstore {
             .delete_file_in_range(from_slot, to_slot)?;
         self.double_merkle_meta_cf
             .delete_file_in_range(from_slot, to_slot)
+    }
+
+    /// Given a range \[`from_slot`, `to_slot`\] to be purged from the
+    /// Blockstore, update the `SlotMeta` for any slots outside of the purge
+    /// range that chain to slots within the purge range. The expectation is
+    /// that the purge will take place in the same `WriteBatch`. Thus, there is
+    /// no need to update chaining between slots within the purge range.
+    ///
+    /// Chaining between two slots is established when the child is inserted.
+    /// The child slot knows its parent, and the parent `SlotMeta` `next_slots`
+    /// field is updated when the child is first inserted. Children slots past
+    /// the purge range may have parents within the purge range. If the parent
+    /// within the purge range is later reinserted, chaining between the parent
+    /// and child would not be automatically reestablished. For this reason,
+    /// - A `SlotMeta` with only the `next_slots` field will be kept for any
+    ///   slots within the purge range with a child after the purge range.
+    /// - To avoid overwriting a retained `SlotMeta`, this method must be
+    ///   called after the range purge. `WriteBatch` respects the ordering.
+    fn cleanup_chaining_for_nonpurged_slots(
+        &self,
+        batch: &mut WriteBatch,
+        from_slot: Slot,
+        to_slot: Slot,
+    ) -> Result<()> {
+        for (slot, mut meta) in self
+            .slot_meta_iterator(from_slot)?
+            .take_while(|(slot, _meta)| *slot <= to_slot)
+        {
+            if let Some(parent_slot) = meta.parent_slot
+                && parent_slot < from_slot
+            {
+                match self.meta(parent_slot)? {
+                    Some(mut parent_meta) => {
+                        // Retain only slots from outside of the purge range
+                        //
+                        // If multiple slots to be purged share a parent, this
+                        // step could be called several times for the same
+                        // parent slot. Because all slots in the purge range are
+                        // removed, the update is the same for each child. A
+                        // write batch can handle multiple updates to the same
+                        // key so there are no issues with this approach. This
+                        // approach avoids an extra HashMap to track dirty
+                        // SlotMeta's
+                        parent_meta
+                            .next_slots
+                            .retain(|slot| *slot < from_slot || *slot > to_slot);
+                        self.meta_cf
+                            .put_in_batch(batch, parent_slot, &parent_meta)
+                            .expect("SlotMeta should serialize into WriteBatch");
+                    }
+                    None => {
+                        error!("Missing parent SlotMeta for slot {slot}, parent {parent_slot}");
+                    }
+                }
+            }
+
+            meta.next_slots.retain(|&next_slot| next_slot > to_slot);
+            if !meta.next_slots.is_empty() {
+                let mut new_meta = SlotMeta::new_orphan(slot);
+                new_meta.next_slots = meta.next_slots;
+                self.meta_cf
+                    .put_in_batch(batch, slot, &new_meta)
+                    .expect("SlotMeta should serialize into WriteBatch");
+            }
+        }
+
+        Ok(())
     }
 
     /// Returns true if the special columns, TransactionStatus and
@@ -714,6 +780,60 @@ pub mod tests {
         all_columns_empty_or_greater_than_slot(&blockstore, 0);
 
         assert_eq!(blockstore.slot_meta_iterator(0).unwrap().next(), None);
+    }
+
+    #[test]
+    fn test_purge_slots_cleanup_chaining() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let (shreds, _) = make_many_slot_entries(0, 15, 10);
+        blockstore.insert_shreds(shreds, false).unwrap();
+
+        let purge_range_from = 5;
+        let purge_range_to = 10;
+        blockstore
+            .purge_slots_cleanup_chaining(purge_range_from, purge_range_to, PurgeType::Exact)
+            .unwrap();
+
+        // Ensure nonpurged parent with purged child removes chaining
+        assert!(
+            blockstore
+                .meta(purge_range_from - 1)
+                .unwrap()
+                .unwrap()
+                .next_slots
+                .is_empty(),
+        );
+
+        // Ensure slots in [purged_range_from, purge_range_to) are empty;
+        // purge_range_to remains for sake of chaining (the check below)
+        for purged_slot in purge_range_from..purge_range_to {
+            assert!(blockstore.meta(purged_slot).unwrap().is_none());
+        }
+
+        // Ensure purged parent with nonpurged child retains chaining
+        let purge_range_to_meta = blockstore.meta(purge_range_to).unwrap().unwrap();
+        assert_eq!(purge_range_to_meta.next_slots[0], purge_range_to + 1);
+        assert!(!purge_range_to_meta.is_full());
+        assert_eq!(
+            blockstore
+                .meta(purge_range_to + 1)
+                .unwrap()
+                .unwrap()
+                .parent_slot
+                .unwrap(),
+            purge_range_to
+        );
+
+        // Purge to the end of the Blockstore and ensure all slots fully gone
+        let purge_range_to = 15;
+        blockstore
+            .purge_slots_cleanup_chaining(purge_range_from, purge_range_to, PurgeType::Exact)
+            .unwrap();
+        for purged_slot in purge_range_from..=purge_range_to {
+            assert!(blockstore.meta(purged_slot).unwrap().is_none());
+        }
     }
 
     #[test]

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -1,6 +1,6 @@
 use {
     super::*, crate::blockstore::error::BlockstoreManualPurgeError, crossbeam_channel::Sender,
-    solana_message::AccountKeys, std::time::Instant,
+    solana_message::AccountKeys,
 };
 
 #[derive(Default)]
@@ -8,6 +8,23 @@ pub struct PurgeStats {
     delete_range: u64,
     write_batch: u64,
     delete_file_in_range: u64,
+}
+
+impl PurgeStats {
+    fn report(&self, from_slot: Slot, to_slot: Slot) {
+        datapoint_info!(
+            "blockstore-purge",
+            ("from_slot", from_slot as i64, i64),
+            ("to_slot", to_slot as i64, i64),
+            ("delete_range_us", self.delete_range as i64, i64),
+            ("write_batch_us", self.write_batch as i64, i64),
+            (
+                "delete_file_in_range_us",
+                self.delete_file_in_range as i64,
+                i64
+            )
+        );
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -39,28 +56,51 @@ impl Blockstore {
     /// based on the `purge_type` setting.
     pub fn purge_slots(&self, from_slot: Slot, to_slot: Slot, purge_type: PurgeType) -> Result<()> {
         let mut purge_stats = PurgeStats::default();
-        let purge_result =
-            self.run_purge_with_stats(from_slot, to_slot, purge_type, &mut purge_stats);
-
-        datapoint_info!(
-            "blockstore-purge",
-            ("from_slot", from_slot as i64, i64),
-            ("to_slot", to_slot as i64, i64),
-            ("delete_range_us", purge_stats.delete_range as i64, i64),
-            ("write_batch_us", purge_stats.write_batch as i64, i64),
-            (
-                "delete_file_in_range_us",
-                purge_stats.delete_file_in_range as i64,
-                i64
+        let purge_result = self
+            .run_purge_with_stats(
+                from_slot,
+                to_slot,
+                purge_type,
+                /*cleanup_chaining:*/ false,
+                &mut purge_stats,
             )
-        );
-        purge_result.map_err(|e| BlockstoreError::PurgeFailed {
-            from_slot,
-            to_slot,
-            purge_type,
-            inner: Box::new(e),
-        })?;
-        Ok(())
+            .map_err(|e| BlockstoreError::PurgeFailed {
+                from_slot,
+                to_slot,
+                purge_type,
+                inner: Box::new(e),
+            });
+        purge_stats.report(from_slot, to_slot);
+
+        purge_result
+    }
+
+    /// Similar to `Blockstore::purge_slots()` with the addition of cleaning up
+    /// chaining for slots that chain to purged slots
+    pub fn purge_slots_cleanup_chaining(
+        &self,
+        from_slot: Slot,
+        to_slot: Slot,
+        purge_type: PurgeType,
+    ) -> Result<()> {
+        let mut purge_stats = PurgeStats::default();
+        let purge_result = self
+            .run_purge_with_stats(
+                from_slot,
+                to_slot,
+                purge_type,
+                /*cleanup_chaining:*/ true,
+                &mut purge_stats,
+            )
+            .map_err(|e| BlockstoreError::PurgeFailed {
+                from_slot,
+                to_slot,
+                purge_type,
+                inner: Box::new(e),
+            });
+        purge_stats.report(from_slot, to_slot);
+
+        purge_result
     }
 
     /// Usually this is paired with .purge_slots() but we can't internally call this in
@@ -74,51 +114,6 @@ impl Blockstore {
         // with Slot::default() for initial compaction filter behavior consistency
         let to_slot = to_slot.checked_add(1).unwrap();
         self.db.set_oldest_slot(to_slot);
-    }
-
-    /// Ensures that the SlotMeta::next_slots vector for all slots contain no references in the
-    /// \[from_slot,to_slot\] range
-    ///
-    /// Dangerous; Use with care
-    pub fn purge_from_next_slots(&self, from_slot: Slot, to_slot: Slot) {
-        let mut count = 0;
-        let mut rewritten = 0;
-        let mut last_print = Instant::now();
-        let mut total_retain_us = 0;
-        for (slot, mut meta) in self
-            .slot_meta_iterator(0)
-            .expect("unable to iterate over meta")
-        {
-            if slot > to_slot {
-                break;
-            }
-
-            count += 1;
-            if last_print.elapsed().as_millis() > 2000 {
-                info!(
-                    "purged: {count} slots rewritten: {rewritten} retain_time: {total_retain_us}us"
-                );
-                count = 0;
-                rewritten = 0;
-                total_retain_us = 0;
-                last_print = Instant::now();
-            }
-            let mut time = Measure::start("retain");
-            let original_len = meta.next_slots.len();
-            meta.next_slots
-                .retain(|slot| *slot < from_slot || *slot > to_slot);
-            if meta.next_slots.len() != original_len {
-                rewritten += 1;
-                info!(
-                    "purge_from_next_slots: meta for slot {} no longer refers to slots {:?}",
-                    slot,
-                    from_slot..=to_slot
-                );
-                self.put_meta(slot, &meta).expect("couldn't update meta");
-            }
-            time.stop();
-            total_retain_us += time.as_us();
-        }
     }
 
     /// Purges all columns relating to `slot`.
@@ -190,11 +185,12 @@ impl Blockstore {
     /// Note: slots > `to_slot` that chained to a purged slot are not properly
     /// cleaned up. This function is not intended to be used if such slots need
     /// to be replayed.
-    pub(crate) fn run_purge_with_stats(
+    fn run_purge_with_stats(
         &self,
         from_slot: Slot,
         to_slot: Slot,
         purge_type: PurgeType,
+        cleanup_chaining: bool,
         purge_stats: &mut PurgeStats,
     ) -> Result<()> {
         let mut write_batch = self.get_write_batch()?;
@@ -207,6 +203,9 @@ impl Blockstore {
             purge_type,
             /* purge_alt_columns */ true,
         )?;
+        if cleanup_chaining {
+            self.cleanup_chaining_for_nonpurged_slots(&mut write_batch, from_slot, to_slot)?;
+        }
         delete_range_timer.stop();
 
         let mut write_timer = Measure::start("write_batch");
@@ -354,6 +353,73 @@ impl Blockstore {
             .delete_file_in_range(from_slot, to_slot)?;
         self.double_merkle_meta_cf
             .delete_file_in_range(from_slot, to_slot)
+    }
+
+    /// Given a range \[`from_slot`, `to_slot`\] to be purged from the
+    /// Blockstore, udpate the `SlotMeta` for any slots outside of the purge
+    /// range that chain to slots within the purge range. The expectation is
+    /// that the purge will take place in the same `WriteBatch`. Thus, there is
+    /// no need to update chaining between slots within the purge range.
+    ///
+    /// Chaining between two slots is established when the child is inserted.
+    /// The child slot knows its parent, and the parent `SlotMeta` `next_slots`
+    /// field is updated when the child is first inserted. Children slots past
+    /// the purge range may have parents within the purge range. If the parent
+    /// within the purge range is later reinserted, chaining between the parent
+    /// and child would not be automatically reestablished. For this reason,
+    /// - A `SlotMeta` with only the `next_slots` field will be kept for any
+    ///   slots within the purge range with a child after the purge range.
+    /// - To avoid overwriting a retained `SlotMeta`, this method must be
+    ///   called after the range purge. `WriteBatch` respects the ordering.
+    fn cleanup_chaining_for_nonpurged_slots(
+        &self,
+        batch: &mut WriteBatch,
+        from_slot: Slot,
+        to_slot: Slot,
+    ) -> Result<()> {
+        for (slot, mut meta) in self
+            .slot_meta_iterator(from_slot)?
+            .take_while(|(slot, _meta)| *slot <= to_slot)
+        {
+            if let Some(parent_slot) = meta.parent_slot
+                && parent_slot < from_slot
+            {
+                match self.meta(parent_slot)? {
+                    Some(mut parent_meta) => {
+                        // Retain only slots from outside of the purge range
+                        //
+                        // If multiple slots to be purged share a parent, this
+                        // step could be called several times for the same
+                        // parent slot. Because all slots in the purge range are
+                        // removed, the update is the same for each child. A
+                        // write batch can handle multiple updates to the same
+                        // key so there are no issues with this approach. This
+                        // approach avoids an extra HashMap to track dirty
+                        // SlotMeta's
+                        parent_meta
+                            .next_slots
+                            .retain(|slot| *slot < from_slot || *slot > to_slot);
+                        self.meta_cf
+                            .put_in_batch(batch, parent_slot, &parent_meta)
+                            .expect("SlotMeta should serialize into WriteBatch: {parent_meta:?}");
+                    }
+                    None => {
+                        error!("Missing parent SlotMeta for slot {slot}, parent {parent_slot}");
+                    }
+                }
+            }
+
+            meta.next_slots.retain(|&next_slot| next_slot > to_slot);
+            if !meta.next_slots.is_empty() {
+                let mut new_meta = SlotMeta::new_orphan(slot);
+                new_meta.next_slots = meta.next_slots;
+                self.meta_cf
+                    .put_in_batch(batch, slot, &new_meta)
+                    .expect("SlotMeta should serialize into WriteBatch: {meta:?}");
+            }
+        }
+
+        Ok(())
     }
 
     /// Returns true if the special columns, TransactionStatus and
@@ -711,6 +777,45 @@ pub mod tests {
         all_columns_empty_or_greater_than_slot(&blockstore, 0);
 
         assert_eq!(blockstore.slot_meta_iterator(0).unwrap().next(), None);
+    }
+
+    #[test]
+    fn test_purge_slots_cleanup_chaining() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let (shreds, _) = make_many_slot_entries(0, 15, 10);
+        blockstore.insert_shreds(shreds, None, false).unwrap();
+
+        let purge_range_from = 5;
+        let purge_range_to = 10;
+        blockstore
+            .purge_slots_cleanup_chaining(purge_range_from, purge_range_to, PurgeType::Exact)
+            .unwrap();
+
+        // Ensure nonpurged parent with purged child removes chaining
+        assert!(
+            blockstore
+                .meta(purge_range_from - 1)
+                .unwrap()
+                .unwrap()
+                .next_slots
+                .is_empty(),
+        );
+
+        // Ensure purged parent with nonpurged child retains chaining
+        let purge_range_to_meta = blockstore.meta(purge_range_to).unwrap().unwrap();
+        assert_eq!(purge_range_to_meta.next_slots[0], purge_range_to + 1);
+        assert!(!purge_range_to_meta.is_full());
+        assert_eq!(
+            blockstore
+                .meta(purge_range_to + 1)
+                .unwrap()
+                .unwrap()
+                .parent_slot
+                .unwrap(),
+            purge_range_to
+        );
     }
 
     #[test]

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -803,6 +803,12 @@ pub mod tests {
                 .is_empty(),
         );
 
+        // Ensure slots in [purged_range_from, purge_range_to) are empty;
+        // purge_range_to remains for sake of chaining (the check below)
+        for purged_slot in purge_range_from..purge_range_to {
+            assert!(blockstore.meta(purged_slot).unwrap().is_none());
+        }
+
         // Ensure purged parent with nonpurged child retains chaining
         let purge_range_to_meta = blockstore.meta(purge_range_to).unwrap().unwrap();
         assert_eq!(purge_range_to_meta.next_slots[0], purge_range_to + 1);
@@ -816,6 +822,15 @@ pub mod tests {
                 .unwrap(),
             purge_range_to
         );
+
+        // Purge to the end of the Blockstore and ensure all slots fully gone
+        let purge_range_to = 15;
+        blockstore
+            .purge_slots_cleanup_chaining(purge_range_from, purge_range_to, PurgeType::Exact)
+            .unwrap();
+        for purged_slot in purge_range_from..=purge_range_to {
+            assert!(blockstore.meta(purged_slot).unwrap().is_none());
+        }
     }
 
     #[test]

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -156,9 +156,8 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
 }
 
 pub fn purge_slots_with_count(blockstore: &Blockstore, start_slot: Slot, slot_count: Slot) {
-    blockstore.purge_from_next_slots(start_slot, start_slot + slot_count - 1);
     blockstore
-        .purge_slots(start_slot, start_slot + slot_count - 1, PurgeType::Exact)
+        .purge_slots_cleanup_chaining(start_slot, start_slot + slot_count - 1, PurgeType::Exact)
         .expect("Purge must succeed");
 }
 

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -155,9 +155,8 @@ pub fn open_blockstore(ledger_path: &Path) -> Blockstore {
 }
 
 pub fn purge_slots_with_count(blockstore: &Blockstore, start_slot: Slot, slot_count: Slot) {
-    blockstore.purge_from_next_slots(start_slot, start_slot + slot_count - 1);
     blockstore
-        .purge_slots(start_slot, start_slot + slot_count - 1, PurgeType::Exact)
+        .purge_slots_cleanup_chaining(start_slot, start_slot + slot_count - 1, PurgeType::Exact)
         .expect("Purge must succeed");
 }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6383,9 +6383,8 @@ fn test_alpenglow_missed_migration_entirely() {
     {
         let blockstore = Blockstore::open(&exit_info.info.ledger_path).unwrap();
         let end_slot = blockstore.highest_slot().unwrap().unwrap();
-        blockstore.purge_from_next_slots(start_slot, end_slot);
         blockstore
-            .purge_slots(start_slot, end_slot, PurgeType::Exact)
+            .purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)
             .unwrap();
     }
 

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6331,9 +6331,8 @@ fn test_alpenglow_missed_migration_entirely() {
     {
         let blockstore = Blockstore::open(&exit_info.info.ledger_path).unwrap();
         let end_slot = blockstore.highest_slot().unwrap().unwrap();
-        blockstore.purge_from_next_slots(start_slot, end_slot);
         blockstore
-            .purge_slots(start_slot, end_slot, PurgeType::Exact)
+            .purge_slots_cleanup_chaining(start_slot, end_slot, PurgeType::Exact)
             .unwrap();
     }
 


### PR DESCRIPTION
#### Problem
Blockstore::purge_from_next_slots() clears any chaining to/from a specified range. All current callers of this function are paired with an immediate call to purge that same specified range.

The current implementation is very slow. It scans the entire blockstore, not just the range being deleted. Additionally, the logic is not smart enough to see that it can skip rewriting the SlotMeta for slots that chain to each other within the purge range. There is no need to rewrite that SlotMeta if it will be deleted immediately after.

#### Summary of Changes
Add a new method, Blockstore::purge_slots_cleanup_chaining(), to replace the old pairing of purge_from_next_slots() and purge_slots(). The new method scans only the purge range, and updates only the necessary metas.

#### Current Callsites
Conversation with Ashwin raised a question about whether we should mark slots whose parent is in the purge range as orphans when calling this method. We do not currently do so and I believe we should not start doing so in this PR either.

The current callsites w/ an explanation:
1. https://github.com/anza-xyz/agave/blob/32422f42148ca741e2638ce405d9d015f70e8e07/core/src/banking_simulation.rs#L728-L731
    - Non production code
    - This usage purges to the end of the Blockstore so there are no orphans created from purge
2. https://github.com/anza-xyz/agave/blob/32422f42148ca741e2638ce405d9d015f70e8e07/core/src/validator.rs#L2884-L2885
    - This usage purges to the end of the Blockstore so there are no orphans created from purge
3. https://github.com/anza-xyz/agave/blob/32422f42148ca741e2638ce405d9d015f70e8e07/ledger-tool/src/blockstore.rs#L848-L849
    - Semi production code; not needed for normal operation
    - `ledger-tool` comes with no guardrails intentionally so I think NOT marking orphans is reasonable
        - My argument stands for both `agave-ledger-tool blockstore purge` and usage with `--dead-slots-only`
4. https://github.com/anza-xyz/agave/blob/32422f42148ca741e2638ce405d9d015f70e8e07/ledger-tool/src/main.rs#L2448-L2451
    - Semi production code, we only hit this on Testnet and Devnet if deactivating features
    - We purge the child bank slot and leave post-child-bank slots in place. However, usage of this is paired with a cluster restart; the logic called out above in `validator.rs` will then purge post-child-bank slots
5. Two callsites in `local-cluster`
    - These are obviously not production code