### PR TITLE
ledger-tool: Insert child bank shreds in create-snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -47,12 +47,14 @@ use {
     solana_feature_gate_interface::{self as feature, Feature},
     solana_inflation::Inflation,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
+    solana_keypair::keypair_from_seed,
     solana_ledger::{
-        blockstore::{Blockstore, banking_trace_path, create_new_ledger},
-        blockstore_options::{AccessType, LedgerColumnOptions},
+        blockstore::{Blockstore, PurgeType, banking_trace_path, create_new_ledger},
+        blockstore_options::{AccessType, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, LedgerColumnOptions},
         blockstore_processor::{
             ProcessSlotCallback, TransactionStatusMessage, TransactionStatusSender,
         },
+        shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_measure::{measure::Measure, measure_time},
     solana_message::SimpleAddressLoader,
@@ -84,6 +86,7 @@ use {
         vote_state::{self, BLS_PUBLIC_KEY_COMPRESSED_SIZE, VoteStateV4},
     },
     std::{
+        borrow::Cow,
         collections::{HashMap, HashSet},
         ffi::{OsStr, OsString},
         fs::{File, read_dir},
@@ -2433,6 +2436,8 @@ fn main() {
                         }
                     }
 
+                    let new_shred_verison =
+                        compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()));
                     if child_bank_required {
                         let num_ticks_per_slot = bank.ticks_per_slot();
                         let num_hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
@@ -2444,6 +2449,83 @@ fn main() {
                         tick_entries.iter().for_each(|tick_entry| {
                             bank.register_tick(&tick_entry.hash, &scheduler);
                         });
+
+                        // Calculate and set the block ID so we can read it to
+                        // properly chain shreds for the child bank
+                        Bank::calculate_and_set_block_id_for_dcou(&bank);
+
+                        // Next steps will need write access to the Blockstore
+                        let rw_blockstore = open_blockstore(
+                            &ledger_path,
+                            arg_matches,
+                            AccessType::PrimaryForMaintenance,
+                        );
+
+                        // If slot exists, back it up in another Blockstore
+                        // just in case and purge from the Blockstore
+                        let slot = bank.slot();
+                        if blockstore.has_existing_shreds_for_slot(slot) {
+                            let backup_directory = format!(
+                                "{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL}_backup_{new_shred_verison}_{slot}"
+                            );
+                            let backup_ledger_path = ledger_path.join(backup_directory);
+                            info!(
+                                "Purging slot {slot} from Blockstore and backing up at {}",
+                                backup_ledger_path.display(),
+                            );
+                            let backup_blockstore = Arc::new(open_blockstore(
+                                &backup_ledger_path,
+                                arg_matches,
+                                AccessType::PrimaryForMaintenance,
+                            ));
+
+                            let shreds = blockstore
+                                .get_data_shreds_for_slot(slot, 0)
+                                .expect("todo: update me since can't use ?")
+                                .into_iter()
+                                .map(Cow::Owned);
+                            let _ = backup_blockstore
+                                .insert_cow_shreds(shreds, None, true)
+                                .expect("todo: update me since can't use ?");
+
+                            // Purge modifies state so use rw_blockstore
+                            rw_blockstore.purge_from_next_slots(slot, slot);
+                            rw_blockstore
+                                .purge_slots(slot, slot, PurgeType::Exact)
+                                .expect("todo: update me since can't use ?");
+                        }
+
+                        // Use a "dummy" but deterministic keyapir to sign
+                        let keypair =
+                            keypair_from_seed(&[0; 64]).expect("todo: update me since can't use ?");
+                        let chained_merkle_root = bank
+                            .block_id()
+                            .expect("Block ID should have been set already");
+
+                        let shredder = Shredder::new(
+                            slot,
+                            bank.parent_slot(),
+                            /*reference_tick:*/ 0,
+                            new_shred_verison,
+                        )
+                        .expect("todo: update me since can't use ?");
+                        let shreds: Vec<_> = shredder
+                            .make_merkle_shreds_from_entries(
+                                &keypair,
+                                &tick_entries,
+                                /*is_last_in_slot:*/ true,
+                                chained_merkle_root,
+                                /*next_shred_index:*/ 0,
+                                /*next_code_index:*/ 0,
+                                &ReedSolomonCache::default(),
+                                &mut ProcessShredsStats::default(),
+                            )
+                            .filter(Shred::is_data)
+                            .map(Cow::Owned)
+                            .collect();
+                        rw_blockstore
+                            .insert_cow_shreds(shreds, None, true)
+                            .expect("todo: update me since can't use ?");
                     }
 
                     let pre_capitalization = bank.capitalization();
@@ -2602,10 +2684,7 @@ fn main() {
                     if let Some(msg) = capitalization_message {
                         println!("{msg}");
                     }
-                    println!(
-                        "Shred version: {}",
-                        compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()))
-                    );
+                    println!("Shred version: {new_shred_verison}",);
 
                     if let Some(system_monitor_service) = system_monitor_service {
                         exit_signal.store(true, Ordering::Relaxed);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -47,12 +47,14 @@ use {
     solana_feature_gate_interface::{self as feature, Feature},
     solana_inflation::Inflation,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
+    solana_keypair::{Keypair, keypair_from_seed},
     solana_ledger::{
-        blockstore::{Blockstore, banking_trace_path, create_new_ledger},
-        blockstore_options::{AccessType, LedgerColumnOptions},
+        blockstore::{Blockstore, PurgeType, banking_trace_path, create_new_ledger},
+        blockstore_options::{AccessType, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, LedgerColumnOptions},
         blockstore_processor::{
             ProcessSlotCallback, TransactionStatusMessage, TransactionStatusSender,
         },
+        shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
     },
     solana_measure::{measure::Measure, measure_time},
     solana_message::SimpleAddressLoader,
@@ -84,6 +86,7 @@ use {
         vote_state::{self, BLS_PUBLIC_KEY_COMPRESSED_SIZE, VoteStateV4},
     },
     std::{
+        borrow::Cow,
         collections::{HashMap, HashSet},
         ffi::{OsStr, OsString},
         fs::{File, read_dir},
@@ -2387,6 +2390,8 @@ fn main() {
                         }
                     }
 
+                    let new_shred_verison =
+                        compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()));
                     if child_bank_required {
                         let num_ticks_per_slot = bank.ticks_per_slot();
                         let num_hashes_per_tick = bank.hashes_per_tick().unwrap_or(0);
@@ -2398,6 +2403,88 @@ fn main() {
                         tick_entries.iter().for_each(|tick_entry| {
                             bank.register_tick(&tick_entry.hash, &scheduler);
                         });
+
+                        // Calculate and set the block ID so we can read it to
+                        // properly chain shreds for the child bank
+                        Bank::calculate_and_set_block_id_for_dcou(&bank);
+
+                        // Next steps will need write access to the Blockstore
+                        // so ensure we have R/W access
+                        let rw_blockstore = if blockstore.is_primary_access() {
+                            blockstore.clone()
+                        } else {
+                            Arc::new(open_blockstore(
+                                &ledger_path,
+                                arg_matches,
+                                AccessType::PrimaryForMaintenance,
+                            ))
+                        };
+
+                        // If slot exists, back it up in another Blockstore
+                        // just in case and purge from the Blockstore
+                        let slot = bank.slot();
+                        if blockstore.has_existing_shreds_for_slot(slot) {
+                            let shreds = blockstore
+                                .get_data_shreds_for_slot(slot, 0)
+                                .expect("Blockstore operation must succeed");
+
+                            let old_shred_version =
+                                shreds.first().expect("Slot must have a shred").version();
+                            let backup_directory = format!(
+                                "{BLOCKSTORE_DIRECTORY_ROCKS_LEVEL}_backup_{old_shred_version}_{slot}"
+                            );
+                            let backup_ledger_path = ledger_path.join(backup_directory);
+                            info!("Backing up {slot} at {}", backup_ledger_path.display(),);
+                            let backup_blockstore = Arc::new(open_blockstore(
+                                &backup_ledger_path,
+                                arg_matches,
+                                AccessType::PrimaryForMaintenance,
+                            ));
+                            let _ = backup_blockstore
+                                .insert_cow_shreds(shreds.into_iter().map(Cow::Owned), true)
+                                .expect("Blockstore operation must succeed");
+
+                            // Purge modifies state so use rw_blockstore
+                            info!("Purging slot {slot} from Blockstore");
+                            rw_blockstore.purge_from_next_slots(slot, slot);
+                            rw_blockstore
+                                .purge_slots(slot, slot, PurgeType::Exact)
+                                .expect("Blockstore operation must succeed");
+                        }
+
+                        // Use a "dummy" but deterministic keyapir to sign
+                        let keypair = keypair_from_seed(&[0; Keypair::SECRET_KEY_LENGTH])
+                            .expect("Keypair creation must succeed");
+                        let chained_merkle_root = bank
+                            .parent()
+                            .expect("Child bank must have parent bank available")
+                            .block_id()
+                            .expect("Parent bank must have block ID set");
+
+                        let shredder = Shredder::new(
+                            slot,
+                            bank.parent_slot(),
+                            /*reference_tick:*/ 0,
+                            new_shred_verison,
+                        )
+                        .expect("Shredder creation must succeed");
+                        let shreds: Vec<_> = shredder
+                            .make_merkle_shreds_from_entries(
+                                &keypair,
+                                &tick_entries,
+                                /*is_last_in_slot:*/ true,
+                                chained_merkle_root,
+                                /*next_shred_index:*/ 0,
+                                /*next_code_index:*/ 0,
+                                &ReedSolomonCache::default(),
+                                &mut ProcessShredsStats::default(),
+                            )
+                            .filter(Shred::is_data)
+                            .map(Cow::Owned)
+                            .collect();
+                        rw_blockstore
+                            .insert_cow_shreds(shreds, true)
+                            .expect("Blockstore operation must succeed");
                     }
 
                     let pre_capitalization = bank.capitalization();
@@ -2556,10 +2643,7 @@ fn main() {
                     if let Some(msg) = capitalization_message {
                         println!("{msg}");
                     }
-                    println!(
-                        "Shred version: {}",
-                        compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()))
-                    );
+                    println!("Shred version: {new_shred_verison}",);
 
                     if let Some(system_monitor_service) = system_monitor_service {
                         exit_signal.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/issues/7287 for more thorough writeup but shorter summary is ...

The create-snapshot command has several CLI arguments that modify account state. If any of these arguments are used, an extra bank is created to make the state modifications in.

This extra bank registers valid ticks to adhere to PoH rules; however, those ticks are not shredded and persisted to the Blockstore. Given that the snapshot is created at the extra bank slot, the lack of shreds creates a gap in block history.

#### Summary of Changes
This change backups any shreds from the extra bank slot and inserts the shredded ticks to make that slot available.

#### Testing
Manual Test Take 1:
```
// Generate a test ledger w/ AG features disabled
$ ./validator/solana-test-validator --deactivate-feature a2penGLz8Vm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP FLHoAWBDjNh6zwmJ5i1NKK4KyD8otAiv7XxvmnFnVnKH

// Switch to ledger-tool directory
$ mv ./validator/test-ledger ./ledger-tool/ledger
$ cargo run --bounds --ledger
...
Ledger has data for 153 slots 0 to 152
  with 121 rooted slots from 0 to 120
  and 32 slots past the last root

// Deactivate a feature like we'd do for testnet restart w/o --enable-capitalization-change
$ cargo run -- create-snapshot 135 --ledger ./ledger--deactivate-feature-gate iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW --incremental 
...
[2026-07-01T02:27:18.712621000Z WARN  agave_ledger_tool] Capitalization change: -953520 lamports
Capitalization change: -953520 lamports
But `--enable-capitalization-change flag not provided

// Inspect backup Blockstore - slot there
$ cargo run -- blockstore slot 136 -v --ledger ./ledger/rocksdb_backup_9019_136
...
Slot 136
  SlotMetaV3 { slot: 136, consumed: 256, received: 256, first_shred_timestamp: 1782873563208, last_index: Some(255), parent_slot: Some(135), next_slots: [], connected_flags: ConnectedFlags(0x0), completed_data_indexes: [31, 63, 95, 127, 159, 191, 223, 255], parent_block_id: 11111111111111111111111111111111, replay_fec_set_index: 0 } is_full: true
  Transactions: 1, hashes: 65, block_hash: 2CpoD5cYDsGf9BDeE5b9Asc1jUEvKuKfnxoqT6GWmZti

// Inspect original Blockstore - all ticks
$ cargo run -- blockstore slot 136 -v --ledger ./ledger/
...
Slot 136
  SlotMetaV3 { slot: 136, consumed: 32, received: 32, first_shred_timestamp: 1782873563260, last_index: Some(31), parent_slot: Some(135), next_slots: [], connected_flags: ConnectedFlags(CONNECTED | PARENT_CONNECTED), completed_data_indexes: [31], parent_block_id: 11111111111111111111111111111111, replay_fec_set_index: 0 } is_full: true
  Transactions: 0, hashes: 0, block_hash: 9hvBqaeVm1NJqyUzwh5WASwQ3ncvC6eJb4JtwSS14Bwv
  
// Rerun create-snapshot with --enable-capitalization-change 
$ cargo run -- create-snapshot 135 --ledger ./ledger --deactivate-feature-gate iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW --incremental --enable-capitalization-change
...
Successfully created incremental snapshot for slot 136, hash EQqCtThdbrky8APXVCNUgH6LQgcJpCbPvzLBU2fxMmBC, base slot: 100: /Users/steviez/src/solana/ledger-tool/ledger/incremental-snapshot-100-136-FKqv4NpFJjEDzuXDbvoGFjkPmkN7pB9r6mZ15cdBTrXp.tar.zst
Capitalization change: -953520 lamports
Shred version: 9019
$ ls ledger | grep incremental
incremental-snapshot-100-136-FKqv4NpFJjEDzuXDbvoGFjkPmkN7pB9r6mZ15cdBTrXp.tar.zst
```
Manual Test Take 2:
- I noticed that I was using `new_shred_version` for the backup instead of `old_shred_version`
- I realized that I forgot to pass `--hard-fork` from command above:
```
$ rm ledger/incremental-snapshot-100-136-FKqv4NpFJjEDzuXDbvoGFjkPmkN7pB9r6mZ15cdBTrXp.tar.zst
$ cargo run -- create-snapshot 135 --ledger ./ledger --deactivate-feature-gate iBRLjhJnkmDZgNoZRDMW11d8ZV7HvsL3vAyRjZB5npW --incremental --enable-capitalization-change --hard-fork 136
...
[2026-07-01T03:20:38.581707000Z INFO  agave_ledger_tool] Backing up 136 at /Users/steviez/src/solana/ledger-tool/ledger/rocksdb_backup_9019_136
...
Successfully created incremental snapshot for slot 136, hash RgozXqJPuVrQgY1q1jh8oM5SnU3PTHj9ScBRAxW5ZyP, base slot: 100: /Users/steviez/src/solana/ledger-tool/ledger/incremental-snapshot-100-136-FpQweBTPovqQUMLg8iqQjP3MnodBmFKxkoDa3qDZUEoP.tar.zst
Capitalization change: -953520 lamports
Shred version: 20252
...
```


Fixes #7287 
