### PR TITLE
test(votor): bound previously-unbounded test-only channels

### DIFF
--- a/votor/src/commitment.rs
+++ b/votor/src/commitment.rs
@@ -45,11 +45,11 @@ pub fn update_commitment_cache(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crossbeam_channel::unbounded};
+    use {super::*, crossbeam_channel::bounded};
 
     #[test]
     fn test_update_commitment_cache() {
-        let (commitment_sender, commitment_receiver) = unbounded();
+        let (commitment_sender, commitment_receiver) = bounded(1024);
         let slot = 3;
         let commitment_type = CommitmentType::Notarize;
         update_commitment_cache(commitment_type, slot, &commitment_sender)

--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -343,14 +343,14 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::vote::{SkipVote, Vote},
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_keypair::Keypair,
         solana_signer::Signer,
         std::thread::sleep,
     };
 
     fn new_metrics() -> ConsensusMetrics {
-        let (_, rx) = unbounded();
+        let (_, rx) = bounded(1024);
         ConsensusMetrics::new(EpochSchedule::custom(100, 100, false), rx) // 100 slots/epoch
     }
 

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -655,7 +655,7 @@ mod tests {
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
             vote::Vote,
         },
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, keypair::Keypair as BLSKeypair,
             signature::Signature as BLSSignature,
@@ -690,7 +690,7 @@ mod tests {
 
     impl Default for TestContext {
         fn default() -> Self {
-            let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
+            let (bls_sender, bls_receiver) = bounded(1024);
             // Create 10 node validatorvotekeypairs vec
             let validator_keypairs = (0..10)
                 .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -895,7 +895,7 @@ mod tests {
     #[test]
     fn test_send_produce_block_event() {
         let mut ctx = TestContext::default();
-        let (repair_event_sender, _repair_event_receiver) = unbounded();
+        let (repair_event_sender, _repair_event_receiver) = bounded(1024);
 
         // Find when is the next leader slot for me (validator 0)
         let next_leader_slot = ctx
@@ -939,9 +939,9 @@ mod tests {
             sharable_banks: ctx.sharable_banks.clone(),
             leader_schedule_cache: ctx.leader_schedule_cache.clone(),
             vote_history_highest_parent_ready: None,
-            consensus_message_receiver: crossbeam_channel::unbounded().1,
+            consensus_message_receiver: bounded(1024).1,
             bls_sender: ctx.bls_sender.clone(),
-            event_sender: crossbeam_channel::unbounded().0,
+            event_sender: bounded(1024).0,
             highest_finalized: ctx.highest_finalized.clone(),
             repair_event_sender,
         };
@@ -980,9 +980,9 @@ mod tests {
     #[test]
     fn test_can_produce_window_immediately_on_restart() {
         let ctx = TestContext::default();
-        let (repair_event_sender, _repair_event_receiver) = unbounded();
-        let (event_sender, event_receiver) = unbounded();
-        let (consensus_message_sender, consensus_message_receiver) = unbounded();
+        let (repair_event_sender, _repair_event_receiver) = bounded(1024);
+        let (event_sender, event_receiver) = bounded(1024);
+        let (consensus_message_sender, consensus_message_receiver) = bounded(1024);
 
         let root_bank = ctx.sharable_banks.root();
         let next_leader_slot = ctx

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -937,7 +937,7 @@ mod tests {
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, SigVerifiedBatch, VoteMessage},
             vote::Vote,
         },
-        crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded},
+        crossbeam_channel::{Receiver, Sender, TryRecvError, bounded},
         parking_lot::RwLock as PlRwLock,
         solana_bls_signatures::{
             keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
@@ -1035,15 +1035,15 @@ mod tests {
     }
 
     fn setup() -> EventHandlerTestContext {
-        let (bls_sender, bls_receiver) = unbounded();
-        let (commitment_sender, commitment_receiver) = unbounded();
-        let (own_vote_sender, own_vote_receiver) = unbounded();
-        let (drop_bank_sender, drop_bank_receiver) = unbounded();
+        let (bls_sender, bls_receiver) = bounded(1024);
+        let (commitment_sender, commitment_receiver) = bounded(1024);
+        let (own_vote_sender, own_vote_receiver) = bounded(1024);
+        let (drop_bank_sender, drop_bank_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
-        let (event_sender, _event_receiver) = unbounded();
-        let (consensus_metrics_sender, consensus_metrics_receiver) = unbounded();
-        let (leader_window_info_sender, leader_window_info_receiver) = unbounded();
-        let (repair_event_sender, repair_event_receiver) = unbounded();
+        let (event_sender, _event_receiver) = bounded(1024);
+        let (consensus_metrics_sender, consensus_metrics_receiver) = bounded(1024);
+        let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
+        let (repair_event_sender, repair_event_receiver) = bounded(1024);
         let latest_switch_request = LatestSwitchRequest::default();
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
             event_sender,

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -86,13 +86,13 @@ impl TimerManager {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::event::VotorEvent, crossbeam_channel::unbounded,
+        super::*, crate::event::VotorEvent, crossbeam_channel::bounded,
         solana_clock::DEFAULT_MS_PER_SLOT, std::time::Duration,
     };
 
     #[test]
     fn test_timer_manager() {
-        let (event_sender, event_receiver) = unbounded();
+        let (event_sender, event_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
         let timer_manager = TimerManager::new(
             event_sender,

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -275,7 +275,7 @@ impl Timers {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::unbounded,
+        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::bounded,
         solana_clock::DEFAULT_MS_PER_SLOT,
     };
 
@@ -331,7 +331,7 @@ mod tests {
     fn timers_progress() {
         let one_micro = Duration::from_micros(1);
         let mut now = Instant::now();
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(1024);
         let mut timers = Timers::new(one_micro, sender);
         assert!(timers.progress(now).is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -257,6 +257,7 @@ mod tests {
             consensus_message::{ConsensusMessage, VoteMessage},
             vote::Vote,
         },
+        crossbeam_channel::bounded,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
@@ -349,7 +350,7 @@ mod tests {
     }))]
     fn test_send_message(bls_op: BLSOp, expected_message: ConsensusMessage) {
         agave_logger::setup();
-        let (bls_sender, bls_receiver) = crossbeam_channel::unbounded();
+        let (bls_sender, bls_receiver) = bounded(1024);
         // Create listener thread on a random port we allocated and return SocketAddr to create VotingService
 
         // Bind to a random UDP port
@@ -363,7 +364,7 @@ mod tests {
         assert!(bls_sender.send(bls_op).is_ok());
 
         // Start a quick streamer to handle quick control packets
-        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (sender, receiver) = bounded(1024);
         let stakes = validator_keypairs
             .iter()
             .map(|x| (x.node_keypair.pubkey(), 100))

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -306,7 +306,7 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::consensus_message::Block,
-        crossbeam_channel::unbounded,
+        crossbeam_channel::bounded,
         solana_hash::Hash,
         solana_runtime::{
             bank::{Bank, SlotLeader},
@@ -359,9 +359,9 @@ mod tests {
 
         let my_keys = &validator_keypairs[my_index];
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
-        let bls_sender = unbounded().0;
-        let commitment_sender = unbounded().0;
-        let consensus_metrics_sender = unbounded().0;
+        let bls_sender = bounded(1024).0;
+        let commitment_sender = bounded(1024).0;
+        let consensus_metrics_sender = bounded(1024).0;
         let voting_context = VotingContext {
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
             vote_account_pubkey: my_keys.vote_keypair.pubkey(),
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_generate_own_vote_message() {
-        let (own_vote_sender, own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -439,7 +439,7 @@ mod tests {
 
     #[test]
     fn test_wait_to_vote_slot() {
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_non_voting_node() {
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn test_wrong_identity_keypair() {
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_wrong_vote_account_pubkey() {
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -571,7 +571,7 @@ mod tests {
     #[should_panic(expected = "could not find rank map for slot 1000000000")]
     fn test_panic_on_future_slot() {
         agave_logger::setup();
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn test_zero_staked_validator_fails_voting() {
         agave_logger::setup();
-        let (own_vote_sender, _own_vote_receiver) = crossbeam_channel::unbounded();
+        let (own_vote_sender, _own_vote_receiver) = bounded(1024);
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))


### PR DESCRIPTION
Replace unbounded() with crossbeam_channel::bounded(1024) at all test-only channel call sites. Production channels are left unbounded.

Goal is to add a future clippy check that refuses usage of unbounded channels.

Related to #12774