### PR TITLE
SIMD-0204: backout migrating slashing program to builtin address

### DIFF
--- a/builtins/src/lib.rs
+++ b/builtins/src/lib.rs
@@ -14,10 +14,7 @@ pub mod core_bpf_migration;
 pub mod prototype;
 
 use {
-    crate::{
-        core_bpf_migration::{CoreBpfMigrationConfig, CoreBpfMigrationTargetType},
-        prototype::{BuiltinPrototype, StatelessBuiltinPrototype},
-    },
+    crate::prototype::{BuiltinPrototype, StatelessBuiltinPrototype},
     agave_feature_set as feature_set,
     solana_program_runtime::solana_sbpf::program::BuiltinFunctionDefinition,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
@@ -111,37 +108,7 @@ pub static BUILTINS: &[BuiltinPrototype] = &[
     },
 ];
 
-pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[StatelessBuiltinPrototype {
-    core_bpf_migration_config: Some(CoreBpfMigrationConfig {
-        source_buffer_address: buffer_accounts::slashing_program::id(),
-        upgrade_authority_address: None,
-        feature_id: feature_set::enshrine_slashing_program::id(),
-        verified_build_hash: Some(buffer_accounts::slashing_program::VERIFIED_BUILD_HASH),
-        migration_target: CoreBpfMigrationTargetType::Stateless,
-        datapoint_name: "enshrine_slashing_program",
-    }),
-    program_id: buffer_accounts::slashing_program::PROGRAM_ID,
-    name: "solana_slashing_program",
-}];
-
-/// Live source buffer accounts for builtin migrations.
-mod buffer_accounts {
-    pub mod slashing_program {
-        use {solana_hash::Hash, solana_pubkey::Pubkey};
-
-        solana_pubkey::declare_id!("S1asHs4je6wPb2kWiHqNNdpNRiDaBEDQyfyCThhsrgv");
-
-        pub(crate) const PROGRAM_ID: Pubkey =
-            Pubkey::from_str_const("S1ashing11111111111111111111111111111111111");
-        // 192ed727334abe822d5accba8b886e25f88b03c76973c2e7290cfb55b9e1115f
-        const HASH_BYTES: [u8; 32] = [
-            0x19, 0x2e, 0xd7, 0x27, 0x33, 0x4a, 0xbe, 0x82, 0x2d, 0x5a, 0xcc, 0xba, 0x8b, 0x88,
-            0x6e, 0x25, 0xf8, 0x8b, 0x03, 0xc7, 0x69, 0x73, 0xc2, 0xe7, 0x29, 0x0c, 0xfb, 0x55,
-            0xb9, 0xe1, 0x11, 0x5f,
-        ];
-        pub(crate) const VERIFIED_BUILD_HASH: Hash = Hash::new_from_array(HASH_BYTES);
-    }
-}
+pub static STATELESS_BUILTINS: &[StatelessBuiltinPrototype] = &[];
 
 // This module contains a number of arbitrary addresses used for testing Core
 // BPF migrations.

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1282,10 +1282,6 @@ pub mod relax_intrabatch_account_locks {
     solana_pubkey::declare_id!("4WeHX6QoXCCwqbSFgi6dxnB6QsPo6YApaNTH7P4MLQ99");
 }
 
-pub mod create_slashing_program {
-    solana_pubkey::declare_id!("sProgVaNWkYdP2eTRAy1CPrgb3b9p8yXCASrPEqo6VJ");
-}
-
 pub mod disable_partitioned_rent_collection {
     solana_pubkey::declare_id!("2B2SBNbUcr438LtGXNcJNBP2GBSxjx81F945SdSkUSfC");
 }
@@ -1304,10 +1300,6 @@ pub mod raise_block_limits_to_60m {
 
 pub mod mask_out_rent_epoch_in_vm_serialization {
     solana_pubkey::declare_id!("RENtePQcDLrAbxAsP3k8dwVcnNYQ466hi2uKvALjnXx");
-}
-
-pub mod enshrine_slashing_program {
-    solana_pubkey::declare_id!("sProgVaNWkYdP2eTRAy1CPrgb3b9p8yXCASrPEqo6VJ");
 }
 
 pub mod enable_extend_program_checked {
@@ -2406,10 +2398,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
             "SIMD-0083: Allow batched transactions to read/write and write/write the same accounts",
         ),
         (
-            create_slashing_program::id(),
-            "SIMD-0204: creates an enshrined slashing program",
-        ),
-        (
             disable_partitioned_rent_collection::id(),
             "SIMD-0175: Disable partitioned rent collection #4562",
         ),
@@ -2428,10 +2416,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             mask_out_rent_epoch_in_vm_serialization::id(),
             "SIMD-0267: Sets rent_epoch to a constant in the VM",
-        ),
-        (
-            enshrine_slashing_program::id(),
-            "SIMD-0204: Slashable event verification",
         ),
         (
             enable_extend_program_checked::id(),

--- a/program-test/tests/core_bpf.rs
+++ b/program-test/tests/core_bpf.rs
@@ -1,10 +1,7 @@
 use {
-    solana_instruction::Instruction,
     solana_program_test::{ProgramTest, ProgramTestContext},
     solana_pubkey::Pubkey,
     solana_sdk_ids::bpf_loader_upgradeable,
-    solana_signer::Signer,
-    solana_transaction::Transaction,
 };
 
 async fn assert_bpf_program(context: &ProgramTestContext, program_id: &Pubkey) {
@@ -27,34 +24,4 @@ async fn test_vended_core_bpf_programs() {
     assert_bpf_program(&context, &solana_sdk_ids::config::id()).await;
     assert_bpf_program(&context, &solana_sdk_ids::feature::id()).await;
     assert_bpf_program(&context, &solana_sdk_ids::stake::id()).await;
-}
-
-// Note this test has to use an entry from `solana_builtins::BUILTINS` with a
-// `core_bpf_migration_config` set.
-#[tokio::test]
-async fn test_add_core_bpf_program_manually() {
-    // Core BPF program: Slashing.
-    let program_id = Pubkey::from_str_const("S1ashing11111111111111111111111111111111111");
-
-    let mut program_test = ProgramTest::default();
-    program_test.add_upgradeable_program_to_genesis("noop_program", &program_id);
-
-    let context = program_test.start_with_context().await;
-
-    // Assert the program is a BPF Loader Upgradeable program.
-    assert_bpf_program(&context, &program_id).await;
-
-    // Invoke the program.
-    let instruction = Instruction::new_with_bytes(program_id, &[], Vec::new());
-    let transaction = Transaction::new_signed_with_payer(
-        &[instruction],
-        Some(&context.payer.pubkey()),
-        &[&context.payer],
-        context.last_blockhash,
-    );
-    context
-        .banks_client
-        .process_transaction(transaction)
-        .await
-        .unwrap();
 }


### PR DESCRIPTION
#### Problem
SIMD-0204, migrating the slashing program from the buffer account to the vanity address is not planned to be activated on any cluster.

We will supercede this with a SIMD to add the alpenglow voting violations.

#### Summary of Changes
Remove the code associated with this migration as well as the (2?!?) feature flags

#### Testing
This feature isn't active on any cluster, did not test this apart from unit tests and local-cluster tests
