### PR TITLE
Fix - Take loading lock in `prepare_program_cache_for_upcoming_feature_set()`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -131,7 +131,9 @@ use {
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
         invoke_context::BuiltinFunctionRegisterer,
-        loaded_programs::{ProgramRuntimeEnvironment, ProgramRuntimeEnvironments},
+        loaded_programs::{
+            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
+        },
         program_cache_entry::ProgramCacheEntry,
     },
     solana_pubkey::Pubkey,
@@ -155,7 +157,7 @@ use {
     solana_svm::{
         account_loader::LoadedTransaction,
         account_overrides::AccountOverrides,
-        program_loader::load_program_with_pubkey,
+        program_loader::{filter_executable_program_accounts, load_program_with_pubkey},
         transaction_balances::{BalanceCollector, SvmTokenInfo},
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_error_metrics::TransactionErrorMetrics,
@@ -1583,26 +1585,54 @@ impl Bank {
                 epoch_boundary_preparation.programs_to_recompile.pop()
             {
                 drop(epoch_boundary_preparation);
-                drop(program_cache);
-                if let Some((recompiled, last_modification_slot)) = load_program_with_pubkey(
+                let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
+                let mut missing_programs = filter_executable_program_accounts(
                     self,
-                    &upcoming_environment,
-                    &key,
-                    self.slot,
-                    &mut ExecuteTimings::default(),
-                ) {
+                    &program_cache_for_tx_batch,
+                    std::iter::once(&key),
+                    self.check_program_deployment_slot(),
+                );
+                let program_to_load = if missing_programs.is_empty() {
+                    // Program account was closed
+                    None
+                } else {
+                    // Figure out if the program was already loaded in the meantime an can be skipped.
+                    program_cache.extract(
+                        &mut missing_programs,
+                        &mut program_cache_for_tx_batch,
+                        &upcoming_environment,
+                        false, // increment_usage_counter
+                        false, // count_hits_and_misses
+                    )
+                };
+                // Unlock the global cache again.
+                drop(program_cache);
+                if let Some(key) = program_to_load {
+                    // Load, verify and compile one program.
+                    let (recompiled, last_modification_slot) = load_program_with_pubkey(
+                        self,
+                        &upcoming_environment,
+                        &key,
+                        self.slot,
+                        &mut ExecuteTimings::default(),
+                    )
+                    .expect("called load_program_with_pubkey() with nonexistent account");
                     recompiled.stats.merge_from(&program_to_recompile.stats);
+                    // Lock the global cache.
                     let mut program_cache = self
                         .transaction_processor
                         .global_program_cache
                         .write()
                         .unwrap();
-                    program_cache.assign_program(
+                    // Submit our last completed loading task.
+                    program_cache.finish_cooperative_loading_task(
                         &upcoming_environment,
+                        self.slot,
                         key,
                         last_modification_slot,
                         recompiled,
                     );
+                    // Unlock the global cache again.
                 }
             }
         } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1567,7 +1567,7 @@ impl Bank {
                 .checked_div(2)
                 .unwrap();
 
-        let program_cache = self
+        let program_cache_guard = self
             .transaction_processor
             .global_program_cache
             .read()
@@ -1597,7 +1597,7 @@ impl Bank {
                     None
                 } else {
                     // Figure out if the program was already loaded in the meantime an can be skipped.
-                    program_cache.extract(
+                    program_cache_guard.extract(
                         &mut missing_programs,
                         &mut program_cache_for_tx_batch,
                         &upcoming_environment,
@@ -1605,8 +1605,8 @@ impl Bank {
                         false, // count_hits_and_misses
                     )
                 };
-                // Unlock the global cache again.
-                drop(program_cache);
+                // Unlock again because load_program_with_pubkey() might take a while.
+                drop(program_cache_guard);
                 if let Some(key) = program_to_load {
                     // Load, verify and compile one program.
                     let (recompiled, last_modification_slot) = load_program_with_pubkey(
@@ -1618,21 +1618,20 @@ impl Bank {
                     )
                     .expect("called load_program_with_pubkey() with nonexistent account");
                     recompiled.stats.merge_from(&program_to_recompile.stats);
-                    // Lock the global cache.
-                    let mut program_cache = self
+                    // Lock the global cache as writable this time.
+                    let mut program_cache_guard = self
                         .transaction_processor
                         .global_program_cache
                         .write()
                         .unwrap();
                     // Submit our last completed loading task.
-                    program_cache.finish_cooperative_loading_task(
+                    program_cache_guard.finish_cooperative_loading_task(
                         &upcoming_environment,
                         self.slot,
                         key,
                         last_modification_slot,
                         recompiled,
                     );
-                    // Unlock the global cache again.
                 }
             }
         } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {
@@ -1647,7 +1646,7 @@ impl Bank {
             let changed_program_runtime_environment = *upcoming_environment != *new_environment;
             if changed_program_runtime_environment {
                 upcoming_environment = new_environment;
-                epoch_boundary_preparation.programs_to_recompile = program_cache
+                epoch_boundary_preparation.programs_to_recompile = program_cache_guard
                     .get_flattened_entries()
                     .into_iter()
                     .map(|(id, _last_modification_slot, entry)| (id, entry))

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -131,9 +131,7 @@ use {
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
         invoke_context::BuiltinFunctionRegisterer,
-        loaded_programs::{
-            ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
-        },
+        loaded_programs::{ProgramRuntimeEnvironment, ProgramRuntimeEnvironments},
         program_cache_entry::ProgramCacheEntry,
     },
     solana_pubkey::Pubkey,
@@ -157,7 +155,6 @@ use {
     solana_svm::{
         account_loader::LoadedTransaction,
         account_overrides::AccountOverrides,
-        program_loader::{filter_executable_program_accounts, load_program_with_pubkey},
         transaction_balances::{BalanceCollector, SvmTokenInfo},
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_error_metrics::TransactionErrorMetrics,
@@ -224,6 +221,7 @@ use {
     solana_nonce as nonce,
     solana_nonce_account::{SystemAccountKind, get_system_account_kind},
     solana_program_runtime::sysvar_cache::SysvarCache,
+    solana_svm::program_loader::load_program_with_pubkey,
 };
 
 /// params to `verify_accounts_hash`
@@ -1567,11 +1565,6 @@ impl Bank {
                 .checked_div(2)
                 .unwrap();
 
-        let program_cache_guard = self
-            .transaction_processor
-            .global_program_cache
-            .read()
-            .unwrap();
         let mut epoch_boundary_preparation = self
             .transaction_processor
             .epoch_boundary_preparation
@@ -1585,54 +1578,14 @@ impl Bank {
                 epoch_boundary_preparation.programs_to_recompile.pop()
             {
                 drop(epoch_boundary_preparation);
-                let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
-                let mut missing_programs = filter_executable_program_accounts(
-                    self,
-                    &program_cache_for_tx_batch,
-                    std::iter::once(&key),
-                    self.check_program_deployment_slot(),
-                );
-                let program_to_load = if missing_programs.is_empty() {
-                    // Program account was closed
-                    None
-                } else {
-                    // Figure out if the program was already loaded in the meantime an can be skipped.
-                    program_cache_guard.extract(
-                        &mut missing_programs,
-                        &mut program_cache_for_tx_batch,
-                        &upcoming_environment,
-                        false, // increment_usage_counter
-                        false, // count_hits_and_misses
-                    )
-                };
-                // Unlock again because load_program_with_pubkey() might take a while.
-                drop(program_cache_guard);
-                if let Some(key) = program_to_load {
-                    // Load, verify and compile one program.
-                    let (recompiled, last_modification_slot) = load_program_with_pubkey(
+                self.transaction_processor
+                    .prepare_one_program_for_upcoming_feature_set(
                         self,
+                        self.check_program_deployment_slot(),
                         &upcoming_environment,
                         &key,
-                        self.slot,
-                        &mut ExecuteTimings::default(),
-                    )
-                    .expect("called load_program_with_pubkey() with nonexistent account");
-                    recompiled.stats.merge_from(&program_to_recompile.stats);
-                    // Lock the global cache as writable this time.
-                    let mut program_cache_guard = self
-                        .transaction_processor
-                        .global_program_cache
-                        .write()
-                        .unwrap();
-                    // Submit our last completed loading task.
-                    program_cache_guard.finish_cooperative_loading_task(
-                        &upcoming_environment,
-                        self.slot,
-                        key,
-                        last_modification_slot,
-                        recompiled,
+                        &program_to_recompile.stats,
                     );
-                }
             }
         } else if slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch {
             // Anticipate the upcoming program runtime environment for the next epoch,
@@ -1646,6 +1599,11 @@ impl Bank {
             let changed_program_runtime_environment = *upcoming_environment != *new_environment;
             if changed_program_runtime_environment {
                 upcoming_environment = new_environment;
+                let program_cache_guard = self
+                    .transaction_processor
+                    .global_program_cache
+                    .read()
+                    .unwrap();
                 epoch_boundary_preparation.programs_to_recompile = program_cache_guard
                     .get_flattened_entries()
                     .into_iter()

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -20,7 +20,6 @@ use {
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
     solana_svm_callback::TransactionProcessingCallback,
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::svm_message::SVMMessage,
     solana_svm_type_overrides::sync::Arc,
     solana_transaction_error::{TransactionError, TransactionResult},
     std::sync::atomic::Ordering,
@@ -250,11 +249,11 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
 pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,
-    tx: &'a impl SVMMessage,
+    keys: impl Iterator<Item = &'a Pubkey>,
     check_program_deployment_slot: bool,
 ) -> Vec<ProgramToLoad<'a>> {
     let mut result = Vec::new();
-    for account_key in tx.account_keys().iter() {
+    for account_key in keys {
         if let Some(cache_entry) = program_cache_for_tx_batch.find(account_key) {
             cache_entry.stats.uses.fetch_add(1, Ordering::Relaxed);
         } else if let Some((account, last_modification_slot)) =
@@ -322,6 +321,7 @@ mod tests {
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
+        solana_svm_transaction::svm_message::SVMMessage,
         solana_svm_type_overrides::sync::atomic::AtomicU64,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::{
@@ -885,7 +885,7 @@ mod tests {
         let missing_programs = filter_executable_program_accounts(
             &mock_bank,
             &loaded_programs_for_tx_batch,
-            &sanitized_tx,
+            sanitized_tx.account_keys().iter(),
             false,
         );
         assert_eq!(
@@ -909,7 +909,7 @@ mod tests {
         let missing_programs = filter_executable_program_accounts(
             &mock_bank,
             &loaded_programs_for_tx_batch,
-            &sanitized_tx,
+            sanitized_tx.account_keys().iter(),
             true,
         );
         assert_eq!(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -509,7 +509,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         measure_us!(filter_executable_program_accounts(
                             &account_loader,
                             &program_cache_for_tx_batch,
-                            tx,
+                            tx.account_keys().iter(),
                             config.check_program_deployment_slot,
                         ));
                     execute_timings.saturating_add_in_place(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -47,6 +47,7 @@ use {
             ProgramToLoad,
         },
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
+        program_metrics::ProgramStatistics,
         solana_sbpf::{program::BuiltinProgram, vm::Config as VmConfig},
         sysvar_cache::SysvarCache,
     },
@@ -893,6 +894,62 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 // missing programs inside the tx batch again.
                 let _new_cookie = task_waiter.wait(task_cookie);
             }
+        }
+    }
+
+    /// Similar to replenish_program_cache() but only used in Bank::prepare_program_cache_for_upcoming_feature_set().
+    pub fn prepare_one_program_for_upcoming_feature_set<CB: TransactionProcessingCallback>(
+        &self,
+        account_loader: &CB,
+        check_program_deployment_slot: bool,
+        upcoming_environment: &ProgramRuntimeEnvironment,
+        key: &Pubkey,
+        stats_of_enqueued_program: &ProgramStatistics,
+    ) {
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(self.slot);
+        let mut missing_programs = filter_executable_program_accounts(
+            account_loader,
+            &program_cache_for_tx_batch,
+            std::iter::once(key),
+            check_program_deployment_slot,
+        );
+        if missing_programs.is_empty() {
+            // Program account was closed
+            return;
+        }
+        let program_to_load = {
+            let program_cache_guard = self.global_program_cache.read().unwrap();
+            program_cache_guard.extract(
+                &mut missing_programs,
+                &mut program_cache_for_tx_batch,
+                upcoming_environment,
+                false, // increment_usage_counter
+                false, // count_hits_and_misses
+            )
+            // Unlock again because load_program_with_pubkey() might take a while.
+        };
+        // Maybe the enqueued program was already loaded and can be skipped.
+        if let Some(key) = program_to_load {
+            // Load, verify and compile one program.
+            let (recompiled, last_modification_slot) = load_program_with_pubkey(
+                account_loader,
+                upcoming_environment,
+                &key,
+                self.slot,
+                &mut ExecuteTimings::default(),
+            )
+            .expect("called load_program_with_pubkey() with nonexistent account");
+            recompiled.stats.merge_from(stats_of_enqueued_program);
+            // Lock the global cache as writable this time.
+            let mut program_cache_guard = self.global_program_cache.write().unwrap();
+            // Submit our last completed loading task.
+            program_cache_guard.finish_cooperative_loading_task(
+                upcoming_environment,
+                self.slot,
+                key,
+                last_modification_slot,
+                recompiled,
+            );
         }
     }
 


### PR DESCRIPTION
#### Problem

After the epoch boundary TX batches can race with the rest of the preparation queue and both compile the same programs.

Fixes https://discord.com/channels/428295358100013066/439194979856809985/1514923799101968416

Alternative patch to #13164.

#### Summary of Changes

- Turns TX keys parameter of `filter_executable_program_accounts()` into a generic iterator.
- Take a loading lock in `prepare_program_cache_for_upcoming_feature_set()` to prevent racing for the program to reload.
- Uses `ProgramCache::extract()` to skip over programs which are already being loaded by others.