### PR TITLE
blockstore: Remove outdated cleanup logic

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -54,7 +54,7 @@ use {
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
-    solana_storage_proto::{StoredExtendedRewards, StoredTransactionStatusMeta},
+    solana_storage_proto::StoredExtendedRewards,
     solana_time_utils::timestamp,
     solana_transaction::{
         TransactionVerificationMode,
@@ -660,7 +660,6 @@ impl Blockstore {
             manual_purge_request_sender: Mutex::default(),
             slots_stats: SlotsStats::default(),
         };
-        blockstore.cleanup_old_entries()?;
 
         Ok(blockstore)
     }
@@ -4215,35 +4214,6 @@ impl Blockstore {
                 })
             })
             .collect()
-    }
-
-    fn cleanup_old_entries(&self) -> Result<()> {
-        if !self.is_primary_access() {
-            return Ok(());
-        }
-
-        // If present, delete dummy entries inserted by old software
-        // https://github.com/solana-labs/solana/blob/bc2b372/ledger/src/blockstore.rs#L2130-L2137
-        let transaction_status_dummy_key = cf::TransactionStatus::as_index(2);
-        if self
-            .transaction_status_cf
-            .get_protobuf_or_wincode::<StoredTransactionStatusMeta>(transaction_status_dummy_key)?
-            .is_some()
-        {
-            self.transaction_status_cf
-                .delete(transaction_status_dummy_key)?;
-        };
-        let address_signatures_dummy_key = cf::AddressSignatures::as_index(2);
-        if self
-            .address_signatures_cf
-            .get(address_signatures_dummy_key)?
-            .is_some()
-        {
-            self.address_signatures_cf
-                .delete(address_signatures_dummy_key)?;
-        };
-
-        Ok(())
     }
 
     pub fn read_transaction_status(

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -24,7 +24,7 @@ use {
     solana_sha256_hasher::hash,
     solana_shred_version::version_from_hash,
     solana_signature::Signature,
-    solana_storage_proto::convert::generated,
+    solana_storage_proto::{StoredTransactionStatusMeta, convert::generated},
     solana_streamer::evicting_sender::EvictingSender,
     solana_transaction::Transaction,
     solana_transaction_context::transaction::TransactionReturnData,


### PR DESCRIPTION
#### Problem
Long ago, several dummy values were inserted into the transaction status and address signature columns. Those values are no longer in use and code was added to remove those dummy entries if they were detected. It has been many release and multiple years since then so we can reasonably delete the cleanup step.

See https://github.com/solana-labs/solana/pull/33511 and https://github.com/solana-labs/solana/pull/33649 for more historical context

#### Summary of Changes
Removed outdated code. This is a small change broken out on the way to ripping out the protobuf-but-fallback-to-bincode logic

#### Testing
CI + inspecting a recent tip of master node to confirm the columns are empty on a non-RPC node (which indicates the dummy entries are not present in the RPC columns)