### PR TITLE
test(banks-server): bound previously-unbounded test-only channels

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -1,6 +1,6 @@
 use {
     bincode::{deserialize, serialize},
-    crossbeam_channel::{Receiver, Sender, unbounded},
+    crossbeam_channel::{Receiver, Sender, bounded, unbounded},
     futures::{future, prelude::stream::StreamExt},
     solana_account::Account,
     solana_banks_interface::{
@@ -114,7 +114,7 @@ impl BanksServer {
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         poll_signature_status_sleep_duration: Duration,
     ) -> Self {
-        let (transaction_sender, transaction_receiver) = unbounded();
+        let (transaction_sender, transaction_receiver) = bounded(1024);
         let bank = bank_forks.read().unwrap().working_bank();
         let slot = bank.slot();
         {


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that forbids usage of unbounded channels.

Related to #13044