### PR TITLE
test(turbine): bound previously-unbounded test-only channels

### DIFF
--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -632,7 +632,7 @@ pub mod test {
     use {
         super::*,
         agave_votor_messages::migration::MigrationStatus,
-        crossbeam_channel::{bounded, unbounded},
+        crossbeam_channel::bounded,
         rand::Rng,
         solana_entry::{entry::create_ticks, entry_or_marker::EntryOrMarker},
         solana_gossip::{cluster_info::ClusterInfo, node::Node},
@@ -789,8 +789,8 @@ pub mod test {
         // Setup
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (transmit_sender, transmit_receiver) = unbounded();
-        let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+        let (transmit_sender, transmit_receiver) = bounded(1024);
+        let (retransmit_slots_sender, retransmit_slots_receiver) = bounded(1024);
 
         // Make some shreds
         let updated_slot = 0;
@@ -914,8 +914,8 @@ pub mod test {
         // Create the leader scheduler
         let leader_keypair = Arc::new(Keypair::new());
 
-        let (entry_sender, entry_receiver) = unbounded();
-        let (retransmit_slots_sender, retransmit_slots_receiver) = unbounded();
+        let (entry_sender, entry_receiver) = bounded(1024);
+        let (retransmit_slots_sender, retransmit_slots_receiver) = bounded(1024);
         let broadcast_service = setup_dummy_broadcast_service(
             leader_keypair,
             ledger_path.path(),

--- a/turbine/src/broadcast_stage/broadcast_utils.rs
+++ b/turbine/src/broadcast_stage/broadcast_utils.rs
@@ -252,7 +252,7 @@ pub(super) fn set_block_id_and_send(
 mod tests {
     use {
         super::*,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_entry::entry_or_marker::EntryOrMarker,
         solana_genesis_config::GenesisConfig,
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
@@ -309,7 +309,7 @@ mod tests {
             SlotLeader::default(),
             1,
         );
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
         let mut last_hash = genesis_config.hash();
 
         assert!(bank1.max_tick_height() > 1);
@@ -342,7 +342,7 @@ mod tests {
     fn test_recv_slot_components_does_not_pre_drain_queue() {
         let (genesis_config, bank0, _bank_forks, tx) = setup_test();
         let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
         let mut last_hash = genesis_config.hash();
         let entries: Vec<_> = (1..=3)
             .map(|tick_height| {
@@ -384,7 +384,7 @@ mod tests {
             SlotLeader::default(),
             2,
         );
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
 
         let mut last_hash = genesis_config.hash();
         assert!(bank1.max_tick_height() > 1);
@@ -433,7 +433,7 @@ mod tests {
     fn test_marker_carryover_does_not_advance_last_tick_height() {
         let (genesis_config, bank0, _bank_forks, tx) = setup_test();
         let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
         let max_tick = bank1.max_tick_height();
 
         let mut last_hash = genesis_config.hash();
@@ -471,7 +471,7 @@ mod tests {
     fn test_marker_preserves_entry_ordering() {
         let (genesis_config, bank0, _bank_forks, tx) = setup_test();
         let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
 
         let mut last_hash = genesis_config.hash();
 
@@ -533,7 +533,7 @@ mod tests {
             SlotLeader::default(),
             2,
         ));
-        let (s, r) = unbounded();
+        let (s, r) = bounded(1024);
 
         let mut last_hash = genesis_config.hash();
 

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -667,7 +667,6 @@ mod test {
     use {
         super::*,
         assert_matches::assert_matches,
-        crossbeam_channel::unbounded,
         rand::Rng,
         solana_entry::entry::create_ticks,
         solana_genesis_config::GenesisConfig,
@@ -783,9 +782,9 @@ mod test {
             bank: bank.clone(),
             last_tick_height: bank.tick_height() + ticks.len() as u64,
         };
-        let (socket_sender, _socket_receiver) = unbounded();
-        let (blockstore_sender, _blockstore_receiver) = unbounded();
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (socket_sender, _socket_receiver) = bounded(1024);
+        let (blockstore_sender, _blockstore_receiver) = bounded(1024);
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
             Arc::new(MigrationStatus::default()),
@@ -813,7 +812,7 @@ mod test {
     #[test]
     fn test_interrupted_slot_last_shred() {
         let keypair = Arc::new(Keypair::new());
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let bank = Bank::new_for_tests(&create_genesis_config(10_000).genesis_config);
         let mut run = StandardBroadcastRun::new(
             0,
@@ -870,7 +869,7 @@ mod test {
         };
 
         // Step 1: Make an incomplete transmission for slot 1
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
             Arc::new(migration_status),
@@ -1024,9 +1023,9 @@ mod test {
             _bank_forks,
         ) = setup(num_shreds_per_slot);
         let bank = new_child_bank(&parent_bank, 1);
-        let (bsend, brecv) = unbounded();
-        let (ssend, _srecv) = unbounded();
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (bsend, brecv) = bounded(1024);
+        let (ssend, _srecv) = bounded(1024);
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut last_tick_height = bank.tick_height();
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
@@ -1100,7 +1099,7 @@ mod test {
             last_tick_height: bank.tick_height() + ticks.len() as u64,
         };
 
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
             Arc::new(MigrationStatus::default()),
@@ -1146,15 +1145,15 @@ mod test {
             )
             .unwrap();
 
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
             Arc::new(MigrationStatus::default()),
             votor_event_sender,
             test_leader_schedule_cache(&bank1),
         );
-        let (bsend, brecv) = unbounded();
-        let (ssend, srecv) = unbounded();
+        let (bsend, brecv) = bounded(1024);
+        let (ssend, srecv) = bounded(1024);
 
         let ticks = create_ticks(1, 0, genesis_config.hash());
         let err = standard_broadcast_run
@@ -1257,7 +1256,7 @@ mod test {
     fn test_component_to_shreds_max() {
         agave_logger::setup();
         let keypair = Keypair::new();
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let bank = Bank::new_for_tests(&create_genesis_config(10_000).genesis_config);
         let mut bs = StandardBroadcastRun::new(
             0,
@@ -1294,7 +1293,7 @@ mod test {
     #[test]
     fn test_update_parent() {
         let keypair = Keypair::new();
-        let (votor_event_sender, _votor_event_receiver) = unbounded();
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let bank = Bank::new_for_tests(&create_genesis_config(10_000).genesis_config);
         let mut bs = StandardBroadcastRun::new(
             0,


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that forbids usage of unbounded channels.

Related to #13044