### PR TITLE
default delay leader block for pending fork

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -477,7 +477,7 @@ impl ValidatorConfig {
             replay_transactions_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             tvu_shred_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             tvu_bls_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
-            delay_leader_block_for_pending_fork: false,
+            delay_leader_block_for_pending_fork: true,
             voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),
             snapshot_packager_niceness_adj: 0,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1139,17 +1139,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("Disables the banking trace"),
     )
     .arg(
-        Arg::with_name("delay_leader_block_for_pending_fork")
+        Arg::with_name("no_delay_leader_block_for_pending_fork")
             .hidden(hidden_unless_forced())
-            .long("delay-leader-block-for-pending-fork")
+            .long("no-delay-leader-block-for-pending-fork")
             .takes_value(false)
             .help(
-                "Delay leader block creation while replaying a block which descends from the \
-                 current fork and has a lower slot than our next leader slot. If we don't delay \
-                 here, our new leader block will be on a different fork from the block we are \
-                 replaying and there is a high chance that the cluster will confirm that block's \
-                 fork rather than our leader block's fork because it was created before we \
-                 started creating ours.",
+                "Disable delaying leader block creation while replaying a block which descends \
+                 from the current fork and has a lower slot than our next leader slot. If we \
+                 don't delay here, our new leader block will be on a different fork from the \
+                 block we are replaying and there is a high chance that the cluster will confirm \
+                 that block's fork rather than our leader block's fork because it was created \
+                 before we started creating ours.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -818,8 +818,8 @@ pub fn execute(
         replay_transactions_threads,
         tvu_shred_sigverify_threads: tvu_sigverify_threads,
         tvu_bls_sigverify_threads,
-        delay_leader_block_for_pending_fork: matches
-            .is_present("delay_leader_block_for_pending_fork"),
+        delay_leader_block_for_pending_fork: !matches
+            .is_present("no_delay_leader_block_for_pending_fork"),
         turbine_mode: TurbineMode::default(),
         broadcast_stage_type: BroadcastStageType::Standard,
         block_verification_method: value_t_or_exit!(


### PR DESCRIPTION
#### Problem
nontrivial skip rate in 2x200 experiments. 

#### Summary of Changes
delay leader block for pending fork by default


#### Testing
1. ran on N=10 colo cluster with 40ms delay, 10% jitter. 8% -> 3% skip rate. average slot time unchanged.
2. ran on N=10 geographically distributed cluster. 3.9% -> 2.5% skip rate. average slot time unchanged.
