### PR TITLE
read layer: add handling for Alpenglow UpdateParent

### DIFF
--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -11,7 +11,7 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_entry::entry::Entry,
     solana_ledger::{
-        blockstore::{Blockstore, CompletedDataSetInfo},
+        blockstore::{Blockstore, CompletedDataSetInfo, UpdateParentReceiver},
         deshred_transaction_notifier_interface::{
             DeshredTransactionNotifier, DeshredTransactionNotifierArc,
         },
@@ -103,6 +103,7 @@ pub struct CompletedDataSetsService {
 impl CompletedDataSetsService {
     pub fn new(
         completed_sets_receiver: CompletedDataSetsReceiver,
+        update_parent_receiver: UpdateParentReceiver,
         blockstore: Arc<Blockstore>,
         rpc_subscriptions: Arc<RpcSubscriptions>,
         deshred_transaction_notifier: Option<DeshredTransactionNotifierArc>,
@@ -120,6 +121,7 @@ impl CompletedDataSetsService {
                     }
                     if let Err(RecvTimeoutError::Disconnected) = Self::recv_completed_data_sets(
                         &completed_sets_receiver,
+                        &update_parent_receiver,
                         &blockstore,
                         &rpc_subscriptions,
                         &deshred_transaction_notifier,
@@ -137,6 +139,7 @@ impl CompletedDataSetsService {
 
     fn recv_completed_data_sets(
         completed_sets_receiver: &CompletedDataSetsReceiver,
+        update_parent_receiver: &UpdateParentReceiver,
         blockstore: &Blockstore,
         rpc_subscriptions: &RpcSubscriptions,
         deshred_transaction_notifier: &Option<DeshredTransactionNotifierArc>,
@@ -144,6 +147,10 @@ impl CompletedDataSetsService {
         bank_forks: &RwLock<BankForks>,
     ) -> Result<(), RecvTimeoutError> {
         const RECV_TIMEOUT: Duration = Duration::from_secs(1);
+        Self::notify_update_parent_signals(
+            update_parent_receiver,
+            deshred_transaction_notifier.as_deref(),
+        );
         let first_completed_data_sets = completed_sets_receiver.recv_timeout(RECV_TIMEOUT)?;
         let root_bank = deshred_transaction_notifier
             .as_ref()
@@ -209,7 +216,30 @@ impl CompletedDataSetsService {
             );
         }
 
+        Self::notify_update_parent_signals(
+            update_parent_receiver,
+            deshred_transaction_notifier.as_deref(),
+        );
         Ok(())
+    }
+
+    fn notify_update_parent_signals(
+        update_parent_receiver: &UpdateParentReceiver,
+        deshred_transaction_notifier: Option<&(dyn DeshredTransactionNotifier + Send + Sync)>,
+    ) {
+        let mut update_parent_count = 0;
+        for update_parent in update_parent_receiver.try_iter() {
+            if let Some(notifier) = deshred_transaction_notifier {
+                notifier.notify_update_parent(&update_parent);
+            }
+            update_parent_count += 1;
+        }
+        if update_parent_count > 0 {
+            datapoint_info!(
+                "completed_data_sets-update-parent",
+                ("update_parent_count", update_parent_count, i64),
+            );
+        }
     }
 
     fn notify_deshred_transactions_for_completed_data_set(
@@ -300,7 +330,9 @@ pub mod test {
         solana_instruction::Instruction,
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore, blockstore::Blockstore, get_tmp_ledger_path_auto_delete,
+            blockstore,
+            blockstore::{Blockstore, UpdateParentSignal},
+            get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
         },
         solana_message::{
@@ -337,6 +369,7 @@ pub mod test {
     #[derive(Default)]
     struct TestDeshredTransactionNotifier {
         notifications: Mutex<Vec<DeshredNotification>>,
+        update_parents: Mutex<Vec<UpdateParentSignal>>,
     }
 
     impl DeshredTransactionNotifier for TestDeshredTransactionNotifier {
@@ -366,6 +399,13 @@ pub mod test {
 
         fn alt_resolution_enabled(&self) -> bool {
             false
+        }
+
+        fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+            self.update_parents
+                .lock()
+                .unwrap()
+                .push(update_parent.clone());
         }
     }
 
@@ -409,6 +449,27 @@ pub mod test {
         ];
         let signatures = CompletedDataSetsService::get_transaction_signatures(entries);
         assert_eq!(signatures.len(), 3);
+    }
+
+    #[test]
+    fn test_notify_update_parent_signals() {
+        let notifier = TestDeshredTransactionNotifier::default();
+        let (sender, receiver) = bounded(1);
+        let update_parent = UpdateParentSignal {
+            slot: 42,
+            update_parent_fec_set_index: 8,
+            parent_slot: 7,
+            parent_block_id: Some(Hash::new_unique()),
+        };
+        sender.send(update_parent.clone()).unwrap();
+
+        CompletedDataSetsService::notify_update_parent_signals(&receiver, Some(&notifier));
+
+        assert_eq!(
+            *notifier.update_parents.lock().unwrap(),
+            vec![update_parent]
+        );
+        assert!(receiver.try_recv().is_err());
     }
 
     #[test]
@@ -541,6 +602,7 @@ pub mod test {
         let test_notifier = Arc::new(TestDeshredTransactionNotifier::default());
         let notifier = Some(test_notifier.clone() as DeshredTransactionNotifierArc);
         let (sender, receiver) = bounded(1);
+        let (_update_parent_sender, update_parent_receiver) = bounded(1);
         let entries = vec![next_versioned_entry(
             &Hash::default(),
             1,
@@ -558,6 +620,7 @@ pub mod test {
 
         CompletedDataSetsService::recv_completed_data_sets(
             &receiver,
+            &update_parent_receiver,
             &blockstore,
             &rpc_subscriptions,
             &notifier,
@@ -597,6 +660,7 @@ pub mod test {
         let test_notifier = Arc::new(TestDeshredTransactionNotifier::default());
         let notifier = Some(test_notifier.clone() as DeshredTransactionNotifierArc);
         let (sender, receiver) = bounded(1);
+        let (_update_parent_sender, update_parent_receiver) = bounded(1);
 
         let num_entries = max_ticks_per_n_shreds(1, None) as usize + 1;
         let mut previous_hash = Hash::default();
@@ -624,6 +688,7 @@ pub mod test {
 
         CompletedDataSetsService::recv_completed_data_sets(
             &receiver,
+            &update_parent_receiver,
             &blockstore,
             &rpc_subscriptions,
             &notifier,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -120,8 +120,8 @@ use {
         DeadSlotContext, DeadSlotDuplicateContext, DeadSlotNotifications, mark_replay_dead_slot,
     },
     update_parent::{
-        ChildBankReplayStart, child_bank_replay_start, handle_abandoned_bank,
-        handle_update_parent_interrupts, process_soft_dead_slots,
+        ChildBankReplayStart, UpdateParentNotificationSenders, child_bank_replay_start,
+        handle_abandoned_bank, handle_update_parent_interrupts, process_soft_dead_slots,
     },
 };
 
@@ -967,6 +967,13 @@ impl ReplayStage {
                     break;
                 }
 
+                let update_parent_notification_senders = UpdateParentNotificationSenders::new(
+                    &replay_vote_sender,
+                    rpc_subscriptions.clone(),
+                    slot_status_notifier.clone(),
+                    transaction_status_sender.as_ref(),
+                );
+
                 handle_update_parent_interrupts(
                     &my_pubkey,
                     &blockstore,
@@ -974,7 +981,7 @@ impl ReplayStage {
                     &mut progress,
                     &mut async_verification_freelist,
                     &update_parent_receiver,
-                    &replay_vote_sender,
+                    &update_parent_notification_senders,
                     migration_status.as_ref(),
                 );
 
@@ -1060,11 +1067,9 @@ impl ReplayStage {
                         &my_pubkey,
                         &blockstore,
                         &bank_forks,
-                        &rpc_subscriptions,
-                        &slot_status_notifier,
                         &mut progress,
                         &mut async_verification_freelist,
-                        &replay_vote_sender,
+                        &update_parent_notification_senders,
                         migration_status.as_ref(),
                     );
                     Self::alpenglow_handle_newly_frozen_banks(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -972,6 +972,8 @@ impl ReplayStage {
                     rpc_subscriptions.clone(),
                     slot_status_notifier.clone(),
                     transaction_status_sender.as_ref(),
+                    entry_notification_sender.as_ref(),
+                    block_metadata_notifier.as_ref(),
                 );
 
                 handle_update_parent_interrupts(

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -2865,7 +2865,7 @@ fn test_update_parent_restart() {
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3004,7 +3004,7 @@ fn test_update_parent_tower_gated() {
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3056,7 +3056,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3111,7 +3111,7 @@ fn test_update_parent_keeps_hard() {
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3332,7 +3332,7 @@ fn test_soft_dead_restarts() {
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3375,7 +3375,7 @@ fn test_full_soft_dead_hardens() {
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
     let update_parent_notification_senders =
-        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -2853,11 +2853,19 @@ fn test_update_parent_restart() {
             parent_block_id,
             32,
         );
-        tx.send(UpdateParentSignal { slot }).unwrap();
+        tx.send(UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index: 32,
+            parent_slot: 0,
+            parent_block_id: Some(parent_block_id),
+        })
+        .unwrap();
     }
 
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -2866,7 +2874,7 @@ fn test_update_parent_restart() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -2986,9 +2994,17 @@ fn test_update_parent_tower_gated() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -2997,7 +3013,7 @@ fn test_update_parent_tower_gated() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &MigrationStatus::default(),
     );
 
@@ -3030,9 +3046,17 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(meta.parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3041,7 +3065,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3077,9 +3101,17 @@ fn test_update_parent_keeps_hard() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3088,7 +3120,7 @@ fn test_update_parent_keeps_hard() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3299,16 +3331,16 @@ fn test_soft_dead_restarts() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
         &blockstore,
         &bank_forks,
-        &None,
-        &None,
         &mut progress,
         &mut async_verification_freelist,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3342,16 +3374,16 @@ fn test_full_soft_dead_hardens() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
         &blockstore,
         &bank_forks,
-        &None,
-        &None,
         &mut progress,
         &mut async_verification_freelist,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -16,11 +16,13 @@ use {
     solana_clock::Slot,
     solana_entry::block_component::VersionedUpdateParent,
     solana_ledger::{
-        blockstore::{Blockstore, UpdateParentReceiver},
+        blockstore::{Blockstore, UpdateParentReceiver, UpdateParentSignal},
         blockstore_meta::SlotMeta,
-        blockstore_processor::AsyncVerificationProgress,
+        blockstore_processor::{AsyncVerificationProgress, TransactionStatusSender},
     },
+    solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
+    solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, leader_schedule_utils::leader_slot_index,
         vote_sender_types::ReplayVoteSender,
@@ -178,6 +180,66 @@ fn try_restart_slot_from_update_parent(
     true
 }
 
+fn update_parent_signal_from_blockstore(
+    blockstore: &Blockstore,
+    slot: Slot,
+) -> Option<UpdateParentSignal> {
+    let slot_meta = blockstore.meta(slot).expect("Blockstore should not fail")?;
+    UpdateParentSignal::from_slot_meta(slot, &slot_meta)
+}
+
+pub(super) struct UpdateParentNotificationSenders<'a> {
+    replay_vote_sender: &'a ReplayVoteSender,
+    rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+    slot_status_notifier: Option<SlotStatusNotifier>,
+    transaction_status_sender: Option<&'a TransactionStatusSender>,
+}
+
+impl<'a> UpdateParentNotificationSenders<'a> {
+    pub(super) fn new(
+        replay_vote_sender: &'a ReplayVoteSender,
+        rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+        slot_status_notifier: Option<SlotStatusNotifier>,
+        transaction_status_sender: Option<&'a TransactionStatusSender>,
+    ) -> Self {
+        Self {
+            replay_vote_sender,
+            rpc_subscriptions,
+            slot_status_notifier,
+            transaction_status_sender,
+        }
+    }
+
+    fn replay_vote_sender(&self) -> &ReplayVoteSender {
+        self.replay_vote_sender
+    }
+
+    fn dead_slot_notifications(&self, blockstore: Arc<Blockstore>) -> DeadSlotNotifications {
+        DeadSlotNotifications {
+            blockstore,
+            rpc_subscriptions: self.rpc_subscriptions.clone(),
+            slot_status_notifier: self.slot_status_notifier.clone(),
+            replay_vote_sender: self.replay_vote_sender.clone(),
+        }
+    }
+
+    fn notify_read_layer_consumers(&self, update_parent: &UpdateParentSignal) {
+        if let Some(transaction_status_sender) = self.transaction_status_sender {
+            transaction_status_sender.send_update_parent(update_parent.clone());
+        }
+        datapoint_info!(
+            "replay-stage-update-parent-read-layer-invalidation",
+            ("slot", update_parent.slot, i64),
+            (
+                "update_parent_fec_set_index",
+                update_parent.update_parent_fec_set_index,
+                i64
+            ),
+            ("parent_slot", update_parent.parent_slot, i64),
+        );
+    }
+}
+
 /// Revisit soft-dead slots as more shreds arrive.
 ///
 /// If an UpdateParent marker is now visible in SlotMeta, replay is restarted
@@ -187,11 +249,9 @@ pub(super) fn process_soft_dead_slots(
     my_pubkey: &Pubkey,
     blockstore: &Arc<Blockstore>,
     bank_forks: &RwLock<BankForks>,
-    rpc_subscriptions: &Option<Arc<solana_rpc::rpc_subscriptions::RpcSubscriptions>>,
-    slot_status_notifier: &Option<solana_rpc::slot_status_notifier::SlotStatusNotifier>,
     progress: &mut ProgressMap,
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
-    replay_vote_sender: &ReplayVoteSender,
+    notification_senders: &UpdateParentNotificationSenders,
     migration_status: &MigrationStatus,
 ) {
     let soft_dead_slots = progress
@@ -220,17 +280,24 @@ pub(super) fn process_soft_dead_slots(
             update_parent_replay_offset(slot, &slot_meta, bank_forks.read().unwrap().root());
 
         if replay_offset.is_some() {
-            try_restart_slot_from_update_parent(
+            let did_restart = try_restart_slot_from_update_parent(
                 my_pubkey,
                 blockstore.as_ref(),
                 bank_forks,
                 progress,
                 async_verification_freelist,
                 slot,
-                replay_vote_sender,
+                notification_senders.replay_vote_sender(),
                 migration_status,
                 "soft-dead scan",
             );
+            if did_restart {
+                if let Some(update_parent) =
+                    update_parent_signal_from_blockstore(blockstore.as_ref(), slot)
+                {
+                    notification_senders.notify_read_layer_consumers(&update_parent);
+                }
+            }
             continue;
         }
 
@@ -252,12 +319,8 @@ pub(super) fn process_soft_dead_slots(
             };
             let bank = bank_forks.read().unwrap().get(slot);
             if let Some(bank) = bank {
-                let notifications = DeadSlotNotifications {
-                    blockstore: blockstore.clone(),
-                    rpc_subscriptions: rpc_subscriptions.clone(),
-                    slot_status_notifier: slot_status_notifier.clone(),
-                    replay_vote_sender: replay_vote_sender.clone(),
-                };
+                let notifications =
+                    notification_senders.dead_slot_notifications(blockstore.clone());
                 mark_hard_dead_slot_notifications(&bank, err, log_level, progress, &notifications);
             }
         }
@@ -274,21 +337,28 @@ pub(super) fn handle_update_parent_interrupts(
     progress: &mut ProgressMap,
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     update_parent_receiver: &UpdateParentReceiver,
-    replay_vote_sender: &ReplayVoteSender,
+    notification_senders: &UpdateParentNotificationSenders,
     migration_status: &MigrationStatus,
 ) {
     while let Ok(signal) = update_parent_receiver.try_recv() {
-        try_restart_slot_from_update_parent(
+        let did_restart = try_restart_slot_from_update_parent(
             my_pubkey,
             blockstore,
             bank_forks,
             progress,
             async_verification_freelist,
             signal.slot,
-            replay_vote_sender,
+            notification_senders.replay_vote_sender(),
             migration_status,
             "UpdateParent signal",
         );
+        if did_restart {
+            if let Some(update_parent) =
+                update_parent_signal_from_blockstore(blockstore, signal.slot)
+            {
+                notification_senders.notify_read_layer_consumers(&update_parent);
+            }
+        }
     }
 }
 

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -15,10 +15,12 @@ use {
     agave_votor_messages::migration::MigrationStatus,
     solana_clock::Slot,
     solana_entry::block_component::VersionedUpdateParent,
+    solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_ledger::{
         blockstore::{Blockstore, UpdateParentReceiver, UpdateParentSignal},
         blockstore_meta::SlotMeta,
         blockstore_processor::{AsyncVerificationProgress, TransactionStatusSender},
+        entry_notifier_service::{EntryNotification, EntryNotifierSender},
     },
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
@@ -193,6 +195,8 @@ pub(super) struct UpdateParentNotificationSenders<'a> {
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     slot_status_notifier: Option<SlotStatusNotifier>,
     transaction_status_sender: Option<&'a TransactionStatusSender>,
+    entry_notification_sender: Option<&'a EntryNotifierSender>,
+    block_metadata_notifier: Option<&'a BlockMetadataNotifierArc>,
 }
 
 impl<'a> UpdateParentNotificationSenders<'a> {
@@ -201,12 +205,16 @@ impl<'a> UpdateParentNotificationSenders<'a> {
         rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
         slot_status_notifier: Option<SlotStatusNotifier>,
         transaction_status_sender: Option<&'a TransactionStatusSender>,
+        entry_notification_sender: Option<&'a EntryNotifierSender>,
+        block_metadata_notifier: Option<&'a BlockMetadataNotifierArc>,
     ) -> Self {
         Self {
             replay_vote_sender,
             rpc_subscriptions,
             slot_status_notifier,
             transaction_status_sender,
+            entry_notification_sender,
+            block_metadata_notifier,
         }
     }
 
@@ -226,6 +234,19 @@ impl<'a> UpdateParentNotificationSenders<'a> {
     fn notify_read_layer_consumers(&self, update_parent: &UpdateParentSignal) {
         if let Some(transaction_status_sender) = self.transaction_status_sender {
             transaction_status_sender.send_update_parent(update_parent.clone());
+        }
+        if let Some(entry_notification_sender) = self.entry_notification_sender {
+            if let Err(err) = entry_notification_sender
+                .send(EntryNotification::UpdateParent(update_parent.clone()))
+            {
+                warn!(
+                    "Slot {} update_parent entry_notification_sender send failed: {err:?}",
+                    update_parent.slot
+                );
+            }
+        }
+        if let Some(block_metadata_notifier) = self.block_metadata_notifier {
+            block_metadata_notifier.notify_update_parent(update_parent);
         }
         datapoint_info!(
             "replay-stage-update-parent-read-layer-invalidation",
@@ -429,6 +450,18 @@ pub(super) fn handle_abandoned_bank(
             &mut dead_slot_context,
         );
         return;
+    }
+
+    if let Some(block_metadata_notifier) = process_active_banks_context
+        .block_metadata_notifier
+        .as_ref()
+    {
+        if let Some(update_parent) = update_parent_signal_from_blockstore(
+            process_active_banks_context.blockstore.as_ref(),
+            bank_slot,
+        ) {
+            block_metadata_notifier.notify_update_parent(&update_parent);
+        }
     }
 
     send_invalid_bank(bank, &process_active_banks_context.replay_vote_sender);

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,7 +1,14 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    solana_entry::{entry::EntrySummary, entry_or_marker::EntryOrMarker},
-    solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
+    solana_entry::{
+        block_component::{VersionedBlockMarker, VersionedUpdateParent},
+        entry::EntrySummary,
+        entry_or_marker::EntryOrMarker,
+    },
+    solana_ledger::{
+        blockstore::UpdateParentSignal,
+        entry_notifier_service::{EntryNotification, EntryNotifierSender},
+    },
     solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     std::{
         sync::{
@@ -74,25 +81,42 @@ impl TpuEntryNotifier {
             *current_index
         };
 
-        if let EntryOrMarker::Entry(ref entry) = entry_or_marker {
-            let entry_summary = EntrySummary {
-                num_hashes: entry.num_hashes,
-                hash: entry.hash,
-                num_transactions: entry.transactions.len() as u64,
-            };
-            if let Err(err) = entry_notification_sender.send(EntryNotification {
-                slot,
-                index,
-                entry: entry_summary,
-                starting_transaction_index: *current_transaction_index,
-            }) {
-                warn!(
-                    "Failed to send slot {slot:?} entry {index:?} from Tpu to \
-                     EntryNotifierService, error {err:?}",
-                );
+        match &entry_or_marker {
+            EntryOrMarker::Entry(entry) => {
+                let entry_summary = EntrySummary {
+                    num_hashes: entry.num_hashes,
+                    hash: entry.hash,
+                    num_transactions: entry.transactions.len() as u64,
+                };
+                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
+                    slot,
+                    index,
+                    entry: entry_summary,
+                    starting_transaction_index: *current_transaction_index,
+                }) {
+                    warn!(
+                        "Failed to send slot {slot:?} entry {index:?} from Tpu to \
+                         EntryNotifierService, error {err:?}",
+                    );
+                }
+                *current_transaction_index += entry.transactions.len();
             }
-            *current_transaction_index += entry.transactions.len();
-        };
+            EntryOrMarker::Marker(marker) => {
+                if let Some(update_parent) = update_parent_signal_from_marker(slot, index, marker) {
+                    if let Err(err) = entry_notification_sender
+                        .send(EntryNotification::UpdateParent(update_parent))
+                    {
+                        warn!(
+                            "Failed to send slot {slot:?} UpdateParent {index:?} from Tpu to \
+                             EntryNotifierService, error {err:?}",
+                        );
+                    }
+                    *current_slot = u64::MAX;
+                    *current_index = 0;
+                    *current_transaction_index = 0;
+                }
+            }
+        }
 
         if let Err(err) = broadcast_entry_sender.send((bank, (entry_or_marker, tick_height))) {
             let index = *current_index;
@@ -109,5 +133,144 @@ impl TpuEntryNotifier {
 
     pub(crate) fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+fn update_parent_signal_from_marker(
+    slot: u64,
+    marker_index: usize,
+    marker: &VersionedBlockMarker,
+) -> Option<UpdateParentSignal> {
+    let update_parent = match marker {
+        VersionedBlockMarker::V1(marker) => marker.as_update_parent()?,
+    };
+    let update_parent_fec_set_index = u32::try_from(marker_index).unwrap_or_else(|_| {
+        warn!(
+            "TPU UpdateParent marker index {marker_index} for slot {slot} exceeded u32::MAX; \
+             saturating invalidation boundary"
+        );
+        u32::MAX
+    });
+    match update_parent {
+        VersionedUpdateParent::V1(update_parent) => Some(UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index,
+            parent_slot: update_parent.new_parent_slot,
+            parent_block_id: Some(update_parent.new_parent_block_id),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::unbounded,
+        solana_entry::{block_component::UpdateParentV1, entry::Entry},
+        solana_genesis_config::GenesisConfig,
+        solana_hash::Hash,
+        solana_runtime::bank::Bank,
+    };
+
+    #[test]
+    fn test_tpu_entry_notifier_sends_update_parent_and_resets_indexes() {
+        let bank = Arc::new(Bank::new_for_tests(&GenesisConfig::default()));
+        let slot = bank.slot();
+        let parent_block_id = Hash::new_unique();
+        let (entry_sender, entry_receiver) = unbounded();
+        let (entry_notification_sender, entry_notification_receiver) = unbounded();
+        let (broadcast_entry_sender, _broadcast_entry_receiver) = unbounded();
+        let exit = Arc::new(AtomicBool::new(false));
+        let mut current_slot = u64::MAX;
+        let mut current_index = 0;
+        let mut current_transaction_index = 0;
+
+        entry_sender
+            .send((
+                bank.clone(),
+                (
+                    EntryOrMarker::Entry(Entry::new(&Hash::default(), 1, vec![])),
+                    0,
+                ),
+            ))
+            .unwrap();
+        entry_sender
+            .send((
+                bank.clone(),
+                (
+                    EntryOrMarker::Marker(VersionedBlockMarker::from_update_parent(
+                        UpdateParentV1 {
+                            new_parent_slot: 0,
+                            new_parent_block_id: parent_block_id,
+                        },
+                    )),
+                    0,
+                ),
+            ))
+            .unwrap();
+        entry_sender
+            .send((
+                bank,
+                (
+                    EntryOrMarker::Entry(Entry::new(&Hash::default(), 1, vec![])),
+                    0,
+                ),
+            ))
+            .unwrap();
+
+        for _ in 0..3 {
+            TpuEntryNotifier::send_entry_notification(
+                exit.clone(),
+                &entry_receiver,
+                &entry_notification_sender,
+                &broadcast_entry_sender,
+                &mut current_slot,
+                &mut current_index,
+                &mut current_transaction_index,
+            )
+            .unwrap();
+        }
+
+        match entry_notification_receiver.try_recv().unwrap() {
+            EntryNotification::Entry {
+                slot: entry_slot,
+                index,
+                starting_transaction_index,
+                ..
+            } => {
+                assert_eq!(entry_slot, slot);
+                assert_eq!(index, 0);
+                assert_eq!(starting_transaction_index, 0);
+            }
+            EntryNotification::UpdateParent(_) => panic!("expected entry notification"),
+        }
+        match entry_notification_receiver.try_recv().unwrap() {
+            EntryNotification::UpdateParent(update_parent) => {
+                assert_eq!(
+                    update_parent,
+                    UpdateParentSignal {
+                        slot,
+                        update_parent_fec_set_index: 1,
+                        parent_slot: 0,
+                        parent_block_id: Some(parent_block_id),
+                    }
+                );
+            }
+            EntryNotification::Entry { .. } => panic!("expected UpdateParent notification"),
+        }
+        match entry_notification_receiver.try_recv().unwrap() {
+            EntryNotification::Entry {
+                slot: entry_slot,
+                index,
+                starting_transaction_index,
+                ..
+            } => {
+                assert_eq!(entry_slot, slot);
+                assert_eq!(index, 0);
+                assert_eq!(starting_transaction_index, 0);
+            }
+            EntryNotification::UpdateParent(_) => panic!("expected replacement entry notification"),
+        }
+        assert!(entry_notification_receiver.try_recv().is_err());
     }
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1334,8 +1334,12 @@ impl Validator {
                 } else {
                     let (completed_data_sets_sender, completed_data_sets_receiver) =
                         bounded(MAX_COMPLETED_DATA_SETS_IN_CHANNEL);
+                    let (completed_data_sets_update_parent_sender, update_parent_receiver) =
+                        bounded(MAX_UPDATE_PARENT_SIGNALS);
+                    blockstore.add_update_parent_signal(completed_data_sets_update_parent_sender);
                     let completed_data_sets_service = CompletedDataSetsService::new(
                         completed_data_sets_receiver,
+                        update_parent_receiver,
                         blockstore.clone(),
                         rpc_subscriptions.clone(),
                         deshred_transaction_notifier.clone(),

--- a/docs/src/validator/geyser.md
+++ b/docs/src/validator/geyser.md
@@ -522,6 +522,35 @@ The following are the tables in the Postgres database
 | transaction   | Transaction data        |
 | account_audit | Account historical data |
 
+## Alpenglow UpdateParent Invalidation
+
+Alpenglow fast leader handover can produce an `UpdateParent` marker in the
+first slot of a leader window. When a validator observes this marker, data that
+was already emitted for the same slot before the marker is stale. The validator
+calls `notify_update_parent` with:
+
+- `slot`: the affected slot
+- `update_parent_fec_set_index`: the marker boundary
+- `parent_slot`: the replacement parent selected by the marker
+- `parent_block_id`: the replacement parent block id, when available
+
+Plugins that store transactions, entries, block metadata, or deshred
+transactions must treat this notification as a same-slot rollback of data before
+the boundary. They should key slot-local records by slot plus ordering metadata,
+such as transaction index, entry index, or completed-data-set shred range, and be
+prepared to delete and rewrite a prefix of the same slot.
+
+Entry and transaction notifications delivered after `notify_update_parent` for
+the same slot represent the replacement block contents. Deshred transaction
+plugins should discard completed-data-set ranges for the slot whose ending shred
+index is at or before the UpdateParent boundary. TPU entry-stream notifications
+use the marker's pre-shred stream position as the boundary because shred indexes
+have not been assigned yet.
+
+Delivery is best-effort and ordered within each validator notification channel.
+Plugins that require stronger durability should make their own writes
+idempotent and reconcile same-slot records when a later UpdateParent arrives.
+
 
 ### Performance Considerations
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -296,6 +296,32 @@ pub enum ReplicaEntryInfoVersions<'a> {
     V0_0_2(&'a ReplicaEntryInfoV2<'a>),
 }
 
+/// Information about an Alpenglow UpdateParent marker that invalidates
+/// same-slot read-layer data observed before `update_parent_fec_set_index`.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaUpdateParentInfo<'a> {
+    /// Slot whose same-slot prefix was invalidated.
+    pub slot: Slot,
+    /// FEC set index of the UpdateParent marker. Entries, transactions, block
+    /// metadata, and deshred transactions previously emitted for this slot
+    /// before this boundary must be discarded or rewritten.
+    ///
+    /// Notifications sourced from TPU entry streaming use the marker's
+    /// pre-shred stream position because no shred index has been assigned yet.
+    pub update_parent_fec_set_index: u32,
+    /// Parent slot selected by UpdateParent.
+    pub parent_slot: Slot,
+    /// Parent block id selected by UpdateParent, when available.
+    pub parent_block_id: Option<&'a Hash>,
+}
+
+/// A wrapper to future-proof ReplicaUpdateParentInfo handling.
+#[repr(u32)]
+pub enum ReplicaUpdateParentInfoVersions<'a> {
+    V0_0_1(&'a ReplicaUpdateParentInfo<'a>),
+}
+
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct ReplicaBlockInfo<'a> {
@@ -629,6 +655,19 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// Called when block's metadata is updated.
     #[allow(unused_variables)]
     fn notify_block_metadata(&self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when an Alpenglow UpdateParent marker invalidates same-slot data
+    /// that may already have been delivered to read-layer consumers.
+    ///
+    /// Plugins that persist entries, transactions, block metadata, or deshred
+    /// transactions must treat this as a rollback of same-slot data observed
+    /// before `update_parent_fec_set_index` and be prepared to accept
+    /// replacement data for the same slot. Delivery is best-effort and ordered
+    /// within each validator notification channel.
+    #[allow(unused_variables)]
+    fn notify_update_parent(&self, update_parent: ReplicaUpdateParentInfoVersions) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,11 +4,13 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV4, ReplicaBlockInfoVersions, ReplicaUpdateParentInfo,
+        ReplicaUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::UnixTimestamp,
+    solana_ledger::blockstore::UpdateParentSignal,
     solana_runtime::bank::KeyedRewardsAndNumPartitions,
     solana_transaction_status::{Reward, RewardsAndNumPartitions},
     std::sync::Arc,
@@ -72,6 +74,30 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             }
         }
     }
+
+    fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+        let plugin_manager = self.plugin_manager.load();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let update_parent_info = Self::build_replica_update_parent_info(update_parent);
+        for plugin in plugin_manager.plugins.iter() {
+            match plugin
+                .notify_update_parent(ReplicaUpdateParentInfoVersions::V0_0_1(&update_parent_info))
+            {
+                Err(err) => error!(
+                    "Failed to notify block metadata UpdateParent, error: ({}) to plugin {}",
+                    err,
+                    plugin.name()
+                ),
+                Ok(_) => trace!(
+                    "Successfully notified block metadata UpdateParent to plugin {}",
+                    plugin.name()
+                ),
+            }
+        }
+    }
 }
 
 impl BlockMetadataNotifierImpl {
@@ -125,6 +151,17 @@ impl BlockMetadataNotifierImpl {
             block_height,
             executed_transaction_count,
             entry_count,
+        }
+    }
+
+    fn build_replica_update_parent_info(
+        update_parent: &UpdateParentSignal,
+    ) -> ReplicaUpdateParentInfo<'_> {
+        ReplicaUpdateParentInfo {
+            slot: update_parent.slot,
+            update_parent_fec_set_index: update_parent.update_parent_fec_set_index,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: update_parent.parent_block_id.as_ref(),
         }
     }
 

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,5 +1,6 @@
 use {
-    solana_clock::UnixTimestamp, solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
+    solana_clock::UnixTimestamp, solana_ledger::blockstore::UpdateParentSignal,
+    solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
 };
 
 /// Interface for notifying block metadata changes
@@ -19,6 +20,10 @@ pub trait BlockMetadataNotifier {
         entry_count: u64,
         commission_rate_in_basis_points: bool,
     );
+
+    /// Notify plugins that an Alpenglow UpdateParent marker invalidated
+    /// same-slot block metadata emitted before the marker boundary.
+    fn notify_update_parent(&self, _update_parent: &UpdateParentSignal) {}
 }
 
 pub type BlockMetadataNotifierArc = Arc<dyn BlockMetadataNotifier + Sync + Send>;

--- a/geyser-plugin-manager/src/deshred_transaction_notifier.rs
+++ b/geyser-plugin-manager/src/deshred_transaction_notifier.rs
@@ -3,11 +3,15 @@ use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaDeshredTransactionInfoV2, ReplicaDeshredTransactionInfoVersions,
+        ReplicaUpdateParentInfo, ReplicaUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::Slot,
-    solana_ledger::deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+    solana_ledger::{
+        blockstore::UpdateParentSignal,
+        deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+    },
     solana_measure::measure::Measure,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
@@ -83,10 +87,49 @@ impl DeshredTransactionNotifier for DeshredTransactionNotifierImpl {
             .load()
             .deshred_transaction_alt_resolution_enabled()
     }
+
+    fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+        let plugin_manager = self.plugin_manager.load();
+
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let update_parent_info = Self::build_replica_update_parent_info(update_parent);
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.deshred_transaction_notifications_enabled() {
+                continue;
+            }
+            match plugin
+                .notify_update_parent(ReplicaUpdateParentInfoVersions::V0_0_1(&update_parent_info))
+            {
+                Err(err) => error!(
+                    "Failed to notify deshred UpdateParent, error: ({}) to plugin {}",
+                    err,
+                    plugin.name()
+                ),
+                Ok(_) => trace!(
+                    "Successfully notified deshred UpdateParent to plugin {}",
+                    plugin.name()
+                ),
+            }
+        }
+    }
 }
 
 impl DeshredTransactionNotifierImpl {
     pub fn new(plugin_manager: Arc<ArcSwap<GeyserPluginManager>>) -> Self {
         Self { plugin_manager }
+    }
+
+    fn build_replica_update_parent_info(
+        update_parent: &UpdateParentSignal,
+    ) -> ReplicaUpdateParentInfo<'_> {
+        ReplicaUpdateParentInfo {
+            slot: update_parent.slot,
+            update_parent_fec_set_index: update_parent.update_parent_fec_set_index,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: update_parent.parent_block_id.as_ref(),
+        }
     }
 }

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -2,13 +2,14 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaEntryInfoV2, ReplicaEntryInfoVersions,
+        ReplicaEntryInfoV2, ReplicaEntryInfoVersions, ReplicaUpdateParentInfo,
+        ReplicaUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::Slot,
     solana_entry::entry::EntrySummary,
-    solana_ledger::entry_notifier_interface::EntryNotifier,
+    solana_ledger::{blockstore::UpdateParentSignal, entry_notifier_interface::EntryNotifier},
     std::sync::Arc,
 };
 
@@ -50,6 +51,33 @@ impl EntryNotifier for EntryNotifierImpl {
             }
         }
     }
+
+    fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+        let plugin_manager = self.plugin_manager.load();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let update_parent_info = Self::build_replica_update_parent_info(update_parent);
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.entry_notifications_enabled() {
+                continue;
+            }
+            match plugin
+                .notify_update_parent(ReplicaUpdateParentInfoVersions::V0_0_1(&update_parent_info))
+            {
+                Err(err) => error!(
+                    "Failed to notify entry UpdateParent, error: ({}) to plugin {}",
+                    err,
+                    plugin.name()
+                ),
+                Ok(_) => trace!(
+                    "Successfully notified entry UpdateParent to plugin {}",
+                    plugin.name()
+                ),
+            }
+        }
+    }
 }
 
 impl EntryNotifierImpl {
@@ -70,6 +98,17 @@ impl EntryNotifierImpl {
             hash: entry.hash.as_ref(),
             executed_transaction_count: entry.num_transactions,
             starting_transaction_index,
+        }
+    }
+
+    fn build_replica_update_parent_info(
+        update_parent: &UpdateParentSignal,
+    ) -> ReplicaUpdateParentInfo<'_> {
+        ReplicaUpdateParentInfo {
+            slot: update_parent.slot,
+            update_parent_fec_set_index: update_parent.update_parent_fec_set_index,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: update_parent.parent_block_id.as_ref(),
         }
     }
 }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,12 +2,14 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
+        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions, ReplicaUpdateParentInfo,
+        ReplicaUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_ledger::blockstore::UpdateParentSignal,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
     solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
@@ -73,6 +75,33 @@ impl TransactionNotifier for TransactionNotifierImpl {
             }
         }
     }
+
+    fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+        let plugin_manager = self.plugin_manager.load();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let update_parent_info = Self::build_replica_update_parent_info(update_parent);
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.transaction_notifications_enabled() {
+                continue;
+            }
+            match plugin
+                .notify_update_parent(ReplicaUpdateParentInfoVersions::V0_0_1(&update_parent_info))
+            {
+                Err(err) => error!(
+                    "Failed to notify UpdateParent, error: ({}) to plugin {}",
+                    err,
+                    plugin.name()
+                ),
+                Ok(_) => trace!(
+                    "Successfully notified UpdateParent to plugin {}",
+                    plugin.name()
+                ),
+            }
+        }
+    }
 }
 
 impl TransactionNotifierImpl {
@@ -95,6 +124,17 @@ impl TransactionNotifierImpl {
             is_vote,
             transaction,
             transaction_status_meta,
+        }
+    }
+
+    fn build_replica_update_parent_info(
+        update_parent: &UpdateParentSignal,
+    ) -> ReplicaUpdateParentInfo<'_> {
+        ReplicaUpdateParentInfo {
+            slot: update_parent.slot,
+            update_parent_fec_set_index: update_parent.update_parent_fec_set_index,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: update_parent.parent_block_id.as_ref(),
         }
     }
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -131,14 +131,33 @@ type UpdateParentShredParentKey = (BlockLocation, Slot, u32);
 type UpdateParentShredParentCache =
     LruCache<UpdateParentShredParentKey, /* parent used for shred filtering */ Slot>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateParentSignal {
-    /// Slot whose parent metadata was updated by an UpdateParent marker.
-    ///
-    /// This is only a wakeup for replay. Consumers must re-read SlotMeta/dead
-    /// state from blockstore so stale queued signals cannot override newer
-    /// parent metadata or a durable dead-slot decision.
+    /// Slot whose same-slot prefix was invalidated by an UpdateParent marker.
     pub slot: Slot,
+    /// FEC set index of the UpdateParent marker. Read-layer consumers should
+    /// discard same-slot data observed before this boundary.
+    ///
+    /// Signals emitted by the TPU entry path use the marker's pre-shred stream
+    /// position as this boundary because no shred index has been assigned yet.
+    pub update_parent_fec_set_index: u32,
+    /// Parent slot selected by the UpdateParent marker.
+    pub parent_slot: Slot,
+    /// Parent block id selected by the UpdateParent marker, when available.
+    pub parent_block_id: Option<Hash>,
+}
+
+impl UpdateParentSignal {
+    pub fn from_slot_meta(slot: Slot, slot_meta: &SlotMeta) -> Option<Self> {
+        Some(Self {
+            slot,
+            update_parent_fec_set_index: slot_meta
+                .has_update_parent()
+                .then_some(slot_meta.replay_fec_set_index)?,
+            parent_slot: slot_meta.parent_slot?,
+            parent_block_id: Some(slot_meta.parent_block_id),
+        })
+    }
 }
 
 // Contiguous, sorted and non-empty ranges of shred indices:
@@ -4310,6 +4329,61 @@ impl Blockstore {
             .put_in_batch(db_write_batch, (*signature, slot), &memos)
     }
 
+    /// Delete transaction-status data for `slot`.
+    ///
+    /// This is used when an Alpenglow UpdateParent marker invalidates the
+    /// prefix of a same-slot block after read-layer data may already have been
+    /// emitted. Slot-scoped block metadata is deleted with the transaction
+    /// status rows so replacement replay can rewrite a coherent view.
+    pub fn delete_transaction_status_slot(&self, slot: Slot) -> Result<usize> {
+        let (_lowest_cleanup_slot, _) = self.ensure_lowest_cleanup_slot();
+
+        let mut signatures = HashSet::new();
+        let mut transaction_status_keys = Vec::new();
+        for ((signature, status_slot), _) in self.transaction_status_cf.iter(IteratorMode::Start)? {
+            if status_slot == slot {
+                signatures.insert(signature);
+                transaction_status_keys.push((signature, status_slot));
+            }
+        }
+
+        let mut transaction_memo_keys = Vec::new();
+        for ((signature, memo_slot), _) in self.transaction_memos_cf.iter(IteratorMode::Start)? {
+            if memo_slot == slot {
+                transaction_memo_keys.push((signature, memo_slot));
+            }
+        }
+
+        let mut address_signature_keys = Vec::new();
+        for ((address, address_slot, transaction_index, signature), _) in
+            self.address_signatures_cf.iter(IteratorMode::Start)?
+        {
+            if address_slot == slot {
+                address_signature_keys.push((address, address_slot, transaction_index, signature));
+            }
+        }
+
+        let mut write_batch = self.get_write_batch()?;
+        for key in transaction_status_keys {
+            self.transaction_status_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        for key in transaction_memo_keys {
+            self.transaction_memos_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        for key in address_signature_keys {
+            self.address_signatures_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        self.blocktime_cf.delete_in_batch(&mut write_batch, slot);
+        self.block_height_cf.delete_in_batch(&mut write_batch, slot);
+        self.rewards_cf.delete_in_batch(&mut write_batch, slot);
+        self.write_batch(write_batch)?;
+
+        Ok(signatures.len())
+    }
+
     /// Acquires the `lowest_cleanup_slot` lock and returns a tuple of the held lock
     /// and lowest available slot.
     ///
@@ -5803,11 +5877,11 @@ impl Blockstore {
             // This signal is only used for replay, so we don't need to consider `Alternate` columns
             if location == BlockLocation::Original
                 && meta.has_update_parent()
-                && meta_backup
-                    .as_ref()
-                    .is_some_and(|m| m.populated_from_block_header())
+                && !meta_backup.as_ref().is_some_and(|m| m.has_update_parent())
             {
-                update_parent_signals.push(UpdateParentSignal { slot });
+                if let Some(update_parent) = UpdateParentSignal::from_slot_meta(slot, meta) {
+                    update_parent_signals.push(update_parent);
+                }
             }
         }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -29,7 +29,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_measure::{measure::Measure, measure_us},
-    solana_metrics::datapoint_error,
+    solana_metrics::{datapoint_error, datapoint_info},
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::{Bank, PreCommitResult, TransactionBalancesSet},
@@ -1901,9 +1901,10 @@ fn confirm_slot_with_components(
                                 completed_range.start,
                                 update_parent,
                             );
-                            send_update_parent_transaction_status_notification(
+                            send_update_parent_read_layer_notifications(
                                 &update_parent,
                                 transaction_status_sender,
+                                entry_notification_sender,
                             );
                         }
                         return Err(err.into());
@@ -1964,7 +1965,7 @@ fn confirm_slot_entries(
         .map(|(i, entry)| {
             if let Some(entry_notification_sender) = entry_notification_sender {
                 let entry_index = progress.num_entries.saturating_add(i);
-                if let Err(err) = entry_notification_sender.send(EntryNotification {
+                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
                     slot,
                     index: entry_index,
                     entry: entry.into(),
@@ -2910,12 +2911,27 @@ fn update_parent_signal_from_marker(
     }
 }
 
-fn send_update_parent_transaction_status_notification(
+fn send_update_parent_read_layer_notifications(
     update_parent: &UpdateParentSignal,
     transaction_status_sender: Option<&TransactionStatusSender>,
+    entry_notification_sender: Option<&EntryNotifierSender>,
 ) {
     if let Some(transaction_status_sender) = transaction_status_sender {
         transaction_status_sender.send_update_parent(update_parent.clone());
+    }
+    if let Some(entry_notification_sender) = entry_notification_sender {
+        if let Err(err) =
+            entry_notification_sender.send(EntryNotification::UpdateParent(update_parent.clone()))
+        {
+            warn!(
+                "Slot {} update_parent entry_notification_sender send failed: {err:?}",
+                update_parent.slot
+            );
+            datapoint_info!(
+                "blockstore_processor-update-parent-entry-notification-send-failed",
+                ("slot", update_parent.slot, i64),
+            );
+        }
     }
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         block_error::BlockError,
-        blockstore::{Blockstore, BlockstoreError},
+        blockstore::{Blockstore, BlockstoreError, UpdateParentSignal},
         blockstore_meta::SlotMeta,
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,
@@ -22,7 +22,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{BlockComponent, VersionedUpdateParent},
         entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
@@ -1883,21 +1883,31 @@ fn confirm_slot_with_components(
                 if let Some(parent_bank) = bank.parent() {
                     let allow_initial_update_parent =
                         replay_starts_at_update_parent && marker.is_update_parent();
-                    processor
-                        .on_marker(
-                            bank.clone_without_scheduler(),
-                            parent_bank,
-                            marker,
-                            allow_initial_update_parent,
-                            finalization_cert_sender,
-                            migration_status,
-                        )
-                        .inspect_err(|err| {
-                            warn!(
-                                "BlockComponentProcessor::on_marker() for slot {slot} failed with \
-                                 {err}"
+                    if let Err(err) = processor.on_marker(
+                        bank.clone_without_scheduler(),
+                        parent_bank,
+                        marker,
+                        allow_initial_update_parent,
+                        finalization_cert_sender,
+                        migration_status,
+                    ) {
+                        warn!(
+                            "BlockComponentProcessor::on_marker() for slot {slot} failed with \
+                             {err}"
+                        );
+                        if let BlockComponentProcessorError::AbandonedBank(update_parent) = &err {
+                            let update_parent = update_parent_signal_from_marker(
+                                slot,
+                                completed_range.start,
+                                update_parent,
                             );
-                        })?;
+                            send_update_parent_transaction_status_notification(
+                                &update_parent,
+                                transaction_status_sender,
+                            );
+                        }
+                        return Err(err.into());
+                    }
                 }
                 progress.num_shreds += num_shreds as u64;
             }
@@ -2885,6 +2895,30 @@ pub fn process_single_slot(
     Ok(())
 }
 
+fn update_parent_signal_from_marker(
+    slot: Slot,
+    update_parent_fec_set_index: u32,
+    update_parent: &VersionedUpdateParent,
+) -> UpdateParentSignal {
+    match update_parent {
+        VersionedUpdateParent::V1(update_parent) => UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index,
+            parent_slot: update_parent.new_parent_slot,
+            parent_block_id: Some(update_parent.new_parent_block_id),
+        },
+    }
+}
+
+fn send_update_parent_transaction_status_notification(
+    update_parent: &UpdateParentSignal,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+) {
+    if let Some(transaction_status_sender) = transaction_status_sender {
+        transaction_status_sender.send_update_parent(update_parent.clone());
+    }
+}
+
 type WorkSequence = u64;
 
 #[allow(clippy::large_enum_variant)]
@@ -2892,6 +2926,13 @@ type WorkSequence = u64;
 pub enum TransactionStatusMessage {
     Batch((TransactionStatusBatch, Option<WorkSequence>)),
     Freeze(Arc<Bank>),
+    /// Invalidate same-slot transaction-status data emitted before an
+    /// Alpenglow UpdateParent marker. Delivery is best-effort and follows the
+    /// same channel-drop behavior as other transaction-status messages.
+    UpdateParent {
+        update_parent: UpdateParentSignal,
+        work_sequence: Option<WorkSequence>,
+    },
 }
 
 #[derive(Debug)]
@@ -2950,6 +2991,25 @@ impl TransactionStatusSender {
         {
             let slot = bank.slot();
             warn!("Slot {slot} transaction_status send freeze message failed: {e:?}");
+        }
+    }
+
+    pub fn send_update_parent(&self, update_parent: UpdateParentSignal) {
+        let slot = update_parent.slot;
+        let work_sequence = self
+            .dependency_tracker
+            .as_ref()
+            .map(|dependency_tracker| dependency_tracker.declare_work());
+
+        if let Err(e) = self.sender.send(TransactionStatusMessage::UpdateParent {
+            update_parent,
+            work_sequence,
+        }) {
+            warn!("Slot {slot} transaction_status send UpdateParent failed: {e:?}");
+            datapoint_error!(
+                "transaction_status-update-parent-send-failed",
+                ("slot", slot, i64),
+            );
         }
     }
 }

--- a/ledger/src/deshred_transaction_notifier_interface.rs
+++ b/ledger/src/deshred_transaction_notifier_interface.rs
@@ -1,6 +1,7 @@
 use {
-    solana_clock::Slot, solana_message::v0::LoadedAddresses, solana_signature::Signature,
-    solana_transaction::versioned::VersionedTransaction, std::sync::Arc,
+    crate::blockstore::UpdateParentSignal, solana_clock::Slot, solana_message::v0::LoadedAddresses,
+    solana_signature::Signature, solana_transaction::versioned::VersionedTransaction,
+    std::sync::Arc,
 };
 
 /// Trait for notifying about transactions when they are deshredded.
@@ -23,6 +24,13 @@ pub trait DeshredTransactionNotifier {
 
     /// Whether any plugin has opted in to ALT resolution for deshred transactions.
     fn alt_resolution_enabled(&self) -> bool;
+
+    /// Called when an Alpenglow UpdateParent marker invalidates same-slot
+    /// deshred transactions emitted before `update_parent_fec_set_index`.
+    ///
+    /// Delivery is best-effort and ordered with completed-data-set processing
+    /// by CompletedDataSetsService.
+    fn notify_update_parent(&self, _update_parent: &UpdateParentSignal) {}
 }
 
 pub type DeshredTransactionNotifierArc = Arc<dyn DeshredTransactionNotifier + Sync + Send>;

--- a/ledger/src/entry_notifier_interface.rs
+++ b/ledger/src/entry_notifier_interface.rs
@@ -1,4 +1,7 @@
-use {solana_clock::Slot, solana_entry::entry::EntrySummary, std::sync::Arc};
+use {
+    crate::blockstore::UpdateParentSignal, solana_clock::Slot, solana_entry::entry::EntrySummary,
+    std::sync::Arc,
+};
 
 pub trait EntryNotifier {
     fn notify_entry(
@@ -8,6 +11,14 @@ pub trait EntryNotifier {
         entry: &EntrySummary,
         starting_transaction_index: usize,
     );
+
+    /// Called when an Alpenglow UpdateParent marker invalidates same-slot
+    /// entries and transactions observed before `update_parent_fec_set_index`.
+    ///
+    /// The callback is delivered on the same channel as entry notifications, so
+    /// consumers observe it before later replacement entries sent by this
+    /// service. Delivery remains best-effort under channel shutdown.
+    fn notify_update_parent(&self, _update_parent: &UpdateParentSignal) {}
 }
 
 pub type EntryNotifierArc = Arc<dyn EntryNotifier + Sync + Send>;

--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -1,5 +1,5 @@
 use {
-    crate::entry_notifier_interface::EntryNotifierArc,
+    crate::{blockstore::UpdateParentSignal, entry_notifier_interface::EntryNotifierArc},
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
     solana_clock::Slot,
     solana_entry::entry::EntrySummary,
@@ -13,11 +13,17 @@ use {
     },
 };
 
-pub struct EntryNotification {
-    pub slot: Slot,
-    pub index: usize,
-    pub entry: EntrySummary,
-    pub starting_transaction_index: usize,
+pub enum EntryNotification {
+    Entry {
+        slot: Slot,
+        index: usize,
+        entry: EntrySummary,
+        starting_transaction_index: usize,
+    },
+    /// Invalidate same-slot entries and transactions observed before an
+    /// Alpenglow UpdateParent marker. Delivery is ordered with entry
+    /// notifications on this channel and is best-effort during shutdown.
+    UpdateParent(UpdateParentSignal),
 }
 
 pub type EntryNotifierSender = Sender<EntryNotification>;
@@ -57,13 +63,17 @@ impl EntryNotifierService {
         entry_notification_receiver: &EntryNotifierReceiver,
         entry_notifier: EntryNotifierArc,
     ) -> Result<(), RecvTimeoutError> {
-        let EntryNotification {
-            slot,
-            index,
-            entry,
-            starting_transaction_index,
-        } = entry_notification_receiver.recv_timeout(Duration::from_secs(1))?;
-        entry_notifier.notify_entry(slot, index, &entry, starting_transaction_index);
+        match entry_notification_receiver.recv_timeout(Duration::from_secs(1))? {
+            EntryNotification::Entry {
+                slot,
+                index,
+                entry,
+                starting_transaction_index,
+            } => entry_notifier.notify_entry(slot, index, &entry, starting_transaction_index),
+            EntryNotification::UpdateParent(update_parent) => {
+                entry_notifier.notify_update_parent(&update_parent)
+            }
+        }
         Ok(())
     }
 
@@ -77,5 +87,122 @@ impl EntryNotifierService {
 
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::entry_notifier_interface::EntryNotifier, solana_hash::Hash,
+        std::sync::Mutex,
+    };
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum TestEvent {
+        Entry {
+            slot: Slot,
+            index: usize,
+            num_hashes: u64,
+            hash: Hash,
+            num_transactions: u64,
+            starting_transaction_index: usize,
+        },
+        UpdateParent(UpdateParentSignal),
+    }
+
+    #[derive(Default)]
+    struct TestEntryNotifier {
+        events: Mutex<Vec<TestEvent>>,
+    }
+
+    impl EntryNotifier for TestEntryNotifier {
+        fn notify_entry(
+            &self,
+            slot: Slot,
+            index: usize,
+            entry: &EntrySummary,
+            starting_transaction_index: usize,
+        ) {
+            self.events.lock().unwrap().push(TestEvent::Entry {
+                slot,
+                index,
+                num_hashes: entry.num_hashes,
+                hash: entry.hash,
+                num_transactions: entry.num_transactions,
+                starting_transaction_index,
+            });
+        }
+
+        fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+            self.events
+                .lock()
+                .unwrap()
+                .push(TestEvent::UpdateParent(update_parent.clone()));
+        }
+    }
+
+    #[test]
+    fn test_entry_notifier_service_forwards_update_parent_in_order() {
+        let (sender, receiver) = unbounded();
+        let notifier = Arc::new(TestEntryNotifier::default());
+        let entry_hash = Hash::new_unique();
+        let entry_summary = || EntrySummary {
+            num_hashes: 1,
+            hash: entry_hash,
+            num_transactions: 2,
+        };
+        let update_parent = UpdateParentSignal {
+            slot: 7,
+            update_parent_fec_set_index: 32,
+            parent_slot: 3,
+            parent_block_id: Some(Hash::new_unique()),
+        };
+
+        sender
+            .send(EntryNotification::Entry {
+                slot: 7,
+                index: 0,
+                entry: entry_summary(),
+                starting_transaction_index: 0,
+            })
+            .unwrap();
+        sender
+            .send(EntryNotification::UpdateParent(update_parent.clone()))
+            .unwrap();
+        sender
+            .send(EntryNotification::Entry {
+                slot: 7,
+                index: 0,
+                entry: entry_summary(),
+                starting_transaction_index: 0,
+            })
+            .unwrap();
+
+        EntryNotifierService::notify_entry(&receiver, notifier.clone()).unwrap();
+        EntryNotifierService::notify_entry(&receiver, notifier.clone()).unwrap();
+        EntryNotifierService::notify_entry(&receiver, notifier.clone()).unwrap();
+
+        assert_eq!(
+            *notifier.events.lock().unwrap(),
+            vec![
+                TestEvent::Entry {
+                    slot: 7,
+                    index: 0,
+                    num_hashes: 1,
+                    hash: entry_hash,
+                    num_transactions: 2,
+                    starting_transaction_index: 0,
+                },
+                TestEvent::UpdateParent(update_parent),
+                TestEvent::Entry {
+                    slot: 7,
+                    index: 0,
+                    num_hashes: 1,
+                    hash: entry_hash,
+                    num_transactions: 2,
+                    starting_transaction_index: 0,
+                },
+            ]
+        );
     }
 }

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
-    solana_clock::Slot, solana_hash::Hash, solana_signature::Signature,
-    solana_transaction::versioned::VersionedTransaction,
+    solana_clock::Slot, solana_hash::Hash, solana_ledger::blockstore::UpdateParentSignal,
+    solana_signature::Signature, solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
 };
 
@@ -15,6 +15,12 @@ pub trait TransactionNotifier {
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &VersionedTransaction,
     );
+
+    /// Called when an Alpenglow UpdateParent marker invalidates transaction
+    /// status data for the same slot that may have been emitted before the
+    /// marker boundary. Delivery is best-effort and ordered by the
+    /// TransactionStatusService message channel.
+    fn notify_update_parent(&self, _update_parent: &UpdateParentSignal) {}
 }
 
 pub type TransactionNotifierArc = Arc<dyn TransactionNotifier + Sync + Send>;

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -12,6 +12,7 @@ use {
         blockstore::{Blockstore, BlockstoreError},
         blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
     },
+    solana_metrics::datapoint_info,
     solana_runtime::{
         bank::{Bank, KeyedRewardsAndNumPartitions},
         dependency_tracker::DependencyTracker,
@@ -272,6 +273,35 @@ impl TransactionStatusService {
                 Self::write_block_meta(&bank, blockstore)?;
                 max_complete_transaction_status_slot.fetch_max(bank.slot(), Ordering::SeqCst);
             }
+            TransactionStatusMessage::UpdateParent {
+                update_parent,
+                work_sequence,
+            } => {
+                let deleted_transaction_statuses =
+                    blockstore.delete_transaction_status_slot(update_parent.slot)?;
+                if let Some(transaction_notifier) = transaction_notifier.as_ref() {
+                    transaction_notifier.notify_update_parent(&update_parent);
+                }
+                datapoint_info!(
+                    "transaction_status-update-parent-invalidated",
+                    ("slot", update_parent.slot, i64),
+                    (
+                        "update_parent_fec_set_index",
+                        update_parent.update_parent_fec_set_index,
+                        i64
+                    ),
+                    (
+                        "deleted_transaction_statuses",
+                        deleted_transaction_statuses,
+                        i64
+                    ),
+                );
+                if let Some(dependency_tracker) = dependency_tracker.as_ref() {
+                    if let Some(work_id) = work_sequence {
+                        dependency_tracker.mark_this_and_all_previous_work_processed(work_id);
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -359,7 +389,10 @@ pub(crate) mod tests {
         solana_fee_structure::FeeDetails,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_ledger::{genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete},
+        solana_ledger::{
+            blockstore::UpdateParentSignal, blockstore_processor::TransactionStatusSender,
+            genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
+        },
         solana_message::SimpleAddressLoader,
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_nonce_account as nonce_account,
@@ -378,7 +411,7 @@ pub(crate) mod tests {
             TransactionStatusMeta, TransactionTokenBalance,
             token_balances::TransactionTokenBalancesSet,
         },
-        std::sync::{Arc, atomic::AtomicBool},
+        std::sync::{Arc, Mutex, atomic::AtomicBool},
     };
 
     #[derive(Eq, Hash, PartialEq)]
@@ -395,12 +428,14 @@ pub(crate) mod tests {
 
     struct TestTransactionNotifier {
         notifications: DashMap<TestNotifierKey, TestNotification>,
+        update_parents: Mutex<Vec<UpdateParentSignal>>,
     }
 
     impl TestTransactionNotifier {
         pub fn new() -> Self {
             Self {
                 notifications: DashMap::default(),
+                update_parents: Mutex::default(),
             }
         }
     }
@@ -427,6 +462,13 @@ pub(crate) mod tests {
                     transaction: transaction.clone(),
                 },
             );
+        }
+
+        fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+            self.update_parents
+                .lock()
+                .unwrap()
+                .push(update_parent.clone());
         }
     }
 
@@ -692,6 +734,158 @@ pub(crate) mod tests {
         assert_eq!(
             expected_transaction2.message_hash(),
             &result2.transaction.message.hash(),
+        );
+    }
+
+    #[test]
+    fn test_update_parent_invalidates_transaction_status_storage() {
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+
+        let sanitize = |transaction: Transaction| {
+            SanitizedTransaction::try_create(
+                VersionedTransaction::from(transaction),
+                MessageHash::Compute,
+                None,
+                SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty_key_set(),
+            )
+            .unwrap()
+        };
+
+        let stale_transaction = sanitize(build_test_transaction_legacy());
+        let replacement_transaction = sanitize(build_test_transaction_legacy());
+        let stale_signature = *stale_transaction.signature();
+        let replacement_signature = *replacement_transaction.signature();
+
+        let commit_result = Ok(CommittedTransaction {
+            status: Ok(()),
+            log_messages: Some(vec!["log".to_string()]),
+            inner_instructions: None,
+            return_data: None,
+            executed_units: 1,
+            fee_details: FeeDetails::default(),
+            loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            fee_payer_post_balance: 0,
+        });
+
+        let slot = bank.slot();
+        blockstore
+            .write_transaction_memos(&stale_signature, slot, "stale memo".to_string())
+            .unwrap();
+        blockstore.set_block_height(slot, 42).unwrap();
+        blockstore
+            .write_rewards(
+                slot,
+                RewardsAndNumPartitions {
+                    rewards: vec![Reward {
+                        pubkey: Pubkey::new_unique().to_string(),
+                        lamports: 1,
+                        post_balance: 2,
+                        reward_type: None,
+                        commission: None,
+                        commission_bps: None,
+                    }],
+                    num_partitions: None,
+                },
+            )
+            .unwrap();
+
+        let test_notifier = Arc::new(TestTransactionNotifier::new());
+        let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(99));
+        let dependency_tracker = Arc::new(DependencyTracker::default());
+        let exit = Arc::new(AtomicBool::new(false));
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            max_complete_transaction_status_slot.clone(),
+            true,
+            Some(test_notifier.clone()),
+            blockstore.clone(),
+            true,
+            Some(dependency_tracker.clone()),
+            exit.clone(),
+        );
+        let update_parent_sender = TransactionStatusSender {
+            sender: transaction_status_sender.clone(),
+            dependency_tracker: Some(dependency_tracker.clone()),
+        };
+
+        let make_batch = |transaction: SanitizedTransaction, index| TransactionStatusBatch {
+            slot,
+            transactions: vec![transaction],
+            commit_results: vec![commit_result.clone()],
+            balances: TransactionBalancesSet {
+                pre_balances: vec![vec![1]],
+                post_balances: vec![vec![2]],
+            },
+            token_balances: TransactionTokenBalancesSet {
+                pre_token_balances: vec![vec![]],
+                post_token_balances: vec![vec![]],
+            },
+            costs: vec![Some(3)],
+            transaction_indexes: vec![index],
+        };
+
+        let update_parent = UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index: 32,
+            parent_slot: 0,
+            parent_block_id: Some(Hash::new_unique()),
+        };
+
+        transaction_status_sender
+            .send(TransactionStatusMessage::Batch((
+                make_batch(stale_transaction, 0),
+                None,
+            )))
+            .unwrap();
+        update_parent_sender.send_update_parent(update_parent.clone());
+        let update_parent_work = dependency_tracker.get_current_declared_work();
+        assert_eq!(update_parent_work, 1);
+        transaction_status_sender
+            .send(TransactionStatusMessage::Batch((
+                make_batch(replacement_transaction, 0),
+                None,
+            )))
+            .unwrap();
+
+        transaction_status_service.quiesce_and_join_for_tests(exit);
+        dependency_tracker.wait_for_dependency(update_parent_work);
+
+        assert!(
+            blockstore
+                .read_transaction_status((stale_signature, slot))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            blockstore
+                .read_transaction_memos(stale_signature, slot)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(blockstore.get_block_height(slot).unwrap(), None);
+        assert_eq!(blockstore.read_rewards(slot).unwrap(), None);
+        assert!(
+            blockstore
+                .read_transaction_status((replacement_signature, slot))
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            max_complete_transaction_status_slot.load(Ordering::SeqCst),
+            99
+        );
+        assert_eq!(
+            *test_notifier.update_parents.lock().unwrap(),
+            vec![update_parent]
         );
     }
 }


### PR DESCRIPTION
Will be split into smaller PRs

#### Problem
The read layer is not aware of the new Alpenglow concept `UpdateParent`.
This block marker allows for a block producer to switch parents midway through the block in certain circumstances

#### Summary of Changes
Add handling for geyser / TSS / rpc

#### Testing
Need to test this against a live cluster with relevant read layer services turned on

Fixes #https://github.com/anza-xyz/agave/issues/12885