### PR TITLE
Renames fn to update_index_for_flush()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5199,10 +5199,10 @@ impl AccountsDb {
     }
 
     /// Updates the accounts index with the given `infos` and `accounts`.
-    /// Used when storing accounts to storage.
+    /// Used when storing accounts to storage for flush.
     /// Returns a vector of `SlotList<AccountInfo>` containing the reclaims for each batch processed.
     /// The element of the returned vector is guaranteed to be non-empty.
-    fn update_index_stored_accounts<'a>(
+    fn update_index_for_flush<'a>(
         &self,
         infos: Vec<AccountInfo>,
         accounts: &impl StorableAccounts<'a>,
@@ -5816,7 +5816,7 @@ impl AccountsDb {
         let mark_zero_lamport_us = mark_zero_lamport_time.end_as_us();
 
         let update_index_time = Measure::start("update_index");
-        let reclaims = self.update_index_stored_accounts(
+        let reclaims = self.update_index_for_flush(
             infos,
             &accounts,
             reclaim_handling,


### PR DESCRIPTION
#### Problem

`update_index_stored_accounts()` is only called by `store_accounts_for_flush()`. And there also exists `update_index_for_shrink()`, which is only called by `store_accounts_for_shrink()`. The naming is inconsistent, and that is mildly confusing.


#### Summary of Changes

Rename the fn to `update_index_for_flush()`.


#### Testing

Nothing extra.