### PR TITLE
xdp: add kernel, driver, zc, nic vendor/model to metrics

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -5,7 +5,13 @@ use core::arch::x86_64::{__cpuid, __cpuid_count, __get_cpuid_max, CpuidResult};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 #[cfg(target_os = "linux")]
-use std::{fs::File, io::BufReader};
+use {
+    agave_xdp::device::NetworkDevice,
+    std::{
+        fs::{self, File},
+        io::{self, BufReader, ErrorKind},
+    },
+};
 use {
     solana_time_utils::AtomicInterval,
     std::{
@@ -26,6 +32,7 @@ const MS_PER_M: u64 = MS_PER_S * 60;
 const MS_PER_H: u64 = MS_PER_M * 60;
 const SAMPLE_INTERVAL_UDP_MS: u64 = 2 * MS_PER_S;
 const SAMPLE_INTERVAL_OS_NETWORK_LIMITS_MS: u64 = MS_PER_H;
+const SAMPLE_INTERVAL_XDP_NETWORK_CONFIG_MS: u64 = MS_PER_H;
 const SAMPLE_INTERVAL_MEM_MS: u64 = 5 * MS_PER_S;
 const SAMPLE_INTERVAL_CPU_MS: u64 = 10 * MS_PER_S;
 const SAMPLE_INTERVAL_CPU_ID_MS: u64 = MS_PER_H;
@@ -38,6 +45,22 @@ const PROC_NET_SNMP_PATH: &str = "/proc/net/snmp";
 const PROC_NET_DEV_PATH: &str = "/proc/net/dev";
 #[cfg(target_os = "linux")]
 const SYS_BLOCK_PATH: &str = "/sys/block";
+#[cfg(target_os = "linux")]
+const PCI_IDS_PATHS: &[&str] = &["/usr/share/hwdata/pci.ids", "/usr/share/misc/pci.ids"];
+
+#[derive(Clone, Debug)]
+pub struct XdpNetworkConfigReport {
+    pub zero_copy: bool,
+    pub interface: String,
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+struct XdpNetworkConfigMetrics {
+    kernel_version: String,
+    driver: String,
+    vendor: String,
+    model: String,
+}
 
 pub struct SystemMonitorService {
     thread_hdl: JoinHandle<()>,
@@ -298,6 +321,157 @@ fn parse_net_dev_stats(reader_dev: &mut impl BufRead) -> Result<NetDevStats, Str
 }
 
 #[cfg(target_os = "linux")]
+fn try_resolve_network_device_pci_names(
+    interface: &str,
+    vendor_id: &str,
+    model_id: &str,
+) -> Result<(String, String), String> {
+    let class = match read_network_device_sysfs_value(interface, "class") {
+        Ok(class) => class,
+        Err(err) => {
+            return Err(err.to_string());
+        }
+    };
+    if !normalize_pci_id(&class).is_some_and(|class| class.starts_with("02")) {
+        return Err(format!(
+            "xdp network config device for interface {interface} has non-network PCI class {class}"
+        ));
+    }
+
+    let (Some(vendor_id), Some(model_id)) =
+        (normalize_pci_id(vendor_id), normalize_pci_id(model_id))
+    else {
+        return Err(format!(
+            "failed to normalize xdp network config PCI ids for interface {interface}: \
+             vendor_id={vendor_id} model_id={model_id}"
+        ));
+    };
+
+    match read_pci_database_device_names(&vendor_id, &model_id) {
+        Ok(Some((vendor, model))) => Ok((vendor, model)),
+        Ok(None) => Err(format!(
+            "failed to find xdp network config PCI names for vendor_id={vendor_id} \
+             model_id={model_id}"
+        )),
+        Err(err) => Err(format!(
+            "failed to read PCI database for xdp network config: {err}"
+        )),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_network_device_sysfs_value(interface: &str, file_name: &str) -> io::Result<String> {
+    let path = format!("/sys/class/net/{interface}/device/{file_name}");
+    let value = fs::read_to_string(&path)
+        .map_err(|e| {
+            io::Error::new(
+                e.kind(),
+                format!("Failed to read {file_name} for interface {interface}: {e}"),
+            )
+        })?
+        .trim()
+        .to_string();
+
+    if value.is_empty() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            format!("Empty {file_name} for interface {interface}"),
+        ));
+    }
+
+    Ok(value)
+}
+
+#[cfg(target_os = "linux")]
+fn normalize_pci_id(value: &str) -> Option<String> {
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+
+    (!value.is_empty() && value.chars().all(|char| char.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+#[cfg(target_os = "linux")]
+fn read_pci_database_device_names(
+    vendor_id: &str,
+    model_id: &str,
+) -> io::Result<Option<(String, String)>> {
+    for path in PCI_IDS_PATHS {
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!("Failed to read {path}: {err}"),
+                ));
+            }
+        };
+        return Ok(parse_pci_database_device_names(
+            &contents, vendor_id, model_id,
+        ));
+    }
+
+    Err(io::Error::new(
+        ErrorKind::NotFound,
+        format!("PCI database not found in {}", PCI_IDS_PATHS.join(", ")),
+    ))
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_pci_database_device_names(
+    contents: &str,
+    vendor_id: &str,
+    model_id: &str,
+) -> Option<(String, String)> {
+    let mut matching_vendor_name: Option<String> = None;
+
+    for line in contents.lines() {
+        if line.is_empty() || line.starts_with('#') || line.starts_with("\t\t") {
+            continue;
+        }
+        //  PCI class-code section starts, done with the vendor/device section.
+        if line.starts_with("C ") {
+            break;
+        }
+
+        if let Some(device_line) = line.strip_prefix('\t') {
+            let Some(vendor_name) = matching_vendor_name.as_ref() else {
+                continue;
+            };
+
+            let Some((device_line_id, device_name)) = parse_pci_ids_line(device_line) else {
+                continue;
+            };
+            if device_line_id.eq_ignore_ascii_case(model_id) {
+                return Some((vendor_name.clone(), device_name.to_string()));
+            }
+            continue;
+        }
+
+        let Some((vendor_line_id, vendor_name)) = parse_pci_ids_line(line) else {
+            continue;
+        };
+        matching_vendor_name = vendor_line_id
+            .eq_ignore_ascii_case(vendor_id)
+            .then(|| vendor_name.to_string());
+    }
+
+    None
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_pci_ids_line(line: &str) -> Option<(&str, &str)> {
+    let line = line.trim();
+    let id_end = line.find(char::is_whitespace)?;
+    let id = &line[..id_end];
+    let name = line[id_end..].trim();
+    (!id.is_empty() && !name.is_empty()).then_some((id, name))
+}
+
+#[cfg(target_os = "linux")]
 pub fn verify_net_stats_access() -> Result<(), String> {
     read_net_stats()?;
     Ok(())
@@ -386,6 +560,7 @@ fn parse_disk_stats(reader_diskstats: &mut impl BufRead) -> Result<DiskStats, St
 pub struct SystemMonitorStatsReportConfig {
     pub report_os_memory_stats: bool,
     pub report_os_network_stats: bool,
+    pub xdp_network_config_report: Option<XdpNetworkConfigReport>,
     pub report_os_cpu_stats: bool,
     pub report_os_disk_stats: bool,
 }
@@ -989,11 +1164,13 @@ impl SystemMonitorService {
         let mut udp_stats = None;
         let mut disk_stats = None;
         let network_limits_timer = AtomicInterval::default();
+        let xdp_network_config_timer = AtomicInterval::default();
         let udp_timer = AtomicInterval::default();
         let mem_timer = AtomicInterval::default();
         let cpu_timer = AtomicInterval::default();
         let cpuid_timer = AtomicInterval::default();
         let disk_timer = AtomicInterval::default();
+        let mut xdp_network_config_metrics = None;
 
         loop {
             if exit.load(Ordering::Relaxed) {
@@ -1005,6 +1182,16 @@ impl SystemMonitorService {
                 }
                 if udp_timer.should_update(SAMPLE_INTERVAL_UDP_MS) {
                     Self::process_net_stats(&mut udp_stats);
+                }
+            }
+            if let Some(xdp_network_config_report) = &config.xdp_network_config_report {
+                if xdp_network_config_timer
+                    .should_update_ext(SAMPLE_INTERVAL_XDP_NETWORK_CONFIG_MS, false)
+                {
+                    let metrics = xdp_network_config_metrics.get_or_insert_with(|| {
+                        Self::load_xdp_network_config_metrics(xdp_network_config_report)
+                    });
+                    Self::report_xdp_network_config(xdp_network_config_report, metrics);
                 }
             }
             if config.report_os_memory_stats && mem_timer.should_update(SAMPLE_INTERVAL_MEM_MS) {
@@ -1028,6 +1215,114 @@ impl SystemMonitorService {
         }
     }
 
+    #[cfg(not(target_os = "linux"))]
+    fn report_xdp_network_config(
+        _config: &XdpNetworkConfigReport,
+        _metrics: &XdpNetworkConfigMetrics,
+    ) {
+    }
+
+    #[cfg(target_os = "linux")]
+    fn load_xdp_network_config_metrics(config: &XdpNetworkConfigReport) -> XdpNetworkConfigMetrics {
+        let Ok(device) = NetworkDevice::new(&config.interface) else {
+            warn!(
+                "failed to get xdp network config device for interface {}",
+                config.interface
+            );
+            return XdpNetworkConfigMetrics {
+                kernel_version: Self::kernel_version(),
+                driver: "unknown".to_string(),
+                vendor: "unknown".to_string(),
+                model: "unknown".to_string(),
+            };
+        };
+        let driver = device.driver().unwrap_or_else(|err| {
+            warn!(
+                "failed to get xdp network config driver for interface {}: {err}",
+                config.interface
+            );
+            "unknown".to_string()
+        });
+        let vendor_id = read_network_device_sysfs_value(&config.interface, "vendor")
+            .unwrap_or_else(|err| {
+                warn!(
+                    "failed to get xdp network config vendor id for interface {}: {err}",
+                    config.interface
+                );
+                "unknown".to_string()
+            });
+        let model_id =
+            read_network_device_sysfs_value(&config.interface, "device").unwrap_or_else(|err| {
+                warn!(
+                    "failed to get xdp network config model id for interface {}: {err}",
+                    config.interface
+                );
+                "unknown".to_string()
+            });
+        let (vendor, model) =
+            match try_resolve_network_device_pci_names(&config.interface, &vendor_id, &model_id) {
+                Ok((vendor, model)) => (vendor, model),
+                Err(err) => {
+                    warn!(
+                        "failed to resolve xdp network config PCI names for interface {}: {}",
+                        config.interface, err
+                    );
+                    // Fall back to reporting raw PCI IDs if name resolution fails
+                    let fallback_vendor =
+                        normalize_pci_id(&vendor_id).unwrap_or_else(|| vendor_id.clone());
+                    let fallback_model =
+                        normalize_pci_id(&model_id).unwrap_or_else(|| model_id.clone());
+                    (fallback_vendor, fallback_model)
+                }
+            };
+
+        XdpNetworkConfigMetrics {
+            kernel_version: Self::kernel_version(),
+            driver,
+            vendor,
+            model,
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn load_xdp_network_config_metrics(
+        _config: &XdpNetworkConfigReport,
+    ) -> XdpNetworkConfigMetrics {
+        XdpNetworkConfigMetrics {
+            kernel_version: "unknown".to_string(),
+            driver: "unknown".to_string(),
+            vendor: "unknown".to_string(),
+            model: "unknown".to_string(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn report_xdp_network_config(
+        config: &XdpNetworkConfigReport,
+        metrics: &XdpNetworkConfigMetrics,
+    ) {
+        solana_metrics::datapoint_info!(
+            "xdp-network-config",
+            "driver" => metrics.driver.clone(),
+            "zero_copy" => config.zero_copy.to_string(),
+            ("kernel_version", metrics.kernel_version.clone(), String),
+            ("vendor", metrics.vendor.clone(), String),
+            ("model", metrics.model.clone(), String),
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    fn kernel_version() -> String {
+        let mut utsname = unsafe { std::mem::zeroed::<libc::utsname>() };
+        if unsafe { libc::uname(&mut utsname) } != 0 {
+            return format!("unknown: {}", std::io::Error::last_os_error());
+        }
+
+        unsafe { std::ffi::CStr::from_ptr(utsname.release.as_ptr()) }
+            .to_string_lossy()
+            .into_owned()
+    }
+
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
     }
@@ -1036,6 +1331,43 @@ impl SystemMonitorService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_pci_database_device_names() {
+        let pci_ids = "\
+8086  Intel Corporation
+\t1593  Ethernet Controller E810-C for QSFP
+\t\t8086 0001  Ethernet Network Adapter E810-C-Q1
+10ec  Realtek Semiconductor Co., Ltd.
+\t8136  RTL810xE PCI Express Fast Ethernet controller
+C 02  Network controller
+\t00  Ethernet controller
+";
+
+        assert_eq!(
+            parse_pci_database_device_names(pci_ids, "8086", "1593"),
+            Some((
+                "Intel Corporation".to_string(),
+                "Ethernet Controller E810-C for QSFP".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_pci_database_device_names(pci_ids, "10EC", "8136"),
+            Some((
+                "Realtek Semiconductor Co., Ltd.".to_string(),
+                "RTL810xE PCI Express Fast Ethernet controller".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_pci_database_device_names(pci_ids, "8086", "0001"),
+            None
+        );
+        assert_eq!(
+            parse_pci_database_device_names(pci_ids, "0000", "1593"),
+            None
+        );
+        assert_eq!(parse_pci_database_device_names(pci_ids, "C", "02"), None);
+    }
 
     #[test]
     fn test_parse_udp_stats() {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -24,7 +24,8 @@ use {
         snapshot_packager_service::SnapshotPackagerService,
         stats_reporter_service::StatsReporterService,
         system_monitor_service::{
-            SystemMonitorService, SystemMonitorStatsReportConfig, verify_net_stats_access,
+            SystemMonitorService, SystemMonitorStatsReportConfig, XdpNetworkConfigReport,
+            verify_net_stats_access,
         },
         tpu::{Tpu, TpuSockets},
         tvu::{AlpenglowInitializationState, Tvu, TvuConfig, TvuSockets},
@@ -360,6 +361,7 @@ pub struct ValidatorConfig {
     pub no_poh_speed_test: bool,
     pub no_os_memory_stats_reporting: bool,
     pub no_os_network_stats_reporting: bool,
+    pub xdp_network_config_report: Option<XdpNetworkConfigReport>,
     pub no_os_cpu_stats_reporting: bool,
     pub no_os_disk_stats_reporting: bool,
     pub enforce_ulimit_nofile: bool,
@@ -441,6 +443,7 @@ impl ValidatorConfig {
             no_poh_speed_test: true,
             no_os_memory_stats_reporting: true,
             no_os_network_stats_reporting: true,
+            xdp_network_config_report: None,
             no_os_cpu_stats_reporting: true,
             no_os_disk_stats_reporting: true,
             // No need to enforce nofile limit in tests
@@ -893,6 +896,7 @@ impl Validator {
             SystemMonitorStatsReportConfig {
                 report_os_memory_stats: !config.no_os_memory_stats_reporting,
                 report_os_network_stats: !config.no_os_network_stats_reporting,
+                xdp_network_config_report: config.xdp_network_config_report.clone(),
                 report_os_cpu_stats: !config.no_os_cpu_stats_reporting,
                 report_os_disk_stats: !config.no_os_disk_stats_reporting,
             },

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1852,6 +1852,7 @@ fn main() {
                         SystemMonitorStatsReportConfig {
                             report_os_memory_stats,
                             report_os_network_stats: false,
+                            xdp_network_config_report: None,
                             report_os_cpu_stats: false,
                             report_os_disk_stats: false,
                         },
@@ -1990,6 +1991,7 @@ fn main() {
                                 SystemMonitorStatsReportConfig {
                                     report_os_memory_stats: true,
                                     report_os_network_stats: false,
+                                    xdp_network_config_report: None,
                                     report_os_cpu_stats: false,
                                     report_os_disk_stats: false,
                                 },

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -45,6 +45,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         no_poh_speed_test: config.no_poh_speed_test,
         no_os_memory_stats_reporting: config.no_os_memory_stats_reporting,
         no_os_network_stats_reporting: config.no_os_network_stats_reporting,
+        xdp_network_config_report: config.xdp_network_config_report.clone(),
         no_os_cpu_stats_reporting: config.no_os_cpu_stats_reporting,
         no_os_disk_stats_reporting: config.no_os_disk_stats_reporting,
         enforce_ulimit_nofile: config.enforce_ulimit_nofile,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -290,13 +290,14 @@ pub fn execute(
     let _ = config;
 
     #[cfg(target_os = "linux")]
-    let xdp_transmit_setup = {
+    let (xdp_transmit_setup, xdp_network_config_report) = {
         use {
             agave_xdp::transmitter::TransmitterBuilder,
             caps::{
                 CapSet,
                 Capability::{CAP_BPF, CAP_NET_ADMIN, CAP_NET_RAW, CAP_PERFMON, CAP_SYS_NICE},
             },
+            solana_core::system_monitor_service::XdpNetworkConfigReport,
         };
 
         let super::Config { primordial_caps } = config;
@@ -372,33 +373,46 @@ pub fn execute(
         // XDP _MUST_ be setup _BEFORE_ the app spawns any threads to ensure linux
         // capabilities do not leak, leaving the process in a state where it could
         // potentially be used as a privilege escalation gadget
-        let xdp_transmit_setup = xdp_transmit_config.clone().map(|xdp_config| {
-            use {
-                agave_xdp::{default_device_ipv4, interface_ipv4},
-                solana_core::validator::XdpTransmitSetup,
-            };
+        let (xdp_transmit_setup, report) = xdp_transmit_config
+            .clone()
+            .map(|mut xdp_config| {
+                use {
+                    agave_xdp::{device::NetworkDevice, interface_ipv4},
+                    solana_core::validator::XdpTransmitSetup,
+                };
 
-            let src_ip = match node.bind_ip_addrs.active() {
-                IpAddr::V4(ip) if !ip.is_unspecified() => ip,
-                IpAddr::V4(_unspecified) => {
-                    if let Some(interface) = xdp_config.interface.as_ref() {
-                        interface_ipv4(interface).expect(
-                            "configured interface should exist and have an IPv4 address assigned",
-                        )
-                    } else {
-                        default_device_ipv4().expect(
-                            "default route device should exist and have an IPv4 address assigned",
-                        )
-                    }
-                }
-                _ => panic!("IPv6 not supported"),
-            };
-            XdpTransmitSetup {
-                transmitter_builder: TransmitterBuilder::new(xdp_config, exit.clone())
-                    .expect("failed to create xdp transmitter"),
-                src_ip,
-            }
-        });
+                let device = if let Some(interface) = xdp_config.interface.as_ref() {
+                    NetworkDevice::new(interface).expect("configured interface should exist")
+                } else {
+                    NetworkDevice::new_from_default_route()
+                        .expect("default route device should exist")
+                };
+
+                let xdp_interface = device.name().to_string();
+                // Keep the transmitter and metrics on the selected XDP device. Source IP lookup
+                // uses the same interface name, with bond-master fallback.
+                xdp_config.interface = Some(xdp_interface.clone());
+                let zero_copy = xdp_config.zero_copy;
+                let src_ip = match node.bind_ip_addrs.active() {
+                    IpAddr::V4(ip) if !ip.is_unspecified() => ip,
+                    IpAddr::V4(_unspecified) => interface_ipv4(&xdp_interface).expect(
+                        "selected interface should exist and have an IPv4 address assigned",
+                    ),
+                    _ => panic!("IPv6 not supported"),
+                };
+                (
+                    XdpTransmitSetup {
+                        transmitter_builder: TransmitterBuilder::new(xdp_config, exit.clone())
+                            .expect("failed to create xdp transmitter"),
+                        src_ip,
+                    },
+                    XdpNetworkConfigReport {
+                        zero_copy,
+                        interface: xdp_interface,
+                    },
+                )
+            })
+            .map_or((None, None), |(setup, report)| (Some(setup), Some(report)));
 
         // we're done with caps needed to init xdp now. remove them from our process
         caps::set(None, CapSet::Effective, &retained_caps)
@@ -406,11 +420,11 @@ pub fn execute(
         caps::set(None, CapSet::Permitted, &retained_caps)
             .expect("linux allows permitted capset to be set");
 
-        xdp_transmit_setup
+        (xdp_transmit_setup, report)
     };
 
     #[cfg(not(target_os = "linux"))]
-    let xdp_transmit_setup = None;
+    let (xdp_transmit_setup, xdp_network_config_report) = (None, None);
 
     let reserved = xdp_transmit_config
         .map(|xdp| xdp.cpus.clone())
@@ -799,6 +813,7 @@ pub fn execute(
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),
         no_os_network_stats_reporting: matches.is_present("no_os_network_stats_reporting"),
+        xdp_network_config_report,
         no_os_cpu_stats_reporting: matches.is_present("no_os_cpu_stats_reporting"),
         no_os_disk_stats_reporting: matches.is_present("no_os_disk_stats_reporting"),
         // The validator needs to open many files, check that the process has


### PR DESCRIPTION
#### Problem

Problem is that we don't have information about kernel, driver, NIC vendor/model and ZC configuration in the metrics.

#### Summary of Changes

This PR introduces such metrics. They can be requested by `SELECT "kernel_version", "vendor", "model" FROM :DB_NAME:."autogen"."xdp-network-config" WHERE time > :dashboardTime: AND time < :upperDashboardTime:` which gives visual representation like the following:

<img width="1421" height="131" alt="Screenshot 2026-06-12 at 19 38 04" src="https://github.com/user-attachments/assets/6b74c6fe-dd64-4346-a8b1-ab8c5d5560a9" />


How often to report has been discussed in https://discord.com/channels/428295358100013066/439194979856809985/1513609775760412772