### PR TITLE
Dynamically probe and set maximum socket buffers on Linux, FreeBSD & MacOS/X

### DIFF
--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -10,10 +10,10 @@ use {
         find_available_ports_in_range,
         multihomed_sockets::BindIpAddrs,
         sockets::{
-            SocketConfiguration as SocketConfig, bind_gossip_port_in_range_with_config,
-            bind_in_range_with_config, bind_more_with_config, bind_to_with_config,
-            get_max_recv_buffer_size, get_max_send_buffer_size, localhost_port_range_for_tests,
-            multi_bind_in_range_with_config,
+            bind_gossip_port_in_range_with_config, bind_in_range_with_config,
+            bind_more_with_config, bind_to_with_config, get_max_udp_recv_buffer_size,
+            get_max_udp_send_buffer_size, localhost_port_range_for_tests,
+            multi_bind_in_range_with_config, SocketConfiguration as SocketConfig,
         },
     },
     solana_pubkey::Pubkey,
@@ -66,66 +66,79 @@ impl Node {
     /// sockets nor receive on primarily_write_udp sockets. Setting the unused
     /// side to 1 avoids increasing it; Linux still enforces a minimum. Note
     /// unlike Linux, MacOS and FreeBSD will not accept a buffer size of zero.
+    /// Furthermore as UDP socket sends on MacOS and FreeBSD are unbuffered,
+    /// there is no point increasing UDP socket send buffers on those platforms.
     ///
     /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
     /// and the minimum receive buffer size (SO_RCVBUF) is 256 bytes
     /// See: https://man7.org/linux/man-pages/man7/socket.7.html
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
     fn create_socket_configs() -> SocketConfigs {
-        if cfg!(any(
-            target_os = "linux",
-            target_os = "freebsd",
-            target_os = "macos"
-        )) {
-            const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
-            let recv_buffer_size = get_max_recv_buffer_size()
-                .map_err(|err| {
-                    error!(
-                        "Maximum socket receive buffer size could not be determined: {}",
-                        err
-                    )
-                })
-                .ok();
-            let send_buffer_size = get_max_send_buffer_size()
-                .map_err(|err| {
-                    error!(
-                        "Maximum socket send buffer size could not be determined: {}",
-                        err
-                    )
-                })
-                .ok();
-            if let Some(sz) = recv_buffer_size {
-                info!("Maximum socket receive buffer size is {}", sz)
-            }
-            if let Some(sz) = send_buffer_size {
-                info!("Maximum socket send buffer size is {}", sz)
-            }
-            let maybe_set_recv_buffer_size = move |c: SocketConfig| {
-                let Some(sz) = recv_buffer_size else { return c };
-                c.recv_buffer_size(sz)
+        const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+
+        let max_recv_buffer_size = get_max_udp_recv_buffer_size()
+            .map(|sz| {
+                info!("Maximum UDP socket receive buffer size is {}", sz);
+                sz
+            })
+            .map_err(|err| {
+                error!(
+                    "Maximum UDP socket receive buffer size could not be determined: {}",
+                    err
+                )
+            })
+            .ok();
+        let max_send_buffer_size = get_max_udp_send_buffer_size()
+            .map(|sz| {
+                info!("Maximum UDP socket send buffer size is {}", sz);
+                sz
+            })
+            .map_err(|err| {
+                error!(
+                    "Maximum UDP socket send buffer size could not be determined: {}",
+                    err
+                )
+            })
+            .ok();
+        let set_max_recv_send_buffer_size =
+            move |c: &mut SocketConfig, recv_size: Option<usize>, send_size: Option<usize>| {
+                let recv_size = match (recv_size, max_recv_buffer_size) {
+                    (Some(sz), Some(max_sz)) => std::cmp::min(sz, max_sz),
+                    (Some(sz), _) | (_, Some(sz)) => sz,
+                    _ => return,
+                };
+                *c = c.recv_buffer_size(recv_size);
+                // As UDP socket sends on freebsd & macos are always
+                // unbuffered, do not change the send buffer size.
+                if cfg!(not(any(target_os = "freebsd", target_os = "macos"))) {
+                    let send_size = match (send_size, max_send_buffer_size) {
+                        (Some(sz), Some(max_sz)) => std::cmp::min(sz, max_sz),
+                        (Some(sz), _) | (_, Some(sz)) => sz,
+                        _ => return,
+                    };
+                    *c = c.send_buffer_size(send_size);
+                }
             };
-            let maybe_set_send_buffer_size = move |c: SocketConfig| {
-                let Some(sz) = send_buffer_size else { return c };
-                c.send_buffer_size(sz)
-            };
-            let maybe_set_recv_and_send_buffer_sizes = move |c| {
-                let c = maybe_set_recv_buffer_size(c);
-                let c = maybe_set_send_buffer_size(c);
-                c
-            };
-            SocketConfigs {
-                read_write: maybe_set_recv_and_send_buffer_sizes(SocketConfig::default()),
-                primarily_read_quic: maybe_set_recv_buffer_size(SocketConfig::default())
-                    .send_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_write_quic: maybe_set_send_buffer_size(SocketConfig::default())
-                    .recv_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_read_udp: maybe_set_recv_buffer_size(SocketConfig::default())
-                    .send_buffer_size(1),
-                primarily_write_udp: maybe_set_send_buffer_size(SocketConfig::default())
-                    .recv_buffer_size(1),
-            }
-        } else {
-            SocketConfigs::default()
-        }
+        let mut c = SocketConfigs::default();
+        set_max_recv_send_buffer_size(&mut c.read_write, None, None);
+        set_max_recv_send_buffer_size(
+            &mut c.primarily_read_quic,
+            None,
+            Some(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+        );
+        set_max_recv_send_buffer_size(
+            &mut c.primarily_write_quic,
+            Some(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
+            None,
+        );
+        set_max_recv_send_buffer_size(&mut c.primarily_read_udp, None, Some(1));
+        set_max_recv_send_buffer_size(&mut c.primarily_write_udp, Some(1), None);
+        c
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
+    fn create_socket_configs() -> SocketConfigs {
+        SocketConfigs::default()
     }
 
     /// create localhost node for tests

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -10,9 +10,10 @@ use {
         find_available_ports_in_range,
         multihomed_sockets::BindIpAddrs,
         sockets::{
-            SocketConfiguration as SocketConfig, bind_gossip_port_in_range,
+            SocketConfiguration as SocketConfig, bind_gossip_port_in_range_with_config,
             bind_in_range_with_config, bind_more_with_config, bind_to_with_config,
-            localhost_port_range_for_tests, multi_bind_in_range_with_config,
+            get_max_recv_buffer_size, get_max_send_buffer_size, localhost_port_range_for_tests,
+            multi_bind_in_range_with_config,
         },
     },
     solana_pubkey::Pubkey,
@@ -63,22 +64,64 @@ impl Node {
     /// (handshakes, ACKs, connection management). For UDP, "read/write" only
     /// describes buffer tuning: Agave does not send from primarily_read_udp
     /// sockets nor receive on primarily_write_udp sockets. Setting the unused
-    /// side to 0 avoids increasing it; Linux still enforces a minimum.
+    /// side to 1 avoids increasing it; Linux still enforces a minimum. Note
+    /// unlike Linux, MacOS and FreeBSD will not accept a buffer size of zero.
     ///
     /// NOTE: In Linux, the minimum send buffer size (SO_SNDBUF) is 2048 bytes
     /// and the minimum receive buffer size (SO_RCVBUF) is 256 bytes
     /// See: https://man7.org/linux/man-pages/man7/socket.7.html
     fn create_socket_configs() -> SocketConfigs {
-        if cfg!(target_os = "linux") {
+        if cfg!(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "macos"
+        )) {
             const QUIC_CONTROL_TRAFFIC_BUFFER_SIZE: usize = 4 * 1024 * 1024; // 4 MiB
+            let recv_buffer_size = get_max_recv_buffer_size()
+                .map_err(|err| {
+                    error!(
+                        "Maximum socket receive buffer size could not be determined: {}",
+                        err
+                    )
+                })
+                .ok();
+            let send_buffer_size = get_max_send_buffer_size()
+                .map_err(|err| {
+                    error!(
+                        "Maximum socket send buffer size could not be determined: {}",
+                        err
+                    )
+                })
+                .ok();
+            if let Some(sz) = recv_buffer_size {
+                info!("Maximum socket receive buffer size is {}", sz)
+            }
+            if let Some(sz) = send_buffer_size {
+                info!("Maximum socket send buffer size is {}", sz)
+            }
+            let maybe_set_recv_buffer_size = move |c: SocketConfig| {
+                let Some(sz) = recv_buffer_size else { return c };
+                c.recv_buffer_size(sz)
+            };
+            let maybe_set_send_buffer_size = move |c: SocketConfig| {
+                let Some(sz) = send_buffer_size else { return c };
+                c.send_buffer_size(sz)
+            };
+            let maybe_set_recv_and_send_buffer_sizes = move |c| {
+                let c = maybe_set_recv_buffer_size(c);
+                let c = maybe_set_send_buffer_size(c);
+                c
+            };
             SocketConfigs {
-                read_write: SocketConfig::default(),
-                primarily_read_quic: SocketConfig::default()
+                read_write: maybe_set_recv_and_send_buffer_sizes(SocketConfig::default()),
+                primarily_read_quic: maybe_set_recv_buffer_size(SocketConfig::default())
                     .send_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_write_quic: SocketConfig::default()
+                primarily_write_quic: maybe_set_send_buffer_size(SocketConfig::default())
                     .recv_buffer_size(QUIC_CONTROL_TRAFFIC_BUFFER_SIZE),
-                primarily_read_udp: SocketConfig::default().send_buffer_size(0),
-                primarily_write_udp: SocketConfig::default().recv_buffer_size(0),
+                primarily_read_udp: maybe_set_recv_buffer_size(SocketConfig::default())
+                    .send_buffer_size(1),
+                primarily_write_udp: maybe_set_send_buffer_size(SocketConfig::default())
+                    .recv_buffer_size(1),
             }
         } else {
             SocketConfigs::default()
@@ -136,16 +179,21 @@ impl Node {
         let mut gossip_sockets = Vec::with_capacity(bind_ip_addrs.len());
         let mut gossip_ports = Vec::with_capacity(bind_ip_addrs.len());
         let mut ip_echo_sockets = Vec::with_capacity(bind_ip_addrs.len());
+
+        let socket_configs = Self::create_socket_configs();
+
         for ip in bind_ip_addrs.iter() {
             let gossip_addr = SocketAddr::new(*ip, gossip_port);
-            let (port, (gossip, ip_echo)) =
-                bind_gossip_port_in_range(&gossip_addr, port_range, *ip);
+            let (port, (gossip, ip_echo)) = bind_gossip_port_in_range_with_config(
+                &gossip_addr,
+                port_range,
+                *ip,
+                socket_configs.read_write,
+            );
             gossip_sockets.push(gossip);
             gossip_ports.push(port);
             ip_echo_sockets.push(ip_echo);
         }
-
-        let socket_configs = Self::create_socket_configs();
 
         let (tvu_port, mut tvu_sockets) = multi_bind_in_range_with_config(
             bind_ip_addr,

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -46,6 +46,15 @@ pub fn bind_gossip_port_in_range(
     bind_ip_addr: IpAddr,
 ) -> (u16, (UdpSocket, TcpListener)) {
     let config = SocketConfiguration::default();
+    bind_gossip_port_in_range_with_config(gossip_addr, port_range, bind_ip_addr, config)
+}
+
+pub fn bind_gossip_port_in_range_with_config(
+    gossip_addr: &SocketAddr,
+    port_range: PortRange,
+    bind_ip_addr: IpAddr,
+    config: SocketConfiguration,
+) -> (u16, (UdpSocket, TcpListener)) {
     if gossip_addr.port() != 0 {
         (
             gossip_addr.port(),
@@ -138,6 +147,77 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
     }
     sock.set_nonblocking(non_blocking)?;
     Ok(sock)
+}
+
+/// The get_max_recv/send_buffer_size functions below will probe buffer sizes
+/// up to this limit which should both be sufficiently large and within the
+/// allowable ranges for the platforms below.
+const MAX_BUF_SIZ: usize = 0x7fff_ffff;
+
+// Linux normally always succeeds, clamping the size to the system limit.
+// A quirk of Linux is that it doubles buffer size internally hence the
+// division by two below.
+#[cfg(target_os = "linux")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    sock.set_recv_buffer_size(MAX_BUF_SIZ)?;
+    sock.recv_buffer_size().map(|sz| sz / 2)
+}
+#[cfg(target_os = "linux")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    sock.set_send_buffer_size(MAX_BUF_SIZ)?;
+    sock.send_buffer_size().map(|sz| sz / 2)
+}
+
+// MacOS will clamp the size to the system limit but will succeed the
+// first time if the clamped size is larger than the current value.
+// Subsequent attempts to increase a buffer that is already at max will
+// fail. Hence we intentionally disregard any error when requesting the
+// maximum buffer size.
+#[cfg(target_os = "macos")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let _ = sock.set_recv_buffer_size(MAX_BUF_SIZ);
+    sock.recv_buffer_size()
+}
+#[cfg(target_os = "macos")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let _ = sock.set_send_buffer_size(MAX_BUF_SIZ);
+    sock.send_buffer_size()
+}
+
+// FreeBSD will not clamp the requested size but rather will return an
+// error if the size requested exceeds the system limit. Thus a binary
+// search algorithm is employed to determine the maximum available size.
+#[cfg(target_os = "freebsd")]
+pub fn get_max_recv_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
+    while lo <= hi {
+        let mid = (lo + hi) / 2;
+        if sock.set_recv_buffer_size(mid).is_ok() {
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    Ok(hi)
+}
+#[cfg(target_os = "freebsd")]
+pub fn get_max_send_buffer_size() -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+    let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
+    while lo <= hi {
+        let mid = (lo + hi) / 2;
+        if sock.set_send_buffer_size(mid).is_ok() {
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    Ok(hi)
 }
 
 /// Find a port in the given range with a socket config that is available for both TCP and UDP

--- a/net-utils/src/sockets.rs
+++ b/net-utils/src/sockets.rs
@@ -154,18 +154,31 @@ pub(crate) fn udp_socket_with_config(config: SocketConfiguration) -> io::Result<
 /// allowable ranges for the platforms below.
 const MAX_BUF_SIZ: usize = 0x7fff_ffff;
 
+pub fn get_max_tcp_recv_buffer_size() -> io::Result<usize> {
+    get_max_recv_buffer_size(Type::STREAM)
+}
+pub fn get_max_tcp_send_buffer_size() -> io::Result<usize> {
+    get_max_send_buffer_size(Type::STREAM)
+}
+pub fn get_max_udp_recv_buffer_size() -> io::Result<usize> {
+    get_max_recv_buffer_size(Type::DGRAM)
+}
+pub fn get_max_udp_send_buffer_size() -> io::Result<usize> {
+    get_max_send_buffer_size(Type::DGRAM)
+}
+
 // Linux normally always succeeds, clamping the size to the system limit.
 // A quirk of Linux is that it doubles buffer size internally hence the
 // division by two below.
 #[cfg(target_os = "linux")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     sock.set_recv_buffer_size(MAX_BUF_SIZ)?;
     sock.recv_buffer_size().map(|sz| sz / 2)
 }
 #[cfg(target_os = "linux")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     sock.set_send_buffer_size(MAX_BUF_SIZ)?;
     sock.send_buffer_size().map(|sz| sz / 2)
 }
@@ -176,14 +189,14 @@ pub fn get_max_send_buffer_size() -> io::Result<usize> {
 // fail. Hence we intentionally disregard any error when requesting the
 // maximum buffer size.
 #[cfg(target_os = "macos")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let _ = sock.set_recv_buffer_size(MAX_BUF_SIZ);
     sock.recv_buffer_size()
 }
 #[cfg(target_os = "macos")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let _ = sock.set_send_buffer_size(MAX_BUF_SIZ);
     sock.send_buffer_size()
 }
@@ -192,8 +205,8 @@ pub fn get_max_send_buffer_size() -> io::Result<usize> {
 // error if the size requested exceeds the system limit. Thus a binary
 // search algorithm is employed to determine the maximum available size.
 #[cfg(target_os = "freebsd")]
-pub fn get_max_recv_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_recv_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
     while lo <= hi {
         let mid = (lo + hi) / 2;
@@ -206,8 +219,8 @@ pub fn get_max_recv_buffer_size() -> io::Result<usize> {
     Ok(hi)
 }
 #[cfg(target_os = "freebsd")]
-pub fn get_max_send_buffer_size() -> io::Result<usize> {
-    let sock = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
+pub fn get_max_send_buffer_size(sock_type: Type) -> io::Result<usize> {
+    let sock = Socket::new(Domain::IPV4, sock_type, None)?;
     let (mut lo, mut hi) = (1, MAX_BUF_SIZ);
     while lo <= hi {
         let mid = (lo + hi) / 2;


### PR DESCRIPTION
#### Problem
Currently sockets in agave use default buffer sizes for the most part requiring not just the maximum size to be increased in systctl (`net.core.rmem_max` / `net.core.wmem_max` on Linux, `kern.ipc.maxsockbuf` on FreeBSD) but also the default size (`net.core.rmem_default` / `net.core.wmem_default` on Linux, `net.inet.udp.recvspace` / `net.inet.udp.maxdgram` on FreeBSD), which means every socket created by any program on the server uses more memory. It is better to set only a high maximum and a normal default in sysctl and have the validator increase the socket buffer sizes for its own sockets, so ntp and other daemons do not needlessly waste memory.

#### Summary of Changes
- Add support for setting socket buffers for freebsd and macosx.
- Add platform specific socket buffer size probes for linux, macosx and freebsd.
- Apply read/write socket configuration to gossip ports.
- Probe maximum socket buffer sizes and configure accordingly at startup.

#### Testing
Socket buffer sizes are logged and confirmed consistent with socket buffer sizes reported by `ss -amnpu` (Linux), `netstat -anx -p udp` (FreeBSD) and `netstat -anv -p udp` (MacOS/X).

#### Notes
This was taken out of draft PR #13000. 