### PR TITLE
test(streamer): bound previously-unbounded test-only channels

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -1140,7 +1140,7 @@ pub mod test {
             },
         },
         assert_matches::assert_matches,
-        crossbeam_channel::{Receiver, unbounded},
+        crossbeam_channel::{Receiver, bounded},
         quinn::{ApplicationClose, ConnectionError},
         solana_keypair::Keypair,
         solana_net_utils::sockets::bind_to_localhost_unique,
@@ -1587,7 +1587,7 @@ pub mod test {
     async fn test_quic_server_unstaked_node_connect_failure() {
         agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, _) = unbounded();
+        let (sender, _) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
@@ -1623,7 +1623,7 @@ pub mod test {
     async fn test_quic_server_multiple_streams() {
         agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));

--- a/streamer/src/nonblocking/testing_utilities.rs
+++ b/streamer/src/nonblocking/testing_utilities.rs
@@ -10,7 +10,7 @@ use {
         quic_socket::QuicSocket,
         streamer::StakedNodes,
     },
-    crossbeam_channel::{Receiver, Sender, unbounded},
+    crossbeam_channel::{Receiver, Sender, bounded},
     quinn::{
         ClientConfig, Connection, EndpointConfig, IdleTimeout, TokioRuntime, TransportConfig,
         crypto::rustls::QuicClientConfig,
@@ -121,7 +121,7 @@ pub fn setup_quic_server(
     qos_config: SwQosConfig,
 ) -> SpawnTestServerResult {
     let sockets = create_quic_server_sockets();
-    let (sender, receiver) = unbounded();
+    let (sender, receiver) = bounded(1024);
     let keypair = Keypair::new();
     let server_address = sockets[0].local_addr().unwrap();
     let staked_nodes = Arc::new(RwLock::new(option_staked_nodes.unwrap_or_default()));

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -724,7 +724,7 @@ mod test {
                 check_multiple_streams, make_client_endpoint, make_client_endpoint_with_bind_ip,
             },
         },
-        crossbeam_channel::{Receiver, unbounded},
+        crossbeam_channel::{Receiver, bounded},
         solana_net_utils::sockets::bind_to_localhost_unique,
         solana_pubkey::Pubkey,
         solana_signer::Signer,
@@ -755,7 +755,7 @@ mod test {
         Arc<SimpleQosBanlist>,
     ) {
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let cancel = CancellationToken::new();
@@ -791,7 +791,7 @@ mod test {
 
         let server_params = QuicStreamerConfig::default_for_tests();
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let cancel = CancellationToken::new();
@@ -846,7 +846,7 @@ mod test {
     fn test_quic_server_multiple_streams() {
         agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
@@ -1038,7 +1038,7 @@ mod test {
     fn test_quic_server_unstaked_node_connect_failure() {
         agave_logger::setup();
         let s = bind_to_localhost_unique().expect("should bind");
-        let (sender, _) = unbounded();
+        let (sender, _) = bounded(1024);
         let keypair = Keypair::new();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -594,7 +594,7 @@ mod test {
             packet::{PACKET_DATA_SIZE, Packet, RecycledPacketBatch},
             streamer::{receiver, responder},
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_net_utils::sockets::bind_to_localhost_unique,
         solana_perf::recycler::Recycler,
         std::{
@@ -634,7 +634,7 @@ mod test {
         let addr = read.local_addr().unwrap();
         let send = bind_to_localhost_unique().expect("should bind sender");
         let exit = Arc::new(AtomicBool::new(false));
-        let (s_reader, r_reader) = unbounded();
+        let (s_reader, r_reader) = bounded(1024);
         let stats = Arc::new(StreamerReceiveStats::new("test"));
         let t_receiver = receiver(
             "solRcvrTest".to_string(),
@@ -649,7 +649,7 @@ mod test {
         );
         const NUM_PACKETS: usize = 5;
         let t_responder = {
-            let (s_responder, r_responder) = unbounded();
+            let (s_responder, r_responder) = bounded(1024);
             let t_responder = responder(
                 "SendTest",
                 Arc::new(send),


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that forbids usage of unbounded channels.

Related to #13044