### PR TITLE
connection cache: bump max connections to 2x vote accounts

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -1,4 +1,4 @@
-pub use solana_connection_cache::connection_cache::Protocol;
+pub use solana_connection_cache::connection_cache::{DEFAULT_MAX_CONNECTIONS, Protocol};
 use {
     solana_connection_cache::{
         client_connection::ClientConnection,
@@ -93,6 +93,25 @@ impl ConnectionCache {
         cert_info: Option<(&Keypair, IpAddr)>,
         stake_info: Option<(&Arc<RwLock<StakedNodes>>, &Pubkey)>,
     ) -> Self {
+        Self::new_with_max_connections(
+            name,
+            connection_pool_size,
+            DEFAULT_MAX_CONNECTIONS,
+            client_socket,
+            cert_info,
+            stake_info,
+        )
+    }
+
+    /// Create a quic connection_cache with configurable max connections
+    pub fn new_with_max_connections(
+        name: &'static str,
+        connection_pool_size: usize,
+        max_connections: usize,
+        client_socket: Option<UdpSocket>,
+        cert_info: Option<(&Keypair, IpAddr)>,
+        stake_info: Option<(&Arc<RwLock<StakedNodes>>, &Pubkey)>,
+    ) -> Self {
         // The minimum pool size is 1.
         let connection_pool_size = 1.max(connection_pool_size);
         let mut config = QuicConfig::new().unwrap();
@@ -106,8 +125,13 @@ impl ConnectionCache {
             config.set_staked_nodes(stake_info.0, stake_info.1);
         }
         let connection_manager = QuicConnectionManager::new_with_connection_config(config);
-        let cache =
-            BackendConnectionCache::new(name, connection_manager, connection_pool_size).unwrap();
+        let cache = BackendConnectionCache::new_with_max_connections(
+            name,
+            connection_manager,
+            connection_pool_size,
+            max_connections,
+        )
+        .unwrap();
         Self::Quic(Arc::new(cache))
     }
 

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -19,8 +19,8 @@ use {
     thiserror::Error,
 };
 
-// Should be non-zero
-const MAX_CONNECTIONS: usize = 1024;
+/// Default maximum number of connections to keep
+pub const DEFAULT_MAX_CONNECTIONS: usize = 1024;
 
 /// Default connection pool size per remote address
 pub const DEFAULT_CONNECTION_POOL_SIZE: usize = 2;
@@ -53,6 +53,7 @@ pub struct ConnectionCache<
     stats: Arc<ConnectionCacheStats>,
     last_stats: AtomicInterval,
     connection_pool_size: usize,
+    max_connections: usize,
     connection_config: Arc<T>,
     sender: Sender<(usize, SocketAddr)>,
 }
@@ -68,26 +69,29 @@ where
         connection_manager: M,
         connection_pool_size: usize,
     ) -> Result<Self, ClientError> {
-        let config = connection_manager.new_connection_config();
-        Ok(Self::new_with_config(
+        Self::new_with_max_connections(
             name,
-            connection_pool_size,
-            config,
             connection_manager,
-        ))
+            connection_pool_size,
+            DEFAULT_MAX_CONNECTIONS,
+        )
     }
 
-    pub fn new_with_config(
+    pub fn new_with_max_connections(
         name: &'static str,
-        connection_pool_size: usize,
-        connection_config: C,
         connection_manager: M,
-    ) -> Self {
-        info!("Creating ConnectionCache {name}, pool size: {connection_pool_size}");
+        connection_pool_size: usize,
+        max_connections: usize,
+    ) -> Result<Self, ClientError> {
+        let config = Arc::new(connection_manager.new_connection_config());
+        let max_connections = 1.max(max_connections); // The minimum is 1.
+        info!(
+            "Creating ConnectionCache {name}, pool size: {connection_pool_size}, max connections: \
+             {max_connections}"
+        );
         let (sender, receiver) = crossbeam_channel::unbounded();
 
-        let map = Arc::new(RwLock::new(IndexMap::with_capacity(MAX_CONNECTIONS)));
-        let config = Arc::new(connection_config);
+        let map = Arc::new(RwLock::new(IndexMap::with_capacity(max_connections)));
         let connection_manager = Arc::new(connection_manager);
         let connection_pool_size = 1.max(connection_pool_size); // The minimum pool size is 1.
 
@@ -95,16 +99,17 @@ where
 
         let _async_connection_thread =
             Self::create_connection_async_thread(map.clone(), receiver, stats.clone());
-        Self {
+        Ok(Self {
             name,
             map,
             stats,
             connection_manager,
             last_stats: AtomicInterval::default(),
             connection_pool_size,
+            max_connections,
             connection_config: config,
             sender,
-        }
+        })
     }
 
     /// This actually triggers the connection creation by sending empty data
@@ -174,6 +179,7 @@ where
                     &mut map,
                     addr,
                     self.connection_pool_size,
+                    self.max_connections,
                     None,
                 )
             } else {
@@ -189,6 +195,7 @@ where
                 &mut map,
                 addr,
                 self.connection_pool_size,
+                self.max_connections,
                 Some(&self.sender),
             );
         }
@@ -211,6 +218,7 @@ where
         map: &mut std::sync::RwLockWriteGuard<'_, IndexMap<SocketAddr, P>>,
         addr: &SocketAddr,
         connection_pool_size: usize,
+        max_connections: usize,
         async_connection_sender: Option<&Sender<(usize, SocketAddr)>>,
     ) -> (bool, u64, u64) {
         // evict a connection if the cache is reaching upper bounds
@@ -218,9 +226,9 @@ where
         let mut get_connection_cache_eviction_measure =
             Measure::start("get_connection_cache_eviction_measure");
         let existing_index = map.get_index_of(addr);
-        while map.len() >= MAX_CONNECTIONS {
+        while map.len() >= max_connections {
             let mut rng = rng();
-            let n = rng.random_range(0..MAX_CONNECTIONS);
+            let n = rng.random_range(0..max_connections);
             if let Some(index) = existing_index {
                 if n == index {
                     continue;
@@ -304,6 +312,7 @@ where
                                 &mut map,
                                 addr,
                                 self.connection_pool_size,
+                                self.max_connections,
                                 Some(&self.sender),
                             );
                         }
@@ -709,7 +718,7 @@ mod tests {
             DEFAULT_CONNECTION_POOL_SIZE,
         )
         .unwrap();
-        let addrs = (0..MAX_CONNECTIONS)
+        let addrs = (0..DEFAULT_MAX_CONNECTIONS)
             .map(|_| {
                 let addr = get_addr(&mut rng);
                 connection_cache.get_connection(&addr);
@@ -718,7 +727,7 @@ mod tests {
             .collect::<Vec<_>>();
         {
             let map = connection_cache.map.read().unwrap();
-            assert!(map.len() == MAX_CONNECTIONS);
+            assert!(map.len() == DEFAULT_MAX_CONNECTIONS);
             addrs.iter().for_each(|addr| {
                 let conn = &map.get(addr).expect("Address not found").get(0).unwrap();
                 let conn = conn.new_blocking_connection(*addr, connection_cache.stats.clone());
@@ -739,7 +748,7 @@ mod tests {
         let port = addr.port();
         let addr_with_quic_port = SocketAddr::new(addr.ip(), port);
         let map = connection_cache.map.read().unwrap();
-        assert!(map.len() == MAX_CONNECTIONS);
+        assert!(map.len() == DEFAULT_MAX_CONNECTIONS);
         let _conn = map.get(&addr_with_quic_port).expect("Address not found");
     }
 

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -123,7 +123,7 @@ use {
             AbsRequestHandlers, AccountsBackgroundService, DroppedSlotsReceiver,
             PendingSnapshotPackages, PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
-        bank::Bank,
+        bank::{Bank, MAX_ALPENGLOW_VOTE_ACCOUNTS},
         bank_forks::BankForks,
         bank_forks_controller::BankForksControllerHandle,
         commitment::BlockCommitmentCache,
@@ -1192,11 +1192,13 @@ impl Validator {
             ))
         };
 
-        let bls_connection_cache = Arc::new(ConnectionCache::new_with_client_options(
+        let bls_connection_cache = Arc::new(ConnectionCache::new_with_max_connections(
             "connection_cache_bls_quic",
             // BLS consensus messaging is extremely low throughput (5 PPS). Even during standstill operations
             // we wouldn't expect more than a 100 PPS. 1 connection is enough.
             1, /* connection_pool_size */
+            // Overprovision to account for epoch boundary validator set rotations
+            MAX_ALPENGLOW_VOTE_ACCOUNTS * 2, /* max_connections */
             Some(node.sockets.quic_alpenglow_client),
             Some((
                 &identity_keypair,


### PR DESCRIPTION
#### Problem

Votor requires up to 2000 connections to work, connection cache maxes out at 1024.

#### Summary of Changes

Bump the config for votor specifically to 2x number of vote accounts so we have ample headroom during epoch transitions.

#### Testing

Tested with [fake peers](https://github.com/alexpyattaev/agave/tree/fake_peers) connecting to 1900 fake [servers](https://github.com/alexpyattaev/agave/blob/alpenglow-tpu-client-next/votor/examples/votor_quic_server.rs). 

Without patch:
```
[2026-06-09T11:49:07.336900209Z ERROR solana_core::block_creation_loop] F4MChdGkBchup9NBhuiKEApMT3TXtAkkK7U1mVt11Ak: Unable to produce window 276-279, skipping window: ReplayIsBehind(251, 276)
[2026-06-09T11:49:31.729829212Z ERROR solana_core::block_creation_loop] F4MChdGkBchup9NBhuiKEApMT3TXtAkkK7U1mVt11Ak: Unable to produce window 280-283, skipping window: ReplayIsBehind(251, 280)

```
solQuicClientRt is the tokio runtime for connection cache (64 threads)
<img width="1670" height="1100" alt="image" src="https://github.com/user-attachments/assets/da700731-95c2-40f4-ae4e-503299feac27" />

With patch:


<img width="1666" height="756" alt="image" src="https://github.com/user-attachments/assets/651bfaf5-c1e1-4082-9ff8-d2f1889bb27c" />




#### Credit to @stablebits for finding this "feature"