### PR TITLE
test(rpc-client): bound previously-unbounded test-only channels

### DIFF
--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -4363,7 +4363,7 @@ mod tests {
         crate::mock_sender::PUBKEY,
         assert_matches::assert_matches,
         base64::{Engine, prelude::BASE64_STANDARD},
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         jsonrpc_core::{Error, IoHandler, Params, futures::prelude::*},
         jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder},
         serde_json::{Number, json},
@@ -4398,7 +4398,7 @@ mod tests {
     }
 
     fn _test_send() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         thread::spawn(move || {
             let rpc_addr = "0.0.0.0:0".parse().unwrap();
             let mut io = IoHandler::default();
@@ -5121,7 +5121,7 @@ mod tests {
         let serialized_message = message.serialize();
         let serialized_message_base64 = BASE64_STANDARD.encode(serialized_message);
 
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         thread::spawn(move || {
             let rpc_addr = "0.0.0.0:0".parse().unwrap();
             let mut io = IoHandler::default();


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that forbids usage of unbounded channels.

Related to #13044