### PR TITLE
Do not read account data from disk in update_index_for_shrink()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5320,11 +5320,10 @@ impl AccountsDb {
             (start..end).for_each(|i| {
                 let info: AccountInfo = infos[i];
                 debug_assert!(!info.is_cached());
-                accounts.account(i, |account| {
-                    let old_slot = accounts.slot(i);
-                    self.accounts_index
-                        .replace(target_slot, old_slot, account.pubkey(), info);
-                });
+                let old_slot = accounts.slot(i);
+                let pubkey = accounts.pubkey(i);
+                self.accounts_index
+                    .replace(target_slot, old_slot, pubkey, info);
             });
         };
 


### PR DESCRIPTION
#### Problem

When shrinking a storage, we must update the index. That is handled by `update_index_for_shrink()`. The current implementation is reading all the accounts from disk unnecessarily.


#### Summary of Changes

Switch the fns being called to not read the account from disk 🙃 


#### Testing

Slowlana'd it:

Before. Here's update_index_for_shrink(), and showing the file io to read the account:

<img width="2635" height="1193" alt="Screenshot 2026-06-12 at 11 26 19 AM" src="https://github.com/user-attachments/assets/3e14a4ff-d35e-4606-b79a-2b9c378ebf1b" />


After. Here's update_index_for_shrink() again, and showing the file io is gone:

<img width="3095" height="1795" alt="Screenshot 2026-06-12 at 11 33 39 AM" src="https://github.com/user-attachments/assets/87b84e1d-f0bd-40a8-8bd7-92e959976442" />


And here's the metrics:

Left of the white line is master. Right of the white line is this PR. The time spent updating the index for shrink decreases with this PR since we are not reading from disk.

<img width="925" height="449" alt="Screenshot 2026-06-12 at 11 35 27 AM" src="https://github.com/user-attachments/assets/5f140113-a3f0-45c5-9aae-9f64f5561305" />
