### PR TITLE
core: Cleanup os_network_limits datapoint

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -625,30 +625,37 @@ impl SystemMonitorService {
     fn linux_report_network_limits(
         current_limits: &[(&'static str, &'static InterestingLimit, i64)],
     ) -> bool {
-        current_limits
-            .iter()
-            .all(|(key, interesting_limit, current_value)| {
-                datapoint_warn!("os-config", (key, *current_value, i64));
-                match interesting_limit {
-                    InterestingLimit::Recommend(recommended_value)
-                        if current_value < recommended_value =>
-                    {
-                        warn!(
-                            "  {key}: recommended={recommended_value}, current={current_value} \
-                             too small"
-                        );
-                        false
-                    }
-                    InterestingLimit::Recommend(recommended_value) => {
-                        info!("  {key}: recommended={recommended_value} current={current_value}");
-                        true
-                    }
-                    InterestingLimit::QueryOnly => {
-                        info!("  {key}: report-only --  current={current_value}");
-                        true
-                    }
+        datapoint_info!(
+            "os-config",
+            ("platform", platform_id(), String),
+            (current_limits[0].0, current_limits[0].2, i64),
+            (current_limits[1].0, current_limits[1].2, i64),
+            (current_limits[2].0, current_limits[2].2, i64),
+            (current_limits[3].0, current_limits[3].2, i64),
+            (current_limits[4].0, current_limits[4].2, i64)
+        );
+
+        current_limits.iter().all(
+            |(key, interesting_limit, current_value)| match interesting_limit {
+                InterestingLimit::Recommend(recommended_value)
+                    if current_value < recommended_value =>
+                {
+                    warn!(
+                        "  {key}: recommended={recommended_value}, current={current_value} too \
+                         small"
+                    );
+                    false
                 }
-            })
+                InterestingLimit::Recommend(recommended_value) => {
+                    info!("  {key}: recommended={recommended_value} current={current_value}");
+                    true
+                }
+                InterestingLimit::QueryOnly => {
+                    info!("  {key}: report-only --  current={current_value}");
+                    true
+                }
+            },
+        )
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -659,7 +666,6 @@ impl SystemMonitorService {
 
     #[cfg(target_os = "linux")]
     pub fn check_os_network_limits() -> bool {
-        datapoint_info!("os-config", ("platform", platform_id(), String));
         let current_limits = Self::linux_get_current_network_limits();
         Self::linux_report_network_limits(&current_limits)
     }

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -580,6 +580,15 @@ const INTERESTING_LIMITS: &[(&str, InterestingLimit)] = &[
     ("net.core.netdev_max_backlog", InterestingLimit::QueryOnly),
 ];
 
+struct NetworkLimit {
+    /// The kernel parameter being read
+    key: &'static str,
+    /// The Agave suggested limit
+    limit: &'static InterestingLimit,
+    /// The value read back from the system
+    current_value: i64,
+}
+
 impl SystemMonitorService {
     pub fn new(exit: Arc<AtomicBool>, config: SystemMonitorStatsReportConfig) -> Self {
         info!("Starting SystemMonitorService");
@@ -594,7 +603,7 @@ impl SystemMonitorService {
     }
 
     #[cfg(target_os = "linux")]
-    fn linux_get_current_network_limits() -> Vec<(&'static str, &'static InterestingLimit, i64)> {
+    fn linux_get_current_network_limits() -> Vec<NetworkLimit> {
         use sysctl::Sysctl;
 
         fn sysctl_read(name: &str) -> Result<String, sysctl::SysctlError> {
@@ -608,7 +617,7 @@ impl SystemMonitorService {
         }
         INTERESTING_LIMITS
             .iter()
-            .map(|(key, interesting_limit)| {
+            .map(|(key, limit)| {
                 let current_value = sysctl_read(key)
                     .map_err(|e| normalize_err(key, e))
                     .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
@@ -616,27 +625,33 @@ impl SystemMonitorService {
                         error!("{e}");
                         -1
                     });
-                (*key, interesting_limit, current_value)
+                NetworkLimit {
+                    key,
+                    limit,
+                    current_value,
+                }
             })
             .collect::<Vec<_>>()
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    fn linux_report_network_limits(
-        current_limits: &[(&'static str, &'static InterestingLimit, i64)],
-    ) -> bool {
+    fn linux_report_network_limits(limits: &[NetworkLimit]) -> bool {
         datapoint_info!(
             "os-config",
             ("platform", platform_id(), String),
-            (current_limits[0].0, current_limits[0].2, i64),
-            (current_limits[1].0, current_limits[1].2, i64),
-            (current_limits[2].0, current_limits[2].2, i64),
-            (current_limits[3].0, current_limits[3].2, i64),
-            (current_limits[4].0, current_limits[4].2, i64)
+            (limits[0].key, limits[0].current_value, i64),
+            (limits[1].key, limits[1].current_value, i64),
+            (limits[2].key, limits[2].current_value, i64),
+            (limits[3].key, limits[3].current_value, i64),
+            (limits[4].key, limits[4].current_value, i64)
         );
 
-        current_limits.iter().all(
-            |(key, interesting_limit, current_value)| match interesting_limit {
+        limits.iter().all(
+            |NetworkLimit {
+                 key,
+                 limit,
+                 current_value,
+             }| match limit {
                 InterestingLimit::Recommend(recommended_value)
                     if current_value < recommended_value =>
                 {

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -572,7 +572,7 @@ enum InterestingLimit {
 }
 
 #[cfg(target_os = "linux")]
-const INTERESTING_LIMITS: &[(&str, InterestingLimit)] = &[
+const INTERESTING_LIMITS: &[(&str, InterestingLimit); 5] = &[
     ("net.core.rmem_max", InterestingLimit::Recommend(134217728)),
     ("net.core.wmem_max", InterestingLimit::Recommend(134217728)),
     ("vm.max_map_count", InterestingLimit::Recommend(1000000)),
@@ -594,7 +594,7 @@ impl SystemMonitorService {
     }
 
     #[cfg(target_os = "linux")]
-    fn linux_get_current_network_limits() -> Vec<(&'static str, &'static InterestingLimit, i64)> {
+    fn linux_get_current_network_limits() -> [(&'static str, &'static InterestingLimit, i64); 5] {
         use sysctl::Sysctl;
 
         fn sysctl_read(name: &str) -> Result<String, sysctl::SysctlError> {
@@ -606,49 +606,64 @@ impl SystemMonitorService {
         fn normalize_err<E: std::fmt::Display>(key: &str, error: E) -> String {
             format!("Failed to query value for {key}: {error}")
         }
-        INTERESTING_LIMITS
-            .iter()
-            .map(|(key, interesting_limit)| {
-                let current_value = sysctl_read(key)
-                    .map_err(|e| normalize_err(key, e))
-                    .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
-                    .unwrap_or_else(|e| {
-                        error!("{e}");
-                        -1
-                    });
-                (*key, interesting_limit, current_value)
-            })
-            .collect::<Vec<_>>()
+
+        fn build_tuple(
+            (key, limit): &'static (&str, InterestingLimit),
+        ) -> (&'static str, &'static InterestingLimit, i64) {
+            let current_value = sysctl_read(key)
+                .map_err(|e| normalize_err(key, e))
+                .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
+                .unwrap_or_else(|e| {
+                    error!("{e}");
+                    -1
+                });
+            (key, limit, current_value)
+        }
+
+        [
+            build_tuple(&INTERESTING_LIMITS[0]),
+            build_tuple(&INTERESTING_LIMITS[1]),
+            build_tuple(&INTERESTING_LIMITS[2]),
+            build_tuple(&INTERESTING_LIMITS[3]),
+            build_tuple(&INTERESTING_LIMITS[4]),
+        ]
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn linux_report_network_limits(
-        current_limits: &[(&'static str, &'static InterestingLimit, i64)],
+        current_limits: [(&'static str, &'static InterestingLimit, i64); 5],
     ) -> bool {
-        current_limits
-            .iter()
-            .all(|(key, interesting_limit, current_value)| {
-                datapoint_warn!("os-config", (key, *current_value, i64));
-                match interesting_limit {
-                    InterestingLimit::Recommend(recommended_value)
-                        if current_value < recommended_value =>
-                    {
-                        warn!(
-                            "  {key}: recommended={recommended_value}, current={current_value} \
-                             too small"
-                        );
-                        false
-                    }
-                    InterestingLimit::Recommend(recommended_value) => {
-                        info!("  {key}: recommended={recommended_value} current={current_value}");
-                        true
-                    }
-                    InterestingLimit::QueryOnly => {
-                        info!("  {key}: report-only --  current={current_value}");
-                        true
-                    }
+        datapoint_info!(
+            "os-config",
+            ("platform", platform_id(), String),
+            (current_limits[0].0, current_limits[0].2, i64),
+            (current_limits[1].0, current_limits[1].2, i64),
+            (current_limits[2].0, current_limits[2].2, i64),
+            (current_limits[3].0, current_limits[3].2, i64),
+            (current_limits[4].0, current_limits[4].2, i64)
+        );
+
+        current_limits.iter().all(
+            |(key, interesting_limit, current_value)| match interesting_limit {
+                InterestingLimit::Recommend(recommended_value)
+                    if current_value < recommended_value =>
+                {
+                    warn!(
+                        "  {key}: recommended={recommended_value}, current={current_value} too \
+                         small"
+                    );
+                    false
                 }
-            })
+                InterestingLimit::Recommend(recommended_value) => {
+                    info!("  {key}: recommended={recommended_value} current={current_value}");
+                    true
+                }
+                InterestingLimit::QueryOnly => {
+                    info!("  {key}: report-only --  current={current_value}");
+                    true
+                }
+            },
+        )
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -659,9 +674,8 @@ impl SystemMonitorService {
 
     #[cfg(target_os = "linux")]
     pub fn check_os_network_limits() -> bool {
-        datapoint_info!("os-config", ("platform", platform_id(), String));
         let current_limits = Self::linux_get_current_network_limits();
-        Self::linux_report_network_limits(&current_limits)
+        Self::linux_report_network_limits(current_limits)
     }
 
     #[cfg(target_os = "linux")]

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -572,7 +572,7 @@ enum InterestingLimit {
 }
 
 #[cfg(target_os = "linux")]
-const INTERESTING_LIMITS: &[(&str, InterestingLimit); 5] = &[
+const INTERESTING_LIMITS: &[(&str, InterestingLimit)] = &[
     ("net.core.rmem_max", InterestingLimit::Recommend(134217728)),
     ("net.core.wmem_max", InterestingLimit::Recommend(134217728)),
     ("vm.max_map_count", InterestingLimit::Recommend(1000000)),
@@ -594,7 +594,7 @@ impl SystemMonitorService {
     }
 
     #[cfg(target_os = "linux")]
-    fn linux_get_current_network_limits() -> [(&'static str, &'static InterestingLimit, i64); 5] {
+    fn linux_get_current_network_limits() -> Vec<(&'static str, &'static InterestingLimit, i64)> {
         use sysctl::Sysctl;
 
         fn sysctl_read(name: &str) -> Result<String, sysctl::SysctlError> {
@@ -606,64 +606,49 @@ impl SystemMonitorService {
         fn normalize_err<E: std::fmt::Display>(key: &str, error: E) -> String {
             format!("Failed to query value for {key}: {error}")
         }
-
-        fn build_tuple(
-            (key, limit): &'static (&str, InterestingLimit),
-        ) -> (&'static str, &'static InterestingLimit, i64) {
-            let current_value = sysctl_read(key)
-                .map_err(|e| normalize_err(key, e))
-                .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
-                .unwrap_or_else(|e| {
-                    error!("{e}");
-                    -1
-                });
-            (key, limit, current_value)
-        }
-
-        [
-            build_tuple(&INTERESTING_LIMITS[0]),
-            build_tuple(&INTERESTING_LIMITS[1]),
-            build_tuple(&INTERESTING_LIMITS[2]),
-            build_tuple(&INTERESTING_LIMITS[3]),
-            build_tuple(&INTERESTING_LIMITS[4]),
-        ]
+        INTERESTING_LIMITS
+            .iter()
+            .map(|(key, interesting_limit)| {
+                let current_value = sysctl_read(key)
+                    .map_err(|e| normalize_err(key, e))
+                    .and_then(|val| val.parse::<i64>().map_err(|e| normalize_err(key, e)))
+                    .unwrap_or_else(|e| {
+                        error!("{e}");
+                        -1
+                    });
+                (*key, interesting_limit, current_value)
+            })
+            .collect::<Vec<_>>()
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn linux_report_network_limits(
-        current_limits: [(&'static str, &'static InterestingLimit, i64); 5],
+        current_limits: &[(&'static str, &'static InterestingLimit, i64)],
     ) -> bool {
-        datapoint_info!(
-            "os-config",
-            ("platform", platform_id(), String),
-            (current_limits[0].0, current_limits[0].2, i64),
-            (current_limits[1].0, current_limits[1].2, i64),
-            (current_limits[2].0, current_limits[2].2, i64),
-            (current_limits[3].0, current_limits[3].2, i64),
-            (current_limits[4].0, current_limits[4].2, i64)
-        );
-
-        current_limits.iter().all(
-            |(key, interesting_limit, current_value)| match interesting_limit {
-                InterestingLimit::Recommend(recommended_value)
-                    if current_value < recommended_value =>
-                {
-                    warn!(
-                        "  {key}: recommended={recommended_value}, current={current_value} too \
-                         small"
-                    );
-                    false
+        current_limits
+            .iter()
+            .all(|(key, interesting_limit, current_value)| {
+                datapoint_warn!("os-config", (key, *current_value, i64));
+                match interesting_limit {
+                    InterestingLimit::Recommend(recommended_value)
+                        if current_value < recommended_value =>
+                    {
+                        warn!(
+                            "  {key}: recommended={recommended_value}, current={current_value} \
+                             too small"
+                        );
+                        false
+                    }
+                    InterestingLimit::Recommend(recommended_value) => {
+                        info!("  {key}: recommended={recommended_value} current={current_value}");
+                        true
+                    }
+                    InterestingLimit::QueryOnly => {
+                        info!("  {key}: report-only --  current={current_value}");
+                        true
+                    }
                 }
-                InterestingLimit::Recommend(recommended_value) => {
-                    info!("  {key}: recommended={recommended_value} current={current_value}");
-                    true
-                }
-                InterestingLimit::QueryOnly => {
-                    info!("  {key}: report-only --  current={current_value}");
-                    true
-                }
-            },
-        )
+            })
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -674,8 +659,9 @@ impl SystemMonitorService {
 
     #[cfg(target_os = "linux")]
     pub fn check_os_network_limits() -> bool {
+        datapoint_info!("os-config", ("platform", platform_id(), String));
         let current_limits = Self::linux_get_current_network_limits();
-        Self::linux_report_network_limits(current_limits)
+        Self::linux_report_network_limits(&current_limits)
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
#### Problem
The datapoint is currently reported as `warn`; this does elevate it but also adds log noise when searching for actual warnings. Additionally, the current setup sends 6 datapoints to submit 6 fields.

#### Summary of Changes
Reduce the datapoint from warn to info and consolidate into a single datapoint submission. Some papertrail
- Datapoints were first introduced in https://github.com/solana-labs/solana/pull/22563
    - They were separate datapoints and only `info` if value was sufficient / `warn` if below recommendation
- Datapoints were changed to all report `warn` in https://github.com/solana-labs/solana/pull/34149

I think there could be some argument for whether an operator running with `warn` loses visibility. I agree that they do lose visibility on this piece; however, they're already flying blind on many other items by not having `info` IMO. I think our best path forward is to cleanup logs (both volume and too-high-severity) such that people don't feel the need to run with `warn` or `error`

#### Testing
Ran it on my dev box
```
// Old datapoints
[2026-06-10T00:15:49.857608851Z INFO  solana_metrics::metrics] datapoint: os-config platform="unix/linux/x86_64"
[2026-06-10T00:15:49.857615091Z WARN  solana_metrics::metrics] datapoint: os-config net.core.rmem_max=134217728i
[2026-06-10T00:15:49.857618021Z WARN  solana_metrics::metrics] datapoint: os-config net.core.wmem_max=134217728i
[2026-06-10T00:15:49.857620381Z WARN  solana_metrics::metrics] datapoint: os-config vm.max_map_count=1000000i
[2026-06-10T00:15:49.857622801Z WARN  solana_metrics::metrics] datapoint: os-config net.core.optmem_max=131072i
[2026-06-10T00:15:49.857624481Z WARN  solana_metrics::metrics] datapoint: os-config net.core.netdev_max_backlog=1000i

// New datapoint
[2026-06-10T22:33:14.062776257Z INFO  solana_metrics::metrics] datapoint: os-config platform="unix/linux/x86_64" net.core.rmem_max=134217728i net.core.wmem_max=134217728i vm.max_map_count=1000000i net.core.optmem_max=131072i net.core.netdev_max_backlog=1000i
```
Also confirmed in metrics that this is a single datapoint with all fields populated instead of 6 datapoint submissions each with one field populated