### PR TITLE
fix: get_fee_for_message for txv1

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4610,6 +4610,7 @@ pub mod tests {
         solana_message::{
             Message, MessageHeader, SimpleAddressLoader, VersionedMessage,
             v0::{self, MessageAddressTableLookup},
+            v1,
         },
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_program_option::COption,
@@ -9447,6 +9448,32 @@ pub mod tests {
             );
             let response: RpcResponse<u64> = parse_success_result(rpc.handle_request_sync(request));
             assert_eq!(response.value, TEST_SIGNATURE_FEE);
+        }
+
+        {
+            const PRIORITY_FEE: u64 = 42;
+            let v1_msg = VersionedMessage::V1(v1::Message::new(
+                MessageHeader {
+                    num_required_signatures: 1,
+                    ..MessageHeader::default()
+                },
+                v1::TransactionConfig {
+                    priority_fee: Some(PRIORITY_FEE),
+                    ..v1::TransactionConfig::empty()
+                },
+                recent_blockhash,
+                vec![Pubkey::new_unique()],
+                vec![],
+            ));
+
+            let request = create_test_request(
+                "getFeeForMessage",
+                Some(json!([
+                    BASE64_STANDARD.encode(wincode::serialize(&v1_msg).unwrap())
+                ])),
+            );
+            let response: RpcResponse<u64> = parse_success_result(rpc.handle_request_sync(request));
+            assert_eq!(response.value, TEST_SIGNATURE_FEE + PRIORITY_FEE);
         }
     }
 

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -1,15 +1,13 @@
 use {
-    super::{ComputeBudgetInstructionDetails, RuntimeTransaction},
+    super::RuntimeTransaction,
     crate::{
         instruction_meta::InstructionMeta,
         transaction_meta::{
-            CachedTransactionMeta, TransactionConfiguration, TransactionMeta,
-            VersionedTransactionConfiguration,
+            CachedTransactionMeta, TransactionMeta, VersionedTransactionConfiguration,
         },
         transaction_with_meta::TransactionWithMeta,
     },
-    solana_message::{AddressLoader, TransactionSignatureDetails, VersionedMessage},
-    solana_program_entrypoint::HEAP_LENGTH,
+    solana_message::{AddressLoader, TransactionSignatureDetails},
     solana_pubkey::Pubkey,
     solana_svm_transaction::instruction::SVMInstruction,
     solana_transaction::{
@@ -56,27 +54,10 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
             precompile_signature_details.num_secp256r1_instruction_signatures,
         );
 
-        let versioned_transaction_config = match &sanitized_versioned_tx.get_message().message {
-            VersionedMessage::V1(msg) => {
-                VersionedTransactionConfiguration::V1(TransactionConfiguration {
-                    priority_fee_lamports: msg.config.priority_fee.unwrap_or(0),
-                    compute_unit_limit: msg.config.compute_unit_limit.unwrap_or(0),
-                    loaded_accounts_data_size_limit: msg
-                        .config
-                        .loaded_accounts_data_size_limit
-                        .unwrap_or(0),
-                    updated_heap_bytes: msg.config.heap_size.unwrap_or(HEAP_LENGTH as u32),
-                })
-            }
-            _ => VersionedTransactionConfiguration::LegacyAndV0(
-                ComputeBudgetInstructionDetails::try_from(
-                    sanitized_versioned_tx
-                        .get_message()
-                        .program_instructions_iter()
-                        .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
-                )?,
-            ),
-        };
+        let versioned_transaction_config =
+            VersionedTransactionConfiguration::try_from_sanitized_versioned_message(
+                sanitized_versioned_tx.get_message(),
+            )?;
 
         Ok(Self {
             transaction: sanitized_versioned_tx,

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -19,7 +19,13 @@ use {
     },
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash,
-    solana_message::TransactionSignatureDetails,
+    solana_message::{
+        SanitizedMessage, SanitizedVersionedMessage, TransactionSignatureDetails, VersionedMessage,
+        v1::TransactionConfig,
+    },
+    solana_program_entrypoint::HEAP_LENGTH,
+    solana_pubkey::Pubkey,
+    solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
     solana_transaction::TransactionError,
 };
 
@@ -54,6 +60,14 @@ pub struct TransactionConfiguration {
 }
 
 impl TransactionConfiguration {
+    pub fn try_from_sanitized_message(
+        message: &SanitizedMessage,
+        feature_set: &FeatureSet,
+    ) -> Result<Self, TransactionError> {
+        VersionedTransactionConfiguration::try_from_sanitized_message(message)?
+            .try_into_config(feature_set)
+    }
+
     /// Compute the compute unit price in micro-lamports per compute unit.
     ///
     /// Note: that this will return an effective price according to the actual
@@ -77,6 +91,51 @@ pub(crate) enum VersionedTransactionConfiguration {
 }
 
 impl VersionedTransactionConfiguration {
+    pub(crate) fn try_from_sanitized_message(
+        message: &SanitizedMessage,
+    ) -> Result<Self, TransactionError> {
+        match message {
+            SanitizedMessage::V1(message) => Ok(Self::from_v1_config(&message.message.config)),
+            SanitizedMessage::Legacy(_) | SanitizedMessage::V0(_) => {
+                Self::try_from_legacy_and_v0_instructions(
+                    SVMStaticMessage::program_instructions_iter(message),
+                )
+            }
+        }
+    }
+
+    pub(crate) fn try_from_sanitized_versioned_message(
+        message: &SanitizedVersionedMessage,
+    ) -> Result<Self, TransactionError> {
+        match &message.message {
+            VersionedMessage::V1(message) => Ok(Self::from_v1_config(&message.config)),
+            VersionedMessage::Legacy(_) | VersionedMessage::V0(_) => {
+                Self::try_from_legacy_and_v0_instructions(
+                    message
+                        .program_instructions_iter()
+                        .map(|(program_id, ix)| (program_id, SVMInstruction::from(ix))),
+                )
+            }
+        }
+    }
+
+    fn from_v1_config(config: &TransactionConfig) -> Self {
+        Self::V1(TransactionConfiguration {
+            priority_fee_lamports: config.priority_fee.unwrap_or(0),
+            compute_unit_limit: config.compute_unit_limit.unwrap_or(0),
+            loaded_accounts_data_size_limit: config.loaded_accounts_data_size_limit.unwrap_or(0),
+            updated_heap_bytes: config.heap_size.unwrap_or(HEAP_LENGTH as u32),
+        })
+    }
+
+    fn try_from_legacy_and_v0_instructions<'a>(
+        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)> + Clone,
+    ) -> Result<Self, TransactionError> {
+        Ok(Self::LegacyAndV0(
+            ComputeBudgetInstructionDetails::try_from(instructions)?,
+        ))
+    }
+
     pub(crate) fn try_into_config(
         &self,
         feature_set: &FeatureSet,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -111,7 +111,6 @@ use {
     },
     solana_cluster_type::ClusterType,
     solana_compute_budget::compute_budget::ComputeBudget,
-    solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_cost_model::cost_tracker::CostTracker,
     solana_epoch_info::EpochInfo,
     solana_epoch_schedule::EpochSchedule,
@@ -139,7 +138,8 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionConfiguration,
+        transaction_with_meta::TransactionWithMeta,
     },
     solana_sdk_ids::{
         bpf_loader_upgradeable, incinerator, native_loader, system_program, sysvar as sysvar_id,
@@ -3293,25 +3293,16 @@ impl Bank {
             self.load_message_nonce_data(message)
                 .map(|(_nonce_address, nonce_data)| nonce_data.get_lamports_per_signature())
         })?;
-        Some(self.get_fee_for_message_with_lamports_per_signature(message))
-    }
 
-    pub fn get_fee_for_message_with_lamports_per_signature(
-        &self,
-        message: &impl SVMMessage,
-    ) -> u64 {
-        let prioritization_fee = process_compute_budget_instructions(
-            message.program_instructions_iter(),
-            &self.feature_set,
-        )
-        .unwrap_or_default()
-        .get_prioritization_fee();
-        solana_fee::calculate_fee(
+        let transaction_configuration =
+            TransactionConfiguration::try_from_sanitized_message(message, &self.feature_set)
+                .ok()?;
+        Some(solana_fee::calculate_fee(
             message,
             self.fee_structure().lamports_per_signature,
-            prioritization_fee,
+            transaction_configuration.priority_fee_lamports,
             FeeFeatures::from(self.feature_set.as_ref()),
-        )
+        ))
     }
 
     pub fn get_blockhash_last_valid_block_height(&self, blockhash: &Hash) -> Option<Slot> {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -63,6 +63,7 @@ use {
     solana_compute_budget::{
         compute_budget::ComputeBudget, compute_budget_limits::ComputeBudgetLimits,
     },
+    solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_cost_model::{
         block_cost_limits::{


### PR DESCRIPTION
#### Problem
- `get_fee_for_message` does not use the appropriate priority fee for transaction v1

#### Summary of Changes
- Add test on rpc `get_fee_for_message` for txv1 with priority fee
- Fix `get_fee_for_message` to go through common `TransactionConfiguration` from runtime-transaction crate

#### Testing
- Confirmed rpc test failed before fix, passes now

Fixes #
