### PR TITLE
refactor: separate sanitization consts from transaction-view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "slotmap",
  "solana-fee",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-transaction",
  "solana-transaction-error",
  "tempfile",
@@ -322,7 +323,6 @@ dependencies = [
  "solana-keypair",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
@@ -331,7 +331,6 @@ dependencies = [
  "solana-svm-transaction",
  "solana-system-interface 3.2.0",
  "solana-transaction",
- "solana-transaction-context",
  "wincode",
 ]
 
@@ -9187,6 +9186,7 @@ dependencies = [
  "solana-packet 4.1.0",
  "solana-perf",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -203,7 +203,8 @@ pub(crate) mod external {
         },
         agave_transaction_view::{
             resolved_transaction_view::ResolvedTransactionView, result::TransactionViewError,
-            transaction_data::TransactionData, transaction_view::SanitizedTransactionView,
+            sanitize::SanitizeConfig, transaction_data::TransactionData,
+            transaction_view::SanitizedTransactionView,
         },
         solana_account::ReadableAccount,
         solana_clock::Slot,
@@ -214,7 +215,9 @@ pub(crate) mod external {
             bank::Bank,
             bank_forks::{BankPair, SharableBanks},
         },
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        },
         solana_transaction::TransactionError,
         std::ptr::NonNull,
     };
@@ -779,16 +782,13 @@ pub(crate) mod external {
             Vec<TxView>,
             &'a mut [CheckResponse],
         ) {
-            let enable_instruction_accounts_limit =
-                bank.feature_set.snapshot().limit_instruction_accounts;
+            let sanitize_config =
+                sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
             let mut parsing_results = Vec::with_capacity(MAX_TRANSACTIONS_PER_MESSAGE);
             let mut parsed_transactions = Vec::with_capacity(MAX_TRANSACTIONS_PER_MESSAGE);
             for (tx_ptr, _) in batch.iter() {
                 // Parsing and basic sanitization checks
-                match SanitizedTransactionView::try_new_sanitized(
-                    tx_ptr,
-                    enable_instruction_accounts_limit,
-                ) {
+                match SanitizedTransactionView::try_new_sanitized(tx_ptr, &sanitize_config) {
                     Ok(view) => {
                         parsing_results.push(Ok(()));
                         parsed_transactions.push(view);
@@ -971,8 +971,8 @@ pub(crate) mod external {
             batch: &TransactionPtrBatch,
             bank: &Bank,
         ) -> (Vec<Result<(), PacketHandlingError>>, Vec<Tx>, Vec<MaxAge>) {
-            let enable_instruction_accounts_limit =
-                bank.feature_set.snapshot().limit_instruction_accounts;
+            let sanitize_config =
+                sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
             let transaction_account_lock_limit = bank.get_transaction_account_lock_limit();
 
             let mut translation_results = Vec::with_capacity(MAX_TRANSACTIONS_PER_MESSAGE);
@@ -983,7 +983,7 @@ pub(crate) mod external {
                     transaction_ptr,
                     bank,
                     transaction_account_lock_limit,
-                    enable_instruction_accounts_limit,
+                    &sanitize_config,
                 ) {
                     Ok((tx, max_age)) => {
                         transactions.push(tx);
@@ -1001,13 +1001,13 @@ pub(crate) mod external {
             transaction_ptr: TransactionPtr,
             bank: &Bank,
             transaction_account_lock_limit: usize,
-            enable_instruction_accounts_limit: bool,
+            sanitize_config: &SanitizeConfig,
         ) -> Result<(Tx, MaxAge), PacketHandlingError> {
             translate_to_runtime_view(
                 transaction_ptr,
                 bank,
                 transaction_account_lock_limit,
-                enable_instruction_accounts_limit,
+                sanitize_config,
             )
             .map(|(view, deactivation_slot)| {
                 (
@@ -1441,7 +1441,7 @@ pub(crate) mod external {
                         &simple_tx[..],
                         &bank,
                         bank.get_transaction_account_lock_limit(),
-                        true,
+                        &sanitize_config(true),
                     )
                     .ok()
                     .unwrap()
@@ -1629,8 +1629,10 @@ pub(crate) mod external {
 
             let parsing_results = [Ok(()), Err(TransactionViewError::ParseError), Ok(())];
             let parsed_transactions = [
-                SanitizedTransactionView::try_new_sanitized(&tx1[..], true).unwrap(),
-                SanitizedTransactionView::try_new_sanitized(&tx2[..], true).unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx1[..], &sanitize_config(true))
+                    .unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx2[..], &sanitize_config(true))
+                    .unwrap(),
             ];
             bank.store_account(
                 &parsed_transactions[1].static_account_keys()[0],
@@ -1680,7 +1682,8 @@ pub(crate) mod external {
             ) -> RuntimeTransaction<ResolvedTransactionView<&'_ [u8]>> {
                 RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
                     RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
-                        SanitizedTransactionView::try_new_sanitized(tx, true).unwrap(),
+                        SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true))
+                            .unwrap(),
                         solana_transaction::sanitized::MessageHash::Compute,
                         Some(false),
                     )

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -108,7 +108,7 @@ impl LatestValidatorVote {
 
         let vote = SanitizedTransactionView::try_new_sanitized(
             std::sync::Arc::new(packet.data(..).unwrap().to_vec()),
-            true,
+            &solana_runtime_transaction::sanitize_config::sanitize_config(true),
         )
         .unwrap();
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -15,8 +15,9 @@ use {
     },
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     agave_transaction_view::{
-        resolved_transaction_view::ResolvedTransactionView, transaction_data::TransactionData,
-        transaction_version::TransactionVersion, transaction_view::SanitizedTransactionView,
+        resolved_transaction_view::ResolvedTransactionView, sanitize::SanitizeConfig,
+        transaction_data::TransactionData, transaction_version::TransactionVersion,
+        transaction_view::SanitizedTransactionView,
     },
     arrayvec::ArrayVec,
     core::time::Duration,
@@ -31,8 +32,8 @@ use {
         bank_forks::{BankPair, SharableBanks},
     },
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
-        transaction_with_meta::TransactionWithMeta,
+        runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        transaction_meta::TransactionMeta, transaction_with_meta::TransactionWithMeta,
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
@@ -244,8 +245,8 @@ impl TransactionViewReceiveAndBuffer {
         // If outside holding window, do not parse.
         let should_parse = !matches!(decision, BufferedPacketsDecision::Forward);
 
-        let enable_instruction_accounts_limit =
-            root_bank.feature_set.snapshot().limit_instruction_accounts;
+        let sanitize_config =
+            sanitize_config(root_bank.feature_set.snapshot().limit_instruction_accounts);
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
 
         // Create temporary batches of transactions to be age-checked.
@@ -349,7 +350,7 @@ impl TransactionViewReceiveAndBuffer {
                             root_bank,
                             working_bank,
                             transaction_account_lock_limit,
-                            enable_instruction_accounts_limit,
+                            &sanitize_config,
                             &self.filter_keys,
                         ) {
                             Ok(state) => Ok(state),
@@ -415,14 +416,14 @@ impl TransactionViewReceiveAndBuffer {
         root_bank: &Bank,
         working_bank: &Bank,
         transaction_account_lock_limit: usize,
-        enable_instruction_accounts_limit: bool,
+        sanitize_config: &SanitizeConfig,
         filter_keys: &HashSet<Pubkey>,
     ) -> Result<TransactionViewState, PacketHandlingError> {
         let (view, deactivation_slot) = translate_to_runtime_view(
             bytes,
             root_bank,
             transaction_account_lock_limit,
-            enable_instruction_accounts_limit,
+            sanitize_config,
         )?;
 
         if !filter_keys.is_empty()
@@ -455,12 +456,10 @@ pub(crate) fn translate_to_runtime_view<D: TransactionData>(
     data: D,
     bank: &Bank,
     transaction_account_lock_limit: usize,
-    enable_instruction_accounts_limit: bool,
+    sanitize_config: &SanitizeConfig,
 ) -> Result<(RuntimeTransaction<ResolvedTransactionView<D>>, u64), PacketHandlingError> {
     // Parsing and basic sanitization checks
-    let Ok(view) =
-        SanitizedTransactionView::try_new_sanitized(data, enable_instruction_accounts_limit)
-    else {
+    let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, sanitize_config) else {
         return Err(PacketHandlingError::Sanitization);
     };
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -396,7 +396,9 @@ mod tests {
         solana_keypair::Keypair,
         solana_message::Message,
         solana_perf::packet::Packet,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        },
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::{
@@ -484,7 +486,8 @@ mod tests {
 
         let reserved_addresses = HashSet::default();
         let packet_parser = |data, priority, cost| {
-            let view = SanitizedTransactionView::try_new_sanitized(data, true).unwrap();
+            let view =
+                SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true)).unwrap();
             let view = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 view,
                 MessageHash::Compute,

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -11,6 +11,7 @@ use {
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
     solana_pubkey::Pubkey,
+    solana_runtime_transaction::sanitize_config::sanitize_config,
     std::{
         collections::HashSet,
         num::Saturating,
@@ -115,8 +116,9 @@ impl VotePacketReceiver {
                 match SanitizedTransactionView::try_new_sanitized(
                     Arc::new(pkt.data(..)?.to_vec()),
                     // Vote instructions are created in the validator code, and they are not
-                    // referencing more than 255 accounts, so it is safe to set this to true.
-                    true,
+                    // referencing more than 255 accounts, so it is safe to enforce the
+                    // instruction accounts limit unconditionally.
+                    &sanitize_config(true),
                 ) {
                     Ok(pkt) => {
                         if self.should_filter_packet(&pkt) {

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -391,6 +391,7 @@ pub(crate) mod tests {
         solana_leader_schedule::SlotLeader,
         solana_perf::packet::{BytesPacket, PacketFlags},
         solana_runtime::genesis_utils::{self, ValidatorVoteKeypairs},
+        solana_runtime_transaction::sanitize_config::sanitize_config,
         solana_signer::Signer,
         solana_vote::vote_transaction::new_tower_sync_transaction,
         solana_vote_program::vote_state::TowerSync,
@@ -519,8 +520,11 @@ pub(crate) mod tests {
     }
 
     fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
-        SanitizedTransactionView::try_new_sanitized(Arc::new(packet.buffer().to_vec()), true)
-            .unwrap()
+        SanitizedTransactionView::try_new_sanitized(
+            Arc::new(packet.buffer().to_vec()),
+            &sanitize_config(true),
+        )
+        .unwrap()
     }
 
     #[test]

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -20,7 +20,8 @@ use {
         bank_forks::SharableBanks,
     },
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
+        runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        transaction_meta::TransactionMeta,
     },
     solana_streamer::sendmmsg::{SendPktsError, batch_send},
     solana_tls_utils::NotifyKeyUpdate,
@@ -265,8 +266,8 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
         is_tpu_vote_batch: bool,
         bank: &Bank,
     ) {
-        let enable_instruction_accounts_limit =
-            bank.feature_set.snapshot().limit_instruction_accounts;
+        let sanitize_config =
+            sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
         for batch in packet_batches.iter() {
             for packet in batch
                 .iter()
@@ -287,21 +288,20 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
 
                 // Perform basic sanitization checks and calculate priority.
                 // If any steps fail, drop the packet.
-                let Some(priority) = SanitizedTransactionView::try_new_sanitized(
-                    packet_data,
-                    enable_instruction_accounts_limit,
-                )
-                .map_err(|_| ())
-                .and_then(|transaction| {
-                    RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
-                        transaction,
-                        MessageHash::Compute,
-                        Some(packet.meta().is_simple_vote_tx()),
-                    )
-                    .map_err(|_| ())
-                })
-                .ok()
-                .and_then(|transaction| calculate_priority(&transaction, bank)) else {
+                let Some(priority) =
+                    SanitizedTransactionView::try_new_sanitized(packet_data, &sanitize_config)
+                        .map_err(|_| ())
+                        .and_then(|transaction| {
+                            RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+                                transaction,
+                                MessageHash::Compute,
+                                Some(packet.meta().is_simple_vote_tx()),
+                            )
+                            .map_err(|_| ())
+                        })
+                        .ok()
+                        .and_then(|transaction| calculate_priority(&transaction, bank))
+                else {
                     self.metrics.votes_dropped_on_receive += vote_count;
                     self.metrics.non_votes_dropped_on_receive += non_vote_count;
                     continue;

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -5,6 +5,7 @@ use {
     solana_runtime::bank::{Bank, CollectorFeeDetails},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction,
+        sanitize_config::sanitize_config,
         transaction_meta::{TransactionConfiguration, TransactionMeta},
     },
     solana_svm_transaction::svm_message::SVMStaticMessage,
@@ -65,9 +66,8 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
 /// Returns `None` if the bytes don't parse as a valid transaction, in which
 /// case the caller should leave the packet to downstream stages to reject.
 pub(crate) fn calculate_priority_from_bytes(bank: &Bank, data: &[u8]) -> Option<u64> {
-    let enable_instruction_accounts_limit = bank.feature_set.snapshot().limit_instruction_accounts;
-    let view = SanitizedTransactionView::try_new_sanitized(data, enable_instruction_accounts_limit)
-        .ok()?;
+    let config = sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
+    let view = SanitizedTransactionView::try_new_sanitized(data, &config).ok()?;
     let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
         view,
         MessageHash::Compute,
@@ -172,7 +172,7 @@ mod tests {
 
         let view = SanitizedTransactionView::try_new_sanitized(
             &bytes[..],
-            bank.feature_set.snapshot().limit_instruction_accounts,
+            &sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts),
         )
         .unwrap();
         let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "slotmap",
  "solana-fee",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
 ]
@@ -332,14 +333,12 @@ dependencies = [
  "solana-hash 4.4.0",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
  "solana-transaction",
- "solana-transaction-context",
 ]
 
 [[package]]
@@ -7781,6 +7780,7 @@ dependencies = [
  "solana-metrics",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -60,6 +60,7 @@ solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode"] }
 solana-pubkey = { workspace = true, default-features = false }
+solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true, features = ["verify"] }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -8,6 +8,7 @@ use {
         transaction_view::SanitizedTransactionView,
     },
     rayon::prelude::*,
+    solana_runtime_transaction::sanitize_config::sanitize_config,
 };
 
 // Empirically derived to constrain max verify latency to ~8ms at lower packet counts
@@ -27,7 +28,8 @@ fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool, enable_tx_v1:
     };
 
     let (is_simple_vote_tx, verified) = {
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, true) else {
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true))
+        else {
             return false;
         };
 
@@ -604,7 +606,7 @@ mod tests {
             let packet = BytesPacket::from_data(None, tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                true,
+                &sanitize_config(true),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -617,7 +619,7 @@ mod tests {
             let packet = BytesPacket::from_data(None, tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                true,
+                &sanitize_config(true),
             )
             .unwrap();
             assert!(is_simple_vote_transaction_view(&view));
@@ -630,7 +632,7 @@ mod tests {
 
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                true,
+                &sanitize_config(true),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -655,7 +657,7 @@ mod tests {
             let packet = BytesPacket::from_data(None, tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                true,
+                &sanitize_config(true),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -670,7 +672,7 @@ mod tests {
             let packet = BytesPacket::from_data(None, tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                true,
+                &sanitize_config(true),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "slotmap",
  "solana-fee",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-transaction-error",
  "thiserror 2.0.18",
 ]
@@ -239,14 +240,12 @@ dependencies = [
  "solana-hash 4.4.0",
  "solana-message",
  "solana-packet 4.1.0",
- "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
  "solana-svm-transaction",
  "solana-transaction",
- "solana-transaction-context",
 ]
 
 [[package]]
@@ -7558,6 +7557,7 @@ dependencies = [
  "solana-metrics",
  "solana-packet 4.1.0",
  "solana-pubkey 4.2.0",
+ "solana-runtime-transaction",
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",

--- a/runtime-transaction/src/lib.rs
+++ b/runtime-transaction/src/lib.rs
@@ -4,6 +4,7 @@
 mod instruction_data_len;
 pub(crate) mod instruction_meta;
 pub mod runtime_transaction;
+pub mod sanitize_config;
 pub mod signature_details;
 pub mod transaction_meta;
 pub mod transaction_with_meta;

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -256,6 +256,7 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
 mod tests {
     use {
         super::*,
+        crate::sanitize_config::sanitize_config,
         agave_reserved_account_keys::ReservedAccountKeys,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -279,8 +280,11 @@ mod tests {
         };
 
         let hash = Hash::new_unique();
-        let transaction =
-            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+        let transaction = SanitizedTransactionView::try_new_sanitized(
+            &serialized_transaction[..],
+            &sanitize_config(true),
+        )
+        .unwrap();
         let static_runtime_transaction =
             RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction,
@@ -313,7 +317,8 @@ mod tests {
         ) {
             let bytes = wincode::serialize(&original_transaction).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config(true))
+                    .unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,
@@ -380,7 +385,8 @@ mod tests {
             let bytes =
                 wincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], true).unwrap();
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config(true))
+                    .unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
                 MessageHash::Compute,
@@ -467,8 +473,11 @@ mod tests {
                 Hash::new_unique(),
             )))
             .unwrap();
-        let transaction_view =
-            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+        let transaction_view = SanitizedTransactionView::try_new_sanitized(
+            &serialized_transaction[..],
+            &sanitize_config(true),
+        )
+        .unwrap();
         let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
             transaction_view,
             MessageHash::Compute,

--- a/runtime-transaction/src/sanitize_config.rs
+++ b/runtime-transaction/src/sanitize_config.rs
@@ -1,0 +1,25 @@
+//! Canonical [`SanitizeConfig`] construction for agave.
+//!
+//! `agave-transaction-view` does not depend on agave crates, so the protocol
+//! limits enforced during sanitization are supplied by the caller. This module
+//! is the single place where those limits are sourced from the agave constants.
+
+use {
+    agave_transaction_view::sanitize::SanitizeConfig,
+    solana_compute_budget::compute_budget_limits::{MAX_HEAP_FRAME_BYTES, MIN_HEAP_FRAME_BYTES},
+    solana_transaction_context::{MAX_ACCOUNTS_PER_INSTRUCTION, MAX_INSTRUCTION_TRACE_LENGTH},
+};
+
+/// Returns the [`SanitizeConfig`] with current protocol limits.
+///
+/// `enable_instruction_accounts_limit` should reflect the
+/// `limit_instruction_accounts` (SIMD-406) feature activation.
+pub fn sanitize_config(enable_instruction_accounts_limit: bool) -> SanitizeConfig {
+    SanitizeConfig {
+        min_requested_heap_size: MIN_HEAP_FRAME_BYTES,
+        max_requested_heap_size: MAX_HEAP_FRAME_BYTES,
+        max_instructions: MAX_INSTRUCTION_TRACE_LENGTH,
+        max_accounts_per_instruction: enable_instruction_accounts_limit
+            .then_some(MAX_ACCOUNTS_PER_INSTRUCTION),
+    }
+}

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -23,6 +23,7 @@ shaq = { workspace = true }
 slotmap = { workspace = true }
 solana-fee = { workspace = true, features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
+solana-runtime-transaction = { workspace = true }
 solana-transaction = { workspace = true, optional = true, features = ["serde"] }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }

--- a/scheduling-utils/src/bridge/bindings.rs
+++ b/scheduling-utils/src/bridge/bindings.rs
@@ -18,6 +18,7 @@ use {
     slotmap::SlotMap,
     solana_fee::FeeFeatures,
     solana_pubkey::Pubkey,
+    solana_runtime_transaction::sanitize_config::sanitize_config,
     std::ptr::NonNull,
     thiserror::Error,
 };
@@ -164,7 +165,7 @@ where
         let tx = unsafe { TransactionPtr::from_raw_parts(ptr, tx.len()) };
 
         // Sanitize the transaction, drop it immediately if it fails sanitization.
-        match SanitizedTransactionView::try_new_sanitized(tx, true) {
+        match SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true)) {
             Ok(tx) => {
                 let key = self.state.insert(TransactionState {
                     dead: false,
@@ -254,7 +255,8 @@ where
             };
 
             // Sanitize the transaction, drop it immediately if it fails sanitization.
-            let Ok(tx) = SanitizedTransactionView::try_new_sanitized(tx, true) else {
+            let Ok(tx) = SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true))
+            else {
                 // SAFETY:
                 // - We own `tx` exclusively.
                 // - The previous `TransactionPtr` has been dropped by `try_new_sanitized`.

--- a/transaction-view/Cargo.toml
+++ b/transaction-view/Cargo.toml
@@ -17,14 +17,12 @@ dev-context-only-utils = []
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-packet = { workspace = true }
-solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
 solana-signature = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true }
 
 [dev-dependencies]
 # See order-crates-for-publishing.py for using this unusual `path = "."`
@@ -34,6 +32,7 @@ criterion = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true, features = ["serde"] }
+solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signature = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["wincode"] }

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -1,5 +1,5 @@
 use {
-    agave_transaction_view::transaction_view::TransactionView,
+    agave_transaction_view::{sanitize::SanitizeConfig, transaction_view::TransactionView},
     criterion::{
         BenchmarkGroup, Criterion, Throughput, criterion_group, criterion_main,
         measurement::Measurement,
@@ -21,6 +21,14 @@ use {
 };
 
 const NUM_TRANSACTIONS: usize = 1024;
+
+// Current protocol values; production callers supply these from agave.
+const SANITIZE_CONFIG: SanitizeConfig = SanitizeConfig {
+    min_requested_heap_size: 32 * 1024,
+    max_requested_heap_size: 256 * 1024,
+    max_instructions: 64,
+    max_accounts_per_instruction: Some(255),
+};
 
 fn serialize_transactions(transactions: Vec<VersionedTransaction>) -> Vec<Vec<u8>> {
     transactions
@@ -66,7 +74,8 @@ fn bench_transactions_parsing(
         c.iter(|| {
             for bytes in serialized_transactions.iter() {
                 let _ =
-                    TransactionView::try_new_sanitized(black_box(bytes.as_ref()), true).unwrap();
+                    TransactionView::try_new_sanitized(black_box(bytes.as_ref()), &SANITIZE_CONFIG)
+                        .unwrap();
             }
         });
     });

--- a/transaction-view/src/lib.rs
+++ b/transaction-view/src/lib.rs
@@ -10,7 +10,7 @@ mod instructions_frame;
 mod message_header_frame;
 pub mod resolved_transaction_view;
 pub mod result;
-mod sanitize;
+pub mod sanitize;
 mod signature_frame;
 mod static_account_keys_frame;
 mod transaction_config_frame;

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -260,7 +260,7 @@ impl<D: TransactionData> Debug for ResolvedTransactionView<D> {
 mod tests {
     use {
         super::*,
-        crate::transaction_view::SanitizedTransactionView,
+        crate::{sanitize::SanitizeConfig, transaction_view::SanitizedTransactionView},
         solana_message::{
             MessageHeader, VersionedMessage,
             compiled_instruction::CompiledInstruction,
@@ -270,6 +270,16 @@ mod tests {
         solana_signature::Signature,
         solana_transaction::versioned::VersionedTransaction,
     };
+
+    // Current protocol values; production callers supply these from agave.
+    fn test_config() -> SanitizeConfig {
+        SanitizeConfig {
+            min_requested_heap_size: 32 * 1024,
+            max_requested_heap_size: 256 * 1024,
+            max_instructions: 64,
+            max_accounts_per_instruction: Some(255),
+        }
+    }
 
     #[test]
     fn test_expected_loaded_addresses() {
@@ -294,7 +304,8 @@ mod tests {
             }),
         };
         let bytes = wincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view =
+            SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config()).unwrap();
         let result = ResolvedTransactionView::try_new(view, None, &HashSet::default());
         assert!(matches!(
             result,
@@ -325,7 +336,8 @@ mod tests {
             }),
         };
         let bytes = wincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view =
+            SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config()).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -362,7 +374,8 @@ mod tests {
             }),
         };
         let bytes = wincode::serialize(&transaction).unwrap();
-        let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+        let view =
+            SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config()).unwrap();
         let result =
             ResolvedTransactionView::try_new(view, Some(loaded_addresses), &HashSet::default());
         assert!(matches!(
@@ -412,7 +425,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -435,7 +449,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -458,7 +473,8 @@ mod tests {
             };
             let transaction = create_transaction_with_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses),
@@ -519,7 +535,8 @@ mod tests {
             let static_keys = vec![key0, key1, key2];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -538,7 +555,8 @@ mod tests {
             let static_keys = vec![key0, key1, bpf_loader_upgradeable::ID];
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
             let resolved_view = ResolvedTransactionView::try_new(
                 view,
                 Some(loaded_addresses.clone()),
@@ -561,7 +579,8 @@ mod tests {
             };
             let transaction = create_transaction_with_static_keys(static_keys, &loaded_addresses);
             let bytes = wincode::serialize(&transaction).unwrap();
-            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), true).unwrap();
+            let view = SanitizedTransactionView::try_new_sanitized(bytes.as_ref(), &test_config())
+                .unwrap();
 
             let resolved_view = ResolvedTransactionView::try_new(
                 view,

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -1,24 +1,38 @@
-use {
-    crate::{
-        result::{Result, TransactionViewError},
-        signature_frame::MAX_SIGNATURES_PER_PACKET,
-        transaction_data::TransactionData,
-        transaction_version::TransactionVersion,
-        transaction_view::UnsanitizedTransactionView,
-    },
-    solana_program_runtime::execution_budget::{MAX_HEAP_FRAME_BYTES, MIN_HEAP_FRAME_BYTES},
+use crate::{
+    result::{Result, TransactionViewError},
+    signature_frame::MAX_SIGNATURES_PER_PACKET,
+    transaction_data::TransactionData,
+    transaction_version::TransactionVersion,
+    transaction_view::UnsanitizedTransactionView,
 };
+
+/// Protocol limits enforced during sanitization.
+///
+/// These values are consensus parameters owned by the caller; this crate
+/// intentionally does not define defaults for them.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct SanitizeConfig {
+    /// Inclusive lower bound for a V1 requested heap size, in bytes.
+    pub min_requested_heap_size: u32,
+    /// Inclusive upper bound for a V1 requested heap size, in bytes.
+    pub max_requested_heap_size: u32,
+    /// SIMD-160: maximum number of top-level instructions.
+    pub max_instructions: usize,
+    /// SIMD-406: maximum number of accounts per instruction.
+    /// `None` means the limit is not enforced.
+    pub max_accounts_per_instruction: Option<usize>,
+}
 
 pub(crate) fn sanitize(
     view: &UnsanitizedTransactionView<impl TransactionData>,
-    enable_instruction_accounts_limit: bool,
+    config: &SanitizeConfig,
 ) -> Result<()> {
     sanitize_transaction_size(view)?;
     sanitize_message_header(view)?;
-    sanitize_config(view)?;
+    sanitize_config(view, config)?;
     sanitize_signatures(view)?;
     sanitize_account_access(view)?;
-    sanitize_instructions(view, enable_instruction_accounts_limit)?;
+    sanitize_instructions(view, config)?;
     sanitize_address_table_lookups(view)
 }
 
@@ -67,13 +81,17 @@ fn sanitize_message_header(view: &UnsanitizedTransactionView<impl TransactionDat
 
 /// Config Constraints:
 /// * heap_size must be multiples of 1024, if specified
-fn sanitize_config(view: &UnsanitizedTransactionView<impl TransactionData>) -> Result<()> {
+fn sanitize_config(
+    view: &UnsanitizedTransactionView<impl TransactionData>,
+    config: &SanitizeConfig,
+) -> Result<()> {
     #[allow(clippy::collapsible_if)]
     if let Some(requested_heap_bytes) = view
         .transaction_config()
         .and_then(|config| config.requested_heap_size())
     {
-        if !(MIN_HEAP_FRAME_BYTES..=MAX_HEAP_FRAME_BYTES).contains(&requested_heap_bytes)
+        if !(config.min_requested_heap_size..=config.max_requested_heap_size)
+            .contains(&requested_heap_bytes)
             || !requested_heap_bytes.is_multiple_of(1024)
         {
             return Err(TransactionViewError::SanitizeError);
@@ -133,12 +151,10 @@ fn sanitize_account_access(view: &UnsanitizedTransactionView<impl TransactionDat
 ///   * all account indices < MaxAccountIndex
 fn sanitize_instructions(
     view: &UnsanitizedTransactionView<impl TransactionData>,
-    enable_instruction_accounts_limit: bool,
+    config: &SanitizeConfig,
 ) -> Result<()> {
     // SIMD-160: transaction can not have more than 64 top level instructions
-    if usize::from(view.num_instructions())
-        > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
-    {
+    if usize::from(view.num_instructions()) > config.max_instructions {
         return Err(TransactionViewError::SanitizeError);
     }
 
@@ -165,10 +181,10 @@ fn sanitize_instructions(
             }
         }
 
-        if enable_instruction_accounts_limit
-            && instruction.accounts.len() > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION
-        {
-            return Err(TransactionViewError::SanitizeError);
+        if let Some(max_accounts_per_instruction) = config.max_accounts_per_instruction {
+            if instruction.accounts.len() > max_accounts_per_instruction {
+                return Err(TransactionViewError::SanitizeError);
+            }
         }
     }
 
@@ -213,6 +229,16 @@ mod tests {
         solana_system_interface::instruction as system_instruction,
         solana_transaction::versioned::VersionedTransaction,
     };
+
+    // Current protocol values; production callers supply these from agave.
+    fn test_config() -> SanitizeConfig {
+        SanitizeConfig {
+            min_requested_heap_size: 32 * 1024,
+            max_requested_heap_size: 256 * 1024,
+            max_instructions: 64,
+            max_accounts_per_instruction: Some(255),
+        }
+    }
 
     fn create_legacy_transaction(
         num_signatures: u8,
@@ -288,7 +314,7 @@ mod tests {
         let transaction = multiple_transfers();
         let data = wincode::serialize(&transaction).unwrap();
         let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-        assert!(view.sanitize(true).is_ok());
+        assert!(view.sanitize(&test_config()).is_ok());
     }
 
     #[test]
@@ -638,7 +664,7 @@ mod tests {
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true).is_ok());
+            assert!(sanitize_instructions(&view, &test_config()).is_ok());
 
             let transaction = create_v0_transaction(
                 num_signatures,
@@ -649,7 +675,7 @@ mod tests {
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_instructions(&view, true).is_ok());
+            assert!(sanitize_instructions(&view, &test_config()).is_ok());
         }
 
         for instruction_index in 0..valid_instructions.len() {
@@ -666,7 +692,7 @@ mod tests {
                 let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, &test_config()),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -685,7 +711,7 @@ mod tests {
                 let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, &test_config()),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -703,7 +729,7 @@ mod tests {
                 let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, &test_config()),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -723,7 +749,7 @@ mod tests {
                 let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, &test_config()),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -747,7 +773,7 @@ mod tests {
                 let data = wincode::serialize(&transaction).unwrap();
                 let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
                 assert_eq!(
-                    sanitize_instructions(&view, true),
+                    sanitize_instructions(&view, &test_config()),
                     Err(TransactionViewError::SanitizeError)
                 );
             }
@@ -770,7 +796,7 @@ mod tests {
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true),
+                sanitize_instructions(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
 
@@ -784,7 +810,7 @@ mod tests {
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true),
+                sanitize_instructions(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -804,7 +830,7 @@ mod tests {
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_instructions(&view, true),
+                sanitize_instructions(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -823,7 +849,7 @@ mod tests {
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             // Exactly 255 accounts must pass sanitization.
-            assert!(sanitize_instructions(&view, true).is_ok());
+            assert!(sanitize_instructions(&view, &test_config()).is_ok());
         }
     }
 
@@ -885,11 +911,11 @@ mod tests {
                 },
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
-                TransactionConfig::empty().with_heap_size(MIN_HEAP_FRAME_BYTES),
+                TransactionConfig::empty().with_heap_size(test_config().min_requested_heap_size),
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_config(&view).is_ok());
+            assert!(sanitize_config(&view, &test_config()).is_ok());
         }
 
         // Valid max heap size.
@@ -903,11 +929,11 @@ mod tests {
                 },
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
-                TransactionConfig::empty().with_heap_size(MAX_HEAP_FRAME_BYTES),
+                TransactionConfig::empty().with_heap_size(test_config().max_requested_heap_size),
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_config(&view).is_ok());
+            assert!(sanitize_config(&view, &test_config()).is_ok());
         }
 
         // Heap size below min.
@@ -921,12 +947,13 @@ mod tests {
                 },
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
-                TransactionConfig::empty().with_heap_size(MIN_HEAP_FRAME_BYTES - 1),
+                TransactionConfig::empty()
+                    .with_heap_size(test_config().min_requested_heap_size - 1),
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_config(&view),
+                sanitize_config(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -942,12 +969,13 @@ mod tests {
                 },
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
-                TransactionConfig::empty().with_heap_size(MAX_HEAP_FRAME_BYTES + 1),
+                TransactionConfig::empty()
+                    .with_heap_size(test_config().max_requested_heap_size + 1),
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_config(&view),
+                sanitize_config(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -963,12 +991,13 @@ mod tests {
                 },
                 (0..2).map(|_| Pubkey::new_unique()).collect(),
                 vec![],
-                TransactionConfig::empty().with_heap_size(MIN_HEAP_FRAME_BYTES + 1),
+                TransactionConfig::empty()
+                    .with_heap_size(test_config().min_requested_heap_size + 1),
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
             assert_eq!(
-                sanitize_config(&view),
+                sanitize_config(&view, &test_config()),
                 Err(TransactionViewError::SanitizeError)
             );
         }
@@ -988,7 +1017,7 @@ mod tests {
             );
             let data = wincode::serialize(&transaction).unwrap();
             let view = TransactionView::try_new_unsanitized(data.as_ref()).unwrap();
-            assert!(sanitize_config(&view).is_ok());
+            assert!(sanitize_config(&view, &test_config()).is_ok());
         }
     }
 }

--- a/transaction-view/src/transaction_view.rs
+++ b/transaction-view/src/transaction_view.rs
@@ -1,9 +1,13 @@
 use {
     crate::{
         address_table_lookup_frame::AddressTableLookupIterator,
-        instructions_frame::InstructionsIterator, result::Result, sanitize::sanitize,
-        transaction_config_frame::TransactionConfigView, transaction_data::TransactionData,
-        transaction_frame::TransactionFrame, transaction_version::TransactionVersion,
+        instructions_frame::InstructionsIterator,
+        result::Result,
+        sanitize::{SanitizeConfig, sanitize},
+        transaction_config_frame::TransactionConfigView,
+        transaction_data::TransactionData,
+        transaction_frame::TransactionFrame,
+        transaction_version::TransactionVersion,
     },
     core::fmt::{Debug, Formatter},
     solana_hash::Hash,
@@ -39,11 +43,8 @@ impl<D: TransactionData> TransactionView<false, D> {
     }
 
     /// Sanitizes the transaction view, returning a sanitized view on success.
-    pub fn sanitize(
-        self,
-        enable_instruction_accounts_limit: bool,
-    ) -> Result<SanitizedTransactionView<D>> {
-        sanitize(&self, enable_instruction_accounts_limit)?;
+    pub fn sanitize(self, config: &SanitizeConfig) -> Result<SanitizedTransactionView<D>> {
+        sanitize(&self, config)?;
         Ok(SanitizedTransactionView {
             data: self.data,
             frame: self.frame,
@@ -53,9 +54,9 @@ impl<D: TransactionData> TransactionView<false, D> {
 
 impl<D: TransactionData> TransactionView<true, D> {
     /// Creates a new `TransactionView`, running sanitization checks.
-    pub fn try_new_sanitized(data: D, enable_instruction_accounts_limit: bool) -> Result<Self> {
+    pub fn try_new_sanitized(data: D, config: &SanitizeConfig) -> Result<Self> {
         let unsanitized_view = TransactionView::try_new_unsanitized(data)?;
-        unsanitized_view.sanitize(enable_instruction_accounts_limit)
+        unsanitized_view.sanitize(config)
     }
 }
 


### PR DESCRIPTION
#### Problem
- We want to separate transaction-view from the monorepo so that it's release cycle is not tied to agave
	- the reason this is desired is because external projects (such as the external schedulers) use view
- Currently transaction-view depends on other agave crates for constants used in sanitization 

#### Summary of Changes
- Pass a `SanitizeConfig` into transaction view's sanitization
- Remove agave dependencies in transaction-view

#### Testing
- CI

Fixes #
