### PR TITLE
runtime: optimize the memcmp syscall

### DIFF
--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -159,13 +159,62 @@ fn memmove(
 
 // Marked unsafe since it assumes that the slices are at least `n` bytes long.
 unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
-    for i in 0..n {
+    let (s1pre, s1mid, s1end) = unsafe {
+        // SAFETY: Caller is required to guarantee both slices are at least n-long.
+        s1.get_unchecked(..n).align_to::<u128>()
+    };
+    let mut s2ptr = s2.as_ptr();
+    for s1pre_byte in s1pre.iter().copied() {
         unsafe {
-            let a = *s1.get_unchecked(i);
-            let b = *s2.get_unchecked(i);
-            if a != b {
-                return (a as i32).saturating_sub(b as i32);
+            // SAFETY: we are guaranteed to stay in bounds of a slice `s2` by virtue of both slices
+            // being no longer than `n`.
+            let s2pre_byte = *s2ptr;
+            if s1pre_byte != s2pre_byte {
+                return i32::from(s1pre_byte).wrapping_sub(s2pre_byte.into());
+            }
+            s2ptr = s2ptr.add(1);
+        }
+    }
+    for s1mid_value in s1mid.iter().copied() {
+        let s2mid_value = unsafe {
+            // SAFETY: Caller is required to guarantee both slices are at least n-long.
+            // SAFETY: Pointer is guaranteed to be dereferenceable by virtue of being derived from
+            // `s2` slice.
+            s2ptr.cast::<u128>().read_unaligned()
+        };
+        if s1mid_value != s2mid_value {
+            // It would seem that we could work with u128s directly here and leave it to LLVM to
+            // figure out how to split up the operations to u64s, but it seems to produce notably
+            // worse code than splitting the u64s out manually (even _when_ these splits result in
+            // the values being re-read from "memory").
+            let (s1_word, s2_word) = if s1mid_value as u64 != s2mid_value as u64 {
+                let w1 = s1mid_value as u64;
+                let w2 = s2mid_value as u64;
+                (w1, w2)
+            } else {
+                let w1 = (s1mid_value >> 64) as u64;
+                let w2 = (s2mid_value >> 64) as u64;
+                (w1, w2)
             };
+            let shift = (s1_word ^ s2_word).trailing_zeros() & !7;
+            let b1 = (s1_word >> shift) as u8;
+            let b2 = (s2_word >> shift) as u8;
+            return i32::from(b1).wrapping_sub(b2.into());
+        }
+        unsafe {
+            // SAFETY: we are guaranteed to stay in bounds of a slice `s2` by virtue of both slices
+            // being no longer than `n`.
+            s2ptr = s2ptr.add(std::mem::size_of::<u128>());
+        }
+    }
+    for s1end_byte in s1end.iter().copied() {
+        unsafe {
+            // This is the same as the `pre` slice loop above.
+            let s2end_byte = *s2ptr;
+            if s1end_byte != s2end_byte {
+                return i32::from(s1end_byte).wrapping_sub(s2end_byte.into());
+            }
+            s2ptr = s2ptr.add(1);
         }
     }
     0

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -180,7 +180,7 @@ unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
             // SAFETY: Caller is required to guarantee both slices are at least n-long.
             // SAFETY: Pointer is guaranteed to be dereferenceable by virtue of being derived from
             // `s2` slice.
-            s2ptr.cast::<u128>().read_unaligned()
+            s2ptr.cast::<u128>().read_unaligned().to_le()
         };
         if s1mid_value != s2mid_value {
             // It would seem that we could work with u128s directly here and leave it to LLVM to
@@ -196,10 +196,7 @@ unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
                 let w2 = (s2mid_value >> 64) as u64;
                 (w1, w2)
             };
-            let shift = cfg_select! {
-                target_endian = "little" => (s1_word ^ s2_word).trailing_zeros() & !7,
-                target_endian = "big" => (63 - (s1_word ^ s2_word).leading_zeros()) & !7,
-            };
+            let shift = (s1_word ^ s2_word).trailing_zeros() & !7;
             let b1 = (s1_word >> shift) as u8;
             let b2 = (s2_word >> shift) as u8;
             return i32::from(b1).wrapping_sub(b2.into());

--- a/syscalls/src/mem_ops.rs
+++ b/syscalls/src/mem_ops.rs
@@ -167,7 +167,7 @@ unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
     for s1pre_byte in s1pre.iter().copied() {
         unsafe {
             // SAFETY: we are guaranteed to stay in bounds of a slice `s2` by virtue of both slices
-            // being no longer than `n`.
+            // containing at least `n` bytes (caller precondition.)
             let s2pre_byte = *s2ptr;
             if s1pre_byte != s2pre_byte {
                 return i32::from(s1pre_byte).wrapping_sub(s2pre_byte.into());
@@ -196,14 +196,17 @@ unsafe fn memcmp(s1: &[u8], s2: &[u8], n: usize) -> i32 {
                 let w2 = (s2mid_value >> 64) as u64;
                 (w1, w2)
             };
-            let shift = (s1_word ^ s2_word).trailing_zeros() & !7;
+            let shift = cfg_select! {
+                target_endian = "little" => (s1_word ^ s2_word).trailing_zeros() & !7,
+                target_endian = "big" => (63 - (s1_word ^ s2_word).leading_zeros()) & !7,
+            };
             let b1 = (s1_word >> shift) as u8;
             let b2 = (s2_word >> shift) as u8;
             return i32::from(b1).wrapping_sub(b2.into());
         }
         unsafe {
             // SAFETY: we are guaranteed to stay in bounds of a slice `s2` by virtue of both slices
-            // being no longer than `n`.
+            // containing at least `n` bytes (caller precondition.)
             s2ptr = s2ptr.add(std::mem::size_of::<u128>());
         }
     }


### PR DESCRIPTION
We cannot use the off-shelf `libc::memcmp` because it does not guarantee any particular return value, only its return sign; and that is not suitable for use in a blockchain protocol.

This implements a less naive non-scalar memcmp instead. Broad algorithm logic stays the same: find a mismatch, then determine what sort of mismatch this is. Using u128s for the type allows the compiler to use 128-bit SIMD which makes this reasonably fast already. It wouldn't be terribly difficult to extend this or change it to use 256-bit mid slices for a different tradeoff.

Surprising to me is that this implementation is slightly better for slices that are less than 16 bytes long. I would have expected less speed due to the `align_to` overhead, but turns out this rewrite of the code makes the rest of the code easier-enough to optimize to the point where the the `align_to` no longer even registers.

See the PR for nice violin plots.

#### Testing

We have preexisting memcmp tests in the unit test suite. For speed testing the old and new functions were extracted into a standalone criterion benchmark.

<img alt="memcmp comparisons on 15 byte slices, showing roughly similar iteration times" src="https://github.com/user-attachments/assets/7d02d0c6-277a-4ad1-8143-9d3aff3eca1c" />
<img alt="memcmp comparisons on 64 byte slices, showing significant improvement in iteration times with the new implementation." src="https://github.com/user-attachments/assets/f6995969-b972-4f01-b73d-dddd5df706d2" />
<img alt="memcmp comparison on 512 byte slices. The old code would take ~100ns in various configurations, and new code is all under 20ns on my machine." src="https://github.com/user-attachments/assets/bb66954a-f389-442a-afc5-daf78b9c2fd6" />