### PR TITLE
[transaction-status] Improve confidential transfer parsing logic

### DIFF
--- a/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
+++ b/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
@@ -68,17 +68,22 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
 
             });
             let map = value.as_object_mut().unwrap();
-            if rotate_supply_data.proof_instruction_offset == 0 {
-                map.insert(
-                    "proofAccount".to_string(),
-                    json!(account_keys[account_indexes[1] as usize].to_string()),
-                );
-            } else {
-                map.insert(
-                    "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[1] as usize].to_string()),
-                );
+            let offset = 1;
+
+            if offset < account_indexes.len().saturating_sub(1) {
+                if rotate_supply_data.proof_instruction_offset == 0 {
+                    map.insert(
+                        "proofContextStateAccount".to_string(),
+                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    );
+                } else {
+                    map.insert(
+                        "instructionsSysvar".to_string(),
+                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    );
+                }
             }
+
             parse_signers(
                 map,
                 2,
@@ -109,11 +114,11 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             });
             let mut offset = 2;
             let map = value.as_object_mut().unwrap();
-            if offset < account_indexes.len() - 1
-                && (mint_data.equality_proof_instruction_offset != 0
-                    || mint_data.ciphertext_validity_proof_instruction_offset != 0
-                    || mint_data.range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = mint_data.equality_proof_instruction_offset != 0
+                || mint_data.ciphertext_validity_proof_instruction_offset != 0
+                || mint_data.range_proof_instruction_offset != 0;
+
+            if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
@@ -121,40 +126,29 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                 offset += 1;
             }
 
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 1 {
-                let label = if mint_data.equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+            if mint_data.equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if mint_data.ciphertext_validity_proof_instruction_offset == 0 {
-                    "ciphertextValidityProofContextStateAccount"
-                } else {
-                    "ciphertextValidityProofRecordAccount"
-                };
+            if mint_data.ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "ciphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if mint_data.range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+            if mint_data.range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
@@ -190,11 +184,11 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             });
             let mut offset = 2;
             let map = value.as_object_mut().unwrap();
-            if offset < account_indexes.len() - 1
-                && (burn_data.equality_proof_instruction_offset != 0
-                    || burn_data.ciphertext_validity_proof_instruction_offset != 0
-                    || burn_data.range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = burn_data.equality_proof_instruction_offset != 0
+                || burn_data.ciphertext_validity_proof_instruction_offset != 0
+                || burn_data.range_proof_instruction_offset != 0;
+
+            if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
@@ -202,40 +196,29 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                 offset += 1;
             }
 
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 1 {
-                let label = if burn_data.equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+            if burn_data.equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if burn_data.ciphertext_validity_proof_instruction_offset == 0 {
-                    "ciphertextValidityProofContextStateAccount"
-                } else {
-                    "ciphertextValidityProofRecordAccount"
-                };
+            if burn_data.ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "ciphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if burn_data.range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+            if burn_data.range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
@@ -284,6 +267,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
+        solana_sdk_ids::sysvar,
         solana_zk_sdk_pod::encryption::{
             auth_encryption::PodAeCiphertext,
             elgamal::{PodElGamalCiphertext, PodElGamalPubkey},
@@ -341,106 +325,552 @@ mod test {
     }
 
     #[test]
-    fn test_rotate() {
-        for location in [
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                &CiphertextCiphertextEqualityProofData::zeroed(),
-            ),
-            ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-        ] {
-            let instructions = rotate_supply_elgamal_pubkey(
-                &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &[],
-                &PodElGamalPubkey::default(),
-                location,
-            )
-            .unwrap();
-            check_no_panic(instructions[0].clone());
-        }
-    }
-
-    #[test]
     fn test_mint() {
-        for (equality_proof_location, ciphertext_validity_proof_location, range_proof_location) in [
+        let destination = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let equality_ctx = Pubkey::new_unique();
+        let validity_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq_1 = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+
+        let offset_val_1 = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+        let offset_val_2 = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+
+        let offset_rng_2 = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+        let offset_rng_3 = ProofLocation::InstructionOffset(
+            NonZero::new(3).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_val = ProofLocation::ContextStateAccount(&validity_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        // We test exhaustive combinations to ensure the parser's offset logic holds.
+        // Array of cases: (Test Name, Eq Proof, Val Proof, Rng Proof, Eq Offset, Val
+        // Offset, Rng Offset)
+        let cases = vec![
             (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &BatchedRangeProofU128Data::zeroed(),
-                ),
+                "All Contexts",
+                context_eq,
+                context_val,
+                context_rng,
+                0,
+                0,
+                0,
             ),
             (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
+                "All Offsets",
+                offset_eq_1,
+                offset_val_2,
+                offset_rng_3,
+                1,
+                2,
+                3,
             ),
-        ] {
+            (
+                "Mixed C-I-C",
+                context_eq,
+                offset_val_1,
+                context_rng,
+                0,
+                1,
+                0,
+            ),
+            (
+                "Mixed I-C-I",
+                offset_eq_1,
+                context_val,
+                offset_rng_2,
+                1,
+                0,
+                2,
+            ),
+        ];
+
+        for (name, eq, val, rng, eq_offset, val_offset, rng_offset) in cases {
             let instructions = confidential_mint_with_split_proofs(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &destination,
+                &mint,
                 &PodElGamalCiphertext::default(),
                 &PodElGamalCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                ciphertext_validity_proof_location,
-                range_proof_location,
+                eq,
+                val,
+                rng,
                 &PodAeCiphertext::default(),
             )
             .unwrap();
-            check_no_panic(instructions[0].clone());
+
+            let message = Message::new(&instructions, None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "confidentialMint",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["destination"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["newDecryptableSupply"],
+                json!(format!("{}", PodAeCiphertext::default())),
+                "Failed on: {}",
+                name
+            );
+
+            // Expected Offsets
+            assert_eq!(
+                parsed.info["equalityProofInstructionOffset"],
+                json!(eq_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["ciphertextValidityProofInstructionOffset"],
+                json!(val_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["rangeProofInstructionOffset"],
+                json!(rng_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // Sysvar Assertion: Only present if at least one proof relies on an
+            // instruction offset
+            if eq_offset != 0 || val_offset != 0 || rng_offset != 0 {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            }
+
+            // Eq Context State Account
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            }
+
+            // Val Context State Account
+            if val_offset == 0 {
+                assert_eq!(
+                    parsed.info["ciphertextValidityProofContextStateAccount"],
+                    json!(validity_ctx.to_string()),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("ciphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            }
+
+            // Rng Context State Account
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            }
         }
     }
 
     #[test]
     fn test_burn() {
-        for (equality_proof_location, ciphertext_validity_proof_location, range_proof_location) in [
+        let destination = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let equality_ctx = Pubkey::new_unique();
+        let validity_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq_1 = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+
+        let offset_val_1 = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+        let offset_val_2 = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+
+        let offset_rng_2 = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+        let offset_rng_3 = ProofLocation::InstructionOffset(
+            NonZero::new(3).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_val = ProofLocation::ContextStateAccount(&validity_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        // We test exhaustive combinations to ensure the parser's offset logic holds.
+        // Array of cases: (Test Name, Eq Proof, Val Proof, Rng Proof, Eq Offset, Val
+        // Offset, Rng Offset)
+        let cases = vec![
             (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &BatchedRangeProofU128Data::zeroed(),
-                ),
+                "All Contexts",
+                context_eq,
+                context_val,
+                context_rng,
+                0,
+                0,
+                0,
             ),
             (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
+                "All Offsets",
+                offset_eq_1,
+                offset_val_2,
+                offset_rng_3,
+                1,
+                2,
+                3,
             ),
-        ] {
+            (
+                "Mixed C-I-C",
+                context_eq,
+                offset_val_1,
+                context_rng,
+                0,
+                1,
+                0,
+            ),
+            (
+                "Mixed I-C-I",
+                offset_eq_1,
+                context_val,
+                offset_rng_2,
+                1,
+                0,
+                2,
+            ),
+        ];
+
+        for (name, eq, val, rng, eq_offset, val_offset, rng_offset) in cases {
             let instructions = confidential_burn_with_split_proofs(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &destination,
+                &mint,
                 &PodAeCiphertext::default(),
                 &PodElGamalCiphertext::default(),
                 &PodElGamalCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                ciphertext_validity_proof_location,
-                range_proof_location,
+                eq,
+                val,
+                rng,
             )
             .unwrap();
+
+            let message = Message::new(&instructions, None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "confidentialBurn",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["destination"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["newDecryptableAvailableBalance"],
+                json!(format!("{}", PodAeCiphertext::default())),
+                "Failed on: {}",
+                name
+            );
+
+            // Expected Offsets
+            assert_eq!(
+                parsed.info["equalityProofInstructionOffset"],
+                json!(eq_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["ciphertextValidityProofInstructionOffset"],
+                json!(val_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["rangeProofInstructionOffset"],
+                json!(rng_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // Sysvar Assertion: Only present if at least one proof relies on an
+            // instruction offset
+            if eq_offset != 0 || val_offset != 0 || rng_offset != 0 {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            }
+
+            // Eq Context State Account
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            }
+
+            // Val Context State Account
+            if val_offset == 0 {
+                assert_eq!(
+                    parsed.info["ciphertextValidityProofContextStateAccount"],
+                    json!(validity_ctx.to_string()),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("ciphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            }
+
+            // Rng Context State Account
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_rotate() {
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let proof_ctx = Pubkey::new_unique();
+
+        let offset_proof = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCiphertextEqualityProofData::zeroed(),
+        );
+        let context_proof = ProofLocation::ContextStateAccount(&proof_ctx);
+
+        let cases = vec![
+            ("Context State Account", context_proof, 0),
+            ("Instruction Offset", offset_proof, 1),
+        ];
+
+        for (name, proof_location, expected_offset) in cases {
+            let instructions = rotate_supply_elgamal_pubkey(
+                &spl_token_2022_interface::id(),
+                &mint,
+                &authority,
+                &[],
+                &PodElGamalPubkey::default(),
+                proof_location,
+            )
+            .unwrap();
+
             check_no_panic(instructions[0].clone());
+
+            let message = Message::new(&instructions, None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "rotateConfidentialMintBurnSupplyElGamalPubkey",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["newSupplyElGamalPubkey"],
+                json!(PodElGamalPubkey::default().to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["proofInstructionOffset"],
+                json!(expected_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // Conditional Proof Context / Sysvar Assertions
+            if expected_offset == 0 {
+                assert_eq!(
+                    parsed.info["proofContextStateAccount"],
+                    json!(proof_ctx.to_string()),
+                    "Proof Context mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar should not be present on: {}",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("proofContextStateAccount").is_none(),
+                    "Proof Context should not be present on: {}",
+                    name
+                );
+            }
+
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
         }
     }
 }

--- a/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
+++ b/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
@@ -429,52 +429,44 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "confidentialMint",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["destination"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["newDecryptableSupply"],
                 json!(format!("{}", PodAeCiphertext::default())),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Expected Offsets
             assert_eq!(
                 parsed.info["equalityProofInstructionOffset"],
                 json!(eq_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["ciphertextValidityProofInstructionOffset"],
                 json!(val_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["rangeProofInstructionOffset"],
                 json!(rng_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Sysvar Assertion: Only present if at least one proof relies on an
@@ -483,14 +475,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             }
 
@@ -499,8 +489,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -508,8 +497,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             }
 
@@ -518,8 +506,7 @@ mod test {
                 assert_eq!(
                     parsed.info["ciphertextValidityProofContextStateAccount"],
                     json!(validity_ctx.to_string()),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -527,8 +514,7 @@ mod test {
                         .info
                         .get("ciphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             }
 
@@ -537,14 +523,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             }
         }
@@ -655,52 +639,44 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "confidentialBurn",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["destination"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["newDecryptableAvailableBalance"],
                 json!(format!("{}", PodAeCiphertext::default())),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Expected Offsets
             assert_eq!(
                 parsed.info["equalityProofInstructionOffset"],
                 json!(eq_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["ciphertextValidityProofInstructionOffset"],
                 json!(val_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["rangeProofInstructionOffset"],
                 json!(rng_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Sysvar Assertion: Only present if at least one proof relies on an
@@ -709,14 +685,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             }
 
@@ -725,8 +699,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -734,8 +707,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             }
 
@@ -744,8 +716,7 @@ mod test {
                 assert_eq!(
                     parsed.info["ciphertextValidityProofContextStateAccount"],
                     json!(validity_ctx.to_string()),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -753,8 +724,7 @@ mod test {
                         .info
                         .get("ciphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             }
 
@@ -763,14 +733,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             }
         }
@@ -816,26 +784,22 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "rotateConfidentialMintBurnSupplyElGamalPubkey",
-                "Failed on: {}",
-                name
+                "Failed on: {name}"
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}"
             );
             assert_eq!(
                 parsed.info["newSupplyElGamalPubkey"],
                 json!(PodElGamalPubkey::default().to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}"
             );
             assert_eq!(
                 parsed.info["proofInstructionOffset"],
                 json!(expected_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}"
             );
 
             // Conditional Proof Context / Sysvar Assertions
@@ -843,33 +807,28 @@ mod test {
                 assert_eq!(
                     parsed.info["proofContextStateAccount"],
                     json!(proof_ctx.to_string()),
-                    "Proof Context mismatch on: {}",
-                    name
+                    "Proof Context mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar should not be present on: {}",
-                    name
+                    "Sysvar should not be present on: {name}",
                 );
             } else {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("proofContextStateAccount").is_none(),
-                    "Proof Context should not be present on: {}",
-                    name
+                    "Proof Context should not be present on: {name}",
                 );
             }
 
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
         }
     }

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -70,32 +70,22 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
 
             });
             let map = value.as_object_mut().unwrap();
-            let offset = if configure_account_data.proof_instruction_offset == 0 {
+
+            if configure_account_data.proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[2] as usize].to_string()),
                 );
-                3
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[2] as usize].to_string()),
                 );
-                // Assume that the extra account is a proof account and not a multisig
-                // signer. This might be wrong, but it's the best possible option.
-                if account_indexes.len() > 4 {
-                    map.insert(
-                        "recordAccount".to_string(),
-                        json!(account_keys[account_indexes[3] as usize].to_string()),
-                    );
-                    4
-                } else {
-                    3
-                }
-            };
+            }
+
             parse_signers(
                 map,
-                offset,
+                3,
                 account_keys,
                 account_indexes,
                 "owner",
@@ -130,32 +120,22 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
 
             });
             let map = value.as_object_mut().unwrap();
-            let offset = if proof_instruction_offset == 0 {
+
+            if proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[1] as usize].to_string()),
                 );
-                2
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[1] as usize].to_string()),
                 );
-                if account_indexes.len() > 3 {
-                    // Assume that the extra account is a proof account and not a multisig
-                    // signer. This might be wrong, but it's the best possible option.
-                    map.insert(
-                        "recordAccount".to_string(),
-                        json!(account_keys[account_indexes[2] as usize].to_string()),
-                    );
-                    3
-                } else {
-                    2
-                }
-            };
+            }
+
             parse_signers(
                 map,
-                offset,
+                2,
                 account_keys,
                 account_indexes,
                 "owner",
@@ -211,12 +191,13 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 "rangeProofInstructionOffset": withdrawal_data.range_proof_instruction_offset,
 
             });
+
             let mut offset = 2;
             let map = value.as_object_mut().unwrap();
-            if offset < account_indexes.len() - 1
-                && (withdrawal_data.equality_proof_instruction_offset != 0
-                    || withdrawal_data.range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = withdrawal_data.equality_proof_instruction_offset != 0
+                || withdrawal_data.range_proof_instruction_offset != 0;
+
+            if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
@@ -224,33 +205,26 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 offset += 1;
             }
 
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 1 {
-                let label = if withdrawal_data.equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+            if withdrawal_data.equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
 
-            if offset < account_indexes.len() - 1 {
-                let label = if withdrawal_data.range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+            if withdrawal_data.range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
+
             parse_signers(
                 map,
                 offset,
@@ -282,11 +256,11 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             });
             let mut offset = 3;
             let map = value.as_object_mut().unwrap();
-            if offset < account_indexes.len() - 1
-                && (transfer_data.equality_proof_instruction_offset != 0
-                    || transfer_data.ciphertext_validity_proof_instruction_offset != 0
-                    || transfer_data.range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = transfer_data.equality_proof_instruction_offset != 0
+                || transfer_data.ciphertext_validity_proof_instruction_offset != 0
+                || transfer_data.range_proof_instruction_offset != 0;
+
+            if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
@@ -294,42 +268,31 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 offset += 1;
             }
 
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 1 {
-                let label = if transfer_data.equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+            if transfer_data.equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
 
-            if offset < account_indexes.len() - 1 {
-                let label = if transfer_data.ciphertext_validity_proof_instruction_offset == 0 {
-                    "ciphertextValidityProofContextStateAccount"
-                } else {
-                    "ciphertextValidityProofRecordAccount"
-                };
+            if transfer_data.ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "ciphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
 
-            if offset < account_indexes.len() - 1 {
-                let label = if transfer_data.range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+            if transfer_data.range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
@@ -377,13 +340,13 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
 
             let mut offset = 3;
             let map = value.as_object_mut().unwrap();
-            if offset < account_indexes.len() - 1
-                && (equality_proof_instruction_offset != 0
-                    || transfer_amount_ciphertext_validity_proof_instruction_offset != 0
-                    || fee_ciphertext_validity_proof_instruction_offset != 0
-                    || fee_sigma_proof_instruction_offset != 0
-                    || range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = equality_proof_instruction_offset != 0
+                || transfer_amount_ciphertext_validity_proof_instruction_offset != 0
+                || fee_sigma_proof_instruction_offset != 0
+                || fee_ciphertext_validity_proof_instruction_offset != 0
+                || range_proof_instruction_offset != 0;
+
+            if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
@@ -391,68 +354,52 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 offset += 1;
             }
 
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 1 {
-                let label = if equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+            if equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if transfer_amount_ciphertext_validity_proof_instruction_offset == 0 {
-                    "transferAmountCiphertextValidityProofContextStateAccount"
-                } else {
-                    "transferAmountCiphertextValidityProofRecordAccount"
-                };
+            if transfer_amount_ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "transferAmountCiphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if fee_ciphertext_validity_proof_instruction_offset == 0 {
-                    "feeCiphertextValidityProofContextStateAccount"
-                } else {
-                    "feeCiphertextValidityProofRecordAccount"
-                };
+            if fee_sigma_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "feeSigmaProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if fee_sigma_proof_instruction_offset == 0 {
-                    "feeSigmaProofContextStateAccount"
-                } else {
-                    "feeSigmaProofRecordAccount"
-                };
+            if fee_ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "feeCiphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 1 {
-                let label = if range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+            if range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(1)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
+
             parse_signers(
                 map,
                 offset,
@@ -598,6 +545,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
+        solana_sdk_ids::sysvar,
         solana_zk_sdk_pod::encryption::{
             auth_encryption::PodAeCiphertext, elgamal::PodElGamalCiphertext,
         },
@@ -669,46 +617,212 @@ mod test {
 
     #[test]
     fn test_configure() {
-        for location in [
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                &PubkeyValidityProofData::zeroed(),
-            ),
-            ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-        ] {
+        let token_account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let proof_ctx = Pubkey::new_unique();
+
+        let decryptable_zero_balance = PodAeCiphertext::default();
+        let maximum_pending_balance_credit_counter = 10_000;
+
+        let offset_proof = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &PubkeyValidityProofData::zeroed(),
+        );
+
+        let context_proof = ProofLocation::ContextStateAccount(&proof_ctx);
+
+        // We test both proof locations to ensure the parser's offset logic holds.
+        // Array of cases: (Test Name, Proof Location, Expected Offset)
+        let cases = vec![
+            ("Context State Account", context_proof, 0),
+            ("Instruction Offset", offset_proof, 1),
+        ];
+
+        for (name, proof_location, expected_offset) in cases {
             let instruction = inner_configure_account(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &PodAeCiphertext::default(),
-                10_000,
-                &Pubkey::new_unique(),
+                &token_account,
+                &mint,
+                &decryptable_zero_balance,
+                maximum_pending_balance_credit_counter,
+                &authority,
                 &[],
-                location,
+                proof_location,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            assert_eq!(
+                parsed.instruction_type, "configureConfidentialTransferAccount",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["account"],
+                json!(token_account.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["decryptableZeroBalance"],
+                json!(format!("{}", decryptable_zero_balance)),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["maximumPendingBalanceCreditCounter"],
+                json!(maximum_pending_balance_credit_counter),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["proofInstructionOffset"],
+                json!(expected_offset),
+                "Failed on: {}",
+                name
+            );
+
+            if expected_offset == 0 {
+                assert_eq!(
+                    parsed.info["proofContextStateAccount"],
+                    json!(proof_ctx.to_string()),
+                    "Proof Context mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar should not be present on: {}",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("proofContextStateAccount").is_none(),
+                    "Proof Context should not be present on: {}",
+                    name
+                );
+            }
         }
     }
 
     #[test]
     fn test_empty_account() {
-        for location in [
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                &ZeroCiphertextProofData::zeroed(),
-            ),
-            ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-        ] {
+        let token_account = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let proof_ctx = Pubkey::new_unique();
+
+        let offset_proof = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &ZeroCiphertextProofData::zeroed(),
+        );
+
+        let context_proof = ProofLocation::ContextStateAccount(&proof_ctx);
+
+        // We test both proof locations to ensure the parser's offset logic holds.
+        // Array of cases: (Test Name, Proof Location, Expected Offset)
+        let cases = vec![
+            ("Context State Account", context_proof, 0),
+            ("Instruction Offset", offset_proof, 1),
+        ];
+
+        for (name, proof_location, expected_offset) in cases {
             let instruction = inner_empty_account(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &token_account,
+                &authority,
                 &[],
-                location,
+                proof_location,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "emptyConfidentialTransferAccount",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["account"],
+                json!(token_account.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+
+            // Expected Offset
+            assert_eq!(
+                parsed.info["proofInstructionOffset"],
+                json!(expected_offset),
+                "Failed on: {}",
+                name
+            );
+
+            if expected_offset == 0 {
+                assert_eq!(
+                    parsed.info["proofContextStateAccount"],
+                    json!(proof_ctx.to_string()),
+                    "Proof Context mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar should not be present on: {}",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("proofContextStateAccount").is_none(),
+                    "Proof Context should not be present on: {}",
+                    name
+                );
+            }
         }
     }
 
@@ -749,182 +863,670 @@ mod test {
     }
 
     #[test]
-    fn test_withdraw_account_mapping() {
+    fn test_withdraw() {
         let token_account = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-        let owner = Pubkey::new_unique();
-        let equality_context = Pubkey::new_unique();
-        let range_context = Pubkey::new_unique();
-        let instruction = inner_withdraw(
-            &spl_token_2022_interface::id(),
-            &token_account,
-            &mint,
-            1,
-            2,
-            &PodAeCiphertext::default(),
-            &owner,
-            &[],
-            ProofLocation::ContextStateAccount(&equality_context),
-            ProofLocation::ContextStateAccount(&range_context),
-        )
-        .unwrap();
-        let message = Message::new(&[instruction], None);
-        let compiled_instruction = &message.instructions[0];
-        let parsed = parse_token(
-            compiled_instruction,
-            &AccountKeys::new(&message.account_keys, None),
-        )
-        .unwrap();
-        assert_eq!(parsed.instruction_type, "withdrawConfidentialTransfer");
-        assert_eq!(parsed.info["account"], json!(token_account.to_string()));
-        assert_eq!(parsed.info["mint"], json!(mint.to_string()));
-        assert_eq!(parsed.info["owner"], json!(owner.to_string()));
-        assert_eq!(
-            parsed.info["equalityProofContextStateAccount"],
-            json!(equality_context.to_string())
-        );
-        assert_eq!(
-            parsed.info["rangeProofContextStateAccount"],
-            json!(range_context.to_string())
-        );
-        assert!(parsed.info.get("destination").is_none());
-        assert_ne!(parsed.info["mint"], parsed.info["owner"]);
-    }
+        let authority = Pubkey::new_unique();
 
-    #[test]
-    fn test_withdraw() {
-        for (equality_proof_location, range_proof_location) in [
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &BatchedRangeProofU64Data::zeroed(),
-                ),
-            ),
-            (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-            ),
-        ] {
+        let equality_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+        let offset_rng_2 = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedRangeProofU64Data::zeroed(),
+        );
+        let offset_rng_1 = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &BatchedRangeProofU64Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        // We test exhaustive combinations to ensure the parser's offset logic holds.
+        // Legend:
+        // 'C' = Context State Account (Proof is in a separate account)
+        // 'I' = Instruction Offset (Proof is bundled in the instruction data payload)
+        // Array of cases: (Test Name, Eq Proof, Rng Proof, Eq Offset, Rng Offset)
+        let cases = vec![
+            ("All Contexts", context_eq, context_rng, 0, 0),
+            ("All Offsets", offset_eq, offset_rng_2, 1, 2),
+            ("Mixed C-I", context_eq, offset_rng_1, 0, 1),
+            ("Mixed I-C", offset_eq, context_rng, 1, 0),
+        ];
+
+        for (name, eq_proof, rng_proof, eq_offset, rng_offset) in cases {
             let instruction = inner_withdraw(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                1,
-                2,
+                &token_account,
+                &mint,
+                42, // amount
+                9,  // decimals
                 &PodAeCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                range_proof_location,
+                eq_proof,
+                rng_proof,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            assert_eq!(
+                parsed.instruction_type, "withdrawConfidentialTransfer",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["account"],
+                json!(token_account.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(parsed.info["amount"], json!(42), "Failed on: {}", name);
+            assert_eq!(parsed.info["decimals"], json!(9), "Failed on: {}", name);
+            assert_eq!(
+                parsed.info["newDecryptableAvailableBalance"],
+                json!(format!("{}", PodAeCiphertext::default())),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["equalityProofInstructionOffset"],
+                json!(eq_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["rangeProofInstructionOffset"],
+                json!(rng_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // Sysvar Assertion: Only present if at least one proof relies on
+            // an instruction offset
+            if eq_offset != 0 || rng_offset != 0 {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            }
+
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            }
         }
     }
 
     #[test]
     fn test_transfer() {
-        for (equality_proof_location, ciphertext_validity_proof_location, range_proof_location) in [
+        let source = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let equality_ctx = Pubkey::new_unique();
+        let validity_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+        let offset_val = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+        let offset_rng = ProofLocation::InstructionOffset(
+            NonZero::new(3).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_val = ProofLocation::ContextStateAccount(&validity_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        // The Confidential Transfer instruction allows proofs to be provided either via
+        // pre-verified Context State accounts or directly in the Instruction data.
+        // We test exhaustive combinations to ensure the parser's offset logic holds.
+        // Legend:
+        // 'C' = Context State Account (Proof is in a separate account)
+        // 'I' = Instruction Offset (Proof is bundled in the instruction data payload)
+        // Array of cases: (Test Name, Eq Proof, Val Proof, Rng Proof)
+        let cases = vec![
             (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &BatchedRangeProofU128Data::zeroed(),
-                ),
+                "All Contexts",
+                context_eq,
+                context_val,
+                context_rng,
+                0,
+                0,
+                0,
             ),
-            (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-            ),
-        ] {
+            ("All Offsets", offset_eq, offset_val, offset_rng, 1, 2, 3),
+            ("Mixed C-I-C", context_eq, offset_val, context_rng, 0, 2, 0),
+            ("Mixed I-C-I", offset_eq, context_val, offset_rng, 1, 0, 3),
+        ];
+
+        for (name, eq, val, rng, eq_offset, val_offset, rng_offset) in cases {
             let instruction = inner_transfer(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &source,
+                &mint,
+                &destination,
                 &PodAeCiphertext::default(),
                 &PodElGamalCiphertext::default(),
                 &PodElGamalCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                ciphertext_validity_proof_location,
-                range_proof_location,
+                eq,
+                val,
+                rng,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            assert_eq!(
+                parsed.instruction_type, "confidentialTransfer",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["source"],
+                json!(source.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["destination"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["equalityProofInstructionOffset"],
+                json!(eq_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["ciphertextValidityProofInstructionOffset"],
+                json!(val_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["rangeProofInstructionOffset"],
+                json!(rng_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // The Instructions Sysvar is only pushed into the account list if
+            // the program needs to read proof data directly from the instruction
+            // payload.
+            if eq_offset != 0 || val_offset != 0 || rng_offset != 0 {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            }
+
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if val_offset == 0 {
+                assert_eq!(
+                    parsed.info["ciphertextValidityProofContextStateAccount"],
+                    json!(validity_ctx.to_string()),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("ciphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Val Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            }
         }
     }
 
     #[test]
     fn test_transfer_with_fee() {
+        let source = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let equality_ctx = Pubkey::new_unique();
+        let transfer_val_ctx = Pubkey::new_unique();
+        let fee_sigma_ctx = Pubkey::new_unique();
+        let fee_val_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+        let offset_transfer_val = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+        let offset_fee_sigma = ProofLocation::InstructionOffset(
+            NonZero::new(3).unwrap(),
+            &PercentageWithCapProofData::zeroed(),
+        );
+        let offset_fee_val = ProofLocation::InstructionOffset(
+            NonZero::new(4).unwrap(),
+            &BatchedGroupedCiphertext2HandlesValidityProofData::zeroed(),
+        );
+        let offset_rng = ProofLocation::InstructionOffset(
+            NonZero::new(5).unwrap(),
+            &BatchedRangeProofU256Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_transfer_val = ProofLocation::ContextStateAccount(&transfer_val_ctx);
+        let context_fee_sigma = ProofLocation::ContextStateAccount(&fee_sigma_ctx);
+        let context_fee_val = ProofLocation::ContextStateAccount(&fee_val_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        // We test exhaustive combinations to ensure the parser's offset logic holds.
+        // Legend:
+        // 'C' = Context State Account (Proof is in a separate account)
+        // 'I' = Instruction Offset (Proof is bundled in the instruction data payload)
+        // Array of cases: (Test Name, Eq, TransferVal, FeeSigma, FeeVal, Rng,
+        // EqOffset, TransferValOffset, FeeSigmaOffset, FeeValOffset, RngOffset)
+        let cases = vec![
+            (
+                "All Contexts",
+                context_eq,
+                context_transfer_val,
+                context_fee_sigma,
+                context_fee_val,
+                context_rng,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ),
+            (
+                "All Offsets",
+                offset_eq,
+                offset_transfer_val,
+                offset_fee_sigma,
+                offset_fee_val,
+                offset_rng,
+                1,
+                2,
+                3,
+                4,
+                5,
+            ),
+            (
+                "Mixed C-I-C-I-C",
+                context_eq,
+                offset_transfer_val,
+                context_fee_sigma,
+                offset_fee_val,
+                context_rng,
+                0,
+                2,
+                0,
+                4,
+                0,
+            ),
+            (
+                "Mixed I-C-I-C-I",
+                offset_eq,
+                context_transfer_val,
+                offset_fee_sigma,
+                context_fee_val,
+                offset_rng,
+                1,
+                0,
+                3,
+                0,
+                5,
+            ),
+        ];
+
         for (
-            equality_proof_location,
-            transfer_amount_ciphertext_validity_proof_location,
-            fee_sigma_proof_location,
-            fee_ciphertext_validity_proof_location,
-            range_proof_location,
-        ) in [
-            (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &PercentageWithCapProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(4).unwrap(),
-                    &BatchedGroupedCiphertext2HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(5).unwrap(),
-                    &BatchedRangeProofU256Data::zeroed(),
-                ),
-            ),
-            (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-            ),
-        ] {
+            name,
+            eq,
+            transfer_val,
+            fee_sigma,
+            fee_val,
+            rng,
+            eq_offset,
+            transfer_val_offset,
+            fee_sigma_offset,
+            fee_val_offset,
+            rng_offset,
+        ) in cases
+        {
             let instruction = inner_transfer_with_fee(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &source,
+                &mint,
+                &destination,
                 &PodAeCiphertext::default(),
                 &PodElGamalCiphertext::default(),
                 &PodElGamalCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                transfer_amount_ciphertext_validity_proof_location,
-                fee_sigma_proof_location,
-                fee_ciphertext_validity_proof_location,
-                range_proof_location,
+                eq,
+                transfer_val,
+                fee_sigma,
+                fee_val,
+                rng,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            assert_eq!(
+                parsed.instruction_type, "confidentialTransferWithFee",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["source"],
+                json!(source.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["destination"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["owner"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["equalityProofInstructionOffset"],
+                json!(eq_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["transferAmountCiphertextValidityProofInstructionOffset"],
+                json!(transfer_val_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["feeSigmaProofInstructionOffset"],
+                json!(fee_sigma_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["feeCiphertextValidityProofInstructionOffset"],
+                json!(fee_val_offset),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["rangeProofInstructionOffset"],
+                json!(rng_offset),
+                "Failed on: {}",
+                name
+            );
+
+            // Sysvar Assertion: Only present if at least one proof relies on an
+            // instruction offset
+            if eq_offset != 0
+                || transfer_val_offset != 0
+                || fee_sigma_offset != 0
+                || fee_val_offset != 0
+                || rng_offset != 0
+            {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+            }
+
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Eq Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if transfer_val_offset == 0 {
+                assert_eq!(
+                    parsed.info["transferAmountCiphertextValidityProofContextStateAccount"],
+                    json!(transfer_val_ctx.to_string()),
+                    "Transfer Val Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("transferAmountCiphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Transfer Val Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if fee_sigma_offset == 0 {
+                assert_eq!(
+                    parsed.info["feeSigmaProofContextStateAccount"],
+                    json!(fee_sigma_ctx.to_string()),
+                    "Fee Sigma Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("feeSigmaProofContextStateAccount")
+                        .is_none(),
+                    "Fee Sigma Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if fee_val_offset == 0 {
+                assert_eq!(
+                    parsed.info["feeCiphertextValidityProofContextStateAccount"],
+                    json!(fee_val_ctx.to_string()),
+                    "Fee Val Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("feeCiphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Fee Val Context mismatch on: {}",
+                    name
+                );
+            }
+
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Rng Context mismatch on: {}",
+                    name
+                );
+            }
         }
     }
 }

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -663,70 +663,59 @@ mod test {
 
             assert_eq!(
                 parsed.instruction_type, "configureConfidentialTransferAccount",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["account"],
                 json!(token_account.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["decryptableZeroBalance"],
-                json!(format!("{}", decryptable_zero_balance)),
-                "Failed on: {}",
-                name
+                json!(format!("{decryptable_zero_balance}")),
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["maximumPendingBalanceCreditCounter"],
                 json!(maximum_pending_balance_credit_counter),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["proofInstructionOffset"],
                 json!(expected_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             if expected_offset == 0 {
                 assert_eq!(
                     parsed.info["proofContextStateAccount"],
                     json!(proof_ctx.to_string()),
-                    "Proof Context mismatch on: {}",
-                    name
+                    "Proof Context mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar should not be present on: {}",
-                    name
+                    "Sysvar should not be present on: {name}",
                 );
             } else {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("proofContextStateAccount").is_none(),
-                    "Proof Context should not be present on: {}",
-                    name
+                    "Proof Context should not be present on: {name}",
                 );
             }
         }
@@ -774,53 +763,45 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "emptyConfidentialTransferAccount",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["account"],
                 json!(token_account.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Expected Offset
             assert_eq!(
                 parsed.info["proofInstructionOffset"],
                 json!(expected_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             if expected_offset == 0 {
                 assert_eq!(
                     parsed.info["proofContextStateAccount"],
                     json!(proof_ctx.to_string()),
-                    "Proof Context mismatch on: {}",
-                    name
+                    "Proof Context mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar should not be present on: {}",
-                    name
+                    "Sysvar should not be present on: {name}",
                 );
             } else {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("proofContextStateAccount").is_none(),
-                    "Proof Context should not be present on: {}",
-                    name
+                    "Proof Context should not be present on: {name}",
                 );
             }
         }
@@ -925,47 +906,40 @@ mod test {
 
             assert_eq!(
                 parsed.instruction_type, "withdrawConfidentialTransfer",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["account"],
                 json!(token_account.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
-            assert_eq!(parsed.info["amount"], json!(42), "Failed on: {}", name);
-            assert_eq!(parsed.info["decimals"], json!(9), "Failed on: {}", name);
+            assert_eq!(parsed.info["amount"], json!(42), "Failed on: {name}");
+            assert_eq!(parsed.info["decimals"], json!(9), "Failed on: {name}");
             assert_eq!(
                 parsed.info["newDecryptableAvailableBalance"],
                 json!(format!("{}", PodAeCiphertext::default())),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["equalityProofInstructionOffset"],
                 json!(eq_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["rangeProofInstructionOffset"],
                 json!(rng_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Sysvar Assertion: Only present if at least one proof relies on
@@ -974,14 +948,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             }
 
@@ -989,8 +961,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -998,8 +969,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             }
 
@@ -1007,14 +977,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             }
         }
@@ -1098,51 +1066,43 @@ mod test {
 
             assert_eq!(
                 parsed.instruction_type, "confidentialTransfer",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["source"],
                 json!(source.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["destination"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["equalityProofInstructionOffset"],
                 json!(eq_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["ciphertextValidityProofInstructionOffset"],
                 json!(val_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["rangeProofInstructionOffset"],
                 json!(rng_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // The Instructions Sysvar is only pushed into the account list if
@@ -1152,14 +1112,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             }
 
@@ -1167,8 +1125,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1176,8 +1133,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             }
 
@@ -1185,8 +1141,7 @@ mod test {
                 assert_eq!(
                     parsed.info["ciphertextValidityProofContextStateAccount"],
                     json!(validity_ctx.to_string()),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1194,8 +1149,7 @@ mod test {
                         .info
                         .get("ciphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Val Context mismatch on: {}",
-                    name
+                    "Val Context mismatch on: {name}",
                 );
             }
 
@@ -1203,14 +1157,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             }
         }
@@ -1360,63 +1312,53 @@ mod test {
 
             assert_eq!(
                 parsed.instruction_type, "confidentialTransferWithFee",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["source"],
                 json!(source.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["destination"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["owner"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["equalityProofInstructionOffset"],
                 json!(eq_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["transferAmountCiphertextValidityProofInstructionOffset"],
                 json!(transfer_val_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["feeSigmaProofInstructionOffset"],
                 json!(fee_sigma_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["feeCiphertextValidityProofInstructionOffset"],
                 json!(fee_val_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["rangeProofInstructionOffset"],
                 json!(rng_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Sysvar Assertion: Only present if at least one proof relies on an
@@ -1430,14 +1372,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
             }
 
@@ -1445,8 +1385,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1454,8 +1393,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Eq Context mismatch on: {}",
-                    name
+                    "Eq Context mismatch on: {name}",
                 );
             }
 
@@ -1463,8 +1401,7 @@ mod test {
                 assert_eq!(
                     parsed.info["transferAmountCiphertextValidityProofContextStateAccount"],
                     json!(transfer_val_ctx.to_string()),
-                    "Transfer Val Context mismatch on: {}",
-                    name
+                    "Transfer Val Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1472,8 +1409,7 @@ mod test {
                         .info
                         .get("transferAmountCiphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Transfer Val Context mismatch on: {}",
-                    name
+                    "Transfer Val Context mismatch on: {name}",
                 );
             }
 
@@ -1481,8 +1417,7 @@ mod test {
                 assert_eq!(
                     parsed.info["feeSigmaProofContextStateAccount"],
                     json!(fee_sigma_ctx.to_string()),
-                    "Fee Sigma Context mismatch on: {}",
-                    name
+                    "Fee Sigma Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1490,8 +1425,7 @@ mod test {
                         .info
                         .get("feeSigmaProofContextStateAccount")
                         .is_none(),
-                    "Fee Sigma Context mismatch on: {}",
-                    name
+                    "Fee Sigma Context mismatch on: {name}",
                 );
             }
 
@@ -1499,8 +1433,7 @@ mod test {
                 assert_eq!(
                     parsed.info["feeCiphertextValidityProofContextStateAccount"],
                     json!(fee_val_ctx.to_string()),
-                    "Fee Val Context mismatch on: {}",
-                    name
+                    "Fee Val Context mismatch on: {name}",
                 );
             } else {
                 assert!(
@@ -1508,8 +1441,7 @@ mod test {
                         .info
                         .get("feeCiphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Fee Val Context mismatch on: {}",
-                    name
+                    "Fee Val Context mismatch on: {name}",
                 );
             }
 
@@ -1517,14 +1449,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Rng Context mismatch on: {}",
-                    name
+                    "Rng Context mismatch on: {name}",
                 );
             }
         }

--- a/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
@@ -265,64 +265,54 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "withdrawWithheldConfidentialTransferTokensFromMint",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["feeRecipient"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["withdrawWithheldAuthority"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["newDecryptableAvailableBalance"],
-                json!(format!("{}", new_decryptable_balance)),
-                "Failed on: {}",
-                name
+                json!(format!("{new_decryptable_balance}")),
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["proofInstructionOffset"],
                 json!(expected_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             if expected_offset == 0 {
                 assert_eq!(
                     parsed.info["proofContextStateAccount"],
                     json!(proof_ctx.to_string()),
-                    "Proof Context mismatch on: {}",
-                    name
+                    "Proof Context mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar should not be present on: {}",
-                    name
+                    "Sysvar should not be present on: {name}",
                 );
             } else {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("proofContextStateAccount").is_none(),
-                    "Proof Context should not be present on: {}",
-                    name
+                    "Proof Context should not be present on: {name}",
                 );
             }
         }
@@ -377,70 +367,59 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "withdrawWithheldConfidentialTransferTokensFromAccounts",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["feeRecipient"],
                 json!(destination.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["withdrawWithheldAuthority"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["sourceAccounts"],
                 json!(vec![source_1.to_string(), source_2.to_string()]),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["newDecryptableAvailableBalance"],
-                json!(format!("{}", new_decryptable_balance)),
-                "Failed on: {}",
-                name
+                json!(format!("{new_decryptable_balance}")),
+                "Failed on: {name}",
             );
 
             assert_eq!(
                 parsed.info["proofInstructionOffset"],
                 json!(expected_offset),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             if expected_offset == 0 {
                 assert_eq!(
                     parsed.info["proofContextStateAccount"],
                     json!(proof_ctx.to_string()),
-                    "Proof Context mismatch on: {}",
-                    name
+                    "Proof Context mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Sysvar should not be present on: {}",
-                    name
+                    "Sysvar should not be present on: {name}",
                 );
             } else {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Sysvar mismatch on: {}",
-                    name
+                    "Sysvar mismatch on: {name}",
                 );
                 assert!(
                     parsed.info.get("proofContextStateAccount").is_none(),
-                    "Proof Context should not be present on: {}",
-                    name
+                    "Proof Context should not be present on: {name}",
                 );
             }
         }

--- a/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
@@ -48,29 +48,22 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
                 "newDecryptableAvailableBalance": format!("{}", withdraw_withheld_data.new_decryptable_available_balance),
             });
             let map = value.as_object_mut().unwrap();
-            let offset = if proof_instruction_offset == 0 {
-                map.insert(
-                    "proofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
-                );
-                3
-            } else {
-                map.insert(
-                    "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
-                );
-                // Assume that the extra account is a proof account and not a multisig
-                // signer. This might be wrong, but it's the best possible option.
-                if account_indexes.len() > 4 {
+            let mut offset = 2;
+            if offset < account_indexes.len().saturating_sub(1) {
+                if proof_instruction_offset == 0 {
                     map.insert(
-                        "recordAccount".to_string(),
-                        json!(account_keys[account_indexes[3] as usize].to_string()),
+                        "proofContextStateAccount".to_string(),
+                        json!(account_keys[account_indexes[offset] as usize].to_string()),
                     );
-                    4
                 } else {
-                    3
+                    map.insert(
+                        "instructionsSysvar".to_string(),
+                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    );
                 }
-            };
+                offset += 1;
+            }
+
             parse_signers(
                 map,
                 offset,
@@ -102,29 +95,17 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
             let first_source_account_index = account_indexes
                 .len()
                 .saturating_sub(num_token_accounts as usize);
-            let offset = if proof_instruction_offset == 0 {
+            if proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[2] as usize].to_string()),
                 );
-                3
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[2] as usize].to_string()),
                 );
-                if first_source_account_index > 4 {
-                    // Assume that the extra account is a proof account and not a multisig
-                    // signer. This might be wrong, but it's the best possible option.
-                    map.insert(
-                        "proofAccount".to_string(),
-                        json!(account_keys[account_indexes[3] as usize].to_string()),
-                    );
-                    4
-                } else {
-                    3
-                }
-            };
+            }
             let mut source_accounts: Vec<String> = vec![];
             for i in account_indexes[first_source_account_index..].iter() {
                 source_accounts.push(account_keys[*i as usize].to_string());
@@ -132,7 +113,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
             map.insert("sourceAccounts".to_string(), json!(source_accounts));
             parse_signers(
                 map,
-                offset,
+                3,
                 account_keys,
                 &account_indexes[..first_source_account_index],
                 "withdrawWithheldAuthority",
@@ -212,6 +193,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
+        solana_sdk_ids::sysvar,
         solana_zk_sdk_pod::encryption::auth_encryption::PodAeCiphertext,
         spl_token_2022_interface::{
             extension::confidential_transfer_fee::instruction::{
@@ -238,49 +220,229 @@ mod test {
     }
 
     #[test]
-    fn test_withdraw_from_accounts() {
-        for location in [
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                &CiphertextCiphertextEqualityProofData::zeroed(),
-            ),
-            ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-        ] {
-            let instruction = inner_withdraw_withheld_tokens_from_accounts(
+    fn test_withdraw_from_mint() {
+        let mint = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let proof_ctx = Pubkey::new_unique();
+
+        let new_decryptable_balance = PodAeCiphertext::default();
+
+        let offset_proof = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCiphertextEqualityProofData::zeroed(),
+        );
+
+        let context_proof = ProofLocation::ContextStateAccount(&proof_ctx);
+
+        // Array of cases: (Test Name, Proof Location, Expected Offset)
+        let cases = vec![
+            ("Context State Account", context_proof, 0),
+            ("Instruction Offset", offset_proof, 1),
+        ];
+
+        for (name, proof_location, expected_offset) in cases {
+            let instruction = inner_withdraw_withheld_tokens_from_mint(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &PodAeCiphertext::default(),
-                &Pubkey::new_unique(),
+                &mint,
+                &destination,
+                &new_decryptable_balance,
+                &authority,
                 &[],
-                &[&Pubkey::new_unique(), &Pubkey::new_unique()],
-                location,
+                proof_location,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "withdrawWithheldConfidentialTransferTokensFromMint",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["feeRecipient"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["withdrawWithheldAuthority"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["newDecryptableAvailableBalance"],
+                json!(format!("{}", new_decryptable_balance)),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["proofInstructionOffset"],
+                json!(expected_offset),
+                "Failed on: {}",
+                name
+            );
+
+            if expected_offset == 0 {
+                assert_eq!(
+                    parsed.info["proofContextStateAccount"],
+                    json!(proof_ctx.to_string()),
+                    "Proof Context mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar should not be present on: {}",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("proofContextStateAccount").is_none(),
+                    "Proof Context should not be present on: {}",
+                    name
+                );
+            }
         }
     }
 
     #[test]
-    fn test_withdraw_from_mint() {
-        for location in [
-            ProofLocation::InstructionOffset(
-                NonZero::new(1).unwrap(),
-                &CiphertextCiphertextEqualityProofData::zeroed(),
-            ),
-            ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-        ] {
-            let instruction = inner_withdraw_withheld_tokens_from_mint(
+    fn test_withdraw_from_accounts() {
+        let mint = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let source_1 = Pubkey::new_unique();
+        let source_2 = Pubkey::new_unique();
+        let proof_ctx = Pubkey::new_unique();
+
+        let new_decryptable_balance = PodAeCiphertext::default();
+
+        let offset_proof = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCiphertextEqualityProofData::zeroed(),
+        );
+
+        let context_proof = ProofLocation::ContextStateAccount(&proof_ctx);
+
+        // Array of cases: (Test Name, Proof Location, Expected Offset)
+        let cases = vec![
+            ("Context State Account", context_proof, 0),
+            ("Instruction Offset", offset_proof, 1),
+        ];
+
+        for (name, proof_location, expected_offset) in cases {
+            let instruction = inner_withdraw_withheld_tokens_from_accounts(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &PodAeCiphertext::default(),
-                &Pubkey::new_unique(),
+                &mint,
+                &destination,
+                &new_decryptable_balance,
+                &authority,
                 &[],
-                location,
+                &[&source_1, &source_2],
+                proof_location,
             )
             .unwrap();
-            check_no_panic(instruction);
+
+            check_no_panic(instruction.clone());
+
+            let message = Message::new(&[instruction], None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "withdrawWithheldConfidentialTransferTokensFromAccounts",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["feeRecipient"],
+                json!(destination.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["withdrawWithheldAuthority"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["sourceAccounts"],
+                json!(vec![source_1.to_string(), source_2.to_string()]),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["newDecryptableAvailableBalance"],
+                json!(format!("{}", new_decryptable_balance)),
+                "Failed on: {}",
+                name
+            );
+
+            assert_eq!(
+                parsed.info["proofInstructionOffset"],
+                json!(expected_offset),
+                "Failed on: {}",
+                name
+            );
+
+            if expected_offset == 0 {
+                assert_eq!(
+                    parsed.info["proofContextStateAccount"],
+                    json!(proof_ctx.to_string()),
+                    "Proof Context mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Sysvar should not be present on: {}",
+                    name
+                );
+            } else {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Sysvar mismatch on: {}",
+                    name
+                );
+                assert!(
+                    parsed.info.get("proofContextStateAccount").is_none(),
+                    "Proof Context should not be present on: {}",
+                    name
+                );
+            }
         }
     }
 }

--- a/transaction-status/src/parse_token/extension/permissioned_burn.rs
+++ b/transaction-status/src/parse_token/extension/permissioned_burn.rs
@@ -106,60 +106,58 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             // trailing accounts; everything between the mint and them is optional
             // proof material. Reserve those two when walking the proof accounts.
             let mut offset = 2;
-            if offset < account_indexes.len() - 2
-                && (burn_data.equality_proof_instruction_offset != 0
-                    || burn_data.ciphertext_validity_proof_instruction_offset != 0
-                    || burn_data.range_proof_instruction_offset != 0)
-            {
+            let has_sysvar = burn_data.equality_proof_instruction_offset != 0
+                || burn_data.ciphertext_validity_proof_instruction_offset != 0
+                || burn_data.range_proof_instruction_offset != 0;
+
+            // We use `saturating_sub(2)` because the permissioned burn authority
+            // and the owner/delegate are always the trailing 2+ accounts.
+            if has_sysvar && offset < account_indexes.len().saturating_sub(2) {
                 map.insert(
                     "instructionsSysvar".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            // Assume that extra accounts are proof accounts and not multisig
-            // signers. This might be wrong, but it's the best possible option.
-            if offset < account_indexes.len() - 2 {
-                let label = if burn_data.equality_proof_instruction_offset == 0 {
-                    "equalityProofContextStateAccount"
-                } else {
-                    "equalityProofRecordAccount"
-                };
+
+            if burn_data.equality_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(2)
+            {
                 map.insert(
-                    label.to_string(),
+                    "equalityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 2 {
-                let label = if burn_data.ciphertext_validity_proof_instruction_offset == 0 {
-                    "ciphertextValidityProofContextStateAccount"
-                } else {
-                    "ciphertextValidityProofRecordAccount"
-                };
+
+            if burn_data.ciphertext_validity_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(2)
+            {
                 map.insert(
-                    label.to_string(),
+                    "ciphertextValidityProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            if offset < account_indexes.len() - 2 {
-                let label = if burn_data.range_proof_instruction_offset == 0 {
-                    "rangeProofContextStateAccount"
-                } else {
-                    "rangeProofRecordAccount"
-                };
+
+            if burn_data.range_proof_instruction_offset == 0
+                && offset < account_indexes.len().saturating_sub(2)
+            {
                 map.insert(
-                    label.to_string(),
+                    "rangeProofContextStateAccount".to_string(),
                     json!(account_keys[account_indexes[offset] as usize].to_string()),
                 );
                 offset += 1;
             }
-            map.insert(
-                "permissionedBurnAuthority".to_string(),
-                json!(account_keys[account_indexes[offset] as usize].to_string()),
-            );
-            offset += 1;
+
+            if offset < account_indexes.len().saturating_sub(1) {
+                map.insert(
+                    "permissionedBurnAuthority".to_string(),
+                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                );
+                offset += 1;
+            }
+
             parse_signers(
                 map,
                 offset,
@@ -184,6 +182,7 @@ mod test {
         solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
+        solana_sdk_ids::sysvar,
         solana_zk_sdk_pod::encryption::{
             auth_encryption::PodAeCiphertext, elgamal::PodElGamalCiphertext,
         },
@@ -275,43 +274,168 @@ mod test {
 
     #[test]
     fn test_parse_permissioned_confidential_burn_instruction() {
-        for (equality_proof_location, ciphertext_validity_proof_location, range_proof_location) in [
+        let account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let permissioned_burn_authority = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+
+        let equality_ctx = Pubkey::new_unique();
+        let validity_ctx = Pubkey::new_unique();
+        let range_ctx = Pubkey::new_unique();
+
+        let offset_eq = ProofLocation::InstructionOffset(
+            NonZero::new(1).unwrap(),
+            &CiphertextCommitmentEqualityProofData::zeroed(),
+        );
+        let offset_val = ProofLocation::InstructionOffset(
+            NonZero::new(2).unwrap(),
+            &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+        );
+        let offset_rng = ProofLocation::InstructionOffset(
+            NonZero::new(3).unwrap(),
+            &BatchedRangeProofU128Data::zeroed(),
+        );
+
+        let context_eq = ProofLocation::ContextStateAccount(&equality_ctx);
+        let context_val = ProofLocation::ContextStateAccount(&validity_ctx);
+        let context_rng = ProofLocation::ContextStateAccount(&range_ctx);
+
+        let cases = vec![
             (
-                ProofLocation::InstructionOffset(
-                    NonZero::new(1).unwrap(),
-                    &CiphertextCommitmentEqualityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(2).unwrap(),
-                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
-                ),
-                ProofLocation::InstructionOffset(
-                    NonZero::new(3).unwrap(),
-                    &BatchedRangeProofU128Data::zeroed(),
-                ),
+                "All Contexts",
+                context_eq,
+                context_val,
+                context_rng,
+                0,
+                0,
+                0,
             ),
-            (
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
-            ),
-        ] {
+            ("All Offsets", offset_eq, offset_val, offset_rng, 1, 2, 3),
+        ];
+
+        for (name, eq, val, rng, eq_offset, val_offset, rng_offset) in cases {
             let instructions = confidential_burn_with_split_proofs(
                 &spl_token_2022_interface::id(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
+                &account,
+                &mint,
+                &permissioned_burn_authority,
                 &PodAeCiphertext::default(),
                 &PodElGamalCiphertext::default(),
                 &PodElGamalCiphertext::default(),
-                &Pubkey::new_unique(),
+                &authority,
                 &[],
-                equality_proof_location,
-                ciphertext_validity_proof_location,
-                range_proof_location,
+                eq,
+                val,
+                rng,
             )
             .unwrap();
+
             check_no_panic(instructions[0].clone());
+
+            let message = Message::new(&instructions, None);
+            let parsed = parse_token(
+                &message.instructions[0],
+                &AccountKeys::new(&message.account_keys, None),
+            )
+            .unwrap();
+
+            // Core Property Assertions
+            assert_eq!(
+                parsed.instruction_type, "permissionedConfidentialBurn",
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["account"],
+                json!(account.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["mint"],
+                json!(mint.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["permissionedBurnAuthority"],
+                json!(permissioned_burn_authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+            assert_eq!(
+                parsed.info["authority"],
+                json!(authority.to_string()),
+                "Failed on: {}",
+                name
+            );
+
+            // Conditional Proof Context / Sysvar Assertions
+            if eq_offset != 0 || val_offset != 0 || rng_offset != 0 {
+                assert_eq!(
+                    parsed.info["instructionsSysvar"],
+                    json!(sysvar::instructions::id().to_string()),
+                    "Failed on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("instructionsSysvar").is_none(),
+                    "Failed on: {}",
+                    name
+                );
+            }
+
+            if eq_offset == 0 {
+                assert_eq!(
+                    parsed.info["equalityProofContextStateAccount"],
+                    json!(equality_ctx.to_string()),
+                    "Failed on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("equalityProofContextStateAccount")
+                        .is_none(),
+                    "Failed on: {}",
+                    name
+                );
+            }
+
+            if val_offset == 0 {
+                assert_eq!(
+                    parsed.info["ciphertextValidityProofContextStateAccount"],
+                    json!(validity_ctx.to_string()),
+                    "Failed on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed
+                        .info
+                        .get("ciphertextValidityProofContextStateAccount")
+                        .is_none(),
+                    "Failed on: {}",
+                    name
+                );
+            }
+
+            if rng_offset == 0 {
+                assert_eq!(
+                    parsed.info["rangeProofContextStateAccount"],
+                    json!(range_ctx.to_string()),
+                    "Failed on: {}",
+                    name
+                );
+            } else {
+                assert!(
+                    parsed.info.get("rangeProofContextStateAccount").is_none(),
+                    "Failed on: {}",
+                    name
+                );
+            }
         }
     }
 }

--- a/transaction-status/src/parse_token/extension/permissioned_burn.rs
+++ b/transaction-status/src/parse_token/extension/permissioned_burn.rs
@@ -342,32 +342,27 @@ mod test {
             // Core Property Assertions
             assert_eq!(
                 parsed.instruction_type, "permissionedConfidentialBurn",
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["account"],
                 json!(account.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["mint"],
                 json!(mint.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["permissionedBurnAuthority"],
                 json!(permissioned_burn_authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
             assert_eq!(
                 parsed.info["authority"],
                 json!(authority.to_string()),
-                "Failed on: {}",
-                name
+                "Failed on: {name}",
             );
 
             // Conditional Proof Context / Sysvar Assertions
@@ -375,14 +370,12 @@ mod test {
                 assert_eq!(
                     parsed.info["instructionsSysvar"],
                     json!(sysvar::instructions::id().to_string()),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("instructionsSysvar").is_none(),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             }
 
@@ -390,8 +383,7 @@ mod test {
                 assert_eq!(
                     parsed.info["equalityProofContextStateAccount"],
                     json!(equality_ctx.to_string()),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             } else {
                 assert!(
@@ -399,8 +391,7 @@ mod test {
                         .info
                         .get("equalityProofContextStateAccount")
                         .is_none(),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             }
 
@@ -408,8 +399,7 @@ mod test {
                 assert_eq!(
                     parsed.info["ciphertextValidityProofContextStateAccount"],
                     json!(validity_ctx.to_string()),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             } else {
                 assert!(
@@ -417,8 +407,7 @@ mod test {
                         .info
                         .get("ciphertextValidityProofContextStateAccount")
                         .is_none(),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             }
 
@@ -426,14 +415,12 @@ mod test {
                 assert_eq!(
                     parsed.info["rangeProofContextStateAccount"],
                     json!(range_ctx.to_string()),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             } else {
                 assert!(
                     parsed.info.get("rangeProofContextStateAccount").is_none(),
-                    "Failed on: {}",
-                    name
+                    "Failed on: {name}",
                 );
             }
         }


### PR DESCRIPTION
#### Problem

The JSON parser for Token-2022 confidential transfers currently uses a simplification that assumes non-zero proof instruction offsets require a "record account" to be present in the instruction's account array. When mixing in-transaction proofs with pre-verified context-state proofs, this causes the parser to incorrectly consume and mislabel valid accounts (e.g., mislabeling a `rangeProofContextStateAccount` as an `equalityProofRecordAccount`). However, as noted in https://github.com/anza-xyz/agave/pull/13149#pullrequestreview-4481354803 (see "Non-blocking suggestion"), it is possible to precisely account for mixed proofs.

#### Summary of Changes

Implemented deterministic account mapping that strictly matches the `spl-token-2022` instruction builders: the `instructionsSysvar` is mapped if any offset is non-zero, and context-state accounts are only mapped if their specific offset is exactly `0`. I also updated the unit tests to test for different combination of proof accounts.

The line changes are long, but most of them are simple repetitive unit test changes.

