### PR TITLE
gossip: use only ipv4

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -67,6 +67,8 @@ pub enum Error {
     InvalidQuicSocket(Option<SocketAddr>, Option<SocketAddr>),
     #[error("IP addresses saturated")]
     IpAddrsSaturated,
+    #[error("IPv6 IP address: {0}")]
+    Ipv6IpAddr(IpAddr),
     #[error("Multicast IP address: {0}")]
     MulticastIpAddr(IpAddr),
     #[error("Port offsets overflow")]
@@ -83,7 +85,7 @@ pub enum Error {
     feature = "frozen-abi",
     derive(StableAbi),
     frozen_abi(
-        abi_digest = "Baf4fGA1YWMEjJTc96iNT4JJPkMKSXorR5LrtiCtnF1C",
+        abi_digest = "8uEsgsqpoykiQgP3Majk8kurCVNB3TESe9dejgDowub4",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire",
     )
@@ -441,13 +443,13 @@ impl ContactInfo {
     }
 
     /// port must not be 0
-    /// ip must be specified and not multicast
+    /// ip must be IPv4, specified, and not multicast
     pub fn is_valid_address(addr: &SocketAddr, socket_addr_space: &SocketAddrSpace) -> bool {
         addr.port() != 0u16 && Self::is_valid_ip(addr.ip()) && socket_addr_space.check(addr)
     }
 
     fn is_valid_ip(addr: IpAddr) -> bool {
-        !(addr.is_unspecified() || addr.is_multicast())
+        addr.is_ipv4() && !addr.is_unspecified() && !addr.is_multicast()
     }
 
     /// New random ContactInfo for tests and simulations.
@@ -646,6 +648,9 @@ pub(crate) fn sanitize_socket(socket: &SocketAddr) -> Result<(), Error> {
         return Err(Error::InvalidPort(socket.port()));
     }
     let addr = socket.ip();
+    if matches!(addr, IpAddr::V6(_)) {
+        return Err(Error::Ipv6IpAddr(addr));
+    }
     if addr.is_unspecified() {
         return Err(Error::UnspecifiedIpAddr(addr));
     }
@@ -661,6 +666,9 @@ fn sanitize_entries(addrs: &[IpAddr], sockets: &[SocketEntry]) -> Result<(), Err
     {
         let mut seen = HashSet::with_capacity(addrs.len());
         for addr in addrs {
+            if matches!(addr, IpAddr::V6(_)) {
+                return Err(Error::Ipv6IpAddr(*addr));
+            }
             if !seen.insert(addr) {
                 return Err(Error::DuplicateIpAddr(*addr));
             }
@@ -807,14 +815,12 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 0, 3)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 1)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 2)),
         ];
         let mut keys: Vec<u8> = (0u8..=u8::MAX).collect();
         keys.shuffle(&mut rng);
         // Duplicate IP addresses.
         {
-            let addrs = [addrs[0], addrs[1], addrs[2], addrs[0], addrs[3]];
+            let addrs = [addrs[0], addrs[1], addrs[2], addrs[0]];
             assert_matches!(
                 sanitize_entries(&addrs, /*sockets:*/ &[]),
                 Err(Error::DuplicateIpAddr(_))
@@ -848,7 +854,7 @@ mod tests {
         }
         // Unused IP address.
         {
-            let sockets: Vec<_> = (0..4u8)
+            let sockets: Vec<_> = (0..2u8)
                 .map(|key| SocketEntry {
                     key,
                     index: key,
@@ -889,6 +895,47 @@ mod tests {
     }
 
     #[test]
+    fn test_reject_ipv6_addresses() {
+        let addr = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 1));
+        let socket = SocketAddr::new(addr, 8000);
+
+        assert_matches!(sanitize_socket(&socket), Err(Error::Ipv6IpAddr(a)) if a == addr);
+        assert!(!ContactInfo::is_valid_address(
+            &socket,
+            &SocketAddrSpace::Unspecified
+        ));
+
+        let mut node = ContactInfo::default();
+        assert_matches!(node.set_gossip(socket), Err(Error::Ipv6IpAddr(a)) if a == addr);
+
+        let addrs = [addr];
+        let sockets = [SocketEntry {
+            key: SOCKET_TAG_GOSSIP,
+            index: 0,
+            offset: 8000,
+        }];
+        assert_matches!(
+            sanitize_entries(&addrs, &sockets),
+            Err(Error::Ipv6IpAddr(a)) if a == addr
+        );
+
+        let node = ContactInfo {
+            pubkey: Pubkey::new_unique(),
+            wallclock: 0,
+            outset: 0,
+            shred_version: 0,
+            version: solana_version::Version::default(),
+            addrs: addrs.to_vec(),
+            sockets: sockets.to_vec(),
+            extensions: Vec::default(),
+            cache: EMPTY_SOCKET_ADDR_CACHE,
+        };
+        let bytes = bincode::serialize(&node).unwrap();
+        assert!(bincode::deserialize::<ContactInfo>(&bytes).is_err());
+        assert!(wincode::deserialize::<ContactInfo>(&bytes).is_err());
+    }
+
+    #[test]
     fn test_round_trip() {
         const KEYS: Range<u8> = 0u8..16u8;
         let mut rng = rand::rng();
@@ -897,10 +944,6 @@ mod tests {
             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 2)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 3)),
             IpAddr::V4(Ipv4Addr::new(10, 0, 1, 4)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 1)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 2)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 3)),
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 2, 0, 0, 0, 0, 4)),
         ];
         let mut node = ContactInfo {
             pubkey: Pubkey::new_unique(),

--- a/gossip/src/crds_data.rs
+++ b/gossip/src/crds_data.rs
@@ -76,7 +76,7 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for RejectNonzeroU8 {
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi),
     frozen_abi(
-        abi_digest = "2LUBVdKAtga4V2tb58xAfGa5sN1ufP9GVG7r6nkGbwRd",
+        abi_digest = "Dqsrw64E4ALKusk5cjbckL6vNHw1ESwTzKUqKrMSQCic",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire",
     )

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -693,10 +693,7 @@ pub(crate) mod tests {
         solana_packet::PACKET_DATA_SIZE,
         solana_sha256_hasher::hash,
         solana_time_utils::timestamp,
-        std::{
-            net::{IpAddr, Ipv6Addr},
-            time::Instant,
-        },
+        std::{net::Ipv4Addr, time::Instant},
         test_case::test_case,
     };
 
@@ -1389,15 +1386,14 @@ pub(crate) mod tests {
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
         let node = {
-            let addr = Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888);
-            let socket = SocketAddr::new(IpAddr::from(addr), 8053);
+            let socket = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 8053));
             let mut node = ContactInfo::new_with_socketaddr(&keypair.pubkey(), &socket);
             node.set_shred_version(rng.random());
             node
         };
         {
             let caller = CrdsValue::new(CrdsData::from(&node), &keypair);
-            assert_eq!(get_max_bloom_filter_bytes(&caller), 1165);
+            assert_eq!(get_max_bloom_filter_bytes(&caller), 1175);
             verify_get_max_bloom_filter_bytes(&mut rng, &caller, num_items);
         }
     }

--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -26,7 +26,7 @@ use {
     feature = "frozen-abi",
     derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "8xNLrmP9ntFynzXsxzf7LyeVve69aWzsmYA3ndrFHTCs",
+        abi_digest = "4ABukH5bS69APB3bu1hbMiGyeKPw21nzXAVzCRMtKPih",
         abi_serializer = ["bincode", "wincode"],
         // `hash` is recomputed from [signature, data] on deserialize, so it can't
         // match an independently-sampled value; verify the wire round-trip only.

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -59,7 +59,7 @@ type GossipProtocolWincodeConfig =
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "8VFHarXNCkGKv89tUFR4uQVLcSum4km8yobxxq16LzmJ",
+        abi_digest = "D3Hqum16i1KHnejUD65odaQSbQnJtTQnTJSUoUrjzY2a",
         abi_serializer = ["bincode", "wincode"],
         // `Protocol` has no `PartialEq` and embeds `CrdsValue` (whose `hash` is
         // recomputed on deserialize), so verify the wire round-trip only.

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -198,16 +198,21 @@ pub fn parse_port_range(port_range: &str) -> Option<PortRange> {
     Some((start_port, end_port))
 }
 
-fn select_ipv4(host: &str, mut ips: impl Iterator<Item = IpAddr>) -> Result<IpAddr, String> {
-    let Some(first_ip) = ips.next() else {
+fn select_ipv4<T>(
+    host: &str,
+    mut values: impl Iterator<Item = T>,
+    mut ip_addr: impl FnMut(&T) -> IpAddr,
+) -> Result<T, String> {
+    let Some(first_value) = values.next() else {
         return Err(format!("Unable to resolve host: {host}"));
     };
 
-    if first_ip.is_ipv4() {
-        return Ok(first_ip);
+    if ip_addr(&first_value).is_ipv4() {
+        return Ok(first_value);
     }
 
-    ips.find(IpAddr::is_ipv4)
+    values
+        .find(|value| ip_addr(value).is_ipv4())
         .ok_or_else(|| format!("IPv6 addresses are not supported: {host}"))
 }
 
@@ -224,12 +229,12 @@ pub fn parse_host(host: &str) -> Result<IpAddr, String> {
     }
 
     // Next, check to see if it resolves to an IPv4 address
-    let mut ips = (host, 0)
+    let ips = (host, 0)
         .to_socket_addrs()
         .map_err(|err| err.to_string())?
         .map(|socket_address| socket_address.ip());
 
-    select_ipv4(host, &mut ips)
+    select_ipv4(host, ips, |ip| *ip)
 }
 
 pub fn is_host(string: String) -> Result<(), String> {
@@ -237,15 +242,10 @@ pub fn is_host(string: String) -> Result<(), String> {
 }
 
 pub fn parse_host_port(host_port: &str) -> Result<SocketAddr, String> {
-    let addrs: Vec<_> = host_port
+    let addrs = host_port
         .to_socket_addrs()
-        .map_err(|err| format!("Unable to resolve host {host_port}: {err}"))?
-        .collect();
-    if addrs.is_empty() {
-        Err(format!("Unable to resolve host: {host_port}"))
-    } else {
-        Ok(addrs[0])
-    }
+        .map_err(|err| format!("Unable to resolve host {host_port}: {err}"))?;
+    select_ipv4(host_port, addrs, SocketAddr::ip)
 }
 
 pub fn is_host_port(string: String) -> Result<(), String> {
@@ -398,7 +398,8 @@ mod tests {
         assert_eq!(
             select_ipv4(
                 "ipv6-only.test",
-                [IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)].into_iter()
+                [IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)].into_iter(),
+                |ip| *ip,
             )
             .unwrap_err(),
             "IPv6 addresses are not supported: ipv6-only.test",
@@ -411,6 +412,7 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::LOCALHOST),
                 ]
                 .into_iter(),
+                |ip| *ip,
             )
             .unwrap(),
             IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -423,6 +425,10 @@ mod tests {
         parse_host_port("localhost").unwrap_err();
         parse_host_port("127.0.0.0:1234").unwrap();
         parse_host_port("127.0.0.0").unwrap_err();
+        assert_eq!(
+            parse_host_port("[2001:db8:abcd:42::dead:beef]:1234").unwrap_err(),
+            "IPv6 addresses are not supported: [2001:db8:abcd:42::dead:beef]:1234",
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Currently, gossip supports both ipv4 and ipv6. De facto, nobody is using ipv6 and it also creates problems with XDP.

#### Summary of Changes

Prohibit ipv6 for gossip.


