### PR TITLE
Add trimmed version of `SlotMeta` for repairs to avoid bitvec alloc

### DIFF
--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -8,7 +8,7 @@ use {
     },
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
+    solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMetaRepair},
     std::collections::{HashMap, HashSet},
 };
 
@@ -51,7 +51,7 @@ impl Iterator for GenericTraversal<'_> {
 pub fn get_unknown_last_index(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -64,7 +64,7 @@ pub fn get_unknown_last_index(
         }
         let slot_meta = slot_meta_cache
             .entry(slot)
-            .or_insert_with(|| blockstore.meta(slot).unwrap());
+            .or_insert_with(|| blockstore.meta_repair(slot).unwrap());
         if let Some(slot_meta) = slot_meta {
             if slot_meta.last_index.is_none() {
                 let shred_index = blockstore.get_index(slot).unwrap();
@@ -97,7 +97,7 @@ pub fn get_unknown_last_index(
 fn get_unrepaired_path(
     start_slot: Slot,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
     visited: &mut HashSet<Slot>,
 ) -> Vec<Slot> {
     let mut path = Vec::new();
@@ -105,7 +105,7 @@ fn get_unrepaired_path(
     while visited.insert(slot) {
         let slot_meta = slot_meta_cache
             .entry(slot)
-            .or_insert_with(|| blockstore.meta(slot).unwrap());
+            .or_insert_with(|| blockstore.meta_repair(slot).unwrap());
         if let Some(slot_meta) = slot_meta {
             if !slot_meta.is_full() {
                 path.push(slot);
@@ -126,7 +126,7 @@ pub fn get_closest_completion(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
     root_slot: Slot,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
     processed_slots: &mut HashSet<Slot>,
     limit: usize,
     repair_eligibility: &mut RepairEligibility,
@@ -140,7 +140,7 @@ pub fn get_closest_completion(
         }
         let slot_meta = slot_meta_cache
             .entry(slot)
-            .or_insert_with(|| blockstore.meta(slot).unwrap());
+            .or_insert_with(|| blockstore.meta_repair(slot).unwrap());
         if let Some(slot_meta) = slot_meta {
             if slot_meta.is_full() {
                 continue;

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -28,8 +28,8 @@ use {
     solana_hash::Hash,
     solana_keypair::Signer,
     solana_ledger::{
-        blockstore::{Blockstore, SlotMeta},
-        blockstore_meta::BlockLocation,
+        blockstore::Blockstore,
+        blockstore_meta::{BlockLocation, SlotMetaRepair},
         shred,
     },
     solana_measure::measure::Measure,
@@ -153,7 +153,7 @@ impl RepairEligibility {
     /// highest received shred falls in an older FEC, that FEC was already
     /// timestamped; if it falls in a future FEC, resizing the vector backfills
     /// any skipped FECs with the same timestamp.
-    fn observe_slot(&mut self, slot: Slot, slot_meta: &SlotMeta) {
+    fn observe_slot(&mut self, slot: Slot, slot_meta: &SlotMetaRepair) {
         let Some(last_received_index) = slot_meta.received.checked_sub(1) else {
             // Have not observed any shreds for this slot yet.
             return;
@@ -207,7 +207,7 @@ impl RepairEligibility {
     pub(crate) fn is_highest_shred_eligible(
         &self,
         slot: Slot,
-        slot_meta: &SlotMeta,
+        slot_meta: &SlotMetaRepair,
         now_ms: u64,
     ) -> bool {
         if slot_meta.last_index.is_some() {
@@ -230,7 +230,11 @@ impl RepairEligibility {
     /// This keeps traversal tests focused on ordering and duplicate suppression
     /// without sleeping in every setup path.
     #[cfg(test)]
-    pub(crate) fn observe_slot_as_elapsed_for_tests(&mut self, slot: Slot, slot_meta: &SlotMeta) {
+    pub(crate) fn observe_slot_as_elapsed_for_tests(
+        &mut self,
+        slot: Slot,
+        slot_meta: &SlotMetaRepair,
+    ) {
         self.observe_slot(slot, slot_meta);
         if let Some(slot_repair) = self.slots.get_mut(&slot) {
             let elapsed_time = timestamp().saturating_sub(FEC_REPAIR_DELAY.as_millis() as u64);
@@ -250,7 +254,7 @@ impl RepairEligibility {
     ) -> Self {
         let mut repair_eligibility = Self::default();
         for slot in slots {
-            if let Some(slot_meta) = blockstore.meta(slot).unwrap() {
+            if let Some(slot_meta) = blockstore.meta_repair(slot).unwrap() {
                 repair_eligibility.observe_slot_as_elapsed_for_tests(slot, &slot_meta);
             }
         }
@@ -966,7 +970,7 @@ impl RepairService {
     pub(crate) fn generate_repairs_for_slot(
         blockstore: &Blockstore,
         slot: Slot,
-        slot_meta: &SlotMeta,
+        slot_meta: &SlotMetaRepair,
         repair_eligibility: &mut RepairEligibility,
         max_repairs: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -1022,7 +1026,7 @@ impl RepairService {
         let mut pending_slots = vec![slot];
         while repairs.len() < max_repairs && !pending_slots.is_empty() {
             let slot = pending_slots.pop().unwrap();
-            if let Some(slot_meta) = blockstore.meta(slot).unwrap() {
+            if let Some(slot_meta) = blockstore.meta_repair(slot).unwrap() {
                 let new_repairs = Self::generate_repairs_for_slot(
                     blockstore,
                     slot,
@@ -1202,11 +1206,11 @@ impl RepairService {
             }
 
             let meta = blockstore
-                .meta(slot)
+                .meta_repair(slot)
                 .expect("Unable to lookup slot meta")
-                .unwrap_or(SlotMeta {
+                .unwrap_or(SlotMetaRepair {
                     slot,
-                    ..SlotMeta::default()
+                    ..SlotMetaRepair::default()
                 });
             repair_eligibility.observe_slot_as_elapsed_for_tests(slot, &meta);
 
@@ -1229,7 +1233,7 @@ impl RepairService {
         blockstore: &Blockstore,
         slot: Slot,
     ) -> Option<Vec<ShredRepairType>> {
-        if let Some(slot_meta) = blockstore.meta(slot).unwrap() {
+        if let Some(slot_meta) = blockstore.meta_repair(slot).unwrap() {
             if slot_meta.is_full() {
                 // If the slot is full, no further need to repair this slot
                 None
@@ -1647,7 +1651,7 @@ mod test {
                 false,
             )
             .unwrap();
-        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        let slot_meta = blockstore.meta_repair(slot).unwrap().unwrap();
         let mut repair_eligibility = RepairEligibility::default();
         assert_eq!(
             RepairService::generate_repairs_for_slot(
@@ -1686,7 +1690,7 @@ mod test {
             .insert_shreds(shreds_to_insert, None, false)
             .unwrap();
 
-        let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+        let slot_meta = blockstore.meta_repair(slot).unwrap().unwrap();
         let mut repair_eligibility = RepairEligibility::default();
         assert_eq!(
             RepairService::generate_repairs_for_slot(
@@ -1788,7 +1792,7 @@ mod test {
             .insert_shreds(vec![shreds_by_index.get(&0).unwrap().clone()], None, false)
             .unwrap();
         let mut repair_eligibility = RepairEligibility::default();
-        let slot_meta = blockstore.meta(0).unwrap().unwrap();
+        let slot_meta = blockstore.meta_repair(0).unwrap().unwrap();
         assert_eq!(
             RepairService::generate_repairs_for_slot(
                 &blockstore,
@@ -1804,7 +1808,7 @@ mod test {
         blockstore
             .insert_shreds(vec![shreds_by_index.get(&1).unwrap().clone()], None, false)
             .unwrap();
-        let slot_meta = blockstore.meta(0).unwrap().unwrap();
+        let slot_meta = blockstore.meta_repair(0).unwrap().unwrap();
         assert_eq!(
             RepairService::generate_repairs_for_slot(
                 &blockstore,

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -13,7 +13,8 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_ledger::{
-        ancestor_iterator::AncestorIterator, blockstore::Blockstore, blockstore_meta::SlotMeta,
+        ancestor_iterator::AncestorIterator, blockstore::Blockstore,
+        blockstore_meta::SlotMetaRepair,
     },
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
@@ -502,7 +503,7 @@ impl RepairWeight {
     fn get_best_shreds(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
         repair_eligibility: &mut RepairEligibility,
@@ -600,7 +601,7 @@ impl RepairWeight {
     fn get_best_unknown_last_index(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -630,7 +631,7 @@ impl RepairWeight {
     fn get_best_closest_completion(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
         processed_slots: &mut HashSet<Slot>,
         max_new_repairs: usize,
         repair_eligibility: &mut RepairEligibility,

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -8,7 +8,7 @@ use {
     },
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMeta},
+    solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMetaRepair},
     std::collections::{HashMap, HashSet},
 };
 
@@ -79,7 +79,7 @@ impl Iterator for RepairWeightTraversal<'_> {
 pub fn get_best_repair_shreds(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMeta>>,
+    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
     repair_eligibility: &mut RepairEligibility,
@@ -99,7 +99,7 @@ pub fn get_best_repair_shreds(
 
         let slot_meta = slot_meta_cache
             .entry(next.slot())
-            .or_insert_with(|| blockstore.meta(next.slot()).unwrap());
+            .or_insert_with(|| blockstore.meta_repair(next.slot()).unwrap());
 
         // May not exist if blockstore purged the SlotMeta due to something
         // like duplicate slots. TODO: Account for duplicate slot may be in orphans, especially

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -780,6 +780,15 @@ impl Blockstore {
         self.meta_cf.get(slot)
     }
 
+    /// Returns the [`SlotMetaRepair`] of the specified slot.
+    pub fn meta_repair(&self, slot: Slot) -> Result<Option<SlotMetaRepair>> {
+        self.meta_cf
+            .get_slice(slot)?
+            .as_deref()
+            .map(|bytes| Ok(wincode::deserialize::<SlotMetaRepair>(bytes)?))
+            .transpose()
+    }
+
     /// Returns the SlotMeta of the specified slot from the specified location
     pub fn meta_from_location(
         &self,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -185,6 +185,24 @@ pub struct SlotMetaV3 {
 
 pub type SlotMeta = SlotMetaV3;
 
+/// Lighter-weight version of [`SlotMeta`] containing just the set
+/// of fields needed for repair.
+///
+/// wincode deserializes in field declaration order, so [`SlotMetaRepair`]
+/// can always be deserialized from [`SlotMeta`].
+#[derive(Clone, Debug, Default, SchemaRead, Eq, PartialEq)]
+pub struct SlotMetaRepair {
+    pub slot: Slot,
+    pub consumed: u64,
+    pub received: u64,
+    pub first_shred_timestamp: u64,
+    #[wincode(with = "wincode_compat::OptionCompat")]
+    pub last_index: Option<u64>,
+    #[wincode(with = "wincode_compat::OptionCompat")]
+    pub parent_slot: Option<Slot>,
+    pub next_slots: Vec<Slot>,
+}
+
 // Wincode implementation of serialize and deserialize for Option<u64>
 // where None is represented as u64::MAX; for backward compatibility.
 mod wincode_compat {
@@ -517,32 +535,33 @@ impl FromIterator<u64> for ShredIndex {
     }
 }
 
-impl SlotMeta {
-    pub fn is_full(&self) -> bool {
-        // last_index is None when it has no information about how
-        // many shreds will fill this slot.
-        // Note: A full slot with zero shreds is not possible.
-        // Should never happen
-        if self
-            .last_index
-            .map(|ix| self.consumed > ix + 1)
-            .unwrap_or_default()
-        {
-            datapoint_error!(
-                "blockstore_error",
-                (
-                    "error",
-                    format!(
-                        "Observed a slot meta with consumed: {} > meta.last_index + 1: {:?}",
-                        self.consumed,
-                        self.last_index.map(|ix| ix + 1),
-                    ),
-                    String
-                )
-            );
-        }
+fn slot_meta_is_full(last_index: Option<u64>, consumed: u64) -> bool {
+    // last_index is None when it has no information about how
+    // many shreds will fill this slot.
+    // Note: A full slot with zero shreds is not possible.
+    // Should never happen
+    if last_index.map(|ix| consumed > ix + 1).unwrap_or_default() {
+        datapoint_error!(
+            "blockstore_error",
+            (
+                "error",
+                format!(
+                    "Observed a slot meta with consumed: {} > meta.last_index + 1: {:?}",
+                    consumed,
+                    last_index.map(|ix| ix + 1),
+                ),
+                String
+            )
+        );
+    }
 
-        Some(self.consumed) == self.last_index.map(|ix| ix + 1)
+    Some(consumed) == last_index.map(|ix| ix + 1)
+}
+
+impl SlotMeta {
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        slot_meta_is_full(self.last_index, self.consumed)
     }
 
     /// Returns a boolean indicating whether this meta's parent slot is known.
@@ -642,6 +661,13 @@ impl SlotMeta {
     /// `UpdateParent` marker.
     pub fn has_update_parent(&self) -> bool {
         self.replay_fec_set_index > 0
+    }
+}
+
+impl SlotMetaRepair {
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        slot_meta_is_full(self.last_index, self.consumed)
     }
 }
 
@@ -980,6 +1006,71 @@ mod test {
                 index.range(indices.clone()).collect::<Vec<_>>(),
                 indices.into_iter().collect::<Vec<_>>()
             );
+        }
+    }
+
+    fn arb_slot_meta() -> impl Strategy<Value = SlotMeta> {
+        (
+            any::<Slot>(),
+            any::<u64>(),
+            any::<u64>(),
+            any::<u64>(),
+            proptest::option::of(any::<u64>()),
+            proptest::option::of(any::<Slot>()),
+            proptest::collection::vec(any::<Slot>(), 0..32),
+            any::<u8>(),
+            proptest::collection::vec(0..MAX_DATA_SHREDS_PER_SLOT as u32, 0..64),
+            any::<[u8; HASH_BYTES]>(),
+            any::<u32>(),
+        )
+            .prop_map(
+                |(
+                    slot,
+                    consumed,
+                    received,
+                    first_shred_timestamp,
+                    last_index,
+                    parent_slot,
+                    next_slots,
+                    connected_flags,
+                    completed_data_indexes,
+                    parent_block_id,
+                    replay_fec_set_index,
+                )| SlotMeta {
+                    slot,
+                    consumed,
+                    received,
+                    first_shred_timestamp,
+                    last_index,
+                    parent_slot,
+                    next_slots,
+                    connected_flags: ConnectedFlags::from_bits_truncate(connected_flags),
+                    completed_data_indexes: completed_data_indexes.into_iter().collect(),
+                    parent_block_id: Hash::new_from_array(parent_block_id),
+                    replay_fec_set_index,
+                },
+            )
+    }
+
+    proptest! {
+        // Property: `SlotMetaRepair` is always deserializable from serialized `SlotMeta`.
+        #[test]
+        fn test_slot_meta_repair_deserialization(
+            slot_meta in arb_slot_meta(),
+        ) {
+            let serialized = wincode::serialize(&slot_meta).unwrap();
+            let deserialized: SlotMetaRepair = wincode::deserialize(&serialized).unwrap();
+
+            prop_assert_eq!(deserialized.slot, slot_meta.slot);
+            prop_assert_eq!(deserialized.consumed, slot_meta.consumed);
+            prop_assert_eq!(deserialized.received, slot_meta.received);
+            prop_assert_eq!(
+                deserialized.first_shred_timestamp,
+                slot_meta.first_shred_timestamp
+            );
+            prop_assert_eq!(deserialized.last_index, slot_meta.last_index);
+            prop_assert_eq!(deserialized.parent_slot, slot_meta.parent_slot);
+            prop_assert_eq!(deserialized.next_slots, slot_meta.next_slots);
         }
     }
 


### PR DESCRIPTION
#### Problem

Repair makes a ton of calls to `blockstore.meta()`. This allocates and the full 32kib `CompletedDataIndexes` even though it's never used.

<img width="1919" height="746" alt="image" src="https://github.com/user-attachments/assets/aa34fdeb-32e2-4c2a-8bc3-e300641d7585" />
<img width="1919" height="739" alt="image" src="https://github.com/user-attachments/assets/25963ba3-91f8-4bfa-b8aa-9f7f67e0587d" />


#### Summary of Changes

This adds a new type, `SlotMetaRepair`, that just includes `SlotMeta` fields up to `next_slots`, which provides all data needed in `get_best_shreds`.

<img width="1919" height="743" alt="image" src="https://github.com/user-attachments/assets/80bc8658-d240-4b87-8581-ac518762f359" />
<img width="1919" height="758" alt="image" src="https://github.com/user-attachments/assets/8a37f86a-5b86-463d-bc57-a1adab7aa768" />


`get_best_shreds` time reduced ~20%

<img width="1870" height="551" alt="image" src="https://github.com/user-attachments/assets/87ea1ee6-ec15-4666-aebc-8b4973c5777a" />
<img width="1868" height="593" alt="image" src="https://github.com/user-attachments/assets/993e949f-4c5c-4a9b-8cb5-6f53bd08acff" />
