### PR TITLE
refactor: alpenglow: simplify socket wiring

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -844,7 +844,7 @@ pub mod tests {
                 retransmit: target1.sockets.retransmit_sockets,
                 fetch: target1.sockets.tvu,
                 ancestor_hashes_requests: target1.sockets.ancestor_hashes_requests,
-                alpenglow: target1.sockets.alpenglow,
+                alpenglow: Some(target1.sockets.alpenglow),
                 block_id_repair: target1.sockets.block_id_repair,
             },
             blockstore,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1586,11 +1586,11 @@ impl Validator {
                 (None, None, None)
             };
 
-        // disable all2all tests if not allowed for a given cluster type
+        // disable Alpenglow votor networking if not allowed for cluster type
         let alpenglow_socket = if genesis_config.cluster_type == ClusterType::Testnet
             || genesis_config.cluster_type == ClusterType::Development
         {
-            node.sockets.alpenglow
+            Some(node.sockets.alpenglow)
         } else {
             None
         };

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2350,7 +2350,7 @@ pub struct Sockets {
     /// Client-side socket for ForwardingStage non-vote transactions
     pub tpu_transaction_forwarding_clients: Box<[UdpSocket]>, // quic write only
     /// Socket for alpenglow consensus logic
-    pub alpenglow: Option<UdpSocket>, // udp read/write
+    pub alpenglow: UdpSocket, // quic read/write
     /// Connection cache endpoint for QUIC-based Vote
     pub quic_vote_client: UdpSocket, // quic write only
     /// Connection cache endpoint for QUIC-based Alpenglow messages
@@ -2895,9 +2895,7 @@ mod tests {
 
     fn check_node_sockets(node: &Node, ip: IpAddr, range: (u16, u16)) {
         check_socket(&node.sockets.repair, ip, range);
-        if let Some(alpenglow_port) = &node.sockets.alpenglow {
-            check_socket(alpenglow_port, ip, range);
-        }
+        check_socket(&node.sockets.alpenglow, ip, range);
         check_sockets(&node.sockets.gossip, ip, range);
         check_sockets(&node.sockets.tvu, ip, range);
         check_sockets(&node.sockets.tpu_quic, ip, range);

--- a/gossip/src/node.rs
+++ b/gossip/src/node.rs
@@ -401,7 +401,7 @@ impl Node {
 
         trace!("new ContactInfo: {info:?}");
         let sockets = Sockets {
-            alpenglow: Some(alpenglow),
+            alpenglow,
             gossip: gossip_sockets.into_iter().collect(),
             tvu: tvu_sockets,
             tpu_vote: tpu_vote_sockets,


### PR DESCRIPTION
#### Problem

alpenglow socket is defined as Option<Socket> where it does not need to be. Having it as Option used to be relevant but no longer is.

#### Summary of Changes

just use Socket

#### Testing

None needed - pure refactor.