### PR TITLE
PER: use proper stake denominator for AG rewards

### DIFF
--- a/runtime/src/alpenglow_epoch_type.rs
+++ b/runtime/src/alpenglow_epoch_type.rs
@@ -16,8 +16,6 @@ use {
 #[derive(Debug)]
 pub(crate) struct RewardEpochDelegatedStakes {
     pub(crate) epoch: Epoch,
-    #[allow(dead_code)]
-    // This will be used in a follow up as part of non Tower PER calculations
     pub(crate) delegated_stakes: HashMap<Pubkey, u64>,
 }
 
@@ -143,15 +141,11 @@ pub(crate) enum AlpenglowEpochType {
         num_tower_slots: Slot,
         num_ag_slots: Slot,
         migration_epoch: Epoch,
-        #[allow(dead_code)]
-        // This will be used in a follow up as part of PER calculations for the migration epoch
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
     },
     /// This is a full alpenglow epoch
     Alpenglow {
         migration_epoch: Epoch,
-        #[allow(dead_code)]
-        // This will be used in a follow up as part of PER calculations for Alpenglow epochs
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
     },
 }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -643,7 +643,6 @@ impl Bank {
             },
             reward_calc_tracer,
             ag_epoch_type,
-            &self.epoch_stakes,
             current_lamports,
             minimum_lamports,
         ) {
@@ -861,7 +860,6 @@ impl Bank {
                         DelegatedVoteState::from(vote_account.vote_state_view()),
                         stake_history,
                         new_warmup_cooldown_rate_epoch,
-                        &self.epoch_stakes,
                         use_fixed_point_stake_math,
                     )
                     .unwrap_or(0)

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1115,6 +1115,7 @@ mod tests {
             },
             bank_forks::BankForks,
             genesis_utils::{self, GenesisConfigInfo, deactivate_features},
+            runtime_config::RuntimeConfig,
             stake_account::StakeAccount,
             stake_utils,
             stakes::{Stakes, tests::create_staked_node_accounts},
@@ -1126,7 +1127,10 @@ mod tests {
         solana_account::{
             AccountSharedData, ReadableAccount, accounts_equal, state_traits::StateMut,
         },
-        solana_accounts_db::partitioned_rewards::PartitionedEpochRewardsConfig,
+        solana_accounts_db::{
+            accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+            partitioned_rewards::PartitionedEpochRewardsConfig,
+        },
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,
@@ -2345,6 +2349,129 @@ mod tests {
         }
 
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
+    }
+
+    #[test]
+    fn test_recalculate_alpenglow_rewards_after_partial_distribution_uses_original_denominator() {
+        let stake_lamports = 2_000_000_000;
+        let validator_keypairs = vec![genesis_utils::ValidatorVoteKeypairs::new_rand()];
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000 * LAMPORTS_PER_SOL,
+            &validator_keypairs,
+            vec![stake_lamports],
+        );
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        let features_to_deactivate = crate::slot_params::slot_time_feature_ids().to_vec();
+        deactivate_features(&mut genesis_config, &features_to_deactivate);
+
+        let mut accounts_db_config: AccountsDbConfig = ACCOUNTS_DB_CONFIG_FOR_TESTING;
+        accounts_db_config.partitioned_epoch_rewards_config =
+            PartitionedEpochRewardsConfig::new_for_test(1);
+        let bank = Bank::new_from_genesis(
+            &genesis_config,
+            Arc::new(RuntimeConfig::default()),
+            Vec::new(),
+            None,
+            accounts_db_config,
+            None,
+            None,
+            Arc::default(),
+            None,
+            None,
+        );
+
+        let vote_pubkey = validator_keypairs[0].vote_keypair.pubkey();
+        let vote_account = bank.get_account(&vote_pubkey).unwrap();
+        let extra_stake_pubkey = Pubkey::new_unique();
+        let extra_stake_account = stake_utils::create_stake_account(
+            &extra_stake_pubkey,
+            &vote_pubkey,
+            &vote_account,
+            &bank.rent_collector.rent,
+            stake_lamports,
+        );
+        bank.store_account_and_update_capitalization(&extra_stake_pubkey, &extra_stake_account);
+
+        let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            SLOTS_PER_EPOCH,
+        );
+        assert_eq!(bank.epoch(), 1);
+
+        let mut vote_account = bank.get_account(&vote_pubkey).unwrap();
+        let VoteStateVersions::V4(mut vote_state) = vote_account
+            .deserialize_data::<VoteStateVersions>()
+            .unwrap()
+        else {
+            panic!("unexpected vote state version");
+        };
+        let last_credits = vote_state
+            .epoch_credits
+            .last()
+            .map(|(_epoch, final_credits, _initial_credits)| *final_credits)
+            .unwrap_or_default();
+        vote_state
+            .epoch_credits
+            .push((bank.epoch(), last_credits + 1_000_000, last_credits));
+        vote_account
+            .serialize_data(&VoteStateVersions::V4(vote_state))
+            .unwrap();
+        bank.store_account(&vote_pubkey, &vote_account);
+
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let mut bank = Bank::new_from_parent(
+            bank,
+            SlotLeader::default(),
+            SLOTS_PER_EPOCH.saturating_mul(2),
+        );
+        assert_eq!(bank.epoch(), 2);
+
+        let EpochRewardStatus::Active(EpochRewardPhase::Calculation(calculation_status)) =
+            bank.epoch_reward_status.clone()
+        else {
+            panic!("{:?} not active calculation", bank.epoch_reward_status);
+        };
+        let original_stake_rewards = calculation_status.all_stake_rewards;
+        let original_rewards = original_stake_rewards
+            .enumerated_rewards_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(original_rewards.len(), 2);
+        let (paid_index, paid_reward) = original_rewards[0];
+        let (unpaid_index, unpaid_reward) = original_rewards[1];
+        assert!(paid_reward.stake_reward > 0);
+        assert!(unpaid_reward.stake_reward > 0);
+
+        // Force exactly one stake reward to be distributed before simulating
+        // snapshot restore. That write updates StakesCache with a larger
+        // delegation for the same vote account.
+        bank.set_epoch_reward_status_distribution(
+            bank.block_height(),
+            Arc::clone(&original_stake_rewards),
+            vec![vec![paid_index], vec![unpaid_index]],
+        );
+        bank.distribute_partitioned_epoch_rewards();
+
+        let epoch_rewards_sysvar = bank.get_epoch_rewards_sysvar();
+        assert!(epoch_rewards_sysvar.active);
+        let (recalculated_stake_rewards, _partition_indices) =
+            bank.recalculate_stake_rewards(&epoch_rewards_sysvar, &thread_pool);
+        let recalculated_unpaid_reward = recalculated_stake_rewards
+            .enumerated_rewards_iter()
+            .find_map(|(_index, reward)| {
+                (reward.stake_pubkey == unpaid_reward.stake_pubkey).then_some(reward)
+            })
+            .expect("unpaid stake reward must still be pending after recalculation");
+
+        assert_eq!(
+            unpaid_reward.stake_reward, recalculated_unpaid_reward.stake_reward,
+            "recalculation after partial distribution must use the same AG delegated stake \
+             denominator as the original epoch-boundary calculation"
+        );
     }
 
     #[test]

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -397,9 +397,8 @@ mod tests {
     use {
         self::points::{PointValue, null_tracer},
         super::*,
-        crate::{
-            alpenglow_epoch_type::RewardEpochDelegatedStakes, epoch_stakes::VersionedEpochStakes,
-        },
+        crate::alpenglow_epoch_type::RewardEpochDelegatedStakes,
+        agave_votor_messages::migration::AG_MIGRATION_EPOCH_CREDIT,
         proptest::prelude::*,
         solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -409,9 +408,7 @@ mod tests {
             stake_history::StakeHistory,
             state::{Delegation, StakeStateV2},
         },
-        solana_vote::vote_account::VoteAccount,
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
-        std::collections::HashMap,
         test_case::{test_case, test_matrix},
     };
 
@@ -427,22 +424,9 @@ mod tests {
         }
     }
 
-    /// Returns an instance of `AlpenglowEpochType`, epoch_stakes, total stake, and first AG epoch.
-    fn get_ag_epoch_type() -> (
-        AlpenglowEpochType,
-        HashMap<Epoch, VersionedEpochStakes>,
-        u64,
-        Epoch,
-    ) {
+    /// Returns an instance of `AlpenglowEpochType`, total stake, and first AG epoch.
+    fn get_ag_epoch_type() -> (AlpenglowEpochType, u64, Epoch) {
         let total_stake = 1_000;
-        let vote_account = VoteAccount::new_random();
-        let vote_account_hash_map = [(Pubkey::default(), (total_stake, vote_account))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_account_hash_map, 0);
-        let epoch_stakes = (0..10)
-            .map(|epoch| (epoch, versioned_epoch_stakes.clone()))
-            .collect();
         let migration_epoch = 0;
         let first_ag_epoch = migration_epoch + 1;
         (
@@ -453,10 +437,33 @@ mod tests {
                     delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
                 },
             },
-            epoch_stakes,
             total_stake,
             first_ag_epoch,
         )
+    }
+
+    fn make_ag_epoch_type_for_test(
+        ag_enabled: bool,
+        vote_state: &VoteStateV4,
+        ag_total_stake_multiplier: u64,
+    ) -> AlpenglowEpochType {
+        if ag_enabled {
+            AlpenglowEpochType::Alpenglow {
+                migration_epoch: 0,
+                reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+                    epoch: vote_state
+                        .epoch_credits
+                        .last()
+                        .map(|(epoch, _final_epoch_credits, _initial_epoch_credits)| *epoch)
+                        .unwrap_or(1),
+                    delegated_stakes: [(Pubkey::default(), ag_total_stake_multiplier)]
+                        .into_iter()
+                        .collect(),
+                },
+            }
+        } else {
+            AlpenglowEpochType::Tower
+        }
     }
 
     #[test_matrix([true, false], [true, false])]
@@ -476,23 +483,22 @@ mod tests {
         let commission_rate_in_basis_points = true;
 
         // epoch credits work differently in AG, so we need a multiplier to account for that.
-        let (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier) = if ag_enabled {
-            let (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier, _) = get_ag_epoch_type();
-            (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier)
+        let ag_total_stake_multiplier = if ag_enabled {
+            let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+            ag_total_stake_multiplier
         } else {
-            (AlpenglowEpochType::Tower, HashMap::new(), 1)
+            1
         };
 
         let inc_credits = |handler: &mut VoteStateHandler, epoch: Epoch, credits: u64| {
             if ag_enabled {
-                let (_, _, _, first_ag_epoch) = get_ag_epoch_type();
+                let (_, _, first_ag_epoch) = get_ag_epoch_type();
                 handler
                     .increment_credits(epoch + first_ag_epoch, credits * ag_total_stake_multiplier);
             } else {
                 handler.increment_credits(epoch, credits);
             }
         };
-
         let mut rent = Rent::default();
         let minimum_balance = rent.minimum_balance(StakeStateV2::size_of());
 
@@ -522,8 +528,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier,
+                ),
                 stake_lamports + minimum_balance,
                 new_minimum_balance,
             )
@@ -552,8 +561,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier,
+                ),
                 stake_lamports + minimum_balance,
                 new_minimum_balance,
             )
@@ -579,23 +591,22 @@ mod tests {
         let adjust_delegations_for_rent = true;
 
         // epoch credits work differently in AG, so we need a multiplier to account for that.
-        let (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier) = if ag_enabled {
-            let (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier, _) = get_ag_epoch_type();
-            (ag_epoch_type, epoch_stakes, ag_total_stake_multiplier)
+        let ag_total_stake_multiplier = if ag_enabled {
+            let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+            ag_total_stake_multiplier
         } else {
-            (AlpenglowEpochType::Tower, HashMap::new(), 1)
+            1
         };
 
         let inc_credits = |handler: &mut VoteStateHandler, epoch: Epoch, credits: u64| {
             if ag_enabled {
-                let (_, _, _, first_ag_epoch) = get_ag_epoch_type();
+                let (_, _, first_ag_epoch) = get_ag_epoch_type();
                 handler
                     .increment_credits(epoch + first_ag_epoch, credits * ag_total_stake_multiplier);
             } else {
                 handler.increment_credits(epoch, credits);
             }
         };
-
         // this one can't collect now, credits_observed == vote_state.credits()
         assert_eq!(
             None,
@@ -616,8 +627,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -648,8 +662,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -678,8 +695,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -711,17 +731,26 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
         // put 1 credit in epoch 2
         inc_credits(&mut vote_state, 2, 1);
-        // this one should be able to collect 2 now
+        // Tower redeems all unobserved epoch credits. Full AG only considers
+        // the latest epoch credit entry.
+        let expected_staker_rewards = if ag_enabled {
+            stake.delegation.stake
+        } else {
+            stake.delegation.stake * 2
+        };
         assert_eq!(
             Some(CalculatedStakeRewards {
-                staker_rewards: stake.delegation.stake * 2,
+                staker_rewards: expected_staker_rewards,
                 voter_rewards: 0,
                 new_credits_observed: 4 * ag_total_stake_multiplier,
             }),
@@ -742,19 +771,27 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
         stake.credits_observed = 0;
-        // this one should be able to collect everything from t=0 a warmed up stake of 2
-        // (2 credits at stake of 1) + (1 credit at a stake of 2)
+        // Tower collects everything from t=0. Full AG only considers the
+        // latest epoch credit entry.
+        let expected_staker_rewards = if ag_enabled {
+            stake.delegation.stake
+        } else {
+            stake.delegation.stake * 2 // epoch 0
+                + stake.delegation.stake // epoch 1
+                + stake.delegation.stake // epoch 2
+        };
         assert_eq!(
             Some(CalculatedStakeRewards {
-                staker_rewards: stake.delegation.stake * 2 // epoch 0
-                    + stake.delegation.stake // epoch 1
-                    + stake.delegation.stake, // epoch 2
+                staker_rewards: expected_staker_rewards,
                 voter_rewards: 0,
                 new_credits_observed: 4 * ag_total_stake_multiplier,
             }),
@@ -775,16 +812,27 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
-        // same as above, but is a really small commission out of 32 bits,
-        //  verify that None comes back on small redemptions where no one gets paid
+        let skipped_small_redemption = || {
+            ag_enabled.then_some(CalculatedStakeRewards {
+                staker_rewards: 0,
+                voter_rewards: 0,
+                new_credits_observed: 4 * ag_total_stake_multiplier,
+            })
+        };
+
+        // same as above, but is a really small commission out of 32 bits.
+        // Tower defers; AG advances credits without paying dust rewards.
         vote_state.set_inflation_rewards_commission_bps(100);
         assert_eq!(
-            None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
+            skipped_small_redemption(),
             calculate_stake_rewards(
                 &stake,
                 vote_state.as_ref_v4().inflation_rewards_commission_bps,
@@ -802,13 +850,16 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
         vote_state.set_inflation_rewards_commission_bps(9900);
         assert_eq!(
-            None, // would be Some((0, 2 * 1 + 1 * 2, 4)),
+            skipped_small_redemption(),
             calculate_stake_rewards(
                 &stake,
                 vote_state.as_ref_v4().inflation_rewards_commission_bps,
@@ -826,8 +877,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -857,8 +911,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -888,8 +945,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -906,8 +966,11 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
                 true,
             )
         );
@@ -929,8 +992,11 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
                 true,
             )
         );
@@ -949,8 +1015,11 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &ag_epoch_type,
-                &epoch_stakes,
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
                 true,
             )
         );
@@ -982,8 +1051,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
 
@@ -1014,8 +1086,11 @@ mod tests {
                     use_fixed_point_stake_math: true,
                 },
                 null_tracer(),
-                &ag_epoch_type,
-                &epoch_stakes
+                &make_ag_epoch_type_for_test(
+                    ag_enabled,
+                    vote_state.as_ref_v4(),
+                    ag_total_stake_multiplier
+                ),
             )
         );
     }
@@ -1055,7 +1130,6 @@ mod tests {
             },
             null_tracer(),
             &AlpenglowEpochType::Tower,
-            &HashMap::new(),
             pre_lamports,
             new_minimum_balance,
         );
@@ -1316,7 +1390,6 @@ mod tests {
             },
             null_tracer(),
             &AlpenglowEpochType::Tower,
-            &HashMap::new(),
         );
     }
 
@@ -1337,11 +1410,11 @@ mod tests {
         let commission_rate_in_basis_points = true;
         let adjust_delegations_for_rent = true;
 
-        let (ag_stake_state, epoch_stakes) = if ag_enabled {
-            let (state, epoch_stakes, _stake, _first_ag_epoch) = get_ag_epoch_type();
-            (state, epoch_stakes)
+        let ag_stake_state = if ag_enabled {
+            let (state, _, _) = get_ag_epoch_type();
+            state
         } else {
-            (AlpenglowEpochType::Tower, HashMap::new())
+            AlpenglowEpochType::Tower
         };
 
         // this one can't collect now, credits_observed == vote_state.credits()
@@ -1365,7 +1438,82 @@ mod tests {
                 },
                 null_tracer(),
                 &ag_stake_state,
-                &epoch_stakes
+            )
+        );
+    }
+
+    #[test]
+    fn test_migration_epoch_skipped_dust_advances_credits() {
+        let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
+        let mut vote_state = VoteStateV4 {
+            inflation_rewards_commission_bps: 100,
+            epoch_credits: vec![
+                AG_MIGRATION_EPOCH_CREDIT,
+                (0, 4 * ag_total_stake_multiplier, 0),
+            ],
+            ..VoteStateV4::default()
+        };
+        let stake = Stake {
+            delegation: Delegation::new(&Pubkey::default(), 1, u64::MAX),
+            credits_observed: 0,
+        };
+        let expected = Some(CalculatedStakeRewards {
+            staker_rewards: 0,
+            voter_rewards: 0,
+            new_credits_observed: 4 * ag_total_stake_multiplier,
+        });
+        let point_value = PointValue {
+            rewards: 4,
+            points: 1,
+        };
+        let stake_history = StakeHistory::default();
+        let calculation_environment = || CalculationEnvironment {
+            rewarded_epoch: 0,
+            point_value: &point_value,
+            stake_history: &stake_history,
+            new_rate_activation_epoch: None,
+            commission_rate_in_basis_points: true,
+            adjust_delegations_for_rent: true,
+            use_fixed_point_stake_math: true,
+        };
+        let migration_epoch_type = AlpenglowEpochType::MigrationEpoch {
+            num_tower_slots: 0,
+            num_ag_slots: 1,
+            migration_epoch: 0,
+            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+                epoch: 0,
+                delegated_stakes: [(Pubkey::default(), ag_total_stake_multiplier)]
+                    .into_iter()
+                    .collect(),
+            },
+        };
+
+        assert_eq!(
+            expected,
+            calculate_stake_rewards(
+                &stake,
+                vote_state.inflation_rewards_commission_bps,
+                DelegatedVoteState::from(&vote_state),
+                calculation_environment(),
+                null_tracer(),
+                &migration_epoch_type,
+            )
+        );
+
+        vote_state.inflation_rewards_commission_bps = 9_900;
+        assert_eq!(
+            Some(CalculatedStakeRewards {
+                staker_rewards: 0,
+                voter_rewards: 0,
+                new_credits_observed: 4 * ag_total_stake_multiplier,
+            }),
+            calculate_stake_rewards(
+                &stake,
+                vote_state.inflation_rewards_commission_bps,
+                DelegatedVoteState::from(&vote_state),
+                calculation_environment(),
+                null_tracer(),
+                &migration_epoch_type,
             )
         );
     }

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -6,17 +6,13 @@ use {
         CalculatedStakePoints, CalculationEnvironment, DelegatedVoteState,
         InflationPointCalculationEvent, SkippedReason, calculate_stake_points_and_credits,
     },
-    crate::{
-        alpenglow_epoch_type::AlpenglowEpochType, epoch_stakes::VersionedEpochStakes,
-        stake_delegation::effective_stake,
-    },
+    crate::{alpenglow_epoch_type::AlpenglowEpochType, stake_delegation::effective_stake},
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
     solana_stake_interface::{
         error::StakeError,
         state::{Delegation, Stake},
     },
-    std::collections::HashMap,
 };
 
 pub mod points;
@@ -41,7 +37,6 @@ pub(crate) fn redeem_rewards<'a>(
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     ag_epoch_type: &AlpenglowEpochType,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     current_lamports: u64,
     minimum_lamports: u64,
 ) -> Result<(u64, u64, Stake), InstructionError> {
@@ -88,7 +83,6 @@ pub(crate) fn redeem_rewards<'a>(
         calculation_environment,
         inflation_point_calc_tracer,
         ag_epoch_type,
-        epoch_stakes,
         current_lamports,
         minimum_lamports,
     ) {
@@ -105,7 +99,6 @@ fn redeem_stake_rewards<'a>(
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     ag_epoch_type: &AlpenglowEpochType,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     current_lamports: u64,
     minimum_lamports: u64,
 ) -> Option<(u64, u64)> {
@@ -125,7 +118,6 @@ fn redeem_stake_rewards<'a>(
         calculation_environment,
         inflation_point_calc_tracer.as_ref(),
         ag_epoch_type,
-        epoch_stakes,
     )
     .map(|calculated_stake_rewards| {
         if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer {
@@ -210,7 +202,6 @@ fn calculate_stake_rewards<'a>(
     calculation_environment: CalculationEnvironment<'a>,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     ag_epoch_type: &AlpenglowEpochType,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
 ) -> Option<CalculatedStakeRewards> {
     let CalculationEnvironment {
         stake_history,
@@ -234,7 +225,6 @@ fn calculate_stake_rewards<'a>(
         inflation_point_calc_tracer.as_ref(),
         new_rate_activation_epoch,
         ag_epoch_type,
-        epoch_stakes,
         use_fixed_point_stake_math,
     );
 
@@ -253,23 +243,38 @@ fn calculate_stake_rewards<'a>(
         force_credits_update_with_skipped_reward = true;
     }
 
-    if force_credits_update_with_skipped_reward {
-        return Some(CalculatedStakeRewards {
+    // Once alpenglow is active we no longer allow for epochs where rewards are not redeemed.
+    let advance_credits_for_skipped_reward = !matches!(ag_epoch_type, AlpenglowEpochType::Tower)
+        && new_credits_observed != stake.credits_observed;
+    let skipped_reward = || {
+        Some(CalculatedStakeRewards {
             staker_rewards: 0,
             voter_rewards: 0,
             new_credits_observed,
-        });
+        })
+    };
+
+    let skip_reward = |reason: SkippedReason| {
+        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            inflation_point_calc_tracer(&reason.into());
+        }
+        if advance_credits_for_skipped_reward {
+            skipped_reward()
+        } else {
+            None
+        }
+    };
+
+    if force_credits_update_with_skipped_reward {
+        return skipped_reward();
     }
 
     let rewards = match ag_epoch_type {
         AlpenglowEpochType::Alpenglow { .. } => {
             if ag_points == 0 {
-                if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                    inflation_point_calc_tracer(&SkippedReason::ZeroPoints.into());
-                }
-                return None;
+                return skip_reward(SkippedReason::ZeroPoints);
             }
-            // In alpenglow, `points` represents the actual reward that this `vote_state` earned.
+            // In alpenglow, `points` represents the actual reward that this `stake` earned.
             ag_points
         }
         AlpenglowEpochType::Tower => {
@@ -300,16 +305,10 @@ fn calculate_stake_rewards<'a>(
             ..
         } => {
             if tower_points == 0 && ag_points == 0 {
-                if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                    inflation_point_calc_tracer(&SkippedReason::ZeroPoints.into());
-                }
-                return None;
+                return skip_reward(SkippedReason::ZeroPoints);
             }
             if ag_points == 0 && point_value.points == 0 {
-                if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-                    inflation_point_calc_tracer(&SkippedReason::ZeroPointValue.into());
-                }
-                return None;
+                return skip_reward(SkippedReason::ZeroPointValue);
             }
             let total_slots = (num_tower_slots + num_ag_slots) as u128;
             let tower_points = tower_points
@@ -329,10 +328,7 @@ fn calculate_stake_rewards<'a>(
 
     // don't bother trying to split if fractional lamports got truncated
     if rewards == 0 {
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&SkippedReason::ZeroReward.into());
-        }
-        return None;
+        return skip_reward(SkippedReason::ZeroReward);
     }
     let (voter_rewards, staker_rewards, is_split) = commission_split(voter_commission_bps, rewards);
     if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
@@ -348,10 +344,7 @@ fn calculate_stake_rewards<'a>(
         // don't collect if we lose a whole lamport somewhere
         //  is_split means there should be tokens on both sides,
         //  uncool to move credits_observed if one side didn't get paid
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&SkippedReason::TooEarlyUnfairSplit.into());
-        }
-        return None;
+        return skip_reward(SkippedReason::TooEarlyUnfairSplit);
     }
 
     Some(CalculatedStakeRewards {

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -244,8 +244,9 @@ fn calculate_stake_rewards<'a>(
     }
 
     // Once alpenglow is active we no longer allow for epochs where rewards are not redeemed.
-    let advance_credits_for_skipped_reward = !matches!(ag_epoch_type, AlpenglowEpochType::Tower)
-        && new_credits_observed != stake.credits_observed;
+    let is_tower_epoch = matches!(ag_epoch_type, AlpenglowEpochType::Tower);
+    let advance_credits_for_skipped_reward =
+        !is_tower_epoch && new_credits_observed != stake.credits_observed;
     let skipped_reward = || {
         Some(CalculatedStakeRewards {
             staker_rewards: 0,
@@ -340,11 +341,14 @@ fn calculate_stake_rewards<'a>(
         ));
     }
 
-    if (voter_rewards == 0 || staker_rewards == 0) && is_split {
-        // don't collect if we lose a whole lamport somewhere
-        //  is_split means there should be tokens on both sides,
-        //  uncool to move credits_observed if one side didn't get paid
-        return skip_reward(SkippedReason::TooEarlyUnfairSplit);
+    if (voter_rewards == 0 || staker_rewards == 0) && is_split && is_tower_epoch {
+        // In Tower, don't collect if we lose a whole lamport somewhere.
+        // is_split means there should be tokens on both sides; don't move
+        // credits_observed if one side didn't get paid.
+        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+            inflation_point_calc_tracer(&SkippedReason::TooEarlyUnfairSplit.into());
+        }
+        return None;
     }
 
     Some(CalculatedStakeRewards {
@@ -820,7 +824,7 @@ mod tests {
             )
         );
 
-        let skipped_small_redemption = || {
+        let small_redemption_result = || {
             ag_enabled.then_some(CalculatedStakeRewards {
                 staker_rewards: 0,
                 voter_rewards: 0,
@@ -828,11 +832,12 @@ mod tests {
             })
         };
 
-        // same as above, but is a really small commission out of 32 bits.
-        // Tower defers; AG advances credits without paying dust rewards.
+        // same as above, but is a small enough reward that both sides round to
+        // zero after the commission split. Tower defers; AG records the
+        // zero-lamport payout and advances credits.
         vote_state.set_inflation_rewards_commission_bps(100);
         assert_eq!(
-            skipped_small_redemption(),
+            small_redemption_result(),
             calculate_stake_rewards(
                 &stake,
                 vote_state.as_ref_v4().inflation_rewards_commission_bps,
@@ -859,7 +864,7 @@ mod tests {
         );
         vote_state.set_inflation_rewards_commission_bps(9900);
         assert_eq!(
-            skipped_small_redemption(),
+            small_redemption_result(),
             calculate_stake_rewards(
                 &stake,
                 vote_state.as_ref_v4().inflation_rewards_commission_bps,
@@ -1443,7 +1448,7 @@ mod tests {
     }
 
     #[test]
-    fn test_migration_epoch_skipped_dust_advances_credits() {
+    fn test_migration_epoch_dust_split_advances_credits() {
         let (_, ag_total_stake_multiplier, _) = get_ag_epoch_type();
         let mut vote_state = VoteStateV4 {
             inflation_rewards_commission_bps: 100,
@@ -1457,11 +1462,6 @@ mod tests {
             delegation: Delegation::new(&Pubkey::default(), 1, u64::MAX),
             credits_observed: 0,
         };
-        let expected = Some(CalculatedStakeRewards {
-            staker_rewards: 0,
-            voter_rewards: 0,
-            new_credits_observed: 4 * ag_total_stake_multiplier,
-        });
         let point_value = PointValue {
             rewards: 4,
             points: 1,
@@ -1489,7 +1489,11 @@ mod tests {
         };
 
         assert_eq!(
-            expected,
+            Some(CalculatedStakeRewards {
+                staker_rewards: 3,
+                voter_rewards: 0,
+                new_credits_observed: 4 * ag_total_stake_multiplier,
+            }),
             calculate_stake_rewards(
                 &stake,
                 vote_state.inflation_rewards_commission_bps,
@@ -1504,7 +1508,7 @@ mod tests {
         assert_eq!(
             Some(CalculatedStakeRewards {
                 staker_rewards: 0,
-                voter_rewards: 0,
+                voter_rewards: 3,
                 new_credits_observed: 4 * ag_total_stake_multiplier,
             }),
             calculate_stake_rewards(

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -375,7 +375,7 @@ fn commission_split(commission_bps: u16, on: u64) -> (u64, u64, bool) {
             let on = u128::from(on);
             // Calculate mine and theirs independently and symmetrically instead of
             // using the remainder of the other to treat them strictly equally.
-            // This is also to cancel the rewarding if either of the parties
+            // In Tower, this is also to cancel the rewarding if either of the parties
             // should receive only fractional lamports, resulting in not being rewarded at all.
             // Thus, note that we intentionally discard any residual fractional lamports.
             let mine = on

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -2,11 +2,11 @@
 
 use {
     crate::{
-        alpenglow_epoch_type::AlpenglowEpochType, epoch_stakes::VersionedEpochStakes,
+        alpenglow_epoch_type::{AlpenglowEpochType, RewardEpochDelegatedStakes},
         stake_delegation::delegation_effective_stake,
     },
     agave_votor_messages::migration::AG_MIGRATION_EPOCH_CREDIT,
-    log::{error, trace},
+    log::error,
     solana_clock::Epoch,
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
@@ -15,7 +15,7 @@ use {
         state::{Delegation, Stake, StakeStateV2},
     },
     solana_vote::vote_state_view::VoteStateView,
-    std::{cmp::Ordering, collections::HashMap},
+    std::cmp::Ordering,
 };
 
 /// captures a rewards round as lamports to be awarded
@@ -107,7 +107,6 @@ pub(crate) fn calculate_points_for_tower(
     vote_state: DelegatedVoteState,
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     use_fixed_point_stake_math: bool,
 ) -> Result<u128, InstructionError> {
     if let StakeStateV2::Stake(_meta, stake, _stake_flags) = stake_state {
@@ -117,7 +116,6 @@ pub(crate) fn calculate_points_for_tower(
             stake_history,
             null_tracer(),
             new_rate_activation_epoch,
-            epoch_stakes,
             use_fixed_point_stake_math,
         ))
     } else {
@@ -133,7 +131,6 @@ fn calculate_stake_points_for_tower(
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     use_fixed_point_stake_math: bool,
 ) -> u128 {
     calculate_stake_points_and_credits(
@@ -143,40 +140,9 @@ fn calculate_stake_points_for_tower(
         inflation_point_calc_tracer,
         new_rate_activation_epoch,
         &AlpenglowEpochType::Tower,
-        epoch_stakes,
         use_fixed_point_stake_math,
     )
     .tower_points
-}
-
-/// Returns the total stake delegated to `vote_pubkey` in the given `epoch`.
-fn get_total_stake(
-    vote_pubkey: Pubkey,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
-    epoch: Epoch,
-) -> Result<u64, ()> {
-    let Some(rank_map) = epoch_stakes.get(&epoch).map(|e| e.bls_pubkey_to_rank_map()) else {
-        record_error(format!(
-            "epoch_stakes.get(epoch={epoch}) for vote_pubkey={vote_pubkey} failed"
-        ));
-        return Err(());
-    };
-    let Some(rank) = rank_map.get_rank_for_vote_pubkey(&vote_pubkey) else {
-        // this is benign and can happen if a staker stakes with a validator not
-        // in the validator set.
-        record_trace(format!(
-            "get_rank_for_vote_pubkey(vote_pubkey={vote_pubkey}) in epoch={epoch} failed"
-        ));
-        return Err(());
-    };
-    let Some(entry) = rank_map.get_pubkey_stake_entry(*rank as usize) else {
-        record_error(format!(
-            "get_pubkey_stake_entry(rank={rank}) for vote_pubkey={vote_pubkey} in epoch={epoch} \
-             failed",
-        ));
-        return Err(());
-    };
-    Ok(entry.stake)
 }
 
 fn record_error(msg: String) {
@@ -184,14 +150,6 @@ fn record_error(msg: String) {
     datapoint_error!(
         "PER-total-stake-calculation-failure",
         ("error", msg, String)
-    );
-}
-
-fn record_trace(msg: String) {
-    trace!("{msg}");
-    datapoint_trace!(
-        "PER-total-stake-calculation-failure",
-        ("trace", msg, String)
     );
 }
 
@@ -277,88 +235,92 @@ fn tower_epoch_credits_iter(
     (points, new_credits_observed, saw_marker)
 }
 
-fn ag_epoch_credits_iter(
-    migration_epoch: Epoch,
-    mut saw_marker: bool,
+/// Calculate alpenglow points for `stake` based on the vote account's `reward_epoch_credits`
+///
+/// This value is the lamports paid to the vote account * `stake_amount` / `vote_account_stake`
+/// `vote_account_stake` is fetched from the precomputed `reward_epoch_delegated_stakes` for the
+/// reward epoch
+///
+/// Returns (alpenglow points, new_credits_observed)
+fn calculate_alpenglow_points(
     stake: &Stake,
-    epoch_credits_iter: impl Iterator<Item = (Epoch, u64, u64)>,
+    reward_epoch_credits: Option<(Epoch, u64, u64)>,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     use_fixed_point_stake_math: bool,
+    reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
 ) -> Result<(u128, u64), CalculatedStakePoints> {
-    let mut points = 0;
     let credits_in_stake = stake.credits_observed;
     let mut new_credits_observed = credits_in_stake;
-
-    for entry in epoch_credits_iter {
-        let (epoch, final_epoch_credits, initial_epoch_credits) = entry;
-        if epoch < migration_epoch {
-            continue;
-        }
-        if entry == AG_MIGRATION_EPOCH_CREDIT {
-            debug_assert!(!saw_marker);
-            saw_marker = true;
-            continue;
-        }
-        if epoch == migration_epoch && !saw_marker {
-            continue;
-        }
-
-        let earned_credits = calc_earned_credits(
-            stake,
-            final_epoch_credits,
-            initial_epoch_credits,
-            &mut new_credits_observed,
-        );
-        let stake_amount = u128::from(delegation_effective_stake(
-            &stake.delegation,
-            epoch,
-            stake_history,
-            new_rate_activation_epoch,
-            use_fixed_point_stake_math,
-        ));
-
-        let earned_points = {
-            if earned_credits == 0 {
-                earned_credits
-            } else {
-                let Ok(total_stake) =
-                    get_total_stake(stake.delegation.voter_pubkey, epoch_stakes, epoch)
-                else {
-                    return Err(CalculatedStakePoints {
-                        tower_points: 0,
-                        ag_points: 0,
-                        new_credits_observed,
-                        force_credits_update_with_skipped_reward: true,
-                    });
-                };
-                earned_credits * stake_amount / total_stake as u128
-            }
-        };
-        points += earned_points;
-        if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
-            inflation_point_calc_tracer(&InflationPointCalculationEvent::CalculatedPoints(
-                epoch,
-                stake_amount,
-                earned_credits,
-                earned_points,
-            ));
-        }
+    let Some((epoch, final_epoch_credits, initial_epoch_credits)) = reward_epoch_credits else {
+        return Ok((0, new_credits_observed));
+    };
+    if epoch != reward_epoch_delegated_stakes.epoch {
+        return Ok((0, new_credits_observed));
     }
-    Ok((points, new_credits_observed))
+
+    let earned_credits = calc_earned_credits(
+        stake,
+        final_epoch_credits,
+        initial_epoch_credits,
+        &mut new_credits_observed,
+    );
+    let stake_amount = u128::from(delegation_effective_stake(
+        &stake.delegation,
+        epoch,
+        stake_history,
+        new_rate_activation_epoch,
+        use_fixed_point_stake_math,
+    ));
+
+    let earned_points = if earned_credits == 0 || stake_amount == 0 {
+        0
+    } else {
+        let Some(total_stake) = reward_epoch_delegated_stakes
+            .delegated_stakes
+            .get(&stake.delegation.voter_pubkey)
+            .copied()
+            .filter(|stake| *stake != 0)
+        else {
+            record_error(format!(
+                "AG delegated stake denominator for vote_pubkey={} in epoch={} failed",
+                stake.delegation.voter_pubkey, reward_epoch_delegated_stakes.epoch
+            ));
+            return Err(CalculatedStakePoints {
+                tower_points: 0,
+                ag_points: 0,
+                new_credits_observed,
+                force_credits_update_with_skipped_reward: true,
+            });
+        };
+        earned_credits * stake_amount / total_stake as u128
+    };
+
+    if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
+        inflation_point_calc_tracer(&InflationPointCalculationEvent::CalculatedPoints(
+            epoch,
+            stake_amount,
+            earned_credits,
+            earned_points,
+        ));
+    }
+    Ok((earned_points, new_credits_observed))
 }
 
-fn migrating_epoch_credits_iter(
-    migration_epoch: Epoch,
+/// Calculates the tower and  alpenglow points for `stake` based on the vote account's `reward_epoch_credits`
+/// for the alpenglow migration epoch
+///
+/// Expects the epoch_credits_iter is sorted in ascending epoch order
+/// Returns (tower_points, alpenglow points, new_credits_observed)
+fn calculate_migration_points(
     stake: &Stake,
     mut epoch_credits_iter: impl Iterator<Item = (Epoch, u64, u64)>,
     stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     use_fixed_point_stake_math: bool,
+    reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
 ) -> Result<(u128, u128, u64), CalculatedStakePoints> {
     let (tower_points, tower_new_credits_observed, saw_marker) = tower_epoch_credits_iter(
         stake,
@@ -368,17 +330,19 @@ fn migrating_epoch_credits_iter(
         new_rate_activation_epoch,
         use_fixed_point_stake_math,
     );
-    let (ag_points, ag_new_credits_observed) = ag_epoch_credits_iter(
-        migration_epoch,
-        saw_marker,
-        stake,
-        epoch_credits_iter,
-        stake_history,
-        inflation_point_calc_tracer,
-        new_rate_activation_epoch,
-        epoch_stakes,
-        use_fixed_point_stake_math,
-    )?;
+    let (ag_points, ag_new_credits_observed) = if saw_marker {
+        calculate_alpenglow_points(
+            stake,
+            epoch_credits_iter.next(),
+            stake_history,
+            inflation_point_calc_tracer,
+            new_rate_activation_epoch,
+            use_fixed_point_stake_math,
+            reward_epoch_delegated_stakes,
+        )?
+    } else {
+        (0, stake.credits_observed)
+    };
 
     let new_credits_observed = tower_new_credits_observed.max(ag_new_credits_observed);
     Ok((tower_points, ag_points, new_credits_observed))
@@ -394,7 +358,6 @@ pub(crate) fn calculate_stake_points_and_credits(
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
     ag_epoch_type: &AlpenglowEpochType,
-    epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
     use_fixed_point_stake_math: bool,
 ) -> CalculatedStakePoints {
     let credits_in_stake = stake.credits_observed;
@@ -458,37 +421,39 @@ pub(crate) fn calculate_stake_points_and_credits(
             (points, 0, credits)
         }
         AlpenglowEpochType::MigrationEpoch {
-            migration_epoch, ..
+            migration_epoch,
+            reward_epoch_delegated_stakes,
+            ..
         } => {
-            match migrating_epoch_credits_iter(
-                *migration_epoch,
+            debug_assert_eq!(reward_epoch_delegated_stakes.epoch, *migration_epoch);
+            match calculate_migration_points(
                 stake,
                 vote_state.epoch_credits_iter,
                 stake_history,
                 inflation_point_calc_tracer,
                 new_rate_activation_epoch,
-                epoch_stakes,
                 use_fixed_point_stake_math,
+                reward_epoch_delegated_stakes,
             ) {
                 Ok(r) => r,
                 Err(e) => return e,
             }
         }
         AlpenglowEpochType::Alpenglow {
-            migration_epoch, ..
+            migration_epoch,
+            reward_epoch_delegated_stakes,
         } => {
-            let (ag_points, credits) = match ag_epoch_credits_iter(
-                *migration_epoch,
-                false,
+            debug_assert!(reward_epoch_delegated_stakes.epoch > *migration_epoch);
+            let (ag_points, credits) = match calculate_alpenglow_points(
                 stake,
-                vote_state.epoch_credits_iter,
+                vote_state.epoch_credits_iter.last(),
                 stake_history,
                 inflation_point_calc_tracer,
                 new_rate_activation_epoch,
-                epoch_stakes,
                 use_fixed_point_stake_math,
+                reward_epoch_delegated_stakes,
             ) {
-                Ok(r) => r,
+                Ok(result) => result,
                 Err(e) => return e,
             };
             (0, ag_points, credits)

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -251,21 +251,26 @@ fn calculate_alpenglow_points(
     use_fixed_point_stake_math: bool,
     reward_epoch_delegated_stakes: &RewardEpochDelegatedStakes,
 ) -> Result<(u128, u64), CalculatedStakePoints> {
-    let credits_in_stake = stake.credits_observed;
-    let mut new_credits_observed = credits_in_stake;
     let Some((epoch, final_epoch_credits, initial_epoch_credits)) = reward_epoch_credits else {
-        return Ok((0, new_credits_observed));
+        return Ok((0, stake.credits_observed));
     };
     if epoch != reward_epoch_delegated_stakes.epoch {
-        return Ok((0, new_credits_observed));
+        // In this case, the vote account did not record any credits in this epoch
+        // The latest entry is from a prior epoch - thus the delegation gets 0 rewards
+        return Ok((0, stake.credits_observed));
     }
 
-    let earned_credits = calc_earned_credits(
-        stake,
-        final_epoch_credits,
-        initial_epoch_credits,
-        &mut new_credits_observed,
-    );
+    let (earned_credits, new_credits_observed) = {
+        let mut new_credits_observed = stake.credits_observed;
+        let earned_credits = calc_earned_credits(
+            stake,
+            final_epoch_credits,
+            initial_epoch_credits,
+            &mut new_credits_observed,
+        );
+        (earned_credits, new_credits_observed)
+    };
+
     let stake_amount = u128::from(delegation_effective_stake(
         &stake.delegation,
         epoch,
@@ -308,10 +313,10 @@ fn calculate_alpenglow_points(
     Ok((earned_points, new_credits_observed))
 }
 
-/// Calculates the tower and  alpenglow points for `stake` based on the vote account's `reward_epoch_credits`
+/// Calculates the tower and alpenglow points for `stake` based on the vote account's `reward_epoch_credits`
 /// for the alpenglow migration epoch
 ///
-/// Expects the epoch_credits_iter is sorted in ascending epoch order
+/// Expects the epoch_credits_iter is sorted in ascending epoch order (excluding the migration marker)
 /// Returns (tower_points, alpenglow points, new_credits_observed)
 fn calculate_migration_points(
     stake: &Stake,

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -472,8 +472,8 @@ mod tests {
     use {
         super::*,
         solana_native_token::LAMPORTS_PER_SOL,
-        solana_vote::vote_account::VoteAccount,
         solana_vote_program::vote_state::{VoteStateV4, handler::VoteStateHandler},
+        std::cell::Cell,
     };
 
     impl<'a> From<&'a VoteStateV4> for DelegatedVoteState<'a> {
@@ -526,7 +526,6 @@ mod tests {
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &HashMap::new(),
                 true,
             )
         );
@@ -603,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ag_epoch_credits_iter() {
+    fn test_calculate_alpenglow_points() {
         let stake_lamports = 10_000_000 * LAMPORTS_PER_SOL;
         let total_stake = stake_lamports * 2;
         let credits = 1235;
@@ -615,60 +614,27 @@ mod tests {
             u64::MAX,
         );
 
-        let vote_account = VoteAccount::new_random();
-        let vote_account_hash_map = [(Pubkey::default(), (total_stake, vote_account))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_account_hash_map, 0);
-        let epoch_stakes = (0..10)
-            .map(|epoch| (epoch, versioned_epoch_stakes.clone()))
-            .collect();
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 1,
+            delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+        };
 
-        for saw_marker in [true, false] {
-            let epoch_credits = vec![(0, credits, 0), (1, credits * 2, credits)];
-            let (points, new_credits) = ag_epoch_credits_iter(
-                2,
-                saw_marker,
-                &stake,
-                epoch_credits.into_iter(),
-                &StakeHistory::default(),
-                null_tracer(),
-                None,
-                &epoch_stakes,
-                true,
-            )
-            .unwrap();
-            assert_eq!(points, 0);
-            assert_eq!(new_credits, 0);
-        }
-
-        for saw_marker in [true, false] {
-            let epoch_credits = vec![(0, credits, 0), (1, credits * 2, credits)];
-            let (points, new_credits) = ag_epoch_credits_iter(
-                0,
-                saw_marker,
-                &stake,
-                epoch_credits.into_iter(),
-                &StakeHistory::default(),
-                null_tracer(),
-                None,
-                &epoch_stakes,
-                true,
-            )
-            .unwrap();
-            if saw_marker {
-                assert_eq!(
-                    points,
-                    (credits as u128 * stake_lamports as u128 / total_stake as u128) * 2
-                );
-            } else {
-                assert_eq!(
-                    points,
-                    credits as u128 * stake_lamports as u128 / total_stake as u128
-                );
-            }
-            assert_eq!(new_credits, credits * 2);
-        }
+        let epoch_credits = vec![(0, credits, 0), (1, credits * 2, credits)];
+        let (points, new_credits) = calculate_alpenglow_points(
+            &stake,
+            epoch_credits.into_iter().last(),
+            &StakeHistory::default(),
+            null_tracer(),
+            None,
+            true,
+            &reward_epoch_delegated_stakes,
+        )
+        .unwrap();
+        assert_eq!(
+            points,
+            credits as u128 * stake_lamports as u128 / total_stake as u128
+        );
+        assert_eq!(new_credits, credits * 2);
 
         let epoch_credits = vec![
             (0, credits, 0),
@@ -676,48 +642,203 @@ mod tests {
             (0, credits * 2, credits),
             (1, credits * 3, credits * 2),
         ];
-        let (points, new_credits) = ag_epoch_credits_iter(
-            0,
-            false,
+        let (points, new_credits) = calculate_alpenglow_points(
             &stake,
-            epoch_credits.into_iter(),
+            epoch_credits.into_iter().last(),
             &StakeHistory::default(),
             null_tracer(),
             None,
-            &epoch_stakes,
             true,
+            &reward_epoch_delegated_stakes,
         )
         .unwrap();
         assert_eq!(
             points,
-            (credits as u128 * stake_lamports as u128 / total_stake as u128) * 2
+            credits as u128 * stake_lamports as u128 / total_stake as u128
         );
         assert_eq!(new_credits, credits * 3);
 
-        for saw_marker in [true, false] {
-            let epoch_credits = vec![(1, credits, 0), (2, credits * 2, credits)];
-            let (points, new_credits) = ag_epoch_credits_iter(
-                0,
-                saw_marker,
-                &stake,
-                epoch_credits.into_iter(),
-                &StakeHistory::default(),
-                null_tracer(),
-                None,
-                &epoch_stakes,
-                true,
-            )
-            .unwrap();
-            assert_eq!(
-                points,
-                (credits as u128 * stake_lamports as u128 / total_stake as u128) * 2
-            );
-            assert_eq!(new_credits, credits * 2);
-        }
+        let missing_reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 2,
+            delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+        };
+        let epoch_credits = vec![(0, credits, 0), (1, credits * 2, credits)];
+        let (points, new_credits) = calculate_alpenglow_points(
+            &stake,
+            epoch_credits.into_iter().last(),
+            &StakeHistory::default(),
+            null_tracer(),
+            None,
+            true,
+            &missing_reward_epoch_delegated_stakes,
+        )
+        .unwrap();
+        assert_eq!(points, 0);
+        assert_eq!(new_credits, 0);
     }
 
     #[test]
-    fn test_migrating_epoch_credits_iter() {
+    fn test_calculate_alpenglow_points_uses_current_delegated_stake_denominator() {
+        let stake_lamports = 200;
+        let current_delegated_total = 200;
+        let credits = 10;
+
+        let stake = Stake {
+            delegation: Delegation {
+                voter_pubkey: Pubkey::default(),
+                stake: stake_lamports,
+                activation_epoch: u64::MAX,
+                deactivation_epoch: u64::MAX,
+                ..Default::default()
+            },
+            credits_observed: 0,
+        };
+
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 1,
+            delegated_stakes: [(Pubkey::default(), current_delegated_total)]
+                .into_iter()
+                .collect(),
+        };
+        let epoch_credits = vec![
+            (0, credits, 0),
+            AG_MIGRATION_EPOCH_CREDIT,
+            (0, credits * 2, credits),
+            (1, credits * 3, credits * 2),
+        ];
+
+        let (points, new_credits) = calculate_alpenglow_points(
+            &stake,
+            epoch_credits.into_iter().last(),
+            &StakeHistory::default(),
+            null_tracer(),
+            None,
+            true,
+            &reward_epoch_delegated_stakes,
+        )
+        .unwrap();
+
+        assert_eq!(points, credits as u128);
+        assert_eq!(new_credits, credits * 3);
+    }
+
+    #[test]
+    fn test_alpenglow_uses_rewarded_epoch_credits_only() {
+        let stake_lamports = 10_000_000 * LAMPORTS_PER_SOL;
+        let total_stake = stake_lamports * 2;
+        let credits = 1235;
+
+        let stake = Stake {
+            delegation: Delegation {
+                voter_pubkey: Pubkey::default(),
+                stake: stake_lamports,
+                activation_epoch: u64::MAX,
+                deactivation_epoch: u64::MAX,
+                ..Default::default()
+            },
+            credits_observed: 0,
+        };
+        let vote_state = VoteStateV4 {
+            epoch_credits: (1..=64)
+                .map(|epoch| {
+                    let initial_credits = (epoch - 1) * credits;
+                    (epoch, initial_credits + credits, initial_credits)
+                })
+                .collect(),
+            ..VoteStateV4::default()
+        };
+
+        let ag_epoch_type = AlpenglowEpochType::Alpenglow {
+            migration_epoch: 0,
+            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+                epoch: 64,
+                delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+            },
+        };
+
+        let calculated_points_events = Cell::new(0);
+        let tracer = |event: &InflationPointCalculationEvent| {
+            if matches!(event, InflationPointCalculationEvent::CalculatedPoints(..)) {
+                calculated_points_events.set(calculated_points_events.get() + 1);
+            }
+        };
+
+        let calculated_stake_points = calculate_stake_points_and_credits(
+            &stake,
+            DelegatedVoteState::from(&vote_state),
+            &StakeHistory::default(),
+            Some(tracer),
+            None,
+            &ag_epoch_type,
+            true,
+        );
+
+        assert_eq!(calculated_points_events.get(), 1);
+        assert_eq!(
+            calculated_stake_points,
+            CalculatedStakePoints {
+                tower_points: 0,
+                ag_points: credits as u128 * stake_lamports as u128 / total_stake as u128,
+                new_credits_observed: credits * 64,
+                force_credits_update_with_skipped_reward: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_alpenglow_rewarded_epoch_uses_delegated_stake_denominator() {
+        let stake_lamports = 200;
+        let current_delegated_total = 200;
+        let credits = 10;
+
+        let stake = Stake {
+            delegation: Delegation {
+                voter_pubkey: Pubkey::default(),
+                stake: stake_lamports,
+                activation_epoch: u64::MAX,
+                deactivation_epoch: u64::MAX,
+                ..Default::default()
+            },
+            credits_observed: 0,
+        };
+        let vote_state = VoteStateV4 {
+            epoch_credits: vec![(1, credits, 0)],
+            ..VoteStateV4::default()
+        };
+
+        let ag_epoch_type = AlpenglowEpochType::Alpenglow {
+            migration_epoch: 0,
+            reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+                epoch: 1,
+                delegated_stakes: [(Pubkey::default(), current_delegated_total)]
+                    .into_iter()
+                    .collect(),
+            },
+        };
+
+        let calculated_stake_points = calculate_stake_points_and_credits(
+            &stake,
+            DelegatedVoteState::from(&vote_state),
+            &StakeHistory::default(),
+            null_tracer(),
+            None,
+            &ag_epoch_type,
+            true,
+        );
+
+        assert_eq!(
+            calculated_stake_points,
+            CalculatedStakePoints {
+                tower_points: 0,
+                ag_points: credits as u128,
+                new_credits_observed: credits,
+                force_credits_update_with_skipped_reward: false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_calculate_migration_points() {
         let stake_lamports = 10_000_000 * LAMPORTS_PER_SOL;
         let total_stake = stake_lamports * 2;
         let credits = 1235;
@@ -729,45 +850,42 @@ mod tests {
             u64::MAX,
         );
 
-        let vote_account = VoteAccount::new_random();
-        let vote_account_hash_map = [(Pubkey::default(), (total_stake, vote_account))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes = VersionedEpochStakes::new_for_tests(vote_account_hash_map, 0);
-        let epoch_stakes = (0..10)
-            .map(|epoch| (epoch, versioned_epoch_stakes.clone()))
-            .collect();
-
         let epoch_credits = vec![(0, credits, 0), (1, credits * 2, credits)];
-        let (tower_points, ag_points, new_credits) = migrating_epoch_credits_iter(
-            2,
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 2,
+            delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+        };
+        let (tower_points, ag_points, new_credits) = calculate_migration_points(
             &stake,
             epoch_credits.into_iter(),
             &StakeHistory::default(),
             null_tracer(),
             None,
-            &epoch_stakes,
             true,
+            &reward_epoch_delegated_stakes,
         )
         .unwrap();
         assert_eq!(tower_points, credits as u128 * stake_lamports as u128 * 2);
         assert_eq!(ag_points, 0);
         assert_eq!(new_credits, credits * 2);
 
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 0,
+            delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+        };
         let epoch_credits = vec![
             (0, credits, 0),
             AG_MIGRATION_EPOCH_CREDIT,
             (0, credits * 2, credits),
         ];
-        let (tower_points, ag_points, new_credits) = migrating_epoch_credits_iter(
-            0,
+        let (tower_points, ag_points, new_credits) = calculate_migration_points(
             &stake,
             epoch_credits.into_iter(),
             &StakeHistory::default(),
             null_tracer(),
             None,
-            &epoch_stakes,
             true,
+            &reward_epoch_delegated_stakes,
         )
         .unwrap();
         assert_eq!(tower_points, credits as u128 * stake_lamports as u128);
@@ -778,15 +896,14 @@ mod tests {
         assert_eq!(new_credits, credits * 2);
 
         let epoch_credits = vec![AG_MIGRATION_EPOCH_CREDIT, (0, credits * 2, credits)];
-        let (tower_points, ag_points, new_credits) = migrating_epoch_credits_iter(
-            0,
+        let (tower_points, ag_points, new_credits) = calculate_migration_points(
             &stake,
             epoch_credits.into_iter(),
             &StakeHistory::default(),
             null_tracer(),
             None,
-            &epoch_stakes,
             true,
+            &reward_epoch_delegated_stakes,
         )
         .unwrap();
         assert_eq!(tower_points, 0);
@@ -800,34 +917,8 @@ mod tests {
     #[test]
     fn test_changing_total_stake() {
         let pubkey = Pubkey::new_unique();
-        let vote_account = VoteAccount::new_random();
         let staker_delegation = LAMPORTS_PER_SOL;
-        let epoch0_validator_stake = staker_delegation * 5;
-        let epoch1_validator_stake = epoch0_validator_stake * 3;
-        let epoch2_validator_stake = epoch0_validator_stake / 3;
-
-        let epoch0_vote_accounts = [(pubkey, (epoch0_validator_stake, vote_account.clone()))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes0 = VersionedEpochStakes::new_for_tests(epoch0_vote_accounts, 0);
-
-        let epoch1_vote_accounts = [(pubkey, (epoch1_validator_stake, vote_account.clone()))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes1 = VersionedEpochStakes::new_for_tests(epoch1_vote_accounts, 0);
-
-        let epoch2_vote_accounts = [(pubkey, (epoch2_validator_stake, vote_account.clone()))]
-            .into_iter()
-            .collect();
-        let versioned_epoch_stakes2 = VersionedEpochStakes::new_for_tests(epoch2_vote_accounts, 0);
-
-        let epoch_stakes = [
-            (0, versioned_epoch_stakes0),
-            (1, versioned_epoch_stakes1),
-            (2, versioned_epoch_stakes2),
-        ]
-        .into_iter()
-        .collect();
+        let reward_epoch_validator_stake = staker_delegation * 5;
         let stake = Stake {
             delegation: Delegation {
                 voter_pubkey: pubkey,
@@ -847,23 +938,24 @@ mod tests {
             (1, credits * 3, credits * 2),
             (2, credits * 4, credits * 3),
         ];
-        let (points, new_credits) = ag_epoch_credits_iter(
-            0,
-            false,
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: 2,
+            delegated_stakes: [(pubkey, reward_epoch_validator_stake)]
+                .into_iter()
+                .collect(),
+        };
+        let (points, new_credits) = calculate_alpenglow_points(
             &stake,
-            epoch_credits.into_iter(),
+            epoch_credits.into_iter().last(),
             &StakeHistory::default(),
             null_tracer(),
             None,
-            &epoch_stakes,
             true,
+            &reward_epoch_delegated_stakes,
         )
         .unwrap();
         assert_eq!(new_credits, credits * 4);
-        let epoch0_expected = credits * staker_delegation / epoch0_validator_stake;
-        let epoch1_expected = credits * staker_delegation / epoch1_validator_stake;
-        let epoch2_expected = credits * staker_delegation / epoch2_validator_stake;
-        let expected_points = epoch0_expected + epoch1_expected + epoch2_expected;
+        let expected_points = credits * staker_delegation / reward_epoch_validator_stake;
         assert_eq!(points, expected_points as u128);
     }
 
@@ -912,38 +1004,32 @@ mod tests {
             };
 
             let total_stake = stake_lamports * 2;
-            let vote_account = VoteAccount::new_random();
-            let vote_account_hash_map = [(Pubkey::default(), (total_stake, vote_account))]
-                .into_iter()
-                .collect();
-            let versioned_epoch_stakes =
-                VersionedEpochStakes::new_for_tests(vote_account_hash_map, 0);
-            let epoch_stakes = (0..10)
-                .map(|epoch| (epoch, versioned_epoch_stakes.clone()))
-                .collect();
-
             let epoch_credits = vec![
                 (0, credits, 0),
                 AG_MIGRATION_EPOCH_CREDIT,
                 (0, credits * 2, credits),
                 (1, credits * 3, credits * 2),
             ];
-            let (points, new_credits) = ag_epoch_credits_iter(
-                0,
-                false,
+            let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+                epoch: 1,
+                delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+            };
+            let (points, new_credits) = calculate_alpenglow_points(
                 &stake,
-                epoch_credits.into_iter(),
+                epoch_credits.into_iter().last(),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &epoch_stakes,
                 true,
+                &reward_epoch_delegated_stakes,
             )
             .unwrap();
-            assert_eq!(
-                points,
+            let expected_points = if activation_epoch == 0 {
                 credits as u128 * stake_lamports as u128 / total_stake as u128
-            );
+            } else {
+                0
+            };
+            assert_eq!(points, expected_points);
             assert_eq!(new_credits, credits * 3);
         }
 
@@ -960,31 +1046,24 @@ mod tests {
             };
 
             let total_stake = stake_lamports * 2;
-            let vote_account = VoteAccount::new_random();
-            let vote_account_hash_map = [(Pubkey::default(), (total_stake, vote_account))]
-                .into_iter()
-                .collect();
-            let versioned_epoch_stakes =
-                VersionedEpochStakes::new_for_tests(vote_account_hash_map, 0);
-            let epoch_stakes = (0..10)
-                .map(|epoch| (epoch, versioned_epoch_stakes.clone()))
-                .collect();
-
             let epoch_credits = vec![
                 (0, credits, 0),
                 AG_MIGRATION_EPOCH_CREDIT,
                 (0, credits * 2, credits),
                 (1, credits * 3, credits * 2),
             ];
-            let (tower_points, ag_points, new_credits) = migrating_epoch_credits_iter(
-                0,
+            let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+                epoch: 0,
+                delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+            };
+            let (tower_points, ag_points, new_credits) = calculate_migration_points(
                 &stake,
                 epoch_credits.into_iter(),
                 &StakeHistory::default(),
                 null_tracer(),
                 None,
-                &epoch_stakes,
                 true,
+                &reward_epoch_delegated_stakes,
             )
             .unwrap();
             if activation_epoch == 0 {
@@ -992,11 +1071,13 @@ mod tests {
             } else {
                 assert_eq!(tower_points, credits as u128 * stake_lamports as u128);
             }
-            assert_eq!(
-                ag_points,
+            let expected_ag_points = if activation_epoch == 0 {
+                0
+            } else {
                 credits as u128 * stake_lamports as u128 / total_stake as u128
-            );
-            assert_eq!(new_credits, credits * 3);
+            };
+            assert_eq!(ag_points, expected_ag_points);
+            assert_eq!(new_credits, credits * 2);
         }
     }
 }


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/12993#issuecomment-4654888815 for full details

TDLR: we compute rewards for a delegation as:
```
credits * delegation_stake_amount / total_vote_account_stake
```

`delegation_stake_amount` was using the stake amount computed from the delegation itself for the epoch. while `total_vote_account_stake` was using `EpochStakes` which was computed at the start of the prior epoch.

Thus in the case where we had stake activating, we would overpay rewards.

#### Summary of Changes
Don't use epoch stakes for the denominator. Instead match the numerator and sum the stake of all delegations for the vote account. This mimics what we do for PER in Tower. This value is stored in the `RewardEpochDelegatedStakes` account.

##### A note on deferred rewards:
- We currently defer sub lamport unfair commission split rewards to be redeemed at a later epoch
- As a result we traverse the past 64 epochs aggregating unredeemed rewards in case the total now qualifies to be paid out
- This makes the `RewardEpochDelegatedStakes` approach here untenable - we would need to scan and persist 64 epochs worth of stake information
- After internal discussion we came to the conclusion that this deferment logic is burdensome and can just be removed for non tower reward epochs

#### Review
Split it out into 2 commits for ease of review - majority of change is test code

`(+122 -172)` Commit 1: Actual logic change

- When alpenglow is active, do not defer rewards
- Instead anytime we skip, forcibly update the credits observed (forfeits those credits)
- Remove `get_total_stake` which was using `EpochStakes` for the denominator, instead use `RewardEpochDelegatedStakes` that was plumbed through in #13187

`(+614, -258)` Commit 2: Update all the tests

- Added a new test to verify skipping of sub lamport dust rewards
- Added a new test to verify that calculations are the same on snapshot restore

#### Testing
Fetched the ledger which caused the initial panic from the community cluster.
Verified that without this change we still panic, however with this change we are able to freeze the first slot in epoch 13.
Verified that for each vote account, the denominator produced by `RewardEpochDelegatedStakes` matches the sum of the numerators `delegation_stake_amount`.

Fixes #12993 