### PR TITLE
Avoid calling StorableAccounts::account() in update_index_stored_accounts()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5227,22 +5227,28 @@ impl AccountsDb {
             (start..end).for_each(|i| {
                 let info: AccountInfo = infos[i];
                 debug_assert!(!info.is_cached());
-                accounts.account(i, |account| {
-                    let old_slot = accounts.slot(i);
-                    self.accounts_index.upsert(
-                        target_slot,
-                        old_slot,
-                        account.pubkey(),
-                        info,
-                        &mut reclaims,
-                        reclaim,
-                    );
-                    self.accounts_index.update_secondary_indexes(
-                        account.pubkey(),
-                        &account,
-                        &self.account_indexes,
-                    );
-                });
+                let old_slot = accounts.slot(i);
+                let pubkey = accounts.pubkey(i);
+                self.accounts_index.upsert(
+                    target_slot,
+                    old_slot,
+                    pubkey,
+                    info,
+                    &mut reclaims,
+                    reclaim,
+                );
+
+                if !self.account_indexes.is_empty() {
+                    // Since StorableAccounts::account() may read the account from disk,
+                    // avoid calling it unless secondary indexes are enabled.
+                    accounts.account(i, |account| {
+                        self.accounts_index.update_secondary_indexes(
+                            pubkey,
+                            &account,
+                            &self.account_indexes,
+                        );
+                    });
+                }
             });
             reclaims
         };


### PR DESCRIPTION
#### Problem

Related to https://github.com/anza-xyz/agave/pull/13171.

`StorableAccounts::account()` gets the account at the specified index. If the accounts are in a storage on disk, this reads disk to load the account. If the accounts are `AccountSharedData`, then no disk read is required.

Inside `update_index_stored_accounts()` we call `StorableAccounts::account()` unnecessarily if secondary indexes are not enabled. Since this fn is called from `flush`, which should have `AccountSharedData`s, we should be ok. But IMO no reason to use the `account()` fn if we don't need to.


#### Summary of Changes

Avoid `StorableAccounts::account()` inside `update_index_stored_accounts()` when calling `upsert()`.


#### Testing

Nothing extra.
