### PR TITLE
Fix - Discard duplicates in `prepare_program_cache_for_upcoming_feature_set()`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -381,15 +381,15 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         self.fork_graph = Some(fork_graph);
     }
 
-    /// Insert a single entry. It's typically called during transaction loading,
-    /// when the cache doesn't contain the entry corresponding to program `key`.
-    pub fn assign_program(
-        &mut self,
+    /// Finds the spot a program belongs in for assign_program().
+    ///
+    /// Can also be used to check if an exact match already exists.
+    pub fn get_insertion_point(
+        &self,
         program_runtime_environment: &ProgramRuntimeEnvironment,
         key: Pubkey,
-        _last_modification_slot: Slot,
-        entry: Arc<ProgramCacheEntry>,
-    ) -> bool {
+        entry: &Arc<ProgramCacheEntry>,
+    ) -> Result<usize, usize> {
         debug_assert!(!matches!(
             &entry.program,
             ProgramCacheEntryType::DelayVisibility
@@ -405,10 +405,13 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 .map(|env| env == program_runtime_environment)
                 .unwrap_or(true)
         }
-        match &mut self.index {
+        match &self.index {
             IndexImplementation::V1 { entries, .. } => {
-                let slot_versions = &mut entries.entry(key).or_default();
-                let insertion_point = slot_versions.binary_search_by(|at| {
+                let slot_versions = entries
+                    .get(&key)
+                    .map(|vec| vec.as_slice())
+                    .unwrap_or_default();
+                slot_versions.binary_search_by(|at| {
                     at.effective_slot
                         .cmp(&entry.effective_slot)
                         .then(at.deployment_slot.cmp(&entry.deployment_slot))
@@ -426,7 +429,24 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 entry.program.get_environment(),
                             )),
                         )
-                });
+                })
+            }
+        }
+    }
+
+    /// Insert a single entry. It's typically called during transaction loading,
+    /// when the cache doesn't contain the entry corresponding to program `key`.
+    pub fn assign_program(
+        &mut self,
+        program_runtime_environment: &ProgramRuntimeEnvironment,
+        key: Pubkey,
+        _last_modification_slot: Slot,
+        entry: Arc<ProgramCacheEntry>,
+    ) -> bool {
+        let insertion_point = self.get_insertion_point(program_runtime_environment, key, &entry);
+        match &mut self.index {
+            IndexImplementation::V1 { entries, .. } => {
+                let slot_versions = &mut entries.entry(key).or_default();
                 match insertion_point {
                     Ok(index) => {
                         let existing = slot_versions.get_mut(index).unwrap();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1612,12 +1612,17 @@ impl Bank {
                         .global_program_cache
                         .write()
                         .unwrap();
-                    program_cache.assign_program(
-                        &upcoming_environment,
-                        key,
-                        last_modification_slot,
-                        recompiled,
-                    );
+                    if program_cache
+                        .get_insertion_point(&upcoming_environment, key, &recompiled)
+                        .is_err()
+                    {
+                        program_cache.assign_program(
+                            &upcoming_environment,
+                            key,
+                            last_modification_slot,
+                            recompiled,
+                        );
+                    }
                 }
             }
         } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {


### PR DESCRIPTION
#### Problem

After the epoch boundary TX batches can race with the rest of the preparation queue and both compile the same programs.

Fixes https://discord.com/channels/428295358100013066/439194979856809985/1514923799101968416

Alternative patch to #13203.

#### Summary of Changes

- Splits `ProgramCache::get_insertion_point()` off from `ProgramCache::assign_program()`.
- Prefilters entries in `Bank::prepare_program_cache_for_upcoming_feature_set()` before calling `ProgramCache::assign_program(`). 