### PR TITLE
gossip: Improve pull bloom filter accounting

### DIFF
--- a/bloom/src/bloom.rs
+++ b/bloom/src/bloom.rs
@@ -5,7 +5,6 @@ use {
     fnv::FnvHasher,
     rand::{self, Rng},
     serde::{Deserialize, Serialize},
-    solana_sanitize::{Sanitize, SanitizeError},
     solana_time_utils::AtomicInterval,
     std::{
         cmp, fmt,
@@ -53,17 +52,6 @@ impl<T: BloomHashIndex> fmt::Debug for Bloom<T> {
             write!(f, "..")?;
         }
         write!(f, " }}")
-    }
-}
-
-impl<T: BloomHashIndex> Sanitize for Bloom<T> {
-    fn sanitize(&self) -> Result<(), SanitizeError> {
-        // Avoid division by zero in self.pos(...).
-        if self.bits.is_empty() {
-            Err(SanitizeError::InvalidValue)
-        } else {
-            Ok(())
-        }
     }
 }
 
@@ -120,6 +108,9 @@ impl<T: BloomHashIndex> Bloom<T> {
         self.num_bits_set = 0;
     }
     pub fn add(&mut self, key: &T) {
+        if self.bits.is_empty() {
+            return;
+        }
         for k in &self.keys {
             let pos = self.pos(key, *k);
             if !self.bits.get(pos) {
@@ -129,6 +120,9 @@ impl<T: BloomHashIndex> Bloom<T> {
         }
     }
     pub fn contains(&self, key: &T) -> bool {
+        if self.keys.is_empty() || self.bits.is_empty() {
+            return false;
+        }
         for k in &self.keys {
             let pos = self.pos(key, *k);
             if !self.bits.get(pos) {
@@ -195,6 +189,9 @@ impl<T: BloomHashIndex> ConcurrentBloom<T> {
     /// Adds an item to the bloom filter and returns true if the item
     /// was not in the filter before.
     pub fn add(&self, key: &T) -> bool {
+        if self.bits.is_empty() {
+            return false;
+        }
         let mut added = false;
         for k in &self.keys {
             let (index, mask) = self.pos(key, *k);
@@ -205,6 +202,9 @@ impl<T: BloomHashIndex> ConcurrentBloom<T> {
     }
 
     pub fn contains(&self, key: &T) -> bool {
+        if self.keys.is_empty() || self.bits.is_empty() {
+            return false;
+        }
         self.keys.iter().all(|k| {
             let (index, mask) = self.pos(key, *k);
             let bit = self.bits[index].load(Ordering::Relaxed) & mask;
@@ -309,6 +309,7 @@ mod test {
         bloom.add(&key);
         assert!(bloom.contains(&key));
     }
+
     #[test]
     fn test_random() {
         let mut b1: Bloom<Hash> = Bloom::random(10, 0.1, 100);

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -17,13 +17,13 @@ use {
     crate::{
         cluster_info_metrics::{Counter, GossipStats, ScopedTimer, TimedGuard},
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
-        crds::{Crds, Cursor, GossipRoute},
+        crds::{CRDS_SHARDS_BITS, Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, MAX_VOTES, SnapshotHashes, Vote},
         crds_filter::{GossipFilterDirection, should_retain_crds_value},
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
-            CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CrdsFilter, CrdsTimeouts, ProcessPullStats,
+            self, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CrdsFilter, CrdsTimeouts, ProcessPullStats,
             PullRequest, get_max_bloom_filter_bytes,
         },
         crds_value::{CrdsValue, CrdsValueLabel},
@@ -53,6 +53,7 @@ use {
         PortRange, SocketAddrSpace, VALIDATOR_PORT_RANGE, bind_in_range,
         multihomed_sockets::BindIpAddrs,
         sockets::{bind_gossip_port_in_range, bind_to_localhost_unique},
+        token_bucket::{KeyedRateLimiter, TokenBucket},
     },
     solana_perf::{
         data_budget::DataBudget,
@@ -121,6 +122,27 @@ pub(crate) const GOSSIP_CHANNEL_CAPACITY: usize = 4096; // 2^12
 const GOSSIP_PING_CACHE_CAPACITY: usize = 126976;
 const GOSSIP_PING_CACHE_TTL: Duration = Duration::from_secs(1280);
 const GOSSIP_PING_CACHE_RATE_LIMIT_DELAY: Duration = Duration::from_secs(1280 / 64);
+// Per-IP scan budget for incoming pull requests; validators are assumed not
+// to share IPs. Mirrors the ping-pong cache capacity.
+const GOSSIP_PULL_SCAN_BUDGET_CACHE_CAPACITY: usize = GOSSIP_PING_CACHE_CAPACITY;
+const GOSSIP_PULL_SCAN_BUDGET_CAPACITY: u64 = 16 * crds_gossip_pull::MIN_NUM_BLOOM_ITEMS as u64;
+const GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC: u64 =
+    4 * crds_gossip_pull::MIN_NUM_BLOOM_ITEMS as u64;
+const GOSSIP_PULL_SCAN_BUDGET_SHARD_COUNT: usize = 64;
+
+/// Estimated CRDS shard scan work for a pull request filter.
+#[inline]
+fn pull_request_scan_cost(crds_len: usize, mask_bits: u32, bloom_hash_count: usize) -> u64 {
+    // Extra mask bits still require one full shard scan.
+    let shift = mask_bits.min(CRDS_SHARDS_BITS);
+    let scan_entries = (crds_len >> shift).max(1) as u64;
+
+    let bloom_hash_count = u64::try_from(bloom_hash_count)
+        .unwrap_or(u64::MAX)
+        .max(crds_gossip_pull::KEYS as u64);
+    scan_entries.saturating_mul(bloom_hash_count)
+}
+
 pub const DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS: u64 = 10_000;
 pub const DEFAULT_CONTACT_SAVE_INTERVAL_MILLIS: u64 = 60_000;
 // Limit number of unique pubkeys in the crds table.
@@ -163,6 +185,7 @@ pub struct ClusterInfo {
     outbound_budget: DataBudget,
     my_contact_info: RwLock<ContactInfo>,
     ping_cache: Mutex<PingCache>,
+    pull_request_budget: KeyedRateLimiter<IpAddr>,
     pub(crate) stats: GossipStats,
     local_message_pending_push_queue: Mutex<Vec<CrdsValue>>,
     contact_debug_interval: u64, // milliseconds, 0 = disabled
@@ -191,6 +214,15 @@ impl ClusterInfo {
                 GOSSIP_PING_CACHE_RATE_LIMIT_DELAY,
                 GOSSIP_PING_CACHE_CAPACITY,
             )),
+            pull_request_budget: KeyedRateLimiter::new(
+                GOSSIP_PULL_SCAN_BUDGET_CACHE_CAPACITY,
+                TokenBucket::new(
+                    GOSSIP_PULL_SCAN_BUDGET_CAPACITY,
+                    GOSSIP_PULL_SCAN_BUDGET_CAPACITY,
+                    GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC as f64,
+                ),
+                GOSSIP_PULL_SCAN_BUDGET_SHARD_COUNT,
+            ),
             stats: GossipStats::default(),
             local_message_pending_push_queue: Mutex::default(),
             contact_debug_interval: DEFAULT_CONTACT_DEBUG_INTERVAL_MILLIS,
@@ -1638,6 +1670,24 @@ impl ClusterInfo {
         }
     }
 
+    fn try_consume_pull_request_scan_budget(&self, request: &PullRequest, crds_len: usize) -> bool {
+        let cost = pull_request_scan_cost(
+            crds_len,
+            request.filter.get_mask_bits(),
+            request.filter.bloom_hash_count(),
+        );
+        if self
+            .pull_request_budget
+            .consume_tokens(request.addr.ip(), cost)
+            .is_ok()
+        {
+            true
+        } else {
+            self.stats.pull_request_scan_budget_exhausted.add_relaxed(1);
+            false
+        }
+    }
+
     // Pull requests take an incoming bloom filter of contained entries from a node
     // and tries to send back to them the values it detects are missing.
     fn handle_pull_requests(
@@ -1673,6 +1723,7 @@ impl ClusterInfo {
                         GossipFilterDirection::EgressPullResponse,
                     )
                 },
+                |request, crds_len| self.try_consume_pull_request_scan_budget(request, crds_len),
                 &self.stats,
             )
         };
@@ -3279,13 +3330,16 @@ mod tests {
         tower.clear();
         tower.extend(0..=slot);
         let vote = new_vote_transaction(vec![slot]);
+        // `KeyedRateLimiter` is not unwind-safe; this test only checks the panic.
         assert!(
-            panic::catch_unwind(|| cluster_info.push_vote(&tower, vote))
-                .err()
-                .and_then(|a| a
-                    .downcast_ref::<String>()
-                    .map(|s| { s.starts_with("Submitting old vote") }))
-                .unwrap_or_default()
+            panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                cluster_info.push_vote(&tower, vote)
+            }))
+            .err()
+            .and_then(|a| a
+                .downcast_ref::<String>()
+                .map(|s| { s.starts_with("Submitting old vote") }))
+            .unwrap_or_default()
         );
     }
 

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -148,6 +148,7 @@ pub struct GossipStats {
     pub(crate) prune_received_cache: Counter,
     pub(crate) pull_from_entrypoint_count: Counter,
     pub(crate) pull_request_ping_pong_check_failed_count: Counter,
+    pub(crate) pull_request_scan_budget_exhausted: Counter,
     pub(crate) purge: Counter,
     pub(crate) purge_count: Counter,
     pub(crate) push_fanout_num_entries: Counter,
@@ -354,6 +355,11 @@ pub(crate) fn submit_gossip_stats(
         (
             "pull_request_ping_pong_check_failed_count",
             stats.pull_request_ping_pong_check_failed_count.clear(),
+            i64
+        ),
+        (
+            "pull_request_scan_budget_exhausted",
+            stats.pull_request_scan_budget_exhausted.clear(),
             i64
         ),
         (

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -55,7 +55,7 @@ use {
     },
 };
 
-const CRDS_SHARDS_BITS: u32 = 12;
+pub(crate) const CRDS_SHARDS_BITS: u32 = 12;
 // Number of vote slots to track in an lru-cache for metrics.
 const VOTE_SLOTS_METRICS_CAP: usize = 100;
 // Required number of leading zero bits for crds signature to get reported to influx

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -236,6 +236,7 @@ impl CrdsGossip {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
+        try_consume_scan_budget: impl Fn(&PullRequest, usize) -> bool + Sync,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         CrdsGossipPull::generate_pull_responses(
@@ -245,6 +246,7 @@ impl CrdsGossip {
             output_size_limit,
             now,
             should_retain_crds_value,
+            try_consume_scan_budget,
             stats,
         )
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -65,6 +65,19 @@ pub struct CrdsFilter {
     mask_bits: u32,
 }
 
+#[cfg(debug_assertions)]
+pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 512;
+#[cfg(not(debug_assertions))]
+pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 65_536;
+
+// Loosest mask_bits floor accepted for incoming pull requests.
+// `PACKET_DATA_SIZE` avoids rejecting honest smaller bloom filters.
+static MIN_PULL_REQUEST_MASK_BITS: LazyLock<u32> = LazyLock::new(|| {
+    let max_bits = (PACKET_DATA_SIZE * 8) as f64;
+    let max_items = CrdsFilter::max_items(max_bits, FALSE_RATE, KEYS);
+    CrdsFilter::mask_bits(MIN_NUM_BLOOM_ITEMS as f64, max_items)
+});
+
 // Incoming gossip pull request from a remote node.
 pub struct PullRequest {
     pub pubkey: Pubkey,   // remote node's pubkey
@@ -85,7 +98,9 @@ impl Default for CrdsFilter {
 
 impl solana_sanitize::Sanitize for CrdsFilter {
     fn sanitize(&self) -> std::result::Result<(), solana_sanitize::SanitizeError> {
-        self.filter.sanitize()?;
+        if self.mask_bits < *MIN_PULL_REQUEST_MASK_BITS {
+            return Err(solana_sanitize::SanitizeError::InvalidValue);
+        }
         Ok(())
     }
 }
@@ -97,9 +112,12 @@ impl CrdsFilter {
         self.mask
     }
 
-    #[cfg(any(test, feature = "conformance"))]
-    pub(crate) fn get_mask_bits(&self) -> u32 {
+    pub fn get_mask_bits(&self) -> u32 {
         self.mask_bits
+    }
+
+    pub fn bloom_hash_count(&self) -> usize {
+        self.filter.keys.len()
     }
 
     #[cfg(any(test, feature = "dev-context-only-utils"))]
@@ -330,6 +348,7 @@ impl CrdsGossipPull {
         output_size_limit: usize, // Limit number of crds values returned.
         now: u64,
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
+        try_consume_scan_budget: impl Fn(&PullRequest, usize) -> bool + Sync,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         Self::filter_crds_values(
@@ -339,6 +358,7 @@ impl CrdsGossipPull {
             output_size_limit,
             now,
             should_retain_crds_value,
+            try_consume_scan_budget,
             stats,
         )
     }
@@ -450,10 +470,6 @@ impl CrdsGossipPull {
         bloom_size: usize,
     ) -> Vec<CrdsFilter> {
         const PAR_MIN_LENGTH: usize = 512;
-        #[cfg(debug_assertions)]
-        const MIN_NUM_BLOOM_ITEMS: usize = 512;
-        #[cfg(not(debug_assertions))]
-        const MIN_NUM_BLOOM_ITEMS: usize = 65_536;
         let failed_inserts = self.failed_inserts.read().unwrap();
         // crds should be locked last after self.failed_inserts.
         let crds = crds.read().unwrap();
@@ -487,6 +503,9 @@ impl CrdsGossipPull {
         now: u64,
         // Predicate returning false if the CRDS value should be discarded.
         should_retain_crds_value: impl Fn(&CrdsValue) -> bool + Sync,
+        // False drops the request before scanning CRDS.
+        // Implementations may consume caller-owned scan budget.
+        try_consume_scan_budget: impl Fn(&PullRequest, usize) -> bool + Sync,
         stats: &GossipStats,
     ) -> Vec<Vec<CrdsValue>> {
         let msg_timeout = CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS;
@@ -499,6 +518,7 @@ impl CrdsGossipPull {
         let output_size_limit = output_size_limit.try_into().unwrap_or(i64::MAX);
         let output_size_limit = AtomicI64::new(output_size_limit);
         let crds = crds.read().unwrap();
+        let crds_len = crds.len();
         let apply_filter = |request: &PullRequest| {
             if output_size_limit.load(Ordering::Relaxed) <= 0 {
                 return Vec::default();
@@ -507,6 +527,10 @@ impl CrdsGossipPull {
             let caller_wallclock = request.wallclock;
             if !caller_wallclock_window.contains(&caller_wallclock) {
                 dropped_requests.fetch_add(1, Ordering::Relaxed);
+                return Vec::default();
+            }
+            // Charge only requests that passed cheaper pre-scan checks.
+            if !try_consume_scan_budget(request, crds_len) {
                 return Vec::default();
             }
             let caller_wallclock = caller_wallclock.checked_add(jitter).unwrap_or(0);
@@ -1119,7 +1143,8 @@ pub(crate) mod tests {
             &requests,
             usize::MAX,
             new_wallclock,
-            |_| true,
+            |_| true,    // should_retain_crds_value
+            |_, _| true, // try_consume_scan_budget
             &GossipStats::default(),
         );
         assert_eq!(rsp.len(), 2);

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -595,7 +595,8 @@ fn network_run_pull(
                                 &requests,
                                 usize::MAX, // output_size_limit
                                 now,
-                                |_| true, // should_retain_crds_value
+                                |_| true,    // should_retain_crds_value
+                                |_, _| true, // try_consume_scan_budget
                                 &GossipStats::default(),
                             )
                             .into_iter()


### PR DESCRIPTION
#### Problem

Sanitize is a bit of an antipattern. Should instead just let packets through to the accounting logic.

#### Summary of Changes

Drop the sanitize step and rely on scan + egress accounting when processing bloom filters.