### PR TITLE
Wakes up read cache evictor every 10 millis

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6131,11 +6131,6 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "read_only_accounts_cache_evictor_wakeup_count_all",
-                    read_cache_stats.evictor_wakeup_count_all,
-                    i64
-                ),
-                (
                     "read_only_accounts_cache_evictor_wakeup_count_productive",
                     read_cache_stats.evictor_wakeup_count_productive,
                     i64

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6131,8 +6131,8 @@ impl AccountsDb {
                     i64
                 ),
                 (
-                    "read_only_accounts_cache_evictor_wakeup_count_productive",
-                    read_cache_stats.evictor_wakeup_count_productive,
+                    "read_only_accounts_cache_evict_run_count",
+                    read_cache_stats.evict_run_count,
                     i64
                 ),
                 (

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -57,7 +57,6 @@ pub struct ReadOnlyCacheStats {
     pub load_us: u64,
     pub store_us: u64,
     pub evict_us: u64,
-    pub evictor_wakeup_count_all: u64,
     pub evictor_wakeup_count_productive: u64,
 }
 
@@ -69,7 +68,6 @@ struct AtomicReadOnlyCacheStats {
     load_us: AtomicU64,
     store_us: AtomicU64,
     evict_us: AtomicU64,
-    evictor_wakeup_count_all: AtomicU64,
     evictor_wakeup_count_productive: AtomicU64,
 }
 
@@ -274,10 +272,6 @@ impl ReadOnlyAccountsCache {
         let load_us = self.stats.load_us.swap(0, Ordering::Relaxed);
         let store_us = self.stats.store_us.swap(0, Ordering::Relaxed);
         let evict_us = self.stats.evict_us.swap(0, Ordering::Relaxed);
-        let evictor_wakeup_count_all = self
-            .stats
-            .evictor_wakeup_count_all
-            .swap(0, Ordering::Relaxed);
         let evictor_wakeup_count_productive = self
             .stats
             .evictor_wakeup_count_productive
@@ -290,7 +284,6 @@ impl ReadOnlyAccountsCache {
             load_us,
             store_us,
             evict_us,
-            evictor_wakeup_count_all,
             evictor_wakeup_count_productive,
         }
     }
@@ -323,10 +316,6 @@ impl ReadOnlyAccountsCache {
                         break;
                     }
                     drop(exit_flag);
-
-                    stats
-                        .evictor_wakeup_count_all
-                        .fetch_add(1, Ordering::Relaxed);
 
                     if data_size.load(Ordering::Relaxed) <= max_data_size_hi {
                         continue;

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -312,12 +312,12 @@ impl ReadOnlyAccountsCache {
                 info!("AccountsReadCacheEvictor has started");
                 let mut rng = SmallRng::from_os_rng();
                 loop {
-                    // Wait up to 100 ms, or until the exit flag is set.
-                    // 100 ms is already four times per slot, which should be plenty.
+                    // Wait up to 10 ms, or until the exit flag is set.
+                    // Ensure this timeout stays many times smaller than the slot time.
                     let exit_flag = control.exit.lock().unwrap();
                     let (exit_flag, _) = control
                         .wake
-                        .wait_timeout_while(exit_flag, Duration::from_millis(100), |exit| !*exit)
+                        .wait_timeout_while(exit_flag, Duration::from_millis(10), |exit| !*exit)
                         .unwrap();
                     if *exit_flag {
                         break;

--- a/accounts-db/src/read_only_accounts_cache.rs
+++ b/accounts-db/src/read_only_accounts_cache.rs
@@ -57,7 +57,7 @@ pub struct ReadOnlyCacheStats {
     pub load_us: u64,
     pub store_us: u64,
     pub evict_us: u64,
-    pub evictor_wakeup_count_productive: u64,
+    pub evict_run_count: u64,
 }
 
 #[derive(Default, Debug)]
@@ -68,7 +68,7 @@ struct AtomicReadOnlyCacheStats {
     load_us: AtomicU64,
     store_us: AtomicU64,
     evict_us: AtomicU64,
-    evictor_wakeup_count_productive: AtomicU64,
+    evict_run_count: AtomicU64,
 }
 
 /// Shared state between the cache and its evictor thread, used to signal
@@ -272,10 +272,7 @@ impl ReadOnlyAccountsCache {
         let load_us = self.stats.load_us.swap(0, Ordering::Relaxed);
         let store_us = self.stats.store_us.swap(0, Ordering::Relaxed);
         let evict_us = self.stats.evict_us.swap(0, Ordering::Relaxed);
-        let evictor_wakeup_count_productive = self
-            .stats
-            .evictor_wakeup_count_productive
-            .swap(0, Ordering::Relaxed);
+        let evict_run_count = self.stats.evict_run_count.swap(0, Ordering::Relaxed);
 
         ReadOnlyCacheStats {
             hits,
@@ -284,7 +281,7 @@ impl ReadOnlyAccountsCache {
             load_us,
             store_us,
             evict_us,
-            evictor_wakeup_count_productive,
+            evict_run_count,
         }
     }
 
@@ -320,9 +317,7 @@ impl ReadOnlyAccountsCache {
                     if data_size.load(Ordering::Relaxed) <= max_data_size_hi {
                         continue;
                     }
-                    stats
-                        .evictor_wakeup_count_productive
-                        .fetch_add(1, Ordering::Relaxed);
+                    stats.evict_run_count.fetch_add(1, Ordering::Relaxed);
 
                     #[cfg(not(feature = "dev-context-only-utils"))]
                     let (num_evicts, evict_us) = measure_us!(Self::evict(


### PR DESCRIPTION
#### Problem

The read cache evictor may sleep too much once slots are shortened.


#### Summary of Changes

Wake up the read cache evictor every 10 millis.


#### Testing

Ran this on a dev box and confirmed no unexpected behavior.