### PR TITLE
accounts-db: remove SlotStatus; trust write-cache hits

### DIFF
--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -36,26 +36,6 @@ impl MaxFlushedRoot {
     }
 }
 
-/// Indicates whether a slot is an ancestor, an unflushed root, or a root being flushed
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SlotStatus {
-    /// Slot is in the ancestors list and not a root being flushed. Slot is guaranteed to be
-    /// the newest version of the account on this fork so the cached copy can be used without
-    /// checking storage
-    Ancestor,
-    /// Slot is in the ancestors list but is also a root being flushed. The version found in the
-    /// accounts cache may not be the newest version of the account, and the storage should be
-    /// checked for newer versions
-    AncestorBeingFlushed,
-    /// Slot is a root that has not yet been claimed for flushing. Slot is guaranteed to be the
-    /// newest version of the account so the cached copy can be used without checking storage
-    UnflushedRoot,
-    /// Slot is a root that is currently being flushed. The version found in the accounts cache
-    /// may not be the newest version of the account, and the storage should be checked for newer
-    /// versions
-    RootBeingFlushed,
-}
-
 #[derive(Debug)]
 pub struct SlotCache {
     cache: DashMap<Pubkey, Arc<CachedAccount>, PubkeyHasherBuilder>,
@@ -347,40 +327,28 @@ impl AccountsCache {
         result
     }
 
-    /// Finds the best write-cache entry for `pubkey` visible from `ancestors`. Searches
-    /// ancestors first (highest to lowest), then unflushed roots, then roots being flushed.
-    /// Ancestors are checked exhaustively before roots, so a lower-slot ancestor wins over a
-    /// higher-slot root. Returns the account, slot, and status, or `None` if not found.
+    /// Finds the newest write-cache entry for `pubkey` visible from `ancestors`. Searches
+    /// ancestors first (highest to lowest), then roots (highest to lowest). Ancestors are
+    /// checked exhaustively before roots, so a lower-slot ancestor wins over a higher-slot
+    /// root. Returns the account and its slot, or `None` if not found.
     pub fn load_latest(
         &self,
         pubkey: &Pubkey,
         ancestors: &Ancestors,
-    ) -> Option<(Arc<CachedAccount>, Slot, SlotStatus)> {
+    ) -> Option<(Arc<CachedAccount>, Slot)> {
         // Exit early if the pubkey isn't in the cache
         let index_max_slot = self.index.max_slot_for_pubkey(pubkey)?;
 
+        // Ancestors take priority over roots regardless of slot. Iterate every slot in the
+        // range in descending order and return the first (highest) ancestor that has it.
         if let Some(ancestors_min_slot) = ancestors.min_slot() {
-            // Iterate every slot in the range in descending order
-            // Grab a read lock on flushing roots once before the loop to avoid locking/unlocking
-            // on every iteration. This lock ensures that the load call in the loop correctly
-            // identifies slots with status AncestorBeingFlushed.
-            let r_roots_being_flushed = self.roots_being_flushed.read().unwrap();
             for slot in (ancestors_min_slot..=index_max_slot).rev() {
                 if ancestors.contains_key(&slot) {
                     if let Some(account) = self.load(slot, pubkey) {
-                        // Need to check flush status of the slot even for ancestors, because
-                        // there could be newer version of the account that has already been
-                        // flushed
-                        let slot_status = if r_roots_being_flushed.contains(&slot) {
-                            SlotStatus::AncestorBeingFlushed
-                        } else {
-                            SlotStatus::Ancestor
-                        };
-                        return Some((account, slot, slot_status));
+                        return Some((account, slot));
                     }
                 }
             }
-            drop(r_roots_being_flushed);
         }
 
         // If the slot is not found in the ancestors fall back to searching roots.
@@ -396,7 +364,7 @@ impl AccountsCache {
         let r_maybe_unflushed_roots = self.maybe_unflushed_roots.read().unwrap();
         for &slot in r_maybe_unflushed_roots.range(..=max_root_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
-                return Some((account, slot, SlotStatus::UnflushedRoot));
+                return Some((account, slot));
             }
         }
         drop(r_maybe_unflushed_roots);
@@ -404,7 +372,7 @@ impl AccountsCache {
         let r_roots_being_flushed = self.roots_being_flushed.read().unwrap();
         for &slot in r_roots_being_flushed.range(..=max_root_slot).rev() {
             if let Some(account) = self.load(slot, pubkey) {
-                return Some((account, slot, SlotStatus::RootBeingFlushed));
+                return Some((account, slot));
             }
         }
         drop(r_roots_being_flushed);
@@ -692,7 +660,7 @@ mod tests {
         assert!(cache.index.max_slot_for_pubkey(&pk1).is_none());
     }
 
-    /// Tests that `load_latest` returns the correct slot, status, and account value
+    /// Tests that `load_latest` returns the correct slot and account value
     /// given various combinations of ancestor slots, root slots, and flushing state.
     ///
     /// Ancestors always take priority over roots regardless of slot
@@ -701,25 +669,25 @@ mod tests {
     // data stored in the cache. This lets us test root bounding by min_slot
     // without the ancestor path short-circuiting the lookup.
     #[test_case(&[], &[], &[], &[], None; "not ancestor not root")]
-    #[test_case(&[10], &[], &[], &[], Some((10, SlotStatus::Ancestor)); "ancestor only")]
-    #[test_case(&[5, 10, 15], &[], &[], &[], Some((15, SlotStatus::Ancestor)); "highest ancestor returned")]
-    #[test_case(&[], &[10, 20], &[], &[], Some((20, SlotStatus::UnflushedRoot)); "rooted, with no ancestors")]
-    #[test_case(&[], &[], &[10], &[], Some((10, SlotStatus::RootBeingFlushed)); "root being flushed")]
-    #[test_case(&[10], &[], &[10], &[], Some((10, SlotStatus::AncestorBeingFlushed)); "ancestor being flushed")]
-    #[test_case(&[5], &[20], &[], &[], Some((5, SlotStatus::Ancestor)); "ancestor wins over higher root")]
-    #[test_case(&[], &[20], &[10], &[], Some((20, SlotStatus::UnflushedRoot));"unflushed root over flushing root")]
-    #[test_case(&[5], &[20], &[10], &[], Some((5, SlotStatus::Ancestor));"ancestor over unflushed and flushing roots")]
+    #[test_case(&[10], &[], &[], &[], Some(10); "ancestor only")]
+    #[test_case(&[5, 10, 15], &[], &[], &[], Some(15); "highest ancestor returned")]
+    #[test_case(&[], &[10, 20], &[], &[], Some(20); "rooted, with no ancestors")]
+    #[test_case(&[], &[], &[10], &[], Some(10); "root being flushed")]
+    #[test_case(&[10], &[], &[10], &[], Some(10); "ancestor being flushed")]
+    #[test_case(&[5], &[20], &[], &[], Some(5); "ancestor wins over higher root")]
+    #[test_case(&[], &[20], &[10], &[], Some(20);"unflushed root over flushing root")]
+    #[test_case(&[5], &[20], &[10], &[], Some(5);"ancestor over unflushed and flushing roots")]
     // Root beyond ancestors.min_slot() is excluded; older root still found
-    #[test_case(&[], &[5, 11], &[], &[10], Some((5, SlotStatus::UnflushedRoot)); "unflushed root beyond min ancestor excluded")]
-    #[test_case(&[], &[], &[5, 11], &[10], Some((5, SlotStatus::RootBeingFlushed)); "flushing root beyond min ancestor excluded")]
+    #[test_case(&[], &[5, 11], &[], &[10], Some(5); "unflushed root beyond min ancestor excluded")]
+    #[test_case(&[], &[], &[5, 11], &[10], Some(5); "flushing root beyond min ancestor excluded")]
     // Root within min_slot bound is still returned
-    #[test_case(&[], &[10], &[], &[15], Some((10, SlotStatus::UnflushedRoot)); "unflushed root below min ancestor returned")]
+    #[test_case(&[], &[10], &[], &[15], Some(10); "unflushed root below min ancestor returned")]
     fn test_load_latest_slot_priority(
         ancestor_slots: &[Slot],
         unflushed_root_slots: &[Slot],
         flushing_root_slots: &[Slot],
         uncached_ancestors: &[Slot],
-        expected: Option<(Slot, SlotStatus)>,
+        expected: Option<Slot>,
     ) {
         let cache = AccountsCache::default();
         let pk = Pubkey::new_unique();
@@ -746,12 +714,10 @@ mod tests {
         let mut all_ancestors: Vec<Slot> = ancestor_slots.to_vec();
         all_ancestors.extend_from_slice(uncached_ancestors);
         let ancestors = Ancestors::from(all_ancestors);
-        let result = cache
-            .load_latest(&pk, &ancestors)
-            .map(|(account, slot, status)| {
-                assert_eq!(account.account.lamports(), slot);
-                (slot, status)
-            });
+        let result = cache.load_latest(&pk, &ancestors).map(|(account, slot)| {
+            assert_eq!(account.account.lamports(), slot);
+            slot
+        });
         assert_eq!(result, expected);
     }
 
@@ -860,30 +826,6 @@ mod tests {
         cache.add_root(3);
         let taken = cache.begin_flush_roots(None);
         assert_eq!(taken, BTreeSet::from([3]));
-        cache.end_flush_roots();
-    }
-
-    #[test]
-    fn test_load_latest_multiple_ancestors_one_being_flushed() {
-        let cache = AccountsCache::default();
-        let pk = Pubkey::new_unique();
-
-        // Store at slots 5 and 10, both will be ancestors
-        cache.store(5, &pk, AccountSharedData::new(5, 0, &Pubkey::default()));
-        cache.store(10, &pk, AccountSharedData::new(10, 0, &Pubkey::default()));
-
-        // Slot 10 is also a root that gets claimed for flushing
-        cache.add_root(10);
-        cache.begin_flush_roots(None);
-
-        let ancestors = Ancestors::from(vec![5, 10]);
-        let (account, slot, status) = cache.load_latest(&pk, &ancestors).unwrap();
-
-        // Slot 10 is highest ancestor but is being flushed, so should return AncestorBeingFlushed
-        assert_eq!(slot, 10);
-        assert_eq!(status, SlotStatus::AncestorBeingFlushed);
-        assert_eq!(account.account.lamports(), 10);
-
         cache.end_flush_roots();
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -36,7 +36,7 @@ use {
             stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         },
         account_storage_entry::AccountStorageEntry,
-        accounts_cache::{AccountsCache, CachedAccount, SlotCache, SlotStatus},
+        accounts_cache::{AccountsCache, CachedAccount, SlotCache},
         accounts_db::stats::{
             AccountsStats, CleanAccountsStats, FlushStats, LoadAccountsStats,
             ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
@@ -3471,7 +3471,7 @@ impl AccountsDb {
                 break;
             }
 
-            if let Some((cached_account, slot, _)) =
+            if let Some((cached_account, slot)) =
                 self.accounts_cache.load_latest(&pubkey, ancestors)
             {
                 cached_versions.insert(pubkey, (cached_account, slot));
@@ -4060,38 +4060,20 @@ impl AccountsDb {
     ) -> Option<(AccountSharedData, Slot)> {
         let starting_max_root = self.accounts_index.max_root_inclusive();
 
-        // First check the write cache
-        let cache_result = self.accounts_cache.load_latest(pubkey, ancestors);
-
-        if let Some((cached_account, cached_slot, slot_status)) = &cache_result {
-            // If the slot is an ancestor or an unflushed root, it hasn't been flushed to
-            // storage yet, so the write cache is authoritative — return it directly.
-            if matches!(
-                slot_status,
-                SlotStatus::Ancestor | SlotStatus::UnflushedRoot
-            ) {
-                self.load_account_stats
-                    .num_loaded_from_write_cache
-                    .fetch_add(1, Ordering::Relaxed);
-                return Some((cached_account.account.clone(), *cached_slot));
-            }
+        // Check the write cache first; a hit is the freshest version visible on this fork,
+        // so return it
+        if let Some((cached_account, cached_slot)) =
+            self.accounts_cache.load_latest(pubkey, ancestors)
+        {
+            self.load_account_stats
+                .num_loaded_from_write_cache
+                .fetch_add(1, Ordering::Relaxed);
+            return Some((cached_account.account.clone(), cached_slot));
         }
 
         let (slot, storage_location, _maybe_account_accessor) =
             self.read_index_for_accessor_or_load_slow(ancestors, pubkey, false)?;
         // Notice the subtle `?` at previous line, we bail out pretty early if missing.
-
-        if let Some((cached_account, cached_slot, _)) = &cache_result {
-            if *cached_slot >= slot {
-                // The write cache holds a version at a slot at least as new as what the
-                // index returned, so it represents the freshest visible value and can be
-                // returned directly without going through the storage accessor.
-                self.load_account_stats
-                    .num_loaded_from_write_cache
-                    .fetch_add(1, Ordering::Relaxed);
-                return Some((cached_account.account.clone(), *cached_slot));
-            }
-        }
 
         let in_write_cache = storage_location.is_cached();
         if !in_write_cache {
@@ -4115,17 +4097,12 @@ impl AccountsDb {
         // since the cache could be flushed in between the 2 calls.
         let in_write_cache = matches!(account_accessor, LoadedAccountAccessor::Cached(_));
         if in_write_cache {
-            // While the account wasn't loaded directly from the write cache, the write cache
-            // provided the correct slot, so count this as a load from the write cache
-            if cache_result.is_some_and(|(_, cached_slot, _)| cached_slot == slot) {
-                self.load_account_stats
-                    .num_loaded_from_write_cache
-                    .fetch_add(1, Ordering::Relaxed);
-            } else {
-                self.load_account_stats
-                    .num_loaded_from_index_cache
-                    .fetch_add(1, Ordering::Relaxed);
-            }
+            // `load_latest` missed above (otherwise we'd have returned early), but the account
+            // was written to the cache between then and the index lookup, so the index pointed
+            // us back at the cache.
+            self.load_account_stats
+                .num_loaded_from_index_cache
+                .fetch_add(1, Ordering::Relaxed);
         } else {
             self.load_account_stats
                 .num_loaded_from_index_storage
@@ -5912,29 +5889,12 @@ impl AccountsDb {
     /// Returns whether the latest version of pubkey from ancestors is zero-lamport
     /// Returns `None` if the account doesn't exist
     fn is_ancestor_zero_lamport(&self, pubkey: &Pubkey, ancestors: &Ancestors) -> Option<bool> {
-        if let Some((cached_account, cache_slot, status)) =
+        if let Some((cached_account, _cache_slot)) =
             self.accounts_cache.load_latest(pubkey, ancestors)
         {
-            let cache_is_zero_lamport = cached_account.account.lamports() == 0;
-            // When the slot isn't being flushed, the cache is definitely the newest
-            if matches!(status, SlotStatus::Ancestor | SlotStatus::UnflushedRoot) {
-                return Some(cache_is_zero_lamport);
-            }
-
-            // Slot is being flushed; a newer version may already exist in storage.
-            if let Some((index_slot, index_is_zero_lamport)) = self
-                .accounts_index
-                .get_with_and_then(pubkey, ancestors, true, |(slot, account)| {
-                    (slot, account.is_zero_lamport())
-                })
-            {
-                // Return the zero lamport status of the newest version between the cache and index
-                // If slots are the same it doesn't matter which is returned (They are identical)
-                if index_slot > cache_slot {
-                    return Some(index_is_zero_lamport);
-                }
-            }
-            Some(cache_is_zero_lamport)
+            // Check the write cache first; a hit is the freshest version visible on this fork,
+            // so return it
+            Some(cached_account.account.lamports() == 0)
         } else {
             self.accounts_index
                 .get_with_and_then(pubkey, ancestors, true, |(_, account)| {

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6833,42 +6833,27 @@ fn test_is_ancestor_zero_lamport_index_only() {
     assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
 }
 
-/// Verifies that when the cache entry is in a `*BeingFlushed` state, is_ancestor_zero_lamport
-/// also consults the index and returns the zero lamport status of whichever version sits on the
-/// higher slot, regardless of whether that version is in the cache or the index.
-#[test_case(10, 5, true; "newer_cache_wins")]
-#[test_case(5, 10, false; "newer_index_wins")]
-fn test_is_ancestor_zero_lamport_being_flushed_picks_higher_slot(
-    cache_slot: Slot,
-    index_slot: Slot,
-    expected: bool,
-) {
+/// Verifies that when a pubkey is in both storage and the write cache, is_ancestor_zero_lamport
+/// returns the cached version's zero lamport status.
+#[test]
+fn test_is_ancestor_zero_lamport_cache_over_storage() {
     let db = AccountsDb::new_single_for_tests();
     let pubkey = Pubkey::new_unique();
+    let storage_slot = 5;
+    let cache_slot = 10;
 
-    // Non-zero lamport entry in the index. Set up first: flushing goes through the cache,
-    // so doing it after the cache setup would conflict with `begin_flush_roots`.
-    let account = AccountSharedData::new(100, 0, &Pubkey::default());
-    db.store_for_tests((index_slot, [(&pubkey, &account)].as_slice()));
-    db.add_root_and_flush_write_cache(index_slot);
+    // Non-zero lamport entry in storage at the older slot.
+    let nonzero_account = AccountSharedData::new(100, 0, &Pubkey::default());
+    db.store_for_tests((storage_slot, [(&pubkey, &nonzero_account)].as_slice()));
+    db.add_root_and_flush_write_cache(storage_slot);
     assert!(!db.accounts_cache.contains_pubkey(&pubkey));
 
-    // Zero lamport entry in the cache. Note: this entry may be older than the slot that was
-    // flushed above which is normally not allowed to be added to the cache. However,
-    // this state is a valid intermediate state when flushing the cache so needs
-    // test coverage
-    let account = AccountSharedData::new(0, 0, &Pubkey::default());
-    db.accounts_cache.store(cache_slot, &pubkey, account);
-    db.accounts_cache.add_root(cache_slot);
-    db.accounts_cache.begin_flush_roots(Some(cache_slot));
+    // Zero lamport entry in the cache at the newer slot.
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
+    db.accounts_cache.store(cache_slot, &pubkey, zero_account);
 
-    let ancestors = Ancestors::from(vec![cache_slot, index_slot]);
-    assert_eq!(
-        db.is_ancestor_zero_lamport(&pubkey, &ancestors),
-        Some(expected)
-    );
-
-    db.accounts_cache.end_flush_roots();
+    let ancestors = Ancestors::from(vec![cache_slot, storage_slot]);
+    assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
 }
 
 /// loading an account through an older bank must not return


### PR DESCRIPTION
#### Problem
Slot Status checks are no longer needed as the write cache always contains the newest version.

#### Summary of Changes
- Remove them!

#### Testing


Fixes #
