### PR TITLE
PER: plumb reward epoch delegated stakes

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -141,7 +141,7 @@ solana-poh-config = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-binaries = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
-solana-pubkey = { workspace = true, features = ["rand"] }
+solana-pubkey = { workspace = true, features = ["rand", "wincode"] }
 solana-rayon-threadlimit = { workspace = true }
 solana-rent = { workspace = true }
 solana-reward-info = { workspace = true }

--- a/runtime/src/alpenglow_epoch_type.rs
+++ b/runtime/src/alpenglow_epoch_type.rs
@@ -1,4 +1,138 @@
-use solana_clock::{Epoch, Slot};
+use {
+    crate::bank::{Bank, MAX_ALPENGLOW_VOTE_ACCOUNTS},
+    solana_account::{AccountSharedData, ReadableAccount},
+    solana_clock::{Epoch, Slot},
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::system_program,
+    solana_vote::vote_account::VoteAccounts,
+    std::{cmp::Ordering, collections::HashMap, sync::LazyLock},
+    wincode::{SchemaRead, SchemaWrite},
+};
+
+/// For alpenglow rewards we only reward lamports earned in the previous epoch.
+/// For this prior epoch we need to know the delegated stake for each vote account.
+/// Note that this is not the same as `epoch_stakes`, which is calculated an epoch
+/// in advance.
+#[derive(Debug)]
+pub(crate) struct RewardEpochDelegatedStakes {
+    pub(crate) epoch: Epoch,
+    #[allow(dead_code)]
+    // This will be used in a follow up as part of non Tower PER calculations
+    pub(crate) delegated_stakes: HashMap<Pubkey, u64>,
+}
+
+#[derive(Debug, SchemaRead, SchemaWrite)]
+struct RewardEpochDelegatedStakesAccount {
+    pub(crate) epoch: Epoch,
+    pub(crate) delegated_stakes: Vec<RewardEpochDelegatedStake>,
+}
+
+#[derive(Debug, Clone, SchemaRead, SchemaWrite)]
+struct RewardEpochDelegatedStake {
+    pub(crate) vote_pubkey: Pubkey,
+    pub(crate) delegated_stake: u64,
+}
+
+/// The off-curve account where we store the bounded reward-epoch delegated stake
+/// denominators used for non-Tower reward recalculation after snapshot restore.
+static REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT: LazyLock<Pubkey> = LazyLock::new(|| {
+    let (pubkey, _) = Pubkey::find_program_address(
+        &[b"reward_epoch_delegated_stakes"],
+        &agave_feature_set::alpenglow::id(),
+    );
+    pubkey
+});
+
+impl RewardEpochDelegatedStakesAccount {
+    pub(crate) fn max_size() -> usize {
+        static REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT_MAX_SIZE: LazyLock<usize> =
+            LazyLock::new(|| {
+                let account = RewardEpochDelegatedStakesAccount {
+                    epoch: u64::MAX,
+                    delegated_stakes: vec![
+                        RewardEpochDelegatedStake {
+                            vote_pubkey: Pubkey::new_from_array([u8::MAX; 32]),
+                            delegated_stake: u64::MAX,
+                        };
+                        MAX_ALPENGLOW_VOTE_ACCOUNTS
+                    ],
+                };
+                wincode::serialized_size(&account)
+                    .expect("reward epoch delegated stakes account must serialize")
+                    .try_into()
+                    .expect(
+                        "reward epoch delegated stakes account serialized size must fit in usize",
+                    )
+            });
+
+        *REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT_MAX_SIZE
+    }
+}
+
+impl RewardEpochDelegatedStakes {
+    pub(crate) fn set(&self, bank: &Bank, distribution_vote_accounts: &VoteAccounts) {
+        assert!(
+            distribution_vote_accounts.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS,
+            "reward epoch delegated stakes account must be bounded by MAX_ALPENGLOW_VOTE_ACCOUNTS"
+        );
+
+        let mut delegated_stakes = distribution_vote_accounts
+            .delegated_stakes()
+            .map(
+                |(vote_pubkey, _delegated_stake)| RewardEpochDelegatedStake {
+                    vote_pubkey: *vote_pubkey,
+                    delegated_stake: self
+                        .delegated_stakes
+                        .get(vote_pubkey)
+                        .copied()
+                        .unwrap_or_default(),
+                },
+            )
+            .collect::<Vec<_>>();
+        delegated_stakes.sort_unstable_by_key(|stake| stake.vote_pubkey);
+
+        let account = RewardEpochDelegatedStakesAccount {
+            epoch: self.epoch,
+            delegated_stakes,
+        };
+        let data = wincode::serialize(&account).unwrap();
+        let lamports = bank
+            .get_minimum_balance_for_rent_exemption(RewardEpochDelegatedStakesAccount::max_size());
+        let mut account = AccountSharedData::new(lamports, data.len(), &system_program::ID);
+        account.set_data_from_slice(&data);
+
+        bank.store_account_and_update_capitalization(
+            &REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT,
+            &account,
+        );
+    }
+
+    pub(crate) fn get(bank: &Bank) -> Option<Self> {
+        let account = bank.get_account(&REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT)?;
+        (!account.data().is_empty()).then(|| {
+            let account: RewardEpochDelegatedStakesAccount = wincode::deserialize(account.data())
+                .expect("Couldn't deserialize reward epoch delegated stakes");
+            assert!(
+                account.delegated_stakes.len() <= MAX_ALPENGLOW_VOTE_ACCOUNTS,
+                "reward epoch delegated stakes account exceeds MAX_ALPENGLOW_VOTE_ACCOUNTS"
+            );
+            account.into()
+        })
+    }
+}
+
+impl From<RewardEpochDelegatedStakesAccount> for RewardEpochDelegatedStakes {
+    fn from(account: RewardEpochDelegatedStakesAccount) -> Self {
+        Self {
+            epoch: account.epoch,
+            delegated_stakes: account
+                .delegated_stakes
+                .into_iter()
+                .map(|stake| (stake.vote_pubkey, stake.delegated_stake))
+                .collect(),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) enum AlpenglowEpochType {
@@ -9,7 +143,90 @@ pub(crate) enum AlpenglowEpochType {
         num_tower_slots: Slot,
         num_ag_slots: Slot,
         migration_epoch: Epoch,
+        #[allow(dead_code)]
+        // This will be used in a follow up as part of PER calculations for the migration epoch
+        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
     },
     /// This is a full alpenglow epoch
-    Alpenglow { migration_epoch: Epoch },
+    Alpenglow {
+        migration_epoch: Epoch,
+        #[allow(dead_code)]
+        // This will be used in a follow up as part of PER calculations for Alpenglow epochs
+        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
+    },
+}
+
+impl AlpenglowEpochType {
+    pub(crate) fn is_alpenglow_or_migration_epoch(bank: &Bank, epoch: Epoch) -> bool {
+        debug_assert!(epoch < bank.epoch());
+        bank.get_alpenglow_migration_slot()
+            .map(|migration_slot| bank.epoch_schedule().get_epoch(migration_slot) <= epoch)
+            .unwrap_or(false)
+    }
+
+    /// Returns `AlpenglowEpochType` for the given `epoch`.
+    ///
+    /// Calling this function with an epoch >= `Bank::epoch` can return false information as it is
+    /// possible that we have not observed the genesis cert yet but will in the upcoming slots.
+    ///
+    /// We pass `reward_epoch_delegated_stakes` as a closure to avoid the potential deserialization
+    /// of `REWARD_EPOCH_DELEGATED_STAKES_ACCOUNT` in the Tower case.
+    pub(crate) fn get(
+        bank: &Bank,
+        epoch: Epoch,
+        reward_epoch_delegated_stakes: impl FnOnce() -> Option<RewardEpochDelegatedStakes>,
+    ) -> Self {
+        debug_assert!(epoch < bank.epoch());
+        let Some(migration_slot) = bank.get_alpenglow_migration_slot() else {
+            return Self::Tower;
+        };
+        let migration_epoch = bank.epoch_schedule().get_epoch(migration_slot);
+        match migration_epoch.cmp(&epoch) {
+            Ordering::Less => {
+                let reward_epoch_delegated_stakes =
+                    reward_epoch_delegated_stakes().unwrap_or_else(|| {
+                        panic!(
+                            "Missing reward epoch delegated stakes for non-Tower reward epoch \
+                             {epoch}"
+                        )
+                    });
+                assert_eq!(
+                    reward_epoch_delegated_stakes.epoch, epoch,
+                    "reward epoch delegated stakes must match rewarded epoch"
+                );
+                Self::Alpenglow {
+                    migration_epoch,
+                    reward_epoch_delegated_stakes,
+                }
+            }
+            Ordering::Greater => Self::Tower,
+            Ordering::Equal => {
+                let first_slot_in_epoch = bank
+                    .epoch_schedule()
+                    .get_first_slot_in_epoch(migration_epoch);
+                // + 1 because the migration_slot is still tower.
+                let num_tower_slots = migration_slot - first_slot_in_epoch + 1;
+                let slots_in_epoch = bank.epoch_schedule().get_slots_in_epoch(migration_epoch);
+                let num_ag_slots = slots_in_epoch - num_tower_slots;
+                assert_eq!(slots_in_epoch, num_tower_slots + num_ag_slots);
+                let reward_epoch_delegated_stakes =
+                    reward_epoch_delegated_stakes().unwrap_or_else(|| {
+                        panic!(
+                            "Missing reward epoch delegated stakes for non-Tower reward epoch \
+                             {epoch}"
+                        )
+                    });
+                assert_eq!(
+                    reward_epoch_delegated_stakes.epoch, epoch,
+                    "reward epoch delegated stakes must match rewarded epoch"
+                );
+                Self::MigrationEpoch {
+                    num_tower_slots,
+                    num_ag_slots,
+                    migration_epoch,
+                    reward_epoch_delegated_stakes,
+                }
+            }
+        }
+    }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -193,7 +193,6 @@ use {
     },
     solana_vote_interface::state::VoteStateV4,
     std::{
-        cmp::Ordering,
         collections::{HashMap, HashSet},
         fmt,
         num::NonZero,
@@ -1717,7 +1716,7 @@ impl Bank {
         let stakes = self.stakes_cache.stakes();
         let stake_delegations = stakes.stake_delegations_vec();
         let (
-            (stake_history, unfiltered_distribution_vote_accounts),
+            (stake_history, unfiltered_distribution_vote_accounts, reward_epoch_delegated_stakes),
             calculate_activated_stake_time_us,
         ) = measure_us!(stakes.calculate_activated_stake(
             self.epoch(),
@@ -1726,6 +1725,7 @@ impl Bank {
             &stake_delegations,
             self.use_fixed_point_stake_math(),
         ));
+        debug_assert_eq!(reward_epoch_delegated_stakes.epoch, rewarded_epoch);
 
         // Apply stake rewards and commission using the distribution vote-account
         // snapshot that matches VAT admission filtering when enabled.
@@ -1738,6 +1738,13 @@ impl Bank {
             } else {
                 unfiltered_distribution_vote_accounts.clone()
             };
+        if AlpenglowEpochType::is_alpenglow_or_migration_epoch(self, rewarded_epoch) {
+            assert!(
+                self.feature_set.snapshot().validator_admission_ticket,
+                "Alpenglow should not be activated before the VAT"
+            );
+            reward_epoch_delegated_stakes.set(self, &filtered_distribution_vote_accounts);
+        }
         let cached_vote_accounts =
             self.get_cached_vote_accounts(rewarded_epoch, &filtered_distribution_vote_accounts);
         let (rewards_calculation, update_rewards_with_thread_pool_time_us) =
@@ -1746,6 +1753,7 @@ impl Bank {
                 stake_delegations,
                 cached_vote_accounts,
                 rewarded_epoch,
+                reward_epoch_delegated_stakes,
                 reward_calc_tracer,
                 thread_pool,
                 rewards_metrics,
@@ -6561,36 +6569,6 @@ impl Bank {
             genesis_cert.cert_type
         );
         Some(genesis_cert.cert_type.slot())
-    }
-
-    /// Returns `AlpenglowEpochType` for the given `epoch`.
-    ///
-    /// Calling this function with an epoch >= `Bank::epoch` can return false information as it is
-    /// possible that we have not observed the genesis cert yet but will in the upcoming slots.
-    pub(crate) fn get_alpenglow_epoch_type(&self, epoch: Epoch) -> AlpenglowEpochType {
-        debug_assert!(epoch < self.epoch);
-        let Some(migration_slot) = self.get_alpenglow_migration_slot() else {
-            return AlpenglowEpochType::Tower;
-        };
-        let migration_epoch = self.epoch_schedule.get_epoch(migration_slot);
-        match migration_epoch.cmp(&epoch) {
-            Ordering::Less => AlpenglowEpochType::Alpenglow { migration_epoch },
-            Ordering::Greater => AlpenglowEpochType::Tower,
-            Ordering::Equal => {
-                let first_slot_in_epoch =
-                    self.epoch_schedule.get_first_slot_in_epoch(migration_epoch);
-                // + 1 because the migration_slot is still tower.
-                let num_tower_slots = migration_slot - first_slot_in_epoch + 1;
-                let slots_in_epoch = self.epoch_schedule.get_slots_in_epoch(migration_epoch);
-                let num_ag_slots = slots_in_epoch - num_tower_slots;
-                assert_eq!(slots_in_epoch, num_tower_slots + num_ag_slots);
-                AlpenglowEpochType::MigrationEpoch {
-                    num_tower_slots,
-                    num_ag_slots,
-                    migration_epoch,
-                }
-            }
-        }
     }
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -7,7 +7,7 @@ use {
         StakeRewardCalculation, epoch_rewards_hasher::hash_rewards_into_partitions,
     },
     crate::{
-        alpenglow_epoch_type::AlpenglowEpochType,
+        alpenglow_epoch_type::{AlpenglowEpochType, RewardEpochDelegatedStakes},
         bank::{
             RewardCalcTracer, RewardCalculationEvent, RewardsMetrics,
             fee_distribution::ExternalCollectorType, null_tracer,
@@ -224,6 +224,7 @@ impl Bank {
         stake_delegations: Vec<(&Pubkey, &StakeAccount<Delegation>)>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
+        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
@@ -257,6 +258,7 @@ impl Bank {
                     stake_delegations,
                     cached_vote_accounts,
                     rewarded_epoch,
+                    reward_epoch_delegated_stakes,
                     reward_calc_tracer,
                     thread_pool,
                     metrics,
@@ -394,6 +396,7 @@ impl Bank {
         stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
+        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl Fn(&RewardCalculationEvent) + Send + Sync>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
@@ -418,6 +421,7 @@ impl Bank {
                 cached_vote_accounts,
                 rewarded_epoch,
                 epoch_inflation_rewards,
+                reward_epoch_delegated_stakes,
                 reward_calc_tracer,
                 thread_pool,
                 metrics,
@@ -439,6 +443,7 @@ impl Bank {
     }
 
     /// Calculate epoch reward and return stake rewards and commissions.
+    #[allow(clippy::too_many_arguments)]
     fn calculate_validator_rewards<'a>(
         &self,
         stake_history: &StakeHistory,
@@ -446,11 +451,13 @@ impl Bank {
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         epoch_inflation_rewards: u64,
+        reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
         reward_calc_tracer: Option<impl RewardCalcTracer>,
         thread_pool: &ThreadPool,
         metrics: &mut RewardsMetrics,
     ) -> Option<CalculateValidatorRewardsResult> {
-        let ag_epoch_type = self.get_alpenglow_epoch_type(rewarded_epoch);
+        let ag_epoch_type =
+            AlpenglowEpochType::get(self, rewarded_epoch, || Some(reward_epoch_delegated_stakes));
         self.calculate_reward_points_partitioned(
             stake_history,
             &stake_delegations,
@@ -905,7 +912,6 @@ impl Bank {
         // If rewards are active, the rewarded epoch is always the immediately
         // preceding epoch.
         let rewarded_epoch = self.epoch().saturating_sub(1);
-        let ag_epoch_type = self.get_alpenglow_epoch_type(rewarded_epoch);
 
         let point_value = PointValue {
             rewards: epoch_rewards_sysvar.total_rewards,
@@ -918,6 +924,9 @@ impl Bank {
             stake_delegations,
             cached_vote_accounts,
         } = self.get_epoch_params_for_recalculation(rewarded_epoch, &stakes);
+        let ag_epoch_type = AlpenglowEpochType::get(self, rewarded_epoch, || {
+            RewardEpochDelegatedStakes::get(self)
+        });
 
         // On recalculation, only the `StakeRewardCalculation::stake_rewards`
         // field is relevant. It is assumed that reward commission accounts have
@@ -1137,11 +1146,18 @@ mod tests {
         },
         solana_vote_program::vote_state::{self, create_bls_proof_of_possession},
         std::{
-            collections::HashSet,
+            collections::{HashMap, HashSet},
             sync::{Arc, RwLock, RwLockReadGuard},
         },
         test_case::{test_case, test_matrix},
     };
+
+    fn reward_epoch_delegated_stakes_for_tests(epoch: Epoch) -> RewardEpochDelegatedStakes {
+        RewardEpochDelegatedStakes {
+            epoch,
+            delegated_stakes: HashMap::default(),
+        }
+    }
 
     #[test]
     fn test_store_commission_accounts_partitioned() {
@@ -1254,6 +1270,7 @@ mod tests {
             cached_vote_accounts,
             rewarded_epoch,
             expected_rewards,
+            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -2114,6 +2131,7 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
+            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -2235,6 +2253,7 @@ mod tests {
             stake_delegations,
             cached_vote_accounts,
             rewarded_epoch,
+            reward_epoch_delegated_stakes_for_tests(rewarded_epoch),
             null_tracer(),
             &thread_pool,
             &mut rewards_metrics,
@@ -2328,6 +2347,56 @@ mod tests {
         }
 
         assert_eq!(bank.epoch_reward_status, EpochRewardStatus::Inactive);
+    }
+
+    #[test]
+    fn test_alpenglow_reward_epoch_delegated_stakes_account_is_bounded() {
+        let num_validators = crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS + 1;
+        let validator_keypairs = (0..num_validators)
+            .map(|_| genesis_utils::ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        // Unique stakes make VAT filtering exclude only the lowest-staked vote
+        // account instead of dropping a tie group at the boundary.
+        let stakes = (0..num_validators)
+            .map(|index| 2_000_000_000 + (num_validators - index) as u64)
+            .collect::<Vec<_>>();
+        let filtered_vote_pubkey = validator_keypairs
+            .last()
+            .expect("validator keypairs must not be empty")
+            .vote_keypair
+            .pubkey();
+        let GenesisConfigInfo {
+            mut genesis_config, ..
+        } = genesis_utils::create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000 * LAMPORTS_PER_SOL,
+            &validator_keypairs,
+            stakes,
+        );
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        let features_to_deactivate = crate::slot_params::slot_time_feature_ids().to_vec();
+        deactivate_features(&mut genesis_config, &features_to_deactivate);
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::default(),
+            SLOTS_PER_EPOCH,
+        );
+
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes::get(&bank)
+            .expect("AG reward epoch delegated stakes must be persisted");
+        assert_eq!(reward_epoch_delegated_stakes.epoch, bank.epoch() - 1);
+        assert_eq!(
+            reward_epoch_delegated_stakes.delegated_stakes.len(),
+            crate::bank::MAX_ALPENGLOW_VOTE_ACCOUNTS
+        );
+        assert!(
+            !reward_epoch_delegated_stakes
+                .delegated_stakes
+                .contains_key(&filtered_vote_pubkey)
+        );
     }
 
     #[test]
@@ -2451,7 +2520,6 @@ mod tests {
                 .enumerated_rewards_iter()
                 .all(|(_, reward)| reward.stake_pubkey != filtered_stake_pubkey)
         );
-
         // Simulate snapshot restore: re-apply features from accounts and
         // rebuild epoch_reward_status from snapshot-stable state.
         bank.feature_set = Arc::new(FeatureSet::default());

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -20,7 +20,7 @@ mod tests {
             certificate::{Certificate, CertificateType},
             consensus_message::Block,
         },
-        solana_account::{Account, ReadableAccount},
+        solana_account::{Account, ReadableAccount, from_account},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_cluster_type::ClusterType,
         solana_epoch_schedule::EpochSchedule,
@@ -34,6 +34,7 @@ mod tests {
         solana_rent::Rent,
         solana_signer::Signer,
         solana_stake_interface::state::StakeStateV2,
+        solana_sysvar::{self as sysvar, epoch_rewards::EpochRewards},
         std::{collections::HashMap, num::NonZero, sync::Arc},
         test_case::test_matrix,
     };
@@ -271,21 +272,12 @@ mod tests {
                 return ret;
             }
 
-            let total_points = self
-                .validators
-                .iter()
-                .map(|validator| {
-                    let vote_pubkey = validator.vote_keypair.pubkey();
-                    let validator_stake = self.get_validator_stake(reward_bank, &vote_pubkey);
-                    let points = validator_stake * self.pay_type.tower();
-                    points as u128
-                })
-                .sum::<u128>();
-
-            let epoch_inflation = payout_bank.calculate_epoch_inflation_rewards(
-                reward_bank.capitalization(),
-                reward_bank.epoch(),
-            );
+            let epoch_rewards: EpochRewards = payout_bank
+                .get_account(&sysvar::epoch_rewards::id())
+                .and_then(|account| from_account(&account))
+                .unwrap();
+            let epoch_inflation = epoch_rewards.total_rewards;
+            let total_points = epoch_rewards.total_points;
             let genesis_cert = payout_bank.get_alpenglow_genesis_certificate().unwrap();
             let first_slot_in_reward_epoch = payout_bank
                 .epoch_schedule

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -297,7 +297,7 @@ fn calculate_stake_rewards<'a>(
         AlpenglowEpochType::MigrationEpoch {
             num_tower_slots,
             num_ag_slots,
-            migration_epoch: _,
+            ..
         } => {
             if tower_points == 0 && ag_points == 0 {
                 if let Some(inflation_point_calc_tracer) = inflation_point_calc_tracer.as_ref() {
@@ -404,7 +404,9 @@ mod tests {
     use {
         self::points::{PointValue, null_tracer},
         super::*,
-        crate::epoch_stakes::VersionedEpochStakes,
+        crate::{
+            alpenglow_epoch_type::RewardEpochDelegatedStakes, epoch_stakes::VersionedEpochStakes,
+        },
         proptest::prelude::*,
         solana_clock::Epoch,
         solana_native_token::LAMPORTS_PER_SOL,
@@ -451,7 +453,13 @@ mod tests {
         let migration_epoch = 0;
         let first_ag_epoch = migration_epoch + 1;
         (
-            AlpenglowEpochType::Alpenglow { migration_epoch },
+            AlpenglowEpochType::Alpenglow {
+                migration_epoch,
+                reward_epoch_delegated_stakes: RewardEpochDelegatedStakes {
+                    epoch: first_ag_epoch,
+                    delegated_stakes: [(Pubkey::default(), total_stake)].into_iter().collect(),
+                },
+            },
             epoch_stakes,
             total_stake,
             first_ag_epoch,

--- a/runtime/src/inflation_rewards/points.rs
+++ b/runtime/src/inflation_rewards/points.rs
@@ -474,7 +474,9 @@ pub(crate) fn calculate_stake_points_and_credits(
                 Err(e) => return e,
             }
         }
-        AlpenglowEpochType::Alpenglow { migration_epoch } => {
+        AlpenglowEpochType::Alpenglow {
+            migration_epoch, ..
+        } => {
             let (ag_points, credits) = match ag_epoch_credits_iter(
                 *migration_epoch,
                 false,

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -2,6 +2,7 @@
 //! node stakes
 use {
     crate::{
+        alpenglow_epoch_type::RewardEpochDelegatedStakes,
         stake_account,
         stake_delegation::{delegation_activation_status, delegation_effective_stake},
         stake_history::StakeHistory,
@@ -24,7 +25,6 @@ use {
     solana_vote_interface::state::VoteStateVersions,
     std::{
         collections::HashMap,
-        ops::Add,
         sync::{Arc, RwLock, RwLockReadGuard},
     },
     thiserror::Error,
@@ -411,15 +411,15 @@ impl Stakes<StakeAccount> {
         new_rate_activation_epoch: Option<Epoch>,
         stake_delegations: &[(&Pubkey, &StakeAccount)],
         use_fixed_point_stake_math: bool,
-    ) -> (StakeHistory, VoteAccounts) {
+    ) -> (StakeHistory, VoteAccounts, RewardEpochDelegatedStakes) {
         // Wrap up the prev epoch by adding new stake history entry for the
         // prev epoch.
-        let stake_history_entry = thread_pool.install(|| {
+        let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
             stake_delegations
                 .par_iter()
                 .fold(
-                    StakeActivationStatus::default,
-                    |acc, (_stake_pubkey, stake_account)| {
+                    || (StakeActivationStatus::default(), HashMap::default()),
+                    |(acc, mut delegated_stakes), (_stake_pubkey, stake_account)| {
                         let delegation = stake_account.delegation();
                         let activation_status = delegation_activation_status(
                             delegation,
@@ -428,10 +428,21 @@ impl Stakes<StakeAccount> {
                             new_rate_activation_epoch,
                             use_fixed_point_stake_math,
                         );
-                        acc + activation_status
+                        *delegated_stakes.entry(delegation.voter_pubkey).or_default() +=
+                            activation_status.effective;
+                        (acc + activation_status, delegated_stakes)
                     },
                 )
-                .reduce(StakeActivationStatus::default, Add::add)
+                .reduce(
+                    || (StakeActivationStatus::default(), HashMap::default()),
+                    |(activation_status_a, delegated_stakes_a),
+                     (activation_status_b, delegated_stakes_b)| {
+                        (
+                            activation_status_a + activation_status_b,
+                            merge_delegated_stakes(delegated_stakes_a, delegated_stakes_b),
+                        )
+                    },
+                )
         });
         let mut stake_history = self.stake_history.clone();
         stake_history.add(self.epoch, stake_history_entry);
@@ -446,7 +457,11 @@ impl Stakes<StakeAccount> {
             new_rate_activation_epoch,
             use_fixed_point_stake_math,
         );
-        (stake_history, vote_accounts)
+        let reward_epoch_delegated_stakes = RewardEpochDelegatedStakes {
+            epoch: self.epoch,
+            delegated_stakes: effective_delegated_stakes,
+        };
+        (stake_history, vote_accounts, reward_epoch_delegated_stakes)
     }
 
     pub(crate) fn activate_epoch(
@@ -668,6 +683,19 @@ impl From<Stakes<Stake>> for Stakes<Delegation> {
     }
 }
 
+fn merge_delegated_stakes(
+    mut stakes: HashMap</*voter:*/ Pubkey, /*stake:*/ u64>,
+    other: HashMap</*voter:*/ Pubkey, /*stake:*/ u64>,
+) -> HashMap</*voter:*/ Pubkey, /*stake:*/ u64> {
+    if stakes.len() < other.len() {
+        return merge_delegated_stakes(other, stakes);
+    }
+    for (pubkey, stake) in other {
+        *stakes.entry(pubkey).or_default() += stake;
+    }
+    stakes
+}
+
 fn refresh_vote_accounts(
     thread_pool: &ThreadPool,
     epoch: Epoch,
@@ -677,16 +705,6 @@ fn refresh_vote_accounts(
     new_rate_activation_epoch: Option<Epoch>,
     use_fixed_point_stake_math: bool,
 ) -> VoteAccounts {
-    type StakesHashMap = HashMap</*voter:*/ Pubkey, /*stake:*/ u64>;
-    fn merge(mut stakes: StakesHashMap, other: StakesHashMap) -> StakesHashMap {
-        if stakes.len() < other.len() {
-            return merge(other, stakes);
-        }
-        for (pubkey, stake) in other {
-            *stakes.entry(pubkey).or_default() += stake;
-        }
-        stakes
-    }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
             .par_iter()
@@ -706,7 +724,7 @@ fn refresh_vote_accounts(
                     delegated_stakes
                 },
             )
-            .reduce(HashMap::default, merge)
+            .reduce(HashMap::default, merge_delegated_stakes)
     });
     vote_accounts
         .iter()
@@ -1091,19 +1109,21 @@ pub(crate) mod tests {
             .stake()
             .unwrap();
 
+        let initial_expected_stake = {
+            let stakes = stakes_cache.stakes();
+            effective_stake(&stake, stakes.epoch, &stakes.stake_history, None, true)
+        };
         {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();
-            let expected_stake =
-                effective_stake(&stake, stakes.epoch, &stakes.stake_history, None, true);
             assert_eq!(
                 vote_accounts.get_delegated_stake(&vote_pubkey),
-                expected_stake
+                initial_expected_stake
             );
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let next_epoch = 3;
-        let (stake_history, vote_accounts) = {
+        let (stake_history, vote_accounts, effective_delegated_stakes) = {
             let stakes = stakes_cache.stakes();
             let stake_delegations = stakes.stake_delegations_vec();
             stakes.calculate_activated_stake(
@@ -1114,6 +1134,13 @@ pub(crate) mod tests {
                 true,
             )
         };
+        assert_eq!(
+            effective_delegated_stakes
+                .delegated_stakes
+                .get(&vote_pubkey)
+                .copied(),
+            Some(initial_expected_stake)
+        );
         stakes_cache.activate_epoch(next_epoch, stake_history, vote_accounts);
         {
             let stakes = stakes_cache.stakes();


### PR DESCRIPTION
Split from #13061 

#### Problem
See #12993 and #13061 for more context

We need to know the delegated stakes for each vote account at the reward epoch to pay out alpenglow rewards. 
E.g. If we create the first bank in epoch 13, we need to know the delegated stakes at the end of epoch 12. 

We cannot use `EpochStakes` for this at it is computed an epoch in advance - at the start of epoch 11, we compute the stakes for epoch 12 using the delegation amounts at epoch 11. This does not take into account any rewards that were distributed for epoch 11 during epoch 12.

#### Summary of Changes
Add a new type `RewardEpochDelegatedStakes` for use in `AlpenglowEpochType::MigrationEpoch` and `AlpenglowEpochType::Alpenglow`

In steady state this is trivially computed during the delegation scan in `calculate_activated_stake`.
However if we restore from a snapshot before all the rewards are paid, we need to recalculate this value.
We are unable to do so - as some delegations could have already been distributed to.

Thus we store `RewardEpochDelegatedStakes` in an off curve account (only when alpenglow is active) and restore it on snapshot restore. We have a strong bound - we only store vote accounts that made the VAT as those are the only ones eligible to be paid out

This PR doesn't change any of the rewards calculations yet, just lays the groundwork for #13061 

#### Testing
Tested as part of #13061, only unit tests for the plumbing change

A part of the fix for #12993 
