### PR TITLE
Remove special casing in calculate_reward_and_burn_fee_details

### DIFF
--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -69,10 +69,6 @@ impl Bank {
     // form of transaction fees as well.
     pub(super) fn distribute_transaction_fee_details(&self) {
         let fee_details = self.collector_fee_details.read().unwrap();
-        if fee_details.total_transaction_fee() == 0 {
-            // nothing to distribute, exit early
-            return;
-        }
 
         let FeeDistribution { deposit, burn } =
             self.calculate_reward_and_burn_fee_details(&fee_details);
@@ -103,10 +99,6 @@ impl Bank {
         &self,
         fee_details: &CollectorFeeDetails,
     ) -> FeeDistribution {
-        if fee_details.transaction_fee == 0 {
-            return FeeDistribution::default();
-        }
-
         let burn = fee_details.transaction_fee * self.burn_percent() / 100;
         let deposit = fee_details
             .priority_fee


### PR DESCRIPTION
#### Problem
- This special case seems to be a leftover from when we used to special-case fee-calculation
- It made me wonder why priority fee was not being distributed in a test I was writing

#### Summary of Changes
- Remove special `transaction_fee == 0` case - it does not happen in production

#### Testing
- CI

Fixes #
