### PR TITLE
transaction-status: fix parsed account labels for confidential transfer `Deposit` and `Withdraw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release channels have their own copy of this changelog:
 ## 4.2.0-Unreleased
 ### RPC
 #### Breaking
+* The `jsonParsed` output for confidential transfer `Deposit` (`depositConfidentialTransfer`) and `Withdraw` (`withdrawConfidentialTransfer`) instructions has been corrected. These instructions operate on a single token account, so the mislabeled `source` and `destination` fields have been replaced by a single `account` field (the `mint` field is unchanged).
 #### Changes
 * Added `RpcClient::get_latest_blockhash_with_commitment_and_context`, which returns the
   `getLatestBlockhash` response together with its context (notably `context.slot`).

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -167,16 +167,15 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             })
         }
         ConfidentialTransferInstruction::Deposit => {
-            check_num_token_accounts(account_indexes, 4)?;
+            check_num_token_accounts(account_indexes, 3)?;
             let deposit_data: DepositInstructionData = *decode_instruction_data(instruction_data)
                 .map_err(|_| {
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let amount: u64 = deposit_data.amount.into();
             let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "destination": account_keys[account_indexes[1] as usize].to_string(),
-                "mint": account_keys[account_indexes[2] as usize].to_string(),
+                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_keys[account_indexes[1] as usize].to_string(),
                 "amount": amount,
                 "decimals": deposit_data.decimals,
 
@@ -184,7 +183,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             let map = value.as_object_mut().unwrap();
             parse_signers(
                 map,
-                3,
+                2,
                 account_keys,
                 account_indexes,
                 "owner",
@@ -196,16 +195,15 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             })
         }
         ConfidentialTransferInstruction::Withdraw => {
-            check_num_token_accounts(account_indexes, 5)?;
+            check_num_token_accounts(account_indexes, 4)?;
             let withdrawal_data: WithdrawInstructionData =
                 *decode_instruction_data(instruction_data).map_err(|_| {
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let amount: u64 = withdrawal_data.amount.into();
             let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "destination": account_keys[account_indexes[1] as usize].to_string(),
-                "mint": account_keys[account_indexes[2] as usize].to_string(),
+                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_keys[account_indexes[1] as usize].to_string(),
                 "amount": amount,
                 "decimals": withdrawal_data.decimals,
                 "newDecryptableAvailableBalance": format!("{}", withdrawal_data.new_decryptable_available_balance),
@@ -213,7 +211,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 "rangeProofInstructionOffset": withdrawal_data.range_proof_instruction_offset,
 
             });
-            let mut offset = 3;
+            let mut offset = 2;
             let map = value.as_object_mut().unwrap();
             if offset < account_indexes.len() - 1
                 && (withdrawal_data.equality_proof_instruction_offset != 0
@@ -714,6 +712,85 @@ mod test {
             .unwrap();
             check_no_panic(instruction);
         }
+    }
+
+    #[test]
+    fn test_deposit() {
+        let token_account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let instruction = deposit(
+            &spl_token_2022_interface::id(),
+            &token_account,
+            &mint,
+            42,
+            9,
+            &owner,
+            &[],
+        )
+        .unwrap();
+        let message = Message::new(&[instruction], None);
+        let compiled_instruction = &message.instructions[0];
+        assert_eq!(
+            parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None)
+            )
+            .unwrap(),
+            ParsedInstructionEnum {
+                instruction_type: "depositConfidentialTransfer".to_string(),
+                info: json!({
+                    "account": token_account.to_string(),
+                    "mint": mint.to_string(),
+                    "amount": 42,
+                    "decimals": 9,
+                    "owner": owner.to_string(),
+                }),
+            }
+        );
+    }
+
+    #[test]
+    fn test_withdraw_account_mapping() {
+        let token_account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let equality_context = Pubkey::new_unique();
+        let range_context = Pubkey::new_unique();
+        let instruction = inner_withdraw(
+            &spl_token_2022_interface::id(),
+            &token_account,
+            &mint,
+            1,
+            2,
+            &PodAeCiphertext::default(),
+            &owner,
+            &[],
+            ProofLocation::ContextStateAccount(&equality_context),
+            ProofLocation::ContextStateAccount(&range_context),
+        )
+        .unwrap();
+        let message = Message::new(&[instruction], None);
+        let compiled_instruction = &message.instructions[0];
+        let parsed = parse_token(
+            compiled_instruction,
+            &AccountKeys::new(&message.account_keys, None),
+        )
+        .unwrap();
+        assert_eq!(parsed.instruction_type, "withdrawConfidentialTransfer");
+        assert_eq!(parsed.info["account"], json!(token_account.to_string()));
+        assert_eq!(parsed.info["mint"], json!(mint.to_string()));
+        assert_eq!(parsed.info["owner"], json!(owner.to_string()));
+        assert_eq!(
+            parsed.info["equalityProofContextStateAccount"],
+            json!(equality_context.to_string())
+        );
+        assert_eq!(
+            parsed.info["rangeProofContextStateAccount"],
+            json!(range_context.to_string())
+        );
+        assert!(parsed.info.get("destination").is_none());
+        assert_ne!(parsed.info["mint"], parsed.info["owner"]);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

The `jsonParsed` parsers for the confidential transfer `Deposit` and `Withdraw` instructions label the accounts as `[0] = source`, `[1] = destination`, `[2] = mint`. Neither instruction has a destination account: both move funds between the public and confidential balances of a **single** token account. The actual account layout is:

```
Deposit:  0. token account  1. mint  2.. owner / multisig signers
Withdraw: 0. token account  1. mint  2.. (optional sysvar / proof accounts), owner / multisig signers
```

Because of the shifted mapping:
- the `mint` field returns the **owner's** pubkey
- the actual mint appears under a `destination` field that doesn't exist for these instructions
- a single-owner `Deposit` (3 accounts) fails the minimum-accounts check and isn't parsed at all

Example on devnet, tx `3qZ7EHKL7uvdf7rMe9RaVmL9e5tEo9RCQ93At8g1Us91YdVukaXHVeCiYgbn4QYXx2uU7XeYW167Eegcz2nYQMyg` (instruction 0):

```json
{
  "type": "depositConfidentialTransfer",
  "info": {
    "source": "A1U5jky...",        // token account
    "destination": "FP6dveH...",   // actually the mint
    "mint": "9WsRo54...",          // actually the owner
    "owner": "9WsRo54...",
    ...
  }
}
```

`Transfer` and `TransferWithFee` are unaffected; they genuinely have source, mint, and destination accounts, which is likely where this mapping was copied from.

#### Summary of Changes

- Label the accounts `account = [0]` and `mint = [1]`, and drop the `destination` field for both instructions. This matches the field naming of the other single-account arms in this file (`ConfigureAccount`, `EmptyAccount`, `ApplyPendingBalance`).
- Start the `Withdraw` optional sysvar/proof-account scan (and signer parsing) at index 2 instead of 3.
- Lower the minimum account counts to the smallest legal forms: `Deposit` 4 → 3, `Withdraw` 5 → 4.

Note this changes the emitted field names for these two instruction types. The previous output was incorrect (wrong pubkey under `mint`, real mint under a nonexistent `destination`), so consumers relying on the old fields were already reading wrong data.

#### Testing

- Added `test_deposit`, which asserts the full parsed output for a single-owner deposit — the 3-account case that previously failed to parse.
- Added `test_withdraw_account_mapping`, which asserts `account`, `mint`, `owner`, and the proof context-state account labels, and that no `destination` field is emitted.

The pre-existing tests for these instructions only checked that parsing doesn't panic, not which account landed in which field, which is how the mislabeling went unnoticed.

Fixes #13148