### PR TITLE
fix: restore dcou gated formatting

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ dev-context-only-utils = [
     "solana-perf/dev-context-only-utils",
     "solana-runtime/dev-context-only-utils",
     "solana-streamer/dev-context-only-utils",
+    "solana-tpu-client-next/dev-context-only-utils",
     "agave-votor/dev-context-only-utils",
 ]
 frozen-abi = [

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -14,14 +14,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
+dev-context-only-utils = [
+    "solana-core/dev-context-only-utils",
+    "agave-votor-messages/dev-context-only-utils",
+    "solana-tpu-client-next/dev-context-only-utils",
+]
 
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
-agave-votor-messages = { workspace = true, features = ["dev-context-only-utils"] }
+agave-votor-messages = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
@@ -34,7 +38,7 @@ solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }
-solana-core = { workspace = true, features = ["dev-context-only-utils"] }
+solana-core = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-feature-gate-interface = { workspace = true }
@@ -68,7 +72,7 @@ solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tpu-client = { workspace = true }
-solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
+solana-tpu-client-next = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-turbine = { workspace = true }


### PR DESCRIPTION
#### Problem

secondary run is failing: https://buildkite.com/anza/agave-secondary/builds/4208. ci is detecting dcou enabled

```
RUSTC_BOOTSTRAP=1 cargo +1.96.0 build --profile release -Z unstable-options --unit-graph --bin solana-stake-accounts --bin solana-tokens --bin agave-install-init --bin solana-test-validator --bin agave-install --bin solana --bin solana-keygen --bin agave-validator --bin agave-watchtower --bin solana-gossip --bin solana-genesis --bin solana-faucet --workspace
```

(looks like this was introduced in https://github.com/anza-xyz/agave/pull/12916)

#### Summary of Changes

restore dcou gated formatting in local-cluster