### PR TITLE
core: Remove metrics counters from WindowService

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -25,7 +25,6 @@ use {
         shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
     solana_measure::measure::Measure,
-    solana_metrics::inc_new_counter_error,
     solana_rayon_threadlimit::get_thread_count,
     solana_runtime::bank_forks::{BankForks, SharableBanks},
     solana_streamer::evicting_sender::EvictingSender,
@@ -373,9 +372,6 @@ impl WindowService {
         duplicate_slots_sender: DuplicateSlotSender,
         bank_forks: Arc<RwLock<BankForks>>,
     ) -> JoinHandle<()> {
-        let handle_error = || {
-            inc_new_counter_error!("solana-check-duplicate-error", 1, 1);
-        };
         Builder::new()
             .name("solWinCheckDup".to_string())
             .spawn(move || {
@@ -387,7 +383,7 @@ impl WindowService {
                         &duplicate_slots_sender,
                         &bank_forks,
                     ) {
-                        if Self::should_exit_on_error(e, &handle_error) {
+                        if Self::should_exit_on_error(e) {
                             break;
                         }
                     }
@@ -407,9 +403,6 @@ impl WindowService {
         completed_data_sets_sender: Option<CompletedDataSetsSender>,
         retransmit_sender: EvictingSender<Vec<shred::Payload>>,
     ) -> JoinHandle<()> {
-        let handle_error = || {
-            inc_new_counter_error!("solana-window-insert-error", 1, 1);
-        };
         let reed_solomon_cache = ReedSolomonCache::default();
         Builder::new()
             .name("solWinInsert".to_string())
@@ -453,7 +446,7 @@ impl WindowService {
                         completed_data_sets_sender.as_ref(),
                     ) {
                         ws_metrics.record_error(&e);
-                        if Self::should_exit_on_error(e, &handle_error) {
+                        if Self::should_exit_on_error(e) {
                             break;
                         }
                     }
@@ -471,16 +464,19 @@ impl WindowService {
             .unwrap()
     }
 
-    fn should_exit_on_error<H>(e: Error, handle_error: &H) -> bool
-    where
-        H: Fn(),
-    {
+    fn should_exit_on_error(e: Error) -> bool {
         match e {
             Error::RecvTimeout(RecvTimeoutError::Disconnected) => true,
             Error::RecvTimeout(RecvTimeoutError::Timeout) => false,
             Error::Send => true,
             _ => {
-                handle_error();
+                let version = solana_version::version!();
+                datapoint_error!(
+                    "error",
+                    ("thread", thread::current().name().unwrap_or("?"), String),
+                    ("message", format!("{e}"), String),
+                    ("version", version, String)
+                );
                 error!("thread {:?} error {:?}", thread::current().name(), e);
                 false
             }


### PR DESCRIPTION
#### Problem
We need to rip out all metrics counters (see https://github.com/anza-xyz/agave/issues/9185)

#### Summary of Changes
These counters were used to report errors and the configured metrics rate means a datapoint will have exact same reporting semantics.

In regards to the rename, see https://github.com/anza-xyz/agave/issues/9185#issuecomment-4656482885 for my thinking on changes. The current code isn't super informative but with the thread name, it hits parity with old name and displaying the reported error means it gives more information. I could see making this nicer in the future but there is more cleanup to be done to enable that 😅 

#### Testing
None - metrics only