### PR TITLE
test(core): bound previously-unbounded test-only channels

### DIFF
--- a/core/benches/sigverify_stage.rs
+++ b/core/benches/sigverify_stage.rs
@@ -2,7 +2,7 @@
 
 use {
     bencher::{Bencher, TDynBenchFn, TestDesc, TestDescAndFn, TestFn, benchmark_main},
-    crossbeam_channel::unbounded,
+    crossbeam_channel::bounded,
     log::*,
     rand::{
         Rng,
@@ -74,11 +74,11 @@ fn bench_sigverify_stage(bencher: &mut Bencher, use_same_tx: bool) {
     let (_bank, bank_forks) =
         Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);
     let sharable_banks = bank_forks.read().unwrap().sharable_banks();
-    let (packet_s, packet_r) = unbounded();
-    let (vote_packet_s, vote_packet_r) = unbounded();
+    let (packet_s, packet_r) = bounded(1024);
+    let (vote_packet_s, vote_packet_r) = bounded(1024);
     let (verified_s, verified_r) = BankingTracer::channel_for_test();
     let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
-    let (forward_stage_s, _forward_stage_r) = unbounded();
+    let (forward_stage_s, _forward_stage_r) = bounded(1024);
     let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
         packet_r,
         vote_packet_r,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -830,7 +830,7 @@ mod tests {
             validator::SchedulerPacing,
         },
         agave_banking_stage_ingress_types::BankingPacketBatch,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         itertools::Itertools,
         solana_entry::{
             entry::{self, EntrySlice},
@@ -896,7 +896,7 @@ mod tests {
             poh_service,
             _entry_receiever,
         ) = create_test_recorder(bank, blockstore, None, None);
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
 
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralSchedulerGreedy,
@@ -958,7 +958,7 @@ mod tests {
             poh_service,
             entry_receiver,
         ) = create_test_recorder(bank, blockstore, None, None);
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
 
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralSchedulerGreedy,
@@ -1104,7 +1104,7 @@ mod tests {
                 .expect("Expected to be able to open database ledger"),
         );
 
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let entry_receiver = {
             // start a banking_stage to eat verified receiver
             let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -1269,7 +1269,7 @@ mod tests {
             poh_service,
             _entry_receiver,
         ) = create_test_recorder(bank.clone(), blockstore, None, None);
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
 
         let banking_stage = BankingStage::new_num_threads(
             BlockProductionMethod::CentralSchedulerGreedy,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1116,7 +1116,7 @@ pub(crate) mod external {
                 handshake::{ClientLogon, client, server::Server},
                 responses_region::{CheckResponsesPtr, ExecutionResponsesPtr},
             },
-            crossbeam_channel::unbounded,
+            crossbeam_channel::bounded,
             solana_account::AccountSharedData,
             solana_genesis_config::GenesisConfig,
             solana_keypair::Keypair,
@@ -1333,7 +1333,7 @@ pub(crate) mod external {
 
             let (record_sender, record_receiver) = record_channels(false);
             let recorder = TransactionRecorder::new(record_sender);
-            let (replay_vote_sender, replay_vote_receiver) = unbounded();
+            let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
             let committer = Committer::new(None, replay_vote_sender, None);
             let consumer = Consumer::new(committer, recorder, None);
             let shared_leader_state = SharedLeaderState::new(0, None, None);
@@ -2817,7 +2817,7 @@ mod tests {
             scheduler_messages::{MaxAge, TransactionBatchId},
             tests::{create_slow_genesis_config, sanitize_transactions},
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_clock::Slot,
         solana_genesis_config::GenesisConfig,
         solana_keypair::Keypair,
@@ -2887,13 +2887,13 @@ mod tests {
         let (record_sender, record_receiver) = record_channels(false);
         let recorder = TransactionRecorder::new(record_sender);
 
-        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
         let shared_leader_state = SharedLeaderState::new(0, None, None);
 
-        let (consume_sender, consume_receiver) = unbounded();
-        let (consumed_sender, consumed_receiver) = unbounded();
+        let (consume_sender, consume_receiver) = bounded(1024);
+        let (consumed_sender, consumed_receiver) = bounded(1024);
         let worker = ConsumeWorker::new(
             0,
             Arc::new(AtomicBool::new(false)),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -508,7 +508,7 @@ mod tests {
         super::*,
         crate::banking_stage::tests::{create_slow_genesis_config, sanitize_transactions},
         agave_reserved_account_keys::ReservedAccountKeys,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_account::{AccountSharedData, state_traits::StateMut},
         solana_address_lookup_table_interface::{
             self as address_lookup_table,
@@ -577,7 +577,7 @@ mod tests {
         let recorder = TransactionRecorder::new(record_sender);
         record_receiver.restart(bank.bank_id());
 
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(transaction_status_sender, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
 
@@ -600,7 +600,7 @@ mod tests {
         let recorder = TransactionRecorder::new(record_sender);
         record_receiver.restart(bank.bank_id());
 
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
         consumer.process_and_record_transactions(&bank, &transactions)
@@ -1255,7 +1255,7 @@ mod tests {
 
     #[test]
     fn test_write_persist_transaction_status() {
-        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
         let tss = Some(TransactionStatusSender {
             sender: transaction_status_sender,
             dependency_tracker: None,
@@ -1326,7 +1326,7 @@ mod tests {
 
     #[test]
     fn test_write_persist_loaded_addresses() {
-        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
         let tss = Some(TransactionStatusSender {
             sender: transaction_status_sender,
             dependency_tracker: None,

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -292,7 +292,7 @@ mod test {
             scheduler_messages::{MaxAge, TransactionId},
             transaction_scheduler::transaction_state_container::TransactionStateContainer,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         itertools::Itertools,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_hash::Hash,
@@ -316,8 +316,8 @@ mod test {
         Sender<FinishedConsumeWork<RuntimeTransaction<SanitizedTransaction>>>,
     ) {
         let (consume_work_senders, consume_work_receivers) =
-            (0..num_threads).map(|_| unbounded()).unzip();
-        let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
+            (0..num_threads).map(|_| bounded(1024)).unzip();
+        let (finished_consume_work_sender, finished_consume_work_receiver) = bounded(1024);
         let scheduler =
             GreedyScheduler::new(consume_work_senders, finished_consume_work_receiver, config);
         (

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -548,7 +548,7 @@ mod tests {
     use {
         super::*,
         crate::banking_stage::tests::create_slow_genesis_config,
-        crossbeam_channel::{Receiver, unbounded},
+        crossbeam_channel::{Receiver, bounded},
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_disconnected_channel() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks);
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_no_hold() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -720,7 +720,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_discard() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -773,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_invalid_transaction_format() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks);
@@ -817,7 +817,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_invalid_blockhash() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks);
@@ -860,7 +860,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_simple_transfer_unfunded_fee_payer() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, _mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -908,7 +908,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_failed_alt_resolve() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -971,7 +971,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_simple_transfer() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_filters_fee_payer() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer_with_filter_keys(
@@ -1049,7 +1049,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_filters_account_key() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let filtered_key = Pubkey::new_unique();
         let (mut receive_and_buffer, mut container) =
@@ -1080,7 +1080,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_does_not_filter_unmatched_keys() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer_with_filter_keys(
@@ -1110,7 +1110,7 @@ mod tests {
 
     #[test]
     fn test_receive_and_buffer_overfull() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
@@ -1189,7 +1189,7 @@ mod tests {
             .unwrap()
         }
 
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -313,7 +313,7 @@ mod tests {
             consumer::RetryableIndex,
             transaction_scheduler::transaction_state_container::TransactionStateContainer,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_pubkey::Pubkey,
@@ -470,8 +470,8 @@ mod tests {
         add_transactions_to_container(&mut container, 3);
 
         let (work_senders, work_receivers): (Vec<Sender<_>>, Vec<Receiver<_>>) =
-            (0..NUM_WORKERS).map(|_| unbounded()).unzip();
-        let (_finished_work_sender, finished_work_receiver) = unbounded();
+            (0..NUM_WORKERS).map(|_| bounded(1024)).unzip();
+        let (_finished_work_sender, finished_work_receiver) = bounded(1024);
         let mut common = SchedulingCommon::new(work_senders, finished_work_receiver, 10);
         assert_eq!(
             common.batches.entry_bytes(),
@@ -524,8 +524,8 @@ mod tests {
         add_transactions_to_container(&mut container, 1);
 
         let (work_senders, work_receivers): (Vec<Sender<_>>, Vec<Receiver<_>>) =
-            (0..NUM_WORKERS).map(|_| unbounded()).unzip();
-        let (finished_work_sender, finished_work_receiver) = unbounded();
+            (0..NUM_WORKERS).map(|_| bounded(1024)).unzip();
+        let (finished_work_sender, finished_work_receiver) = bounded(1024);
         let mut common = SchedulingCommon::new(work_senders, finished_work_receiver, 10);
 
         // Send a batch. Return completed work.
@@ -579,8 +579,8 @@ mod tests {
         let mut container = TransactionStateContainer::with_capacity(1024);
 
         let (work_senders, work_receivers): (Vec<Sender<_>>, Vec<Receiver<_>>) =
-            (0..NUM_WORKERS).map(|_| unbounded()).unzip();
-        let (finished_work_sender, finished_work_receiver) = unbounded();
+            (0..NUM_WORKERS).map(|_| bounded(1024)).unzip();
+        let (finished_work_sender, finished_work_receiver) = bounded(1024);
         let mut common = SchedulingCommon::new(work_senders, finished_work_receiver, 10);
         // Retryable indexes out-of-order.
         add_transactions_to_container(&mut container, 2);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -536,7 +536,7 @@ mod tests {
             transaction_scheduler::greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
         },
         agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
-        crossbeam_channel::{Receiver, Sender, unbounded},
+        crossbeam_channel::{Receiver, Sender, bounded},
         itertools::Itertools,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_fee_calculator::FeeRateGovernor,
@@ -556,7 +556,7 @@ mod tests {
     };
 
     fn create_channels<T>(num: usize) -> (Vec<Sender<T>>, Vec<Receiver<T>>) {
-        (0..num).map(|_| unbounded()).unzip()
+        (0..num).map(|_| bounded(1024)).unzip()
     }
 
     // Helper struct to create tests that hold channels, files, etc.
@@ -603,12 +603,12 @@ mod tests {
 
         let decision_maker = DecisionMaker::new(shared_leader_state.clone());
 
-        let (banking_packet_sender, banking_packet_receiver) = unbounded();
+        let (banking_packet_sender, banking_packet_receiver) = bounded(1024);
         let receive_and_buffer =
             create_receive_and_buffer(banking_packet_receiver, bank_forks.clone());
 
         let (consume_work_senders, consume_work_receivers) = create_channels(num_threads);
-        let (finished_consume_work_sender, finished_consume_work_receiver) = unbounded();
+        let (finished_consume_work_sender, finished_consume_work_receiver) = bounded(1024);
 
         let test_frame = TestFrame {
             bank,

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -280,7 +280,7 @@ mod tests {
             leader_slot_metrics::LeaderSlotMetricsTracker,
             vote_storage::{VoteStorage, tests::packet_from_slots},
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_perf::packet::PacketBatch,
         solana_runtime::{
             bank::Bank,
@@ -294,7 +294,7 @@ mod tests {
         filter_keys: Arc<HashSet<Pubkey>>,
     ) -> VoteStorage {
         let vote_packet = packet_from_slots(vec![(1, 1)], keypairs, None);
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         sender
             .send(Arc::new(vec![PacketBatch::from(vec![vote_packet])]))
             .unwrap();

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -577,7 +577,7 @@ mod tests {
             tests::{create_slow_genesis_config, sanitize_transactions},
             vote_storage::tests::packet_from_slots,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_perf::packet::BytesPacket,
         solana_poh::record_channels::record_channels,
@@ -764,7 +764,7 @@ mod tests {
         let recorder = solana_poh::transaction_recorder::TransactionRecorder::new(record_sender);
         record_receiver.restart(bank.bank_id());
 
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1342,7 +1342,7 @@ mod tests {
         super::*,
         crate::banking_trace::BankingTracer,
         agave_banking_stage_ingress_types::BankingPacketReceiver,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
         solana_keypair::Keypair,
@@ -1536,7 +1536,7 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let (_record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
         let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
         let (reward_certs_requestor, _receiver) = CertsRequestor::new();
@@ -1579,8 +1579,8 @@ mod tests {
         let in_flight_commit = bank.freeze_lock();
         ctx.record_receiver.shutdown();
         for _ in ctx.record_receiver.drain_after_shutdown() {}
-        let (abort_started_sender, abort_started_receiver) = unbounded();
-        let (abort_done_sender, abort_done_receiver) = unbounded();
+        let (abort_started_sender, abort_started_receiver) = bounded(1024);
+        let (abort_done_sender, abort_done_receiver) = bounded(1024);
         std::thread::scope(|scope| {
             scope.spawn(|| {
                 abort_started_sender.send(()).unwrap();
@@ -1652,7 +1652,7 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let (_record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
         let mut genesis_cert_block_marker = test_genesis_cert_block_marker();
         genesis_cert_block_marker.slot = parent_bank.slot();
@@ -1729,7 +1729,7 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let (record_sender, record_receiver) = record_channels(false);
-        let (_leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (_leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (banking_stage_sender, _banking_stage_receiver) = BankingTracer::channel_for_test();
         let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
         let (reward_certs_requestor, _reward_request_receiver) = CertsRequestor::new();
@@ -1838,7 +1838,7 @@ mod tests {
         let poh_recorder = Arc::new(RwLock::new(poh_recorder));
 
         let (record_sender, record_receiver) = record_channels(false);
-        let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
+        let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
         let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
         let (reward_certs_requestor, _receiver) = CertsRequestor::new();

--- a/core/src/bls_sigverify/bls_sigverifier.rs
+++ b/core/src/bls_sigverify/bls_sigverifier.rs
@@ -343,7 +343,7 @@ mod tests {
             vote::Vote,
         },
         bitvec::prelude::{BitVec, Lsb0},
-        crossbeam_channel::{Receiver, TryRecvError},
+        crossbeam_channel::{Receiver, TryRecvError, bounded},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature},
         solana_epoch_schedule::EpochSchedule,
         solana_gossip::contact_info::ContactInfo,
@@ -383,7 +383,7 @@ mod tests {
 
     impl TestContext {
         fn new() -> Self {
-            let (channel_to_pool, pool_receiver) = crossbeam_channel::unbounded();
+            let (channel_to_pool, pool_receiver) = bounded(1024);
             Self::new_with_pool_channel(channel_to_pool, pool_receiver)
         }
 
@@ -417,10 +417,10 @@ mod tests {
             let leader_schedule =
                 Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
 
-            let (channel_to_repair, repair_receiver) = crossbeam_channel::unbounded();
-            let (channel_to_reward, reward_receiver) = crossbeam_channel::unbounded();
-            let (packet_sender, packet_receiver) = crossbeam_channel::unbounded();
-            let (channel_to_metrics, metrics_receiver) = crossbeam_channel::unbounded();
+            let (channel_to_repair, repair_receiver) = bounded(1024);
+            let (channel_to_reward, reward_receiver) = bounded(1024);
+            let (packet_sender, packet_receiver) = bounded(1024);
+            let (channel_to_metrics, metrics_receiver) = bounded(1024);
 
             let generated_cert_types = Arc::new(GeneratedCertTypes::default());
             let banlist = new_test_banlist();
@@ -1350,10 +1350,10 @@ mod tests {
 
     #[test]
     fn test_verify_old_vote_and_cert() {
-        let (message_sender, message_receiver) = crossbeam_channel::unbounded();
-        let (votes_for_repair_sender, _) = crossbeam_channel::unbounded();
-        let (consensus_metrics_sender, _) = crossbeam_channel::unbounded();
-        let (reward_votes_sender, _reward_votes_receiver) = crossbeam_channel::unbounded();
+        let (message_sender, message_receiver) = bounded(1024);
+        let (votes_for_repair_sender, _) = bounded(1024);
+        let (consensus_metrics_sender, _) = bounded(1024);
+        let (reward_votes_sender, _reward_votes_receiver) = bounded(1024);
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -1381,7 +1381,7 @@ mod tests {
             SocketAddrSpace::Unspecified,
         ));
         let leader_schedule = Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
-        let (_packet_sender, packet_receiver) = crossbeam_channel::unbounded();
+        let (_packet_sender, packet_receiver) = bounded(1024);
         let mut sig_verifier = SigVerifier::new(
             SigVerifierContext {
                 migration_status: Arc::new(MigrationStatus::default()),

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -997,6 +997,7 @@ mod tests {
     use {
         super::*,
         crate::sigverify::GossipVerifiedVoteBatch,
+        crossbeam_channel::bounded,
         itertools::Itertools,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -1053,8 +1054,8 @@ mod tests {
         votes: Vec<Transaction>,
         sharable_banks: &SharableBanks,
     ) -> (Vec<Transaction>, Vec<PacketBatch>) {
-        let (worker_sender, _worker_receiver) = unbounded();
-        let (verified_vote_sender, verified_vote_receiver) = unbounded();
+        let (worker_sender, _worker_receiver) = bounded(1024);
+        let (verified_vote_sender, verified_vote_receiver) = bounded(1024);
         let mut gossip_sigverify_handle =
             GossipSigVerifyHandle::new_for_tests(worker_sender, verified_vote_receiver);
 
@@ -1160,10 +1161,10 @@ mod tests {
             subscriptions,
             ..
         } = setup();
-        let (votes_sender, votes_receiver) = unbounded();
-        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
-        let (replay_votes_sender, replay_votes_receiver) = unbounded();
+        let (votes_sender, votes_receiver) = bounded(1024);
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = bounded(1024);
+        let (replay_votes_sender, replay_votes_receiver) = bounded(1024);
         let mut latest_vote_slot_per_validator = HashMap::new();
 
         let GenesisConfigInfo { genesis_config, .. } =
@@ -1288,10 +1289,10 @@ mod tests {
             bank: bank0,
             ..
         } = setup();
-        let (votes_txs_sender, votes_txs_receiver) = unbounded();
-        let (replay_votes_sender, replay_votes_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
+        let (votes_txs_sender, votes_txs_receiver) = bounded(1024);
+        let (replay_votes_sender, replay_votes_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = bounded(1024);
+        let (verified_voter_slots_sender, verified_voter_slots_receiver) = bounded(1024);
         let mut latest_vote_slot_per_validator = HashMap::new();
 
         let gossip_vote_slots = vec![1, 2];
@@ -1437,10 +1438,10 @@ mod tests {
         } = setup();
 
         // Send some votes to process
-        let (votes_txs_sender, votes_txs_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
-        let (_replay_votes_sender, replay_votes_receiver) = unbounded();
+        let (votes_txs_sender, votes_txs_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = bounded(1024);
+        let (verified_voter_slots_sender, verified_voter_slots_receiver) = bounded(1024);
+        let (_replay_votes_sender, replay_votes_receiver) = bounded(1024);
         let mut latest_vote_slot_per_validator = HashMap::new();
 
         let mut expected_voter_slots = vec![];
@@ -1530,11 +1531,11 @@ mod tests {
     }
 
     fn run_test_process_votes3(switch_proof_hash: Option<Hash>) {
-        let (votes_sender, votes_receiver) = unbounded();
-        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
+        let (votes_sender, votes_receiver) = bounded(1024);
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = bounded(1024);
         let (replay_votes_sender, replay_votes_receiver): (ReplayVoteSender, ReplayVoteReceiver) =
-            unbounded();
+            bounded(1024);
         let mut latest_vote_slot_per_validator = HashMap::new();
 
         let vote_slot = 1;
@@ -1933,8 +1934,8 @@ mod tests {
             None,
         )];
 
-        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = bounded(1024);
         let notifiers = ConfirmationNotifiers {
             gossip_verified_vote_hash_sender: gossip_verified_vote_hash_sender.clone(),
             verified_voter_slots_sender: verified_voter_slots_sender.clone(),
@@ -2183,8 +2184,8 @@ mod tests {
         ));
         let mut latest_vote_slot_per_validator = HashMap::new();
 
-        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = unbounded();
-        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = unbounded();
+        let (verified_voter_slots_sender, _verified_voter_slots_receiver) = bounded(1024);
+        let (gossip_verified_vote_hash_sender, _gossip_verified_vote_hash_receiver) = bounded(1024);
         let mut diff = HashMap::default();
         let mut new_optimistic_confirmed_slots = vec![];
 

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -765,7 +765,7 @@ fn initial_packet_meta_filter(meta: &packet::Meta) -> bool {
 mod tests {
     use {
         super::*,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         packet::PacketFlags,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn test_forwarding() {
-        let (packet_batch_sender, packet_batch_receiver) = unbounded();
+        let (packet_batch_sender, packet_batch_receiver) = bounded(1024);
 
         let (_bank, bank_forks) =
             Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -915,7 +915,7 @@ mod test {
     #[test]
     pub fn test_ancestor_hashes_service_process_replay_updates() {
         let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         let ancestor_hashes_request_statuses = DashMap::new();
         let mut dead_slot_pool = HashSet::new();
         let mut repairable_dead_slot_pool = HashSet::new();
@@ -1056,7 +1056,7 @@ mod test {
     #[test]
     pub fn test_ancestor_hashes_service_process_pruned_replay_updates() {
         let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         let ancestor_hashes_request_statuses = DashMap::new();
         let mut dead_slot_pool = HashSet::new();
         let mut repairable_dead_slot_pool = HashSet::new();
@@ -1259,8 +1259,8 @@ mod test {
 
             // Set up thread to give us responses
             let exit = Arc::new(AtomicBool::new(false));
-            let (requests_sender, requests_receiver) = unbounded();
-            let (response_sender, response_receiver) = unbounded();
+            let (requests_sender, requests_receiver) = bounded(1024);
+            let (response_sender, response_receiver) = bounded(1024);
 
             // Create slots [slot - MAX_ANCESTOR_RESPONSES, slot) with 5 shreds apiece
             let (shreds, _) = make_many_slot_entries(
@@ -1354,7 +1354,8 @@ mod test {
                     bank_forks_r.migration_status(),
                 )
             };
-            let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) = unbounded();
+            let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) =
+                bounded(1024);
             let repair_info = RepairInfo {
                 bank_forks,
                 cluster_info: requester_cluster_info,
@@ -1366,8 +1367,8 @@ mod test {
             };
 
             let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
-                unbounded();
-            let (retryable_slots_sender, retryable_slots_receiver) = unbounded();
+                bounded(1024);
+            let (retryable_slots_sender, retryable_slots_receiver) = bounded(1024);
             Self {
                 ancestor_hashes_request_statuses,
                 ancestor_hashes_request_socket,
@@ -1978,7 +1979,7 @@ mod test {
             ref cluster_slots,
             ..
         } = repair_info;
-        let (dumped_slots_sender, _dumped_slots_receiver) = unbounded();
+        let (dumped_slots_sender, _dumped_slots_receiver) = bounded(1024);
 
         // Add the responder to the eligible list for requests
         let responder_id = *responder_info.pubkey();
@@ -2204,7 +2205,7 @@ mod test {
 
     #[test]
     fn test_process_replay_updates_continue_after_skipped_update() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let ancestor_hashes_request_statuses = DashMap::new();
         let mut dead_slot_pool = HashSet::new();
         let mut repairable_dead_slot_pool = HashSet::new();

--- a/core/src/repair/cluster_slot_state_verifier.rs
+++ b/core/src/repair/cluster_slot_state_verifier.rs
@@ -954,7 +954,7 @@ mod test {
     use {
         super::*,
         crate::{consensus::progress_map::ProgressMap, replay_stage::tests::setup_forks_from_tree},
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_runtime::bank_forks::BankForks,
         std::{
             collections::{HashMap, HashSet},
@@ -1616,7 +1616,7 @@ mod test {
             .unwrap()
             .hash();
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         apply_state_changes(
             duplicate_slot,
             &mut heaviest_subtree_fork_choice,
@@ -1699,7 +1699,7 @@ mod test {
         // BankFrozen should mark it down in Blockstore.
         assert!(blockstore.get_bank_hash(duplicate_slot).is_none());
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         apply_state_changes(
             duplicate_slot,
             &mut heaviest_subtree_fork_choice,
@@ -1780,7 +1780,7 @@ mod test {
         )];
         modify_state_changes(our_duplicate_slot_hash, &mut state_changes);
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         apply_state_changes(
             duplicate_slot,
             &mut heaviest_subtree_fork_choice,
@@ -1864,7 +1864,7 @@ mod test {
             || initial_bank_hash,
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             duplicate_slot,
             root,
@@ -1976,7 +1976,7 @@ mod test {
             || Some(slot2_hash),
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             2,
             root,
@@ -2098,7 +2098,7 @@ mod test {
             || Some(slot2_hash),
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             2,
             root,
@@ -2222,7 +2222,7 @@ mod test {
             || Some(slot3_hash),
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             3,
             root,
@@ -2308,7 +2308,7 @@ mod test {
             false,
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             3,
             root,
@@ -2338,7 +2338,7 @@ mod test {
             || Some(slot3_hash),
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             3,
             root,
@@ -2402,7 +2402,7 @@ mod test {
             false,
         );
         let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-            unbounded();
+            bounded(1024);
         check_slot_agrees_with_cluster(
             3,
             root,

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1940,6 +1940,7 @@ mod tests {
         super::*,
         crate::repair::repair_response,
         agave_feature_set::FeatureSet,
+        crossbeam_channel::bounded,
         solana_gossip::{contact_info::ContactInfo, socketaddr, socketaddr_any},
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -2545,8 +2546,7 @@ mod tests {
             .root_bank()
             .epoch_schedule()
             .clone();
-        let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) =
-            crossbeam_channel::unbounded();
+        let (ancestor_duplicate_slots_sender, _ancestor_duplicate_slots_receiver) = bounded(1024);
         RepairInfo {
             bank_forks,
             cluster_info,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -19,7 +19,7 @@ use {
         ConfirmationProgress, ProcessOptions, confirm_full_slot, fill_blockstore_slot_with_ticks,
         process_bank_0,
     },
-    crossbeam_channel::{bounded, unbounded},
+    crossbeam_channel::bounded,
     itertools::Itertools,
     solana_account::{ReadableAccount, state_traits::StateMut},
     solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
@@ -93,11 +93,10 @@ impl ProcessActiveBanksContext {
         blockstore: Arc<Blockstore>,
         replay_vote_sender: ReplayVoteSender,
     ) -> Self {
-        use crossbeam_channel::unbounded;
-        let (cluster_slots_update_sender, _) = unbounded();
-        let (cost_update_sender, _) = unbounded();
-        let (ancestor_hashes_replay_update_sender, _) = unbounded();
-        let (votor_event_sender, _) = unbounded();
+        let (cluster_slots_update_sender, _) = bounded(1024);
+        let (cost_update_sender, _) = bounded(1024);
+        let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
+        let (votor_event_sender, _) = bounded(1024);
         let migration_status = Arc::new(MigrationStatus::default());
         let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(1)
@@ -535,7 +534,7 @@ fn test_handle_new_root() {
         .into_iter()
         .map(|slot| (slot, Hash::default()))
         .collect();
-    let (drop_bank_sender, _drop_bank_receiver) = unbounded();
+    let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
     let mut tbft_structs = TowerBFTStructures {
         heaviest_subtree_fork_choice,
         duplicate_slots_tracker,
@@ -626,7 +625,7 @@ fn test_handle_new_root_ahead_of_highest_super_majority_root() {
             ForkProgress::new(Hash::default(), None, None, 0, 0, None),
         );
     }
-    let (drop_bank_sender, _drop_bank_receiver) = unbounded();
+    let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
     let mut tbft_structs = TowerBFTStructures {
         heaviest_subtree_fork_choice: HeaviestSubtreeForkChoice::new((root, root_hash)),
         duplicate_slots_tracker: DuplicateSlotsTracker::default(),
@@ -958,8 +957,8 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
     let bank = bank_forks.write().unwrap().insert(child_bank);
 
     let slot = bank.slot();
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-    let (finalization_cert_sender, _finalization_cert_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (finalization_cert_sender, _finalization_cert_receiver) = bounded(1024);
     let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
         bank_forks.clone(),
         blockstore.clone(),
@@ -1084,7 +1083,7 @@ fn test_cmr_mismatch_hard_dead() {
         ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
     );
 
-    let (replay_vote_sender, replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
     let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
         bank_forks.clone(),
         blockstore.clone(),
@@ -1146,7 +1145,7 @@ fn test_abandon_invalidates() {
         ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
     );
 
-    let (replay_vote_sender, replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
     let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
         bank_forks.clone(),
         blockstore,
@@ -1224,8 +1223,8 @@ where
         blockstore.insert_shreds(shreds, None, false).unwrap();
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let exit = Arc::new(AtomicBool::new(false));
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let (finalization_cert_sender, _finalization_cert_receiver) = unbounded();
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+        let (finalization_cert_sender, _finalization_cert_receiver) = bounded(1024);
         let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
             bank_forks.clone(),
             blockstore.clone(),
@@ -1262,7 +1261,7 @@ where
             block_commitment_cache,
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks),
         ));
-        let (replay_vote_sender, replay_vote_receiver) = unbounded();
+        let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
         let dead_slots = Arc::new(Mutex::new(HashSet::default()));
 
         let slot_status_notifier: Option<SlotStatusNotifier> = Some(Arc::new(RwLock::new(
@@ -2843,7 +2842,7 @@ fn test_update_parent_restart() {
         progress.insert(slot, p);
     }
 
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = bounded(1024);
     for slot in [4, 8] {
         let parent_block_id = Hash::new_unique();
         insert_update_parent_slot(
@@ -2858,7 +2857,7 @@ fn test_update_parent_restart() {
     }
 
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
-    let (replay_vote_sender, replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -2986,10 +2985,10 @@ fn test_update_parent_tower_gated() {
     p.replay_progress.write().unwrap().num_shreds = 5;
     progress.insert(slot, p);
 
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = bounded(1024);
     tx.send(UpdateParentSignal { slot }).unwrap();
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3030,10 +3029,10 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
     p.replay_progress.write().unwrap().num_shreds = 5;
     progress.insert(slot, p);
 
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = bounded(1024);
     tx.send(UpdateParentSignal { slot }).unwrap();
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3077,10 +3076,10 @@ fn test_update_parent_keeps_hard() {
     p.mark_dead(DeadSlotReason::Hard);
     progress.insert(slot, p);
 
-    let (tx, rx) = crossbeam_channel::unbounded();
+    let (tx, rx) = bounded(1024);
     tx.send(UpdateParentSignal { slot }).unwrap();
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3122,8 +3121,8 @@ fn test_pre_update_soft_dead() {
     p.replay_progress.write().unwrap().num_shreds = 5;
     progress.insert(slot, p);
 
-    let (replay_vote_sender, replay_vote_receiver) = unbounded();
-    let (ancestor_hashes_replay_update_sender, _) = unbounded();
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
     let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
     let migration_status = post_migration_status_for_tests();
@@ -3181,8 +3180,8 @@ fn test_after_update_hard_dead() {
     p.replay_progress.write().unwrap().num_shreds = 5;
     progress.insert(slot, p);
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-    let (ancestor_hashes_replay_update_sender, _) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
     let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
     let migration_status = post_migration_status_for_tests();
@@ -3244,8 +3243,8 @@ fn test_before_update_soft_dead() {
     p.replay_progress.write().unwrap().num_shreds = 5;
     progress.insert(slot, p);
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-    let (ancestor_hashes_replay_update_sender, _) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
     let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
     let migration_status = post_migration_status_for_tests();
@@ -3299,7 +3298,7 @@ fn test_soft_dead_restarts() {
     p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
     progress.insert(slot, p);
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3342,7 +3341,7 @@ fn test_full_soft_dead_hardens() {
     p.mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
     progress.insert(slot, p);
 
-    let (replay_vote_sender, _replay_vote_receiver) = unbounded();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3727,7 +3726,7 @@ fn test_unconfirmed_duplicate_slots_and_lockouts_for_non_heaviest_fork() {
         || Some(bank5_hash),
     );
     let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-        unbounded();
+        bounded(1024);
     check_slot_agrees_with_cluster(
         5,
         bank_forks.read().unwrap().root(),
@@ -3938,7 +3937,7 @@ fn test_unconfirmed_duplicate_slots_and_lockouts() {
         || Some(bank4_hash),
     );
     let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-        unbounded();
+        bounded(1024);
     check_slot_agrees_with_cluster(
         4,
         bank_forks.read().unwrap().root(),
@@ -4073,7 +4072,7 @@ fn test_dump_then_repair_correct_slots() {
     duplicate_slots_to_repair.insert(1, Hash::new_unique());
     duplicate_slots_to_repair.insert(2, Hash::new_unique());
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
-    let (dumped_slots_sender, dumped_slots_receiver) = unbounded();
+    let (dumped_slots_sender, dumped_slots_receiver) = bounded(1024);
     let should_be_dumped = duplicate_slots_to_repair
         .iter()
         .map(|(&s, &h)| (s, h))
@@ -4176,7 +4175,7 @@ fn setup_vote_then_rollback(
         || Some(our_bank2_hash),
     );
     let (ancestor_hashes_replay_update_sender, _ancestor_hashes_replay_update_receiver) =
-        unbounded();
+        bounded(1024);
     check_slot_agrees_with_cluster(
         2,
         bank_forks.read().unwrap().root(),
@@ -4196,7 +4195,7 @@ fn setup_vote_then_rollback(
     let mut ancestors = bank_forks.read().unwrap().ancestors();
     let mut descendants = bank_forks.read().unwrap().descendants();
     let old_descendants_of_2 = descendants.get(&2).unwrap().clone();
-    let (dumped_slots_sender, _dumped_slots_receiver) = unbounded();
+    let (dumped_slots_sender, _dumped_slots_receiver) = bounded(1024);
 
     ReplayStage::dump_then_repair_correct_slots(
         &mut duplicate_slots_to_repair,
@@ -4487,7 +4486,7 @@ fn test_gossip_vote_doesnt_affect_fork_choice() {
 
     let vote_pubkey = vote_pubkeys[0];
     let mut unfrozen_gossip_verified_vote_hashes = UnfrozenGossipVerifiedVoteHashes::default();
-    let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
+    let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = bounded(1024);
 
     // Best slot is 4
     assert_eq!(
@@ -4575,7 +4574,7 @@ fn test_replay_stage_refresh_last_vote() {
         ),
     );
 
-    let (voting_sender, voting_receiver) = unbounded();
+    let (voting_sender, voting_receiver) = bounded(1024);
 
     // Simulate landing a vote for slot 0 landing in slot 1
     let bank1 = Bank::new_from_parent_with_bank_forks(
@@ -5104,7 +5103,7 @@ fn test_replay_stage_last_vote_outside_slot_hashes() {
         )
     });
 
-    let (voting_sender, voting_receiver) = unbounded();
+    let (voting_sender, voting_receiver) = bounded(1024);
     let mut cursor = Cursor::default();
 
     let mut new_bank = send_vote_in_new_bank(
@@ -5272,7 +5271,7 @@ fn test_retransmit_latest_unpropagated_leader_slot() {
     } = vote_simulator;
 
     let poh_recorder = Arc::new(poh_recorder);
-    let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+    let (retransmit_slots_sender, retransmit_slots_receiver) = bounded(1024);
 
     let bank1 = Bank::new_from_parent(
         bank_forks.read().unwrap().get(0).unwrap(),
@@ -5446,7 +5445,7 @@ fn test_maybe_retransmit_unpropagated_slots() {
         ..
     } = vote_simulator;
 
-    let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+    let (retransmit_slots_sender, retransmit_slots_receiver) = bounded(1024);
     let retry_time = Instant::now()
         .checked_sub(Duration::from_millis(RETRANSMIT_BASE_DELAY_MS + 1))
         .unwrap();
@@ -5534,7 +5533,7 @@ fn test_dumped_slot_not_causing_panic() {
     } = vote_simulator;
 
     let poh_recorder = Arc::new(poh_recorder);
-    let (retransmit_slots_sender, _) = unbounded();
+    let (retransmit_slots_sender, _) = bounded(1024);
 
     // Use a bank slot when I was not leader to avoid panic for dumping my own slot
     let slot_to_dump = (1..100)
@@ -5590,7 +5589,7 @@ fn test_dumped_slot_not_causing_panic() {
     let bank_to_dump_bad_hash = Hash::new_unique();
     duplicate_slots_to_repair.insert(slot_to_dump, bank_to_dump_bad_hash);
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
-    let (dumped_slots_sender, dumped_slots_receiver) = unbounded();
+    let (dumped_slots_sender, dumped_slots_receiver) = bounded(1024);
 
     ReplayStage::dump_then_repair_correct_slots(
         &mut duplicate_slots_to_repair,
@@ -5675,7 +5674,7 @@ fn test_dump_own_slots_fails() {
     duplicate_slots_to_repair.insert(1, Hash::new_unique());
     duplicate_slots_to_repair.insert(2, Hash::new_unique());
     let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
-    let (dumped_slots_sender, _) = unbounded();
+    let (dumped_slots_sender, _) = bounded(1024);
 
     ReplayStage::dump_then_repair_correct_slots(
         &mut duplicate_slots_to_repair,
@@ -6291,7 +6290,7 @@ fn test_skip_leader_slot_for_existing_slot() {
         .unwrap();
 
     let poh_recorder = Arc::new(poh_recorder);
-    let (retransmit_slots_sender, _) = unbounded();
+    let (retransmit_slots_sender, _) = bounded(1024);
     let (banking_tracer, _) = BankingTracer::new(None).unwrap();
     // A vote has not technically been rooted, but it doesn't matter for
     // this test to use true to avoid skipping the leader slot
@@ -6384,7 +6383,7 @@ fn test_mark_slots_duplicate_confirmed() {
         ..
     } = vote_simulator;
 
-    let (ancestor_hashes_replay_update_sender, _) = unbounded();
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
     let mut duplicate_confirmed_slots = DuplicateConfirmedSlots::default();
     let bank_hash_0 = bank_forks.read().unwrap().bank_hash(0).unwrap();
     bank_forks.write().unwrap().set_root(1, None, None);
@@ -6503,8 +6502,8 @@ fn test_process_duplicate_confirmed_slots(same_batch: bool) {
         ..
     } = vote_simulator;
 
-    let (ancestor_hashes_replay_update_sender, _) = unbounded();
-    let (sender, receiver) = unbounded();
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
+    let (sender, receiver) = bounded(1024);
     let mut duplicate_confirmed_slots = DuplicateConfirmedSlots::default();
     let bank_hash_0 = bank_forks.read().unwrap().bank_hash(0).unwrap();
     bank_forks.write().unwrap().set_root(1, None, None);

--- a/core/src/result.rs
+++ b/core/src/result.rs
@@ -44,12 +44,12 @@ impl<T> std::convert::From<crossbeam_channel::SendError<T>> for Error {
 mod tests {
     use {
         crate::result::{Error, Result},
-        crossbeam_channel::{RecvError, RecvTimeoutError, unbounded},
+        crossbeam_channel::{RecvError, RecvTimeoutError, bounded},
         std::{io, io::Write, panic},
     };
 
     fn send_error() -> Result<()> {
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
         drop(r);
         s.send(())?;
         Ok(())

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -354,7 +354,7 @@ mod tests {
     use {
         super::*,
         crate::banking_trace::BankingTracer,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_message::{VersionedMessage, v1},
@@ -410,11 +410,11 @@ mod tests {
         let (_bank, bank_forks) =
             Bank::new_with_bank_forks_for_tests(&create_genesis_config(1).genesis_config);
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
-        let (packet_s, packet_r) = unbounded();
-        let (vote_packet_s, vote_packet_r) = unbounded();
+        let (packet_s, packet_r) = bounded(1024);
+        let (vote_packet_s, vote_packet_r) = bounded(1024);
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
         let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
-        let (forward_stage_s, _forward_stage_r) = unbounded();
+        let (forward_stage_s, _forward_stage_r) = bounded(1024);
         let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
             packet_r,
             vote_packet_r,
@@ -485,11 +485,11 @@ mod tests {
         }
         let (_bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
-        let (packet_s, packet_r) = unbounded();
-        let (vote_packet_s, vote_packet_r) = unbounded();
+        let (packet_s, packet_r) = bounded(1024);
+        let (vote_packet_s, vote_packet_r) = bounded(1024);
         let (verified_s, verified_r) = BankingTracer::channel_for_test();
         let (tpu_vote_s, _tpu_vote_r) = BankingTracer::channel_for_test();
-        let (forward_stage_s, _forward_stage_r) = unbounded();
+        let (forward_stage_s, _forward_stage_r) = bounded(1024);
         let (stage, gossip_sigverify_handle) = SigVerifyStage::new(
             packet_r,
             vote_packet_r,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -780,11 +780,11 @@ pub mod tests {
         let vote_keypair = Keypair::new();
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
-        let (retransmit_slots_sender, _retransmit_slots_receiver) = unbounded();
-        let (_gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
-        let (verified_voter_slots_sender, verified_voter_slots_receiver) = unbounded();
-        let (replay_vote_sender, _replay_vote_receiver) = unbounded();
-        let (_, gossip_confirmed_slots_receiver) = unbounded();
+        let (retransmit_slots_sender, _retransmit_slots_receiver) = bounded(1024);
+        let (_gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = bounded(1024);
+        let (verified_voter_slots_sender, verified_voter_slots_receiver) = bounded(1024);
+        let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+        let (_, gossip_confirmed_slots_receiver) = bounded(1024);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let outstanding_repair_requests = Arc::<RwLock<OutstandingShredRepairs>>::default();
         let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
@@ -804,8 +804,8 @@ pub mod tests {
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
-        let (leader_window_info_sender, _leader_window_info_receiver) = unbounded();
-        let (optimistic_parent_sender, optimistic_parent_receiver) = unbounded();
+        let (leader_window_info_sender, _leader_window_info_receiver) = bounded(1024);
+        let (optimistic_parent_sender, optimistic_parent_receiver) = bounded(1024);
         let highest_parent_ready = Arc::new(RwLock::new((
             0,
             Block {
@@ -814,7 +814,7 @@ pub mod tests {
             },
         )));
         let (votor_event_sender, votor_event_receiver): (VotorEventSender, VotorEventReceiver) =
-            unbounded();
+            bounded(1024);
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let key_notifiers = Arc::new(RwLock::new(KeyUpdaters::default()));
         let cancel = CancellationToken::new();
@@ -832,7 +832,7 @@ pub mod tests {
         let (bank_forks_controller, bank_forks_controller_receiver) =
             BankForksControllerHandle::new();
         let bank_forks_controller = Arc::new(bank_forks_controller);
-        let (reward_votes_sender, _reward_votes_receiver) = unbounded();
+        let (reward_votes_sender, _reward_votes_receiver) = bounded(1024);
 
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -17,7 +17,7 @@ use {
         replay_stage::{HeaviestForkFailures, ReplayStage, TowerBFTStructures},
         unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
     },
-    crossbeam_channel::unbounded,
+    crossbeam_channel::bounded,
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
@@ -247,7 +247,7 @@ impl VoteSimulator {
     }
 
     pub fn set_root(&mut self, new_root: Slot) {
-        let (drop_bank_sender, _drop_bank_receiver) = unbounded();
+        let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
         ReplayStage::handle_new_root(
             new_root,
             &self.bank_forks,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -499,6 +499,7 @@ impl WindowService {
 mod test {
     use {
         super::*,
+        crossbeam_channel::bounded,
         rand::Rng,
         solana_entry::entry::{Entry, create_ticks},
         solana_gossip::contact_info::ContactInfo,
@@ -558,8 +559,8 @@ mod test {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (sender, receiver) = unbounded();
-        let (duplicate_slot_sender, duplicate_slot_receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
+        let (duplicate_slot_sender, duplicate_slot_receiver) = bounded(1024);
         let (shreds, _) = make_many_slot_entries(5, 5, 10);
         blockstore
             .insert_shreds(shreds.clone(), None, false)
@@ -608,8 +609,8 @@ mod test {
     fn test_store_duplicate_shreds_same_batch() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (duplicate_shred_sender, duplicate_shred_receiver) = unbounded();
-        let (duplicate_slot_sender, duplicate_slot_receiver) = unbounded();
+        let (duplicate_shred_sender, duplicate_shred_receiver) = bounded(1024);
+        let (duplicate_slot_sender, duplicate_slot_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
         let keypair = Keypair::new();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -6,7 +6,7 @@ use {
         SnapshotInterval, SnapshotKind, paths as snapshot_paths,
         snapshot_archive_info::FullSnapshotArchiveInfo, snapshot_config::SnapshotConfig,
     },
-    crossbeam_channel::unbounded,
+    crossbeam_channel::bounded,
     itertools::Itertools,
     log::{info, trace},
     solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
@@ -172,7 +172,7 @@ where
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
     let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
-    let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
+    let (snapshot_request_sender, snapshot_request_receiver) = bounded(1024);
     let snapshot_controller = Arc::new(SnapshotController::new(
         snapshot_request_sender,
         snapshot_test_config.snapshot_config.clone(),
@@ -276,7 +276,7 @@ fn test_slots_to_snapshot() {
     let num_set_roots = status_cache_max_entries * 2;
 
     for add_root_interval in &[1, 3, 9] {
-        let (snapshot_sender, _snapshot_receiver) = unbounded();
+        let (snapshot_sender, _snapshot_receiver) = bounded(1024);
         // Make sure this test never clears bank.slots_since_snapshot
         let snapshot_test_config = SnapshotTestConfig::new(
             SnapshotInterval::Slots(
@@ -405,7 +405,7 @@ fn test_bank_forks_incremental_snapshot() {
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
     let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
-    let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
+    let (snapshot_request_sender, snapshot_request_receiver) = bounded(1024);
     let snapshot_controller = Arc::new(SnapshotController::new(
         snapshot_request_sender,
         snapshot_test_config.snapshot_config.clone(),
@@ -594,8 +594,8 @@ fn test_snapshots_with_background_services() {
         SocketAddrSpace::Unspecified,
     ));
 
-    let (pruned_banks_sender, pruned_banks_receiver) = unbounded();
-    let (snapshot_request_sender, snapshot_request_receiver) = unbounded();
+    let (pruned_banks_sender, pruned_banks_receiver) = bounded(1024);
+    let (snapshot_request_sender, snapshot_request_receiver) = bounded(1024);
     let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
 
     let bank_forks = snapshot_test_config.bank_forks.clone();
@@ -777,7 +777,7 @@ fn test_fastboot_snapshots_teardown(exit_backpressure: bool) {
         SocketAddrSpace::Unspecified,
     ));
 
-    let (snapshot_request_sender, _snapshot_request_receiver) = unbounded();
+    let (snapshot_request_sender, _snapshot_request_receiver) = bounded(1024);
     let pending_snapshot_packages = Arc::new(Mutex::new(PendingSnapshotPackages::default()));
 
     let bank_forks = snapshot_test_config.bank_forks.clone();

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -1,5 +1,5 @@
 use {
-    crossbeam_channel::unbounded,
+    crossbeam_channel::bounded,
     itertools::Itertools,
     log::*,
     solana_core::{
@@ -109,8 +109,8 @@ fn test_scheduler_waited_by_drop_bank_service() {
     drop(lock_to_stall);
 
     // Create 2 channels to check actual pruned banks
-    let (drop_bank_sender1, drop_bank_receiver1) = unbounded();
-    let (drop_bank_sender2, drop_bank_receiver2) = unbounded();
+    let (drop_bank_sender1, drop_bank_receiver1) = bounded(1024);
+    let (drop_bank_sender2, drop_bank_receiver2) = bounded(1024);
     let drop_bank_service = DropBankService::new(drop_bank_receiver2);
 
     info!("calling handle_new_root()...");


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites (cfg(test) modules, tests/ integration tests, benches). Production channels are left unbounded.

Related to #12774