### PR TITLE
Improves naming of fields in `VotePayload` and `CertPayload`

### DIFF
--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -83,9 +83,9 @@ fn generate_test_data(num_distinct_messages: usize, batch_size: usize) -> Vec<Vo
 
         votes_to_verify.push(VotePayload {
             vote_message,
-            bls_pubkey: bls_keypair.public,
-            pubkey: Keypair::new().pubkey(),
-            remote_pubkey: Keypair::new().pubkey(),
+            sender_bls_pubkey: bls_keypair.public,
+            sender_vote_account_pubkey: Keypair::new().pubkey(),
+            sender_identity_pubkey: Keypair::new().pubkey(),
             prepared_payload: None,
         });
     }

--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -25,7 +25,7 @@ use {
 #[derive(Clone, Debug)]
 pub(super) struct CertPayload {
     pub(super) cert: Certificate,
-    pub(super) remote_pubkey: Pubkey,
+    pub(super) sender_identity_pubkey: Pubkey,
 }
 
 #[derive(Debug, Error)]
@@ -123,12 +123,12 @@ fn verify_certs(
                 match &e {
                     CertVerifyError::NotEnoughStake { .. }
                     | CertVerifyError::CertVerifyFailed(_) => {
-                        if banlist.ban(cert_payload.remote_pubkey, BAN_TIMEOUT) {
+                        if banlist.ban(cert_payload.sender_identity_pubkey, BAN_TIMEOUT) {
                             stats.already_banned += 1;
                         } else {
                             info!(
                                 "bls_cert_sigverify: banned sender={} due to error {e}",
-                                cert_payload.remote_pubkey
+                                cert_payload.sender_identity_pubkey
                             );
                         }
                     }

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -223,19 +223,21 @@ impl SigVerifier {
                 self.stats.num_malformed_pkts += 1;
                 continue;
             };
-            let Some(remote_pubkey) = packet.meta().remote_pubkey() else {
+            let Some(sender_identity_pubkey) = packet.meta().remote_pubkey() else {
                 debug_assert!(false, "BLS packet missing remote pubkey");
                 self.stats.num_malformed_pkts += 1;
                 continue;
             };
             match msg {
                 ConsensusMessage::Vote(vote) => {
-                    if let Some((pubkey, bls_pubkey)) = self.keep_vote(&vote, root_bank) {
+                    if let Some((sender_vote_account_pubkey, sender_bls_pubkey)) =
+                        self.keep_vote(&vote, root_bank)
+                    {
                         votes.push(VotePayload {
                             vote_message: vote,
-                            bls_pubkey,
-                            pubkey,
-                            remote_pubkey,
+                            sender_bls_pubkey,
+                            sender_vote_account_pubkey,
+                            sender_identity_pubkey,
                             prepared_payload: None,
                         });
                     }
@@ -255,7 +257,7 @@ impl SigVerifier {
                     }
                     certs.push(CertPayload {
                         cert,
-                        remote_pubkey,
+                        sender_identity_pubkey,
                     });
                 }
             }

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -45,21 +45,21 @@ const PREPARED_PAYLOAD_CACHE_DISTINCT_VOTE_THRESHOLD_PERCENT: usize = 90;
 #[derive(Clone, Debug)]
 pub(super) struct VotePayload {
     pub vote_message: VoteMessage,
-    pub bls_pubkey: PopVerified<BlsPubkeyAffine>,
-    pub pubkey: Pubkey,
-    pub remote_pubkey: Pubkey,
+    pub sender_bls_pubkey: PopVerified<BlsPubkeyAffine>,
+    pub sender_vote_account_pubkey: Pubkey,
+    pub sender_identity_pubkey: Pubkey,
     pub prepared_payload: Option<Arc<PreparedHashedMessage>>,
 }
 
 impl VotePayload {
     fn verify(self) -> Option<Self> {
         let is_verified = if let Some(prepared_payload) = self.prepared_payload.as_deref() {
-            self.bls_pubkey
+            self.sender_bls_pubkey
                 .verify_signature_prepared(&self.vote_message.signature, prepared_payload)
                 .is_ok()
         } else {
             let payload = wincode::serialize(&self.vote_message.vote).ok()?;
-            self.bls_pubkey
+            self.sender_bls_pubkey
                 .verify_signature(&self.vote_message.signature, &payload)
                 .is_ok()
         };
@@ -111,7 +111,7 @@ fn inspect_for_repair(vote: &VotePayload, msgs_for_repair: &mut HashMap<Pubkey, 
     match vote.vote_message.vote {
         Vote::Notarize(_) | Vote::Finalize(_) | Vote::NotarizeFallback(_) => {
             msgs_for_repair
-                .entry(vote.pubkey)
+                .entry(vote.sender_vote_account_pubkey)
                 .or_default()
                 .push(vote_slot);
         }
@@ -151,7 +151,7 @@ fn process_verified_votes(
         inspect_for_repair(&payload, &mut msgs_for_repair);
 
         votes_for_metrics.push(ConsensusMetricsEvent::Vote {
-            id: payload.pubkey,
+            id: payload.sender_vote_account_pubkey,
             vote: payload.vote_message.vote,
         });
         votes_for_pool.push(payload.vote_message);
@@ -208,11 +208,14 @@ fn verify_votes(
         distinct_payloads,
         thread_pool,
     ));
-    for remote_pubkey in invalid_remote_pubkeys {
-        if banlist.ban(remote_pubkey, BAN_TIMEOUT) {
+    for sender_identity_pubkey in invalid_remote_pubkeys {
+        if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
             stats.already_banned += 1;
         } else {
-            info!("bls_vote_sigverify: banned sender={remote_pubkey} due to failed verification");
+            info!(
+                "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed \
+                 verification"
+            );
         }
     }
     stats.fn_verify_individual_votes_stats.add_sample(time_us);
@@ -351,7 +354,7 @@ fn aggregate_pubkeys_by_payload(
         grouped_votes
             .entry(&v.vote_message.vote)
             .or_default()
-            .push(&v.bls_pubkey);
+            .push(&v.sender_bls_pubkey);
     }
 
     stats
@@ -389,7 +392,7 @@ fn aggregate_pubkeys_by_payload(
 ///
 /// Returns:
 /// - `Vec<VotePayload>`: votes that passed verification.
-/// - `Vec<Pubkey>`: remote pubkeys for votes that failed verification.
+/// - `Vec<Pubkey>`: senders' identity pubkeys for votes that failed verification.
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn verify_individual_votes(
     mut votes_to_verify: Vec<VotePayload>,
@@ -410,10 +413,10 @@ fn verify_individual_votes(
 
     thread_pool.install(|| {
         votes_to_verify.into_par_iter().partition_map(|vote| {
-            let remote_pubkey = vote.remote_pubkey;
+            let sender_identity_pubkey = vote.sender_identity_pubkey;
             match vote.verify() {
                 Some(vote) => Either::Left(vote),
-                None => Either::Right(remote_pubkey),
+                None => Either::Right(sender_identity_pubkey),
             }
         })
     })


### PR DESCRIPTION
#### Problem

While working on https://github.com/anza-xyz/agave/pull/13050, I keep getting confused by the ambigious names of some fields in `VotePayload` and `CertPayload`.


#### Summary of Changes

Improves the naming


#### Testing

No function changes so just CI.