### PR TITLE
Enable XDP copy mode by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Release channels have their own copy of this changelog:
   `getLatestBlockhash` response together with its context (notably `context.slot`).
 ### Validator
 #### Breaking
+* XDP transmit is now enabled by default on Linux in copy mode on an auto-selected CPU
+  separate from the PoH pinned CPU core. Use `--xdp-cpu-cores` to override the XDP
+  CPU assignment; configured XDP cores must not include the PoH pinned CPU core.
+  Use `--xdp-zero-copy` with `--xdp-cpu-cores` to opt in to zero copy. When using
+  zero copy with a bonded interface, pass `--xdp-interface` with the underlying member
+  interface. Default validator startup now requires the XDP copy-mode capabilities.
+* The default PoH pinned CPU core is CPU core 0. Use `--poh-pinned-cpu-core` to override it.
 #### Deprecations
 * `--accounts-db-access-storages-method` is now deprecated and a no-op (the `mmap` value was
   deprecated in v4.0.0; mmap mode has now been removed entirely). The flag is still accepted for

--- a/docs/src/operations/running-with-af-xdp.md
+++ b/docs/src/operations/running-with-af-xdp.md
@@ -15,27 +15,33 @@ Before rolling out XDP on a production validator, you should test it on your set
 * **Performance Gain:** Confirm that performance is improved with the new configuration (e.g. lower CPU usage or higher throughput in Turbine’s retransmit stage).
 * **Metric Visibility:** Verify that you can observe the retransmit-stage metrics, which show time spent sending shreds, to gauge the impact of XDP on network transmission.
 
-To enable XDP in Agave, add the following command-line flags to your validator startup command (using Agave v3.0.9+):
+XDP is enabled by default on Linux in Agave. The default XDP configuration uses copy mode on an auto-selected CPU separate from the PoH pinned CPU core. To use different CPU cores for XDP, pass:
 
 ```bash
---experimental-retransmit-xdp-cpu-cores 1
---experimental-retransmit-xdp-zero-copy # Do NOT pass this flag when using the bnxt_en driver.
---experimental-poh-pinned-cpu-core 10
+--xdp-cpu-cores 1
 ```
 
-Note that --experimental-retransmit-xdp-zero-copy will avoid using socket buffers for data, but this is only possible when talking directly to the Network Interface Card (NIC). As a result, zero copy cannot be used with the bonded interface itself. When using a bonded network interface, specify the underlying member interface to which the XDP program should be attached:
+Zero copy avoids using socket buffers for data, but this is only possible when talking directly to the Network Interface Card (NIC). To opt in to zero copy, pass:
 
 ```bash
---experimental-retransmit-xdp-interface <bond-member-interface>
+--xdp-zero-copy
 ```
 
- Also note that XDP and PoH *must* be assigned to separate (physical) cores. The
---experimental-poh-pinned-cpu-core N flag can be used to move the PoH thread.
-
-Next, your validator binary will need to have access to a few higher level permissions. The validator process requires the CAP_NET_RAW, CAP_NET_ADMIN, CAP_BPF, and CAP_PERFMON capabilities. These can be configured in the systemd service file by setting CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_BPF CAP_PERFMON under the [Service] section or directly on the binary with the command:
+When using zero copy with a bonded network interface, you must pass `--xdp-interface` with the underlying member interface to which the XDP program should be attached:
 
 ```bash
-sudo setcap cap_net_raw,cap_net_admin,cap_bpf,cap_perfmon=p <path/to/agave-validator>
+--xdp-zero-copy --xdp-interface <bond-member-interface>
+```
+
+Also note that XDP and PoH *must* be assigned to separate (physical) cores. The
+`--poh-pinned-cpu-core N` flag can be used to move the PoH thread.
+
+Next, your validator binary will need to have access to a few higher level permissions. With default copy-mode XDP, the validator process requires the CAP_NET_RAW and CAP_NET_ADMIN capabilities. Zero copy additionally requires CAP_BPF and CAP_PERFMON. These capabilities can be configured in the systemd service file by setting CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN under the [Service] section or directly on the binary with the command:
+
+```bash
+sudo setcap cap_net_raw,cap_net_admin=p <path/to/agave-validator> # for default XDP w/o zero copy
+# OR
+sudo setcap cap_net_raw,cap_net_admin,cap_bpf,cap_perfmon=p <path/to/agave-validator> # for XDP w/ zero copy
 #this command must be run each time the binary is replaced
 ```
 

--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -144,6 +144,7 @@ args+=(
   --no-wait-for-vote-to-start-leader
   --full-rpc-api
   --allow-private-addr
+  --no-xdp
 )
 default_arg --gossip-port 8001
 default_arg --log -

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -10,6 +10,7 @@ args=(
   --max-genesis-archive-unpacked-size 1073741824
   --no-poh-speed-test
   --no-os-network-limits-test
+  --no-xdp
 )
 airdrops_enabled=1
 node_sol=500 # 500 SOL: number of SOL to airdrop the node for transaction fees and vote account rent exemption (ignored if airdrops_enabled=0)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -121,6 +121,7 @@ args=(
   --require-tower
   --no-wait-for-vote-to-start-leader
   --no-os-network-limits-test
+  --no-xdp
 )
 # shellcheck disable=SC2086
 agave-validator "${args[@]}" $SOLANA_RUN_SH_VALIDATOR_ARGS &

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -164,12 +164,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("experimental-retransmit-xdp-cpu-cores")
             .takes_value(true)
             .value_name("CPU_LIST")
+            .conflicts_with("no_xdp")
             .conflicts_with("xdp_cpu_cores")
             .validator(|value| {
                 validate_cpu_ranges(value, "--experimental-retransmit-xdp-cpu-cores")
             })
             .help(
-                "Enable XDP retransmit on the specified CPU cores. Use --xdp-cpu-cores instead",
+                "Use the specified CPU cores for XDP; must not include the PoH pinned CPU core. \
+                 Use --xdp-cpu-cores instead",
             ),
         replaced_by: "xdp-cpu-cores",
     );
@@ -179,9 +181,10 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("experimental-retransmit-xdp-interface")
             .takes_value(true)
             .value_name("INTERFACE")
+            .conflicts_with("no_xdp")
             .conflicts_with("xdp_interface")
             .requires("experimental_retransmit_xdp_cpu_cores")
-            .help("Network interface to use for XDP retransmit. Use --xdp-interface instead"),
+            .help("Network interface to use for XDP. Use --xdp-interface instead"),
         replaced_by: "xdp-interface",
     );
     add_arg!(
@@ -189,6 +192,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         Arg::with_name("experimental_retransmit_xdp_zero_copy")
             .long("experimental-retransmit-xdp-zero-copy")
             .takes_value(false)
+            .conflicts_with("no_xdp")
             .conflicts_with("xdp_zero_copy")
             .requires("experimental_retransmit_xdp_cpu_cores")
             .help("Enable XDP zero copy. Use --xdp-zero-copy instead"),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1209,10 +1209,23 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help(DefaultSchedulerPool::cli_message()),
     )
     .arg(
+        Arg::with_name("no_xdp")
+            .long("no-xdp")
+            .takes_value(false)
+            .conflicts_with("experimental_retransmit_xdp_cpu_cores")
+            .conflicts_with("experimental_retransmit_xdp_interface")
+            .conflicts_with("experimental_retransmit_xdp_zero_copy")
+            .conflicts_with("xdp_cpu_cores")
+            .conflicts_with("xdp_interface")
+            .conflicts_with("xdp_zero_copy")
+            .help("Do not use XDP transmit"),
+    )
+    .arg(
         Arg::with_name("xdp_interface")
             .long("xdp-interface")
             .takes_value(true)
             .value_name("INTERFACE")
+            .conflicts_with("no_xdp")
             .requires("xdp_cpu_cores")
             .help("Network interface to use for XDP"),
     )
@@ -1221,13 +1234,15 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .long("xdp-cpu-cores")
             .takes_value(true)
             .value_name("CPU_LIST")
+            .conflicts_with("no_xdp")
             .validator(|value| validate_cpu_ranges(value, "--xdp-cpu-cores"))
-            .help("Use the specified CPU cores for XDP"),
+            .help("Use the specified CPU cores for XDP; must not include the PoH pinned CPU core"),
     )
     .arg(
         Arg::with_name("xdp_zero_copy")
             .long("xdp-zero-copy")
             .takes_value(false)
+            .conflicts_with("no_xdp")
             .requires("xdp_cpu_cores")
             .help("Enable XDP zero copy. Requires hardware support"),
     )

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "linux")]
+use agave_cpu_utils::cpu_affinity;
 use {
     crate::{
         admin_rpc_service::{self, StakedNodesOverrides, load_staked_nodes_overrides},
@@ -84,10 +86,69 @@ use {
 #[cfg(target_os = "linux")]
 use {agave_xdp::transmitter::XdpConfig, solana_clap_utils::input_parsers::parse_cpu_ranges};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Operation {
     Initialize,
     Run,
+}
+
+#[cfg(target_os = "linux")]
+fn parse_xdp_transmit_config(
+    matches: &ArgMatches,
+    bind_addresses: &BindIpAddrs,
+    operation: Operation,
+) -> Result<Option<XdpConfig>, String> {
+    if matches.is_present("no_xdp") || operation == Operation::Initialize {
+        return Ok(None);
+    }
+
+    if bind_addresses.len() > 1 {
+        return Err(String::from("XDP cannot be used in a multihoming context"));
+    }
+
+    let xdp_interface = matches
+        .value_of("xdp_interface")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
+    let xdp_zero_copy = matches.is_present("xdp_zero_copy")
+        || matches.is_present("experimental_retransmit_xdp_zero_copy");
+    let xdp_cpu_ranges = matches
+        .value_of("xdp_cpu_cores")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"));
+    let poh_pinned_cpu_core = value_of(matches, "poh_pinned_cpu_core")
+        .or_else(|| value_of(matches, "experimental_poh_pinned_cpu_core"))
+        .or(poh_service::DEFAULT_PINNED_CPU_CORE);
+    let is_poh_pinned_cpu_core = |cpu| Some(cpu) == poh_pinned_cpu_core;
+    let xdp_cpus = if let Some(cpu_ranges) = xdp_cpu_ranges {
+        let xdp_cpus = parse_cpu_ranges(cpu_ranges).map_err(|err| err.to_string())?;
+        if let Some(poh_cpu) = poh_pinned_cpu_core.filter(|poh_cpu| xdp_cpus.contains(poh_cpu)) {
+            return Err(format!(
+                "XDP CPU cores must not include the PoH pinned CPU core ({poh_cpu})"
+            ));
+        }
+        xdp_cpus
+    } else {
+        let cpu = cpu_affinity(None)
+            .map_err(|err| {
+                format!(
+                    "failed to query CPU affinity for XDP CPU selection: {err}. Provide \
+                     --xdp-cpu-cores explicitly"
+                )
+            })?
+            .into_iter()
+            .rev()
+            .map(|cpu| *cpu)
+            .find(|cpu| !is_poh_pinned_cpu_core(*cpu))
+            .ok_or_else(|| {
+                format!(
+                    "XDP requires an allowed CPU core separate from PoH (core \
+                     {poh_pinned_cpu_core:?})"
+                )
+            })?;
+        vec![cpu]
+    };
+
+    info!("XDP enabled on CPU cores: {xdp_cpus:?}");
+    Ok(Some(XdpConfig::new(xdp_interface, xdp_cpus, xdp_zero_copy)))
 }
 
 pub fn execute(
@@ -164,29 +225,7 @@ pub fn execute(
         }
     }
     #[cfg(target_os = "linux")]
-    let xdp_transmit_config = if let Some(xdp_cpu_cores) = matches
-        .value_of("xdp_cpu_cores")
-        .or_else(|| matches.value_of("experimental_retransmit_xdp_cpu_cores"))
-    {
-        let xdp_interface = matches
-            .value_of("xdp_interface")
-            .or_else(|| matches.value_of("experimental_retransmit_xdp_interface"));
-        let xdp_zero_copy = matches.is_present("xdp_zero_copy")
-            || matches.is_present("experimental_retransmit_xdp_zero_copy");
-        let config = XdpConfig::new(
-            xdp_interface,
-            parse_cpu_ranges(xdp_cpu_cores).unwrap(),
-            xdp_zero_copy,
-        );
-        if bind_addresses.len() > 1 {
-            Err(String::from(
-                "--xdp-cpu-cores cannot be used in a multihoming context",
-            ))?;
-        }
-        Some(config)
-    } else {
-        None
-    };
+    let xdp_transmit_config = parse_xdp_transmit_config(matches, &bind_addresses, operation)?;
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())
@@ -431,6 +470,11 @@ pub fn execute(
 
     #[cfg(not(target_os = "linux"))]
     let poh_pinned_cpu_core = None;
+
+    #[cfg(target_os = "linux")]
+    if let Some(poh_pinned_cpu_core) = poh_pinned_cpu_core {
+        info!("PoH pinned CPU core: {poh_pinned_cpu_core}");
+    }
 
     solana_core::validator::report_target_features();
 

--- a/validator/tests/cli.rs
+++ b/validator/tests/cli.rs
@@ -25,6 +25,7 @@ fn test_use_the_same_path_for_accounts_and_snapshots() {
         "--log",
         "-",
         "--no-voting",
+        "--no-xdp",
         "--accounts",
         temp_dir_str,
         "--snapshots",


### PR DESCRIPTION
Replacement for https://github.com/anza-xyz/agave/pull/12119 which enables xdp w/ zc 

#### Problem
Need XDP in order to increase block sizes and reduce transmit latency. 
agave XDP adoption has been steadily increasing:
mainnet: 40.20% adoption
testnet: 67.42% adoption

We are ready to turn xdp w/o ZC on by default. 

#### Summary of Changes
1) Turn xdp w/o ZC on by default. 
2) Enforce poh core != xdp core
3) pass `--no-xdp` to turn off xdp

