### PR TITLE
nit: use the parent bank when fetching the timestamp for BCL

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -517,7 +517,7 @@ fn produce_block_footer(
 
     if let Some(parent_bank) = bank.parent() {
         // Get parent time from alpenglow clock (nanoseconds) or fall back to clock sysvar (seconds -> nanoseconds)
-        let parent_time_nanos = bank
+        let parent_time_nanos = parent_bank
             .get_nanosecond_clock()
             .unwrap_or_else(|| bank.clock().unix_timestamp.saturating_mul(1_000_000_000));
         let parent_slot = parent_bank.slot();


### PR DESCRIPTION
#### Problem
When enforcing the clock bounds in BCP we use the `parent_bank` for this check

https://github.com/anza-xyz/agave/blob/038013d928de79a20bcadf5c4a1ec3b92d4aa882/runtime/src/block_component_processor.rs#L457-L461

However here in BCL we use the current `bank`.

These are the exact same, as the clock sysvar is populated at the end of the block in AG. However it has tripped up code reviewers.

#### Summary of Changes
Change it to `parent_bank`