### PR TITLE
ci: run release dcou check in sanity

### DIFF
--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -82,4 +82,6 @@ EOF
   fi
 )
 
+./scripts/cargo-install-all.sh --dcou-check
+
 echo --- ok

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -82,6 +82,6 @@ EOF
   fi
 )
 
-./scripts/cargo-install-all.sh --dcou-check
+./scripts/cargo-install-all.sh --dcou-check-only
 
 echo --- ok

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -70,7 +70,7 @@ noSPLToken=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
-    if [[ $1 = --dcou-check ]]; then
+    if [[ $1 = --dcou-check-only ]]; then
       dcouCheckOnly=true
       shift
     elif [[ $1 = --debug ]]; then

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -130,17 +130,17 @@ while [[ -n $1 ]]; do
 done
 
 
-if [[ -n "$installDir" ]]; then
+if [[ -n "$dcouCheckOnly" ]]; then
+  echo "(dcou check mode: ignore installDir)"
+else
+  if [[ -z "$installDir" ]]; then
+    usage "Install directory not specified"
+  fi
+
   installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
   mkdir -p "$installDir/bin/deps"
 
   echo "Install location: $installDir ($buildProfile)"
-else
-  if [[ -n "$dcouCheckOnly" ]]; then
-    echo "(dcou check mode: ignore installDir validation)"
-  else
-    usage "Install directory not specified"
-  fi
 fi
 
 cd "$(dirname "$0")"/..

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -33,6 +33,7 @@ usage: $0 [+<cargo version>] [options] <install directory>
   +<cargo version>      Build using <cargo version> instead of the version defined in rust-toolchain.toml.
 
   Options:
+    --dcou-check                Only check that dcou feature activation is correct and exit (no build).
     --debug                     Build with debug profile instead of release profile.
     --release-with-debug        Build with release-with-debug profile instead of release profile.
     --release-with-lto          Build with release-with-lto profile instead of release profile.
@@ -58,6 +59,7 @@ buildProfileArg='--profile release'
 buildProfile='release'
 
 # Build selection
+dcouCheckOnly=
 noBuildDCOUBins=
 noBuildDeprecatedBins=
 noBuildDevBins=
@@ -68,7 +70,10 @@ noSPLToken=
 
 while [[ -n $1 ]]; do
   if [[ ${1:0:1} = - ]]; then
-    if [[ $1 = --debug ]]; then
+    if [[ $1 = --dcou-check ]]; then
+      dcouCheckOnly=true
+      shift
+    elif [[ $1 = --debug ]]; then
       buildProfileArg=      # the default cargo profile is 'debug'
       buildProfile='debug'
       shift
@@ -124,15 +129,17 @@ while [[ -n $1 ]]; do
   fi
 done
 
-if [[ -z "$installDir" ]]; then
-  usage "Install directory not specified"
-  exit 1
+
+if [[ -n "$installDir" ]]; then
+  installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
+  mkdir -p "$installDir/bin/deps"
+
+  echo "Install location: $installDir ($buildProfile)"
+else
+  if [[ -z "$dcouCheckOnly" ]]; then
+    usage "Install directory not specified"
+  fi
 fi
-
-installDir="$(mkdir -p "$installDir"; cd "$installDir"; pwd)"
-mkdir -p "$installDir/bin/deps"
-
-echo "Install location: $installDir ($buildProfile)"
 
 cd "$(dirname "$0")"/..
 
@@ -204,6 +211,21 @@ check_dcou() {
      exit 1
   fi
 
+  # Likewise, make sure the dev tools really do activate dcou. Done before
+  # building so that `--dcou-check` can verify both expectations up front.
+  if [[ ${#dcouBinArgs[@]} -gt 0 ]]; then
+    if ! check_dcou --manifest-path "dev-bins/Cargo.toml" "${dcouBinArgs[@]}"; then
+       echo 'dcou feature activation is incorrectly remain to be deactivated!'
+       exit 1
+    fi
+  fi
+
+  # Stop here if we only want to check the dcou feature activation.
+  if [[ -n "$dcouCheckOnly" ]]; then
+    echo 'dcou feature activation check passed.'
+    exit 0
+  fi
+
   # Build our production binaries without dcou.
   if [[ ${#binArgs[@]} -gt 0 ]]; then
     cargo_build "${binArgs[@]}" --workspace
@@ -211,10 +233,6 @@ check_dcou() {
 
   # Finally, build the remaining dev tools with dcou.
   if [[ ${#dcouBinArgs[@]} -gt 0 ]]; then
-    if ! check_dcou --manifest-path "dev-bins/Cargo.toml" "${dcouBinArgs[@]}"; then
-       echo 'dcou feature activation is incorrectly remain to be deactivated!'
-       exit 1
-    fi
     cargo_build --manifest-path "dev-bins/Cargo.toml" "${dcouBinArgs[@]}"
   fi
 
@@ -227,6 +245,11 @@ check_dcou() {
     "$cargo" $maybeRustVersion install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi
 )
+
+# The subshell above exits early in dcou-check mode; stop here before installing.
+if [[ -n "$dcouCheckOnly" ]]; then
+  exit 0
+fi
 
 for bin in "${BINS[@]}"; do
   cp -fv "target/$buildProfile/$bin" "$installDir"/bin

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -136,7 +136,9 @@ if [[ -n "$installDir" ]]; then
 
   echo "Install location: $installDir ($buildProfile)"
 else
-  if [[ -z "$dcouCheckOnly" ]]; then
+  if [[ -n "$dcouCheckOnly" ]]; then
+    echo "(dcou check mode: ignore installDir validation)"
+  else
     usage "Install directory not specified"
   fi
 fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -217,7 +217,7 @@ check_dcou() {
   # building so that `--dcou-check` can verify both expectations up front.
   if [[ ${#dcouBinArgs[@]} -gt 0 ]]; then
     if ! check_dcou --manifest-path "dev-bins/Cargo.toml" "${dcouBinArgs[@]}"; then
-       echo 'dcou feature activation is incorrectly remain to be deactivated!'
+       echo 'dcou feature activation is incorrectly deactivated!'
        exit 1
     fi
   fi

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -33,7 +33,7 @@ usage: $0 [+<cargo version>] [options] <install directory>
   +<cargo version>      Build using <cargo version> instead of the version defined in rust-toolchain.toml.
 
   Options:
-    --dcou-check                Only check that dcou feature activation is correct and exit (no build).
+    --dcou-check-only                Only check that dcou feature activation is correct and exit (no build).
     --debug                     Build with debug profile instead of release profile.
     --release-with-debug        Build with release-with-debug profile instead of release profile.
     --release-with-lto          Build with release-with-lto profile instead of release profile.


### PR DESCRIPTION
#### Problem

we have a dcou check in our release script. however, we don't run it in the main pipeline, which means problematic code can slip through and only be caught during the release process

#### Summary of Changes

- add `--dcou-check` option to the script
- run it in the `sanity` step