### PR TITLE
svm: decouple callback traits

### DIFF
--- a/svm-callback/src/lib.rs
+++ b/svm-callback/src/lib.rs
@@ -33,7 +33,7 @@ pub trait InvokeContextCallback {
 }
 
 /// Runtime callbacks for transaction processing.
-pub trait TransactionProcessingCallback: InvokeContextCallback {
+pub trait TransactionProcessingCallback {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)>;
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -321,14 +321,6 @@ impl<CB: TransactionProcessingCallback> TransactionProcessingCallback for Accoun
     }
 }
 
-// NOTE this is a required subtrait of TransactionProcessingCallback.
-// It may make sense to break out a second subtrait just for the above two functions,
-// but this would be a nontrivial breaking change and require careful consideration.
-impl<CB: TransactionProcessingCallback> solana_svm_callback::InvokeContextCallback
-    for AccountLoader<'_, CB>
-{
-}
-
 /// Set the rent epoch to u64::MAX if the account is rent exempt.
 ///
 /// TODO: This function is used to update the rent epoch of an account. Once we
@@ -689,7 +681,7 @@ mod tests {
         },
         solana_signature::Signature,
         solana_signer::Signer,
-        solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+        solana_svm_callback::TransactionProcessingCallback,
         solana_system_transaction::transfer,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_context::{
@@ -729,8 +721,6 @@ mod tests {
             }
         }
     }
-
-    impl InvokeContextCallback for TestCallbacks {}
 
     impl TransactionProcessingCallback for TestCallbacks {
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -16,7 +16,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
-    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+    solana_svm_callback::TransactionProcessingCallback,
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_timings::ExecuteTimings,
     solana_syscalls::create_program_runtime_environment,
@@ -177,8 +177,6 @@ pub fn fill_program_cache_from_accounts(
 }
 
 struct FillFromAccountsCallback<'a>(&'a [(Pubkey, Account)]);
-
-impl InvokeContextCallback for FillFromAccountsCallback<'_> {}
 
 impl TransactionProcessingCallback for FillFromAccountsCallback<'_> {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, u64)> {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -322,7 +322,6 @@ mod tests {
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
-        solana_svm_callback::InvokeContextCallback,
         solana_svm_type_overrides::sync::atomic::AtomicU64,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::{
@@ -346,8 +345,6 @@ mod tests {
     pub(crate) struct MockBankCallback {
         pub(crate) account_shared_data: RefCell<HashMap<Pubkey, (AccountSharedData, Slot)>>,
     }
-
-    impl InvokeContextCallback for MockBankCallback {}
 
     impl TransactionProcessingCallback for MockBankCallback {
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -52,7 +52,7 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_rent::Rent,
-    solana_svm_callback::TransactionProcessingCallback,
+    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_log_collector::LogCollector,
     solana_svm_measure::{measure::Measure, measure_us},
@@ -391,7 +391,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     }
 
     /// Main entrypoint to the SVM.
-    pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
+    pub fn load_and_execute_sanitized_transactions<
+        CB: TransactionProcessingCallback + InvokeContextCallback,
+    >(
         &self,
         callbacks: &CB,
         sanitized_txs: &[impl SVMTransaction],
@@ -895,7 +897,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
     /// Execute a transaction using the provided loaded accounts and update
     /// the executors cache if the transaction was successful.
-    fn execute_loaded_transaction<CB: TransactionProcessingCallback>(
+    fn execute_loaded_transaction<CB: InvokeContextCallback>(
         &self,
         callback: &CB,
         tx: &impl SVMTransaction,


### PR DESCRIPTION
#### Problem
SVM currently requires two traits, one for transaction processing (`TransactionProcessingCallback`) and one for invoking the VM (`InvokeContextCallback`). The latter is currently a requirement of the former, but we don't actually need this constraint for any particular reason.

#### Summary of Changes
Decouple the traits, update any function signatures to only require the trait bounds they need, and update any mock callbacks who unnecessarily implement both.

#### Testing
No testing necessary, Rust type-checks these trait requirements.
