### PR TITLE
Introduces wire format for AG consensus messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "bitvec",
  "criterion",
  "qualifier_attr",
+ "rand 0.9.4",
  "rayon",
  "solana-bls-signatures",
  "solana-hash 4.4.0",

--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -29,6 +29,7 @@ agave-bls-cert-verify = { path = ".", features = ["agave-unstable-api", "dev-con
 # See order-crates-for-publishing.py for using this unusual `path`
 agave-votor = { path = "../votor", features = ["agave-unstable-api"] }
 criterion = { workspace = true }
+rand = { workspace = true }
 solana-hash = { workspace = true }
 
 [[bench]]

--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -2,12 +2,15 @@ use {
     agave_bls_cert_verify::cert_verify::{aggregate_pubkeys, collect_pubkeys, verify_certificate},
     agave_votor::consensus_pool::certificate_builder::CertificateBuilder,
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::CertificateType,
         consensus_message::{Block, VoteMessage},
+        unverified_vote_message::UnverifiedCertificate,
         vote::Vote,
+        wire::get_vote_payload_to_sign,
     },
     bitvec::vec::BitVec,
-    criterion::{BenchmarkId, Criterion, criterion_group, criterion_main},
+    criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main},
+    rand::Rng,
     solana_bls_signatures::{
         keypair::Keypair as BlsKeypair,
         pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine},
@@ -23,8 +26,13 @@ fn create_bls_keypairs(num_signers: usize) -> Vec<BlsKeypair> {
 }
 
 // Creates vote messages for bench tests
-fn create_signed_vote_message(bls_keypair: &BlsKeypair, vote: Vote, rank: usize) -> VoteMessage {
-    let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
+fn create_signed_vote_message(
+    bls_keypair: &BlsKeypair,
+    shred_version: u16,
+    vote: Vote,
+    rank: usize,
+) -> VoteMessage {
+    let payload = get_vote_payload_to_sign(&vote, shred_version);
     let signature: BlsSignature = bls_keypair.sign(&payload).into();
     VoteMessage {
         vote,
@@ -34,7 +42,11 @@ fn create_signed_vote_message(bls_keypair: &BlsKeypair, vote: Vote, rank: usize)
 }
 
 // Creates a standard Base2 Certificate (All validators sign the same vote)
-fn create_base2_cert(keypairs: &[BlsKeypair], num_signers: usize) -> Certificate {
+fn create_base2_cert(
+    keypairs: &[BlsKeypair],
+    shred_version: u16,
+    num_signers: usize,
+) -> UnverifiedCertificate {
     let slot = 100;
     let hash = Hash::new_unique();
     let cert_type = CertificateType::Notarize(Block {
@@ -44,21 +56,28 @@ fn create_base2_cert(keypairs: &[BlsKeypair], num_signers: usize) -> Certificate
     let vote = cert_type.to_source_vote();
 
     let vote_messages: Vec<VoteMessage> = (0..num_signers)
-        .map(|rank| create_signed_vote_message(&keypairs[rank], vote, rank))
+        .map(|rank| create_signed_vote_message(&keypairs[rank], shred_version, vote, rank))
         .collect();
 
     let mut builder = CertificateBuilder::new(cert_type);
     builder.aggregate(&vote_messages).unwrap();
-    builder.build().unwrap()
+    let cert = builder.build().unwrap();
+    UnverifiedCertificate {
+        cert_type: cert.cert_type,
+        signature: cert.signature,
+        bitmap: cert.bitmap,
+        shred_version,
+    }
 }
 
 // Creates a Split Vote Base3 Certificate (Validators split between Notarize and Fallback)
 #[allow(clippy::arithmetic_side_effects)]
 fn create_base3_cert(
     keypairs: &[BlsKeypair],
+    shred_version: u16,
     num_notarize: usize,
     num_fallback: usize,
-) -> Certificate {
+) -> UnverifiedCertificate {
     let slot = 100;
     let hash = Hash::new_unique();
     let cert_type = CertificateType::NotarizeFallback(Block {
@@ -80,7 +99,12 @@ fn create_base3_cert(
     // Group 1: Signs Notarize
     for (i, keypair) in keypairs.iter().take(num_notarize).enumerate() {
         let rank = i;
-        vote_messages.push(create_signed_vote_message(keypair, vote_notarize, rank));
+        vote_messages.push(create_signed_vote_message(
+            keypair,
+            shred_version,
+            vote_notarize,
+            rank,
+        ));
     }
 
     // Group 2: Signs Fallback
@@ -91,12 +115,23 @@ fn create_base3_cert(
         .enumerate()
     {
         let rank = num_notarize + i;
-        vote_messages.push(create_signed_vote_message(keypair, vote_fallback, rank));
+        vote_messages.push(create_signed_vote_message(
+            keypair,
+            shred_version,
+            vote_fallback,
+            rank,
+        ));
     }
 
     let mut builder = CertificateBuilder::new(cert_type);
     builder.aggregate(&vote_messages).unwrap();
-    builder.build().unwrap()
+    let cert = builder.build().unwrap();
+    UnverifiedCertificate {
+        cert_type: cert.cert_type,
+        signature: cert.signature,
+        bitmap: cert.bitmap,
+        shred_version,
+    }
 }
 
 #[allow(clippy::arithmetic_side_effects)]
@@ -120,6 +155,7 @@ fn bench_verify_cert(c: &mut Criterion) {
 
     for &size in &validator_sizes {
         let keypairs = create_bls_keypairs(size);
+        let shred_version = rand::rng().random();
 
         // Pre-calculate public keys to simulate efficient Bank lookup
         let pubkeys: Vec<PopVerified<BlsPubkeyAffine>> =
@@ -129,7 +165,7 @@ fn bench_verify_cert(c: &mut Criterion) {
         // Base2 Setup
         // Assume 2/3rds of validators sign
         let num_signers_base2 = (size * 2) / 3;
-        let cert_base2 = create_base2_cert(&keypairs, num_signers_base2);
+        let cert_base2 = create_base2_cert(&keypairs, shred_version, num_signers_base2);
 
         // Collect pubkeys
         let mut ranks_bitvec = BitVec::<u8>::with_capacity(size);
@@ -161,16 +197,20 @@ fn bench_verify_cert(c: &mut Criterion) {
             &size,
             |b, &total_validators| {
                 let total_stake = NonZero::new(TEST_STAKE * total_validators as u64).unwrap();
-                b.iter(|| {
-                    // The rank_map closure simulates the Bank lookup.
-                    // It adds stake (we use 1000 per validator) and returns the pubkey.
-                    verify_certificate(&cert_base2, total_validators, total_stake, |rank| {
-                        pubkeys_ref
-                            .get(rank)
-                            .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
-                    })
-                    .unwrap();
-                })
+                b.iter_batched(
+                    || cert_base2.clone(),
+                    |cert_base2| {
+                        // The rank_map closure simulates the Bank lookup.
+                        // It adds stake (we use 1000 per validator) and returns the pubkey.
+                        verify_certificate(cert_base2, total_validators, total_stake, |rank| {
+                            pubkeys_ref
+                                .get(rank)
+                                .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
+                        })
+                        .unwrap();
+                    },
+                    BatchSize::SmallInput,
+                )
             },
         );
 
@@ -178,21 +218,25 @@ fn bench_verify_cert(c: &mut Criterion) {
         // 40% sign Notarize, 30% sign Fallback (Total 70%)
         let num_notarize = (size * 40) / 100;
         let num_fallback = (size * 30) / 100;
-        let cert_base3 = create_base3_cert(&keypairs, num_notarize, num_fallback);
+        let cert_base3 = create_base3_cert(&keypairs, shred_version, num_notarize, num_fallback);
 
         group.bench_with_input(
             BenchmarkId::new("Base3_NotarizeFallback", size),
             &size,
             |b, &total_validators| {
                 let total_stake = NonZero::new(TEST_STAKE * total_validators as u64).unwrap();
-                b.iter(|| {
-                    verify_certificate(&cert_base3, total_validators, total_stake, |rank| {
-                        pubkeys_ref
-                            .get(rank)
-                            .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
-                    })
-                    .unwrap();
-                })
+                b.iter_batched(
+                    || cert_base3.clone(),
+                    |cert_base3| {
+                        verify_certificate(cert_base3, total_validators, total_stake, |rank| {
+                            pubkeys_ref
+                                .get(rank)
+                                .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
+                        })
+                        .unwrap();
+                    },
+                    BatchSize::SmallInput,
+                )
             },
         );
     }

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -2,9 +2,8 @@
 use qualifier_attr::qualifiers;
 use {
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
-        fraction::Fraction,
-        vote::Vote,
+        certificate::Certificate, fraction::Fraction,
+        unverified_vote_message::UnverifiedCertificate,
     },
     bitvec::vec::BitVec,
     rayon::iter::IntoParallelRefIterator,
@@ -45,18 +44,16 @@ pub enum Error {
     },
 }
 
-/// Verifies an Alpenglow `Certificate` and calculates the total signing stake.
+/// Verifies an Alpenglow `UnverifiedCertificate`.
 ///
 /// This function verifies that the aggregate signature matches the vote payload(s)
-/// derived from the certificate type. It concurrently accumulates the stake of
-/// the signers using the provided `rank_map`.
+/// derived from the certificate type.
 ///
 /// # Core Functionality
 /// - **Signature Verification**: Validates aggregate BLS signatures for `votor-messages`.
 /// - **Bitmap Processing**: Supports verification using bitmaps that conform to the
 ///   `solana-signer-store` format.
-/// - **Stake Accumulation**: Calculates the total signing stake during the verification
-///   process.
+/// - **Stake verification**: Verifies that sufficient stake signed the certificate.
 ///
 /// # Ledger State and Rank Map
 ///
@@ -68,13 +65,14 @@ pub enum Error {
 ///
 /// * `cert` - The certificate to verify.
 /// * `max_validators` - The maximum number of validators (used for decoding the bitmap).
+/// * `total_stake` - The total stake for the network for the epoch in which this certificate was produced.
 /// * `rank_map` - A closure that maps a validator's rank (index) to their stake and public key.
 pub fn verify_certificate(
-    cert: &Certificate,
+    cert: UnverifiedCertificate,
     max_validators: usize,
     total_stake: NonZero<u64>,
     mut rank_map: impl FnMut(usize) -> Option<(u64, PopVerified<BlsPubkeyAffine>)>,
-) -> Result<(), Error> {
+) -> Result<Certificate, Error> {
     let mut aggregate_stake = 0u64;
 
     // Wrap the `rank_map` to accumulate stake as a side-effect
@@ -85,11 +83,9 @@ pub fn verify_certificate(
         })
     };
 
-    let (primary_vote, fallback_vote) = get_vote_payloads(cert.cert_type);
-    let primary_payload = serialize_vote(&primary_vote);
+    let (primary_payload, fallback_payload) = cert.cert_type.get_vote_payload(cert.shred_version);
 
-    if let Some(fallback_vote) = fallback_vote {
-        let fallback_payload = serialize_vote(&fallback_vote);
+    if let Some(fallback_payload) = fallback_payload {
         verify_base3(
             &primary_payload,
             &fallback_payload,
@@ -107,12 +103,16 @@ pub fn verify_certificate(
             accumulating_rank_map,
         )
     }?;
-    verify_stake(cert, aggregate_stake, total_stake)?;
-    Ok(())
+    verify_stake(&cert, aggregate_stake, total_stake)?;
+    Ok(Certificate {
+        cert_type: cert.cert_type,
+        signature: cert.signature,
+        bitmap: cert.bitmap,
+    })
 }
 
 fn verify_stake(
-    cert: &Certificate,
+    cert: &UnverifiedCertificate,
     aggregate_stake: u64,
     total_stake: NonZero<u64>,
 ) -> Result<(), Error> {
@@ -127,31 +127,6 @@ fn verify_stake(
             required_fraction,
         })
     }
-}
-
-fn get_vote_payloads(cert_type: CertificateType) -> (Vote, Option<Vote>) {
-    match cert_type {
-        CertificateType::Notarize(block) | CertificateType::FinalizeFast(block) => {
-            (Vote::new_notarization_vote(block), None)
-        }
-        CertificateType::Finalize(slot) => (Vote::new_finalization_vote(slot), None),
-        CertificateType::Genesis(block) => (Vote::new_genesis_vote(block), None),
-        CertificateType::NotarizeFallback(block) => (
-            Vote::new_notarization_vote(block),
-            Some(Vote::new_notarization_fallback_vote(block)),
-        ),
-        CertificateType::Skip(slot) => (
-            Vote::new_skip_vote(slot),
-            Some(Vote::new_skip_fallback_vote(slot)),
-        ),
-    }
-}
-
-fn serialize_vote(vote: &Vote) -> Vec<u8> {
-    // `expect` is safe because the `Vote` struct is composed entirely of primitive
-    // types (u64, Hash, enums) that are inherently serializable and it is constructed
-    // locally within this module.
-    wincode::serialize(vote).expect("Vote serialization should never fail for valid Vote structs")
 }
 
 /// Verifies a signature for a single payload signed by a set of validators.
@@ -296,9 +271,12 @@ mod test {
         super::*,
         agave_votor::consensus_pool::certificate_builder::CertificateBuilder,
         agave_votor_messages::{
+            certificate::CertificateType,
             consensus_message::{Block, VoteMessage},
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
+        rand::Rng,
         solana_bls_signatures::{
             keypair::Keypair as BLSKeypair, signature::Signature as BLSSignature,
         },
@@ -314,11 +292,12 @@ mod test {
 
     fn create_signed_vote_message(
         bls_keypairs: &[BLSKeypair],
+        shred_version: u16,
         vote: Vote,
         rank: usize,
     ) -> VoteMessage {
         let bls_keypair = &bls_keypairs[rank];
-        let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
+        let payload = get_vote_payload_to_sign(&vote, shred_version);
         let signature: BLSSignature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,
@@ -329,36 +308,45 @@ mod test {
 
     fn create_signed_certificate_message(
         bls_keypairs: &[BLSKeypair],
+        shred_version: u16,
         cert_type: CertificateType,
         ranks: &[usize],
-    ) -> Certificate {
+    ) -> UnverifiedCertificate {
         let mut builder = CertificateBuilder::new(cert_type);
         // Assumes Base2 encoding (single vote type) for simplicity in this helper.
         let vote = cert_type.to_source_vote();
         let vote_messages: Vec<VoteMessage> = ranks
             .iter()
-            .map(|&rank| create_signed_vote_message(bls_keypairs, vote, rank))
+            .map(|&rank| create_signed_vote_message(bls_keypairs, shred_version, vote, rank))
             .collect();
 
         builder
             .aggregate(&vote_messages)
             .expect("Failed to aggregate votes");
-        builder.build().expect("Failed to build certificate")
+        let cert = builder.build().expect("Failed to build certificate");
+        UnverifiedCertificate {
+            cert_type: cert.cert_type,
+            signature: cert.signature,
+            bitmap: cert.bitmap,
+            shred_version,
+        }
     }
 
     #[test]
     fn test_verify_certificate_base2_valid() {
         let bls_keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(Block {
             slot: 10,
             block_id: Hash::new_unique(),
         });
         let cert = create_signed_certificate_message(
             &bls_keypairs,
+            shred_version,
             cert_type,
             &(0..6).collect::<Vec<_>>(),
         );
-        verify_certificate(&cert, 10, NonZero::new(600).unwrap(), |rank| {
+        verify_certificate(cert, 10, NonZero::new(600).unwrap(), |rank| {
             bls_keypairs.get(rank).map(|kp| (100, kp.public))
         })
         .unwrap();
@@ -367,6 +355,7 @@ mod test {
     #[test]
     fn test_stake_verification() {
         let bls_keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(Block {
             slot: 10,
             block_id: Hash::new_unique(),
@@ -378,10 +367,11 @@ mod test {
         // with enough stake should succeed.
         let cert = create_signed_certificate_message(
             &bls_keypairs,
+            shred_version,
             cert_type,
             &(0..6).collect::<Vec<_>>(),
         );
-        verify_certificate(&cert, 10, total_stake, |rank| {
+        verify_certificate(cert, 10, total_stake, |rank| {
             bls_keypairs.get(rank).map(|kp| (100, kp.public))
         })
         .unwrap();
@@ -389,10 +379,11 @@ mod test {
         // not enough stake, should fail.
         let cert = create_signed_certificate_message(
             &bls_keypairs,
+            shred_version,
             cert_type,
             &(0..5).collect::<Vec<_>>(),
         );
-        let Err(err) = verify_certificate(&cert, 10, total_stake, |rank| {
+        let Err(err) = verify_certificate(cert, 10, total_stake, |rank| {
             bls_keypairs.get(rank).map(|kp| (100, kp.public))
         }) else {
             panic!("should fail");
@@ -413,6 +404,7 @@ mod test {
     #[test]
     fn test_verify_certificate_base3_valid() {
         let bls_keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let block = Block {
             slot: 20,
             block_id: Hash::new_unique(),
@@ -421,11 +413,17 @@ mod test {
         let notarize_fallback_vote = Vote::new_notarization_fallback_vote(block);
         let mut all_vote_messages = Vec::new();
         (0..4).for_each(|i| {
-            all_vote_messages.push(create_signed_vote_message(&bls_keypairs, notarize_vote, i))
+            all_vote_messages.push(create_signed_vote_message(
+                &bls_keypairs,
+                shred_version,
+                notarize_vote,
+                i,
+            ))
         });
         (4..7).for_each(|i| {
             all_vote_messages.push(create_signed_vote_message(
                 &bls_keypairs,
+                shred_version,
                 notarize_fallback_vote,
                 i,
             ))
@@ -436,7 +434,14 @@ mod test {
             .aggregate(&all_vote_messages)
             .expect("Failed to aggregate votes");
         let cert = builder.build().expect("Failed to build certificate");
-        verify_certificate(&cert, 10, NonZero::new(700).unwrap(), |rank| {
+        let cert = UnverifiedCertificate {
+            cert_type: cert.cert_type,
+            signature: cert.signature,
+            bitmap: cert.bitmap,
+            shred_version,
+        };
+
+        verify_certificate(cert, 10, NonZero::new(700).unwrap(), |rank| {
             bls_keypairs.get(rank).map(|kp| (100, kp.public))
         })
         .unwrap();
@@ -445,6 +450,7 @@ mod test {
     #[test]
     fn test_verify_certificate_invalid_signature() {
         let bls_keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
 
         let num_signers = 7;
         let block = Block {
@@ -459,13 +465,14 @@ mod test {
         }
         let encoded_bitmap = encode_base2(&bitmap).unwrap();
 
-        let cert = Certificate {
+        let cert = UnverifiedCertificate {
             cert_type,
             signature: BLSSignature([0; 192]), // Use a default/wrong signature
             bitmap: encoded_bitmap,
+            shred_version,
         };
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(1000).unwrap(), |rank| {
+            verify_certificate(cert, 10, NonZero::new(1000).unwrap(), |rank| {
                 bls_keypairs.get(rank).map(|kp| (100, kp.public))
             })
             .unwrap_err(),
@@ -477,6 +484,7 @@ mod test {
     fn base3_cert_with_no_primary_verifies() {
         let max_validators = 10;
         let bls_keypairs = create_bls_keypairs(max_validators);
+        let shred_version = rand::rng().random();
         let block = Block {
             slot: 20,
             block_id: Hash::new_unique(),
@@ -485,13 +493,19 @@ mod test {
         let mut builder = CertificateBuilder::new(cert_type);
         let vote = Vote::new_notarization_fallback_vote(block);
         let vote_msgs = (0..max_validators)
-            .map(|i| create_signed_vote_message(&bls_keypairs, vote, i))
+            .map(|i| create_signed_vote_message(&bls_keypairs, shred_version, vote, i))
             .collect::<Vec<_>>();
         builder.aggregate(&vote_msgs).unwrap();
         let cert = builder.build().unwrap();
+        let cert = UnverifiedCertificate {
+            cert_type: cert.cert_type,
+            signature: cert.signature,
+            bitmap: cert.bitmap,
+            shred_version,
+        };
         let per_validator_stake = 100;
         verify_certificate(
-            &cert,
+            cert,
             10,
             NonZero::new(per_validator_stake * max_validators as u64).unwrap(),
             |rank| {
@@ -590,11 +604,16 @@ mod test {
 
     /// A certificate with the given bitmap and a placeholder (all-zero) signature,
     /// for tests whose rejection is independent of the signature contents.
-    fn unsigned_cert(cert_type: CertificateType, bitmap: Vec<u8>) -> Certificate {
-        Certificate {
+    fn unsigned_cert(
+        cert_type: CertificateType,
+        bitmap: Vec<u8>,
+        shred_version: u16,
+    ) -> UnverifiedCertificate {
+        UnverifiedCertificate {
             cert_type,
             signature: BLSSignature([0; 192]),
             bitmap,
+            shred_version,
         }
     }
 
@@ -602,6 +621,7 @@ mod test {
     /// the notarization vote and `fallback_ranks` signed the notarization fallback vote.
     fn signed_notarize_fallback_cert(
         keypairs: &[BLSKeypair],
+        shred_version: u16,
         block: Block,
         primary_ranks: &[usize],
         fallback_ranks: &[usize],
@@ -610,10 +630,20 @@ mod test {
         let fallback = Vote::new_notarization_fallback_vote(block);
         let mut messages = Vec::new();
         for &rank in primary_ranks {
-            messages.push(create_signed_vote_message(keypairs, notarize, rank));
+            messages.push(create_signed_vote_message(
+                keypairs,
+                shred_version,
+                notarize,
+                rank,
+            ));
         }
         for &rank in fallback_ranks {
-            messages.push(create_signed_vote_message(keypairs, fallback, rank));
+            messages.push(create_signed_vote_message(
+                keypairs,
+                shred_version,
+                fallback,
+                rank,
+            ));
         }
         let mut builder = CertificateBuilder::new(CertificateType::NotarizeFallback(block));
         builder.aggregate(&messages).unwrap();
@@ -626,8 +656,14 @@ mod test {
     #[test]
     fn tampered_bitmap_adding_unsigned_validator_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(fresh_block(10));
-        let mut cert = create_signed_certificate_message(&keypairs, cert_type, &[0, 1, 2, 3, 4, 5]);
+        let mut cert = create_signed_certificate_message(
+            &keypairs,
+            shred_version,
+            cert_type,
+            &[0, 1, 2, 3, 4, 5],
+        );
 
         // Claim rank 6 also signed, even though it never did.
         cert.bitmap = encoded_base2_bitmap(&[0, 1, 2, 3, 4, 5, 6], 7);
@@ -635,7 +671,7 @@ mod test {
         // Must fail at the signature stage (not via a decode / missing-rank path),
         // proving the extra validator cannot be smuggled in.
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
@@ -647,14 +683,20 @@ mod test {
     #[test]
     fn tampered_bitmap_removing_signer_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(fresh_block(10));
-        let mut cert = create_signed_certificate_message(&keypairs, cert_type, &[0, 1, 2, 3, 4, 5]);
+        let mut cert = create_signed_certificate_message(
+            &keypairs,
+            shred_version,
+            cert_type,
+            &[0, 1, 2, 3, 4, 5],
+        );
 
         // Drop rank 5 from the bitmap while keeping its signature in the aggregate.
         cert.bitmap = encoded_base2_bitmap(&[0, 1, 2, 3, 4], 6);
 
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
@@ -666,20 +708,23 @@ mod test {
     #[test]
     fn tampered_cert_type_payload_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert = create_signed_certificate_message(
             &keypairs,
+            shred_version,
             CertificateType::Notarize(fresh_block(10)),
             &[0, 1, 2, 3, 4, 5],
         );
 
-        let forged = Certificate {
+        let forged = UnverifiedCertificate {
             cert_type: CertificateType::Notarize(fresh_block(10)),
             signature: cert.signature,
             bitmap: cert.bitmap.clone(),
+            shred_version,
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
@@ -690,14 +735,16 @@ mod test {
     #[test]
     fn empty_bitmap_certificate_does_not_verify() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert = unsigned_cert(
             CertificateType::Notarize(fresh_block(10)),
             encoded_base2_bitmap(&[], 0),
+            shred_version,
         );
 
         // An empty signer set cannot produce a valid aggregate signature.
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::EmptyAggregation)
         );
@@ -709,11 +756,16 @@ mod test {
     #[test]
     fn base3_bitmap_rejected_for_base2_certificate() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let bitmap = encoded_base3_bitmap(&[0, 1], &[2], 6);
-        let cert = unsigned_cert(CertificateType::Notarize(fresh_block(10)), bitmap);
+        let cert = unsigned_cert(
+            CertificateType::Notarize(fresh_block(10)),
+            bitmap,
+            shred_version,
+        );
 
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::WrongEncoding
         );
@@ -725,11 +777,17 @@ mod test {
     #[test]
     fn unknown_rank_in_bitmap_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(fresh_block(10));
-        let cert = create_signed_certificate_message(&keypairs, cert_type, &[0, 1, 2, 3, 4, 5]);
+        let cert = create_signed_certificate_message(
+            &keypairs,
+            shred_version,
+            cert_type,
+            &[0, 1, 2, 3, 4, 5],
+        );
 
         // rank_map returns None for rank 3, simulating an unknown/unstaked validator.
-        let result = verify_certificate(&cert, 10, NonZero::new(10).unwrap(), |rank| {
+        let result = verify_certificate(cert, 10, NonZero::new(10).unwrap(), |rank| {
             if rank == 3 {
                 None
             } else {
@@ -747,14 +805,16 @@ mod test {
     #[test]
     fn oversized_bitmap_is_rejected() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         // 20 bits declared, but only 10 validators allowed.
         let cert = unsigned_cert(
             CertificateType::Notarize(fresh_block(10)),
             encoded_base2_bitmap(&[0, 1], 20),
+            shred_version,
         );
 
         assert_eq!(
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::Decode(DecodeError::CorruptDataPayload)
         );
@@ -765,15 +825,20 @@ mod test {
     #[test]
     fn garbage_bitmap_never_panics_and_never_verifies() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         for seed in 0u64..512 {
             let len = (seed % 40) as usize;
             let bitmap: Vec<u8> = (0..len)
                 .map(|i| seed.wrapping_mul(2_654_435_761).wrapping_add(i as u64 * 7) as u8)
                 .collect();
-            let cert = unsigned_cert(CertificateType::Notarize(fresh_block(10)), bitmap);
+            let cert = unsigned_cert(
+                CertificateType::Notarize(fresh_block(10)),
+                bitmap,
+                shred_version,
+            );
             // Must return (Ok/Err) without panicking; a zero signature can never
             // produce a valid certificate, so the result must be an error.
-            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err();
         }
     }
@@ -784,19 +849,21 @@ mod test {
     #[test]
     fn base3_tampered_swapping_vote_types_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let block = fresh_block(20);
         // 0,1 signed the primary (notarize) vote; 2,3 signed the fallback vote.
-        let cert = signed_notarize_fallback_cert(&keypairs, block, &[0, 1], &[2, 3]);
+        let cert = signed_notarize_fallback_cert(&keypairs, shred_version, block, &[0, 1], &[2, 3]);
 
         // Forge a bitmap claiming the opposite: 2,3 as primary and 0,1 as fallback.
-        let forged = Certificate {
+        let forged = UnverifiedCertificate {
             cert_type: cert.cert_type,
             signature: cert.signature,
             bitmap: encoded_base3_bitmap(&[2, 3], &[0, 1], 4),
+            shred_version,
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
@@ -807,18 +874,20 @@ mod test {
     #[test]
     fn base3_tampered_adding_unsigned_validator_fails() {
         let keypairs = create_bls_keypairs(10);
+        let shred_version = rand::rng().random();
         let block = fresh_block(20);
-        let cert = signed_notarize_fallback_cert(&keypairs, block, &[0, 1], &[2, 3]);
+        let cert = signed_notarize_fallback_cert(&keypairs, shred_version, block, &[0, 1], &[2, 3]);
 
         // Claim rank 4 also cast a fallback vote, though it never signed.
-        let forged = Certificate {
+        let forged = UnverifiedCertificate {
             cert_type: cert.cert_type,
             signature: cert.signature,
             bitmap: encoded_base3_bitmap(&[0, 1], &[2, 3, 4], 5),
+            shred_version,
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+            verify_certificate(forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
                 .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );

--- a/bls-sigverify/Cargo.toml
+++ b/bls-sigverify/Cargo.toml
@@ -12,8 +12,9 @@ edition = { workspace = true }
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "solana-runtime/dev-context-only-utils",
     "agave-votor-messages/dev-context-only-utils",
+    "solana-perf/dev-context-only-utils",
+    "solana-runtime/dev-context-only-utils",
 ]
 
 [dependencies]

--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -6,14 +6,14 @@
 use {
     agave_bls_sigverify::{
         bls_vote_sigverify::{
-            VotePayload, aggregate_pubkeys_by_payload, aggregate_signatures,
+            UnverifiedVotePayload, aggregate_pubkeys_by_payload, aggregate_signatures,
             verify_individual_votes, verify_votes_optimistic,
         },
         stats::SigVerifyVoteStats,
     },
     agave_votor_messages::{
-        consensus_message::{Block, VoteMessage},
-        vote::Vote,
+        consensus_message::Block, unverified_vote_message::UnverifiedVoteMessage, vote::Vote,
+        wire::get_vote_payload_to_sign,
     },
     criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     rayon::{ThreadPool, ThreadPoolBuilder},
@@ -47,41 +47,46 @@ fn get_matrix_params() -> impl Iterator<Item = (usize, usize)> {
     })
 }
 
-fn generate_test_data(num_distinct_messages: usize, batch_size: usize) -> Vec<VotePayload> {
+fn generate_test_data(
+    shred_version: u16,
+    num_distinct_messages: usize,
+    batch_size: usize,
+) -> Vec<UnverifiedVotePayload> {
     assert!(
         batch_size >= num_distinct_messages,
         "Batch size must be >= distinct messages"
     );
 
     // Pre-calculate the payloads to ensure exact distinctness
-    let base_payloads: Vec<Arc<Vec<u8>>> = (0..num_distinct_messages)
+    let base_payloads = (0..num_distinct_messages)
         .map(|i| {
             let slot = (i as u64).saturating_add(100);
             let vote = Vote::new_notarization_vote(Block {
                 slot,
                 block_id: Hash::new_unique(),
             });
-            Arc::new(bincode::serialize(&vote).unwrap())
+            let payload = get_vote_payload_to_sign(&vote, shred_version);
+            (vote, Arc::new(payload))
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     let mut votes_to_verify = Vec::with_capacity(batch_size);
 
     for i in 0..batch_size {
-        let payload = &base_payloads[i.rem_euclid(num_distinct_messages)];
+        let (vote, payload) = &base_payloads[i.rem_euclid(num_distinct_messages)];
 
         let bls_keypair = BLSKeypair::new();
-        let vote: Vote = bincode::deserialize(payload).unwrap();
 
         let signature = bls_keypair.sign(payload);
 
-        let vote_message = VoteMessage {
-            vote,
+        let vote_message = UnverifiedVoteMessage {
+            vote: *vote,
             signature: signature.into(),
             rank: 0,
+            shred_version,
         };
 
-        votes_to_verify.push(VotePayload {
+        votes_to_verify.push(UnverifiedVotePayload {
             vote_message,
             sender_bls_pubkey: bls_keypair.public,
             sender_vote_account_pubkey: Keypair::new().pubkey(),
@@ -135,12 +140,13 @@ fn bench_verify_single_signature_with_prepared_message(c: &mut Criterion) {
 // Optimistic Verification - aggregates the public keys and signatures first before verifying.
 // Depends on both batch size and message distinctness due to pairing checks.
 fn bench_verify_votes_optimistic(c: &mut Criterion) {
+    let shred_version = 1234;
     let mut group = c.benchmark_group("verify_votes_optimistic");
     let mut stats = SigVerifyVoteStats::default();
     let thread_pool = get_thread_pool();
 
     for (batch_size, num_distinct) in get_matrix_params() {
-        let votes = generate_test_data(num_distinct, batch_size);
+        let votes = generate_test_data(shred_version, num_distinct, batch_size);
         let label = format!("msgs_{num_distinct}/batch_{batch_size}");
 
         group.bench_function(&label, |b| {
@@ -157,11 +163,12 @@ fn bench_verify_votes_optimistic(c: &mut Criterion) {
 // Public Key Aggregation
 // Depends on message distinctness because keys are grouped by messages.
 fn bench_aggregate_pubkeys(c: &mut Criterion) {
+    let shred_version = 1234;
     let mut group = c.benchmark_group("aggregate_pubkeys");
     let mut stats = SigVerifyVoteStats::default();
 
     for (batch_size, num_distinct) in get_matrix_params() {
-        let votes = generate_test_data(num_distinct, batch_size);
+        let votes = generate_test_data(shred_version, num_distinct, batch_size);
         let label = format!("msgs_{num_distinct}/batch_{batch_size}");
 
         group.bench_function(&label, |b| {
@@ -178,12 +185,13 @@ fn bench_aggregate_pubkeys(c: &mut Criterion) {
 // Signature Aggregation
 // Pure G1 addition - message distinctness is irrelevant.
 fn bench_aggregate_signatures(c: &mut Criterion) {
+    let shred_version = 1234;
     let mut group = c.benchmark_group("aggregate_signatures");
 
     for &batch_size in BATCH_SIZES {
         // Use 1 distinct message just to generate valid data cheaply.
         // It doesn't affect signature aggregation performance.
-        let votes = generate_test_data(1, batch_size);
+        let votes = generate_test_data(shred_version, 1, batch_size);
         let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {
@@ -199,12 +207,13 @@ fn bench_aggregate_signatures(c: &mut Criterion) {
 // Individual Verification - verifies each signatures in parallel threads
 // Message distinctness is irrelevant.
 fn bench_verify_individual_votes(c: &mut Criterion) {
+    let shred_version = 134;
     let mut group = c.benchmark_group("verify_votes_fallback");
     let thread_pool = get_thread_pool();
 
     for &batch_size in BATCH_SIZES {
         // Distinctness doesn't affect the cost of N individual verifications.
-        let votes = generate_test_data(1, batch_size);
+        let votes = generate_test_data(shred_version, 1, batch_size);
         let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {

--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -7,7 +7,10 @@ use {
         utils::send_certs_to_pool,
     },
     agave_bls_cert_verify::cert_verify::Error as BlsCertVerifyError,
-    agave_votor_messages::certificate::{Certificate, CertificateType},
+    agave_votor_messages::{
+        certificate::{Certificate, CertificateType},
+        unverified_vote_message::UnverifiedCertificate,
+    },
     crossbeam_channel::Sender,
     log::info,
     rayon::{
@@ -23,9 +26,8 @@ use {
     thiserror::Error,
 };
 
-#[derive(Clone, Debug)]
 pub(super) struct CertPayload {
-    pub(super) cert: Certificate,
+    pub(super) cert: UnverifiedCertificate,
     pub(super) sender_identity_pubkey: Pubkey,
 }
 
@@ -98,17 +100,16 @@ fn verify_certs(
         certs
             .into_par_iter()
             .map(|cert_payload| {
-                let res = verify_cert(&cert_payload.cert, root_bank);
-                (cert_payload, res)
+                let res = verify_cert(cert_payload.cert, root_bank);
+                (res, cert_payload.sender_identity_pubkey)
             })
             .collect::<Vec<_>>()
     });
 
     let certs = verified
         .into_iter()
-        .filter_map(|(cert_payload, res)| match res {
-            Ok(()) => {
-                let cert = cert_payload.cert;
+        .filter_map(|(res, sender_identity_pubkey)| match res {
+            Ok(cert) => {
                 if !verified_certs_set.insert(cert.cert_type) {
                     stats.unnecessary_certs_verified += 1;
                 }
@@ -117,12 +118,12 @@ fn verify_certs(
             Err(e) => {
                 match &e {
                     CertVerifyError::CertVerifyFailed(_) => {
-                        if banlist.ban(cert_payload.sender_identity_pubkey, BAN_TIMEOUT) {
+                        if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
                             stats.already_banned += 1;
                         } else {
                             info!(
-                                "bls_cert_sigverify: banned sender={} due to error {e}",
-                                cert_payload.sender_identity_pubkey
+                                "bls_cert_sigverify: banned sender={sender_identity_pubkey} due \
+                                 to error {e}"
                             );
                         }
                     }
@@ -144,7 +145,10 @@ fn verify_certs(
     SigVerifiedBatch::Certificates(certs)
 }
 
-fn verify_cert(cert: &Certificate, root_bank: &Bank) -> Result<(), CertVerifyError> {
+fn verify_cert(
+    cert: UnverifiedCertificate,
+    root_bank: &Bank,
+) -> Result<Certificate, CertVerifyError> {
     let cert_slot = cert.cert_type.slot();
     let root_slot = root_bank.slot();
     if cert_slot > root_slot.saturating_add(NUM_SLOTS_FOR_VERIFY) {
@@ -153,6 +157,6 @@ fn verify_cert(cert: &Certificate, root_bank: &Bank) -> Result<(), CertVerifyErr
             root_slot,
         });
     }
-    root_bank.verify_certificate(cert)?;
-    Ok(())
+    let cert = root_bank.verify_certificate(cert)?;
+    Ok(cert)
 }

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -3,7 +3,7 @@
 use {
     crate::{
         bls_cert_sigverify::{CertPayload, verify_and_send_certificates},
-        bls_vote_sigverify::{VotePayload, verify_and_send_votes},
+        bls_vote_sigverify::{UnverifiedVotePayload, verify_and_send_votes},
         errors::SigVerifyError,
         generated_cert_types::GeneratedCertTypes,
         rewards::rewards_wants_vote,
@@ -13,10 +13,11 @@ use {
     agave_votor_messages::{
         VerifiedVoterSlotsSender,
         certificate::CertificateType,
-        consensus_message::{ConsensusMessage, VoteMessage},
         metric_types::ConsensusMetricsEventSender,
         migration::MigrationStatus,
         reward_certificate::AddVoteMessage,
+        unverified_vote_message::{DecodedWireConsensusMessage, UnverifiedVoteMessage},
+        wire::VersionedWireConsensusMessage,
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError},
     log::error,
@@ -210,18 +211,20 @@ impl SigVerifier {
         &mut self,
         batches: Vec<PacketBatch>,
         root_bank: &Bank,
-    ) -> (Vec<CertPayload>, Vec<VotePayload>) {
+    ) -> (Vec<CertPayload>, Vec<UnverifiedVotePayload>) {
         let root_slot = root_bank.slot();
         let mut certs = Vec::new();
         let mut votes = Vec::new();
         let mut num_pkts = 0u64;
+        let my_shred_version = self.cluster_info.my_shred_version();
         for packet in batches.iter().flatten() {
             num_pkts = num_pkts.saturating_add(1);
             if packet.meta().discard() {
                 self.stats.num_discarded_pkts += 1;
                 continue;
             }
-            let Ok(msg) = wincode::config::deserialize_exact(
+            // TODO(#13227): Enforce shred_version matching during deserialization
+            let Ok(msg) = wincode::config::deserialize_exact::<VersionedWireConsensusMessage, _>(
                 packet.data(..).unwrap_or_default(),
                 packet_config(),
             ) else {
@@ -233,12 +236,18 @@ impl SigVerifier {
                 self.stats.num_malformed_pkts += 1;
                 continue;
             };
-            match msg {
-                ConsensusMessage::Vote(vote) => {
+            let Some(decoded_msg) = DecodedWireConsensusMessage::try_new(msg, my_shred_version)
+            else {
+                self.stats.num_malformed_pkts += 1;
+                continue;
+            };
+
+            match decoded_msg {
+                DecodedWireConsensusMessage::Vote(vote) => {
                     if let Some((sender_vote_account_pubkey, sender_bls_pubkey)) =
                         self.keep_vote(&vote, root_bank)
                     {
-                        votes.push(VotePayload {
+                        votes.push(UnverifiedVotePayload {
                             vote_message: vote,
                             sender_bls_pubkey,
                             sender_vote_account_pubkey,
@@ -247,7 +256,7 @@ impl SigVerifier {
                         });
                     }
                 }
-                ConsensusMessage::Certificate(cert) => {
+                DecodedWireConsensusMessage::Certificate(cert) => {
                     if cert.cert_type.slot() < root_slot {
                         self.stats.num_old_certs_received += 1;
                         continue;
@@ -274,25 +283,30 @@ impl SigVerifier {
     /// If this vote should be verified, then returns the sender's Pubkey and BlsPubkey.
     fn keep_vote(
         &mut self,
-        vote: &VoteMessage,
+        msg: &UnverifiedVoteMessage,
         root_bank: &Bank,
     ) -> Option<(Pubkey, PopVerified<BlsPubkeyAffine>)> {
         let root_slot = root_bank.slot();
-        let Some(rank_map) = root_bank.get_rank_map(vote.vote.slot()) else {
+        let Some(rank_map) = root_bank.get_rank_map(msg.vote.slot()) else {
             self.stats.discard_vote_no_epoch_stakes += 1;
             return None;
         };
         let entry = rank_map
-            .get_pubkey_stake_entry(vote.rank.into())
+            .get_pubkey_stake_entry(msg.rank.into())
             .or_else(|| {
                 self.stats.discard_vote_invalid_rank += 1;
                 None
             })?;
         let ret = Some((entry.vote_account_pubkey, entry.bls_pubkey));
-        if vote.vote.slot() > root_slot {
+        if msg.vote.slot() > root_slot {
             return ret;
         }
-        if rewards_wants_vote(&self.cluster_info, &self.leader_schedule, root_slot, vote) {
+        if rewards_wants_vote(
+            &self.cluster_info,
+            &self.leader_schedule,
+            root_slot,
+            &msg.vote,
+        ) {
             return ret;
         }
         self.stats.num_old_votes_received += 1;
@@ -345,6 +359,7 @@ mod tests {
             consensus_message::{Block, ConsensusMessage, VoteMessage},
             metric_types::ConsensusMetricsEventReceiver,
             vote::Vote,
+            wire::{VersionedWireConsensusMessage, get_vote_payload_to_sign},
         },
         bitvec::prelude::{BitVec, Lsb0},
         crossbeam_channel::{Receiver, TryRecvError, bounded},
@@ -354,7 +369,7 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_net_utils::SocketAddrSpace,
-        solana_perf::packet::{Packet, RecycledPacketBatch},
+        solana_perf::packet::{BytesPacket, BytesPacketBatch, Packet, RecycledPacketBatch},
         solana_pubkey::Pubkey,
         solana_runtime::{
             bank::{Bank, SlotLeader},
@@ -462,11 +477,12 @@ mod tests {
 
     fn create_signed_vote_message(
         validator_keypairs: &[ValidatorVoteKeypairs],
+        shred_version: u16,
         vote: Vote,
         rank: usize,
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
-        let payload = wincode::serialize(&vote).expect("Failed to serialize vote");
+        let payload = get_vote_payload_to_sign(&vote, shred_version);
         let signature: Signature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,
@@ -476,6 +492,7 @@ mod tests {
     }
 
     fn create_signed_certificate_message(
+        shred_version: u16,
         validator_keypairs: &[ValidatorVoteKeypairs],
         cert_type: CertificateType,
         ranks: &[usize],
@@ -485,7 +502,7 @@ mod tests {
         let vote = cert_type.to_source_vote();
         let vote_messages: Vec<VoteMessage> = ranks
             .iter()
-            .map(|&rank| create_signed_vote_message(validator_keypairs, vote, rank))
+            .map(|&rank| create_signed_vote_message(validator_keypairs, shred_version, vote, rank))
             .collect();
 
         builder
@@ -503,9 +520,13 @@ mod tests {
         }
     }
 
-    fn message_to_packet(message: &ConsensusMessage, remote_pubkey: Pubkey) -> Packet {
-        let mut packet = Packet::default();
-        packet.populate_packet(None, message).unwrap();
+    fn message_to_packet(
+        message: &ConsensusMessage,
+        shred_version: u16,
+        remote_pubkey: Pubkey,
+    ) -> BytesPacket {
+        let msg = VersionedWireConsensusMessage::new(message.clone(), shred_version);
+        let mut packet = BytesPacket::from_data(&msg).unwrap();
         packet.meta_mut().set_remote_pubkey(remote_pubkey);
         packet
     }
@@ -519,18 +540,26 @@ mod tests {
         let cert_type = CertificateType::Finalize(4);
         let vote_message1 = create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_finalization_vote(5),
             vote_rank1,
         );
-        let cert =
-            create_signed_certificate_message(&ctx.validator_keypairs, cert_type, &cert_ranks);
+        let cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
+            &ctx.validator_keypairs,
+            cert_type,
+            &cert_ranks,
+        );
         let messages1 = vec![
             ConsensusMessage::Vote(vote_message1),
             ConsensusMessage::Certificate(cert),
         ];
 
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&messages1))
+            .verify_and_send_batches(messages_to_batches(
+                &messages1,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
         assert_eq!(ctx.pool_receiver.try_iter().count(), 2);
         assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
@@ -547,6 +576,7 @@ mod tests {
         let vote_rank2 = 3;
         let vote_message2 = create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_notarization_vote(Block {
                 slot: 6,
                 block_id: Hash::new_unique(),
@@ -556,7 +586,10 @@ mod tests {
         let messages2 = vec![ConsensusMessage::Vote(vote_message2)];
         ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&messages2))
+            .verify_and_send_batches(messages_to_batches(
+                &messages2,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
 
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
@@ -574,6 +607,7 @@ mod tests {
         let vote_rank3 = 9;
         let vote_message3 = create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_notarization_fallback_vote(Block {
                 slot: 7,
                 block_id: Hash::new_unique(),
@@ -583,7 +617,10 @@ mod tests {
         let messages3 = vec![ConsensusMessage::Vote(vote_message3)];
         ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&messages3))
+            .verify_and_send_batches(messages_to_batches(
+                &messages3,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
         assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
@@ -617,13 +654,17 @@ mod tests {
         // Send a packet with no epoch stakes
         let vote_message_no_stakes = create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_finalization_vote(5_000_000_000), // very high slot
             0,
         );
         let messages_no_stakes = vec![ConsensusMessage::Vote(vote_message_no_stakes)];
 
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&messages_no_stakes))
+            .verify_and_send_batches(messages_to_batches(
+                &messages_no_stakes,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
 
         assert_eq!(ctx.verifier.stats.discard_vote_no_epoch_stakes.0, 1);
@@ -638,7 +679,10 @@ mod tests {
             rank: 1000, // Invalid rank
         })];
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(&messages_invalid_rank))
+            .verify_and_send_batches(messages_to_batches(
+                &messages_invalid_rank,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
         assert_eq!(ctx.verifier.stats.discard_vote_invalid_rank.0, 1);
 
@@ -647,15 +691,37 @@ mod tests {
     }
 
     #[test]
+    fn test_shred_version_mismatch() {
+        let mut ctx = TestContext::new();
+        let msgs = [ConsensusMessage::Vote(create_signed_vote_message(
+            &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version() + 1,
+            Vote::new_finalization_vote(5),
+            0,
+        ))];
+        // creating a packet with the wrong shred version
+        let packets = messages_to_batches(&msgs, ctx.verifier.cluster_info.my_shred_version() + 1);
+        ctx.verifier.verify_and_send_batches(packets).unwrap();
+        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.num_malformed_pkts.0, 1);
+    }
+
+    #[test]
     fn test_blssigverifier_send_packets_channel_full() {
         agave_logger::setup();
         let (channel_to_pool, pool_receiver) = crossbeam_channel::bounded(1);
         let mut ctx = TestContext::new_with_pool_channel(channel_to_pool, pool_receiver);
 
-        let msg1 =
-            create_signed_vote_message(&ctx.validator_keypairs, Vote::new_finalization_vote(5), 0);
+        let msg1 = create_signed_vote_message(
+            &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
+            Vote::new_finalization_vote(5),
+            0,
+        );
         let msg2 = create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_notarization_fallback_vote(Block {
                 slot: 6,
                 block_id: Hash::new_unique(),
@@ -663,9 +729,10 @@ mod tests {
             2,
         );
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(std::slice::from_ref(
-                &ConsensusMessage::Vote(msg1.clone()),
-            )))
+            .verify_and_send_batches(messages_to_batches(
+                std::slice::from_ref(&ConsensusMessage::Vote(msg1.clone())),
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
 
         // The cap-1 channel is now full.  The second send hits Full and falls
@@ -684,9 +751,10 @@ mod tests {
         });
 
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches(std::slice::from_ref(
-                &ConsensusMessage::Vote(msg2.clone()),
-            )))
+            .verify_and_send_batches(messages_to_batches(
+                std::slice::from_ref(&ConsensusMessage::Vote(msg2.clone())),
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
 
         let (m1_recv, m2_recv) = drain.join().expect("drain joined");
@@ -707,13 +775,15 @@ mod tests {
 
         let msg = ConsensusMessage::Vote(create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_finalization_vote(5),
             0,
         ));
         let messages = vec![msg];
-        let result = ctx
-            .verifier
-            .verify_and_send_batches(messages_to_batches(&messages));
+        let result = ctx.verifier.verify_and_send_batches(messages_to_batches(
+            &messages,
+            ctx.verifier.cluster_info.my_shred_version(),
+        ));
         assert!(result.is_err());
     }
 
@@ -723,14 +793,18 @@ mod tests {
 
         let message = ConsensusMessage::Vote(create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_finalization_vote(5),
             0,
         ));
-        let mut packet = message_to_packet(&message, Pubkey::new_unique());
+        let mut packet = message_to_packet(
+            &message,
+            ctx.verifier.cluster_info.my_shred_version(),
+            Pubkey::new_unique(),
+        );
         packet.meta_mut().set_discard(true); // Manually discard
 
-        let packets = vec![packet];
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(vec![packet]).into()];
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -747,7 +821,8 @@ mod tests {
         let num_votes = 5;
         let mut packets = Vec::with_capacity(num_votes);
         let vote = Vote::new_skip_vote(42);
-        let vote_payload = wincode::serialize(&vote).expect("Failed to serialize vote");
+        let vote_payload =
+            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
 
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
@@ -758,10 +833,14 @@ mod tests {
                 signature,
                 rank,
             });
-            packets.push(message_to_packet(&consensus_message, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &consensus_message,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(packets).into()];
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -785,12 +864,10 @@ mod tests {
         let mut packets = Vec::with_capacity(num_votes);
 
         let vote1 = Vote::new_skip_vote(42);
-        let _vote1_payload = wincode::serialize(&vote1).expect("Failed to serialize vote");
         let vote2 = Vote::new_notarization_vote(Block {
             slot: 43,
             block_id: Hash::new_unique(),
         });
-        let _vote2_payload = wincode::serialize(&vote2).expect("Failed to serialize vote");
 
         // Group 1 votes
         for (i, _) in ctx
@@ -801,10 +878,15 @@ mod tests {
         {
             let msg = ConsensusMessage::Vote(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 vote1,
                 i,
             ));
-            packets.push(message_to_packet(&msg, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &msg,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
         // Group 2 votes
@@ -817,13 +899,18 @@ mod tests {
         {
             let msg = ConsensusMessage::Vote(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 vote2,
                 i,
             ));
-            packets.push(message_to_packet(&msg, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &msg,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(packets).into()];
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -859,11 +946,15 @@ mod tests {
         let mut packets = Vec::with_capacity(num_votes);
 
         let vote1 = Vote::new_skip_vote(42);
-        let vote1_payload = wincode::serialize(&vote1).expect("Failed to serialize vote");
+        let vote1_payload =
+            get_vote_payload_to_sign(&vote1, ctx.verifier.cluster_info.my_shred_version());
         let vote2 = Vote::new_skip_vote(43);
-        let vote2_payload = wincode::serialize(&vote2).expect("Failed to serialize vote");
-        let invalid_payload =
-            wincode::serialize(&Vote::new_skip_vote(99)).expect("Failed to serialize vote");
+        let vote2_payload =
+            get_vote_payload_to_sign(&vote2, ctx.verifier.cluster_info.my_shred_version());
+        let invalid_payload = get_vote_payload_to_sign(
+            &Vote::new_skip_vote(99),
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
@@ -887,10 +978,14 @@ mod tests {
                 signature,
                 rank,
             });
-            packets.push(message_to_packet(&consensus_message, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &consensus_message,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(packets).into()];
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -928,9 +1023,12 @@ mod tests {
         let mut consensus_messages = Vec::with_capacity(num_votes); // ADDED: To hold messages for later comparison.
 
         let vote = Vote::new_skip_vote(42);
-        let valid_vote_payload = wincode::serialize(&vote).expect("Failed to serialize vote");
-        let invalid_vote_payload =
-            wincode::serialize(&Vote::new_skip_vote(99)).expect("Failed to serialize vote");
+        let valid_vote_payload =
+            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+        let invalid_vote_payload = get_vote_payload_to_sign(
+            &Vote::new_skip_vote(99),
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
@@ -950,10 +1048,14 @@ mod tests {
 
             consensus_messages.push(consensus_message.clone());
 
-            packets.push(message_to_packet(&consensus_message, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &consensus_message,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(packets).into()];
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -993,12 +1095,16 @@ mod tests {
             block_id: Hash::new_unique(),
         });
         let cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
             &ctx.validator_keypairs,
             cert_type,
             &(0..num_signers).collect::<Vec<_>>(),
         );
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1021,12 +1127,16 @@ mod tests {
             block_id: Hash::new_unique(),
         });
         let cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
             &ctx.validator_keypairs,
             cert_type,
             &(0..num_signers).collect::<Vec<_>>(),
         );
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1054,6 +1164,7 @@ mod tests {
         (0..4).for_each(|i| {
             all_vote_messages.push(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 notarize_vote,
                 i,
             ))
@@ -1061,6 +1172,7 @@ mod tests {
         (4..7).for_each(|i| {
             all_vote_messages.push(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 notarize_fallback_vote,
                 i,
             ))
@@ -1072,7 +1184,10 @@ mod tests {
             .expect("Failed to aggregate votes");
         let cert = builder.build().expect("Failed to build certificate");
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1100,6 +1215,7 @@ mod tests {
         (0..4).for_each(|i| {
             all_vote_messages.push(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 notarize_vote,
                 i,
             ))
@@ -1107,6 +1223,7 @@ mod tests {
         (4..6).for_each(|i| {
             all_vote_messages.push(create_signed_vote_message(
                 &ctx.validator_keypairs,
+                ctx.verifier.cluster_info.my_shred_version(),
                 notarize_fallback_vote,
                 i,
             ))
@@ -1118,7 +1235,10 @@ mod tests {
             .expect("Failed to aggregate votes");
         let cert = builder.build().expect("Failed to build certificate");
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1155,7 +1275,10 @@ mod tests {
             bitmap: encoded_bitmap,
         };
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1179,7 +1302,8 @@ mod tests {
         let num_votes = 2;
 
         let vote = Vote::new_skip_vote(42);
-        let vote_payload = wincode::serialize(&vote).unwrap();
+        let vote_payload =
+            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
@@ -1189,7 +1313,11 @@ mod tests {
                 signature,
                 rank,
             });
-            packets.push(message_to_packet(&consensus_message, Pubkey::new_unique()));
+            packets.push(message_to_packet(
+                &consensus_message,
+                ctx.verifier.cluster_info.my_shred_version(),
+                Pubkey::new_unique(),
+            ));
         }
 
         // 70% of validators sign.
@@ -1199,7 +1327,10 @@ mod tests {
             block_id: Hash::new_unique(),
         });
         let cert_original_vote = Vote::new_notarization_vote(cert_type.to_block().unwrap());
-        let cert_payload = wincode::serialize(&cert_original_vote).unwrap();
+        let cert_payload = get_vote_payload_to_sign(
+            &cert_original_vote,
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         let cert_vote_messages: Vec<VoteMessage> = (0..num_signers)
             .map(|i| {
@@ -1219,10 +1350,11 @@ mod tests {
         let consensus_message_cert = ConsensusMessage::Certificate(cert);
         packets.push(message_to_packet(
             &consensus_message_cert,
+            ctx.verifier.cluster_info.my_shred_version(),
             Pubkey::new_unique(),
         ));
 
-        let packet_batches = vec![RecycledPacketBatch::new(packets).into()];
+        let packet_batches = vec![BytesPacketBatch::from(packets).into()];
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -1260,7 +1392,8 @@ mod tests {
 
         let invalid_rank = 999;
         let vote = Vote::new_skip_vote(42);
-        let vote_payload = wincode::serialize(&vote).unwrap();
+        let vote_payload =
+            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
         let signature: Signature = bls_keypair.sign(&vote_payload).into();
 
@@ -1270,7 +1403,10 @@ mod tests {
             rank: invalid_rank,
         });
 
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -1332,7 +1468,8 @@ mod tests {
         );
 
         let vote = Vote::new_skip_vote(2);
-        let vote_payload = wincode::serialize(&vote).unwrap();
+        let vote_payload =
+            get_vote_payload_to_sign(&vote, sig_verifier.cluster_info.my_shred_version());
         let bls_keypair = &validator_keypairs[0].bls_keypair;
         let signature: Signature = bls_keypair.sign(&vote_payload).into();
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
@@ -1340,7 +1477,10 @@ mod tests {
             signature,
             rank: 0,
         });
-        let packet_batches_vote = messages_to_batches(&[consensus_message_vote]);
+        let packet_batches_vote = messages_to_batches(
+            &[consensus_message_vote],
+            sig_verifier.cluster_info.my_shred_version(),
+        );
 
         sig_verifier
             .verify_and_send_batches(packet_batches_vote)
@@ -1349,12 +1489,16 @@ mod tests {
         assert_eq!(sig_verifier.stats.num_old_votes_received.0, 1);
 
         let cert = create_signed_certificate_message(
+            sig_verifier.cluster_info.my_shred_version(),
             &validator_keypairs,
             CertificateType::Finalize(3),
             &[0], // Signer rank 0
         );
         let consensus_message_cert = ConsensusMessage::Certificate(cert);
-        let packet_batches_cert = messages_to_batches(&[consensus_message_cert]);
+        let packet_batches_cert = messages_to_batches(
+            &[consensus_message_cert],
+            sig_verifier.cluster_info.my_shred_version(),
+        );
 
         sig_verifier
             .verify_and_send_batches(packet_batches_cert)
@@ -1378,7 +1522,8 @@ mod tests {
         };
         let cert_type = CertificateType::Notarize(block);
         let original_vote = Vote::new_notarization_vote(block);
-        let signed_payload = wincode::serialize(&original_vote).unwrap();
+        let signed_payload =
+            get_vote_payload_to_sign(&original_vote, ctx.verifier.cluster_info.my_shred_version());
         let mut vote_messages: Vec<VoteMessage> = (0..num_signers)
             .map(|i| {
                 let signature = ctx.validator_keypairs[i].bls_keypair.sign(&signed_payload);
@@ -1396,7 +1541,10 @@ mod tests {
             .expect("Failed to aggregate votes");
         let cert1 = builder1.build().expect("Failed to build certificate");
         let consensus_message1 = ConsensusMessage::Certificate(cert1);
-        let packet_batches1 = messages_to_batches(&[consensus_message1]);
+        let packet_batches1 = messages_to_batches(
+            &[consensus_message1],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches1)
@@ -1413,7 +1561,10 @@ mod tests {
             .expect("Failed to aggregate votes");
         let cert2 = builder2.build().expect("Failed to build certificate");
         let consensus_message2 = ConsensusMessage::Certificate(cert2);
-        let packet_batches2 = messages_to_batches(&[consensus_message2]);
+        let packet_batches2 = messages_to_batches(
+            &[consensus_message2],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier.stats = SigVerifierStats::new(ctx.verifier.sharable_banks.root().slot());
         ctx.verifier
@@ -1430,10 +1581,12 @@ mod tests {
 
         let vote_message = ConsensusMessage::Vote(create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_skip_vote(42),
             0,
         ));
         let cert_message = ConsensusMessage::Certificate(create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
             &ctx.validator_keypairs,
             CertificateType::Notarize(Block {
                 slot: 43,
@@ -1443,10 +1596,10 @@ mod tests {
         ));
         let vote_sender = Pubkey::new_unique();
         let cert_sender = Pubkey::new_unique();
-        let packet_batches = messages_to_batches_with_remote_pubkeys(&[
-            (vote_message, vote_sender),
-            (cert_message, cert_sender),
-        ]);
+        let packet_batches = messages_to_batches_with_remote_pubkeys(
+            &[(vote_message, vote_sender), (cert_message, cert_sender)],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
 
         ctx.verifier
             .verify_and_send_batches(packet_batches)
@@ -1461,8 +1614,12 @@ mod tests {
         let mut ctx = TestContext::new();
 
         let vote = Vote::new_skip_vote(42);
-        let valid_payload = wincode::serialize(&vote).unwrap();
-        let invalid_payload = wincode::serialize(&Vote::new_skip_vote(999)).unwrap();
+        let valid_payload =
+            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+        let invalid_payload = get_vote_payload_to_sign(
+            &Vote::new_skip_vote(999),
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
         let invalid_indexes = [1usize, 3usize];
         let messages: Vec<_> = ctx
             .validator_keypairs
@@ -1485,7 +1642,10 @@ mod tests {
             .collect();
 
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches_with_remote_pubkeys(&messages))
+            .verify_and_send_batches(messages_to_batches_with_remote_pubkeys(
+                &messages,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
         assert_eq!(batches.len(), 1);
@@ -1524,6 +1684,7 @@ mod tests {
                     block_id: Hash::new_unique(),
                 });
                 let mut cert = create_signed_certificate_message(
+                    ctx.verifier.cluster_info.my_shred_version(),
                     &ctx.validator_keypairs,
                     cert_type,
                     &(0..7).collect::<Vec<_>>(),
@@ -1536,7 +1697,10 @@ mod tests {
             .collect();
 
         ctx.verifier
-            .verify_and_send_batches(messages_to_batches_with_remote_pubkeys(&messages))
+            .verify_and_send_batches(messages_to_batches_with_remote_pubkeys(
+                &messages,
+                ctx.verifier.cluster_info.my_shred_version(),
+            ))
             .unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
         assert_eq!(batches.len(), 1);
@@ -1569,12 +1733,16 @@ mod tests {
         let cert_type = CertificateType::Skip(slot);
         ctx.generated_cert_types.insert_cert(cert_type);
         let cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
             &ctx.validator_keypairs,
             cert_type,
             &(0..ctx.validator_keypairs.len()).collect::<Vec<usize>>(),
         );
         let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
+        let packet_batches = messages_to_batches(
+            &[consensus_message],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -1587,6 +1755,7 @@ mod tests {
         let slot = ctx.verifier.sharable_banks.root().slot() + NUM_SLOTS_FOR_VERIFY + 1;
         let cert_type = CertificateType::Skip(slot);
         let cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
             &ctx.validator_keypairs,
             cert_type,
             &(0..ctx.validator_keypairs.len()).collect::<Vec<usize>>(),
@@ -1594,10 +1763,12 @@ mod tests {
         let cert = ConsensusMessage::Certificate(cert);
         let vote = ConsensusMessage::Vote(create_signed_vote_message(
             &ctx.validator_keypairs,
+            ctx.verifier.cluster_info.my_shred_version(),
             Vote::new_skip_vote(slot),
             0,
         ));
-        let packet_batches = messages_to_batches(&[cert, vote]);
+        let packet_batches =
+            messages_to_batches(&[cert, vote], ctx.verifier.cluster_info.my_shred_version());
         ctx.verifier
             .verify_and_send_batches(packet_batches)
             .unwrap();
@@ -1605,22 +1776,25 @@ mod tests {
         assert_eq!(ctx.verifier.stats.vote_stats.too_far_in_future.0, 1);
     }
 
-    fn messages_to_batches(messages: &[ConsensusMessage]) -> Vec<PacketBatch> {
+    fn messages_to_batches(messages: &[ConsensusMessage], shred_version: u16) -> Vec<PacketBatch> {
         let messages_with_remote_pubkeys: Vec<_> = messages
             .iter()
             .cloned()
             .map(|message| (message, Pubkey::new_unique()))
             .collect();
-        messages_to_batches_with_remote_pubkeys(&messages_with_remote_pubkeys)
+        messages_to_batches_with_remote_pubkeys(&messages_with_remote_pubkeys, shred_version)
     }
 
     fn messages_to_batches_with_remote_pubkeys(
         messages: &[(ConsensusMessage, Pubkey)],
+        shred_version: u16,
     ) -> Vec<PacketBatch> {
         let packets: Vec<_> = messages
             .iter()
-            .map(|(message, remote_pubkey)| message_to_packet(message, *remote_pubkey))
+            .map(|(message, remote_pubkey)| {
+                message_to_packet(message, shred_version, *remote_pubkey)
+            })
             .collect();
-        vec![RecycledPacketBatch::new(packets).into()]
+        vec![BytesPacketBatch::from(packets).into()]
     }
 }

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -13,7 +13,8 @@ use {
     },
     agave_votor_messages::{
         consensus_message::VoteMessage, metric_types::ConsensusMetricsEvent,
-        reward_certificate::AddVoteMessage, vote::Vote,
+        reward_certificate::AddVoteMessage, unverified_vote_message::UnverifiedVoteMessage,
+        vote::Vote, wire::get_vote_payload_to_sign,
     },
     log::info,
     rayon::{
@@ -35,34 +36,52 @@ use {
     std::{collections::HashMap, sync::Arc},
 };
 
+fn into_vote_msg(msg: UnverifiedVoteMessage) -> VoteMessage {
+    VoteMessage {
+        vote: msg.vote,
+        signature: msg.signature,
+        rank: msg.rank,
+    }
+}
+
 /// This is the percentage threshold of distinct votes among the total votes under which we will prepare a cache of
 /// prepared payloads for individual verification.
 const PREPARED_PAYLOAD_CACHE_DISTINCT_VOTE_THRESHOLD_PERCENT: usize = 90;
 
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+struct VerifiedVotePayload {
+    vote_message: VoteMessage,
+    sender_vote_account_pubkey: Pubkey,
+}
+
 /// [`VoteMessage`] along with other information needed to sig verify it.
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 #[derive(Clone, Debug)]
-pub(super) struct VotePayload {
-    pub vote_message: VoteMessage,
+pub(super) struct UnverifiedVotePayload {
+    pub vote_message: UnverifiedVoteMessage,
     pub sender_bls_pubkey: PopVerified<BlsPubkeyAffine>,
     pub sender_vote_account_pubkey: Pubkey,
     pub sender_identity_pubkey: Pubkey,
     pub prepared_payload: Option<Arc<PreparedHashedMessage>>,
 }
 
-impl VotePayload {
-    fn verify(self) -> Option<Self> {
+impl UnverifiedVotePayload {
+    fn verify(self) -> Option<VerifiedVotePayload> {
         let is_verified = if let Some(prepared_payload) = self.prepared_payload.as_deref() {
             self.sender_bls_pubkey
                 .verify_signature_prepared(&self.vote_message.signature, prepared_payload)
                 .is_ok()
         } else {
-            let payload = wincode::serialize(&self.vote_message.vote).ok()?;
+            let payload =
+                get_vote_payload_to_sign(&self.vote_message.vote, self.vote_message.shred_version);
             self.sender_bls_pubkey
                 .verify_signature(&self.vote_message.signature, &payload)
                 .is_ok()
         };
-        is_verified.then_some(self)
+        is_verified.then_some(VerifiedVotePayload {
+            vote_message: into_vote_msg(self.vote_message),
+            sender_vote_account_pubkey: self.sender_vote_account_pubkey,
+        })
     }
 }
 
@@ -71,7 +90,7 @@ impl VotePayload {
 ///
 /// Any vote that fails fallback individual signature verification will have its sender banlisted.
 pub(super) fn verify_and_send_votes(
-    votes_to_verify: Vec<VotePayload>,
+    votes_to_verify: Vec<UnverifiedVotePayload>,
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
@@ -105,7 +124,10 @@ pub(super) fn verify_and_send_votes(
 
 /// If the vote is relevant to repair, then adds it to the [`msgs_for_repair`] so it can eventually
 /// be sent to repair.
-fn inspect_for_repair(vote: &VotePayload, msgs_for_repair: &mut HashMap<Pubkey, Vec<Slot>>) {
+fn inspect_for_repair(
+    vote: &VerifiedVotePayload,
+    msgs_for_repair: &mut HashMap<Pubkey, Vec<Slot>>,
+) {
     let vote_slot = vote.vote_message.vote.slot();
     match vote.vote_message.vote {
         Vote::Notarize(_) | Vote::Finalize(_) | Vote::NotarizeFallback(_) => {
@@ -123,7 +145,7 @@ fn inspect_for_repair(vote: &VotePayload, msgs_for_repair: &mut HashMap<Pubkey, 
 /// In particular, collects and returns the relevant messages for the consensus pool; rewards;
 /// repair; and metrics;
 fn process_verified_votes(
-    verified_votes: Vec<VotePayload>,
+    verified_votes: Vec<VerifiedVotePayload>,
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
@@ -142,7 +164,7 @@ fn process_verified_votes(
             cluster_info,
             leader_schedule,
             root_bank.slot(),
-            &payload.vote_message,
+            &payload.vote_message.vote,
         ) {
             votes_for_reward.push(payload.vote_message.clone());
         }
@@ -177,11 +199,11 @@ fn process_verified_votes(
 /// Sig verifies `votes_to_verify` and returns a `Vec` of votes that passed verification.
 fn verify_votes(
     root_bank: &Bank,
-    votes_to_verify: Vec<VotePayload>,
+    votes_to_verify: Vec<UnverifiedVotePayload>,
     stats: &mut SigVerifyVoteStats,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
-) -> Vec<VotePayload> {
+) -> Vec<VerifiedVotePayload> {
     // Filter votes too far in the future.
     let len_before = votes_to_verify.len();
     let votes_to_verify = votes_to_verify
@@ -197,7 +219,13 @@ fn verify_votes(
     let (optimistic_result, distinct_votes, distinct_payloads) =
         verify_votes_optimistic(&votes_to_verify, stats, thread_pool);
     if matches!(optimistic_result, OptimisticVerificationResult::Verified) {
-        return votes_to_verify;
+        return votes_to_verify
+            .into_iter()
+            .map(|v| VerifiedVotePayload {
+                vote_message: into_vote_msg(v.vote_message),
+                sender_vote_account_pubkey: v.sender_vote_account_pubkey,
+            })
+            .collect();
     }
 
     // Fallback to individual verification
@@ -246,7 +274,7 @@ enum OptimisticVerificationResult {
 /// messages and their prepared payloads, which can be reused by the fallback
 /// path.
 fn verify_votes_optimistic(
-    votes: &[VotePayload],
+    votes: &[UnverifiedVotePayload],
     stats: &mut SigVerifyVoteStats,
     thread_pool: &ThreadPool,
 ) -> (
@@ -324,7 +352,7 @@ fn verify_votes_optimistic(
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn aggregate_signatures(votes: &[VotePayload]) -> Result<SignatureProjective, BlsError> {
+fn aggregate_signatures(votes: &[UnverifiedVotePayload]) -> Result<SignatureProjective, BlsError> {
     debug_assert!(current_thread_index().is_some());
     let signatures = votes.par_iter().map(|v| &v.vote_message.signature);
     // TODO(sam): Currently, `par_aggregate` performs full validation
@@ -339,7 +367,7 @@ fn aggregate_signatures(votes: &[VotePayload]) -> Result<SignatureProjective, Bl
 #[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn aggregate_pubkeys_by_payload(
-    votes: &[VotePayload],
+    votes: &[UnverifiedVotePayload],
     stats: &mut SigVerifyVoteStats,
 ) -> (
     Vec<Vote>,
@@ -347,12 +375,15 @@ fn aggregate_pubkeys_by_payload(
     Result<Vec<PopVerified<PubkeyProjective>>, BlsError>,
 ) {
     debug_assert!(current_thread_index().is_some());
-    let mut grouped_votes: HashMap<&Vote, Vec<&PopVerified<BlsPubkeyAffine>>> = HashMap::new();
+    let mut grouped_votes: HashMap<Vote, (u16, Vec<&PopVerified<BlsPubkeyAffine>>)> =
+        HashMap::new();
 
     for v in votes {
+        let shred_version = v.vote_message.shred_version;
         grouped_votes
-            .entry(&v.vote_message.vote)
-            .or_default()
+            .entry(v.vote_message.vote)
+            .or_insert_with(|| (shred_version, Vec::new()))
+            .1
             .push(&v.sender_bls_pubkey);
     }
 
@@ -362,14 +393,13 @@ fn aggregate_pubkeys_by_payload(
 
     let distinct_grouped_votes = grouped_votes
         .into_par_iter()
-        .filter_map(|(vote, pubkeys)| {
-            wincode::serialize(vote).ok().map(|serialized_vote| {
-                // converting aggregate pubkey to `PopVerified` is safe here
-                // since the pubkeys are all PoP verified in the vote account
-                let pubkey = PubkeyProjective::par_aggregate(pubkeys.into_par_iter())
-                    .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
-                (*vote, PreparedHashedMessage::new(&serialized_vote), pubkey)
-            })
+        .map(|(vote, (shred_version, pubkeys))| {
+            let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
+            // converting aggregate pubkey to `PopVerified` is safe here
+            // since the pubkeys are all PoP verified in the vote account
+            let pubkey = PubkeyProjective::par_aggregate(pubkeys.into_par_iter())
+                .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
+            (vote, PreparedHashedMessage::new(&serialized_vote), pubkey)
         })
         .collect::<Vec<_>>();
     let (distinct_votes, distinct_payloads, distinct_pubkeys_results): (Vec<_>, Vec<_>, Vec<_>) =
@@ -394,11 +424,11 @@ fn aggregate_pubkeys_by_payload(
 /// - `Vec<Pubkey>`: senders' identity pubkeys for votes that failed verification.
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn verify_individual_votes(
-    mut votes_to_verify: Vec<VotePayload>,
+    mut votes_to_verify: Vec<UnverifiedVotePayload>,
     distinct_votes: Vec<Vote>,
     distinct_payloads: Vec<PreparedHashedMessage>,
     thread_pool: &ThreadPool,
-) -> (Vec<VotePayload>, Vec<Pubkey>) {
+) -> (Vec<VerifiedVotePayload>, Vec<Pubkey>) {
     if should_prepare_payload_cache(distinct_votes.len(), votes_to_verify.len()) {
         let prepared_payloads: HashMap<_, _> = distinct_votes
             .into_iter()

--- a/bls-sigverify/src/rewards.rs
+++ b/bls-sigverify/src/rewards.rs
@@ -1,7 +1,5 @@
 use {
-    agave_votor_messages::{
-        consensus_message::VoteMessage, reward_certificate::NUM_SLOTS_FOR_REWARD, vote::Vote,
-    },
+    agave_votor_messages::{reward_certificate::NUM_SLOTS_FOR_REWARD, vote::Vote},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
@@ -13,16 +11,16 @@ pub fn rewards_wants_vote(
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
     root_slot: Slot,
-    vote: &VoteMessage,
+    vote: &Vote,
 ) -> bool {
-    match vote.vote {
+    match vote {
         Vote::Notarize(_) | Vote::Skip(_) => (),
         Vote::Finalize(_)
         | Vote::NotarizeFallback(_)
         | Vote::SkipFallback(_)
         | Vote::Genesis(_) => return false,
     }
-    let vote_slot = vote.vote.slot();
+    let vote_slot = vote.slot();
     if vote_slot.saturating_add(NUM_SLOTS_FOR_REWARD) <= root_slot {
         return false;
     }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -138,6 +138,7 @@ pub struct BlockCreationLoopConfig {
 
 struct LeaderContext {
     exit: Arc<AtomicBool>,
+    my_shred_version: u16,
     my_pubkey: Pubkey,
     /// Finalized leader-window notifications from Votor.
     leader_window_info_receiver: Receiver<LeaderWindowInfo>,
@@ -272,6 +273,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
 
     let mut ctx = LeaderContext {
         exit,
+        my_shred_version: cluster_info.my_shred_version(),
         my_pubkey,
         highest_parent_ready,
         leader_window_info_receiver,
@@ -763,7 +765,7 @@ fn record_and_complete_block(
             notar,
             validators: _,
         } = reward_certs;
-        let reward_cert = ValidatedRewardCert::try_new(&bank, &skip, &notar)?;
+        let reward_cert = ValidatedRewardCert::try_new(&bank, ctx.my_shred_version, &skip, &notar)?;
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
         let final_cert_input = guard.as_ref().map(|c| c.vote_rewards_input());
@@ -1321,6 +1323,7 @@ fn maybe_include_genesis_certificate(
     processor
         .on_genesis_cert_block_marker(
             bank.clone(),
+            ctx.my_shred_version,
             ctx.genesis_cert_block_marker.clone(),
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
@@ -1344,9 +1347,11 @@ mod tests {
         crossbeam_channel::bounded,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
+        solana_gossip::node::Node,
         solana_keypair::Keypair,
         solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
+        solana_net_utils::SocketAddrSpace,
         solana_poh::{
             poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
             record_channels::record_channels,
@@ -1356,6 +1361,7 @@ mod tests {
             bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader,
             installed_scheduler_pool::BankWithScheduler,
         },
+        solana_signer::Signer,
         solana_system_transaction as system_transaction,
         std::num::NonZeroUsize,
     };
@@ -1390,6 +1396,20 @@ mod tests {
             leader_schedule: Arc::new(schedule),
         }));
         Arc::new(leader_schedule_cache)
+    }
+
+    fn test_cluster_info() -> (Pubkey, Arc<ClusterInfo>) {
+        let keypair = Arc::new(Keypair::new());
+        let my_pubkey = keypair.pubkey();
+        let contact_info = Node::new_localhost_with_pubkey(&my_pubkey).info;
+        (
+            my_pubkey,
+            Arc::new(ClusterInfo::new(
+                contact_info,
+                keypair,
+                SocketAddrSpace::Unspecified,
+            )),
+        )
     }
 
     struct TestBankForksController {
@@ -1510,7 +1530,7 @@ mod tests {
     fn test_abort_failed_working_bank() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let my_pubkey = Pubkey::new_unique();
+        let (my_pubkey, cluster_info) = test_cluster_info();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1542,6 +1562,7 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
+            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1614,7 +1635,7 @@ mod tests {
     fn test_marker_send_clears_bank() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let my_pubkey = Pubkey::new_unique();
+        let (my_pubkey, cluster_info) = test_cluster_info();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1660,6 +1681,7 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
+            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1703,7 +1725,7 @@ mod tests {
     fn test_moved_on_aborts() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let my_pubkey = Pubkey::new_unique();
+        let (my_pubkey, cluster_info) = test_cluster_info();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1735,6 +1757,7 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
+            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1788,7 +1811,7 @@ mod tests {
     fn test_sad_leader_handover() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let my_pubkey = Pubkey::new_unique();
+        let (my_pubkey, cluster_info) = test_cluster_info();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.set_block_id(Some(Hash::new_unique()));
@@ -1844,6 +1867,7 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
+            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,

--- a/core/src/block_creation_loop/rewards/certs_builder.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder.rs
@@ -87,7 +87,12 @@ impl CertsBuilder {
 
     /// Returns [`true`] if the rewards container is interested in this vote else [`false`].
     fn wants_vote(&self, root_slot: Slot, vote: &VoteMessage) -> bool {
-        if !rewards_wants_vote(&self.cluster_info, &self.leader_schedule, root_slot, vote) {
+        if !rewards_wants_vote(
+            &self.cluster_info,
+            &self.leader_schedule,
+            root_slot,
+            &vote.vote,
+        ) {
             return false;
         }
         let Some(entry) = self.votes.get(&vote.vote.slot()) else {

--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -120,7 +120,8 @@ impl Entry {
 mod tests {
     use {
         super::*,
-        agave_votor_messages::consensus_message::Block,
+        agave_votor_messages::{consensus_message::Block, wire::get_vote_payload_to_sign},
+        rand::Rng,
         solana_bls_signatures::{Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed},
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
@@ -142,8 +143,13 @@ mod tests {
         }
     }
 
-    pub(crate) fn new_vote(vote: Vote, rank: usize, keypairs: &[BlsKeypair]) -> VoteMessage {
-        let serialized = wincode::serialize(&vote).unwrap();
+    pub(crate) fn new_vote(
+        vote: Vote,
+        rank: usize,
+        keypairs: &[BlsKeypair],
+        shred_version: u16,
+    ) -> VoteMessage {
+        let serialized = get_vote_payload_to_sign(&vote, shred_version);
         let signature = keypairs[rank].sign(&serialized).into();
         VoteMessage {
             vote,
@@ -201,13 +207,14 @@ mod tests {
         let slot = 123;
         let max_validators = 5;
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let shred_version = rand::rng().random();
         let mut entry = Entry::new(max_validators);
         let resp = entry.clone().build_certs(slot).unwrap();
         assert_eq!(resp.skip, None);
         assert_eq!(resp.notar, None);
 
         let skip = Vote::new_skip_vote(7);
-        let vote = new_vote(skip, 0, &keypairs);
+        let vote = new_vote(skip, 0, &keypairs, shred_version);
         entry.add_vote(&rank_map, &vote).unwrap();
         let resp = entry.build_certs(slot).unwrap();
         assert_eq!(resp.notar, None);
@@ -220,6 +227,7 @@ mod tests {
     fn validate_build_notar_cert() {
         let slot = 123;
         let max_validators = 5;
+        let shred_version = rand::rng().random();
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
 
         let mut entry = Entry::new(max_validators);
@@ -235,7 +243,7 @@ mod tests {
                 slot,
                 block_id: blockid0,
             });
-            let vote = new_vote(notar, rank, &keypairs);
+            let vote = new_vote(notar, rank, &keypairs, shred_version);
             entry.add_vote(&rank_map, &vote).unwrap();
         }
         for rank in 2..5 {
@@ -243,7 +251,7 @@ mod tests {
                 slot,
                 block_id: blockid1,
             });
-            let vote = new_vote(notar, rank, &keypairs);
+            let vote = new_vote(notar, rank, &keypairs, shred_version);
             entry.add_vote(&rank_map, &vote).unwrap();
         }
         let resp = entry.build_certs(slot).unwrap();

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -101,6 +101,7 @@ mod tests {
             consensus_message::{Block, VoteMessage},
             vote::Vote,
         },
+        rand::Rng,
         solana_bls_signatures::signature::BLS_SIGNATURE_AFFINE_SIZE,
         solana_hash::Hash,
     };
@@ -109,6 +110,7 @@ mod tests {
     fn validator_add_vote() {
         let slot = 123;
         let max_validators = 5;
+        let shred_version = rand::rng().random();
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
         let rank = 0;
         let mut entry = NotarEntry::new(max_validators);
@@ -133,7 +135,7 @@ mod tests {
             )
             .unwrap_err();
 
-        let vote = new_vote(notar, rank as usize, &keypairs);
+        let vote = new_vote(notar, rank as usize, &keypairs, shred_version);
         entry
             .add_vote(
                 &rank_map,
@@ -160,6 +162,7 @@ mod tests {
         let slot = 123;
         let max_validators = 5;
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let shred_version = rand::rng().random();
 
         let mut entry = NotarEntry::new(max_validators);
         assert_eq!(entry.clone().build_cert(slot).unwrap(), None);
@@ -172,7 +175,7 @@ mod tests {
                 slot,
                 block_id: blockid0,
             });
-            let vote = new_vote(notar, rank, &keypairs);
+            let vote = new_vote(notar, rank, &keypairs, shred_version);
             entry
                 .add_vote(
                     &rank_map,
@@ -188,7 +191,7 @@ mod tests {
                 slot,
                 block_id: blockid1,
             });
-            let vote = new_vote(notar, rank, &keypairs);
+            let vote = new_vote(notar, rank, &keypairs, shred_version);
             entry
                 .add_vote(
                     &rank_map,

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -108,6 +108,7 @@ mod tests {
             get_rank_map_keypairs, new_vote, validate_bitmap,
         },
         agave_votor_messages::{consensus_message::VoteMessage, vote::Vote},
+        rand::Rng,
         solana_bls_signatures::Keypair as BlsKeypair,
     };
 
@@ -127,10 +128,11 @@ mod tests {
         let slot = 123;
         let max_validators = 2;
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let shred_version = rand::rng().random();
         let skip = Vote::new_skip_vote(7);
         let mut partial_cert = PartialCert::new(max_validators);
         for rank in 0..max_validators {
-            let vote = new_vote(skip, rank, &keypairs);
+            let vote = new_vote(skip, rank, &keypairs, shred_version);
             partial_cert
                 .add_vote(&rank_map, vote.rank, &vote.signature)
                 .unwrap();
@@ -142,6 +144,7 @@ mod tests {
     fn validate_build_sig_bitmap() {
         let slot = 123;
         let max_validators = 2;
+        let shred_version = rand::rng().random();
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
         let mut partial_cert = PartialCert::new(max_validators);
         assert!(matches!(
@@ -150,7 +153,7 @@ mod tests {
         ));
         let skip = Vote::new_skip_vote(slot);
         for rank in 0..max_validators {
-            let vote = new_vote(skip, rank, &keypairs);
+            let vote = new_vote(skip, rank, &keypairs, shred_version);
             partial_cert
                 .add_vote(&rank_map, vote.rank, &vote.signature)
                 .unwrap();
@@ -163,6 +166,7 @@ mod tests {
     fn validate_add_vote() {
         let slot = 123;
         let max_validators = 2;
+        let shred_version = rand::rng().random();
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
         let mut partial_cert = PartialCert::new(max_validators);
         let skip = Vote::new_skip_vote(slot);
@@ -171,7 +175,7 @@ mod tests {
             partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
             Err(AddVoteError::InvalidRank)
         ));
-        let vote = new_vote(skip, 0, &keypairs);
+        let vote = new_vote(skip, 0, &keypairs, shred_version);
         partial_cert
             .add_vote(&rank_map, vote.rank, &vote.signature)
             .unwrap();
@@ -179,11 +183,11 @@ mod tests {
             partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
             Err(AddVoteError::Duplicate)
         ));
-        let vote = new_vote(skip, 1, &keypairs);
+        let vote = new_vote(skip, 1, &keypairs, shred_version);
         partial_cert
             .add_vote(&rank_map, vote.rank, &vote.signature)
             .unwrap();
-        let vote = new_vote(skip, 0, &keypairs);
+        let vote = new_vote(skip, 0, &keypairs, shred_version);
         assert!(matches!(
             partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
             Err(AddVoteError::Duplicate)
@@ -194,18 +198,19 @@ mod tests {
     fn validate_wants_vote() {
         let slot = 123;
         let max_validators = 2;
+        let shred_version = rand::rng().random();
         let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
         let skip = Vote::new_skip_vote(slot);
         let mut partial_cert = PartialCert::new(max_validators);
         let vote = new_invalid_vote(skip, 2);
         assert!(!partial_cert.wants_vote(vote.rank));
-        let vote = new_vote(skip, 0, &keypairs);
+        let vote = new_vote(skip, 0, &keypairs, shred_version);
         assert!(partial_cert.wants_vote(vote.rank));
         partial_cert
             .add_vote(&rank_map, vote.rank, &vote.signature)
             .unwrap();
         assert!(!partial_cert.wants_vote(vote.rank));
-        let vote = new_vote(skip, 1, &keypairs);
+        let vote = new_vote(skip, 1, &keypairs, shred_version);
         partial_cert
             .add_vote(&rank_map, vote.rank, &vote.signature)
             .unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -995,6 +995,7 @@ impl ReplayStage {
                     (r_bank_forks.ancestors(), r_bank_forks.descendants())
                 };
                 let new_frozen_slots = Self::process_active_banks(
+                    cluster_info.my_shred_version(),
                     &process_active_banks_context,
                     &mut progress,
                     &mut async_verification_freelist,
@@ -1213,6 +1214,7 @@ impl ReplayStage {
                     if last_genesis_vote_refresh_time.elapsed() > GENESIS_VOTE_REFRESH
                         && migration_status.is_in_migration()
                         && Self::maybe_send_genesis_vote(
+                            cluster_info.my_shred_version(),
                             migration_status.as_ref(),
                             bank_forks.as_ref(),
                             vote_account,
@@ -1736,6 +1738,7 @@ impl ReplayStage {
     /// If we have an eligible genesis block, send out a genesis vote
     /// Returns false if no eligible block was found
     fn maybe_send_genesis_vote(
+        my_shred_version: u16,
         migration_status: &MigrationStatus,
         bank_forks: &RwLock<BankForks>,
         vote_account: Pubkey,
@@ -1754,6 +1757,7 @@ impl ReplayStage {
             vote,
             bank_forks.read().unwrap().root_bank().as_ref(),
             vote_account,
+            my_shred_version,
             identity_keypair,
             authorized_voter_keypairs,
             None,
@@ -2974,6 +2978,7 @@ impl ReplayStage {
     }
 
     fn replay_blockstore_into_bank(
+        my_shred_version: u16,
         process_active_banks_context: &ProcessActiveBanksContext,
         bank: &BankWithScheduler,
         replay_stats: &RwLock<ReplaySlotStats>,
@@ -2989,6 +2994,7 @@ impl ReplayStage {
         blockstore_processor::confirm_slot(
             &process_active_banks_context.blockstore,
             bank,
+            my_shred_version,
             &process_active_banks_context.replay_tx_thread_pool,
             &mut w_replay_stats,
             &mut w_replay_progress,
@@ -3654,6 +3660,7 @@ impl ReplayStage {
     }
 
     fn replay_active_bank(
+        my_shred_version: u16,
         process_active_banks_context: &ProcessActiveBanksContext,
         bank_replay_result_tracker: BankReplayResultTracker,
         my_pubkey: &Pubkey,
@@ -3706,6 +3713,7 @@ impl ReplayStage {
 
         let mut replay_blockstore_time = Measure::start("replay_blockstore_into_bank");
         let blockstore_result = Self::replay_blockstore_into_bank(
+            my_shred_version,
             process_active_banks_context,
             &bank,
             &replay_stats,
@@ -3727,6 +3735,7 @@ impl ReplayStage {
     }
 
     fn replay_active_banks(
+        my_shred_version: u16,
         process_active_banks_context: &ProcessActiveBanksContext,
         bank_replay_result_trackers: Vec<BankReplayResultTracker>,
         replay_timing: &mut ReplayLoopTiming,
@@ -3750,6 +3759,7 @@ impl ReplayStage {
                                 );
                                 let (replay_result, replay_blockstore_us) =
                                     Self::replay_active_bank(
+                                        my_shred_version,
                                         process_active_banks_context,
                                         bank_replay_result_tracker,
                                         my_pubkey,
@@ -3778,6 +3788,7 @@ impl ReplayStage {
                         bank_replay_result_tracker.replay_result.bank_slot
                     );
                     let (replay_result, replay_blockstore_us) = Self::replay_active_bank(
+                        my_shred_version,
                         process_active_banks_context,
                         bank_replay_result_tracker,
                         my_pubkey,
@@ -4207,6 +4218,7 @@ impl ReplayStage {
 
     #[allow(clippy::too_many_arguments)]
     fn process_active_banks(
+        my_shred_version: u16,
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
@@ -4232,6 +4244,7 @@ impl ReplayStage {
 
         // Perform replay execution.
         let replay_result_vec = Self::replay_active_banks(
+            my_shred_version,
             process_active_banks_context,
             bank_replay_result_trackers,
             replay_timing,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -63,6 +63,7 @@ use {
         genesis_utils::{GenesisConfigInfo, ValidatorVoteKeypairs},
     },
     solana_sha256_hasher::hash,
+    solana_shred_version::compute_shred_version,
     solana_signature::Signature,
     solana_system_transaction as system_transaction,
     solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
@@ -142,6 +143,16 @@ fn post_migration_status_for_tests() -> MigrationStatus {
     migration_status.set_genesis_certificate(genesis_certificate);
     migration_status.enable_alpenglow_during_startup();
     migration_status
+}
+
+fn cluster_info_for_tests() -> ClusterInfo {
+    let keypair = Arc::new(Keypair::new());
+    let my_pubkey = keypair.pubkey();
+    ClusterInfo::new(
+        Node::new_localhost_with_pubkey(&my_pubkey).info,
+        keypair,
+        SocketAddrSpace::Unspecified,
+    )
 }
 
 fn block_marker_shreds(
@@ -1008,11 +1019,13 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
         let entries = make_complete_slot_entries(&bank, vec![tx]);
         let shreds = entries_to_test_shreds(&entries, slot, bank.parent_slot(), true, 0);
         blockstore.insert_shreds(shreds, None, false).unwrap();
+        let cluster_info = cluster_info_for_tests();
 
         ReplaySlotFromBlockstore {
             is_slot_dead: false,
             bank_slot: slot,
             replay_result: Some(ReplayStage::replay_blockstore_into_bank(
+                cluster_info.my_shred_version(),
                 &process_active_banks_context,
                 &bank,
                 &bank_progress.replay_stats,
@@ -1230,7 +1243,9 @@ where
             blockstore.clone(),
             replay_vote_sender,
         );
+        let cluster_info = cluster_info_for_tests();
         let res = ReplayStage::replay_blockstore_into_bank(
+            cluster_info.my_shred_version(),
             &process_active_banks_context,
             &bank1,
             &bank1_progress.replay_stats,
@@ -6147,6 +6162,7 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
     // Set up bank0
     let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
     let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
+    let shred_version = compute_shred_version(&genesis_config.hash(), None);
     let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
         .num_threads(1)
         .thread_name(|i| format!("solReplayTx{i:02}"))
@@ -6155,6 +6171,7 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
 
     process_bank_0(
         &bank0,
+        shred_version,
         &blockstore,
         &replay_tx_thread_pool,
         &ProcessOptions::default(),
@@ -6176,6 +6193,7 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
     confirm_full_slot(
         &blockstore,
         &bank1,
+        shred_version,
         &replay_tx_thread_pool,
         &ProcessOptions::default(),
         &mut ConfirmationProgress::new(bank0.last_blockhash()),
@@ -6195,6 +6213,7 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
     blockstore_processor::process_blockstore_from_root(
         &blockstore,
         &bank_forks,
+        shred_version,
         &leader_schedule_cache,
         &ProcessOptions::default(),
         None,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1134,6 +1134,7 @@ impl Validator {
             blockstore_root_scan,
             &snapshot_controller,
             config,
+            cluster_info.my_shred_version(),
         );
 
         maybe_warp_slot(
@@ -2485,6 +2486,7 @@ pub struct ProcessBlockStore<'a> {
     config: &'a ValidatorConfig,
     tower: Option<Tower>,
     vote_history: Option<VoteHistory>,
+    my_shred_version: u16,
 }
 
 impl<'a> ProcessBlockStore<'a> {
@@ -2503,6 +2505,7 @@ impl<'a> ProcessBlockStore<'a> {
         blockstore_root_scan: BlockstoreRootScan,
         snapshot_controller: &'a SnapshotController,
         config: &'a ValidatorConfig,
+        my_shred_version: u16,
     ) -> Self {
         Self {
             id,
@@ -2520,6 +2523,7 @@ impl<'a> ProcessBlockStore<'a> {
             config,
             tower: None,
             vote_history: None,
+            my_shred_version,
         }
     }
 
@@ -2555,6 +2559,7 @@ impl<'a> ProcessBlockStore<'a> {
         blockstore_processor::process_blockstore_from_root(
             self.blockstore,
             self.bank_forks,
+            self.my_shred_version,
             self.leader_schedule_cache,
             self.process_options,
             self.transaction_status_sender,

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -133,7 +133,6 @@ use {
     crate::entry::{Entry, MaxDataShredsLen},
     agave_votor_messages::{
         certificate::{Certificate, CertificateType},
-        consensus_message::Block,
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
     },
     solana_bls_signatures::{
@@ -264,19 +263,6 @@ impl TryFrom<Certificate> for GenesisCertBlockMarker {
             bls_signature: cert.signature,
             bitmap: cert.bitmap,
         })
-    }
-}
-
-impl From<GenesisCertBlockMarker> for Certificate {
-    fn from(cert: GenesisCertBlockMarker) -> Self {
-        Self {
-            cert_type: CertificateType::Genesis(Block {
-                slot: cert.slot,
-                block_id: cert.block_id,
-            }),
-            signature: cert.bls_signature,
-            bitmap: cert.bitmap,
-        }
     }
 }
 

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -43,6 +43,7 @@ use {
         snapshot_controller::SnapshotController,
         snapshot_utils,
     },
+    solana_shred_version::compute_shred_version,
     solana_transaction::versioned::VersionedTransaction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{
@@ -460,10 +461,15 @@ pub fn load_and_process_ledger(
     };
     let accounts_background_service =
         AccountsBackgroundService::new(bank_forks.clone(), exit.clone(), abs_request_handler);
+    let shred_version = {
+        let hard_forks = bank_forks.read().unwrap().root_bank().hard_forks();
+        compute_shred_version(&genesis_config.hash(), Some(&hard_forks))
+    };
 
     let result = blockstore_processor::process_blockstore_from_root(
         blockstore.as_ref(),
         &bank_forks,
+        shred_version,
         &leader_schedule_cache,
         &process_options,
         transaction_status_sender.as_ref(),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -49,6 +49,7 @@ use {
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
     },
+    solana_shred_version::compute_shred_version,
     solana_signature::Signature,
     solana_svm::{
         transaction_commit_result::{TransactionCommitResult, TransactionCommitResultExtensions},
@@ -918,6 +919,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         None,
     );
     let bank0_slot = bank0.slot();
+    let hard_forks = bank0.hard_forks();
     let bank_forks = BankForks::new_rw_arc(bank0);
 
     info!("Processing ledger for slot 0...");
@@ -928,6 +930,7 @@ pub(crate) fn process_blockstore_for_bank_0(
             .unwrap()
             .get_with_scheduler(bank0_slot)
             .unwrap(),
+        compute_shred_version(&genesis_config.hash(), Some(&hard_forks)),
         blockstore,
         &replay_tx_thread_pool,
         opts,
@@ -944,6 +947,7 @@ pub(crate) fn process_blockstore_for_bank_0(
 pub fn process_blockstore_from_root(
     blockstore: &Blockstore,
     bank_forks: &RwLock<BankForks>,
+    shred_version: u16,
     leader_schedule_cache: &LeaderScheduleCache,
     opts: &ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
@@ -1001,6 +1005,7 @@ pub fn process_blockstore_from_root(
         let replay_tx_thread_pool = create_thread_pool(num_cpus::get());
         load_frozen_forks(
             bank_forks,
+            shred_version,
             &start_slot_meta,
             blockstore,
             &replay_tx_thread_pool,
@@ -1118,6 +1123,7 @@ fn verify_ticks(
 fn confirm_full_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
+    shred_version: u16,
     replay_tx_thread_pool: &ThreadPool,
     opts: &ProcessOptions,
     progress: &mut ConfirmationProgress,
@@ -1143,6 +1149,7 @@ fn confirm_full_slot(
     confirm_slot(
         blockstore,
         bank,
+        shred_version,
         replay_tx_thread_pool,
         &mut confirmation_timing,
         progress,
@@ -1668,6 +1675,7 @@ impl AsyncVerificationProgress {
 pub fn confirm_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
+    shred_version: u16,
     replay_tx_thread_pool: &ThreadPool,
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
@@ -1688,6 +1696,7 @@ pub fn confirm_slot(
         true => confirm_slot_with_components(
             blockstore,
             bank,
+            shred_version,
             replay_tx_thread_pool,
             timing,
             progress,
@@ -1771,6 +1780,7 @@ fn confirm_slot_with_entries(
 fn confirm_slot_with_components(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
+    shred_version: u16,
     replay_tx_thread_pool: &ThreadPool,
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
@@ -1887,6 +1897,7 @@ fn confirm_slot_with_components(
                         .on_marker(
                             bank.clone_without_scheduler(),
                             parent_bank,
+                            shred_version,
                             marker,
                             allow_initial_update_parent,
                             finalization_cert_sender,
@@ -2173,6 +2184,7 @@ fn confirm_slot_entries(
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn process_bank_0(
     bank0: &BankWithScheduler,
+    shred_version: u16,
     blockstore: &Blockstore,
     replay_tx_thread_pool: &ThreadPool,
     opts: &ProcessOptions,
@@ -2185,6 +2197,7 @@ fn process_bank_0(
     confirm_full_slot(
         blockstore,
         bank0,
+        shred_version,
         replay_tx_thread_pool,
         opts,
         &mut progress,
@@ -2390,6 +2403,7 @@ pub fn set_alpenglow_ticks(bank: &Bank, migration_status: &MigrationStatus) {
 #[allow(clippy::too_many_arguments)]
 fn load_frozen_forks(
     bank_forks: &RwLock<BankForks>,
+    shred_version: u16,
     start_slot_meta: &SlotMeta,
     blockstore: &Blockstore,
     replay_tx_thread_pool: &ThreadPool,
@@ -2487,6 +2501,7 @@ fn load_frozen_forks(
             if let Err(error) = process_single_slot(
                 blockstore,
                 &bank,
+                shred_version,
                 replay_tx_thread_pool,
                 opts,
                 &mut progress,
@@ -2804,6 +2819,7 @@ fn reset_dead_if_primary_access(blockstore: &Blockstore, slot: Slot) {
 pub fn process_single_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
+    shred_version: u16,
     replay_tx_thread_pool: &ThreadPool,
     opts: &ProcessOptions,
     progress: &mut ConfirmationProgress,
@@ -2835,6 +2851,7 @@ pub fn process_single_slot(
     confirm_full_slot(
         blockstore,
         bank,
+        shred_version,
         replay_tx_thread_pool,
         opts,
         progress,
@@ -3127,6 +3144,7 @@ pub mod tests {
         process_blockstore_from_root(
             blockstore,
             &bank_forks,
+            compute_shred_version(&genesis_config.hash(), None),
             &leader_schedule_cache,
             opts,
             None,
@@ -4933,6 +4951,7 @@ pub mod tests {
         let replay_tx_thread_pool = create_thread_pool(1);
         process_bank_0(
             &bank0,
+            compute_shred_version(&genesis_config.hash(), None),
             &blockstore,
             &replay_tx_thread_pool,
             &opts,
@@ -4948,6 +4967,7 @@ pub mod tests {
         confirm_full_slot(
             &blockstore,
             &bank1,
+            compute_shred_version(&genesis_config.hash(), None),
             &replay_tx_thread_pool,
             &opts,
             &mut ConfirmationProgress::new(bank0_last_blockhash),
@@ -4966,6 +4986,7 @@ pub mod tests {
         process_blockstore_from_root(
             &blockstore,
             &bank_forks,
+            compute_shred_version(&genesis_config.hash(), None),
             &leader_schedule_cache,
             &opts,
             None,
@@ -6242,25 +6263,24 @@ pub mod tests {
         );
         let bank1 = bank_forks.write().unwrap().insert(bank1);
 
-        assert!(
-            confirm_slot(
-                &blockstore,
-                &bank1,
-                &replay_tx_thread_pool,
-                &mut ConfirmationTiming::default(),
-                &mut ConfirmationProgress::new(bank0.last_blockhash()),
-                false,
-                None,
-                None,
-                None,
-                None,
-                false,
-                None,
-                None,
-                &MigrationStatus::default(),
-            )
-            .is_err()
-        );
+        confirm_slot(
+            &blockstore,
+            &bank1,
+            compute_shred_version(&genesis_config.hash(), None),
+            &replay_tx_thread_pool,
+            &mut ConfirmationTiming::default(),
+            &mut ConfirmationProgress::new(bank0.last_blockhash()),
+            false,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            &MigrationStatus::default(),
+        )
+        .unwrap_err();
     }
 
     #[test]
@@ -6279,25 +6299,24 @@ pub mod tests {
         );
         let bank1 = bank_forks.write().unwrap().insert(bank1);
 
-        assert!(
-            confirm_slot(
-                &blockstore,
-                &bank1,
-                &replay_tx_thread_pool,
-                &mut ConfirmationTiming::default(),
-                &mut ConfirmationProgress::new(bank0.last_blockhash()),
-                true,
-                None,
-                None,
-                None,
-                None,
-                false,
-                None,
-                None,
-                &MigrationStatus::post_migration_status(),
-            )
-            .is_ok()
-        );
+        confirm_slot(
+            &blockstore,
+            &bank1,
+            compute_shred_version(&genesis_config.hash(), None),
+            &replay_tx_thread_pool,
+            &mut ConfirmationTiming::default(),
+            &mut ConfirmationProgress::new(bank0.last_blockhash()),
+            true,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            &MigrationStatus::post_migration_status(),
+        )
+        .unwrap();
     }
 
     #[test]

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -5,7 +5,10 @@
 use log::*;
 use {
     crate::{cluster::QuicTpuClient, local_cluster::LocalCluster},
-    agave_votor_messages::consensus_message::ConsensusMessage,
+    agave_votor_messages::{
+        consensus_message::VoteMessage, unverified_vote_message::DecodedWireConsensusMessage,
+        wire::VersionedWireConsensusMessage,
+    },
     crossbeam_channel::bounded,
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
@@ -30,7 +33,7 @@ use {
     solana_keypair::Keypair,
     solana_ledger::blockstore::Blockstore,
     solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
-    solana_perf::packet::packet_config,
+    solana_perf::packet::{PacketRef, packet_config},
     solana_poh_config::PohConfig,
     solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
@@ -622,8 +625,28 @@ pub fn start_quic_streamer_to_listen_for_votes_and_certs(
     (cancel, result.thread, receiver)
 }
 
+fn convert_packet_to_vote_message(packet: PacketRef, my_shred_version: u16) -> Option<VoteMessage> {
+    let Ok(msg) = wincode::config::deserialize_exact::<VersionedWireConsensusMessage, _>(
+        packet.data(..).unwrap_or_default(),
+        packet_config(),
+    ) else {
+        return None;
+    };
+    let DecodedWireConsensusMessage::Vote(vote_msg) =
+        DecodedWireConsensusMessage::try_new(msg, my_shred_version).unwrap()
+    else {
+        return None;
+    };
+    Some(VoteMessage {
+        vote: vote_msg.vote,
+        signature: vote_msg.signature,
+        rank: vote_msg.rank,
+    })
+}
+
 /// Check that all nodes in the cluster are producing notarized votes.
 pub fn check_for_new_notarized_votes(
+    my_shred_version: u16,
     num_new_votes: usize,
     contact_infos: &[ContactInfo],
     test_name: &str,
@@ -673,11 +696,8 @@ pub fn check_for_new_notarized_votes(
                     continue;
                 };
                 for packet in packet_batch.iter() {
-                    let Ok(ConsensusMessage::Vote(vote_message)) =
-                        wincode::config::deserialize_exact(
-                            packet.data(..).unwrap_or_default(),
-                            packet_config(),
-                        )
+                    let Some(vote_message) =
+                        convert_packet_to_vote_message(packet, my_shred_version)
                     else {
                         continue;
                     };

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -42,6 +42,7 @@ use {
         GenesisConfigInfo, ValidatorVoteKeypairs,
         create_genesis_config_with_vote_accounts_and_cluster_type,
     },
+    solana_shred_version::compute_shred_version,
     solana_signer::{Signer, signers::Signers},
     solana_stake_interface::{
         instruction as stake_instruction,
@@ -921,6 +922,7 @@ impl LocalCluster {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
         info!("{test_name} looking for new notarized votes on all nodes");
         cluster_tests::check_for_new_notarized_votes(
+            compute_shred_version(&self.genesis_config.hash(), None),
             num_new_notarized_votes,
             &alive_node_contact_infos,
             test_name,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -81,6 +81,7 @@ use {
         response::RpcSignatureResult,
     },
     solana_runtime::{commitment::VOTE_THRESHOLD_SIZE, snapshot_bank_utils, snapshot_utils},
+    solana_shred_version::compute_shred_version,
     solana_signer::Signer,
     solana_stake_interface as stake,
     solana_system_interface::program as system_program,
@@ -2250,6 +2251,7 @@ fn create_snapshot_to_hard_fork(
     blockstore_processor::process_blockstore_from_root(
         blockstore,
         &bank_forks,
+        compute_shred_version(&genesis_config.hash(), None),
         &leader_schedule_cache,
         &process_options,
         None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -81,7 +81,10 @@ use {
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::snapshot_hash::SnapshotHash,
-    agave_votor_messages::{certificate::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT},
+    agave_votor_messages::{
+        certificate::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT,
+        unverified_vote_message::UnverifiedCertificate,
+    },
     ahash::AHashSet,
     log::*,
     partitioned_epoch_rewards::PartitionedRewardsCalculation,
@@ -5758,8 +5761,8 @@ impl Bank {
     /// Verify a BLS certificate's signature using this bank's epoch stakes.
     pub fn verify_certificate(
         &self,
-        cert: &Certificate,
-    ) -> std::result::Result<(), CertVerifyError> {
+        cert: UnverifiedCertificate,
+    ) -> std::result::Result<Certificate, CertVerifyError> {
         let slot = cert.cert_type.slot();
         let epoch_stakes = self
             .epoch_stakes_from_slot(slot)
@@ -5768,13 +5771,14 @@ impl Bank {
         let total_stake =
             NonZero::new(key_to_rank_map.total_stake()).expect("total stake cannot be 0");
 
-        cert_verify::verify_certificate(cert, key_to_rank_map.len(), total_stake, |rank| {
-            key_to_rank_map
-                .get_pubkey_stake_entry(rank)
-                .map(|entry| (entry.stake, entry.bls_pubkey))
-        })?;
+        let cert =
+            cert_verify::verify_certificate(cert, key_to_rank_map.len(), total_stake, |rank| {
+                key_to_rank_map
+                    .get_pubkey_stake_entry(rank)
+                    .map(|entry| (entry.stake, entry.bls_pubkey))
+            })?;
 
-        Ok(())
+        Ok(cert)
     }
 
     pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, VersionedEpochStakes> {

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -11,7 +11,10 @@ use {
         validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
     },
     agave_votor_messages::{
-        certificate::Certificate, consensus_message::ConsensusMessage, migration::MigrationStatus,
+        certificate::{Certificate, CertificateType},
+        consensus_message::{Block, ConsensusMessage},
+        migration::MigrationStatus,
+        unverified_vote_message::UnverifiedCertificate,
     },
     crossbeam_channel::Sender,
     log::*,
@@ -176,6 +179,7 @@ impl BlockComponentProcessor {
         &mut self,
         bank: Arc<Bank>,
         parent_bank: Arc<Bank>,
+        shred_version: u16,
         marker: VersionedBlockMarker,
         allow_initial_update_parent: bool,
         finalization_cert_sender: Option<&Sender<ConsensusMessage>>,
@@ -199,6 +203,7 @@ impl BlockComponentProcessor {
             {
                 self.on_genesis_cert_block_marker(
                     bank,
+                    shred_version,
                     genesis_cert_block_marker.into_inner(),
                     migration_status,
                 )
@@ -208,6 +213,7 @@ impl BlockComponentProcessor {
             BlockMarkerV1::BlockFooter(footer) if markers_fully_enabled => self.on_footer(
                 bank,
                 parent_bank,
+                shred_version,
                 footer.into_inner(),
                 finalization_cert_sender,
             ),
@@ -224,6 +230,7 @@ impl BlockComponentProcessor {
     pub fn on_genesis_cert_block_marker(
         &self,
         bank: Arc<Bank>,
+        shred_version: u16,
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
@@ -245,8 +252,16 @@ impl BlockComponentProcessor {
             return Err(BlockComponentProcessorError::GenesisCertificateAlreadyPopulated);
         }
 
-        let genesis_cert = Certificate::from(genesis_block_marker);
-        Self::verify_genesis_certificate(&bank, &genesis_cert)?;
+        let unverified_genesis_cert = UnverifiedCertificate {
+            cert_type: CertificateType::Genesis(Block {
+                slot: genesis_block_marker.slot,
+                block_id: genesis_block_marker.block_id,
+            }),
+            signature: genesis_block_marker.bls_signature,
+            bitmap: genesis_block_marker.bitmap,
+            shred_version,
+        };
+        let genesis_cert = Self::verify_genesis_certificate(&bank, unverified_genesis_cert)?;
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
         bank.set_hashes_per_tick(None);
 
@@ -280,12 +295,12 @@ impl BlockComponentProcessor {
 
     fn verify_genesis_certificate(
         bank: &Bank,
-        cert: &Certificate,
-    ) -> Result<(), BlockComponentProcessorError> {
+        cert: UnverifiedCertificate,
+    ) -> Result<Certificate, BlockComponentProcessorError> {
         debug_assert!(cert.cert_type.is_genesis());
 
         let cert_slot = cert.cert_type.slot();
-        bank.verify_certificate(cert).map_err(|_| {
+        let cert = bank.verify_certificate(cert).map_err(|_| {
             warn!(
                 "Failed to verify genesis certificate for slot {cert_slot} in bank slot {}",
                 bank.slot()
@@ -293,13 +308,14 @@ impl BlockComponentProcessor {
             BlockComponentProcessorError::GenesisCertificateFailedVerification
         })?;
 
-        Ok(())
+        Ok(cert)
     }
 
     fn on_footer(
         &mut self,
         bank: Arc<Bank>,
         parent_bank: Arc<Bank>,
+        shred_version: u16,
         footer: VersionedBlockFooter,
         finalization_cert_sender: Option<&Sender<ConsensusMessage>>,
     ) -> Result<(), BlockComponentProcessorError> {
@@ -324,13 +340,17 @@ impl BlockComponentProcessor {
             notar_reward_cert,
         } = footer;
 
-        let reward_cert =
-            ValidatedRewardCert::try_new(&bank, &skip_reward_cert, &notar_reward_cert)?;
+        let reward_cert = ValidatedRewardCert::try_new(
+            &bank,
+            shred_version,
+            &skip_reward_cert,
+            &notar_reward_cert,
+        )?;
         let block_producer_time_nanos =
             Self::block_producer_time_nanos_as_i64(block_producer_time_nanos)?;
         let final_cert = block_final_cert
             .map(|final_cert| {
-                ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank)
+                ValidatedBlockFinalizationCert::try_from_footer(final_cert, &bank, shred_version)
                     .map_err(BlockComponentProcessorError::InvalidFinalizationCertificate)
             })
             .transpose()?;
@@ -536,6 +556,7 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
         },
+        rand::Rng,
         solana_clock::DEFAULT_MS_PER_SLOT,
         solana_entry::block_component::{
             BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
@@ -627,6 +648,7 @@ mod tests {
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -642,17 +664,23 @@ mod tests {
         });
 
         // First footer should succeed
-        assert!(
-            processor
-                .on_footer(bank.clone(), parent.clone(), footer.clone(), None)
-                .is_ok()
-        );
+        processor
+            .on_footer(
+                bank.clone(),
+                parent.clone(),
+                shred_version,
+                footer.clone(),
+                None,
+            )
+            .unwrap();
 
         // Second footer should fail
-        let result = processor.on_footer(bank, parent, footer, None);
+        let err = processor
+            .on_footer(bank, parent, shred_version, footer, None)
+            .unwrap_err();
         assert!(matches!(
-            result,
-            Err(BlockComponentProcessorError::MultipleBlockFooters)
+            err,
+            BlockComponentProcessorError::MultipleBlockFooters
         ));
     }
 
@@ -665,6 +693,7 @@ mod tests {
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -681,7 +710,7 @@ mod tests {
         });
 
         processor
-            .on_footer(bank.clone(), parent, footer, None)
+            .on_footer(bank.clone(), parent, shred_version, footer, None)
             .unwrap();
 
         assert!(processor.has_footer);
@@ -730,9 +759,18 @@ mod tests {
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         processor
-            .on_marker(bank, parent, marker, false, None, &migration_status)
+            .on_marker(
+                bank,
+                parent,
+                shred_version,
+                marker,
+                false,
+                None,
+                &migration_status,
+            )
             .unwrap();
         assert!(processor.has_header);
     }
@@ -748,9 +786,18 @@ mod tests {
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         assert!(matches!(
-            processor.on_marker(bank, parent, marker, false, None, &migration_status),
+            processor.on_marker(
+                bank,
+                parent,
+                shred_version,
+                marker,
+                false,
+                None,
+                &migration_status
+            ),
             Err(BlockComponentProcessorError::HeaderParentSlotMismatch {
                 header_parent_slot: 7,
                 bank_parent_slot: 0,
@@ -768,6 +815,7 @@ mod tests {
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -784,7 +832,15 @@ mod tests {
         });
 
         processor
-            .on_marker(bank.clone(), parent, marker, false, None, &migration_status)
+            .on_marker(
+                bank.clone(),
+                parent,
+                shred_version,
+                marker,
+                false,
+                None,
+                &migration_status,
+            )
             .unwrap();
         assert!(processor.has_footer);
 
@@ -798,6 +854,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -824,7 +881,7 @@ mod tests {
             notar_reward_cert: None,
         });
         processor
-            .on_footer(bank.clone(), parent.clone(), footer, None)
+            .on_footer(bank.clone(), parent.clone(), shred_version, footer, None)
             .unwrap();
 
         // Verify clock sysvar was updated
@@ -841,6 +898,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Try to process a block header marker pre-migration - should fail
         let marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
@@ -848,10 +906,20 @@ mod tests {
             parent_block_id: Hash::default(),
         });
 
-        let result = processor.on_marker(bank, parent, marker, false, None, &migration_status);
+        let err = processor
+            .on_marker(
+                bank,
+                parent,
+                shred_version,
+                marker,
+                false,
+                None,
+                &migration_status,
+            )
+            .unwrap_err();
         assert!(matches!(
-            result,
-            Err(BlockComponentProcessorError::BlockComponentPreMigration)
+            err,
+            BlockComponentProcessorError::BlockComponentPreMigration
         ));
     }
 
@@ -860,6 +928,7 @@ mod tests {
         let migration_status = MigrationStatus::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
         let footer_marker = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
@@ -873,15 +942,18 @@ mod tests {
 
         let mut processor = BlockComponentProcessor::default();
         assert!(matches!(
-            processor.on_marker(
-                bank.clone(),
-                parent.clone(),
-                footer_marker,
-                false,
-                None,
-                &migration_status
-            ),
-            Err(BlockComponentProcessorError::BlockComponentPreMigration)
+            processor
+                .on_marker(
+                    bank.clone(),
+                    parent.clone(),
+                    shred_version,
+                    footer_marker,
+                    false,
+                    None,
+                    &migration_status
+                )
+                .unwrap_err(),
+            BlockComponentProcessorError::BlockComponentPreMigration
         ));
 
         let update_parent_marker = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
@@ -891,15 +963,18 @@ mod tests {
 
         let mut processor = BlockComponentProcessor::default();
         assert!(matches!(
-            processor.on_marker(
-                bank,
-                parent,
-                update_parent_marker,
-                false,
-                None,
-                &migration_status
-            ),
-            Err(BlockComponentProcessorError::BlockComponentPreMigration)
+            processor
+                .on_marker(
+                    bank,
+                    parent,
+                    shred_version,
+                    update_parent_marker,
+                    false,
+                    None,
+                    &migration_status
+                )
+                .unwrap_err(),
+            BlockComponentProcessorError::BlockComponentPreMigration
         ));
     }
 
@@ -923,6 +998,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Process header marker
         let header_marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
@@ -933,6 +1009,7 @@ mod tests {
             .on_marker(
                 bank.clone(),
                 parent.clone(),
+                shred_version,
                 header_marker,
                 false,
                 None,
@@ -961,6 +1038,7 @@ mod tests {
             .on_marker(
                 bank.clone(),
                 parent,
+                shred_version,
                 footer_marker,
                 false,
                 None,
@@ -981,6 +1059,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         let footer = VersionedBlockFooter::V1(BlockFooterV1 {
             bank_hash: Hash::new_unique(),
@@ -992,10 +1071,12 @@ mod tests {
         });
 
         // Try to process footer without header - should fail
-        let result = processor.on_footer(bank, parent, footer, None);
+        let err = processor
+            .on_footer(bank, parent, shred_version, footer, None)
+            .unwrap_err();
         assert!(matches!(
-            result,
-            Err(BlockComponentProcessorError::MissingParentMarker)
+            err,
+            BlockComponentProcessorError::MissingParentMarker
         ));
     }
 
@@ -1005,6 +1086,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
 
         // Process header first
         processor.has_header = true;
@@ -1025,15 +1107,17 @@ mod tests {
         });
 
         // Should succeed - footer is processed
-        let result = processor.on_marker(
-            bank.clone(),
-            parent,
-            footer_marker,
-            false,
-            None,
-            &migration_status,
-        );
-        assert!(result.is_ok());
+        processor
+            .on_marker(
+                bank.clone(),
+                parent,
+                shred_version,
+                footer_marker,
+                false,
+                None,
+                &migration_status,
+            )
+            .unwrap();
         assert!(processor.has_footer);
 
         // Verify clock sysvar was updated
@@ -1059,6 +1143,7 @@ mod tests {
             has_header: true,
             ..Default::default()
         };
+        let shred_version = rand::rng().random();
 
         // Create genesis bank
         let genesis_config_info = create_genesis_config(10_000);
@@ -1106,7 +1191,7 @@ mod tests {
         });
 
         processor
-            .on_footer(bank.clone(), parent, footer, None)
+            .on_footer(bank.clone(), parent, shred_version, footer, None)
             .unwrap();
 
         // Verify clock sysvar was updated
@@ -1126,6 +1211,7 @@ mod tests {
             has_header: true,
             ..Default::default()
         };
+        let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -1152,13 +1238,13 @@ mod tests {
             notar_reward_cert: None,
         });
 
-        let result = processor.on_footer(bank, parent, footer, None);
+        let result = processor.on_footer(bank, parent, shred_version, footer, None);
         if should_pass {
-            assert!(result.is_ok());
+            result.unwrap();
         } else {
             assert!(matches!(
-                result,
-                Err(BlockComponentProcessorError::NanosecondClockOutOfBounds)
+                result.unwrap_err(),
+                BlockComponentProcessorError::NanosecondClockOutOfBounds
             ));
         }
     }
@@ -1208,6 +1294,7 @@ mod tests {
             has_header: true,
             ..Default::default()
         };
+        let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
         assert_eq!(parent.get_nanosecond_clock(), None);
@@ -1231,8 +1318,10 @@ mod tests {
         });
 
         assert!(matches!(
-            processor.on_footer(bank, parent, footer, None),
-            Err(BlockComponentProcessorError::NanosecondClockOutOfBounds)
+            processor
+                .on_footer(bank, parent, shred_version, footer, None)
+                .unwrap_err(),
+            BlockComponentProcessorError::NanosecondClockOutOfBounds
         ));
     }
 
@@ -1242,6 +1331,7 @@ mod tests {
             has_header: true,
             ..Default::default()
         };
+        let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -1258,8 +1348,10 @@ mod tests {
         });
 
         assert!(matches!(
-            processor.on_footer(bank, parent, footer, None),
-            Err(BlockComponentProcessorError::NanosecondClockOutOfBounds)
+            processor
+                .on_footer(bank, parent, shred_version, footer, None)
+                .unwrap_err(),
+            BlockComponentProcessorError::NanosecondClockOutOfBounds
         ));
     }
 
@@ -1435,6 +1527,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 4);
+        let shred_version = rand::rng().random();
 
         processor
             .on_update_parent(
@@ -1458,7 +1551,9 @@ mod tests {
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
-        processor.on_footer(bank, parent, footer, None).unwrap();
+        processor
+            .on_footer(bank, parent, shred_version, footer, None)
+            .unwrap();
 
         assert!(processor.on_final(&migration_status, 1).is_ok());
     }

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -10,6 +10,7 @@ use {
         certificate::{Certificate, CertificateType},
         consensus_message::Block,
         finalized_slot::FinalizedSlot,
+        unverified_vote_message::UnverifiedCertificate,
     },
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
@@ -85,6 +86,7 @@ impl ValidatedBlockFinalizationCert {
     pub fn try_from_footer(
         block_final_cert: BlockFinalizationCert,
         bank: &Bank,
+        shred_version: u16,
     ) -> Result<Self, BlockFinalizationCertError> {
         let block = Block {
             slot: block_final_cert.slot,
@@ -96,25 +98,27 @@ impl ValidatedBlockFinalizationCert {
             let notarize_cert_type = CertificateType::Notarize(block);
             let finalize_cert_type = CertificateType::Finalize(block.slot);
 
-            let notarize_cert = Certificate {
+            let notarize_cert = UnverifiedCertificate {
                 cert_type: notarize_cert_type,
                 signature: notar_aggregate
                     .uncompress_signature()
                     .map_err(|e| BlockFinalizationCertError::BlsError(notarize_cert_type, e))?,
                 bitmap: notar_aggregate.into_bitmap(),
+                shred_version,
             };
-            let finalize_cert = Certificate {
+            let finalize_cert = UnverifiedCertificate {
                 cert_type: finalize_cert_type,
                 signature: block_final_cert
                     .final_aggregate
                     .uncompress_signature()
                     .map_err(|e| BlockFinalizationCertError::BlsError(finalize_cert_type, e))?,
                 bitmap: block_final_cert.final_aggregate.into_bitmap(),
+                shred_version,
             };
 
             // Verify both certificates
-            Self::verify_certificate(bank, &notarize_cert)?;
-            Self::verify_certificate(bank, &finalize_cert)?;
+            let notarize_cert = Self::verify_certificate(bank, notarize_cert)?;
+            let finalize_cert = Self::verify_certificate(bank, finalize_cert)?;
 
             let signers = Self::extract_signers(bank, &finalize_cert)?;
             Ok(Self {
@@ -128,7 +132,7 @@ impl ValidatedBlockFinalizationCert {
             // Fast finalization
             let fast_finalize_cert_type = CertificateType::FinalizeFast(block);
 
-            let fast_finalize_cert = Certificate {
+            let fast_finalize_cert = UnverifiedCertificate {
                 cert_type: fast_finalize_cert_type,
                 signature: block_final_cert
                     .final_aggregate
@@ -137,9 +141,10 @@ impl ValidatedBlockFinalizationCert {
                         BlockFinalizationCertError::BlsError(fast_finalize_cert_type, e)
                     })?,
                 bitmap: block_final_cert.final_aggregate.into_bitmap(),
+                shred_version,
             };
 
-            Self::verify_certificate(bank, &fast_finalize_cert)?;
+            let fast_finalize_cert = Self::verify_certificate(bank, fast_finalize_cert)?;
 
             let signers = Self::extract_signers(bank, &fast_finalize_cert)?;
             Ok(Self {
@@ -313,12 +318,13 @@ impl ValidatedBlockFinalizationCert {
     /// Verifies the certificate, returning (stake present in certificate, total stake in validator set) on success.
     fn verify_certificate(
         bank: &Bank,
-        cert: &Certificate,
-    ) -> Result<(), BlockFinalizationCertError> {
-        bank.verify_certificate(cert).map_err(|_| {
-            BlockFinalizationCertError::CertificateVerificationFailed(cert.cert_type)
-        })?;
-        Ok(())
+        cert: UnverifiedCertificate,
+    ) -> Result<Certificate, BlockFinalizationCertError> {
+        let cert_type = cert.cert_type;
+        let cert = bank
+            .verify_certificate(cert)
+            .map_err(|_| BlockFinalizationCertError::CertificateVerificationFailed(cert_type))?;
+        Ok(cert)
     }
 
     fn extract_signers(
@@ -360,8 +366,9 @@ mod tests {
         crate::genesis_utils::{
             ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
         },
-        agave_votor_messages::vote::Vote,
+        agave_votor_messages::{vote::Vote, wire::get_vote_payload_to_sign},
         bitvec::prelude::*,
+        rand::Rng,
         solana_bls_signatures::SignatureProjective,
         solana_entry::block_component::VotesAggregate,
         solana_hash::Hash,
@@ -395,10 +402,11 @@ mod tests {
     fn build_certificate_manual(
         cert_type: CertificateType,
         vote: Vote,
+        shred_version: u16,
         signing_ranks: &[usize],
         validator_keypairs: &[ValidatorVoteKeypairs],
     ) -> Certificate {
-        let serialized_vote = bincode::serialize(&vote).unwrap();
+        let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
 
         // Aggregate signatures
         let mut signature = SignatureProjective::identity();
@@ -431,6 +439,7 @@ mod tests {
             .map(|i| (1000u64).saturating_sub((i as u64).saturating_mul(100)))
             .collect();
         let (bank, validator_keypairs) = create_bank_with_bls_validators(num_validators, stakes);
+        let shred_version = rand::rng().random();
 
         let block = Block {
             slot: bank.slot(),
@@ -443,8 +452,13 @@ mod tests {
             let cert_type = CertificateType::FinalizeFast(block);
             let vote = Vote::new_notarization_vote(block);
             let signing_ranks: Vec<usize> = (0..6).collect();
-            let fast_finalize_cert =
-                build_certificate_manual(cert_type, vote, &signing_ranks, &validator_keypairs);
+            let fast_finalize_cert = build_certificate_manual(
+                cert_type,
+                vote,
+                shred_version,
+                &signing_ranks,
+                &validator_keypairs,
+            );
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
@@ -453,9 +467,12 @@ mod tests {
                 notar_aggregate: None,
             };
 
-            let validated =
-                ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
-                    .expect("Valid fast finalize certificate should pass verification");
+            let validated = ValidatedBlockFinalizationCert::try_from_footer(
+                block_final_cert,
+                &bank,
+                shred_version,
+            )
+            .expect("Valid fast finalize certificate should pass verification");
             assert_eq!(validated.clone_certificates(), vec![fast_finalize_cert]);
         }
 
@@ -468,6 +485,7 @@ mod tests {
             let notarize_cert = build_certificate_manual(
                 notarize_cert_type,
                 notarize_vote,
+                shred_version,
                 &notarize_signing_ranks,
                 &validator_keypairs,
             );
@@ -478,6 +496,7 @@ mod tests {
             let finalize_cert = build_certificate_manual(
                 finalize_cert_type,
                 finalize_vote,
+                shred_version,
                 &finalize_signing_ranks,
                 &validator_keypairs,
             );
@@ -489,9 +508,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let validated =
-                ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
-                    .expect("Valid slow finalize certificate should pass verification");
+            let validated = ValidatedBlockFinalizationCert::try_from_footer(
+                block_final_cert,
+                &bank,
+                shred_version,
+            )
+            .expect("Valid slow finalize certificate should pass verification");
             assert_eq!(
                 validated.clone_certificates(),
                 vec![finalize_cert, notarize_cert]
@@ -508,6 +530,7 @@ mod tests {
             .map(|i| (1000u64).saturating_sub((i as u64).saturating_mul(100)))
             .collect();
         let (bank, validator_keypairs) = create_bank_with_bls_validators(num_validators, stakes);
+        let shred_version = rand::rng().random();
 
         let block = Block {
             slot: bank.slot(),
@@ -520,8 +543,13 @@ mod tests {
             let cert_type = CertificateType::FinalizeFast(block);
             let vote = Vote::new_notarization_vote(block);
             let signing_ranks: Vec<usize> = (0..5).collect();
-            let fast_finalize_cert =
-                build_certificate_manual(cert_type, vote, &signing_ranks, &validator_keypairs);
+            let fast_finalize_cert = build_certificate_manual(
+                cert_type,
+                vote,
+                shred_version,
+                &signing_ranks,
+                &validator_keypairs,
+            );
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
@@ -530,8 +558,12 @@ mod tests {
                 notar_aggregate: None,
             };
 
-            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
-                .unwrap_err();
+            let err = ValidatedBlockFinalizationCert::try_from_footer(
+                block_final_cert,
+                &bank,
+                shred_version,
+            )
+            .unwrap_err();
             assert!(
                 matches!(
                     err,
@@ -550,6 +582,7 @@ mod tests {
             let notarize_cert = build_certificate_manual(
                 notarize_cert_type,
                 notarize_vote,
+                shred_version,
                 &notarize_signing_ranks,
                 &validator_keypairs,
             );
@@ -561,6 +594,7 @@ mod tests {
             let finalize_cert = build_certificate_manual(
                 finalize_cert_type,
                 finalize_vote,
+                shred_version,
                 &finalize_signing_ranks,
                 &validator_keypairs,
             );
@@ -572,8 +606,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
-                .unwrap_err();
+            let err = ValidatedBlockFinalizationCert::try_from_footer(
+                block_final_cert,
+                &bank,
+                shred_version,
+            )
+            .unwrap_err();
             assert!(
                 matches!(
                     err,
@@ -593,6 +631,7 @@ mod tests {
             let notarize_cert = build_certificate_manual(
                 notarize_cert_type,
                 notarize_vote,
+                shred_version,
                 &notarize_signing_ranks,
                 &validator_keypairs,
             );
@@ -605,6 +644,7 @@ mod tests {
             let finalize_cert = build_certificate_manual(
                 finalize_cert_type,
                 finalize_vote,
+                shred_version,
                 &finalize_signing_ranks,
                 &validator_keypairs,
             );
@@ -616,8 +656,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
-                .unwrap_err();
+            let err = ValidatedBlockFinalizationCert::try_from_footer(
+                block_final_cert,
+                &bank,
+                shred_version,
+            )
+            .unwrap_err();
             assert!(
                 matches!(
                     err,

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -5,6 +5,7 @@ use {
         consensus_message::Block,
         reward_certificate::{NUM_SLOTS_FOR_REWARD, NotarRewardCertificate, SkipRewardCertificate},
         vote::Vote,
+        wire::get_vote_payload_to_sign,
     },
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
@@ -80,6 +81,7 @@ impl ValidatedRewardCert {
     /// If validation of the provided reward certs succeeds, returns an instance of [`ValidatedRewardCert`].
     pub fn try_new(
         bank: &Bank,
+        shred_version: u16,
         skip: &Option<SkipRewardCertificate>,
         notar: &Option<NotarRewardCertificate>,
     ) -> Result<Option<Self>, Error> {
@@ -102,8 +104,7 @@ impl ValidatedRewardCert {
 
         if let Some(skip) = skip {
             let vote = Vote::new_skip_vote(skip.slot);
-            // unwrap should be safe as we contructed the vote ourselves.
-            let payload = bincode::serialize(&vote).unwrap();
+            let payload = get_vote_payload_to_sign(&vote, shred_version);
             verify_base2(
                 &payload,
                 &skip.signature,
@@ -117,8 +118,7 @@ impl ValidatedRewardCert {
                 slot: notar.slot,
                 block_id: notar.block_id,
             });
-            // unwrap should be safe as we contructed the vote ourselves.
-            let payload = bincode::serialize(&vote).unwrap();
+            let payload = get_vote_payload_to_sign(&vote, shred_version);
             verify_base2(
                 &payload,
                 &notar.signature,
@@ -163,6 +163,7 @@ mod tests {
         },
         agave_votor_messages::consensus_message::VoteMessage,
         bitvec::vec::BitVec,
+        rand::Rng,
         solana_bls_signatures::{
             Keypair as BlsKeypair, Signature as BLSSignature,
             SignatureCompressed as BlsSignatureCompressed, SignatureProjective,
@@ -174,9 +175,9 @@ mod tests {
         std::collections::HashMap,
     };
 
-    fn new_vote(vote: Vote, rank: usize, keypair: &BlsKeypair) -> VoteMessage {
-        let serialized = bincode::serialize(&vote).unwrap();
-        let signature = keypair.sign(&serialized).into();
+    fn new_vote(vote: Vote, rank: usize, keypair: &BlsKeypair, shred_version: u16) -> VoteMessage {
+        let payload = get_vote_payload_to_sign(&vote, shred_version);
+        let signature = keypair.sign(&payload).into();
         VoteMessage {
             vote,
             signature,
@@ -211,6 +212,7 @@ mod tests {
         let validator_keypairs = (0..num_validators)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
+        let shred_version = rand::rng().random();
         let keypair_map = validator_keypairs
             .iter()
             .map(|k| {
@@ -248,7 +250,7 @@ mod tests {
             block_id,
         });
         let notar_votes = (0..num_notar_validators)
-            .map(|rank| new_vote(notar_vote, rank, signing_keys[rank]))
+            .map(|rank| new_vote(notar_vote, rank, signing_keys[rank], shred_version))
             .collect::<Vec<_>>();
         let (signature, bitmap) = build_sig_bitmap(&notar_votes);
         let notar_reward_cert =
@@ -256,16 +258,20 @@ mod tests {
 
         let skip_vote = Vote::new_skip_vote(reward_slot);
         let skip_votes = (num_notar_validators..num_validators)
-            .map(|rank| new_vote(skip_vote, rank, signing_keys[rank]))
+            .map(|rank| new_vote(skip_vote, rank, signing_keys[rank], shred_version))
             .collect::<Vec<_>>();
         let (signature, bitmap) = build_sig_bitmap(&skip_votes);
         let skip_reward_cert =
             SkipRewardCertificate::try_new(reward_slot, signature, bitmap).unwrap();
 
-        let validated_reward_cert =
-            ValidatedRewardCert::try_new(&bank, &Some(skip_reward_cert), &Some(notar_reward_cert))
-                .unwrap()
-                .unwrap();
+        let validated_reward_cert = ValidatedRewardCert::try_new(
+            &bank,
+            shred_version,
+            &Some(skip_reward_cert),
+            &Some(notar_reward_cert),
+        )
+        .unwrap()
+        .unwrap();
         assert_eq!(validated_reward_cert.validators.len(), num_validators);
     }
 }

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -6,6 +6,7 @@ use {
         fraction::Fraction,
         migration::GENESIS_VOTE_THRESHOLD,
         vote::{Vote, VoteType},
+        wire::get_vote_payload_to_sign,
     },
     serde::{Deserialize, Serialize},
     solana_bls_signatures::Signature as BLSSignature,
@@ -21,11 +22,6 @@ pod_wrapper! {
 
 /// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
 /// BLS vote message, we need rank to look up pubkey
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "5WqvPnvSnVXQFrAs9o29szFGDiCk45Pgk8K1evTZSrwo")
-)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 pub struct Certificate {
     /// The certificate type.
@@ -39,11 +35,6 @@ pub struct Certificate {
 }
 
 /// The different types of certificates and their relevant state.
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "Fi1rPdeeVstWxxnnPiS7bYtXMEyX6sDGV4o3R2aDMnjt")
-)]
 #[derive(
     Debug,
     Copy,
@@ -83,6 +74,43 @@ impl CertificateType {
             | CertificateType::Notarize(Block { slot, block_id: _ })
             | CertificateType::Genesis(Block { slot, block_id: _ })
             | CertificateType::Skip(slot) => *slot,
+        }
+    }
+
+    /// Returns the serialized vote payloads needed to verify signature on the cert
+    pub fn get_vote_payload(&self, shred_version: u16) -> (Vec<u8>, Option<Vec<u8>>) {
+        match self {
+            Self::Notarize(block) | Self::FinalizeFast(block) => {
+                let vote = Vote::new_notarization_vote(*block);
+                (get_vote_payload_to_sign(&vote, shred_version), None)
+            }
+            Self::Genesis(block) => {
+                let vote = Vote::new_genesis_vote(*block);
+                (get_vote_payload_to_sign(&vote, shred_version), None)
+            }
+            Self::Finalize(slot) => {
+                let vote = Vote::new_finalization_vote(*slot);
+                (get_vote_payload_to_sign(&vote, shred_version), None)
+            }
+            Self::Skip(slot) => {
+                let skip_vote = Vote::new_skip_vote(*slot);
+                let skip_fallback_vote = Vote::new_skip_fallback_vote(*slot);
+                (
+                    get_vote_payload_to_sign(&skip_vote, shred_version),
+                    Some(get_vote_payload_to_sign(&skip_fallback_vote, shred_version)),
+                )
+            }
+            Self::NotarizeFallback(block) => {
+                let notar_vote = Vote::new_notarization_vote(*block);
+                let notar_fallback_vote = Vote::new_notarization_fallback_vote(*block);
+                (
+                    get_vote_payload_to_sign(&notar_vote, shred_version),
+                    Some(get_vote_payload_to_sign(
+                        &notar_fallback_vote,
+                        shred_version,
+                    )),
+                )
+            }
         }
     }
 

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -20,12 +20,14 @@ pod_wrapper! {
 /// The seed used to derive the BLS keypair
 pub const BLS_KEYPAIR_DERIVE_SEED: &[u8; 9] = b"alpenglow";
 
+#[cfg(feature = "frozen-abi")]
+fn sample_hash(rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized)) -> Hash {
+    use solana_frozen_abi::stable_abi::StableAbi;
+    Hash::new_from_array(<[u8; solana_hash::HASH_BYTES] as StableAbi>::random(rng))
+}
+
 /// An alpenglow block
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "xCqtGMfgy9TMmCDZP9o4BidVTPKfMWrLmqxpRDLYwtR")
-)]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(
     Clone,
     Copy,
@@ -45,15 +47,11 @@ pub struct Block {
     /// The slot in the block.
     pub slot: Slot,
     /// The block_id of the block.
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "sample_hash(rng)"))]
     pub block_id: Hash,
 }
 
 /// A consensus vote.
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "CTiXEk2aQbpf6TS6PNKcaTsGkLruDvAYsTLFhHKW2vsm")
-)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 pub struct VoteMessage {
     /// The type of the vote.
@@ -66,11 +64,6 @@ pub struct VoteMessage {
 }
 
 /// A consensus message sent between validators.
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "CbPatwRWz8NyUAj3HeAxAAWAWTxJnHGAfekLspUQpMHN")
-)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -16,7 +16,9 @@ pub mod fraction;
 pub mod metric_types;
 pub mod migration;
 pub mod reward_certificate;
+pub mod unverified_vote_message;
 pub mod vote;
+pub mod wire;
 
 #[cfg_attr(feature = "frozen-abi", macro_use)]
 #[cfg(feature = "frozen-abi")]

--- a/votor-messages/src/unverified_vote_message.rs
+++ b/votor-messages/src/unverified_vote_message.rs
@@ -1,0 +1,157 @@
+//! Defines unverified vote message and related types
+
+use {
+    crate::{
+        certificate::CertificateType,
+        vote::Vote,
+        wire::{VersionedWireConsensusMessage, WireConsensusMessageKind},
+    },
+    solana_bls_signatures::Signature as BLSSignature,
+};
+
+/// An unverified vote message.
+#[derive(Clone, Debug)]
+pub struct UnverifiedVoteMessage {
+    /// The vote payload that is signed.
+    pub vote: Vote,
+    /// The signature
+    pub signature: BLSSignature,
+    /// rank of the validator that signed the payload
+    pub rank: u16,
+    /// the shred version
+    pub shred_version: u16,
+}
+
+/// an unverified certificate
+#[derive(Clone, Debug)]
+pub struct UnverifiedCertificate {
+    /// The certificate type.
+    pub cert_type: CertificateType,
+    /// The aggregate signature.
+    pub signature: BLSSignature,
+    /// A rank bitmap for validators' signatures included in the aggregate.
+    /// See solana-signer-store for encoding format.
+    pub bitmap: Vec<u8>,
+    /// the shred version
+    pub shred_version: u16,
+}
+
+/// Output of decoding a wire consensus message into unverified vote or certificate.
+pub enum DecodedWireConsensusMessage {
+    /// Decoded to a vote
+    Vote(UnverifiedVoteMessage),
+    /// Decoded to a certificate
+    Certificate(UnverifiedCertificate),
+}
+
+impl DecodedWireConsensusMessage {
+    /// Decodes a wire consensus message.
+    pub fn try_new(msg: VersionedWireConsensusMessage, shred_version: u16) -> Option<Self> {
+        let VersionedWireConsensusMessage::V1(msg) = msg;
+        if msg.shred_version != shred_version {
+            return None;
+        }
+        let msg = match msg.kind {
+            WireConsensusMessageKind::NotarVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_notarization_vote(v.block),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+            WireConsensusMessageKind::NotarFallbackVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_notarization_fallback_vote(v.block),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+            WireConsensusMessageKind::FinalizeVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_finalization_vote(v.slot),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+            WireConsensusMessageKind::SkipVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_skip_vote(v.slot),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+            WireConsensusMessageKind::SkipFallbackVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_skip_fallback_vote(v.slot),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+            WireConsensusMessageKind::GenesisVote(v) => Self::Vote(UnverifiedVoteMessage {
+                vote: Vote::new_genesis_vote(v.block),
+                signature: v.signature.signature,
+                rank: v.signature.rank,
+                shred_version: msg.shred_version,
+            }),
+
+            WireConsensusMessageKind::NotarCert(c) => {
+                let cert_type = CertificateType::Notarize(c.block);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+            WireConsensusMessageKind::FinalizeCert(c) => {
+                let cert_type = CertificateType::Finalize(c.slot);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+            WireConsensusMessageKind::FastFinalizeCert(c) => {
+                let cert_type = CertificateType::FinalizeFast(c.block);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+            WireConsensusMessageKind::NotarFallbackCert(c) => {
+                let cert_type = CertificateType::NotarizeFallback(c.block);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+            WireConsensusMessageKind::SkipCert(c) => {
+                let cert_type = CertificateType::Skip(c.slot);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+            WireConsensusMessageKind::GenesisCert(c) => {
+                let cert_type = CertificateType::Genesis(c.block);
+                Self::Certificate(UnverifiedCertificate {
+                    cert_type,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
+                    shred_version: msg.shred_version,
+                })
+            }
+        };
+        Some(msg)
+    }
+
+    /// returns the shred version
+    pub fn shred_version(&self) -> u16 {
+        match self {
+            Self::Vote(v) => v.shred_version,
+            Self::Certificate(c) => c.shred_version,
+        }
+    }
+}

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -1,0 +1,387 @@
+//! This module defines various types relevant to the wire format of alpenglow
+//! votes and certificates.
+//!
+//! When a validator wants to send a `Vote` to other nodes, it needs to include
+//! the `shred_version` in the signed payload so that other validators can
+//! ensure that they are both in the same cluster instance.  To get the
+//! appropriate vote payload with the shred version, the sender should use
+//! `get_vote_payload_to_sign()`.  The shred version does not need to be part of
+//! the vote payload.  The receiver can use `get_vote_payload_to_sign()` with
+//! its own shred_version to get the payload that should be verified.  If the
+//! signature does not match, then the vote should be rejected.  Once the sender
+//! has the signature on the payload, it can construct a `VoteMessage` using the
+//! signature.
+//!
+//! We do not need to include such a shred_version for certificates because they
+//! are aggregating signatures on the votes.  When verifying a `Certificate`,
+//! the verifier would use `Certificate::get_vote_payload()` passing in its own
+//! shred_version and if the signature verifies then that implies that the shred
+//! versions also match.
+//!
+//! The actual message that the sender sends over the wire is
+//! `VersionedWireConsensusMessage` which can be constructed from a
+//! `VoteMessage` or a `Certificate`.  This contains a message version to
+//! support upgrades and unlike `ConsensusMessage` the different vote and
+//! certificate variants are under a single enum tag to enable [de]coding times.
+//! Generally, when a signature on a vote or a certificate does not verify, the
+//! receiver would ban the sender.  However, tt is possible that two validators
+//! with different shred versions accidentally exchange messages and this should
+//! not cause the sender to get banned.  To avoid this,
+//! `VersionedWireConsensusMessage` also contains a shred_version that is used
+//! to filter out accidental shred_version mismatches.
+//!
+//! When a receiver processes a `VersionedWireConsensusMessage`, it first
+//! converts it to a `DecodedWireConsensusMessage` which performs the
+//! shred_version check to avoid accidental mismatches.  This enum contains
+//! either a `UnverifiedVoteMessage` or `UnverifiedCertificate`.  Both of these
+//! contain all the relevant information to verify them and once verified, the
+//! receiver can convert them to `VoteMessage` and `Certificate` respectively.
+//!
+//! `VoteMessage` verification happens in the bls-sigverify crate and
+//! `Certificate` verfication happens in the `bls-cert-verify` crate.
+
+use {
+    crate::{
+        certificate::{Certificate, CertificateType},
+        consensus_message::{Block, ConsensusMessage, VoteMessage},
+        vote::Vote,
+    },
+    serde::Serialize,
+    solana_bls_signatures::Signature as BLSSignature,
+    solana_clock::Slot,
+    wincode::{SchemaRead, SchemaWrite, pod_wrapper},
+};
+
+#[cfg(feature = "frozen-abi")]
+fn sample_bls_signature(
+    rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized),
+) -> BLSSignature {
+    use solana_frozen_abi::stable_abi::StableAbi;
+    BLSSignature(<[u8; solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE] as StableAbi>::random(rng))
+}
+
+// Use `BLSSignature` directly once `BLSSignature` wincode support
+// is released in solana-sdk.
+pod_wrapper! {
+    unsafe struct PodBLSSignature(BLSSignature);
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireVoteSignature {
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_bls_signature(rng)")
+    )]
+    #[wincode(with = "PodBLSSignature")]
+    pub(crate) signature: BLSSignature,
+    pub(crate) rank: u16,
+}
+
+impl From<VoteMessage> for WireVoteSignature {
+    fn from(msg: VoteMessage) -> Self {
+        Self {
+            signature: msg.signature,
+            rank: msg.rank,
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireBlockVoteMessage {
+    pub(crate) block: Block,
+    pub(crate) signature: WireVoteSignature,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireSlotVoteMessage {
+    pub(crate) slot: Slot,
+    pub(crate) signature: WireVoteSignature,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireCertSignature {
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_bls_signature(rng)")
+    )]
+    #[wincode(with = "PodBLSSignature")]
+    pub(crate) signature: BLSSignature,
+    pub(crate) bitmap: Vec<u8>,
+}
+
+impl From<Certificate> for WireCertSignature {
+    fn from(cert: Certificate) -> Self {
+        Self {
+            signature: cert.signature,
+            bitmap: cert.bitmap,
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireSlotCertMessage {
+    pub(crate) slot: Slot,
+    pub(crate) signature: WireCertSignature,
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+pub(crate) struct WireBlockCertMessage {
+    pub(crate) block: Block,
+    pub(crate) signature: WireCertSignature,
+}
+
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, AbiEnumVisitor)
+)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead, Serialize)]
+#[wincode(tag_encoding = "u8")]
+pub(crate) enum WireConsensusMessageKind {
+    #[wincode(tag = 1)]
+    NotarVote(WireBlockVoteMessage),
+    #[wincode(tag = 2)]
+    FinalizeVote(WireSlotVoteMessage),
+    #[wincode(tag = 3)]
+    SkipVote(WireSlotVoteMessage),
+    #[wincode(tag = 4)]
+    NotarFallbackVote(WireBlockVoteMessage),
+    #[wincode(tag = 5)]
+    SkipFallbackVote(WireSlotVoteMessage),
+    #[wincode(tag = 6)]
+    GenesisVote(WireBlockVoteMessage),
+
+    #[wincode(tag = 7)]
+    FinalizeCert(WireSlotCertMessage),
+    #[wincode(tag = 8)]
+    FastFinalizeCert(WireBlockCertMessage),
+    #[wincode(tag = 9)]
+    NotarCert(WireBlockCertMessage),
+    #[wincode(tag = 10)]
+    NotarFallbackCert(WireBlockCertMessage),
+    #[wincode(tag = 11)]
+    SkipCert(WireSlotCertMessage),
+    #[wincode(tag = 12)]
+    GenesisCert(WireBlockCertMessage),
+}
+
+impl WireConsensusMessageKind {
+    fn new(msg: ConsensusMessage) -> Self {
+        match msg {
+            ConsensusMessage::Vote(v) => Self::new_from_vote(v),
+            ConsensusMessage::Certificate(c) => Self::new_from_cert(c),
+        }
+    }
+
+    fn new_from_vote(msg: VoteMessage) -> Self {
+        let vote = msg.vote;
+        let signature = WireVoteSignature::from(msg);
+        match vote {
+            Vote::Notarize(v) => Self::NotarVote(WireBlockVoteMessage {
+                block: v.block,
+                signature,
+            }),
+            Vote::NotarizeFallback(v) => Self::NotarFallbackVote(WireBlockVoteMessage {
+                block: v.block,
+                signature,
+            }),
+            Vote::Finalize(v) => Self::FinalizeVote(WireSlotVoteMessage {
+                slot: v.slot,
+                signature,
+            }),
+            Vote::Skip(v) => Self::SkipVote(WireSlotVoteMessage {
+                slot: v.slot,
+                signature,
+            }),
+            Vote::SkipFallback(v) => Self::SkipFallbackVote(WireSlotVoteMessage {
+                slot: v.slot,
+                signature,
+            }),
+            Vote::Genesis(v) => Self::GenesisVote(WireBlockVoteMessage {
+                block: v.block,
+                signature,
+            }),
+        }
+    }
+
+    fn new_from_cert(cert: Certificate) -> Self {
+        let cert_type = cert.cert_type;
+        let signature = WireCertSignature::from(cert);
+        match cert_type {
+            CertificateType::Finalize(slot) => {
+                Self::FinalizeCert(WireSlotCertMessage { slot, signature })
+            }
+            CertificateType::FinalizeFast(block) => {
+                Self::FastFinalizeCert(WireBlockCertMessage { block, signature })
+            }
+            CertificateType::Notarize(block) => {
+                Self::NotarCert(WireBlockCertMessage { block, signature })
+            }
+            CertificateType::NotarizeFallback(block) => {
+                Self::NotarFallbackCert(WireBlockCertMessage { block, signature })
+            }
+            CertificateType::Skip(slot) => Self::SkipCert(WireSlotCertMessage { slot, signature }),
+            CertificateType::Genesis(block) => {
+                Self::GenesisCert(WireBlockCertMessage { block, signature })
+            }
+        }
+    }
+
+    /// Returns the slot on the message
+    fn slot(&self) -> Slot {
+        match self {
+            Self::NotarVote(v) | Self::NotarFallbackVote(v) | Self::GenesisVote(v) => v.block.slot,
+            Self::FinalizeVote(v) | Self::SkipVote(v) | Self::SkipFallbackVote(v) => v.slot,
+            Self::NotarCert(c)
+            | Self::GenesisCert(c)
+            | Self::FastFinalizeCert(c)
+            | Self::NotarFallbackCert(c) => c.block.slot,
+            Self::FinalizeCert(c) | Self::SkipCert(c) => c.slot,
+        }
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, SchemaWrite, SchemaRead)]
+/// First version of a wire consensus message
+pub struct WireConsensusMessageV1 {
+    pub(crate) kind: WireConsensusMessageKind,
+    pub(crate) shred_version: u16,
+}
+
+impl WireConsensusMessageV1 {
+    fn new(msg: ConsensusMessage, shred_version: u16) -> Self {
+        Self {
+            kind: WireConsensusMessageKind::new(msg),
+            shred_version,
+        }
+    }
+
+    fn new_from_vote(msg: VoteMessage, shred_version: u16) -> Self {
+        Self {
+            kind: WireConsensusMessageKind::new_from_vote(msg),
+            shred_version,
+        }
+    }
+
+    fn new_from_cert(cert: Certificate, shred_version: u16) -> Self {
+        Self {
+            kind: WireConsensusMessageKind::new_from_cert(cert),
+            shred_version,
+        }
+    }
+
+    fn slot(&self) -> Slot {
+        self.kind.slot()
+    }
+}
+
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    frozen_abi(
+        digest = "Gf8GEMXaXezQnGsqwDdpZN3WtNkMZw5wfp3nwep9j55V",
+        abi_digest = "AHPJsANgE3T8wfzkFZwao1PAWwd6LtS5GAhGrN9X4Xhy",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+/// versioned wire format of consensus message
+pub enum VersionedWireConsensusMessage {
+    /// The first version
+    #[wincode(tag = 1)]
+    V1(WireConsensusMessageV1),
+}
+
+impl VersionedWireConsensusMessage {
+    /// Constructs a new versioned wire consensus message.
+    pub fn new(msg: ConsensusMessage, shred_version: u16) -> Self {
+        let v1 = WireConsensusMessageV1::new(msg, shred_version);
+        Self::V1(v1)
+    }
+
+    /// Constructs a new versioned wire consensus message from a vote.
+    pub fn new_from_vote(vote: VoteMessage, shred_version: u16) -> Self {
+        let v1 = WireConsensusMessageV1::new_from_vote(vote, shred_version);
+        Self::V1(v1)
+    }
+
+    /// Constructs a new versioned wire consensus message from a cert.
+    pub fn new_from_cert(cert: Certificate, shred_version: u16) -> Self {
+        let v1 = WireConsensusMessageV1::new_from_cert(cert, shred_version);
+        Self::V1(v1)
+    }
+
+    /// Returns the slot on the message.
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::V1(v1) => v1.slot(),
+        }
+    }
+}
+
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    frozen_abi(
+        digest = "AKMt6bqYRf1xh7tWg4eAgG7jNN1qtUvNVPb5XZn9vjtV",
+        abi_digest = "2aBMTuPyDgGSYeYX1aBbXURgA4qqr92Eh9yiTeHX6qZq",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, SchemaWrite, SchemaRead)]
+#[wincode(tag_encoding = "u8")]
+/// Vote payload that must be signed
+enum VotePayloadToSign {
+    #[wincode(tag = 1)]
+    Notar { block: Block, shred_version: u16 },
+    #[wincode(tag = 2)]
+    Finalize { slot: Slot, shred_version: u16 },
+    #[wincode(tag = 3)]
+    Skip { slot: Slot, shred_version: u16 },
+    #[wincode(tag = 4)]
+    NotarFallback { block: Block, shred_version: u16 },
+    #[wincode(tag = 5)]
+    SkipFallback { slot: Slot, shred_version: u16 },
+    #[wincode(tag = 6)]
+    Genesis { block: Block, shred_version: u16 },
+}
+
+/// Returns the appropriate vote payload to sign.
+pub fn get_vote_payload_to_sign(vote: &Vote, shred_version: u16) -> Vec<u8> {
+    let vote_to_sign = match vote {
+        Vote::Notarize(v) => VotePayloadToSign::Notar {
+            block: v.block,
+            shred_version,
+        },
+        Vote::NotarizeFallback(v) => VotePayloadToSign::NotarFallback {
+            block: v.block,
+            shred_version,
+        },
+        Vote::Genesis(v) => VotePayloadToSign::Genesis {
+            block: v.block,
+            shred_version,
+        },
+        Vote::Finalize(v) => VotePayloadToSign::Finalize {
+            slot: v.slot,
+            shred_version,
+        },
+        Vote::Skip(v) => VotePayloadToSign::Skip {
+            slot: v.slot,
+            shred_version,
+        },
+        Vote::SkipFallback(v) => VotePayloadToSign::SkipFallback {
+            slot: v.slot,
+            shred_version,
+        },
+    };
+    wincode::serialize(&vote_to_sign).unwrap()
+}

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -670,7 +670,10 @@ mod tests {
     use {
         super::*,
         crate::tests::get_cluster_info,
-        agave_votor_messages::consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
+        agave_votor_messages::{
+            consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
+            wire::get_vote_payload_to_sign,
+        },
         bitvec::vec::BitVec,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature, VerifiableSignature,
@@ -745,7 +748,12 @@ mod tests {
 
         fn add_certificate(&mut self, vote: Vote) {
             for rank in 0..=6 {
-                self.add_message(dummy_vote_message(&self.validators, &vote, rank));
+                self.add_message(dummy_vote_message(
+                    &self.validators,
+                    self.pool.cluster_info.my_shred_version(),
+                    &vote,
+                    rank,
+                ));
             }
             match vote {
                 Vote::Notarize(vote) => {
@@ -767,15 +775,15 @@ mod tests {
 
     fn dummy_vote_message(
         keypairs: &[ValidatorVoteKeypairs],
+        shred_version: u16,
         vote: &Vote,
         rank: usize,
     ) -> ConsensusMessage {
         let bls_keypair =
             BLSKeypair::derive_from_signer(&keypairs[rank].vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
-        let signature: BLSSignature = bls_keypair
-            .sign(wincode::serialize(vote).unwrap().as_slice())
-            .into();
+        let payload = get_vote_payload_to_sign(vote, shred_version);
+        let signature: BLSSignature = bls_keypair.sign(&payload).into();
         ConsensusMessage::new_vote(*vote, signature, rank as u16)
     }
 
@@ -806,7 +814,7 @@ mod tests {
             pool.add_message(
                 root_bank,
                 &Pubkey::new_unique(),
-                dummy_vote_message(keypairs, &vote, rank),
+                dummy_vote_message(keypairs, pool.cluster_info.my_shred_version(), &vote, rank),
                 &mut vec![],
             )
             .unwrap();
@@ -1097,19 +1105,38 @@ mod tests {
             Vote::SkipFallback(_) => |pool: &ConsensusPool| pool.highest_skip_slot(),
             Vote::Genesis(_genesis_vote) => |_pool: &ConsensusPool| 0,
         };
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, my_validator_ix));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            my_validator_ix,
+        ));
         let slot = vote.slot();
         assert!(highest_slot_fn(&ctx.pool) < slot);
         // Same key voting again shouldn't make a certificate
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, my_validator_ix));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            my_validator_ix,
+        ));
         assert!(highest_slot_fn(&ctx.pool) < slot);
         for rank in 0..4 {
-            ctx.add_message(dummy_vote_message(&ctx.validators, &vote, rank));
+            ctx.add_message(dummy_vote_message(
+                &ctx.validators,
+                ctx.pool.cluster_info.my_shred_version(),
+                &vote,
+                rank,
+            ));
         }
         assert!(highest_slot_fn(&ctx.pool) < slot);
         let new_validator_ix = 6;
-        let (new_finalized_slot, certs_to_send) =
-            ctx.add_message(dummy_vote_message(&ctx.validators, &vote, new_validator_ix));
+        let (new_finalized_slot, certs_to_send) = ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            new_validator_ix,
+        ));
         if vote.is_finalize() {
             assert_eq!(new_finalized_slot, Some(slot));
         } else {
@@ -1206,7 +1233,12 @@ mod tests {
                 .add_message(
                     &root_bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut vec![],
                 )
                 .unwrap();
@@ -1258,7 +1290,12 @@ mod tests {
             let slot = (i as u64).saturating_add(16);
             let vote = Vote::new_skip_vote(slot);
             // These should not extend the skip range
-            ctx.add_message(dummy_vote_message(&ctx.validators, &vote, i));
+            ctx.add_message(dummy_vote_message(
+                &ctx.validators,
+                ctx.pool.cluster_info.my_shred_version(),
+                &vote,
+                i,
+            ));
         }
 
         assert_single_certificate_range(&ctx.pool, 15, 15);
@@ -1370,20 +1407,35 @@ mod tests {
         }
         // 10% vote for skip 2
         let vote = Vote::new_skip_vote(2);
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, 6));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            6,
+        ));
         assert_eq!(ctx.pool.highest_skip_slot(), 2);
 
         assert_single_certificate_range(&ctx.pool, 2, 2);
         // 10% vote for skip 4
         let vote = Vote::new_skip_vote(4);
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, 7));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            7,
+        ));
         assert_eq!(ctx.pool.highest_skip_slot(), 4);
 
         assert_single_certificate_range(&ctx.pool, 2, 2);
         assert_single_certificate_range(&ctx.pool, 4, 4);
         // 10% vote for skip 3
         let vote = Vote::new_skip_vote(3);
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, 8));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            8,
+        ));
         assert_eq!(ctx.pool.highest_skip_slot(), 4);
         assert_single_certificate_range(&ctx.pool, 2, 4);
         assert!(ctx.pool.skip_certified(3));
@@ -1417,7 +1469,12 @@ mod tests {
         }
         // Range expansion on a singleton vote should be ok
         let vote = Vote::new_skip_vote(1);
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, 6));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            6,
+        ));
         assert_eq!(ctx.pool.highest_skip_slot(), 1);
         add_skip_vote_range(
             &mut ctx.pool,
@@ -1446,7 +1503,12 @@ mod tests {
 
         // AlreadyExists, silently fail
         let vote = Vote::new_skip_vote(20);
-        ctx.add_message(dummy_vote_message(&ctx.validators, &vote, 6));
+        ctx.add_message(dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            6,
+        ));
     }
 
     #[test]
@@ -1529,7 +1591,12 @@ mod tests {
             .add_message(
                 &bank,
                 &my_vote_key,
-                dummy_vote_message(&ctx.validators, &vote, 0),
+                dummy_vote_message(
+                    &ctx.validators,
+                    ctx.pool.cluster_info.my_shred_version(),
+                    &vote,
+                    0,
+                ),
                 &mut new_events,
             )
             .unwrap();
@@ -1542,7 +1609,12 @@ mod tests {
                 .add_message(
                     &bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut new_events,
                 )
                 .unwrap();
@@ -1566,7 +1638,12 @@ mod tests {
                 .add_message(
                     &bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut new_events,
                 )
                 .unwrap();
@@ -1582,7 +1659,12 @@ mod tests {
             .add_message(
                 &bank,
                 &my_vote_key,
-                dummy_vote_message(&ctx.validators, &vote, 0),
+                dummy_vote_message(
+                    &ctx.validators,
+                    ctx.pool.cluster_info.my_shred_version(),
+                    &vote,
+                    0,
+                ),
                 &mut new_events,
             )
             .unwrap();
@@ -1596,7 +1678,12 @@ mod tests {
                 .add_message(
                     &bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut new_events,
                 )
                 .unwrap();
@@ -1626,7 +1713,12 @@ mod tests {
                 .add_message(
                     &bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut new_events,
                 )
                 .unwrap();
@@ -1661,7 +1753,12 @@ mod tests {
             .add_message(
                 &bank,
                 &my_vote_key,
-                dummy_vote_message(&ctx.validators, &vote, 0),
+                dummy_vote_message(
+                    &ctx.validators,
+                    ctx.pool.cluster_info.my_shred_version(),
+                    &vote,
+                    0,
+                ),
                 &mut new_events,
             )
             .unwrap();
@@ -1674,7 +1771,12 @@ mod tests {
                 .add_message(
                     &bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, rank),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        rank,
+                    ),
                     &mut new_events,
                 )
                 .unwrap();
@@ -1692,7 +1794,12 @@ mod tests {
             .add_message(
                 &bank,
                 &Pubkey::new_unique(),
-                dummy_vote_message(&ctx.validators, &vote, 6),
+                dummy_vote_message(
+                    &ctx.validators,
+                    ctx.pool.cluster_info.my_shred_version(),
+                    &vote,
+                    6,
+                ),
                 &mut new_events,
             )
             .unwrap();
@@ -1732,14 +1839,14 @@ mod tests {
         pool.add_message(
             bank,
             &Pubkey::new_unique(),
-            dummy_vote_message(validators, &vote_1, 0),
+            dummy_vote_message(validators, pool.cluster_info.my_shred_version(), &vote_1, 0),
             &mut vec![],
         )
         .unwrap();
         pool.add_message(
             bank,
             &Pubkey::new_unique(),
-            dummy_vote_message(validators, &vote_2, 0),
+            dummy_vote_message(validators, pool.cluster_info.my_shred_version(), &vote_2, 0),
             &mut vec![],
         )
         .unwrap_err();
@@ -1826,7 +1933,12 @@ mod tests {
                 .add_message(
                     &new_bank,
                     &Pubkey::new_unique(),
-                    dummy_vote_message(&ctx.validators, &vote, 0),
+                    dummy_vote_message(
+                        &ctx.validators,
+                        ctx.pool.cluster_info.my_shred_version(),
+                        &vote,
+                        0
+                    ),
                     &mut vec![]
                 )
                 .is_err()
@@ -2109,7 +2221,12 @@ mod tests {
             block_id: Hash::new_unique(),
         });
 
-        let consensus_message = dummy_vote_message(&ctx.validators, &vote, rank_to_test);
+        let consensus_message = dummy_vote_message(
+            &ctx.validators,
+            ctx.pool.cluster_info.my_shred_version(),
+            &vote,
+            rank_to_test,
+        );
         let ConsensusMessage::Vote(vote_message) = consensus_message else {
             panic!("Expected Vote message")
         };
@@ -2119,10 +2236,10 @@ mod tests {
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
 
-        let signed_message = wincode::serialize(&vote).unwrap();
+        let payload = get_vote_payload_to_sign(&vote, ctx.pool.cluster_info.my_shred_version());
         vote_message
             .signature
-            .verify(&bls_keypair.public, &signed_message)
+            .verify(&bls_keypair.public, &payload)
             .expect("vote message signature should verify");
     }
 

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -216,7 +216,9 @@ mod tests {
             certificate::CertificateType,
             consensus_message::{Block, VoteMessage},
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
+        rand::Rng,
         solana_bls_signatures::{
             BLS_SIGNATURE_AFFINE_SIZE, Keypair as BLSKeypair, PreparedHashedMessage,
             PubkeyProjective as BLSPubkeyProjective, Signature as BLSSignature,
@@ -403,6 +405,7 @@ mod tests {
             slot: 10,
             block_id: Hash::new_unique(),
         };
+        let shred_version = rand::rng().random();
         let cert_type = CertificateType::Notarize(block);
 
         // 1. Setup: Create keypairs and a single vote object.
@@ -411,7 +414,7 @@ mod tests {
         let mut keypairs = Vec::new();
         let mut vote_messages = Vec::new();
         let vote = Vote::new_notarization_vote(block);
-        let serialized_vote = wincode::serialize(&vote).unwrap();
+        let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
 
         for i in 0..num_validators {
             let keypair = BLSKeypair::new();
@@ -449,13 +452,14 @@ mod tests {
         // A NotarizeFallback certificate can be composed of both Notarize and NotarizeFallback
         // votes.
         let cert_type = CertificateType::NotarizeFallback(block);
+        let shred_version = rand::rng().random();
 
         // 1. Setup: Create two groups of validators signing two different vote types.
         let mut all_vote_messages = Vec::new();
         let mut all_pubkeys = Vec::new();
         // Group 1: Signs a Notarize vote.
         let notarize_vote = Vote::new_notarization_vote(block);
-        let serialized_notarize_vote = wincode::serialize(&notarize_vote).unwrap();
+        let serialized_notarize_vote = get_vote_payload_to_sign(&notarize_vote, shred_version);
         for i in 0..3 {
             let keypair = BLSKeypair::new();
             let signature = keypair.sign(&serialized_notarize_vote);
@@ -469,7 +473,8 @@ mod tests {
 
         // Group 2: Signs a NotarizeFallback vote.
         let notarize_fallback_vote = Vote::new_notarization_fallback_vote(block);
-        let serialized_fallback_vote = wincode::serialize(&notarize_fallback_vote).unwrap();
+        let serialized_fallback_vote =
+            get_vote_payload_to_sign(&notarize_fallback_vote, shred_version);
         for i in 3..6 {
             let keypair = BLSKeypair::new();
             let signature = keypair.sign(&serialized_fallback_vote);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -678,6 +678,7 @@ mod tests {
             certificate::CertificateType,
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
         crossbeam_channel::{bounded, unbounded},
         solana_bls_signatures::{
@@ -812,7 +813,8 @@ mod tests {
             let vote_keypair = &ctx.validator_keypairs[my_rank].vote_keypair;
             let bls_keypair =
                 BLSKeypair::derive_from_signer(vote_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
-            let vote_serialized = wincode::serialize(&notarize_vote).unwrap();
+            let vote_serialized =
+                get_vote_payload_to_sign(&notarize_vote, ctx.ctx.cluster_info.my_shred_version());
             let message = ConsensusMessage::Vote(VoteMessage {
                 vote: notarize_vote,
                 signature: bls_keypair.sign(&vote_serialized).into(),

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -964,6 +964,7 @@ mod tests {
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, ConsensusMessage, VoteMessage},
             metric_types::ConsensusMetricsEventReceiver,
             vote::Vote,
+            wire::get_vote_payload_to_sign,
         },
         crossbeam_channel::{Receiver, Sender, TryRecvError, bounded},
         parking_lot::RwLock as PlRwLock,
@@ -1138,6 +1139,7 @@ mod tests {
 
         let vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
         let voting_context = VotingContext {
+            cluster_info: cluster_info.clone(),
             identity_keypair: Arc::new(my_node_keypair.insecure_clone()),
             sharable_banks: bank_forks.read().unwrap().sharable_banks(),
             vote_history,
@@ -1395,9 +1397,9 @@ mod tests {
         }
 
         fn expected_vote_message(&self, expected_vote: &Vote) -> VoteMessage {
-            let expected_vote_serialized = wincode::serialize(expected_vote).unwrap();
-            let signature: BLSSignature =
-                self.my_bls_keypair.sign(&expected_vote_serialized).into();
+            let payload =
+                get_vote_payload_to_sign(expected_vote, self.cluster_info.my_shred_version());
+            let signature: BLSSignature = self.my_bls_keypair.sign(&payload).into();
             VoteMessage {
                 vote: *expected_vote,
                 rank: 0,

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -4,8 +4,8 @@ use {
         vote_history_storage::{SavedVoteHistoryVersions, VoteHistoryStorage},
     },
     agave_votor_messages::{
-        certificate::Certificate,
-        consensus_message::{ConsensusMessage, VoteMessage},
+        certificate::Certificate, consensus_message::VoteMessage,
+        wire::VersionedWireConsensusMessage,
     },
     crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_client::connection_cache::ConnectionCache,
@@ -75,7 +75,7 @@ pub enum BLSOp {
 /// When we are not in standstill the queue will be cleared as it's prune by the highest
 /// finalized slot.
 struct StandstillRefreshQueue {
-    messages: BTreeMap<Slot, HashSet<ConsensusMessage>>,
+    messages: BTreeMap<Slot, HashSet<VersionedWireConsensusMessage>>,
     last_refresh: Instant,
     cursor: Slot,
 }
@@ -91,7 +91,7 @@ impl Default for StandstillRefreshQueue {
 }
 
 impl StandstillRefreshQueue {
-    fn insert(&mut self, message: ConsensusMessage) {
+    fn insert(&mut self, message: VersionedWireConsensusMessage) {
         let slot = message.slot();
         self.messages.entry(slot).or_default().insert(message);
     }
@@ -114,7 +114,7 @@ impl StandstillRefreshQueue {
     fn for_next_n_messages(
         &mut self,
         limit: usize,
-        mut handle_message: impl FnMut(&ConsensusMessage),
+        mut handle_message: impl FnMut(&VersionedWireConsensusMessage),
     ) -> usize {
         if limit == 0 || self.is_empty() {
             return 0;
@@ -180,7 +180,7 @@ impl StandstillRefreshQueue {
     }
 
     #[cfg(test)]
-    fn next_messages(&mut self, limit: usize) -> Vec<(Slot, ConsensusMessage)> {
+    fn next_messages(&mut self, limit: usize) -> Vec<(Slot, VersionedWireConsensusMessage)> {
         let mut messages = Vec::new();
         self.for_next_n_messages(limit, |message| {
             messages.push((message.slot(), message.clone()));
@@ -361,7 +361,10 @@ impl VotingService {
 
             // Refresh the latest finalization (either Finalize + Notarize or FastFinalize)
             for certificate in certificates {
-                let message = ConsensusMessage::Certificate(certificate);
+                let message = VersionedWireConsensusMessage::new_from_cert(
+                    certificate,
+                    cluster_info.my_shred_version(),
+                );
                 Self::broadcast_consensus_message(
                     cluster_info,
                     &message,
@@ -390,7 +393,7 @@ impl VotingService {
 
     fn broadcast_consensus_message(
         cluster_info: &ClusterInfo,
-        message: &ConsensusMessage,
+        message: &VersionedWireConsensusMessage,
         connection_cache: &ConnectionCache,
         additional_listeners: &[SocketAddr],
         staked_validators_cache: &mut StakedValidatorsCache,
@@ -440,7 +443,10 @@ impl VotingService {
                 }
                 measure.stop();
                 trace!("{measure}");
-                let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
+                let msg = VersionedWireConsensusMessage::new_from_vote(
+                    Arc::unwrap_or_clone(vote),
+                    cluster_info.my_shred_version(),
+                );
                 Self::broadcast_consensus_message(
                     cluster_info,
                     &msg,
@@ -451,10 +457,13 @@ impl VotingService {
             }
             BLSOp::PushCertificates { certificates } => {
                 for certificate in certificates {
-                    let message = ConsensusMessage::Certificate(Arc::unwrap_or_clone(certificate));
+                    let msg = VersionedWireConsensusMessage::new_from_cert(
+                        Arc::unwrap_or_clone(certificate),
+                        cluster_info.my_shred_version(),
+                    );
                     Self::broadcast_consensus_message(
                         cluster_info,
-                        &message,
+                        &msg,
                         connection_cache,
                         additional_listeners,
                         staked_validators_cache,
@@ -463,13 +472,19 @@ impl VotingService {
             }
             BLSOp::RefreshVotes { votes } => {
                 for vote in votes {
-                    let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
+                    let msg = VersionedWireConsensusMessage::new_from_vote(
+                        Arc::unwrap_or_clone(vote),
+                        cluster_info.my_shred_version(),
+                    );
                     standstill_queue.insert(msg);
                 }
             }
             BLSOp::RefreshCertificates { certificates } => {
                 for certificate in certificates {
-                    let message = ConsensusMessage::Certificate(Arc::unwrap_or_clone(certificate));
+                    let message = VersionedWireConsensusMessage::new_from_cert(
+                        Arc::unwrap_or_clone(certificate),
+                        cluster_info.my_shred_version(),
+                    );
                     standstill_queue.insert(message);
                 }
             }
@@ -494,10 +509,12 @@ mod tests {
             vote::Vote,
         },
         crossbeam_channel::bounded,
+        rand::Rng,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
+        solana_perf::packet::packet_config,
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,
@@ -519,28 +536,42 @@ mod tests {
         tokio_util::sync::CancellationToken,
     };
 
-    fn test_vote_message(vote: Vote, rank: u16) -> ConsensusMessage {
-        ConsensusMessage::Vote(VoteMessage {
-            vote,
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            rank,
-        })
+    fn test_vote_message(
+        vote: Vote,
+        rank: u16,
+        shred_verion: u16,
+    ) -> VersionedWireConsensusMessage {
+        VersionedWireConsensusMessage::new_from_vote(
+            VoteMessage {
+                vote,
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                rank,
+            },
+            shred_verion,
+        )
     }
 
-    fn test_certificate_message(cert_type: CertificateType) -> ConsensusMessage {
-        ConsensusMessage::Certificate(Certificate {
-            cert_type,
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: Vec::new(),
-        })
+    fn test_certificate_message(
+        cert_type: CertificateType,
+        my_shred_version: u16,
+    ) -> VersionedWireConsensusMessage {
+        VersionedWireConsensusMessage::new_from_cert(
+            Certificate {
+                cert_type,
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: Vec::new(),
+            },
+            my_shred_version,
+        )
     }
 
     #[test]
     fn test_standstill_refresh_queue_cycles_by_slot() {
+        let shred_verion = rand::rng().random();
         let mut queue = StandstillRefreshQueue::default();
-        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1);
-        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
-        let cert_6 = test_certificate_message(CertificateType::Finalize(6));
+        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1, shred_verion);
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1, shred_verion);
+        let cert_6 = test_certificate_message(CertificateType::Finalize(6), shred_verion);
 
         queue.insert(vote_6.clone());
         queue.insert(cert_6.clone());
@@ -556,8 +587,9 @@ mod tests {
 
     #[test]
     fn test_standstill_refresh_queue_deduplicates_identical_messages() {
+        let shred_verion = rand::rng().random();
         let mut queue = StandstillRefreshQueue::default();
-        let message = test_vote_message(Vote::new_skip_vote(8), 1);
+        let message = test_vote_message(Vote::new_skip_vote(8), 1, shred_verion);
 
         queue.insert(message.clone());
         queue.insert(message.clone());
@@ -568,9 +600,10 @@ mod tests {
     #[test]
     fn test_standstill_refresh_queue_wraps_to_fill_budget() {
         let mut queue = StandstillRefreshQueue::default();
-        let vote_3 = test_vote_message(Vote::new_skip_vote(3), 1);
-        let vote_4 = test_vote_message(Vote::new_skip_vote(4), 1);
-        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
+        let shred_verion = rand::rng().random();
+        let vote_3 = test_vote_message(Vote::new_skip_vote(3), 1, shred_verion);
+        let vote_4 = test_vote_message(Vote::new_skip_vote(4), 1, shred_verion);
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1, shred_verion);
 
         queue.insert(vote_3.clone());
         queue.insert(vote_4.clone());
@@ -585,11 +618,12 @@ mod tests {
 
     #[test]
     fn test_standstill_refresh_queue_prunes_finalized_messages() {
+        let shred_verion = rand::rng().random();
         let mut queue = StandstillRefreshQueue::default();
-        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1);
-        let cert_6 = test_certificate_message(CertificateType::Finalize(6));
-        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
-        let vote_7 = test_vote_message(Vote::new_skip_vote(7), 1);
+        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1, shred_verion);
+        let cert_6 = test_certificate_message(CertificateType::Finalize(6), shred_verion);
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1, shred_verion);
+        let vote_7 = test_vote_message(Vote::new_skip_vote(7), 1, shred_verion);
 
         queue.insert(vote_5);
         queue.insert(cert_6);
@@ -603,7 +637,7 @@ mod tests {
     fn create_voting_service(
         bls_receiver: Receiver<BLSOp>,
         listener: SocketAddr,
-    ) -> (VotingService, Vec<ValidatorVoteKeypairs>) {
+    ) -> (VotingService, Vec<ValidatorVoteKeypairs>, Arc<ClusterInfo>) {
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -617,16 +651,16 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank0);
         let keypair = Keypair::new();
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), 0);
-        let cluster_info = ClusterInfo::new(
+        let cluster_info = Arc::new(ClusterInfo::new(
             contact_info,
             Arc::new(keypair),
             SocketAddrSpace::Unspecified,
-        );
+        ));
 
         (
             VotingService::new(
                 bls_receiver,
-                Arc::new(cluster_info),
+                cluster_info.clone(),
                 Arc::new(NullVoteHistoryStorage::default()),
                 Arc::new(ConnectionCache::new_quic(
                     "TestAlpenglowConnectionCache",
@@ -640,6 +674,7 @@ mod tests {
                 }),
             ),
             validator_keypairs,
+            cluster_info,
         )
     }
 
@@ -687,7 +722,8 @@ mod tests {
         let listener_addr = socket.local_addr().unwrap();
 
         // Create VotingService with the listener address
-        let (_, validator_keypairs) = create_voting_service(bls_receiver, listener_addr);
+        let (_, validator_keypairs, cluster_info) =
+            create_voting_service(bls_receiver, listener_addr);
 
         // Send a BLS message via the VotingService
         assert!(bls_sender.send(bls_op).is_ok());
@@ -722,15 +758,12 @@ mod tests {
 
         let packets = receiver.recv().unwrap();
         let packet = packets.first().expect("No packets received");
-        let received_message = wincode::deserialize::<ConsensusMessage>(packet.data(..).unwrap())
-            .unwrap_or_else(|err| {
-                panic!(
-                    "Failed to deserialize BLSMessage: {:?} {:?}",
-                    size_of::<ConsensusMessage>(),
-                    err
-                )
-            });
-        assert_eq!(received_message, expected_message);
+        let received_message =
+            wincode::config::deserialize_exact(packet.data(..).unwrap(), packet_config()).unwrap();
+        assert_eq!(
+            VersionedWireConsensusMessage::new(expected_message, cluster_info.my_shred_version()),
+            received_message
+        );
         cancel.cancel();
         quic_server_thread.join().unwrap();
     }

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -9,10 +9,12 @@ use {
         consensus_message::{BLS_KEYPAIR_DERIVE_SEED, ConsensusMessage, VoteMessage},
         metric_types::ConsensusMetricsEventSender,
         vote::Vote,
+        wire::get_vote_payload_to_sign,
     },
     crossbeam_channel::{SendError, Sender},
     solana_bls_signatures::{BlsError, keypair::Keypair as BLSKeypair},
     solana_clock::{Epoch, Slot},
+    solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, bank_forks::SharableBanks, epoch_stakes::BLSPubkeyStakeEntry},
@@ -111,6 +113,7 @@ pub enum VoteError {
 
 /// Context required to construct vote transactions
 pub struct VotingContext {
+    pub cluster_info: Arc<ClusterInfo>,
     pub vote_history: VoteHistory,
     pub vote_account_pubkey: Pubkey,
     pub identity_keypair: Arc<Keypair>,
@@ -147,6 +150,7 @@ pub fn generate_vote_tx(
     vote: Vote,
     bank: &Bank,
     vote_account_pubkey: Pubkey,
+    shred_version: u16,
     identity_keypair: &Keypair,
     authorized_voter_keypairs: &RwLock<Vec<Arc<Keypair>>>,
     wait_to_vote_slot: Option<u64>,
@@ -215,10 +219,10 @@ pub fn generate_vote_tx(
         return GenerateVoteTxResult::NonVoting;
     };
 
-    let vote_serialized = wincode::serialize(&vote).unwrap();
+    let vote_payload_to_sign = get_vote_payload_to_sign(&vote, shred_version);
     GenerateVoteTxResult::Vote(VoteMessage {
         vote,
-        signature: bls_keypair.sign(&vote_serialized).into(),
+        signature: bls_keypair.sign(&vote_payload_to_sign).into(),
         rank: my_rank,
     })
 }
@@ -239,6 +243,7 @@ fn create_vote_message(
         vote,
         &bank,
         context.vote_account_pubkey,
+        context.cluster_info.my_shred_version(),
         &context.identity_keypair,
         &context.authorized_voter_keypairs,
         wait_to_vote_slot,
@@ -339,7 +344,9 @@ mod tests {
         super::*,
         agave_votor_messages::consensus_message::Block,
         crossbeam_channel::bounded,
+        solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
+        solana_net_utils::SocketAddrSpace,
         solana_runtime::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
@@ -351,9 +358,13 @@ mod tests {
         std::sync::{Arc, RwLock},
     };
 
-    fn generate_expected_consensus_message(vote: Vote, my_bls_keypair: &BLSKeypair) -> VoteMessage {
-        let vote_serialized = wincode::serialize(&vote).unwrap();
-        let signature = my_bls_keypair.sign(&vote_serialized);
+    fn generate_expected_consensus_message(
+        ctx: &VotingContext,
+        vote: Vote,
+        my_bls_keypair: &BLSKeypair,
+    ) -> VoteMessage {
+        let payload = get_vote_payload_to_sign(&vote, ctx.cluster_info.my_shred_version());
+        let signature = my_bls_keypair.sign(&payload);
         VoteMessage {
             vote,
             signature: signature.into(),
@@ -390,11 +401,18 @@ mod tests {
         let bank_forks = BankForks::new_rw_arc(bank0);
 
         let my_keys = &validator_keypairs[my_index];
+        let contact_info = ContactInfo::new_localhost(&my_keys.node_keypair.pubkey(), 0);
+        let cluster_info = Arc::new(ClusterInfo::new(
+            contact_info,
+            Arc::new(my_keys.node_keypair.insecure_clone()),
+            SocketAddrSpace::Unspecified,
+        ));
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let bls_sender = bounded(1024).0;
         let commitment_sender = bounded(1024).0;
         let consensus_metrics_sender = bounded(1024).0;
         let voting_context = VotingContext {
+            cluster_info,
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
             vote_account_pubkey: my_keys.vote_keypair.pubkey(),
             identity_keypair: Arc::new(my_keys.node_keypair.insecure_clone()),
@@ -439,7 +457,8 @@ mod tests {
             .ok()
             .unwrap()
             .unwrap();
-        let expected_message = generate_expected_consensus_message(vote, &my_bls_keypair);
+        let expected_message =
+            generate_expected_consensus_message(&voting_context, vote, &my_bls_keypair);
         if let BLSOp::PushVote {
             vote,
             saved_vote_history,
@@ -529,6 +548,7 @@ mod tests {
                 vote,
                 &voting_context.sharable_banks.root(),
                 voting_context.vote_account_pubkey,
+                voting_context.cluster_info.my_shred_version(),
                 &voting_context.identity_keypair,
                 &voting_context.authorized_voter_keypairs,
                 voting_context.wait_to_vote_slot,
@@ -570,6 +590,7 @@ mod tests {
                 vote,
                 &voting_context.sharable_banks.root(),
                 voting_context.vote_account_pubkey,
+                voting_context.cluster_info.my_shred_version(),
                 &wrong_identity_keypair,
                 &voting_context.authorized_voter_keypairs,
                 voting_context.wait_to_vote_slot,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -195,6 +195,7 @@ impl Votor {
         };
 
         let voting_context = VotingContext {
+            cluster_info: cluster_info.clone(),
             vote_history,
             vote_account_pubkey: vote_account,
             identity_keypair,


### PR DESCRIPTION
#### Problem

Also see #12737. 

- in order to ensure that msgs from different startups of the clusters do not interfere, we need to add shred version to differentiate between msgs from older clusters.
- we should add versioning to consensus msgs making it easier to upgrade them in future.
- As discussed in https://docs.google.com/document/d/1zMA9tA7bjTKV8K0trKbNEt0b35ORP5lmK_jE5pqKLPk/edit?tab=t.0#heading=h.p0moca5yrf6u, we would like to update how the consensus messages are defined so that they are can be packed more efficiently and they are easier to use.


#### Summary of Changes

- Introduces a whole new batch of definitions related to consensus messages.  These batches are how consensus messages should be sent and received over the network.  The messages follow the definition proposed in the google doc above; are versioned; and have a shred version.
- bls-cert-verify is updated to verify the wire version of certs and return `Certificate`.
- bls-sigverify is updated to receive Wire versions of votes and certs and only covert them to Certificate and Vote after verification.
- Vote signing is updated to sign the wire vote payload.
- The new batch of definitions have frozen-abi set
- when this PR lands, we can update the internal ConsensusMessage definitions at leisure as changing them will not be a protocol impacting change.

Deferring to future work:
- https://github.com/anza-xyz/agave/issues/13227


#### Testing

- Standard CI
- Ran on alpenglow invalidator cluster as well


Fixes #12737
