### PR TITLE
Give write permissions to release jobs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,8 @@ jobs:
   version-bump:
     if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/publish-windows-tarball.yml
+++ b/.github/workflows/publish-windows-tarball.yml
@@ -89,6 +89,8 @@ jobs:
     if: ${{ needs.windows-build.outputs.tag != '' }}
     needs: [windows-build]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Download
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
   draft-release:
     if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Create Release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0


### PR DESCRIPTION
#### Problem

Release jobs use default GITHUB_TOKEN for several jobs: to create version bump PRs and to create releases. These operations require the token to have `content: write`

#### Summary of Changes

Provide `content: write` permissions to jobs that need it.

#### Testing

Fixes #

Release workflows after defaults being changed.