### PR TITLE
accounts-db: decouple flush dedup from iteration order

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -64,6 +64,7 @@ use {
         utils::{self, create_account_shared_data},
     },
     agave_fs::buffered_reader::RequiredLenBufFileRead,
+    ahash::HashMapExt,
     bv::BitVec,
     dashmap::{DashMap, DashSet},
     log::*,
@@ -1023,18 +1024,6 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
         accounts_db.add_root_and_flush_write_cache(0);
         accounts_db
     }
-}
-
-/// Which of a slot's cached accounts to write to storage when flushing it.
-#[derive(Debug, PartialEq, Eq)]
-enum PubkeysToFlush {
-    /// Flush every account in the slot, reclaiming nothing. Used for roots above
-    /// `max_clean_root` and when not cleaning, since an in-flight scan may still need
-    /// those versions.
-    All,
-    /// Flush only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
-    /// purging the rest from the index and reclaiming older versions.
-    Only(HashSet<Pubkey, PubkeyHasherBuilder>),
 }
 
 impl AccountsDb {
@@ -4701,27 +4690,29 @@ impl AccountsDb {
         // If there is a long running scan going on, this could prevent any cleaning
         // based on updates from slots > `max_clean_root`.
         let max_clean_root = self.max_clean_root(requested_flush_root);
-        self.flush_rooted_accounts_cache(requested_flush_root, max_clean_root, true)
+        self.flush_rooted_accounts_cache(
+            requested_flush_root,
+            FlushShouldClean::Yes { max_clean_root },
+        )
     }
 
     // Flush all rooted slots without cleaning. This is used when rooted accounts must be flushed
     // to storage but older versions of the accounts are still required. For example, the
     // older versions may be needed for snapshotting.
     fn flush_rooted_accounts_cache_without_clean(&self) -> (usize, usize, FlushStats) {
-        self.flush_rooted_accounts_cache(None, None, false)
+        self.flush_rooted_accounts_cache(None, FlushShouldClean::No)
     }
 
     /// Flush all rooted slots up to `requested_flush_root`.
     ///
-    /// When `should_clean` is true, only the newest version of each account across the
-    /// flushed roots (at or below `max_clean_root`) is written to storage; older
-    /// versions are purged from the index instead. When false, every account in
+    /// When `should_clean` is `Yes`, only the newest version of each account across the
+    /// flushed roots (at or below its `max_clean_root`) is written to storage; older
+    /// versions are purged from the index instead. When `No`, every account in
     /// every flushed root is written.
     fn flush_rooted_accounts_cache(
         &self,
         requested_flush_root: Option<Slot>,
-        max_clean_root: Option<Slot>,
-        should_clean: bool,
+        should_clean: FlushShouldClean,
     ) -> (usize, usize, FlushStats) {
         // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
         let flushed_roots: BTreeSet<Slot> =
@@ -4730,8 +4721,19 @@ impl AccountsDb {
         let num_new_roots = flushed_roots.len();
 
         // For each root being flushed, which of its cached accounts to write to storage.
-        let (pubkeys_to_flush, select_pubkeys_us) =
-            measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root, should_clean));
+        let (pubkeys_to_flush, select_pubkeys_us) = match should_clean {
+            FlushShouldClean::Yes { max_clean_root } => {
+                measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root))
+            }
+            // Not cleaning: every root writes all of its accounts.
+            FlushShouldClean::No => (
+                flushed_roots
+                    .iter()
+                    .map(|&root| (root, PubkeysToFlush::All))
+                    .collect(),
+                0,
+            ),
+        };
 
         // Iterate from highest to lowest so that we don't need to flush earlier
         // outdated updates in earlier roots
@@ -4755,35 +4757,29 @@ impl AccountsDb {
         (num_new_roots, num_roots_flushed, flush_stats)
     }
 
-    /// Determines which of each flushed root's accounts to write to storage. A root normally
-    /// keeps `Only` the newest version of each account, deduped newest-first; a root above
-    /// `max_clean_root` (or any root when not cleaning) instead flushes `All`.
+    /// Determines which of each flushed root's accounts to write to storage when cleaning: each
+    /// root keeps `Only` the newest version of each account, deduped newest-first. A root above
+    /// `max_clean_root` instead flushes `All`, since an in-flight scan may still need those
+    /// versions; `None` means there is no bound and every flushed root is cleaned.
     fn select_pubkeys_to_flush(
         &self,
         flushed_roots: &BTreeSet<Slot>,
         max_clean_root: Option<Slot>,
-        should_clean: bool,
     ) -> IntMap<Slot, PubkeysToFlush> {
-        let mut pubkeys_to_flush =
-            IntMap::with_capacity_and_hasher(flushed_roots.len(), BuildNoHashHasher::default());
+        let mut pubkeys_to_flush = IntMap::with_capacity(flushed_roots.len());
 
         // Presize the dedup set from the newest root (flushed first), doubled to leave room
         // for unique accounts contributed by older roots.
-        let dedup_capacity = if should_clean {
-            flushed_roots
-                .last()
-                .and_then(|&root| self.accounts_cache.slot_cache(root))
-                .map_or(0, |slot_cache| slot_cache.len() * 2)
-        } else {
-            0
-        };
+        let dedup_capacity = flushed_roots
+            .last()
+            .and_then(|&root| self.accounts_cache.slot_cache(root))
+            .map_or(0, |slot_cache| slot_cache.len() * 2);
         let mut written_accounts =
             HashSet::with_capacity_and_hasher(dedup_capacity, PubkeyHasherBuilder::default());
 
         // Iterate from newest root to oldest root being flushed in this batch
         for &root in flushed_roots.iter().rev() {
-            let cleaned =
-                should_clean && max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
+            let cleaned = max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
             let to_flush = if !cleaned {
                 PubkeysToFlush::All
             } else {
@@ -6965,6 +6961,30 @@ impl AccountsDb {
             );
         }
     }
+}
+
+/// Whether a rooted-cache flush should clean (dedup across roots, keeping only the newest
+/// version of each account and reclaiming older ones) or write every account untouched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlushShouldClean {
+    /// Write every account in every flushed root. Older versions must be preserved (e.g. for
+    /// snapshotting).
+    No,
+    /// Clean roots at or below `max_clean_root`; roots above it still flush all their accounts
+    /// (`None` means clean every flushed root).
+    Yes { max_clean_root: Option<Slot> },
+}
+
+/// Which of a slot's cached accounts to write to storage when flushing it.
+#[derive(Debug, PartialEq, Eq)]
+enum PubkeysToFlush {
+    /// Flush every account in the slot, reclaiming nothing. Used for roots above
+    /// `max_clean_root` and when not cleaning, since an in-flight scan may still need
+    /// those versions.
+    All,
+    /// Flush only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
+    /// purging the rest from the index and reclaiming older versions.
+    Only(HashSet<Pubkey, PubkeyHasherBuilder>),
 }
 
 /// Specify whether obsolete accounts should be marked or not during reclaims

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1025,6 +1025,18 @@ impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
     }
 }
 
+/// Which of a slot's cached accounts to write to storage when flushing it.
+#[derive(Debug, PartialEq, Eq)]
+enum PubkeysToFlush {
+    /// Flush every account in the slot, reclaiming nothing. Used for roots above
+    /// `max_clean_root` and when not cleaning, since an in-flight scan may still need
+    /// those versions.
+    All,
+    /// Flush only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
+    /// purging the rest from the index and reclaiming older versions.
+    Only(HashSet<Pubkey>),
+}
+
 impl AccountsDb {
     // The default high and low watermark sizes for the accounts read cache.
     // If the cache size exceeds MAX_SIZE_HI, it'll evict entries until the size is <= MAX_SIZE_LO.
@@ -4673,6 +4685,7 @@ impl AccountsDb {
                 flush_stats.store_accounts_timing.handle_reclaims_elapsed,
                 i64
             ),
+            ("select_pubkeys_us", flush_stats.select_pubkeys_us.0, i64),
         );
     }
 
@@ -4688,36 +4701,27 @@ impl AccountsDb {
         // If there is a long running scan going on, this could prevent any cleaning
         // based on updates from slots > `max_clean_root`.
         let max_clean_root = self.max_clean_root(requested_flush_root);
-
-        let mut written_accounts = HashSet::new();
-
-        let mut should_flush_f = {
-            Some(move |&pubkey: &Pubkey| {
-                // if not in hashset, then not flushed previously, so flush it
-                written_accounts.insert(pubkey)
-            })
-        };
-
-        self.flush_rooted_accounts_cache(
-            requested_flush_root,
-            max_clean_root,
-            should_flush_f.as_mut(),
-        )
+        self.flush_rooted_accounts_cache(requested_flush_root, max_clean_root, true)
     }
 
     // Flush all rooted slots without cleaning. This is used when rooted accounts must be flushed
     // to storage but older versions of the accounts are still required. For example, the
     // older versions may be needed for snapshotting.
     fn flush_rooted_accounts_cache_without_clean(&self) -> (usize, usize, FlushStats) {
-        self.flush_rooted_accounts_cache(None, None, None::<&mut fn(&_) -> bool>)
+        self.flush_rooted_accounts_cache(None, None, false)
     }
 
     /// Flush all rooted slots up to `requested_flush_root`.
+    ///
+    /// When `clean` is true, only the newest version of each account across the
+    /// flushed roots (at or below `max_clean_root`) is written to storage; older
+    /// versions are purged from the index instead. When false, every account in
+    /// every flushed root is written.
     fn flush_rooted_accounts_cache(
         &self,
         requested_flush_root: Option<Slot>,
         max_clean_root: Option<Slot>,
-        mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
+        clean: bool,
     ) -> (usize, usize, FlushStats) {
         // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
         let flushed_roots: BTreeSet<Slot> =
@@ -4725,14 +4729,19 @@ impl AccountsDb {
         let max_flush_root = flushed_roots.last().copied();
         let num_new_roots = flushed_roots.len();
 
+        // For each root being flushed, which of its cached accounts to write to storage.
+        let (pubkeys_to_flush, select_pubkeys_us) =
+            measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root, clean));
+
         // Iterate from highest to lowest so that we don't need to flush earlier
         // outdated updates in earlier roots
         let mut num_roots_flushed = 0;
-        let mut flush_stats = FlushStats::default();
+        let mut flush_stats = FlushStats {
+            select_pubkeys_us: Saturating(select_pubkeys_us),
+            ..FlushStats::default()
+        };
         for root in flushed_roots.into_iter().rev() {
-            if let Some(stats) =
-                self.flush_slot_cache(root, should_flush_f.as_mut(), max_clean_root)
-            {
+            if let Some(stats) = self.flush_slot_cache(root, &pubkeys_to_flush[&root]) {
                 num_roots_flushed += 1;
                 flush_stats.accumulate(&stats);
             }
@@ -4746,37 +4755,73 @@ impl AccountsDb {
         (num_new_roots, num_roots_flushed, flush_stats)
     }
 
+    /// Determines which of each flushed root's accounts to write to storage. A root normally
+    /// keeps `Only` the newest version of each account, deduped newest-first; a root above
+    /// `max_clean_root` (or any root when not cleaning) instead flushes `All`.
+    fn select_pubkeys_to_flush(
+        &self,
+        flushed_roots: &BTreeSet<Slot>,
+        max_clean_root: Option<Slot>,
+        clean: bool,
+    ) -> HashMap<Slot, PubkeysToFlush> {
+        let mut pubkeys_to_flush = HashMap::with_capacity(flushed_roots.len());
+
+        // Presize the dedup set from the newest root (flushed first), doubled to leave room
+        // for unique accounts contributed by older roots.
+        let dedup_capacity = if clean {
+            flushed_roots
+                .last()
+                .and_then(|&root| self.accounts_cache.slot_cache(root))
+                .map_or(0, |slot_cache| slot_cache.len() * 2)
+        } else {
+            0
+        };
+        let mut written_accounts = HashSet::with_capacity(dedup_capacity);
+
+        // Iterate from newest root to oldest root being flushed in this batch
+        for &root in flushed_roots.iter().rev() {
+            let cleaned =
+                clean && max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
+            let to_flush = if !cleaned {
+                PubkeysToFlush::All
+            } else {
+                let mut flush_keys = HashSet::new();
+                if let Some(slot_cache) = self.accounts_cache.slot_cache(root) {
+                    for entry in slot_cache.iter() {
+                        let pubkey = *entry.key();
+                        // If not seen in a newer root, this is the newest version, so flush it.
+                        if written_accounts.insert(pubkey) {
+                            flush_keys.insert(pubkey);
+                        }
+                    }
+                }
+                PubkeysToFlush::Only(flush_keys)
+            };
+            pubkeys_to_flush.insert(root, to_flush);
+        }
+        pubkeys_to_flush
+    }
+
     fn do_flush_slot_cache(
         &self,
         slot: Slot,
         slot_cache: &SlotCache,
-        mut should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
-        max_clean_root: Option<Slot>,
+        pubkeys_to_flush: &PubkeysToFlush,
     ) -> FlushStats {
         debug_assert!(self.accounts_index.is_alive_root(slot));
         let mut flush_stats = FlushStats::default();
         let iter_items: Vec<_> = slot_cache.iter().collect();
-        let mut pubkeys: Vec<Pubkey> = vec![];
-        if should_flush_f.is_some() {
-            if let Some(max_clean_root) = max_clean_root {
-                if slot > max_clean_root {
-                    // Only if the root is greater than the `max_clean_root` do we
-                    // have to prevent cleaning, otherwise, just default to `should_flush_f`
-                    // for any slots <= `max_clean_root`
-                    should_flush_f = None;
-                }
-            }
-        }
+        let mut purged_pubkeys: Vec<Pubkey> = vec![];
 
         let accounts: Vec<(&Pubkey, &AccountSharedData)> = iter_items
             .iter()
             .filter_map(|iter_item| {
                 let key = iter_item.key();
                 let account = &iter_item.value().account;
-                let should_flush = should_flush_f
-                    .as_mut()
-                    .map(|should_flush_f| should_flush_f(key))
-                    .unwrap_or(true);
+                let should_flush = match pubkeys_to_flush {
+                    PubkeysToFlush::All => true,
+                    PubkeysToFlush::Only(flush_keys) => flush_keys.contains(key),
+                };
                 if should_flush {
                     flush_stats.num_bytes_flushed +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
@@ -4785,7 +4830,7 @@ impl AccountsDb {
                 } else {
                     // If we don't flush, we have to remove the entry from the
                     // index, since it's equivalent to purging
-                    pubkeys.push(*key);
+                    purged_pubkeys.push(*key);
                     flush_stats.num_bytes_purged +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
                     flush_stats.num_accounts_purged += 1;
@@ -4797,17 +4842,16 @@ impl AccountsDb {
         let is_dead_slot = accounts.is_empty();
         // Remove the account index entries from earlier roots that are outdated by later roots.
         // Safe because queries to the index will be reading updates from later roots.
-        self.purge_slot_cache_pubkeys(slot, pubkeys, is_dead_slot);
+        self.purge_slot_cache_pubkeys(slot, purged_pubkeys, is_dead_slot);
 
-        // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning
-        // Cleaning is enabled if `should_flush_f` is Some.
-        // should_flush_f is set to None when
+        // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning.
+        // Cleaning is enabled if pubkeys_to_flush is PubkeysToFlush::Only
+        // pubkeys_to_flush is PubkeysToFlush::All when
         // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
         // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
-        let reclaim_method = if should_flush_f.is_some() {
-            UpsertReclaim::ReclaimOldSlots
-        } else {
-            UpsertReclaim::IgnoreReclaims
+        let reclaim_method = match pubkeys_to_flush {
+            PubkeysToFlush::Only(_) => UpsertReclaim::ReclaimOldSlots,
+            PubkeysToFlush::All => UpsertReclaim::IgnoreReclaims,
         };
 
         if !is_dead_slot {
@@ -4863,19 +4907,18 @@ impl AccountsDb {
         flush_stats
     }
 
-    /// `should_flush_f` is an optional closure that determines whether a given
-    /// account should be flushed. Passing `None` will by default flush all
-    /// accounts
+    /// `pubkeys_to_flush` selects which accounts are written to storage: `Only(set)` flushes
+    /// just the pubkeys in the set (purging the rest from the index), while `All` flushes
+    /// every account in the slot.
     fn flush_slot_cache(
         &self,
         slot: Slot,
-        should_flush_f: Option<&mut impl FnMut(&Pubkey) -> bool>,
-        max_clean_root: Option<Slot>,
+        pubkeys_to_flush: &PubkeysToFlush,
     ) -> Option<FlushStats> {
         // If a slot cache exists for this slot, flush it.
-        self.accounts_cache.slot_cache(slot).map(|slot_cache| {
-            self.do_flush_slot_cache(slot, &slot_cache, should_flush_f, max_clean_root)
-        })
+        self.accounts_cache
+            .slot_cache(slot)
+            .map(|slot_cache| self.do_flush_slot_cache(slot, &slot_cache, pubkeys_to_flush))
     }
 
     fn report_store_stats(&self) {
@@ -7013,7 +7056,7 @@ impl AccountsDb {
                 .contains(&slot),
             "slot: {slot}"
         );
-        self.flush_slot_cache(slot, None::<&mut fn(&_) -> bool>, None);
+        self.flush_slot_cache(slot, &PubkeysToFlush::All);
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1034,7 +1034,7 @@ enum PubkeysToFlush {
     All,
     /// Flush only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
     /// purging the rest from the index and reclaiming older versions.
-    Only(HashSet<Pubkey>),
+    Only(HashSet<Pubkey, PubkeyHasherBuilder>),
 }
 
 impl AccountsDb {
@@ -4713,7 +4713,7 @@ impl AccountsDb {
 
     /// Flush all rooted slots up to `requested_flush_root`.
     ///
-    /// When `clean` is true, only the newest version of each account across the
+    /// When `should_clean` is true, only the newest version of each account across the
     /// flushed roots (at or below `max_clean_root`) is written to storage; older
     /// versions are purged from the index instead. When false, every account in
     /// every flushed root is written.
@@ -4721,7 +4721,7 @@ impl AccountsDb {
         &self,
         requested_flush_root: Option<Slot>,
         max_clean_root: Option<Slot>,
-        clean: bool,
+        should_clean: bool,
     ) -> (usize, usize, FlushStats) {
         // Always flush up to `requested_flush_root`, which is necessary for things like snapshotting.
         let flushed_roots: BTreeSet<Slot> =
@@ -4731,7 +4731,7 @@ impl AccountsDb {
 
         // For each root being flushed, which of its cached accounts to write to storage.
         let (pubkeys_to_flush, select_pubkeys_us) =
-            measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root, clean));
+            measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root, should_clean));
 
         // Iterate from highest to lowest so that we don't need to flush earlier
         // outdated updates in earlier roots
@@ -4762,13 +4762,14 @@ impl AccountsDb {
         &self,
         flushed_roots: &BTreeSet<Slot>,
         max_clean_root: Option<Slot>,
-        clean: bool,
-    ) -> HashMap<Slot, PubkeysToFlush> {
-        let mut pubkeys_to_flush = HashMap::with_capacity(flushed_roots.len());
+        should_clean: bool,
+    ) -> IntMap<Slot, PubkeysToFlush> {
+        let mut pubkeys_to_flush =
+            IntMap::with_capacity_and_hasher(flushed_roots.len(), BuildNoHashHasher::default());
 
         // Presize the dedup set from the newest root (flushed first), doubled to leave room
         // for unique accounts contributed by older roots.
-        let dedup_capacity = if clean {
+        let dedup_capacity = if should_clean {
             flushed_roots
                 .last()
                 .and_then(|&root| self.accounts_cache.slot_cache(root))
@@ -4776,16 +4777,17 @@ impl AccountsDb {
         } else {
             0
         };
-        let mut written_accounts = HashSet::with_capacity(dedup_capacity);
+        let mut written_accounts =
+            HashSet::with_capacity_and_hasher(dedup_capacity, PubkeyHasherBuilder::default());
 
         // Iterate from newest root to oldest root being flushed in this batch
         for &root in flushed_roots.iter().rev() {
             let cleaned =
-                clean && max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
+                should_clean && max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
             let to_flush = if !cleaned {
                 PubkeysToFlush::All
             } else {
-                let mut flush_keys = HashSet::new();
+                let mut flush_keys = HashSet::default();
                 if let Some(slot_cache) = self.accounts_cache.slot_cache(root) {
                     for entry in slot_cache.iter() {
                         let pubkey = *entry.key();

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -353,6 +353,7 @@ pub struct FlushStats {
     pub num_bytes_purged: Saturating<u64>,
     pub store_accounts_timing: StoreAccountsTiming,
     pub store_accounts_total_us: Saturating<u64>,
+    pub select_pubkeys_us: Saturating<u64>,
 }
 
 impl FlushStats {
@@ -364,6 +365,7 @@ impl FlushStats {
         self.store_accounts_timing
             .accumulate(&other.store_accounts_timing);
         self.store_accounts_total_us += other.store_accounts_total_us;
+        self.select_pubkeys_us += other.select_pubkeys_us;
     }
 }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3331,8 +3331,7 @@ fn test_load_with_read_only_accounts_cache() {
 }
 
 /// `select_pubkeys_to_flush` keeps only the newest version of each account across the
-/// cleaned roots, flushes roots above `max_clean_root` in full, and flushes everything
-/// when not cleaning.
+/// cleaned roots and flushes roots above `max_clean_root` in full.
 #[test]
 fn test_select_pubkeys_to_flush() {
     let db = AccountsDb::new_single_for_tests();
@@ -3348,24 +3347,25 @@ fn test_select_pubkeys_to_flush() {
     let shared_only = PubkeysToFlush::Only([shared].into_iter().collect());
     let deduped = PubkeysToFlush::Only(HashSet::default());
 
-    // All roots cleaned: `shared` is written only at its newest root (15), deduped from 5 and 10.
-    let plans = db.select_pubkeys_to_flush(&roots, Some(15), true);
+    // No bound: every flushed root is cleaned, so `shared` is written only at its newest root
+    // (15), deduped from 5 and 10.
+    let plans = db.select_pubkeys_to_flush(&roots, None);
+    assert_eq!(plans[&15], shared_only);
+    assert_eq!(plans[&10], deduped);
+    assert_eq!(plans[&5], deduped);
+
+    // max_clean_root = 15 (== newest root): same result, every root is at or below the bound.
+    let plans = db.select_pubkeys_to_flush(&roots, Some(15));
     assert_eq!(plans[&15], shared_only);
     assert_eq!(plans[&10], deduped);
     assert_eq!(plans[&5], deduped);
 
     // max_clean_root = 10: root 15 is above the boundary and flushes `All` (no dedup), so
     // `shared` is not dropped from root 10 — a scan at root 10 may still need that version.
-    let plans = db.select_pubkeys_to_flush(&roots, Some(10), true);
+    let plans = db.select_pubkeys_to_flush(&roots, Some(10));
     assert_eq!(plans[&15], PubkeysToFlush::All);
     assert_eq!(plans[&10], shared_only);
     assert_eq!(plans[&5], deduped);
-
-    // Not cleaning: every root flushes `All`.
-    let plans = db.select_pubkeys_to_flush(&roots, Some(15), false);
-    for root in &roots {
-        assert_eq!(plans[root], PubkeysToFlush::All);
-    }
 }
 
 #[test]

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3330,6 +3330,44 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(slot, 2);
 }
 
+/// `select_pubkeys_to_flush` keeps only the newest version of each account across the
+/// cleaned roots, flushes roots above `max_clean_root` in full, and flushes everything
+/// when not cleaning.
+#[test]
+fn test_select_pubkeys_to_flush() {
+    let db = AccountsDb::new_single_for_tests();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // The same account is written in all three roots.
+    let roots = BTreeSet::from([5, 10, 15]);
+    let shared = Pubkey::new_unique();
+    for &slot in &roots {
+        db.accounts_cache.store(slot, &shared, account.clone());
+    }
+
+    let shared_only = PubkeysToFlush::Only(HashSet::from([shared]));
+    let deduped = PubkeysToFlush::Only(HashSet::new());
+
+    // All roots cleaned: `shared` is written only at its newest root (15), deduped from 5 and 10.
+    let plans = db.select_pubkeys_to_flush(&roots, Some(15), true);
+    assert_eq!(plans[&15], shared_only);
+    assert_eq!(plans[&10], deduped);
+    assert_eq!(plans[&5], deduped);
+
+    // max_clean_root = 10: root 15 is above the boundary and flushes `All` (no dedup), so
+    // `shared` is not dropped from root 10 — a scan at root 10 may still need that version.
+    let plans = db.select_pubkeys_to_flush(&roots, Some(10), true);
+    assert_eq!(plans[&15], PubkeysToFlush::All);
+    assert_eq!(plans[&10], shared_only);
+    assert_eq!(plans[&5], deduped);
+
+    // Not cleaning: every root flushes `All`.
+    let plans = db.select_pubkeys_to_flush(&roots, Some(15), false);
+    for root in &roots {
+        assert_eq!(plans[root], PubkeysToFlush::All);
+    }
+}
+
 #[test]
 fn test_flush_cache_clean() {
     let db = Arc::new(AccountsDb::new_single_for_tests());

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3345,8 +3345,8 @@ fn test_select_pubkeys_to_flush() {
         db.accounts_cache.store(slot, &shared, account.clone());
     }
 
-    let shared_only = PubkeysToFlush::Only(HashSet::from([shared]));
-    let deduped = PubkeysToFlush::Only(HashSet::new());
+    let shared_only = PubkeysToFlush::Only([shared].into_iter().collect());
+    let deduped = PubkeysToFlush::Only(HashSet::default());
 
     // All roots cleaned: `shared` is written only at its newest root (15), deduped from 5 and 10.
     let plans = db.select_pubkeys_to_flush(&roots, Some(15), true);


### PR DESCRIPTION
#### Problem
- Deduplication inline and reverse flushing adds additional complexity, while saving limited cycles vs deduplication before hand a flushing in order

#### Summary of Changes
- deduplicate inline
- Will be 3 follow-up PRs once this is merged 
-- Iterate in order rather than reverse during flush
-- Simplify load logic 
-- Simplify unflushed root logic in accounts cache

#### Testing
Note: Testing was run with all 4 changes, not this single change. Didn't see the need to run each individually. 

Load/Store times:
Load time is reduced by 10% as load function is simplified. 
<img width="1727" height="640" alt="image" src="https://github.com/user-attachments/assets/82a9d852-e192-48a3-98a0-31e9c80cae6d" />

Flush:
Before restart this was running the reduced memory single hashset version (Where the hashset index (Pubkey, Slot). 
After the restart this was running multiple hashset version implemented here (Where presence of a pubkey is tracked in one Hashset and there is a separate per slot Hashset of pubkeys present. 

Perf is better in the second one despite additional allocations
<img width="1727" height="640" alt="image" src="https://github.com/user-attachments/assets/4ad26d37-0e13-4ac4-b1b8-d27a7e884639" />

Edit Improved Flush with new hasher: It looks like perf improves beyond baseline with the updated hasher. 
<img width="918" height="285" alt="image" src="https://github.com/user-attachments/assets/e54b904f-565e-40c3-bd8b-6079945dc11a" />



Fixes #
