### PR TITLE
feat(snapshots): stop using slot->storages len mapping from snapshot fields

### DIFF
--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -62,10 +62,10 @@ impl AccountsFile {
     /// Creates a new AccountsFile for the underlying storage at `file_info`
     ///
     /// This version of `new()` may only be called when reconstructing storages as part of startup.
-    /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
-    /// accounts verification to ensure it is valid.
-    pub fn new_for_startup(file_info: FileInfo, current_len: usize) -> Result<Self> {
-        let av = AppendVec::new_for_startup(file_info, current_len)?;
+    /// The storage length is taken to be the full file size; this is trusted and relies on later
+    /// index generation or accounts verification to ensure it is valid.
+    pub fn new_for_startup(file_info: FileInfo) -> Result<Self> {
+        let av = AppendVec::new_for_startup(file_info)?;
         Ok(Self::AppendVec(av))
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -612,13 +612,13 @@ impl AppendVec {
             ValidSlice(unsafe { slice::from_raw_parts(buf.as_ptr() as *const u8, bytes_read) });
         let (meta, next) = Self::get_type::<StoredMeta>(valid_bytes, 0)?;
         let (account_meta, _) = Self::get_type::<AccountMeta>(valid_bytes, next)?;
-        let stored_size = Self::calculate_stored_size_checked(meta.data_len as usize)?;
+        // Guard against a corrupt `data_len` whose stored size would overflow.
+        Self::calculate_stored_size_checked(meta.data_len as usize)?;
 
         Some(callback(StoredAccountNoData {
             meta,
             account_meta,
             offset,
-            stored_size,
         }))
     }
 
@@ -968,7 +968,6 @@ impl AppendVec {
                 meta: stored_meta,
                 account_meta,
                 offset,
-                stored_size,
             });
             reader.consume_or_skip(stored_size);
         }
@@ -1985,7 +1984,7 @@ mod tests {
                         let offset = account_offsets.get(i).unwrap();
 
                         assert_eq!(
-                            stored_account.stored_size,
+                            stored_account.stored_size(),
                             AppendVec::calculate_stored_size(account.data().len()),
                         );
                         assert_eq!(stored_account.offset(), *offset);

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -342,36 +342,11 @@ impl AppendVec {
     /// Creates a new AppendVec for the underlying storage at `file_info`
     ///
     /// This version of `new()` may only be called when reconstructing storages as part of startup.
-    /// It trusts the snapshot's value for `current_len`, and relies on later index generation or
-    /// accounts verification to ensure it is valid.
-    pub fn new_for_startup(file_info: FileInfo, current_len: usize) -> Result<Self> {
-        let new = Self::new_from_file_info_unchecked(file_info, current_len)?;
-
-        // The current_len is allowed to be either exactly the same as file_size, or
-        // u64-aligned-equivalent to file_size.  This is because `flush` and `shink` compute the
-        // required file size with *aligned* stored size per account, including the very last
-        // account.  So the file size may have padding to the next u64-alignment.
-        // For our usage, this is still safe as these padding bytes could never be used for an
-        // account.  This renders the `get_` and `scan_` functions safe.
-        if (current_len as u64 == new.file_size)
-            || (u64_align!(current_len) as u64 == new.file_size)
-        {
-            Ok(new)
-        } else {
-            // However, if opening a minimized snapshot, the file sizes can be
-            // larger than current length [^1].  So when the `if` condition fails,
-            // fallback to the old/slow impl that does the full sanitization.
-            // [^1]: https://github.com/anza-xyz/agave/issues/6797
-            info!(
-                "Could not optimistically create new AppendVec, falling back to pessimistic impl: \
-                 file size ({}) and current length ({}) do not match for '{}'",
-                new.file_size,
-                current_len,
-                new.path.display(),
-            );
-            let _num_accounts = new.sanitize_layout_and_length()?;
-            Ok(new)
-        }
+    /// The storage length is taken to be the full file size; this is trusted and relies on later
+    /// index generation or accounts verification to ensure it is valid.
+    pub fn new_for_startup(file_info: FileInfo) -> Result<Self> {
+        let current_len = file_info.size as usize;
+        Self::new_from_file_info_unchecked(file_info, current_len)
     }
 
     /// Creates an appendvec in read-only mode from existing `FileInfo` and without full data checks
@@ -402,6 +377,7 @@ impl AppendVec {
     }
 
     /// Checks that all accounts layout is correct and returns the number of accounts.
+    #[cfg(feature = "dev-context-only-utils")]
     fn sanitize_layout_and_length(&self) -> Result<usize> {
         // This discards allocated accounts immediately after check at each loop iteration.
         //

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -1,6 +1,6 @@
 use {
     crate::is_zero_lamport::IsZeroLamport, solana_account::ReadableAccount, solana_clock::Epoch,
-    solana_pubkey::Pubkey, std::ptr,
+    solana_pubkey::Pubkey,
 };
 
 /// Meta contains enough context to recover the index from storage itself
@@ -96,7 +96,6 @@ pub struct StoredAccountNoData<'append_vec> {
     pub meta: &'append_vec StoredMeta,
     pub account_meta: &'append_vec AccountMeta,
     pub offset: usize,
-    pub stored_size: usize,
 }
 
 impl<'append_vec> StoredAccountNoData<'append_vec> {
@@ -115,6 +114,7 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
         &self.meta.pubkey
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn sanitize(&self) -> bool {
         self.sanitize_executable() && self.sanitize_lamports()
     }
@@ -124,9 +124,12 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
         self.offset
     }
 
+    /// The on-disk size of this account, derived from its data length. The view is transient and
+    /// not persisted, so the size is computed on demand rather than stored.
+    #[cfg(feature = "dev-context-only-utils")]
     #[inline(always)]
     pub fn stored_size(&self) -> usize {
-        self.stored_size
+        crate::append_vec::AppendVec::calculate_stored_size(self.meta.data_len as usize)
     }
 
     #[inline(always)]
@@ -144,6 +147,7 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
         self.account_meta.rent_epoch
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn sanitize_executable(&self) -> bool {
         // Sanitize executable to ensure higher 7-bits are cleared correctly.
         self.ref_executable_byte() & !1 == 0
@@ -153,6 +157,7 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
     ///
     /// Note that we are not comparing against AccountSharedData::default() because we do not have access to the account data,
     /// so we compare data _length_ in lieu of actual data. This check otherwise identical to AccountSharedData::default().
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn is_default_account(&self) -> bool {
         self.account_meta.lamports == 0
             && self.meta.data_len == 0
@@ -161,12 +166,15 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
             && self.account_meta.owner == Pubkey::default()
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn sanitize_lamports(&self) -> bool {
         // Check if the account data matches that of a default account if it has 0 lamports.
         self.account_meta.lamports != 0 || self.is_default_account()
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn ref_executable_byte(&self) -> &u8 {
+        use std::ptr;
         // Use extra references to avoid value silently clamped to 1 (=true) and 0 (=false)
         // Yes, this really happens; see test_new_from_file_crafted_executable
         let executable_bool: &bool = &self.account_meta.executable;

--- a/accounts-db/src/append_vec/meta.rs
+++ b/accounts-db/src/append_vec/meta.rs
@@ -129,7 +129,7 @@ impl<'append_vec> StoredAccountNoData<'append_vec> {
     #[cfg(feature = "dev-context-only-utils")]
     #[inline(always)]
     pub fn stored_size(&self) -> usize {
-        crate::append_vec::AppendVec::calculate_stored_size(self.meta.data_len as usize)
+        super::AppendVec::calculate_stored_size(self.meta.data_len as usize)
     }
 
     #[inline(always)]

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -96,38 +96,6 @@ pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, Hash)>,
 );
 
-impl<T: SerializableStorage> AccountsDbFields<T> {
-    /// Get snapshot storage lengths filtering to slots above base slot (if provided).
-    ///
-    /// Returns an error if storage slots exceed snapshot slot indicating inconsistency of data.
-    pub(crate) fn get_storage_lengths_for_snapshot_slots(
-        &self,
-        base_slot: Option<Slot>,
-    ) -> Result<HashMap<Slot, usize>, SnapshotError> {
-        let AccountsDbFields(snapshot_storage, _, snapshot_slot, ..) = self;
-        let filtered_min_slot = base_slot.map(|slot| slot + 1).unwrap_or(Slot::MIN);
-        let mut lengths = HashMap::with_capacity(snapshot_storage.len());
-
-        for (slot, slot_storage) in snapshot_storage {
-            if slot > snapshot_slot {
-                return Err(SnapshotError::MismatchedSnapshotStorageSlot(
-                    *slot,
-                    *snapshot_slot,
-                ));
-            }
-            if *slot < filtered_min_slot {
-                // Serialized bank includes storage mapping for all slots, but it might be used for
-                // rebuilding storages only up from `base_slot`, so this case is not an error.
-                continue;
-            }
-            assert_eq!(slot_storage.len(), 1, "invalid storage count (slot={slot})");
-            let storage_entry = &slot_storage[0];
-            lengths.insert(*slot, storage_entry.current_len());
-        }
-        Ok(lengths)
-    }
-}
-
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -867,28 +835,31 @@ where
 pub(crate) fn reconstruct_single_storage(
     slot: &Slot,
     append_vec_file_info: FileInfo,
-    current_len: usize,
     id: AccountsFileId,
     obsolete_accounts: Option<(ObsoleteAccounts, AccountsFileId, usize)>,
 ) -> Result<Arc<AccountStorageEntry>, SnapshotError> {
-    // When restoring from an archive, obsolete accounts will always be `None`
+    // The storage length is taken directly from the on-disk file size (see
+    // `AccountsFile::new_for_startup`). When restoring from an archive the obsolete accounts have
+    // been physically removed during serialization, and when restoring from a snapshot directory
+    // they are still present in the file. In both cases the file size already reflects the exact
+    // number of bytes the storage spans, so there is no need to carry the length separately in the
+    // snapshot fields.
+    //
+    // When restoring from an archive, obsolete accounts will always be `None`.
     // When restoring from fastboot, obsolete accounts will be 'Some' if the storage contained
     // accounts marked obsolete at the time the snapshot was taken.
-    let (current_len, obsolete_accounts) = if let Some(obsolete_accounts) = obsolete_accounts {
-        let updated_len = current_len + obsolete_accounts.2;
-        if obsolete_accounts.1 != id {
-            return Err(SnapshotError::MismatchedAccountsFileId(
-                id,
-                obsolete_accounts.1,
-            ));
-        }
+    let obsolete_accounts =
+        if let Some((obsolete_accounts, obsolete_id, _obsolete_bytes)) = obsolete_accounts {
+            if obsolete_id != id {
+                return Err(SnapshotError::MismatchedAccountsFileId(id, obsolete_id));
+            }
 
-        (updated_len, obsolete_accounts.0)
-    } else {
-        (current_len, ObsoleteAccounts::default())
-    };
+            obsolete_accounts
+        } else {
+            ObsoleteAccounts::default()
+        };
 
-    let accounts_file = AccountsFile::new_for_startup(append_vec_file_info, current_len)?;
+    let accounts_file = AccountsFile::new_for_startup(append_vec_file_info)?;
     Ok(Arc::new(AccountStorageEntry::new_existing(
         *slot,
         id,
@@ -982,7 +953,6 @@ pub(crate) fn remap_append_vec_file(
 pub(crate) fn remap_and_reconstruct_single_storage(
     slot: Slot,
     old_append_vec_id: SerializedAccountsFileId,
-    current_len: usize,
     append_vec_file_info: FileInfo,
     next_append_vec_id: &AtomicAccountsFileId,
     num_collisions: &mut usize,
@@ -997,7 +967,6 @@ pub(crate) fn remap_and_reconstruct_single_storage(
     let storage = reconstruct_single_storage(
         &slot,
         remapped_append_vec_file_info,
-        current_len,
         remapped_append_vec_id,
         None,
     )?;

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -55,7 +55,6 @@ use {
         thread,
         time::Instant,
     },
-    storage::SerializableStorage,
     types::{SerdeAccountsLtHash, UnusedRentCollector},
     wincode::{
         SchemaReadOwned, SchemaWrite,
@@ -781,10 +780,7 @@ pub(crate) fn reconstruct_bank_from_fields<E>(
     accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> Result<(Bank, ReconstructedBankInfo), Error>
-where
-    E: SerializableStorage + std::marker::Sync,
-{
+) -> Result<(Bank, ReconstructedBankInfo), Error> {
     let mut bank_fields = bank_fields.collapse_into();
     // Epoch stakes take several seconds to reconstruct, do it in parallel with loading accountsdb
     let deserializable_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
@@ -994,10 +990,7 @@ fn reconstruct_accountsdb_from_fields<E>(
     accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error>
-where
-    E: SerializableStorage + std::marker::Sync,
-{
+) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error> {
     let mut accounts_db = AccountsDb::new_with_config(
         account_paths.to_vec(),
         accounts_db_config,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -33,15 +33,9 @@ impl SerializableAccountStorageEntry {
     }
 }
 
-pub(crate) trait SerializableStorage {
-    fn current_len(&self) -> usize;
-}
+pub(crate) trait SerializableStorage {}
 
-impl SerializableStorage for SerializableAccountStorageEntry {
-    fn current_len(&self) -> usize {
-        self.accounts_current_len
-    }
-}
+impl SerializableStorage for SerializableAccountStorageEntry {}
 
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -33,9 +33,5 @@ impl SerializableAccountStorageEntry {
     }
 }
 
-pub(crate) trait SerializableStorage {}
-
-impl SerializableStorage for SerializableAccountStorageEntry {}
-
 #[cfg(feature = "frozen-abi")]
 impl solana_frozen_abi::abi_example::TransparentAsHelper for SerializableAccountStorageEntry {}

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1011,7 +1011,6 @@ pub fn verify_and_unarchive_snapshots(
         account_paths,
         full_snapshot_archive_info.archive_format(),
         next_append_vec_id.clone(),
-        None,
         io_setup,
     )?;
 
@@ -1038,7 +1037,6 @@ pub fn verify_and_unarchive_snapshots(
             account_paths,
             incremental_snapshot_archive_info.archive_format(),
             next_append_vec_id.clone(),
-            Some(incremental_snapshot_archive_info.base_slot()),
             io_setup,
         )?;
         (
@@ -1230,7 +1228,6 @@ fn unarchive_snapshot(
     account_paths: &[PathBuf],
     archive_format: ArchiveFormat,
     next_append_vec_id: Arc<AtomicAccountsFileId>,
-    base_slot: Option<Slot>,
     io_setup: &IoSetupState,
 ) -> Result<UnarchivedSnapshot> {
     let unpack_dir = tempfile::Builder::new()
@@ -1258,11 +1255,8 @@ fn unarchive_snapshot(
                  append_vec_files,
                  ..
              }| {
-                let snapshot_storage_lengths =
-                    accounts_db_fields.get_storage_lengths_for_snapshot_slots(base_slot)?;
                 let (storage, measure_untar) = measure_time!(
                     SnapshotStorageRebuilder::rebuild_storages(
-                        snapshot_storage_lengths,
                         append_vec_files.into_iter().chain(file_receiver),
                         next_append_vec_id,
                         SnapshotFrom::Archive,
@@ -1536,10 +1530,7 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
              append_vec_files,
              ..
          }| {
-            let snapshot_storage_lengths =
-                accounts_db_fields.get_storage_lengths_for_snapshot_slots(None)?;
             let storage = SnapshotStorageRebuilder::rebuild_storages(
-                snapshot_storage_lengths,
                 append_vec_files.into_iter().chain(file_receiver),
                 next_append_vec_id,
                 SnapshotFrom::Dir,

--- a/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
+++ b/runtime/src/snapshot_utils/snapshot_storage_rebuilder.rs
@@ -27,8 +27,6 @@ const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(2);
 /// Stores state for rebuilding snapshot storages
 #[derive(Debug)]
 pub(crate) struct SnapshotStorageRebuilder {
-    /// Snapshot storage lengths - from the snapshot file
-    snapshot_storage_lengths: HashMap<Slot, usize>,
     /// Container for storing rebuilt snapshot storages
     storage: AccountStorageMap,
     /// Tracks next append_vec_id
@@ -46,15 +44,13 @@ pub(crate) struct SnapshotStorageRebuilder {
 impl SnapshotStorageRebuilder {
     /// Rebuild snapshot storages on the current thread by consuming `files`.
     pub(crate) fn rebuild_storages(
-        snapshot_storage_lengths: HashMap<Slot, usize>,
         files: impl IntoIterator<Item = FileInfo>,
         next_append_vec_id: Arc<AtomicAccountsFileId>,
         snapshot_from: SnapshotFrom,
         obsolete_accounts: Option<SerdeObsoleteAccountsMap>,
     ) -> Result<AccountStorageMap, SnapshotError> {
         let mut rebuilder = Self {
-            storage: AccountStorageMap::with_capacity(snapshot_storage_lengths.len()),
-            snapshot_storage_lengths,
+            storage: AccountStorageMap::default(),
             next_append_vec_id,
             num_collisions: 0,
             processed_slot_count: 0,
@@ -80,10 +76,8 @@ impl SnapshotStorageRebuilder {
 
     fn log_progress(&self) {
         info!(
-            "rebuilt storages for {}/{} slots with {} collisions",
-            self.processed_slot_count,
-            self.snapshot_storage_lengths.len(),
-            self.num_collisions,
+            "rebuilt storages for {} slots with {} collisions",
+            self.processed_slot_count, self.num_collisions,
         );
     }
 
@@ -112,17 +106,11 @@ impl SnapshotStorageRebuilder {
     ) -> Result<(), SnapshotError> {
         let filename = file_info.path.file_name().unwrap().to_str().unwrap();
         let (_, old_append_vec_id) = get_slot_and_append_vec_id(filename)?;
-        let Some(&current_len) = self.snapshot_storage_lengths.get(&slot) else {
-            return Err(SnapshotError::RebuildStorages(format!(
-                "account storage file '{filename}' for slot outside of expected range in snapshot"
-            )));
-        };
 
         let storage_entry = match &self.snapshot_from {
             SnapshotFrom::Archive => remap_and_reconstruct_single_storage(
                 slot,
                 old_append_vec_id,
-                current_len,
                 file_info,
                 &self.next_append_vec_id,
                 &mut self.num_collisions,
@@ -130,7 +118,6 @@ impl SnapshotStorageRebuilder {
             SnapshotFrom::Dir => reconstruct_single_storage(
                 &slot,
                 file_info,
-                current_len,
                 old_append_vec_id as AccountsFileId,
                 self.obsolete_accounts
                     .remove(&slot)

--- a/snapshots/src/error.rs
+++ b/snapshots/src/error.rs
@@ -75,9 +75,6 @@ pub enum SnapshotError {
     #[error("snapshot epoch stakes are invalid: {0}")]
     VerifyEpochStakes(#[from] VerifyEpochStakesError),
 
-    #[error("slot in storages map {0} exceeds snapshot slot: {1}")]
-    MismatchedSnapshotStorageSlot(Slot, Slot),
-
     #[error("bank_snapshot_info new_from_dir failed: {0}")]
     NewFromDir(#[from] SnapshotNewFromDirError),
 


### PR DESCRIPTION
#### Problem
When rebuilding snapshot storages, the storage length for each account file was carried separately in the serialized snapshot fields (`snapshot_storage_lengths`, derived from the storage map) and threaded through `rebuild_storages` → `reconstruct_single_storage` → `AppendVec::new_for_startup`. This is redundant: the on-disk file size already encodes the exact storage length in every case — archives physically drop obsolete accounts during serialization, and snapshot directories keep them, so the file size equals the bytes the storage spans either way. Maintaining the parallel length metadata adds coupling to the storage map and an obsolete-bytes fixup in the reconstruction path.

#### Summary of Changes
Derive storage length directly from `FileInfo::size` in `reconstruct_single_storage`; drop the `current_len` parameter from it, `remap_and_reconstruct_single_storage`, and `AppendVec`/`AccountsFile::new_for_startup`.
- Remove `snapshot_storage_lengths` from `SnapshotStorageRebuilder` and the `get_storage_lengths_for_snapshot_slots` helper; the rebuilder no longer reads the snapshot storage map. The progress log now reports processed slots without a precomputed total.
- Drop the now-unused `base_slot` parameter from `unarchive_snapshot` and the orphaned `MismatchedSnapshotStorageSlot` error variant.
- Simplify `new_for_startup` to trust the file size, `sanitize_layout_and_length` is retained for its dev/test-only caller `new_from_file`