### PR TITLE
test(ledger): bound previously-unbounded test-only channels

### DIFF
--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -10,7 +10,6 @@ use {
     },
     agave_feature_set::discard_unexpected_data_complete_shreds,
     assert_matches::assert_matches,
-    crossbeam_channel::unbounded,
     rand::{rng, seq::SliceRandom},
     solana_account_decoder::parse_token::UiTokenAmount,
     solana_entry::entry::next_entry_mut,
@@ -5751,9 +5750,9 @@ fn test_get_slot_entries_dead_slot_race() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (slot_sender, slot_receiver) = unbounded();
-        let (shred_sender, shred_receiver) = unbounded::<Vec<Shred>>();
-        let (signal_sender, signal_receiver) = unbounded();
+        let (slot_sender, slot_receiver) = bounded(1024);
+        let (shred_sender, shred_receiver) = bounded::<Vec<Shred>>(1024);
+        let (signal_sender, signal_receiver) = bounded(1024);
 
         std::thread::scope(|scope| {
             scope.spawn(|| {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2972,6 +2972,7 @@ pub mod tests {
             consensus_message::Block,
         },
         assert_matches::assert_matches,
+        crossbeam_channel::bounded,
         rand::{Rng, rng},
         rayon::ThreadPoolBuilder,
         solana_account::{AccountSharedData, WritableAccount},
@@ -5216,7 +5217,7 @@ pub mod tests {
             })
             .collect();
         let entry = next_entry(&bank_1_blockhash, 1, vote_txs);
-        let (replay_vote_sender, replay_vote_receiver) = crossbeam_channel::unbounded();
+        let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
         let _ = process_entries_for_tests(
             &BankWithScheduler::new_without_scheduler(bank1),
             vec![entry],
@@ -5589,8 +5590,7 @@ pub mod tests {
         bank.transfer(LAMPORTS_PER_SOL, &mint_keypair, &keypair2.pubkey())
             .unwrap();
 
-        let (transaction_status_sender, transaction_status_receiver) =
-            crossbeam_channel::unbounded();
+        let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
         let transaction_status_sender = TransactionStatusSender {
             sender: transaction_status_sender,
             dependency_tracker: None,
@@ -5911,7 +5911,7 @@ pub mod tests {
             transaction_indexes: vec![],
         };
         let mut timing = ExecuteTimings::default();
-        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (sender, receiver) = bounded(1024);
 
         assert_eq!(bank.transaction_count(), 0);
         assert_eq!(bank.transaction_error_count(), 0);

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -243,7 +243,7 @@ mod tests {
             },
             staking_utils::tests::setup_vote_and_stake_accounts,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_clock::DEFAULT_SLOTS_PER_EPOCH,
         solana_epoch_schedule::{
             DEFAULT_LEADER_SCHEDULE_SLOT_OFFSET, EpochSchedule, MINIMUM_SLOTS_PER_EPOCH,
@@ -337,7 +337,7 @@ mod tests {
             .map(|_| {
                 let cache = cache.clone();
                 let bank = bank.clone();
-                let (sender, receiver) = unbounded();
+                let (sender, receiver) = bounded(1024);
                 (
                     Builder::new()
                         .name("test_thread_race_leader_schedule_cache".to_string())


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that forbids usage of unbounded channels.

Related to #13044