### PR TITLE
geyser: Remove metrics counter from plugin-manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8425,7 +8425,6 @@ dependencies = [
  "solana-ledger",
  "solana-measure",
  "solana-message",
- "solana-metrics",
  "solana-pubkey 4.2.0",
  "solana-rpc",
  "solana-runtime",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7140,7 +7140,6 @@ dependencies = [
  "solana-ledger",
  "solana-measure",
  "solana-message",
- "solana-metrics",
  "solana-pubkey 4.2.0",
  "solana-rpc",
  "solana-runtime",

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -35,7 +35,6 @@ solana-hash = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
-solana-metrics = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rpc = { workspace = true }
 solana-runtime = { workspace = true }

--- a/geyser-plugin-manager/src/deshred_transaction_notifier.rs
+++ b/geyser-plugin-manager/src/deshred_transaction_notifier.rs
@@ -10,7 +10,6 @@ use {
     solana_ledger::deshred_transaction_notifier_interface::DeshredTransactionNotifier,
     solana_measure::measure::Measure,
     solana_message::v0::LoadedAddresses,
-    solana_metrics::*,
     solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
     std::sync::Arc,
@@ -77,12 +76,6 @@ impl DeshredTransactionNotifier for DeshredTransactionNotifierImpl {
             }
         }
         measure.stop();
-        inc_new_counter_debug!(
-            "geyser-plugin-notify_plugins_of_deshred_transaction_info-us",
-            measure.as_us() as usize,
-            10000,
-            10000
-        );
     }
 
     fn alt_resolution_enabled(&self) -> bool {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6989,7 +6989,6 @@ dependencies = [
  "solana-ledger",
  "solana-measure",
  "solana-message",
- "solana-metrics",
  "solana-pubkey 4.2.0",
  "solana-rpc",
  "solana-runtime",


### PR DESCRIPTION
#### Problem
We need to rip out all metrics counters (see https://github.com/anza-xyz/agave/issues/9185)

#### Summary of Changes
Remove the counter; it is at debug level so effectively disabled anyways

#### Testing
Given the change, none