### PR TITLE
feat: switch SlotHistory sysvar to wincode (de)serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7449,6 +7449,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tiny-bip39",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
@@ -10362,6 +10363,7 @@ dependencies = [
  "serde_derive",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -42,7 +42,7 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
-solana-slot-history = { workspace = true }
+solana-slot-history = { workspace = true, features = ["wincode"] }
 solana-stake-interface = { workspace = true, features = ["bincode", "sysvar"] }
 solana-sysvar = { workspace = true }
 solana-vote-interface = { workspace = true, features = ["bincode"] }

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -69,12 +69,14 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                     SysvarAccountType::SlotHashes(slot_hashes)
                 })
         } else if pubkey == &sysvar::slot_history::id() {
-            deserialize::<SlotHistory>(data).ok().map(|slot_history| {
-                SysvarAccountType::SlotHistory(UiSlotHistory {
-                    next_slot: slot_history.next_slot,
-                    bits: format!("{:?}", SlotHistoryBits(slot_history.bits)),
+            wincode::deserialize::<SlotHistory>(data)
+                .ok()
+                .map(|slot_history| {
+                    SysvarAccountType::SlotHistory(UiSlotHistory {
+                        next_slot: slot_history.next_slot,
+                        bits: format!("{:?}", SlotHistoryBits(slot_history.bits)),
+                    })
                 })
-            })
         } else if pubkey == &sysvar::stake_history::id() {
             deserialize::<StakeHistory>(data).ok().map(|stake_history| {
                 let stake_history = stake_history

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,7 +81,7 @@ solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
-solana-slot-history = { workspace = true }
+solana-slot-history = { workspace = true, features = ["wincode"] }
 solana-stake-interface = { workspace = true }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
@@ -95,6 +95,7 @@ spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
 tiny-bip39 = { workspace = true }
 tokio = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1258,9 +1258,8 @@ pub async fn process_show_block_production(
         .value
         .unwrap();
 
-    let slot_history: SlotHistory = from_account(&slot_history_account).ok_or_else(|| {
-        CliError::RpcRequestError("Failed to deserialize slot history".to_string())
-    })?;
+    let slot_history: SlotHistory = wincode::deserialize(&slot_history_account.data)
+        .map_err(|_| CliError::RpcRequestError("Failed to deserialize slot history".to_string()))?;
 
     let (confirmed_blocks, start_slot) =
         if start_slot >= slot_history.oldest() && end_slot <= slot_history.newest() {

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8716,6 +8716,7 @@ dependencies = [
  "serde_derive",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9254,6 +9254,7 @@ dependencies = [
  "serde_derive",
  "solana-sdk-ids",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -153,7 +153,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
-solana-slot-history = { workspace = true }
+solana-slot-history = { workspace = true, features = ["wincode"] }
 solana-stake-interface = { workspace = true }
 solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-callback = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2532,7 +2532,7 @@ impl Bank {
         self.update_sysvar_account(&sysvar::slot_history::id(), |account| {
             let mut slot_history = account
                 .as_ref()
-                .map(|account| from_account::<SlotHistory, _>(account).unwrap())
+                .map(|account| wincode::deserialize::<SlotHistory>(account.data()).unwrap())
                 .unwrap_or_default();
             slot_history.add(self.slot());
             create_account(
@@ -2557,7 +2557,8 @@ impl Bank {
     }
 
     pub fn get_slot_history(&self) -> Option<SlotHistory> {
-        from_account(&self.get_account(&sysvar::slot_history::id())?)
+        wincode::deserialize::<SlotHistory>(self.get_account(&sysvar::slot_history::id())?.data())
+            .ok()
     }
 
     fn update_epoch_stakes(
@@ -3875,7 +3876,7 @@ impl Bank {
             let current_account = self.get_account_with_fixed_root(&slot_history_id);
             let slot_history = current_account
                 .as_ref()
-                .map(|account| from_account::<SlotHistory, _>(account).unwrap())
+                .map(|account| wincode::deserialize::<SlotHistory>(account.data()).unwrap())
                 .unwrap_or_default();
             if slot_history.check(self.slot()) == Check::Found {
                 let ancestors = Ancestors::from(self.proper_ancestors().collect::<Vec<_>>());


### PR DESCRIPTION
#### Problem
bincode shows up in profiles when deserializing `SlotHistory`

#### Summary of Changes
Use wincode instead of bincode/from_account for serializing and deserializing the SlotHistory sysvar across the runtime, account-decoder and CLI.

#### Testing
* rely on SlotHistory wincode schema being purely auto-derives
* the tests in `account-decoder` / `runtime` actually still exercise `serialize with bincode` -> `parse with wincode` code path (since they call `create_account_for_test` from `solana-account` still on bincode)