### PR TITLE
cli: only look up AG cert if AG feature is active

### DIFF
--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -14,7 +14,9 @@ use {
         spend_utils::{SpendAmount, resolve_spend_tx_and_check_account_balances},
         stake::check_current_authority,
     },
-    agave_feature_set::{bls_pubkey_management_in_vote_account, vote_account_initialize_v2},
+    agave_feature_set::{
+        alpenglow, bls_pubkey_management_in_vote_account, vote_account_initialize_v2,
+    },
     agave_votor_messages::consensus_message::BLS_KEYPAIR_DERIVE_SEED,
     clap::{App, Arg, ArgMatches, SubCommand, value_t_or_exit},
     solana_account::Account,
@@ -1616,7 +1618,14 @@ pub async fn process_show_vote_account(
         .and_then(|feature| feature.activated_at);
     let tvc_activation_epoch = tvc_activation_slot.map(|s| epoch_schedule.get_epoch(s));
 
-    let ag_genesis_cert = rpc_client.get_ag_genesis_cert().await?;
+    let ag_is_active = get_feature_is_active(rpc_client, &alpenglow::id())
+        .await
+        .unwrap_or(false);
+    let ag_genesis_cert = if ag_is_active {
+        rpc_client.get_ag_genesis_cert().await?
+    } else {
+        None
+    };
     let votes_observed = VotesObserved::new(&vote_state, &ag_genesis_cert);
     let epoch_voting_history = get_epoch_history(
         &epoch_schedule,


### PR DESCRIPTION
#### Problem

https://discord.com/channels/428295358100013066/439194979856809985/1513844511024087152

If a newer CLI is used against an older version of the network, then we can see the following error:

```
sol@tse1:~$ solana --version
solana-cli 4.2.0-alpha.0 (src:7cf0a6c2; feat:1ca53821, client:Agave)
sol@tse1:~$ solana -ut vote-account 3cPeXaMuxjAZUq9gqH9qaH77FoKB9WsARqc1XyzNkVgG
Error: RPC response error -32601: Method not found;
```

This is because the network does not have the rpc request handler for getting the AG cert while the CLI does.


#### Summary of Changes

Added a check in the cli to only try to look up the AG cert if the AG feature is activated.  Another method might be to handle the "method not found" return.  I am happy to change it if reviewers think that approach is cleaner.

#### Testing

- I reproduced the problem by running `cargo run --package solana-cli --bin solana -- -ut vote-account 3cPeXaMuxjAZUq9gqH9qaH77FoKB9WsARqc1XyzNkVgG` on top of `master` locally.
- Running the same command again works i.e. does not produce the "method not found" error and instead prints the expected info for the vote account.