### PR TITLE
Expect grcov checksum to always exist

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -126,7 +126,7 @@ RUN \
   chmod -R a+w /.npm && \
   # grcov
   curl -LOsS "https://github.com/mozilla/grcov/releases/download/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" && \
-  curl -LsS "https://github.com/mozilla/grcov/releases/download/$GRCOV_VERSION/checksums.sha256" | sha256sum -c --ignore-missing - && \
+  curl -LsS "https://github.com/mozilla/grcov/releases/download/$GRCOV_VERSION/checksums.sha256" | grep 'grcov-x86_64-unknown-linux-musl.tar.bz2$' | sha256sum -c - && \
   tar -xf grcov-x86_64-unknown-linux-musl.tar.bz2 && \
   mv ./grcov $CARGO_HOME/bin && \
   rm grcov-x86_64-unknown-linux-musl.tar.bz2 && \


### PR DESCRIPTION
#### Problem

https://github.com/anza-xyz/agave/pull/12821 introduced checksum verification. As raised in review commens however `--ignore-missing` will silently pass if there will be no checksum for the file downloaded (the file renamed, the checksum file is empty etc).

#### Summary of Changes

Change the code to expect the checksum to always exist and fail if it does not.