### PR TITLE
chore(lints): move and sync lints to workspace Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ check-cfg = [
 arithmetic_side_effects = "deny"
 default_trait_access = "deny"
 manual_let_else = "deny"
+uninlined_format_args = "deny"
 used_underscore_binding = "deny"
 
 # Allowed lints

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -41,3 +41,15 @@ debug = "line-tables-only"
 [profile.full-dev]
 inherits = "dev"
 debug = "full"
+
+# Keep in sync with the root [workspace.lints.clippy].
+[lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -25,6 +25,7 @@ check-cfg = [
 arithmetic_side_effects = "deny"
 default_trait_access = "deny"
 manual_let_else = "deny"
+uninlined_format_args = "deny"
 used_underscore_binding = "deny"
 
 # Allowed lints

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -109,3 +109,18 @@ harness = false
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(build_target_feature_avx)', 'cfg(build_target_feature_avx2)']
+
+# Duplicated from the root [workspace.lints.clippy]. This crate defines its own
+# [lints.rust.unexpected_cfgs] above, and cargo does not support combining
+# `lints.workspace = true` with crate-specific lints in the same manifest
+# (see https://github.com/rust-lang/cargo/issues/13157). Keep in sync with the workspace.
+[lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -88,6 +88,18 @@ check-cfg = [
     'cfg(target_feature, values("dynamic-frames"))',
 ]
 
+# Keep in sync with the root [workspace.lints.clippy].
+[workspace.lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
+
 [workspace.dependencies]
 agave-feature-set = { path = "../../feature-set", version = "=4.2.0-alpha.0" }
 agave-logger = { path = "../../logger", version = "=4.2.0-alpha.0" }
@@ -233,3 +245,6 @@ opt-level = 1
 # The test programs are build in release mode
 # Minimize their file size so that they fit into the account size limit
 strip = true
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/128bit_dep/Cargo.toml
+++ b/programs/sbf/rust/128bit_dep/Cargo.toml
@@ -9,3 +9,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/dep_crate/Cargo.toml
+++ b/programs/sbf/rust/dep_crate/Cargo.toml
@@ -14,3 +14,6 @@ crate-type = ["cdylib"]
 [dependencies]
 byteorder = { workspace = true }
 solana-program-entrypoint = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/invoke_dep/Cargo.toml
@@ -10,3 +10,6 @@ edition = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/invoked_dep/Cargo.toml
+++ b/programs/sbf/rust/invoked_dep/Cargo.toml
@@ -14,3 +14,6 @@ solana-pubkey = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/many_args_dep/Cargo.toml
+++ b/programs/sbf/rust/many_args_dep/Cargo.toml
@@ -11,3 +11,6 @@ edition = { workspace = true }
 [dependencies]
 solana-msg = { workspace = true }
 solana-program = { workspace = true }
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/mem_dep/Cargo.toml
+++ b/programs/sbf/rust/mem_dep/Cargo.toml
@@ -12,3 +12,6 @@ edition = { workspace = true }
 crate-type = ["lib"]
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/param_passing_dep/Cargo.toml
+++ b/programs/sbf/rust/param_passing_dep/Cargo.toml
@@ -9,3 +9,6 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/realloc_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_dep/Cargo.toml
@@ -14,3 +14,6 @@ solana-pubkey = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
+
+[lints]
+workspace = true

--- a/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
@@ -10,3 +10,6 @@ edition = { workspace = true }
 
 [lib]
 crate-type = ["lib"]
+
+[lints]
+workspace = true

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -25,9 +25,4 @@ source "$here/../ci/rust-version.sh" nightly
 "$here/cargo-for-all-lock-files.sh" -- \
   "+${rust_nightly}" clippy \
   --workspace --all-targets --features dummy-for-ci-check,frozen-abi -- \
-  --deny=warnings \
-  --deny=clippy::default_trait_access \
-  --deny=clippy::arithmetic_side_effects \
-  --deny=clippy::manual_let_else \
-  --deny=clippy::uninlined-format-args \
-  --deny=clippy::used_underscore_binding
+  --deny=warnings


### PR DESCRIPTION
#### Problem
Specific clippy denies were hardcoded in `scripts/cargo-clippy-nightly.sh`, so they only ran under nightly CI and didn't surface in IDEs or stable builds. Most duplicated lints already in `[workspace.lints.clippy]`, and `uninlined_format_args` was enforced only via the script.

#### Summary of Changes
- Added `uninlined_format_args = "deny"` to root `[workspace.lints.clippy]` (and `dev-bins`, which was missing it).
- Added the lint set to the other workspaces so they're covered via Cargo.toml: `programs/sbf` and `ci/xtask` (plus opting the `programs/sbf` root + `*_dep` crates into workspace lints). 
- `perf` uses a direct `[lints.clippy]` since cargo can't combine `lints.workspace = true` with its custom cfg lints (rust-lang/cargo#13157).
- `collapsible_if = "allow"` left only where it already existed (root, `dev-bins`).
- Removed the specific `--deny=clippy::*` flags from the script, keeping `--deny=warnings`.

#### Testing
* scripts / CI tested
* git ls-files ':**Cargo.lock' (the command used to check where scripts clippy is run) gives us the workspaces we need to look at:
```
Cargo.lock
ci/xtask/Cargo.lock
dev-bins/Cargo.lock
programs/sbf/Cargo.lock
```
(meaning `svm/tests/example-programs` isn't currently checked by the clippy script - those are also excluded from changes in this PR)