### PR TITLE
xdp: decouple XDP handoff from retransmit port

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -152,7 +152,7 @@ use {
         borrow::Cow,
         cmp,
         collections::{HashMap, HashSet},
-        net::{SocketAddr, SocketAddrV4},
+        net::{Ipv4Addr, SocketAddr, SocketAddrV4},
         num::{NonZeroU64, NonZeroUsize},
         path::{Path, PathBuf},
         str::FromStr,
@@ -532,6 +532,11 @@ pub enum ValidatorStartProgress {
     Running,
 }
 
+pub struct XdpTransmitSetup {
+    pub transmitter_builder: TransmitterBuilder,
+    pub src_ip: Ipv4Addr,
+}
+
 struct BlockstoreRootScan {
     thread: Option<JoinHandle<Result<usize, BlockstoreError>>>,
 }
@@ -691,7 +696,7 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
-        xdp_builder_with_src_addr: Option<(TransmitterBuilder, SocketAddrV4)>,
+        xdp_transmit_setup: Option<XdpTransmitSetup>,
     ) -> Result<Self> {
         let exit = Arc::new(AtomicBool::new(false));
         Self::new_with_exit(
@@ -707,7 +712,7 @@ impl Validator {
             socket_addr_space,
             tpu_config,
             admin_rpc_service_post_init,
-            xdp_builder_with_src_addr,
+            xdp_transmit_setup,
             exit,
         )
     }
@@ -726,7 +731,7 @@ impl Validator {
         socket_addr_space: SocketAddrSpace,
         tpu_config: ValidatorTpuConfig,
         admin_rpc_service_post_init: Arc<RwLock<Option<AdminRpcRequestMetadataPostInit>>>,
-        xdp_builder_with_src_addr: Option<(TransmitterBuilder, SocketAddrV4)>,
+        xdp_transmit_setup: Option<XdpTransmitSetup>,
         exit: Arc<AtomicBool>,
     ) -> Result<Self> {
         #[cfg(debug_assertions)]
@@ -1556,12 +1561,24 @@ impl Validator {
         let (votor_event_sender, votor_event_receiver) = bounded(1000);
 
         let (xdp_transmitter, turbine_xdp_sender, quic_xdp_sender) =
-            if let Some((xdp_transmit_builder, src_addr)) = xdp_builder_with_src_addr {
-                let (transmitter, sender) = xdp_transmit_builder.build();
+            if let Some(XdpTransmitSetup {
+                transmitter_builder,
+                src_ip,
+            }) = xdp_transmit_setup
+            {
+                let turbine_src_port = node.sockets.retransmit_sockets[0]
+                    .local_addr()
+                    .expect("retransmit socket should have local address")
+                    .port();
+
+                let (transmitter, sender) = transmitter_builder.build();
                 (
                     Some(transmitter),
-                    Some(TurbineXdpSender::new(sender.clone(), src_addr)),
-                    Some((sender, *src_addr.ip())),
+                    Some(TurbineXdpSender::new(
+                        sender.clone(),
+                        SocketAddrV4::new(src_ip, turbine_src_port),
+                    )),
+                    Some((sender, src_ip)),
                 )
             } else {
                 (None, None, None)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -165,26 +165,29 @@ pub fn execute(
         }
     }
 
-    let xdp_interface = matches
-        .value_of("xdp_interface")
-        .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
-    let xdp_zero_copy = matches.is_present("xdp_zero_copy")
-        || matches.is_present("experimental_retransmit_xdp_zero_copy");
-    let retransmit_xdp = matches
+    let xdp_transmit_config = if let Some(xdp_cpu_cores) = matches
         .value_of("xdp_cpu_cores")
         .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"))
-        .map(|cpus| {
-            XdpConfig::new(
-                xdp_interface,
-                parse_cpu_ranges(cpus).unwrap(),
-                xdp_zero_copy,
-            )
-        });
-    if bind_addresses.len() > 1 && retransmit_xdp.is_some() {
-        Err(String::from(
-            "--xdp-cpu-cores cannot be used in a multihoming context",
-        ))?;
-    }
+    {
+        let xdp_interface = matches
+            .value_of("xdp_interface")
+            .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
+        let xdp_zero_copy = matches.is_present("xdp_zero_copy")
+            || matches.is_present("experimental_retransmit_xdp_zero_copy");
+        let config = XdpConfig::new(
+            xdp_interface,
+            parse_cpu_ranges(xdp_cpu_cores).unwrap(),
+            xdp_zero_copy,
+        );
+        if bind_addresses.len() > 1 {
+            Err(String::from(
+                "--xdp-cpu-cores cannot be used in a multihoming context",
+            ))?;
+        }
+        Some(config)
+    } else {
+        None
+    };
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())
@@ -287,7 +290,7 @@ pub fn execute(
     let _ = config;
 
     #[cfg(target_os = "linux")]
-    let xdp_builder_with_src_addr = {
+    let xdp_transmit_setup = {
         use {
             agave_xdp::transmitter::TransmitterBuilder,
             caps::{
@@ -313,7 +316,7 @@ pub fn execute(
         required_caps.extend(primordial_caps.clone());
         retained_caps.extend(primordial_caps.clone());
 
-        if let Some(xdp_config) = retransmit_xdp.as_ref() {
+        if let Some(xdp_config) = xdp_transmit_config.as_ref() {
             required_caps.insert(CAP_NET_ADMIN);
             required_caps.insert(CAP_NET_RAW);
             if xdp_config.zero_copy {
@@ -369,16 +372,12 @@ pub fn execute(
         // XDP _MUST_ be setup _BEFORE_ the app spawns any threads to ensure linux
         // capabilities do not leak, leaving the process in a state where it could
         // potentially be used as a privilege escalation gadget
-        let xdp_builder_with_src_addr = retransmit_xdp.clone().map(|xdp_config| {
+        let xdp_transmit_setup = xdp_transmit_config.clone().map(|xdp_config| {
             use {
                 agave_xdp::{default_device_ipv4, interface_ipv4},
-                std::net::SocketAddrV4,
+                solana_core::validator::XdpTransmitSetup,
             };
 
-            let src_port = node.sockets.retransmit_sockets[0]
-                .local_addr()
-                .expect("failed to get local address")
-                .port();
             let src_ip = match node.bind_ip_addrs.active() {
                 IpAddr::V4(ip) if !ip.is_unspecified() => ip,
                 IpAddr::V4(_unspecified) => {
@@ -394,11 +393,11 @@ pub fn execute(
                 }
                 _ => panic!("IPv6 not supported"),
             };
-            (
-                TransmitterBuilder::new(xdp_config, exit.clone())
+            XdpTransmitSetup {
+                transmitter_builder: TransmitterBuilder::new(xdp_config, exit.clone())
                     .expect("failed to create xdp transmitter"),
-                SocketAddrV4::new(src_ip, src_port),
-            )
+                src_ip,
+            }
         });
 
         // we're done with caps needed to init xdp now. remove them from our process
@@ -407,13 +406,13 @@ pub fn execute(
         caps::set(None, CapSet::Permitted, &retained_caps)
             .expect("linux allows permitted capset to be set");
 
-        xdp_builder_with_src_addr
+        xdp_transmit_setup
     };
 
     #[cfg(not(target_os = "linux"))]
-    let xdp_builder_with_src_addr = None;
+    let xdp_transmit_setup = None;
 
-    let reserved = retransmit_xdp
+    let reserved = xdp_transmit_config
         .map(|xdp| xdp.cpus.clone())
         .unwrap_or_default()
         .iter()
@@ -1117,7 +1116,7 @@ pub fn execute(
             sigverify_threads: tpu_sigverify_threads,
         },
         admin_service_post_init,
-        xdp_builder_with_src_addr,
+        xdp_transmit_setup,
         exit,
     )
     .map_err(|err| format!("{err:?}"))?;


### PR DESCRIPTION
#### Problem

XDP passed a retransmit socket address from execute.rs into validator.rs. That tied the shared XDP transmitter setup to the retransmit port and made it harder to reuse for other protocols such as gossip or repair.

#### Summary of Changes

Pass the source IP with the transmitter builder instead, and let validator.rs derive protocol-specific source ports from its node sockets.