### PR TITLE
rewards: prints data if assertion fires

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -320,7 +320,11 @@ impl Bank {
                 >= distributed_lamports
                     + distributed_to_incinerator_lamports
                     + burned_lamports
-                    + total_stake_rewards_lamports
+                    + total_stake_rewards_lamports,
+            "point_value={point_value:?}, distributed_lamports={distributed_lamports}, \
+             distributed_to_incinerator_lamports={distributed_to_incinerator_lamports} \
+             burned_lamports={burned_lamports}, \
+             total_stake_rewards_lamports={total_stake_rewards_lamports}"
         );
         info!(
             "distributed reward commissions: {} out of {}, remaining {}",


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/issues/12993 we are seeing an assertion fire on the AG community cluster.  As this is an `assert!`, we are not collecting info about what the values are.  


#### Summary of Changes

Updates the assert to print values if it fires.
