### PR TITLE
bcp: enforce clock bounds on first alpenglow block

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -6118,9 +6118,16 @@ pub mod tests {
         });
         let header_component = BlockComponent::new_block_marker(header);
 
+        let block_producer_time_nanos = u64::try_from(
+            genesis_config
+                .creation_time
+                .saturating_mul(1_000_000_000)
+                .saturating_add(1),
+        )
+        .unwrap();
         let footer = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
-            block_producer_time_nanos: 1_000_000_000,
+            block_producer_time_nanos,
             block_user_agent: b"test".to_vec(),
             block_final_cert: None,
             skip_reward_cert: None,

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -454,12 +454,11 @@ impl BlockComponentProcessor {
         parent_bank: &Bank,
         footer: &BlockFooterV1,
     ) -> Result<(), BlockComponentProcessorError> {
-        // Get parent time from nanosecond clock account
-        // If nanosecond clock hasn't been populated, don't enforce the bounds; note that the
-        // nanosecond clock is populated as soon as Alpenglow migration is complete.
-        let Some(parent_time_nanos) = parent_bank.get_nanosecond_clock() else {
-            return Ok(());
-        };
+        // Get parent time from the nanosecond clock account, or from the Tower-based
+        // clock for the first Alpenglow block.
+        let parent_time_nanos = parent_bank
+            .get_nanosecond_clock()
+            .unwrap_or_else(|| bank.clock().unix_timestamp.saturating_mul(1_000_000_000));
 
         let parent_slot = parent_bank.slot();
         let current_time_nanos =
@@ -1214,6 +1213,40 @@ mod tests {
     fn test_clock_bounds_timestamp_equals_parent() {
         // Timestamp equal to parent time (should fail, must be strictly greater)
         test_clock_bounds_helper(1, |parent_time, _, _| parent_time, false);
+    }
+
+    #[test]
+    fn test_clock_bounds_without_parent_nanosecond_clock_rejects_out_of_bounds() {
+        let mut processor = BlockComponentProcessor {
+            has_header: true,
+            ..Default::default()
+        };
+
+        let (parent, bank_forks) = create_test_bank_alpenglow();
+        assert_eq!(parent.get_nanosecond_clock(), None);
+
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let parent_time_nanos = bank.clock().unix_timestamp.saturating_mul(1_000_000_000);
+        let elapsed_slot_duration_nanos =
+            bank.slot_range_duration_nanos(parent.slot().saturating_add(1), bank.slot());
+        let (_, upper_bound) = BlockComponentProcessor::nanosecond_time_bounds(
+            parent_time_nanos,
+            elapsed_slot_duration_nanos,
+        );
+
+        let footer = VersionedBlockFooter::V1(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: u64::try_from(upper_bound.saturating_add(1)).unwrap(),
+            block_user_agent: vec![],
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+
+        assert!(matches!(
+            processor.on_footer(bank, parent, footer, None),
+            Err(BlockComponentProcessorError::NanosecondClockOutOfBounds)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
For the very first alpenglow block we don't enforce bounds on the clock value specified by the leader.
This means the leader could set the clock to some ridiculous value

#### Summary of Changes
Instead enforce the bound correctly using the Tower based clock value. This matches what BCL already does

#### Testing
Unit tests