### PR TITLE
feat: switch SlotHashes sysvar to wincode (de)serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6776,6 +6776,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 
@@ -9446,6 +9447,7 @@ dependencies = [
  "solana-transaction-context",
  "test-case",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -10347,6 +10349,7 @@ dependencies = [
  "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -10721,6 +10724,7 @@ dependencies = [
  "solana-transaction-context",
  "test-case",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -41,7 +41,7 @@ solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
-solana-slot-hashes = { workspace = true }
+solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-slot-history = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode", "sysvar"] }
 solana-sysvar = { workspace = true }
@@ -52,6 +52,7 @@ spl-token-group-interface = { workspace = true }
 spl-token-interface = { workspace = true }
 spl-token-metadata-interface = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -56,16 +56,18 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                 .ok()
                 .map(|rewards| SysvarAccountType::Rewards(rewards.into()))
         } else if pubkey == &sysvar::slot_hashes::id() {
-            deserialize::<SlotHashes>(data).ok().map(|slot_hashes| {
-                let slot_hashes = slot_hashes
-                    .iter()
-                    .map(|slot_hash| UiSlotHashEntry {
-                        slot: slot_hash.0,
-                        hash: slot_hash.1.to_string(),
-                    })
-                    .collect();
-                SysvarAccountType::SlotHashes(slot_hashes)
-            })
+            wincode::deserialize::<SlotHashes>(data)
+                .ok()
+                .map(|slot_hashes| {
+                    let slot_hashes = slot_hashes
+                        .iter()
+                        .map(|slot_hash| UiSlotHashEntry {
+                            slot: slot_hash.0,
+                            hash: slot_hash.1.to_string(),
+                        })
+                        .collect();
+                    SysvarAccountType::SlotHashes(slot_hashes)
+                })
         } else if pubkey == &sysvar::slot_history::id() {
             deserialize::<SlotHistory>(data).ok().map(|slot_history| {
                 SysvarAccountType::SlotHistory(UiSlotHistory {

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -5,7 +5,7 @@ use {
     ahash::HashMap,
     itertools::Itertools,
     rand::{Rng, rng},
-    solana_account::from_account,
+    solana_account::ReadableAccount as _,
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
     solana_runtime::{
@@ -146,7 +146,7 @@ impl VoteStorage {
     pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<SanitizedTransactionView<SharedBytes>> {
         let slot_hashes = bank
             .get_account(&sysvar::slot_hashes::id())
-            .and_then(|account| from_account::<SlotHashes, _>(&account));
+            .and_then(|account| wincode::deserialize::<SlotHashes>(account.data()).ok());
         if slot_hashes.is_none() {
             error!(
                 "Slot hashes sysvar doesn't exist on bank {}. Including all votes without \

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5912,6 +5912,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 
@@ -7946,6 +7947,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -8701,6 +8703,7 @@ dependencies = [
  "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -8979,6 +8982,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -59,7 +59,7 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
 solana-sdk-ids = { workspace = true }
-solana-slot-hashes = { workspace = true }
+solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-stable-layout = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode", "sysvar"] }
 solana-svm-callback = { workspace = true }
@@ -74,6 +74,7 @@ solana-sysvar = { workspace = true, features = ["bincode"] }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/program-runtime/src/sysvar_cache.rs
+++ b/program-runtime/src/sysvar_cache.rs
@@ -91,7 +91,7 @@ impl SysvarCache {
             }
             sysvar::slot_hashes::ID => {
                 let slot_hashes: SlotHashes =
-                    bincode::deserialize(&data).expect("Failed to deserialize SlotHashes sysvar.");
+                    wincode::deserialize(&data).expect("Failed to deserialize SlotHashes sysvar.");
                 self.slot_hashes = Some(data);
                 self.slot_hashes_obj = Some(Arc::new(slot_hashes));
             }
@@ -229,7 +229,7 @@ impl SysvarCache {
 
         if self.slot_hashes.is_none() {
             get_account_data(&SlotHashes::id(), &mut |data: &[u8]| {
-                if let Ok(obj) = bincode::deserialize::<SlotHashes>(data) {
+                if let Ok(obj) = wincode::deserialize::<SlotHashes>(data) {
                     self.slot_hashes = Some(data.to_vec());
                     self.slot_hashes_obj = Some(Arc::new(obj));
                 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5816,6 +5816,7 @@ dependencies = [
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
+ "wincode",
  "zstd",
 ]
 
@@ -7769,6 +7770,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -9239,6 +9241,7 @@ dependencies = [
  "solana-hash 4.3.0",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -9516,6 +9519,7 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -152,7 +152,7 @@ solana-sha256-hasher = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
-solana-slot-hashes = { workspace = true }
+solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-slot-history = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-svm = { workspace = true, features = ["metrics"] }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2546,7 +2546,7 @@ impl Bank {
         self.update_sysvar_account(&sysvar::slot_hashes::id(), |account| {
             let mut slot_hashes = account
                 .as_ref()
-                .map(|account| from_account::<SlotHashes, _>(account).unwrap())
+                .map(|account| wincode::deserialize::<SlotHashes>(account.data()).unwrap())
                 .unwrap_or_default();
             slot_hashes.add(self.parent_slot, self.parent_hash);
             create_account(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12378,7 +12378,7 @@ fn test_new_for_txn_tests_system_transfer() {
         ),
         (
             solana_sdk_ids::sysvar::slot_hashes::id(),
-            make_sysvar(bincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
+            make_sysvar(wincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
         ),
         (system_program::id(), {
             let mut acct = AccountSharedData::new(1, 14, &native_loader::id());
@@ -12551,7 +12551,7 @@ fn test_new_for_block_tests_with_vote_account() {
         ),
         (
             solana_sdk_ids::sysvar::slot_hashes::id(),
-            make_sysvar(bincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
+            make_sysvar(wincode::serialize(&solana_slot_hashes::SlotHashes::default()).unwrap()),
         ),
         (system_program::id(), {
             let mut acct = AccountSharedData::new(1, 14, &native_loader::id());

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -35,7 +35,7 @@ solana-bn254 = { workspace = true }
 solana-clock = { workspace = true }
 solana-cpi = { workspace = true }
 solana-curve25519 = { workspace = true }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["wincode"] }
 solana-hash-512 = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keccak-hasher = { workspace = true, features = ["sha3"] }
@@ -57,6 +57,7 @@ solana-sysvar = { workspace = true }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -4604,7 +4604,7 @@ mod tests {
         let src_hashes = src_hashes;
 
         let mut src_hashes_buf = vec![0; SlotHashes::size_of()];
-        bincode::serialize_into(&mut src_hashes_buf, &src_hashes).unwrap();
+        wincode::serialize_into(&mut src_hashes_buf, &src_hashes).unwrap();
 
         let transaction_accounts = vec![(
             sysvar::slot_hashes::id(),
@@ -4643,7 +4643,7 @@ mod tests {
             );
             assert_eq!(result.unwrap(), 0);
 
-            let hashes_from_buf = bincode::deserialize::<SlotHashes>(&got_hashes_buf).unwrap();
+            let hashes_from_buf = wincode::deserialize::<SlotHashes>(&got_hashes_buf).unwrap();
             assert_eq!(hashes_from_buf, src_hashes);
         }
     }


### PR DESCRIPTION
#### Problem
sysvars are serialized using bincode through `SysvarSerialize` - we want to get rid of both bincode dep and `SysvarSerialize` trait, we can use `wincode` directly, since the sysvar abtraction was just calling directly into free functions for account data bytes.

#### Summary of Changes
Use wincode instead of bincode/from_account for serializing and deserializing the `SlotHashes` sysvar across the runtime, program-runtime, account-decoder, syscalls and banking stage.
