### PR TITLE
feat: Add observability about VAT in 'monitor'

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -109,7 +109,6 @@ use {
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
     },
-    thiserror::Error,
 };
 
 mod dead_slots;
@@ -140,16 +139,6 @@ const MAX_REPAIR_RETRY_LOOP_ATTEMPTS: usize = 10;
 const REFRESH_VOTE_BLOCKHEIGHT: usize = 16;
 
 const VAT_STATUS_CHECK_INTERVAL_SECS: u64 = 30;
-
-#[derive(Error, Debug)]
-enum VATHealthError {
-    #[error("vote account not found")]
-    VoteAccountNotFound,
-    #[error("missing BLS pubkey")]
-    NoBLSPubkey,
-    #[error("insufficient lamports in vote account: {0} < {1}")]
-    InsufficientFundsInVoteAccount(u64, u64),
-}
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum HeaviestForkFailures {
@@ -3168,7 +3157,7 @@ impl ReplayStage {
         }
 
         let epoch = bank.epoch();
-        if let Err(vat_failure_reason) = Self::check_vat_health(&bank, vote_account) {
+        if let Err(vat_failure_reason) = bank.get_vat_health_for_next_epoch(vote_account) {
             warn!(
                 "VAT Health Check: Currently you will fail the VAT check at the start of epoch {} \
                  meaning that you will be unable to vote or produce blocks in epoch {}. Reason: {}",
@@ -3184,33 +3173,6 @@ impl ReplayStage {
                 epoch.saturating_add(2),
             );
         }
-    }
-
-    fn check_vat_health(bank: &Bank, vote_account_pubkey: &Pubkey) -> Result<(), VATHealthError> {
-        let vote_accounts = bank.vote_accounts();
-
-        let Some((_, vote_account)) = vote_accounts.get(vote_account_pubkey) else {
-            return Err(VATHealthError::VoteAccountNotFound);
-        };
-
-        if vote_account
-            .vote_state_view()
-            .bls_pubkey_compressed()
-            .is_none()
-        {
-            return Err(VATHealthError::NoBLSPubkey);
-        }
-
-        let my_balance = vote_account.lamports();
-        let minimum_vote_account_balance_for_vat = bank.minimum_vote_account_balance_for_vat();
-        if vote_account.lamports() < minimum_vote_account_balance_for_vat {
-            return Err(VATHealthError::InsufficientFundsInVoteAccount(
-                my_balance,
-                minimum_vote_account_balance_for_vat,
-            ));
-        }
-
-        Ok(())
     }
 
     fn generate_vote_tx(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -210,6 +210,7 @@ use {
         },
         time::{Duration, Instant},
     },
+    thiserror::Error,
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -462,6 +463,16 @@ impl TransactionLogCollector {
             }),
         }
     }
+}
+
+#[derive(Error, Debug, Serialize, Deserialize)]
+pub enum VATHealthError {
+    #[error("vote account not found")]
+    VoteAccountNotFound,
+    #[error("missing BLS pubkey")]
+    NoBLSPubkey,
+    #[error("insufficient lamports in vote account: {0} < {1}")]
+    InsufficientFundsInVoteAccount(u64, u64),
 }
 
 /// Bank's common fields shared by all supported snapshot versions for deserialization.
@@ -2778,6 +2789,36 @@ impl Bank {
     /// Returns the Validator Admission Ticket burn for this bank's slot params.
     pub(crate) fn vat_to_burn_per_epoch(&self) -> u64 {
         self.current_slot_params().vat_to_burn_per_epoch()
+    }
+
+    pub fn get_vat_health_for_next_epoch(
+        &self,
+        vote_account_pubkey: &Pubkey,
+    ) -> std::result::Result<(), VATHealthError> {
+        let vote_accounts = self.vote_accounts();
+
+        let Some((_, vote_account)) = vote_accounts.get(vote_account_pubkey) else {
+            return Err(VATHealthError::VoteAccountNotFound);
+        };
+
+        if vote_account
+            .vote_state_view()
+            .bls_pubkey_compressed()
+            .is_none()
+        {
+            return Err(VATHealthError::NoBLSPubkey);
+        }
+
+        let my_balance = vote_account.lamports();
+        let minimum_vote_account_balance_for_vat = self.minimum_vote_account_balance_for_vat();
+        if vote_account.lamports() < minimum_vote_account_balance_for_vat {
+            return Err(VATHealthError::InsufficientFundsInVoteAccount(
+                my_balance,
+                minimum_vote_account_balance_for_vat,
+            ));
+        }
+
+        Ok(())
     }
 
     /// Returns the effective slot duration for `slot`.

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -11,7 +11,7 @@ use {
     },
     log::*,
     serde::{Deserialize, Serialize, de::Deserializer},
-    solana_clock::Slot,
+    solana_clock::{Epoch, Slot},
     solana_core::{
         admin_rpc_post_init::AdminRpcRequestMetadataPostInit,
         banking_stage::{
@@ -30,7 +30,7 @@ use {
     solana_keypair::{Keypair, read_keypair_file},
     solana_metrics::{datapoint_info, datapoint_warn},
     solana_pubkey::Pubkey,
-    solana_runtime::snapshot_controller::SnapshotController,
+    solana_runtime::{bank::VATHealthError, snapshot_controller::SnapshotController},
     solana_signer::Signer,
     solana_validator_exit::Exit,
     std::{
@@ -110,6 +110,17 @@ pub struct AdminRpcContactInfo {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct AdminRpcRepairWhitelist {
     pub whitelist: Vec<Pubkey>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AdminRpcValidatorAdmissionTicketStatus {
+    pub vote_account: Pubkey,
+    pub current_epoch: Epoch,
+    pub vat_active: bool,
+    pub in_current_epoch_vat: bool,
+    pub current_epoch_vote_account_stake: u64,
+    pub current_epoch_vote_accounts: usize,
+    pub next_epoch_vat_failure_reason: Option<VATHealthError>,
 }
 
 impl From<ContactInfo> for AdminRpcContactInfo {
@@ -240,6 +251,9 @@ pub trait AdminRpc {
 
     #[rpc(meta, name = "contactInfo")]
     fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo>;
+
+    #[rpc(meta, name = "validatorAdmissionTicketStatus")]
+    fn vat_status(&self, meta: Self::Metadata) -> Result<AdminRpcValidatorAdmissionTicketStatus>;
 
     #[rpc(meta, name = "selectActiveInterface")]
     fn select_active_interface(&self, meta: Self::Metadata, interface: IpAddr) -> Result<()>;
@@ -623,6 +637,38 @@ impl AdminRpc for AdminRpcImpl {
 
     fn contact_info(&self, meta: Self::Metadata) -> Result<AdminRpcContactInfo> {
         meta.with_post_init(|post_init| Ok(post_init.cluster_info.my_contact_info().into()))
+    }
+
+    fn vat_status(&self, meta: Self::Metadata) -> Result<AdminRpcValidatorAdmissionTicketStatus> {
+        debug!("vat_status request received");
+        meta.with_post_init(|post_init| {
+            let bank = post_init.bank_forks.read().unwrap().root_bank();
+            let current_epoch = bank.epoch();
+            let vat_active = bank.feature_set.snapshot().validator_admission_ticket;
+            let epoch_vote_accounts = bank
+                .epoch_vote_accounts(current_epoch)
+                .ok_or_else(jsonrpc_core::Error::internal_error)?;
+            let current_epoch_vote_account_stake = epoch_vote_accounts
+                .get(&post_init.vote_account)
+                .map(|(stake, _vote_account)| *stake)
+                .unwrap_or_default();
+            let in_current_epoch_vote_accounts =
+                epoch_vote_accounts.contains_key(&post_init.vote_account);
+
+            let next_epoch_vat_failure_reason = bank
+                .get_vat_health_for_next_epoch(&post_init.vote_account)
+                .err();
+
+            Ok(AdminRpcValidatorAdmissionTicketStatus {
+                vote_account: post_init.vote_account,
+                current_epoch,
+                vat_active,
+                in_current_epoch_vat: vat_active && in_current_epoch_vote_accounts,
+                current_epoch_vote_account_stake,
+                current_epoch_vote_accounts: epoch_vote_accounts.len(),
+                next_epoch_vat_failure_reason,
+            })
+        })
     }
 
     fn select_active_interface(&self, meta: Self::Metadata, interface: IpAddr) -> Result<()> {
@@ -1285,6 +1331,41 @@ mod tests {
             .recv()
             .expect("Failed to receive SetIdentity event");
         assert_matches!(event, VotorEvent::SetIdentity);
+    }
+
+    #[test]
+    fn test_vat_status() {
+        let rpc = RpcHandler::_start();
+        let RpcHandler { io, meta, .. } = rpc;
+        let post_init = meta.post_init.read().unwrap().clone().unwrap();
+        let bank = post_init.bank_forks.read().unwrap().root_bank();
+        let current_epoch = bank.epoch();
+        let epoch_vote_accounts = bank.epoch_vote_accounts(current_epoch).unwrap();
+        let expected_vat_active = bank.feature_set.snapshot().validator_admission_ticket;
+        let expected_in_vat =
+            expected_vat_active && epoch_vote_accounts.contains_key(&post_init.vote_account);
+        let expected_stake = epoch_vote_accounts
+            .get(&post_init.vote_account)
+            .map(|(stake, _vote_account)| *stake)
+            .unwrap_or_default();
+
+        let request =
+            r#"{"jsonrpc":"2.0","id":1,"method":"validatorAdmissionTicketStatus","params":[]}"#;
+        let response = io.handle_request_sync(request, meta.clone());
+        let result: Value = serde_json::from_str(&response.expect("actual response"))
+            .expect("actual response deserialization");
+        let status: AdminRpcValidatorAdmissionTicketStatus =
+            serde_json::from_value(result["result"].clone()).unwrap();
+
+        assert_eq!(status.vote_account, post_init.vote_account);
+        assert_eq!(status.current_epoch, current_epoch);
+        assert_eq!(status.vat_active, expected_vat_active);
+        assert_eq!(status.in_current_epoch_vat, expected_in_vat);
+        assert_eq!(status.current_epoch_vote_account_stake, expected_stake);
+        assert_eq!(
+            status.current_epoch_vote_accounts,
+            epoch_vote_accounts.len()
+        );
     }
 
     struct TestValidatorWithAdminRpc {

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -118,6 +118,10 @@ impl Dashboard {
 
             let progress_bar = new_spinner_progress_bar();
             let mut snapshot_slot_info = None;
+            let mut vat_status = None;
+            let mut admin_client = runtime
+                .block_on(admin_rpc_service::connect(&ledger_path))
+                .ok();
             for i in 0.. {
                 if exit.load(Ordering::Relaxed) {
                     break;
@@ -130,6 +134,26 @@ impl Dashboard {
                 if identity != new_identity {
                     identity = new_identity;
                     progress_bar.println(format_name_value("Identity:", &identity.to_string()));
+                }
+
+                if i % 30 == 0 {
+                    if admin_client.is_none() {
+                        admin_client = runtime
+                            .block_on(admin_rpc_service::connect(&ledger_path))
+                            .ok();
+                    }
+
+                    let vat_status_result = admin_client
+                        .as_ref()
+                        .map(|admin_client| runtime.block_on(admin_client.vat_status()));
+                    vat_status = match vat_status_result {
+                        Some(Ok(status)) => Some(status),
+                        Some(Err(_err)) => {
+                            admin_client = None;
+                            None
+                        }
+                        None => None,
+                    };
                 }
 
                 match get_validator_stats(&rpc_client, &identity) {
@@ -153,10 +177,12 @@ impl Dashboard {
                             )
                         };
 
+                        let vat_status_formatted = format_vat_status(vat_status.as_ref());
+
                         progress_bar.set_message(format!(
                             "{}{}| Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: {} | \
                              Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
-                             Transactions: {} | {}",
+                             Transactions: {} | {}\n{}",
                             uptime,
                             if health == "ok" {
                                 "".to_string()
@@ -177,7 +203,8 @@ impl Dashboard {
                                     .map(|incremental| incremental.to_string()))
                                 .unwrap_or_else(|| '-'.to_string()),
                             transaction_count,
-                            identity_balance
+                            identity_balance,
+                            vat_status_formatted,
                         ));
                         thread::sleep(refresh_interval);
                     }
@@ -188,6 +215,49 @@ impl Dashboard {
                 }
             }
         }
+    }
+}
+
+fn format_vat_status(
+    status: Option<&admin_rpc_service::AdminRpcValidatorAdmissionTicketStatus>,
+) -> String {
+    let Some(status) = status else {
+        return "VAT: failed to connect to admin RPC".to_string();
+    };
+
+    if !status.vat_active {
+        return "VAT: inactive".to_string();
+    }
+
+    format!(
+        "{}{}",
+        format_current_vat_status(status),
+        format_effective_epoch_vat_status(status)
+    )
+}
+
+fn format_current_vat_status(
+    status: &admin_rpc_service::AdminRpcValidatorAdmissionTicketStatus,
+) -> String {
+    if status.in_current_epoch_vat {
+        format!(
+            "VAT: epoch {} in (stake: {})",
+            status.current_epoch,
+            Sol(status.current_epoch_vote_account_stake)
+        )
+    } else {
+        format!("VAT: epoch {} out", status.current_epoch)
+    }
+}
+
+fn format_effective_epoch_vat_status(
+    status: &admin_rpc_service::AdminRpcValidatorAdmissionTicketStatus,
+) -> String {
+    let vat_effective_epoch = status.current_epoch.saturating_add(2);
+    if let Some(vat_failure_reason) = &status.next_epoch_vat_failure_reason {
+        format!(", epoch {vat_effective_epoch}: {vat_failure_reason}")
+    } else {
+        format!(", epoch {vat_effective_epoch}: eligible if staked")
     }
 }
 


### PR DESCRIPTION
#### Problem
We have no alerting or monitoring about the validators' VAT status in the 'monitor' CLI command.

#### Summary of Changes

- Refactored VAT health status checks to `bank.rs`
- Add VAT status for current epoch in 'monitor'
- Add VAT eligibility status for next epoch in 'monitor'

#### Testing
`test_validator_admission_ticket_status` in `/validator/src/admin_rpc_services.rs`

This addresses the validator logging and monitor portions of #12631. Watchtower notifications remain out of scope for this PR.
