### PR TITLE
ci: trigger docs workflow on pre-release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - v[0-9]+.[0-9]+
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+-*
   pull_request:
     branches:
       - master


### PR DESCRIPTION
#### Problem

we don't trigger docs build on pre-release tags ... 🫠 

#### Summary of Changes

fix it