### PR TITLE
votor: rm unnecessary stake check

### DIFF
--- a/votor/src/staked_validators_cache.rs
+++ b/votor/src/staked_validators_cache.rs
@@ -106,12 +106,7 @@ impl StakedValidatorsCache {
 
         let mut nodes: Vec<_> = epoch_staked_nodes
             .iter()
-            .filter(|(pubkey, stake)| {
-                let positive_stake = **stake > 0;
-                let not_self = pubkey != &&cluster_info.id();
-
-                positive_stake && (self.include_self || not_self)
-            })
+            .filter(|(pubkey, _stake)| self.include_self || pubkey != &&cluster_info.id())
             .filter_map(|(pubkey, stake)| {
                 cluster_info.lookup_contact_info(pubkey, |node| {
                     node.alpenglow().map(|alpenglow_socket| Node {


### PR DESCRIPTION
#### Problem

Votor checks for stake > 0 in epoch_staked_nodes

#### Summary of Changes

rm the check

#### Testing

CI only. Logic: if a node with 0 stake is in staked_nodes list we are in deep trouble.
