### PR TITLE
Perf - Discard TX batch if block is abandoned

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -325,7 +325,6 @@ impl Consumer {
                     account_overrides: None,
                     check_program_deployment_slot: bank.check_program_deployment_slot(),
                     log_messages_bytes_limit: self.log_messages_bytes_limit,
-                    limit_to_load_programs: true,
                     recording_config: ExecutionRecordingConfig::new_single_setting(
                         transaction_status_sender_enabled
                     ),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -709,7 +709,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         cooperative_loading_task
     }
 
-    /// Called by Bank::replenish_program_cache() for each program that is done loading.
+    /// Called by TransactionBatchProcessor::replenish_program_cache() for each program that is done loading.
     pub fn finish_cooperative_loading_task(
         &mut self,
         program_runtime_environment: &ProgramRuntimeEnvironment,
@@ -724,6 +724,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             } => {
                 let loading_thread = loading_entries.get_mut().unwrap().remove(&key);
                 debug_assert_eq!(loading_thread, Some((current_slot, thread::current().id())));
+                if current_slot < self.latest_root_slot {
+                    self.loading_task_waiter.notify();
+                    return true;
+                }
                 // Check that it will be visible to our own fork once inserted
                 if loaded_program.deployment_slot > self.latest_root_slot
                     && !matches!(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -270,7 +270,7 @@ pub struct ProgramCacheForTxBatch {
     /// Program entries modified during the transaction batch.
     modified_entries: HashMap<Pubkey, Arc<ProgramCacheEntry>>,
     slot: Slot,
-    pub hit_max_limit: bool,
+    pub abandon: bool,
     pub loaded_missing: bool,
     pub merged_modified: bool,
 }
@@ -281,7 +281,7 @@ impl ProgramCacheForTxBatch {
             entries: HashMap::new(),
             modified_entries: HashMap::new(),
             slot,
-            hit_max_limit: false,
+            abandon: false,
             loaded_missing: false,
             merged_modified: false,
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3779,7 +3779,6 @@ impl Bank {
                 account_overrides: Some(&account_overrides),
                 check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit: None,
-                limit_to_load_programs: true,
                 recording_config: ExecutionRecordingConfig {
                     enable_cpi_recording,
                     enable_log_recording: true,
@@ -4517,7 +4516,6 @@ impl Bank {
                 account_overrides: None,
                 check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit,
-                limit_to_load_programs: false,
                 recording_config,
                 drop_on_failure: false,
                 all_or_nothing: false,

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -187,8 +187,6 @@ the transaction processor.
   deployment slot when replenishing a program cache instance.
 - `log_messages_bytes_limit`: The maximum number of bytes that log messages can
   consume.
-- `limit_to_load_programs`: Whether to limit the number of programs loaded for
-  the transaction batch.
 - `recording_config`: Recording capabilities for transaction execution.
 
 ### `LoadAndExecuteSanitizedTransactionsOutput`

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1770,6 +1770,26 @@ mod tests {
             ProgramCacheEntryType::FailedVerification(_)
         ));
         assert!(loaded_missing > 0);
+
+        {
+            let mut program_cache = batch_processor.global_program_cache.write().unwrap();
+            program_cache.remove_programs(std::iter::once(key));
+            program_cache.latest_root_slot = 32;
+        }
+        batch_processor.replenish_program_cache(
+            &account_loader,
+            vec![ProgramToLoad {
+                program_id: &key,
+                loader: ProgramCacheEntryOwner::LoaderV2,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                last_modification_slot: 0,
+            }],
+            &program_runtime_environment_for_execution,
+            &mut program_cache_for_tx_batch,
+            &mut ExecuteTimings::default(),
+            true,
+        );
+        assert!(program_cache_for_tx_batch.abandon);
     }
 
     #[test]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -123,9 +123,6 @@ pub struct TransactionProcessingConfig<'a> {
     pub check_program_deployment_slot: bool,
     /// The maximum number of bytes that log messages can consume.
     pub log_messages_bytes_limit: Option<usize>,
-    /// Whether to limit the number of programs loaded for the transaction
-    /// batch.
-    pub limit_to_load_programs: bool,
     /// Recording capabilities for transaction execution.
     pub recording_config: ExecutionRecordingConfig,
     /// Should failing transactions within the batch be dropped (no fee charged
@@ -526,7 +523,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                                 .get_env_for_execution(),
                             &mut program_cache_for_tx_batch,
                             &mut execute_timings,
-                            config.limit_to_load_programs,
                             true, // increment_usage_counter
                         );
                     });
@@ -828,7 +824,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
         program_cache_for_tx_batch: &mut ProgramCacheForTxBatch,
         execute_timings: &mut ExecuteTimings,
-        limit_to_load_programs: bool,
         increment_usage_counter: bool,
     ) {
         let mut count_hits_and_misses = true;
@@ -872,8 +867,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     key,
                     last_modification_slot,
                     program,
-                ) && limit_to_load_programs
-                {
+                ) {
                     // This branch is taken when there is an error in assigning a program to a
                     // cache slot. It is not possible to mock this error for SVM unit
                     // tests purposes.
@@ -1730,7 +1724,6 @@ mod tests {
             &mut program_cache_for_tx_batch,
             &mut ExecuteTimings::default(),
             true,
-            true,
         );
     }
 
@@ -1754,34 +1747,30 @@ mod tests {
         let account_loader = (&mock_bank).into();
 
         let mut loaded_missing = 0;
-        for limit_to_load_programs in [false, true] {
-            let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(batch_processor.slot);
-
-            batch_processor.replenish_program_cache(
-                &account_loader,
-                vec![ProgramToLoad {
-                    program_id: &key,
-                    loader: ProgramCacheEntryOwner::LoaderV2,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
-                    last_modification_slot: 0,
-                }],
-                &program_runtime_environment_for_execution,
-                &mut program_cache_for_tx_batch,
-                &mut ExecuteTimings::default(),
-                limit_to_load_programs,
-                true,
-            );
-            assert!(!program_cache_for_tx_batch.hit_max_limit);
-            if program_cache_for_tx_batch.loaded_missing {
-                loaded_missing += 1;
-            }
-
-            let program = program_cache_for_tx_batch.find(&key).unwrap();
-            assert!(matches!(
-                program.program,
-                ProgramCacheEntryType::FailedVerification(_)
-            ));
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(batch_processor.slot);
+        batch_processor.replenish_program_cache(
+            &account_loader,
+            vec![ProgramToLoad {
+                program_id: &key,
+                loader: ProgramCacheEntryOwner::LoaderV2,
+                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                last_modification_slot: 0,
+            }],
+            &program_runtime_environment_for_execution,
+            &mut program_cache_for_tx_batch,
+            &mut ExecuteTimings::default(),
+            true,
+        );
+        assert!(!program_cache_for_tx_batch.hit_max_limit);
+        if program_cache_for_tx_batch.loaded_missing {
+            loaded_missing += 1;
         }
+
+        let program = program_cache_for_tx_batch.find(&key).unwrap();
+        assert!(matches!(
+            program.program,
+            ProgramCacheEntryType::FailedVerification(_)
+        ));
         assert!(loaded_missing > 0);
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -437,7 +437,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // in the transaction loop below.
         let mut program_cache_for_tx_batch = self.builtin_program_cache.read().unwrap().clone();
 
-        if program_cache_for_tx_batch.hit_max_limit {
+        if program_cache_for_tx_batch.abandon {
             return LoadAndExecuteSanitizedTransactionsOutput {
                 error_metrics,
                 execute_timings,
@@ -531,7 +531,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         program_cache_us,
                     );
 
-                    if program_cache_for_tx_batch.hit_max_limit {
+                    if program_cache_for_tx_batch.abandon {
                         return LoadAndExecuteSanitizedTransactionsOutput {
                             error_metrics,
                             execute_timings,
@@ -868,11 +868,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     last_modification_slot,
                     program,
                 ) {
-                    // This branch is taken when there is an error in assigning a program to a
-                    // cache slot. It is not possible to mock this error for SVM unit
-                    // tests purposes.
+                    // Proceeding with this transaction batch is pointless
                     *program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
-                    program_cache_for_tx_batch.hit_max_limit = true;
+                    program_cache_for_tx_batch.abandon = true;
                     return;
                 }
             } else if missing_programs.is_empty() {
@@ -1761,7 +1759,7 @@ mod tests {
             &mut ExecuteTimings::default(),
             true,
         );
-        assert!(!program_cache_for_tx_batch.hit_max_limit);
+        assert!(!program_cache_for_tx_batch.abandon);
         if program_cache_for_tx_batch.loaded_missing {
             loaded_missing += 1;
         }

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -85,7 +85,6 @@ fn program_cache_execution(threads: usize) {
                     &mut result,
                     &mut ExecuteTimings::default(),
                     true,
-                    true,
                 );
                 for key in programs.iter() {
                     let cache_entry = result.find(key);


### PR DESCRIPTION
#### Problem

We can optimize the case in which we are still replaying a slot that has been abandoned (by rerooting) and stop loading programs (which can take a while) and is pointless in that situation anyway.

#### Summary of Changes

- Removes the (inaptly named) `TransactionProcessingConfig::limit_to_load_programs` to not discard transaction batches, which was used in `do_load_execute_and_commit_transactions_with_pre_commit_callback()`. This amounts to no change as abandoning TX batches was dead code before.
- Renames the (equally inaptly named)`ProgramCacheForTxBatch::hit_max_limit` to `ProgramCacheForTxBatch::abandon`.
- Immediately abandons a TX batch in `ProgramCache::finish_cooperative_loading_task()` if we are on a slot which has been abandoned in the meantime while we were loading a program cooperatively. This can not be done in `TransactionBatchProcessor::replenish_program_cache()` because we still need to unlock the program loading lock and give other threads the chance to grab it.

#### Testing

Added case of `abandon=true` to `test_replenish_program_cache()`.