### PR TITLE
Add camelCase rewrite on data structures in getAgGenesisCert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9982,6 +9982,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
+ "solana-bls-signatures",
  "solana-cli-output",
  "solana-client",
  "solana-clock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10008,6 +10008,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
+ "solana-bls-signatures",
  "solana-cli-output",
  "solana-client",
  "solana-clock",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -108,6 +108,7 @@ wincode = { workspace = true }
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 serial_test = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -113,6 +113,7 @@ agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-address-lookup-table-interface = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-client = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-compute-budget-interface = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5221,6 +5221,43 @@ pub mod tests {
     }
 
     #[test]
+    fn test_rpc_get_ag_genesis_cert() {
+        use {
+            agave_votor_messages::{
+                certificate::{Certificate, CertificateType},
+                consensus_message::Block,
+            },
+            solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        };
+
+        let rpc = RpcHandler::start();
+        // Seed the bank with a genesis certificate for the RPC to return.
+        rpc.working_bank()
+            .set_alpenglow_genesis_certificate(&Certificate {
+                cert_type: CertificateType::Genesis(Block {
+                    slot: 0,
+                    block_id: Hash::default(),
+                }),
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![1, 2, 3],
+            });
+
+        let request = create_test_request("getAgGenesisCert", None);
+        let result: Value = parse_success_result(rpc.handle_request_sync(request));
+        let expected = json!({
+            "certType": {
+                "genesis": {
+                    "slot": 0,
+                    "blockId": vec![0u8; 32],
+                }
+            },
+            "signature": vec![0u8; BLS_SIGNATURE_AFFINE_SIZE],
+            "bitmap": [1, 2, 3],
+        });
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_rpc_get_cluster_nodes() {
         let rpc = RpcHandler::start();
         let version = solana_version::Version::default();

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5239,6 +5239,45 @@ pub mod tests {
     }
 
     #[test]
+    fn test_rpc_get_ag_genesis_cert() {
+        use {
+            agave_votor_messages::{
+                certificate::{CertSignature, GenesisCert},
+                consensus_message::Block,
+            },
+            solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        };
+
+        let rpc = RpcHandler::start();
+        // Seed the bank with a genesis certificate for the RPC to return.
+        rpc.working_bank()
+            .set_alpenglow_genesis_certificate(&GenesisCert {
+                block: Block {
+                    slot: 0,
+                    block_id: Hash::default(),
+                },
+                signature: CertSignature {
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                    bitmap: vec![1, 2, 3],
+                },
+            });
+
+        let request = create_test_request("getAgGenesisCert", None);
+        let result: Value = parse_success_result(rpc.handle_request_sync(request));
+        let expected = json!({
+            "block": {
+                "slot": 0,
+                "blockId": vec![0u8; 32],
+            },
+            "signature": {
+                "signature": vec![0u8; BLS_SIGNATURE_AFFINE_SIZE],
+                "bitmap": [1, 2, 3],
+            },
+        });
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_rpc_get_cluster_nodes() {
         let rpc = RpcHandler::start();
         let version = solana_version::Version::default();

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -23,6 +23,7 @@ pod_wrapper! {
 /// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
 /// BLS vote message, we need rank to look up pubkey
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[serde(rename_all = "camelCase")]
 pub struct Certificate {
     /// The certificate type.
     pub cert_type: CertificateType,
@@ -49,6 +50,7 @@ pub struct Certificate {
     SchemaWrite,
     SchemaRead,
 )]
+#[serde(rename_all = "camelCase")]
 pub enum CertificateType {
     /// Finalize certificate
     Finalize(Slot),

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -43,6 +43,7 @@ fn sample_hash(rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized)) -> Ha
     SchemaWrite,
     SchemaRead,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct Block {
     /// The slot in the block.
     pub slot: Slot,

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -44,6 +44,7 @@ fn sample_hash(rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized)) -> Ha
     SchemaWrite,
     SchemaRead,
 )]
+#[serde(rename_all = "camelCase")]
 pub struct Block {
     /// The slot in the block.
     pub slot: Slot,

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -113,6 +113,7 @@ pub(crate) struct WireSlotVoteMessage {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 /// Signature on a wire cert message
 pub struct WireCertSignature {
     #[cfg_attr(
@@ -147,6 +148,7 @@ pub(crate) struct WireSlotCertMessage {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 /// A wire cert message that holds a block.
 pub struct WireBlockCertMessage {
     /// the block the cert is certifying.
@@ -346,7 +348,7 @@ impl WireConsensusMessageV1 {
         SchemaRead
     ),
     frozen_abi(
-        digest = "DjdpNzNd3eQ569wuRQq7cKAsj791nkjbbhcqWa7TQeKj",
+        digest = "BuNdLfQfseGa7sL29neSwUYqrWo1AVRyTYxMGxLATzia",
         abi_digest = "ErGjoTr18hn3dvPVA7jFgK5WLwb4jgx7a39Yn8dSzB2K",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",
@@ -435,7 +437,7 @@ impl VersionedWireConsensusMessage {
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize),
     frozen_abi(
-        digest = "AKMt6bqYRf1xh7tWg4eAgG7jNN1qtUvNVPb5XZn9vjtV",
+        digest = "FaLMAAzQUX8FfCZhUqETKB1xdBwQuC3pwz2mEaC6t3Gb",
         abi_digest = "2aBMTuPyDgGSYeYX1aBbXURgA4qqr92Eh9yiTeHX6qZq",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire",


### PR DESCRIPTION
#### Problem

The new RPC method `getAgGenesisCert` exposes `Block`, `WireCertSignature` and `WireBlockCertMessage` as RPC responses.

These did not have the `#[serde(rename_all = "camelCase")]` macro, so they returned their fields from the RPC as snake case.

#### Summary of Changes

- Add the `camelCase` macro to these types in `votor-messages`. Note that some don't need it because their fields are currently all single word, but they're exposed to RPC so I've added it. 
- Update affected ABIs

#### Testing

- Unit test for the RPC result including field `blockId`
