### PR TITLE
Unify `translate_signers_c` and `translate_signers_rust`.

### DIFF
--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -533,12 +533,6 @@ pub trait SyscallInvokeSigned {
         account_infos_len: u64,
         invoke_context: &InvokeContext,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error>;
-    fn translate_signers(
-        program_id: &Pubkey,
-        signers_seeds_addr: u64,
-        signers_seeds_len: u64,
-        invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Error>;
 }
 
 pub fn translate_instruction_rust(
@@ -642,7 +636,6 @@ pub fn translate_signers(
 ) -> Result<Vec<Pubkey>, Error> {
     let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
-    let mut signers = Vec::new();
     if signers_seeds_len > 0 {
         let signers_seeds = translate_slice::<VmSlice<VmSlice<u8>>>(
             memory_mapping,
@@ -653,27 +646,28 @@ pub fn translate_signers(
         if signers_seeds.len() > MAX_SIGNERS {
             return Err(Box::new(CpiError::TooManySigners));
         }
-        for signer_seeds in signers_seeds.iter() {
-            let untranslated_seeds = translate_slice::<VmSlice<u8>>(
-                memory_mapping,
-                signer_seeds.ptr(),
-                signer_seeds.len(),
-                check_aligned,
-            )?;
-            if untranslated_seeds.len() > MAX_SEEDS {
-                return Err(Box::new(InstructionError::MaxSeedLengthExceeded));
-            }
-            let seeds = untranslated_seeds
-                .iter()
-                .map(|untranslated_seed| {
-                    translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
-                })
-                .collect::<Result<Vec<_>, Error>>()?;
-            let signer =
-                Pubkey::create_program_address(&seeds, program_id).map_err(CpiError::BadSeeds)?;
-            signers.push(signer);
-        }
-        Ok(signers)
+        Ok(signers_seeds
+            .iter()
+            .map(|signer_seeds| {
+                let untranslated_seeds = translate_slice::<VmSlice<u8>>(
+                    memory_mapping,
+                    signer_seeds.ptr(),
+                    signer_seeds.len(),
+                    check_aligned,
+                )?;
+                if untranslated_seeds.len() > MAX_SEEDS {
+                    return Err(Box::new(InstructionError::MaxSeedLengthExceeded) as Error);
+                }
+                let seeds_bytes = untranslated_seeds
+                    .iter()
+                    .map(|untranslated_seed| {
+                        translate_vm_slice(untranslated_seed, memory_mapping, check_aligned)
+                    })
+                    .collect::<Result<Vec<_>, Error>>()?;
+                Pubkey::create_program_address(&seeds_bytes, program_id)
+                    .map_err(|err| Box::new(CpiError::BadSeeds(err)) as Error)
+            })
+            .collect::<Result<Vec<_>, Error>>()?)
     } else {
         Ok(vec![])
     }
@@ -804,7 +798,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
         .transaction_context
         .get_current_instruction_context()?;
     let caller_program_id = instruction_context.get_program_key()?;
-    let signers = S::translate_signers(
+    let signers = translate_signers(
         caller_program_id,
         signers_seeds_addr,
         signers_seeds_len,

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -102,22 +102,6 @@ struct SolAccountInfo {
     pub executable: bool,
 }
 
-/// Rust representation of C's SolSignerSeed
-#[derive(Debug)]
-#[repr(C)]
-struct SolSignerSeedC {
-    pub addr: u64,
-    pub len: u64,
-}
-
-/// Rust representation of C's SolSignerSeeds
-#[derive(Debug)]
-#[repr(C)]
-struct SolSignerSeedsC {
-    pub addr: u64,
-    pub len: u64,
-}
-
 /// Maximum number of account info structs that can be used in a single CPI invocation
 const MAX_CPI_ACCOUNT_INFOS: usize = 255;
 
@@ -800,7 +784,7 @@ pub fn translate_signers_c(
     let check_aligned = invoke_context.get_check_aligned();
     let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
     if signers_seeds_len > 0 {
-        let signers_seeds = translate_slice::<SolSignerSeedsC>(
+        let signers_seeds = translate_slice::<VmSlice<u8>>(
             memory_mapping,
             signers_seeds_addr,
             signers_seeds_len,
@@ -812,10 +796,10 @@ pub fn translate_signers_c(
         Ok(signers_seeds
             .iter()
             .map(|signer_seeds| {
-                let seeds = translate_slice::<SolSignerSeedC>(
+                let seeds = translate_slice::<VmSlice<u8>>(
                     memory_mapping,
-                    signer_seeds.addr,
-                    signer_seeds.len,
+                    signer_seeds.ptr(),
+                    signer_seeds.len(),
                     check_aligned,
                 )?;
                 if seeds.len() > MAX_SEEDS {
@@ -824,7 +808,7 @@ pub fn translate_signers_c(
                 let seeds_bytes = seeds
                     .iter()
                     .map(|seed| {
-                        translate_slice::<u8>(memory_mapping, seed.addr, seed.len, check_aligned)
+                        translate_slice::<u8>(memory_mapping, seed.ptr(), seed.len(), check_aligned)
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
                 Pubkey::create_program_address(&seeds_bytes, program_id)

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -634,7 +634,7 @@ pub fn translate_accounts_rust<'a>(
     )?
 }
 
-pub fn translate_signers_rust(
+pub fn translate_signers(
     program_id: &Pubkey,
     signers_seeds_addr: u64,
     signers_seeds_len: u64,
@@ -773,51 +773,6 @@ pub fn translate_accounts_c<'a>(
             )
         },
     )?
-}
-
-pub fn translate_signers_c(
-    program_id: &Pubkey,
-    signers_seeds_addr: u64,
-    signers_seeds_len: u64,
-    invoke_context: &InvokeContext,
-) -> Result<Vec<Pubkey>, Error> {
-    let check_aligned = invoke_context.get_check_aligned();
-    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
-    if signers_seeds_len > 0 {
-        let signers_seeds = translate_slice::<VmSlice<u8>>(
-            memory_mapping,
-            signers_seeds_addr,
-            signers_seeds_len,
-            check_aligned,
-        )?;
-        if signers_seeds.len() > MAX_SIGNERS {
-            return Err(Box::new(CpiError::TooManySigners));
-        }
-        Ok(signers_seeds
-            .iter()
-            .map(|signer_seeds| {
-                let seeds = translate_slice::<VmSlice<u8>>(
-                    memory_mapping,
-                    signer_seeds.ptr(),
-                    signer_seeds.len(),
-                    check_aligned,
-                )?;
-                if seeds.len() > MAX_SEEDS {
-                    return Err(Box::new(InstructionError::MaxSeedLengthExceeded) as Error);
-                }
-                let seeds_bytes = seeds
-                    .iter()
-                    .map(|seed| {
-                        translate_slice::<u8>(memory_mapping, seed.ptr(), seed.len(), check_aligned)
-                    })
-                    .collect::<Result<Vec<_>, Error>>()?;
-                Pubkey::create_program_address(&seeds_bytes, program_id)
-                    .map_err(|err| Box::new(CpiError::BadSeeds(err)) as Error)
-            })
-            .collect::<Result<Vec<_>, Error>>()?)
-    } else {
-        Ok(vec![])
-    }
 }
 
 /// Call process instruction, common to both Rust and C
@@ -1919,7 +1874,7 @@ mod tests {
             ))
             .unwrap();
 
-        let signers = translate_signers_rust(&program_id, vm_addr, 1, &invoke_context).unwrap();
+        let signers = translate_signers(&program_id, vm_addr, 1, &invoke_context).unwrap();
         assert_eq!(signers[0], derived_key);
     }
 

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -4,7 +4,6 @@ use {
     solana_program_runtime::cpi::{
         SyscallInvokeSigned, TranslatedAccount, cpi_common, translate_accounts_c,
         translate_accounts_rust, translate_instruction_c, translate_instruction_rust,
-        translate_signers,
     },
 };
 
@@ -45,20 +44,6 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
         translate_accounts_rust(account_infos_addr, account_infos_len, invoke_context)
     }
-
-    fn translate_signers(
-        program_id: &Pubkey,
-        signers_seeds_addr: u64,
-        signers_seeds_len: u64,
-        invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Error> {
-        translate_signers(
-            program_id,
-            signers_seeds_addr,
-            signers_seeds_len,
-            invoke_context,
-        )
-    }
 }
 
 declare_builtin_function!(
@@ -97,19 +82,5 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         invoke_context: &InvokeContext,
     ) -> Result<Vec<TranslatedAccount<'a>>, Error> {
         translate_accounts_c(account_infos_addr, account_infos_len, invoke_context)
-    }
-
-    fn translate_signers(
-        program_id: &Pubkey,
-        signers_seeds_addr: u64,
-        signers_seeds_len: u64,
-        invoke_context: &InvokeContext,
-    ) -> Result<Vec<Pubkey>, Error> {
-        translate_signers(
-            program_id,
-            signers_seeds_addr,
-            signers_seeds_len,
-            invoke_context,
-        )
     }
 }

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -4,7 +4,7 @@ use {
     solana_program_runtime::cpi::{
         SyscallInvokeSigned, TranslatedAccount, cpi_common, translate_accounts_c,
         translate_accounts_rust, translate_instruction_c, translate_instruction_rust,
-        translate_signers_rust,
+        translate_signers,
     },
 };
 
@@ -52,7 +52,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedRust {
         signers_seeds_len: u64,
         invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
-        translate_signers_rust(
+        translate_signers(
             program_id,
             signers_seeds_addr,
             signers_seeds_len,
@@ -105,7 +105,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         signers_seeds_len: u64,
         invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
-        translate_signers_rust(
+        translate_signers(
             program_id,
             signers_seeds_addr,
             signers_seeds_len,

--- a/syscalls/src/cpi.rs
+++ b/syscalls/src/cpi.rs
@@ -4,7 +4,7 @@ use {
     solana_program_runtime::cpi::{
         SyscallInvokeSigned, TranslatedAccount, cpi_common, translate_accounts_c,
         translate_accounts_rust, translate_instruction_c, translate_instruction_rust,
-        translate_signers_c, translate_signers_rust,
+        translate_signers_rust,
     },
 };
 
@@ -105,7 +105,7 @@ impl SyscallInvokeSigned for SyscallInvokeSignedC {
         signers_seeds_len: u64,
         invoke_context: &InvokeContext,
     ) -> Result<Vec<Pubkey>, Error> {
-        translate_signers_c(
+        translate_signers_rust(
             program_id,
             signers_seeds_addr,
             signers_seeds_len,

--- a/transaction-context/src/vm_slice.rs
+++ b/transaction-context/src/vm_slice.rs
@@ -11,6 +11,8 @@
 
 use std::marker::PhantomData;
 
+/// VmSlice serves as a stable layout for slices shared between the guest and the host.
+/// It is also the layout for SolSignerSeedC and SolSignerSeedsC.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct VmSlice<T> {


### PR DESCRIPTION
#### Problem


`translate_signers_c` and `translate_signers_rust` are exactly the same functions, with the only difference being the different translated type, which is unironically the same as a `VmSlice`.

#### Summary of Changes

1. Delete `translate_signers_c`, `SolSignerSeedsC` and `SolSignerSeedC`.
2. Update comment on `VmSlice`.
3. Rename `translate_signers_c` to `translate_signers`.

#### Testing

I'm relying on the existing testing infrastructure to confirm both function maintain equal behavior.
