### PR TITLE
Leverage blockstore `Index` in `find_missing_data_indexes`

### DIFF
--- a/ledger/src/bit_vec.rs
+++ b/ledger/src/bit_vec.rs
@@ -12,6 +12,10 @@ use {
 type Word = u8;
 const BITS_PER_WORD: usize = std::mem::size_of::<Word>() * 8;
 
+const fn num_words<const NUM_BITS: usize>() -> usize {
+    NUM_BITS.div_ceil(BITS_PER_WORD)
+}
+
 /// A bit vector implementation optimized for efficient bidirectional range
 /// scanning and iteration.
 ///
@@ -36,6 +40,34 @@ impl<const NUM_BITS: usize> Default for BitVec<NUM_BITS> {
             words: vec![0; Self::NUM_WORDS].into_boxed_slice(),
         }
     }
+}
+
+#[inline]
+fn location_of(idx: usize) -> (usize, usize) {
+    let word_idx = idx / BITS_PER_WORD;
+    let bit_idx = idx & (BITS_PER_WORD - 1);
+    (word_idx, bit_idx)
+}
+
+#[inline]
+fn check_bounds<const NUM_BITS: usize>(idx: usize) -> Result<(), BitVecError> {
+    if idx >= NUM_BITS {
+        return Err(BitVecError::OutOfBounds {
+            index: idx,
+            num_bits: NUM_BITS,
+        });
+    }
+    Ok(())
+}
+
+#[inline]
+fn contains<const NUM_BITS: usize>(words: &[Word], idx: usize) -> bool {
+    if check_bounds::<NUM_BITS>(idx).is_err() {
+        return false;
+    }
+
+    let (word_idx, bit_idx) = location_of(idx);
+    (words[word_idx] & (1 << bit_idx)) != 0
 }
 
 // Note: bincode/wincode would construct a variable-length buffer,
@@ -66,7 +98,7 @@ pub enum BitVecError {
 }
 
 impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
-    const NUM_WORDS: usize = NUM_BITS.div_ceil(BITS_PER_WORD);
+    const NUM_WORDS: usize = num_words::<NUM_BITS>();
 
     /// Get the word and bit offset for the given index.
     ///
@@ -78,20 +110,14 @@ impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
     /// assert_eq!(word_idx, 7);
     /// assert_eq!(bit_idx, 7);
     /// ```
+    #[inline]
     pub fn location_of(idx: usize) -> (usize, usize) {
-        let word_idx = idx / BITS_PER_WORD;
-        let bit_idx = idx & (BITS_PER_WORD - 1);
-        (word_idx, bit_idx)
+        location_of(idx)
     }
 
+    #[inline]
     fn check_bounds(&self, idx: usize) -> Result<(), BitVecError> {
-        if idx >= NUM_BITS {
-            return Err(BitVecError::OutOfBounds {
-                index: idx,
-                num_bits: NUM_BITS,
-            });
-        }
-        Ok(())
+        check_bounds::<NUM_BITS>(idx)
     }
 
     /// Remove a bit at the given index.
@@ -228,13 +254,9 @@ impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
     /// bit_vec.insert(63);
     /// assert!(bit_vec.contains(63));
     /// ```
+    #[inline]
     pub fn contains(&self, idx: usize) -> bool {
-        if self.check_bounds(idx).is_err() {
-            return false;
-        }
-
-        let (word_idx, bit_idx) = Self::location_of(idx);
-        (self.words[word_idx] & (1 << bit_idx)) != 0
+        contains::<NUM_BITS>(&self.words, idx)
     }
 
     /// Get an iterator over the bits in the array within the given range.
@@ -253,7 +275,7 @@ impl<const NUM_BITS: usize> BitVec<NUM_BITS> {
     /// assert_eq!(bit_vec.range(1..).count_ones(), 1);
     /// ```
     pub fn range(&self, bounds: impl RangeBounds<usize>) -> BitVecSlice<'_, NUM_BITS> {
-        BitVecSlice::from_range_bounds(self, bounds)
+        BitVecSlice::from_range_bounds(&self.words, bounds)
     }
 
     /// Get an iterator over the positions of the set bits in the array.
@@ -310,6 +332,47 @@ impl<const NUM_BITS: usize> FromIterator<usize> for BitVec<NUM_BITS> {
     }
 }
 
+/// A reference to a [`BitVec`] that does not own the underlying data.
+#[derive(Debug, PartialEq, Eq)]
+pub struct BitVecRef<'a, const NUM_BITS: usize> {
+    words: &'a [Word],
+}
+
+impl<const NUM_BITS: usize> BitVecRef<'_, NUM_BITS> {
+    const NUM_WORDS: usize = num_words::<NUM_BITS>();
+
+    /// Check if a bit is set at the given index.
+    ///
+    /// See [`BitVec::contains`].
+    #[inline]
+    pub fn contains(&self, idx: usize) -> bool {
+        contains::<NUM_BITS>(self.words, idx)
+    }
+
+    /// Get an iterator over the bits in the array within the given range.
+    ///
+    /// See [`BitVec::range`].
+    pub fn range(&self, bounds: impl RangeBounds<usize>) -> BitVecSlice<'_, NUM_BITS> {
+        BitVecSlice::from_range_bounds(self.words, bounds)
+    }
+}
+
+unsafe impl<'de, const NUM_BITS: usize, C: Config> SchemaRead<'de, C> for BitVecRef<'de, NUM_BITS> {
+    type Dst = Self;
+
+    #[inline]
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        use wincode::ReadError;
+
+        let words = <&'de [Word] as SchemaRead<C>>::get(reader)?;
+        if words.len() != Self::NUM_WORDS {
+            return Err(ReadError::Custom("Invalid BitVec length"));
+        }
+        dst.write(Self { words });
+        Ok(())
+    }
+}
+
 /// A slice of a [`BitVec`] that provides efficient bit-level iteration.
 pub struct BitVecSlice<'a, const NUM_BITS: usize> {
     mask_iter: BitVecMaskIter<'a, NUM_BITS>,
@@ -319,7 +382,7 @@ impl<'a, const NUM_BITS: usize> BitVecSlice<'a, NUM_BITS> {
     /// Construct a new [`BitVecSlice`] from a [`BitVec`] and a range.
     ///
     /// Internal function -- use [`BitVec::range`].
-    fn from_range_bounds(bit_vec: &'a BitVec<NUM_BITS>, bounds: impl RangeBounds<usize>) -> Self {
+    fn from_range_bounds(bit_vec: &'a [u8], bounds: impl RangeBounds<usize>) -> Self {
         let start = match bounds.start_bound() {
             Bound::Included(&n) => n,
             Bound::Excluded(&n) => n + 1,
@@ -340,7 +403,7 @@ impl<'a, const NUM_BITS: usize> BitVecSlice<'a, NUM_BITS> {
                 start,
                 end,
                 start_word,
-                iter: bit_vec.words[start_word..end_word].iter().enumerate(),
+                iter: bit_vec[start_word..end_word].iter().enumerate(),
             },
         }
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7,8 +7,10 @@ use trees::{Tree, TreeWalk};
 use {
     crate::{
         ancestor_iterator::AncestorIterator,
-        blockstore::column::{Column, TypedColumn, columns as cf},
-        blockstore_db::{IteratorDirection, IteratorMode, LedgerColumn, Rocks, WriteBatch},
+        blockstore::column::{TypedColumn, columns as cf},
+        blockstore_db::{
+            DBPinnedT, IteratorDirection, IteratorMode, LedgerColumn, Rocks, WriteBatch,
+        },
         blockstore_meta::*,
         blockstore_options::{
             BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, BlockstoreOptions, LedgerColumnOptions,
@@ -34,7 +36,7 @@ use {
     lru::LruCache,
     rand::Rng,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
-    rocksdb::{DBRawIterator, LiveFile},
+    rocksdb::LiveFile,
     solana_account::ReadableAccount,
     solana_address_lookup_table_interface::state::AddressLookupTable,
     solana_clock::{Slot, UnixTimestamp},
@@ -90,7 +92,7 @@ use {
     tar,
     tempfile::{Builder, TempDir},
     thiserror::Error,
-    wincode::{Deserialize as _, containers::Vec as WincodeVec},
+    wincode::{Deserialize as _, config::DefaultConfig, containers::Vec as WincodeVec},
 };
 
 pub mod blockstore_purge;
@@ -3848,6 +3850,14 @@ impl Blockstore {
         self.index_cf.get(slot)
     }
 
+    /// Get a DB pinned reference to the [`Index`] via [`IndexRef`].
+    fn get_index_ref(
+        &self,
+        slot: Slot,
+    ) -> Result<Option<DBPinnedT<'_, DefaultConfig, IndexRef<'_>>>> {
+        self.index_cf.get_pinned_t(slot)
+    }
+
     pub fn get_index_from_location(
         &self,
         slot: Slot,
@@ -3894,69 +3904,10 @@ impl Blockstore {
     /// [`start_index`, `end_index`].
     ///
     /// Arguments:
-    ///  - `db_iterator`: Iterator to run search over.
     ///  - `slot`: The slot to search for missing shreds for.
     ///  - `start_index`: Begin search (inclusively) at this shred index.
     ///  - `end_index`: Finish search (exclusively) at this shred index.
     ///  - `max_missing`: Limit result to this many indices.
-    fn find_missing_indexes<C>(
-        db_iterator: &mut DBRawIterator,
-        slot: Slot,
-        start_index: u64,
-        end_index: u64,
-        max_missing: usize,
-    ) -> Vec<u64>
-    where
-        C: Column<Index = (u64, u64)>,
-    {
-        if start_index >= end_index || max_missing == 0 {
-            return vec![];
-        }
-
-        let mut missing_indexes = vec![];
-
-        // Seek to the first shred with index >= start_index
-        db_iterator.seek(C::key(&(slot, start_index)));
-
-        // The index of the first missing shred in the slot
-        let mut prev_index = start_index;
-        loop {
-            if !db_iterator.valid() {
-                let num_to_take = max_missing - missing_indexes.len();
-                missing_indexes.extend((prev_index..end_index).take(num_to_take));
-                break;
-            }
-            let (current_slot, index) = C::index(db_iterator.key().expect("Expect a valid key"));
-
-            let current_index = {
-                if current_slot > slot {
-                    end_index
-                } else {
-                    index
-                }
-            };
-
-            let upper_index = cmp::min(current_index, end_index);
-            let num_to_take = max_missing - missing_indexes.len();
-            missing_indexes.extend((prev_index..upper_index).take(num_to_take));
-
-            if missing_indexes.len() == max_missing
-                || current_slot > slot
-                || current_index >= end_index
-            {
-                break;
-            }
-
-            prev_index = current_index + 1;
-            db_iterator.next();
-        }
-
-        missing_indexes
-    }
-
-    /// Find missing data shreds for the given `slot`.
-    ///
-    /// For more details on the arguments, see [`find_missing_indexes`].
     pub fn find_missing_data_indexes(
         &self,
         slot: Slot,
@@ -3964,17 +3915,45 @@ impl Blockstore {
         end_index: u64,
         max_missing: usize,
     ) -> Vec<u64> {
-        let Ok(mut db_iterator) = self.db.raw_iterator_cf(self.data_shred_cf.handle()) else {
+        if start_index >= end_index || max_missing == 0 {
             return vec![];
-        };
+        }
 
-        Self::find_missing_indexes::<cf::ShredData>(
-            &mut db_iterator,
-            slot,
-            start_index,
-            end_index,
-            max_missing,
-        )
+        let max_missing = max_missing.min((end_index - start_index) as usize);
+
+        let index = match self.get_index_ref(slot) {
+            Ok(Some(index)) => index,
+            Ok(None) => return (start_index..end_index).take(max_missing).collect(),
+            Err(err) => {
+                warn!("failed to read index for slot {slot}: {err}");
+                return vec![];
+            }
+        };
+        let index = index.data();
+
+        if index.num_shreds() == 0 {
+            return (start_index..end_index).take(max_missing).collect();
+        }
+
+        let mut missing_indexes = Vec::with_capacity(max_missing);
+        let mut prev_index = start_index;
+        for current_index in index.range(start_index..end_index) {
+            let num_to_take = max_missing - missing_indexes.len();
+            missing_indexes.extend((prev_index..current_index).take(num_to_take));
+
+            if missing_indexes.len() == max_missing {
+                break;
+            }
+
+            prev_index = current_index + 1;
+        }
+
+        if missing_indexes.len() < max_missing {
+            let num_to_take = max_missing - missing_indexes.len();
+            missing_indexes.extend((prev_index..end_index).take(num_to_take));
+        }
+
+        missing_indexes
     }
 
     fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -20,8 +20,8 @@ use {
     prost::Message,
     rocksdb::{
         self, ColumnFamily, ColumnFamilyDescriptor, CompactionDecision, DB, DBCompressionType,
-        DBIterator, DBPinnableSlice, DBRawIterator, IteratorMode as RocksIteratorMode, LiveFile,
-        Options, WriteBatch as RWriteBatch,
+        DBIterator, DBPinnableSlice, IteratorMode as RocksIteratorMode, LiveFile, Options,
+        WriteBatch as RWriteBatch,
         compaction_filter::CompactionFilter,
         compaction_filter_factory::{CompactionFilterContext, CompactionFilterFactory},
         properties as RocksProperties,
@@ -39,7 +39,11 @@ use {
             atomic::{AtomicU64, Ordering},
         },
     },
-    wincode::{SchemaReadOwned, deserialize},
+    wincode::{
+        SchemaRead, SchemaReadOwned,
+        config::{ConfigCore, DefaultConfig},
+        deserialize,
+    },
 };
 
 const BLOCKSTORE_METRICS_ERROR: i64 = -1;
@@ -396,7 +400,8 @@ impl Rocks {
         self.db.iterator_cf(cf, iterator_mode)
     }
 
-    pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<DBRawIterator<'_>> {
+    #[cfg(test)]
+    pub(crate) fn raw_iterator_cf(&self, cf: &ColumnFamily) -> Result<rocksdb::DBRawIterator<'_>> {
         Ok(self.db.raw_iterator_cf(cf))
     }
 
@@ -566,6 +571,55 @@ impl WriteBatch {
     }
 }
 
+/// A pinned deserialized value with the ability to hold references into a [`DBPinnableSlice`].
+///
+/// All references in the deserialized payload will be tied to the lifetime of the [`DBPinnableSlice`].
+///
+/// Use this for zero-copy access to a value stored in the blockstore -- no reason to keep
+/// the [`DBPinnableSlice`] alive for owned values.
+pub struct DBPinnedT<'a, C: ConfigCore, T: SchemaRead<'a, C>> {
+    val: T::Dst,
+    _slice: DBPinnableSlice<'a>,
+    _phantom: PhantomData<C>,
+}
+
+impl<'a, C, T> std::ops::Deref for DBPinnedT<'a, C, T>
+where
+    C: ConfigCore,
+    T: SchemaRead<'a, C>,
+{
+    type Target = T::Dst;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.val
+    }
+}
+
+impl<'de, T, C> DBPinnedT<'de, C, T>
+where
+    C: ConfigCore,
+    T: SchemaRead<'de, C>,
+{
+    fn decode(slice: DBPinnableSlice<'de>) -> Result<Self> {
+        let bytes = slice.as_ref();
+        // SAFETY: `DBPinnableSlice` provides a stable reference into the underlying storage and keeps
+        // the RocksDB value pointer valid until it is dropped.
+        // `DBPinnedT` stores `val` before `_slice`, so `val` is dropped first;
+        // any references decoded into `val` cannot outlive the pinned bytes.
+        let val = T::get(unsafe { std::slice::from_raw_parts(bytes.as_ptr(), bytes.len()) })?;
+        Ok(Self {
+            val,
+            _slice: slice,
+            _phantom: PhantomData,
+        })
+    }
+
+    #[inline]
+    pub fn get(&self) -> &T::Dst {
+        &self.val
+    }
+}
 impl<C> LedgerColumn<C>
 where
     C: Column + ColumnName,
@@ -608,6 +662,17 @@ where
             );
         }
         result
+    }
+
+    #[inline]
+    pub fn get_pinned_t<'a, T>(
+        &'a self,
+        index: C::Index,
+    ) -> Result<Option<DBPinnedT<'a, DefaultConfig, T>>>
+    where
+        T: SchemaRead<'a, DefaultConfig>,
+    {
+        self.get_slice(index)?.map(DBPinnedT::decode).transpose()
     }
 
     /// Create a key type suitable for use with multi_get_bytes() and

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        bit_vec::BitVec,
+        bit_vec::{BitVec, BitVecRef},
         blockstore::ParentInfo,
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, Shred, ShredType,
@@ -295,6 +295,13 @@ pub struct Index {
     coding: ShredIndex,
 }
 
+#[derive(Debug, SchemaRead, PartialEq, Eq)]
+pub struct IndexRef<'a> {
+    pub slot: Slot,
+    data: ShredIndexRef<'a>,
+    coding: ShredIndexRef<'a>,
+}
+
 #[derive(Clone, Copy, Debug, SchemaRead, SchemaWrite, Eq, PartialEq)]
 /// Erasure coding information
 pub struct ErasureMeta {
@@ -466,6 +473,12 @@ impl Index {
     }
 }
 
+impl IndexRef<'_> {
+    pub fn data(&self) -> &ShredIndexRef<'_> {
+        &self.data
+    }
+}
+
 /// A bitvec (`Box<[u8]>`) of shred indices, where each u8 represents 8 shred indices.
 ///
 /// Bit vec implementation provides:
@@ -532,6 +545,31 @@ impl FromIterator<u64> for ShredIndex {
             index.insert(idx);
         }
         index
+    }
+}
+
+/// A reference to a [`ShredIndex`].
+#[derive(Debug, SchemaRead, PartialEq, Eq)]
+pub struct ShredIndexRef<'a> {
+    index: BitVecRef<'a, MAX_DATA_SHREDS_PER_SLOT>,
+    num_shreds: usize,
+}
+
+impl ShredIndexRef<'_> {
+    pub fn num_shreds(&self) -> usize {
+        self.num_shreds
+    }
+
+    pub(crate) fn range<R>(&self, bounds: R) -> impl Iterator<Item = u64> + '_
+    where
+        R: RangeBounds<u64>,
+    {
+        let start = bounds.start_bound().map(|&b| b as usize);
+        let end = bounds.end_bound().map(|&b| b as usize);
+        self.index
+            .range((start, end))
+            .iter_ones()
+            .map(|idx| idx as u64)
     }
 }
 
@@ -1052,6 +1090,24 @@ mod test {
             )
     }
 
+    fn arb_index() -> impl Strategy<Value = Index> {
+        (
+            any::<Slot>(),
+            proptest::collection::vec(0..MAX_DATA_SHREDS_PER_SLOT as u64, 0..128),
+            proptest::collection::vec(0..MAX_DATA_SHREDS_PER_SLOT as u64, 0..128),
+        )
+            .prop_map(|(slot, data_indexes, coding_indexes)| {
+                let mut index = Index::new(slot);
+                for index_to_insert in data_indexes {
+                    index.data_mut().insert(index_to_insert);
+                }
+                for index_to_insert in coding_indexes {
+                    index.coding_mut().insert(index_to_insert);
+                }
+                index
+            })
+    }
+
     proptest! {
         // Property: `SlotMetaRepair` is always deserializable from serialized `SlotMeta`.
         #[test]
@@ -1071,6 +1127,29 @@ mod test {
             prop_assert_eq!(deserialized.last_index, slot_meta.last_index);
             prop_assert_eq!(deserialized.parent_slot, slot_meta.parent_slot);
             prop_assert_eq!(deserialized.next_slots, slot_meta.next_slots);
+        }
+    }
+
+    proptest! {
+        // Property: `IndexRef` is always deserializable from `Index`.
+        #[test]
+        fn test_index_ref_deserialization(
+            index in arb_index(),
+        ) {
+            let serialized = wincode::serialize(&index).unwrap();
+            let deserialized: IndexRef = wincode::deserialize(&serialized).unwrap();
+
+            prop_assert_eq!(deserialized.slot, index.slot);
+            prop_assert_eq!(
+                deserialized.data().range(..).collect::<Vec<_>>(),
+                index.data().range(..).collect::<Vec<_>>()
+            );
+            prop_assert_eq!(
+                deserialized.coding.range(..).collect::<Vec<_>>(),
+                index.coding().range(..).collect::<Vec<_>>()
+            );
+            prop_assert_eq!(deserialized.data().num_shreds(), index.data().num_shreds());
+            prop_assert_eq!(deserialized.coding.num_shreds(), index.coding().num_shreds());
         }
     }
 


### PR DESCRIPTION
#### Problem

`find_missing_data_indexes` currently identifies missing shreds by creating a RocksDB iterator over the data-shred column and walking shred keys for the requested slot/range. This entails RocksDB iterator setup, seek/next traversal, etc.

The blockstore already maintains an `Index` column that records which data shreds are present for each slot. For this query, walking the data-shred column repeats work that has already been materialized in the per-slot index.

<img width="1919" height="757" alt="image" src="https://github.com/user-attachments/assets/0a87ea22-41c7-4e07-903c-f78adebd418e" />

#### Summary of Changes

This PR updates `find_missing_data_indexes` to leverage the existing slot `Index` to identify missing shreds. 

There is some additional functionality added here to make this efficient. In particular, this leverages wincode's zero-copy functionality in conjunction with RocksDB's `DBPinnableSlice`. This avoids allocating + copying two 32kib `ShredIndex`es required to deserialize an owned `Index`, and instead deserializes into a borrowed `IndexRef`. This required adding the following:

##### `BitVecRef`

`BitVecRef` is as the name would imply -- a reference to a `BitVec`'s internal array. This required adding a few little helpers and slight tweaks, but pretty much all the existing machinery works without changes.

##### `DBPinnedT`

A wrapper around RocksDB's `DBPinnableSlice<'a>` paired with some `T: SchemaRead<'a>` to facilitate zero-copy deserialization from RocksDB. This will plug in to any existing column with an appropriate wincode-annotated reference type -- which makes it suitable for further blockstore optimizations like this.

<img width="1919" height="759" alt="image" src="https://github.com/user-attachments/assets/baceffa2-8696-4c55-97d3-e7633d6f2181" />

`get_best_shreds` time reduced ~25%

<img width="1873" height="562" alt="image" src="https://github.com/user-attachments/assets/5965d473-c7e9-4902-9ace-1e0e3979dc4b" />

<img width="1868" height="596" alt="image" src="https://github.com/user-attachments/assets/1296a813-86dd-43a0-8be6-931a883eb1d3" />
