### PR TITLE
perf: skip writing untouched accounts

### DIFF
--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
-    core::{borrow::Borrow, cell::Cell},
+    core::borrow::Borrow,
     solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
     solana_svm::{
@@ -110,7 +110,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [KeyedAccountSharedData],
-    touched_flags: &[Cell<bool>],
+    touched_flags: &[bool],
 ) {
     for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {
@@ -118,7 +118,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
         }
 
         // Skip write-locked accounts the transaction left unmodified.
-        if !touched_flags[i].get() {
+        if !touched_flags[i] {
             continue;
         }
 
@@ -186,10 +186,8 @@ mod tests {
 
     /// Builds touched flags for `num_total` accounts with the first
     /// `num_touched` of them marked as touched.
-    fn touched_flags_for_test(num_touched: usize, num_total: usize) -> Box<[Cell<bool>]> {
-        (0..num_total)
-            .map(|index| Cell::new(index < num_touched))
-            .collect()
+    fn touched_flags_for_test(num_touched: usize, num_total: usize) -> Box<[bool]> {
+        (0..num_total).map(|index| index < num_touched).collect()
     }
 
     fn new_sanitized_tx<T: Signers>(

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
-    core::borrow::Borrow,
+    core::{borrow::Borrow, cell::Cell},
     solana_account::AccountSharedData,
     solana_pubkey::Pubkey,
     solana_svm::{
@@ -13,9 +13,7 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::{
-        transaction::TouchedAccounts, transaction_accounts::KeyedAccountSharedData,
-    },
+    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
 };
 
 // Used to approximate how many accounts will be calculated for storage so that
@@ -82,7 +80,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                         transaction,
                         transaction_ref,
                         &executed_tx.loaded_transaction.accounts,
-                        executed_tx.loaded_transaction.touched,
+                        &executed_tx.loaded_transaction.touched_flags,
                     );
                 } else {
                     collect_accounts_for_failed_tx(
@@ -112,7 +110,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [KeyedAccountSharedData],
-    touched: TouchedAccounts,
+    touched_flags: &[Cell<bool>],
 ) {
     for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {
@@ -120,7 +118,7 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
         }
 
         // Skip write-locked accounts the transaction left unmodified.
-        if !touched.is_touched(i) {
+        if !touched_flags[i].get() {
             continue;
         }
 
@@ -186,13 +184,12 @@ mod tests {
         std::collections::{HashMap, HashSet},
     };
 
-    /// Builds a [`TouchedAccounts`] with the given account `indices` marked.
-    fn touched_set(indices: impl IntoIterator<Item = usize>) -> TouchedAccounts {
-        let mut touched = TouchedAccounts::default();
-        for index in indices {
-            touched.touch(index);
-        }
-        touched
+    /// Builds touched flags for `num_total` accounts with the first
+    /// `num_touched` of them marked as touched.
+    fn touched_flags_for_test(num_touched: usize, num_total: usize) -> Box<[Cell<bool>]> {
+        (0..num_total)
+            .map(|index| Cell::new(index < num_touched))
+            .collect()
     }
 
     fn new_sanitized_tx<T: Signers>(
@@ -270,20 +267,22 @@ mod tests {
         ];
         let tx1 = new_sanitized_tx(&[&keypair1], message, Hash::default());
 
-        let touched0 = touched_set(0..transaction_accounts0.len());
+        let touched0 =
+            touched_flags_for_test(transaction_accounts0.len(), transaction_accounts0.len());
         let loaded0 = LoadedTransaction {
             accounts: transaction_accounts0,
-            touched: touched0,
+            touched_flags: touched0,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
         };
 
-        let touched1 = touched_set(0..transaction_accounts1.len());
+        let touched1 =
+            touched_flags_for_test(transaction_accounts1.len(), transaction_accounts1.len());
         let loaded1 = LoadedTransaction {
             accounts: transaction_accounts1,
-            touched: touched1,
+            touched_flags: touched1,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -362,8 +361,8 @@ mod tests {
         // modified. Here only index 1 was modified; the writable account at
         // index 2 was left untouched and must not be written back.
         let loaded = LoadedTransaction {
+            touched_flags: touched_flags_for_test(2, transaction_accounts.len()),
             accounts: transaction_accounts,
-            touched: touched_set([0, 1]),
             ..Default::default()
         };
 
@@ -403,12 +402,13 @@ mod tests {
 
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
-        let touched = touched_set(0..transaction_accounts.len());
+        let touched_flags =
+            touched_flags_for_test(transaction_accounts.len(), transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             // Worst case: every writable account appears modified, yet a failed
             // tx must still persist only its rollback accounts.
-            touched,
+            touched_flags,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::FeePayerOnly {
                 fee_payer: (from_address, from_account_pre.clone()),
@@ -497,12 +497,13 @@ mod tests {
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
-        let touched = touched_set(0..transaction_accounts.len());
+        let touched_flags =
+            touched_flags_for_test(transaction_accounts.len(), transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             // Worst case: every writable account appears modified, yet a failed
             // tx must still persist only its rollback accounts.
-            touched,
+            touched_flags,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),
@@ -608,12 +609,13 @@ mod tests {
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
 
-        let touched = touched_set(0..transaction_accounts.len());
+        let touched_flags =
+            touched_flags_for_test(transaction_accounts.len(), transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
             // Worst case: every writable account appears modified, yet a failed
             // tx must still persist only its rollback accounts.
-            touched,
+            touched_flags,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),

--- a/runtime/src/account_saver.rs
+++ b/runtime/src/account_saver.rs
@@ -13,7 +13,9 @@ use {
     },
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::SanitizedTransaction,
-    solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
+    solana_transaction_context::{
+        transaction::TouchedAccounts, transaction_accounts::KeyedAccountSharedData,
+    },
 };
 
 // Used to approximate how many accounts will be calculated for storage so that
@@ -80,6 +82,7 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
                         transaction,
                         transaction_ref,
                         &executed_tx.loaded_transaction.accounts,
+                        executed_tx.loaded_transaction.touched,
                     );
                 } else {
                     collect_accounts_for_failed_tx(
@@ -109,9 +112,15 @@ fn collect_accounts_for_successful_tx<'a, T: SVMMessage>(
     transaction: &'a T,
     transaction_ref: Option<&'a SanitizedTransaction>,
     transaction_accounts: &'a [KeyedAccountSharedData],
+    touched: TouchedAccounts,
 ) {
     for (i, (address, account)) in (0..transaction.account_keys().len()).zip(transaction_accounts) {
         if !transaction.is_writable(i) {
+            continue;
+        }
+
+        // Skip write-locked accounts the transaction left unmodified.
+        if !touched.is_touched(i) {
             continue;
         }
 
@@ -174,8 +183,17 @@ mod tests {
         solana_system_interface::{instruction as system_instruction, program as system_program},
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         solana_transaction_error::{TransactionError, TransactionResult as Result},
-        std::collections::HashMap,
+        std::collections::{HashMap, HashSet},
     };
+
+    /// Builds a [`TouchedAccounts`] with the given account `indices` marked.
+    fn touched_set(indices: impl IntoIterator<Item = usize>) -> TouchedAccounts {
+        let mut touched = TouchedAccounts::default();
+        for index in indices {
+            touched.touch(index);
+        }
+        touched
+    }
 
     fn new_sanitized_tx<T: Signers>(
         from_keypairs: &T,
@@ -252,16 +270,20 @@ mod tests {
         ];
         let tx1 = new_sanitized_tx(&[&keypair1], message, Hash::default());
 
+        let touched0 = touched_set(0..transaction_accounts0.len());
         let loaded0 = LoadedTransaction {
             accounts: transaction_accounts0,
+            touched: touched0,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
             loaded_accounts_data_size: 0,
         };
 
+        let touched1 = touched_set(0..transaction_accounts1.len());
         let loaded1 = LoadedTransaction {
             accounts: transaction_accounts1,
+            touched: touched1,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -304,6 +326,65 @@ mod tests {
     }
 
     #[test]
+    fn test_collect_accounts_to_store_skips_untouched_accounts() {
+        let fee_payer = Keypair::new();
+        let (touched_key, untouched_key) = (solana_pubkey::new_rand(), solana_pubkey::new_rand());
+
+        let fee_payer_account = AccountSharedData::new(100, 0, &Pubkey::default());
+        let touched_account = AccountSharedData::new(1, 0, &Pubkey::default());
+        let untouched_account = AccountSharedData::new(2, 0, &Pubkey::default());
+        let program_account = AccountSharedData::new(3, 0, &Pubkey::default());
+
+        // Writable accounts at indices 0, 1, 2, plus a readonly program at index 3.
+        let instructions = vec![CompiledInstruction::new(3, &(), vec![1, 2])];
+        let message = Message::new_with_compiled_instructions(
+            1, // num_required_signatures
+            0, // num_readonly_signed_accounts
+            1, // num_readonly_unsigned_accounts -> only the program is readonly
+            vec![
+                fee_payer.pubkey(),
+                touched_key,
+                untouched_key,
+                native_loader::id(),
+            ],
+            Hash::default(),
+            instructions,
+        );
+        let transaction_accounts = vec![
+            (message.account_keys[0], fee_payer_account),
+            (message.account_keys[1], touched_account),
+            (message.account_keys[2], untouched_account),
+            (message.account_keys[3], program_account),
+        ];
+        let tx = new_sanitized_tx(&[&fee_payer], message, Hash::default());
+
+        // The processor marks the fee payer (index 0) and every account the VM
+        // modified. Here only index 1 was modified; the writable account at
+        // index 2 was left untouched and must not be written back.
+        let loaded = LoadedTransaction {
+            accounts: transaction_accounts,
+            touched: touched_set([0, 1]),
+            ..Default::default()
+        };
+
+        let txs = vec![tx];
+        let processing_results = vec![new_executed_processing_result(Ok(()), loaded)];
+
+        let transaction_refs: Option<Vec<&SanitizedTransaction>> = None;
+        let (collected_accounts, _transactions) =
+            collect_accounts_to_store(&txs, &transaction_refs, &processing_results);
+
+        // Only the fee payer and the touched writable account are stored; the
+        // untouched writable account and the readonly program are skipped.
+        let collected_keys =
+            HashSet::from_iter(collected_accounts.into_iter().map(|(pubkey, _act)| *pubkey));
+        assert_eq!(
+            collected_keys,
+            HashSet::from([fee_payer.pubkey(), touched_key]),
+        );
+    }
+
+    #[test]
     fn test_collect_accounts_for_failed_tx_rollback_fee_payer_only() {
         let from = keypair_from_seed(&[1; 32]).unwrap();
         let from_address = from.pubkey();
@@ -322,8 +403,12 @@ mod tests {
 
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
+        let touched = touched_set(0..transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
+            // Worst case: every writable account appears modified, yet a failed
+            // tx must still persist only its rollback accounts.
+            touched,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::FeePayerOnly {
                 fee_payer: (from_address, from_account_pre.clone()),
@@ -412,8 +497,12 @@ mod tests {
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
         let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
 
+        let touched = touched_set(0..transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
+            // Worst case: every writable account appears modified, yet a failed
+            // tx must still persist only its rollback accounts.
+            touched,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SeparateNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),
@@ -519,8 +608,12 @@ mod tests {
         let nonce_account_pre =
             AccountSharedData::new_data(42, &nonce_state, &system_program::id()).unwrap();
 
+        let touched = touched_set(0..transaction_accounts.len());
         let loaded = LoadedTransaction {
             accounts: transaction_accounts,
+            // Worst case: every writable account appears modified, yet a failed
+            // tx must still persist only its rollback accounts.
+            touched,
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::SameNonceAndFeePayer {
                 nonce: (nonce_address, nonce_account_pre.clone()),

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -8,7 +8,6 @@ use {
         transaction_error_metrics::TransactionErrorMetrics,
     },
     ahash::{AHashMap, AHashSet},
-    core::cell::Cell,
     solana_account::{
         Account, AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
     },
@@ -145,7 +144,7 @@ pub struct LoadedTransaction {
     pub accounts: Vec<KeyedAccountSharedData>,
     /// Parallel to `accounts`: whether each account must be written back. Empty
     /// until execution.
-    pub touched_flags: Box<[Cell<bool>]>,
+    pub touched_flags: Box<[bool]>,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
@@ -294,7 +293,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         &mut self,
         message: &impl SVMMessage,
         transaction_accounts: &[KeyedAccountSharedData],
-        touched_flags: &[Cell<bool>],
+        touched_flags: &[bool],
         current_slot: Slot,
     ) {
         for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
@@ -303,7 +302,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             }
 
             // Skip write-locked accounts the transaction left unmodified.
-            if !touched_flags[i].get() {
+            if !touched_flags[i] {
                 continue;
             }
 
@@ -842,7 +841,7 @@ mod tests {
 
         // Fee payer (index 0) and the VM-modified account (index 1) are marked;
         // the writable account at index 2 is left untouched.
-        let touched_flags: Box<[Cell<bool>]> = [true, true, false, false].map(Cell::new).into();
+        let touched_flags: Box<[bool]> = [true, true, false, false].into();
 
         let callbacks = TestCallbacks::default();
         let mut account_loader: AccountLoader<TestCallbacks> = (&callbacks).into();

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -8,6 +8,7 @@ use {
         transaction_error_metrics::TransactionErrorMetrics,
     },
     ahash::{AHashMap, AHashSet},
+    core::cell::Cell,
     solana_account::{
         Account, AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
     },
@@ -30,9 +31,7 @@ use {
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::{
-        IndexOfAccount, transaction::TouchedAccounts, transaction_accounts::KeyedAccountSharedData,
-    },
+    solana_transaction_context::{IndexOfAccount, transaction_accounts::KeyedAccountSharedData},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
 };
 
@@ -144,8 +143,9 @@ pub(crate) struct LoadedTransactionAccount {
 )]
 pub struct LoadedTransaction {
     pub accounts: Vec<KeyedAccountSharedData>,
-    /// Set of indices of accounts which must be written back. Empty until execution.
-    pub touched: TouchedAccounts,
+    /// Parallel to `accounts`: whether each account must be written back. Empty
+    /// until execution.
+    pub touched_flags: Box<[Cell<bool>]>,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
@@ -294,7 +294,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         &mut self,
         message: &impl SVMMessage,
         transaction_accounts: &[KeyedAccountSharedData],
-        touched: TouchedAccounts,
+        touched_flags: &[Cell<bool>],
         current_slot: Slot,
     ) {
         for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
@@ -303,7 +303,7 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
             }
 
             // Skip write-locked accounts the transaction left unmodified.
-            if !touched.is_touched(i) {
+            if !touched_flags[i].get() {
                 continue;
             }
 
@@ -430,7 +430,7 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
                 Ok(accounts) => TransactionLoadResult::Loaded(LoadedTransaction {
                     accounts,
                     // Populated after execution by execute_loaded_transaction.
-                    touched: TouchedAccounts::default(),
+                    touched_flags: Box::default(),
                     fee_details: tx_details.fee_details,
                     rollback_accounts: tx_details.rollback_accounts,
                     compute_budget: tx_details.compute_budget,
@@ -842,16 +842,14 @@ mod tests {
 
         // Fee payer (index 0) and the VM-modified account (index 1) are marked;
         // the writable account at index 2 is left untouched.
-        let mut touched = TouchedAccounts::default();
-        touched.touch(0);
-        touched.touch(1);
+        let touched_flags: Box<[Cell<bool>]> = [true, true, false, false].map(Cell::new).into();
 
         let callbacks = TestCallbacks::default();
         let mut account_loader: AccountLoader<TestCallbacks> = (&callbacks).into();
         account_loader.update_accounts_for_successful_tx(
             &message,
             &transaction_accounts,
-            touched,
+            &touched_flags,
             5,
         );
 
@@ -2209,7 +2207,7 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
-                touched: TouchedAccounts::default(),
+                touched_flags: Box::default(),
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget: SVMTransactionExecutionBudget::default(),

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -30,7 +30,9 @@ use {
     solana_svm_callback::{AccountState, TransactionProcessingCallback},
     solana_svm_feature_set::SVMFeatureSet,
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction_context::{IndexOfAccount, transaction_accounts::KeyedAccountSharedData},
+    solana_transaction_context::{
+        IndexOfAccount, transaction::TouchedAccounts, transaction_accounts::KeyedAccountSharedData,
+    },
     solana_transaction_error::{TransactionError, TransactionResult as Result},
 };
 
@@ -142,6 +144,8 @@ pub(crate) struct LoadedTransactionAccount {
 )]
 pub struct LoadedTransaction {
     pub accounts: Vec<KeyedAccountSharedData>,
+    /// Set of indices of accounts which must be written back. Empty until execution.
+    pub touched: TouchedAccounts,
     pub fee_details: FeeDetails,
     pub rollback_accounts: RollbackAccounts,
     pub(crate) compute_budget: SVMTransactionExecutionBudget,
@@ -290,10 +294,16 @@ impl<'a, CB: TransactionProcessingCallback> AccountLoader<'a, CB> {
         &mut self,
         message: &impl SVMMessage,
         transaction_accounts: &[KeyedAccountSharedData],
+        touched: TouchedAccounts,
         current_slot: Slot,
     ) {
         for (i, (address, account)) in (0..message.account_keys().len()).zip(transaction_accounts) {
             if !message.is_writable(i) {
+                continue;
+            }
+
+            // Skip write-locked accounts the transaction left unmodified.
+            if !touched.is_touched(i) {
                 continue;
             }
 
@@ -419,6 +429,8 @@ pub(crate) fn load_transaction<CB: TransactionProcessingCallback>(
             match load_result {
                 Ok(accounts) => TransactionLoadResult::Loaded(LoadedTransaction {
                     accounts,
+                    // Populated after execution by execute_loaded_transaction.
+                    touched: TouchedAccounts::default(),
                     fee_details: tx_details.fee_details,
                     rollback_accounts: tx_details.rollback_accounts,
                     compute_budget: tx_details.compute_budget,
@@ -794,6 +806,64 @@ mod tests {
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
+    }
+
+    #[test]
+    fn test_update_accounts_for_successful_tx_skips_untouched() {
+        let fee_payer = Keypair::new();
+        let (touched_key, untouched_key) = (Pubkey::new_unique(), Pubkey::new_unique());
+        let program = Pubkey::new_unique();
+
+        // Writable accounts at indices 0, 1, 2; readonly program at index 3.
+        let instructions = vec![CompiledInstruction::new(3, &(), vec![1, 2])];
+        let message = new_unchecked_sanitized_message(Message::new_with_compiled_instructions(
+            1, // num_required_signatures
+            0, // num_readonly_signed_accounts
+            1, // num_readonly_unsigned_accounts -> only the program is readonly
+            vec![fee_payer.pubkey(), touched_key, untouched_key, program],
+            Hash::default(),
+            instructions,
+        ));
+        let transaction_accounts = [
+            (
+                fee_payer.pubkey(),
+                AccountSharedData::new(100, 0, &Pubkey::default()),
+            ),
+            (
+                touched_key,
+                AccountSharedData::new(1, 0, &Pubkey::default()),
+            ),
+            (
+                untouched_key,
+                AccountSharedData::new(2, 0, &Pubkey::default()),
+            ),
+            (program, AccountSharedData::new(3, 0, &Pubkey::default())),
+        ];
+
+        // Fee payer (index 0) and the VM-modified account (index 1) are marked;
+        // the writable account at index 2 is left untouched.
+        let mut touched = TouchedAccounts::default();
+        touched.touch(0);
+        touched.touch(1);
+
+        let callbacks = TestCallbacks::default();
+        let mut account_loader: AccountLoader<TestCallbacks> = (&callbacks).into();
+        account_loader.update_accounts_for_successful_tx(
+            &message,
+            &transaction_accounts,
+            touched,
+            5,
+        );
+
+        // Only touched writable accounts propagate to the in-batch loader cache.
+        assert!(
+            account_loader
+                .loaded_accounts
+                .contains_key(&fee_payer.pubkey())
+        );
+        assert!(account_loader.loaded_accounts.contains_key(&touched_key));
+        assert!(!account_loader.loaded_accounts.contains_key(&untouched_key));
+        assert!(!account_loader.loaded_accounts.contains_key(&program));
     }
 
     #[test]
@@ -2139,6 +2209,7 @@ mod tests {
                     ),
                     (key3.pubkey(), account_data),
                 ],
+                touched: TouchedAccounts::default(),
                 fee_details: FeeDetails::default(),
                 rollback_accounts: RollbackAccounts::default(),
                 compute_budget: SVMTransactionExecutionBudget::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1041,15 +1041,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             accounts_resize_delta,
         } = execution_record;
 
-        // changed_account_count reflects the accounts the VM actually modified,
-        // counted before the fee payer is force-marked below.
-        let touched_account_count = touched_flags.iter().filter(|touched| **touched).count();
-
         // The fee payer (account index 0) is debited during loading, outside the
         // VM, so it carries no VM touch flag but must still be written back.
         if let Some(fee_payer_touched) = touched_flags.first_mut() {
             *fee_payer_touched = true;
         }
+
+        // changed_account_count reflects every account that will be written back,
+        // including the fee payer marked above.
+        let touched_account_count = touched_flags.iter().filter(|touched| **touched).count();
 
         if post_account_state_info_result.is_ok()
             && transaction_accounts_lamports_sum(&accounts)

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -569,7 +569,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             account_loader.update_accounts_for_successful_tx(
                                 tx,
                                 &executed_tx.loaded_transaction.accounts,
-                                executed_tx.loaded_transaction.touched,
+                                &executed_tx.loaded_transaction.touched_flags,
                                 self.slot,
                             );
                             // Also update local program cache with modifications made by the
@@ -1037,18 +1037,20 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let ExecutionRecord {
             accounts,
             return_data,
-            mut touched,
+            touched_flags,
             accounts_resize_delta,
         } = execution_record;
 
         // changed_account_count reflects the accounts the VM actually modified.
-        let touched_account_count = touched.count();
+        let touched_account_count = touched_flags.iter().filter(|touched| touched.get()).count();
 
         // The fee payer (account index 0) is debited during loading, outside the
         // VM, so it carries no VM touch flag but must still be written back. Mark
         // it as touched so account collection can treat "needs store" uniformly
         // as "was touched".
-        touched.touch(0);
+        if let Some(fee_payer_touched) = touched_flags.first() {
+            fee_payer_touched.set(true);
+        }
 
         if post_account_state_info_result.is_ok()
             && transaction_accounts_lamports_sum(&accounts)
@@ -1075,9 +1077,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .unwrap_or_else(|err| (Err(err), None));
 
         loaded_transaction.accounts = accounts;
-        loaded_transaction.touched = touched;
+        loaded_transaction.touched_flags = touched_flags;
         execute_timings.details.total_account_count += loaded_transaction.accounts.len() as u64;
-        execute_timings.details.changed_account_count += touched_account_count;
+        execute_timings.details.changed_account_count += touched_account_count as u64;
 
         let return_data = if config.recording_config.enable_return_data_recording
             && !return_data.data.is_empty()
@@ -1292,7 +1294,7 @@ mod tests {
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
         solana_transaction::sanitized::SanitizedTransaction,
-        solana_transaction_context::transaction::{TouchedAccounts, TransactionContext},
+        solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
@@ -1594,7 +1596,7 @@ mod tests {
 
         let loaded_transaction = LoadedTransaction {
             accounts: vec![(Pubkey::new_unique(), AccountSharedData::default())],
-            touched: TouchedAccounts::default(),
+            touched_flags: Box::default(),
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -1689,7 +1691,7 @@ mod tests {
                 (key1, AccountSharedData::default()),
                 (key2, AccountSharedData::default()),
             ],
-            touched: TouchedAccounts::default(),
+            touched_flags: Box::default(),
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1037,19 +1037,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let ExecutionRecord {
             accounts,
             return_data,
-            touched_flags,
+            mut touched_flags,
             accounts_resize_delta,
         } = execution_record;
-
-        // We now own the flags and no longer need interior mutability, so unwrap
-        // the per-element `Cell`s into a plain `Box<[bool]>`. `Vec::from` reuses
-        // the box's allocation, and the mapped collect reuses that same buffer in
-        // place (`Cell<bool>` and `bool` have identical layout), so no
-        // reallocation occurs.
-        let mut touched_flags: Box<[bool]> = Vec::from(touched_flags)
-            .into_iter()
-            .map(|flag| flag.into_inner())
-            .collect();
 
         // changed_account_count reflects the accounts the VM actually modified,
         // counted before the fee payer is force-marked below.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1041,15 +1041,22 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             accounts_resize_delta,
         } = execution_record;
 
-        // changed_account_count reflects the accounts the VM actually modified.
-        let touched_account_count = touched_flags.iter().filter(|touched| touched.get()).count();
+        // We now own the flags and no longer need interior mutability, so
+        // reinterpret them as a plain `Box<[bool]>`, reusing the allocation.
+        // SAFETY: `Cell<bool>` is `repr(transparent)` over `bool`, so
+        // `[Cell<bool>]` and `[bool]` have identical layout, and every flag holds
+        // a valid `bool`.
+        let mut touched_flags: Box<[bool]> =
+            unsafe { Box::from_raw(Box::into_raw(touched_flags) as *mut [bool]) };
+
+        // changed_account_count reflects the accounts the VM actually modified,
+        // counted before the fee payer is force-marked below.
+        let touched_account_count = touched_flags.iter().filter(|touched| **touched).count();
 
         // The fee payer (account index 0) is debited during loading, outside the
-        // VM, so it carries no VM touch flag but must still be written back. Mark
-        // it as touched so account collection can treat "needs store" uniformly
-        // as "was touched".
-        if let Some(fee_payer_touched) = touched_flags.first() {
-            fee_payer_touched.set(true);
+        // VM, so it carries no VM touch flag but must still be written back.
+        if let Some(fee_payer_touched) = touched_flags.first_mut() {
+            *fee_payer_touched = true;
         }
 
         if post_account_state_info_result.is_ok()

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1041,13 +1041,15 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             accounts_resize_delta,
         } = execution_record;
 
-        // We now own the flags and no longer need interior mutability, so
-        // reinterpret them as a plain `Box<[bool]>`, reusing the allocation.
-        // SAFETY: `Cell<bool>` is `repr(transparent)` over `bool`, so
-        // `[Cell<bool>]` and `[bool]` have identical layout, and every flag holds
-        // a valid `bool`.
-        let mut touched_flags: Box<[bool]> =
-            unsafe { Box::from_raw(Box::into_raw(touched_flags) as *mut [bool]) };
+        // We now own the flags and no longer need interior mutability, so unwrap
+        // the per-element `Cell`s into a plain `Box<[bool]>`. `Vec::from` reuses
+        // the box's allocation, and the mapped collect reuses that same buffer in
+        // place (`Cell<bool>` and `bool` have identical layout), so no
+        // reallocation occurs.
+        let mut touched_flags: Box<[bool]> = Vec::from(touched_flags)
+            .into_iter()
+            .map(|flag| flag.into_inner())
+            .collect();
 
         // changed_account_count reflects the accounts the VM actually modified,
         // counted before the fee payer is force-marked below.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -569,6 +569,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             account_loader.update_accounts_for_successful_tx(
                                 tx,
                                 &executed_tx.loaded_transaction.accounts,
+                                executed_tx.loaded_transaction.touched,
                                 self.slot,
                             );
                             // Also update local program cache with modifications made by the
@@ -1036,9 +1037,18 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         let ExecutionRecord {
             accounts,
             return_data,
-            touched_account_count,
+            mut touched,
             accounts_resize_delta,
         } = execution_record;
+
+        // changed_account_count reflects the accounts the VM actually modified.
+        let touched_account_count = touched.count();
+
+        // The fee payer (account index 0) is debited during loading, outside the
+        // VM, so it carries no VM touch flag but must still be written back. Mark
+        // it as touched so account collection can treat "needs store" uniformly
+        // as "was touched".
+        touched.touch(0);
 
         if post_account_state_info_result.is_ok()
             && transaction_accounts_lamports_sum(&accounts)
@@ -1065,6 +1075,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .unwrap_or_else(|err| (Err(err), None));
 
         loaded_transaction.accounts = accounts;
+        loaded_transaction.touched = touched;
         execute_timings.details.total_account_count += loaded_transaction.accounts.len() as u64;
         execute_timings.details.changed_account_count += touched_account_count;
 
@@ -1281,7 +1292,7 @@ mod tests {
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
         solana_transaction::sanitized::SanitizedTransaction,
-        solana_transaction_context::transaction::TransactionContext,
+        solana_transaction_context::transaction::{TouchedAccounts, TransactionContext},
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
@@ -1583,6 +1594,7 @@ mod tests {
 
         let loaded_transaction = LoadedTransaction {
             accounts: vec![(Pubkey::new_unique(), AccountSharedData::default())],
+            touched: TouchedAccounts::default(),
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),
@@ -1677,6 +1689,7 @@ mod tests {
                 (key1, AccountSharedData::default()),
                 (key2, AccountSharedData::default()),
             ],
+            touched: TouchedAccounts::default(),
             fee_details: FeeDetails::default(),
             rollback_accounts: RollbackAccounts::default(),
             compute_budget: SVMTransactionExecutionBudget::default(),

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -607,46 +607,13 @@ pub struct TransactionReturnData {
     pub data: Vec<u8>,
 }
 
-/// Bit set tracking which transaction accounts were modified, indexed by
-/// account index. A transaction may reference at most `MAX_TX_ACCOUNT_LOCKS`
-/// (128) accounts, so a `u128` always has room for every account and avoids a
-/// per-transaction heap allocation.
-#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct TouchedAccounts(u128);
-
-#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
-impl TouchedAccounts {
-    /// Mark the account at `index` as modified. Caller must ensure
-    /// `index < 128`, which always holds for transaction account indices.
-    #[inline]
-    pub fn touch(&mut self, index: usize) {
-        debug_assert!(index < 128, "transaction account index out of range");
-        self.0 |= 1u128 << index;
-    }
-
-    /// Whether the account at `index` was modified. Caller must ensure
-    /// `index < 128`, which always holds for transaction account indices.
-    #[inline]
-    pub fn is_touched(&self, index: usize) -> bool {
-        debug_assert!(index < 128, "transaction account index out of range");
-        (self.0 >> index) & 1 == 1
-    }
-
-    /// Number of accounts marked as modified.
-    #[inline]
-    pub fn count(&self) -> u64 {
-        u64::from(self.0.count_ones())
-    }
-}
-
 /// Everything that needs to be recorded from a TransactionContext after execution
 #[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 pub struct ExecutionRecord {
     pub accounts: Vec<KeyedAccountSharedData>,
     pub return_data: TransactionReturnData,
-    /// Which accounts were modified by the VM (indexed by account index).
-    pub touched: TouchedAccounts,
+    /// Parallel to `accounts`: whether each account was modified by the VM.
+    pub touched_flags: Box<[Cell<bool>]>,
     pub accounts_resize_delta: i64,
 }
 
@@ -657,12 +624,6 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
         let (accounts, touched_flags, resize_delta) = Rc::try_unwrap(context.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs")
             .take();
-        let mut touched = TouchedAccounts::default();
-        for (index, was_touched) in touched_flags.iter().enumerate() {
-            if was_touched.get() {
-                touched.touch(index);
-            }
-        }
 
         let return_data = TransactionReturnData {
             program_id: context.transaction_frame.return_data_pubkey,
@@ -672,7 +633,7 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
         Self {
             accounts,
             return_data,
-            touched,
+            touched_flags,
             accounts_resize_delta: Cell::into_inner(resize_delta),
         }
     }
@@ -681,29 +642,6 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
 #[cfg(all(test, not(target_arch = "sbf"), not(target_arch = "bpf")))]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_touched_accounts() {
-        let mut touched = TouchedAccounts::default();
-        // Nothing is touched by default.
-        assert_eq!(touched.count(), 0);
-        for index in 0..128 {
-            assert!(!touched.is_touched(index));
-        }
-
-        // Marking is per-index and idempotent.
-        touched.touch(0);
-        touched.touch(5);
-        touched.touch(127); // highest valid transaction account index
-        touched.touch(5);
-
-        assert!(touched.is_touched(0));
-        assert!(touched.is_touched(5));
-        assert!(touched.is_touched(127));
-        assert!(!touched.is_touched(1));
-        assert!(!touched.is_touched(126));
-        assert_eq!(touched.count(), 3);
-    }
 
     #[test]
     fn test_instructions_sysvar_store_index_checked() {

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -613,7 +613,7 @@ pub struct ExecutionRecord {
     pub accounts: Vec<KeyedAccountSharedData>,
     pub return_data: TransactionReturnData,
     /// Parallel to `accounts`: whether each account was modified by the VM.
-    pub touched_flags: Box<[Cell<bool>]>,
+    pub touched_flags: Box<[bool]>,
     pub accounts_resize_delta: i64,
 }
 
@@ -624,6 +624,16 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
         let (accounts, touched_flags, resize_delta) = Rc::try_unwrap(context.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs")
             .take();
+
+        // The flags only needed interior mutability while the VM was running.
+        // Now that we own them, unwrap the per-element `Cell`s into a plain
+        // `Box<[bool]>`. `Vec::from` reuses the box's allocation and the mapped
+        // collect reuses that same buffer in place (`Cell<bool>` and `bool` have
+        // identical layout), so no reallocation occurs.
+        let touched_flags: Box<[bool]> = Vec::from(touched_flags)
+            .into_iter()
+            .map(|flag| flag.into_inner())
+            .collect();
 
         let return_data = TransactionReturnData {
             program_id: context.transaction_frame.return_data_pubkey,

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -607,12 +607,46 @@ pub struct TransactionReturnData {
     pub data: Vec<u8>,
 }
 
+/// Bit set tracking which transaction accounts were modified, indexed by
+/// account index. A transaction may reference at most `MAX_TX_ACCOUNT_LOCKS`
+/// (128) accounts, so a `u128` always has room for every account and avoids a
+/// per-transaction heap allocation.
+#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TouchedAccounts(u128);
+
+#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
+impl TouchedAccounts {
+    /// Mark the account at `index` as modified. Caller must ensure
+    /// `index < 128`, which always holds for transaction account indices.
+    #[inline]
+    pub fn touch(&mut self, index: usize) {
+        debug_assert!(index < 128, "transaction account index out of range");
+        self.0 |= 1u128 << index;
+    }
+
+    /// Whether the account at `index` was modified. Caller must ensure
+    /// `index < 128`, which always holds for transaction account indices.
+    #[inline]
+    pub fn is_touched(&self, index: usize) -> bool {
+        debug_assert!(index < 128, "transaction account index out of range");
+        (self.0 >> index) & 1 == 1
+    }
+
+    /// Number of accounts marked as modified.
+    #[inline]
+    pub fn count(&self) -> u64 {
+        u64::from(self.0.count_ones())
+    }
+}
+
 /// Everything that needs to be recorded from a TransactionContext after execution
 #[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 pub struct ExecutionRecord {
     pub accounts: Vec<KeyedAccountSharedData>,
     pub return_data: TransactionReturnData,
-    pub touched_account_count: u64,
+    /// Which accounts were modified by the VM (indexed by account index).
+    pub touched: TouchedAccounts,
     pub accounts_resize_delta: i64,
 }
 
@@ -623,11 +657,12 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
         let (accounts, touched_flags, resize_delta) = Rc::try_unwrap(context.accounts)
             .expect("transaction_context.accounts has unexpected outstanding refs")
             .take();
-        let touched_account_count = touched_flags
-            .iter()
-            .fold(0usize, |accumulator, was_touched| {
-                accumulator.saturating_add(was_touched.get() as usize)
-            }) as u64;
+        let mut touched = TouchedAccounts::default();
+        for (index, was_touched) in touched_flags.iter().enumerate() {
+            if was_touched.get() {
+                touched.touch(index);
+            }
+        }
 
         let return_data = TransactionReturnData {
             program_id: context.transaction_frame.return_data_pubkey,
@@ -637,7 +672,7 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
         Self {
             accounts,
             return_data,
-            touched_account_count,
+            touched,
             accounts_resize_delta: Cell::into_inner(resize_delta),
         }
     }
@@ -646,6 +681,29 @@ impl From<TransactionContext<'_>> for ExecutionRecord {
 #[cfg(all(test, not(target_arch = "sbf"), not(target_arch = "bpf")))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_touched_accounts() {
+        let mut touched = TouchedAccounts::default();
+        // Nothing is touched by default.
+        assert_eq!(touched.count(), 0);
+        for index in 0..128 {
+            assert!(!touched.is_touched(index));
+        }
+
+        // Marking is per-index and idempotent.
+        touched.touch(0);
+        touched.touch(5);
+        touched.touch(127); // highest valid transaction account index
+        touched.touch(5);
+
+        assert!(touched.is_touched(0));
+        assert!(touched.is_touched(5));
+        assert!(touched.is_touched(127));
+        assert!(!touched.is_touched(1));
+        assert!(!touched.is_touched(126));
+        assert_eq!(touched.count(), 3);
+    }
 
     #[test]
     fn test_instructions_sysvar_store_index_checked() {


### PR DESCRIPTION
#### Problem
We always update all writable accounts from transaction into accounts-db even though in SVM there is tracking of which write locked accounts got actually modified.

#### Summary of Changes
The VM's per-account dirty info is now preserved end-to-end and used to skip writing back unmodified write-locked accounts.

Because the fee payer is force-marked at the source, every downstream consumer is a uniform `if !touched { continue; }` with the "index 0 == fee payer" assumption living in exactly one place.

**Correctness rests on two facts:**
- The lt-hash (`hash_account_helper`, `accounts_db.rs:4545`) hashes lamports/data/executable/owner/pubkey but **not `rent_epoch`** — so the load-time rent_epoch bump on untouched accounts produces a zero hash delta and doesn't need persisting.
- On the successful path the only out-of-VM mutation that affects the hash is the fee payer debit (nonce advance runs in the VM via `AdvanceNonceAccount`, so it's touched).

#### Testing
* added relevant unit-tests
* run devbox validator for a few hours with this change, restarting (verifies on-disk accounts state by lt-hash calculation)