### PR TITLE
test-validator add --alpenglow option and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ name = "agave-validator"
 version = "4.2.0-alpha.0"
 dependencies = [
  "agave-cpu-utils",
+ "agave-feature-set",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -10915,6 +10916,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
+ "agave-votor-messages",
  "arc-swap",
  "base64 0.22.1",
  "bincode",
@@ -10923,6 +10925,7 @@ dependencies = [
  "serde_json",
  "solana-account 4.3.0",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-cli-output",
  "solana-clock",
  "solana-cluster-type",
@@ -10960,6 +10963,7 @@ dependencies = [
  "solana-test-validator",
  "solana-transaction",
  "solana-validator-exit",
+ "solana-vote-interface",
  "tokio",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -290,6 +290,7 @@ name = "agave-validator"
 version = "4.2.0-alpha.0"
 dependencies = [
  "agave-cpu-utils",
+ "agave-feature-set",
  "agave-logger",
  "agave-snapshots",
  "agave-votor",
@@ -7587,7 +7588,9 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "serde",
+ "solana-clock",
  "solana-hash 4.4.0",
+ "solana-keypair",
  "solana-message",
  "solana-metrics",
  "solana-packet 4.1.0",
@@ -7595,8 +7598,14 @@ dependencies = [
  "solana-sdk-ids",
  "solana-short-vec",
  "solana-signature",
+ "solana-signer",
+ "solana-system-interface 3.2.0",
+ "solana-system-transaction",
  "solana-time-utils",
+ "solana-transaction",
  "solana-transaction-context",
+ "solana-vote",
+ "solana-vote-program",
  "wincode",
 ]
 
@@ -9694,6 +9703,7 @@ version = "4.2.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-snapshots",
+ "agave-votor-messages",
  "arc-swap",
  "base64 0.22.1",
  "bincode",
@@ -9702,6 +9712,7 @@ dependencies = [
  "serde_json",
  "solana-account 4.3.0",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-cli-output",
  "solana-clock",
  "solana-cluster-type",
@@ -9738,6 +9749,7 @@ dependencies = [
  "solana-syscalls",
  "solana-transaction",
  "solana-validator-exit",
+ "solana-vote-interface",
  "tokio",
 ]
 

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -322,7 +322,15 @@ pub fn create_genesis_config_with_leader_with_mint_keypair(
 
 pub fn activate_all_features_alpenglow(genesis_config: &mut GenesisConfig) {
     do_activate_all_features::<true>(genesis_config);
+    configure_alpenglow_at_genesis(genesis_config);
+}
 
+pub fn activate_alpenglow_at_genesis(genesis_config: &mut GenesisConfig) {
+    activate_feature(genesis_config, agave_feature_set::alpenglow::id());
+    configure_alpenglow_at_genesis(genesis_config);
+}
+
+fn configure_alpenglow_at_genesis(genesis_config: &mut GenesisConfig) {
     // PoH is in low power mode
     genesis_config.poh_config.hashes_per_tick = None;
 

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -13,11 +13,16 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = []
+dev-context-only-utils = [
+    "solana-core/dev-context-only-utils",
+    "solana-ledger/dev-context-only-utils",
+    "solana-runtime/dev-context-only-utils",
+]
 
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-snapshots = { workspace = true }
+agave-votor-messages = { workspace = true }
 arc-swap.workspace = true
 base64 = { workspace = true }
 bincode = { workspace = true }
@@ -26,6 +31,7 @@ log = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
+solana-bls-signatures = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
@@ -62,6 +68,7 @@ solana-streamer = { workspace = true }
 solana-syscalls = { workspace = true }
 solana-transaction = { workspace = true }
 solana-validator-exit = { workspace = true }
+solana-vote-interface = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1,10 +1,14 @@
 #![cfg(feature = "agave-unstable-api")]
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    agave_feature_set::{FEATURE_NAMES, FeatureSet, alpenglow, raise_cpi_nesting_limit_to_8},
+    agave_feature_set::{
+        FEATURE_NAMES, FeatureSet, alpenglow, raise_cpi_nesting_limit_to_8,
+        validator_admission_ticket,
+    },
     agave_snapshots::{
         SnapshotInterval, paths::BANK_SNAPSHOTS_DIR, snapshot_config::SnapshotConfig,
     },
+    agave_votor_messages::consensus_message::BLS_KEYPAIR_DERIVE_SEED,
     arc_swap::ArcSwap,
     base64::{Engine, prelude::BASE64_STANDARD},
     crossbeam_channel::Receiver,
@@ -15,6 +19,7 @@ use {
         accounts_index::{AccountsIndexConfig, ScanFilter},
         utils::create_accounts_run_and_snapshot_dirs,
     },
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_cli_output::CliAccount,
     solana_clock::{DEFAULT_MS_PER_SLOT, Slot},
     solana_commitment_config::CommitmentConfig,
@@ -58,7 +63,8 @@ use {
         client_error::Error as RpcClientError, request::MAX_MULTIPLE_ACCOUNTS,
     },
     solana_runtime::{
-        bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader_ex,
+        bank_forks::BankForks,
+        genesis_utils::{activate_alpenglow_at_genesis, create_genesis_config_with_leader_ex},
         runtime_config::RuntimeConfig,
     },
     solana_sbpf::{elf::Executable, verifier::RequisiteVerifier},
@@ -68,6 +74,7 @@ use {
     solana_syscalls::create_program_runtime_environment,
     solana_transaction::{Transaction, TransactionError},
     solana_validator_exit::Exit,
+    solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     std::{
         collections::{HashMap, HashSet},
         ffi::OsStr,
@@ -201,6 +208,15 @@ impl Default for TestValidatorGenesis {
     }
 }
 
+fn derive_bls_pubkey_from_authorized_voter_keypair(
+    authorized_voter_keypair: &Keypair,
+) -> [u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE] {
+    BLSKeypair::derive_from_signer(authorized_voter_keypair, BLS_KEYPAIR_DERIVE_SEED)
+        .unwrap()
+        .public
+        .to_bytes_compressed()
+}
+
 #[cfg(feature = "dev-context-only-utils")]
 impl TestValidatorGenesis {
     /// Defaults suitable for unit tests; a disjoint port range will be used to
@@ -257,6 +273,14 @@ impl TestValidatorGenesis {
         self.deactivate_feature_set.extend(deactivate_list);
         self
     }
+
+    pub fn activate_alpenglow(&mut self) -> &mut Self {
+        self.deactivate_feature_set.remove(&alpenglow::id());
+        self.deactivate_feature_set
+            .remove(&validator_admission_ticket::id());
+        self
+    }
+
     pub fn ledger_path<P: Into<PathBuf>>(&mut self, ledger_path: P) -> &mut Self {
         self.ledger_path = Some(ledger_path.into());
         self
@@ -537,6 +561,8 @@ impl TestValidatorGenesis {
                         .is_none()
                     {
                         self.deactivate_feature_set.insert(*feature_id);
+                    } else {
+                        self.deactivate_feature_set.remove(feature_id);
                     }
                 });
         }
@@ -893,6 +919,12 @@ impl TestValidator {
                 warn!("Feature {feature:?} set for deactivation is not a known Feature public key",)
             }
         }
+        let is_alpenglow_active = feature_set.is_active(&alpenglow::id());
+        if is_alpenglow_active && !feature_set.is_active(&validator_admission_ticket::id()) {
+            return Err(
+                "Alpenglow requires the validator_admission_ticket feature to be active".into(),
+            );
+        }
 
         let runtime_features = feature_set.runtime_features();
         let program_runtime_environment = create_program_runtime_environment(
@@ -963,13 +995,17 @@ impl TestValidator {
             );
         }
 
+        // Test validator genesis uses the vote account pubkey as the authorized voter,
+        // so the Alpenglow BLS pubkey is derived from the vote account keypair.
         let mut genesis_config = create_genesis_config_with_leader_ex(
             mint_lamports,
             &mint_address,
             &validator_identity.pubkey(),
             &validator_vote_account.pubkey(),
             &validator_stake_account.pubkey(),
-            None,
+            Some(derive_bls_pubkey_from_authorized_voter_keypair(
+                &validator_vote_account,
+            )),
             validator_stake_lamports,
             validator_identity_lamports,
             config.fee_rate_governor.clone(),
@@ -978,6 +1014,9 @@ impl TestValidator {
             &feature_set,
             accounts.into_iter().collect(),
         );
+        if is_alpenglow_active {
+            activate_alpenglow_at_genesis(&mut genesis_config);
+        }
         genesis_config.epoch_schedule = config
             .epoch_schedule
             .as_ref()
@@ -1106,7 +1145,8 @@ impl TestValidator {
                 .iter()
                 .any(|x| x.pubkey() == vote_account_address)
             {
-                authorized_voter_keypairs.push(Arc::new(validator_vote_account))
+                // Test validator genesis uses the vote account pubkey as the authorized voter.
+                authorized_voter_keypairs.push(Arc::new(validator_vote_account));
             }
         }
 
@@ -1387,7 +1427,63 @@ impl Drop for TestValidator {
 
 #[cfg(test)]
 mod test {
-    use {super::*, solana_feature_gate_interface::Feature};
+    use {
+        super::*,
+        solana_feature_gate_interface::{Feature, create_account as create_feature_account},
+    };
+
+    async fn assert_feature_accounts(
+        rpc_client: &nonblocking::rpc_client::RpcClient,
+        active_features: &[Pubkey],
+        inactive_features: &[Pubkey],
+    ) {
+        for chunk in active_features.chunks(100) {
+            let active_feature_accounts = rpc_client.get_multiple_accounts(chunk).await.unwrap();
+            for feature_account in active_feature_accounts {
+                let account = feature_account.unwrap();
+                let feature_state: Feature = bincode::deserialize(account.data()).unwrap();
+                assert!(feature_state.activated_at.is_some());
+            }
+        }
+
+        if !inactive_features.is_empty() {
+            let inactive_feature_accounts = rpc_client
+                .get_multiple_accounts(inactive_features)
+                .await
+                .unwrap();
+            for feature_account in inactive_feature_accounts {
+                assert!(feature_account.is_none());
+            }
+        }
+    }
+
+    async fn wait_for_alpenglow_enabled(test_validator: &TestValidator) {
+        for _ in 0..240 {
+            let migration_status = test_validator
+                .bank_forks()
+                .read()
+                .unwrap()
+                .migration_status();
+            if migration_status.is_alpenglow_enabled() {
+                return;
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+        let bank_forks = test_validator.bank_forks();
+        let bank_forks = bank_forks.read().unwrap();
+        let root_bank = bank_forks.root_bank();
+        let migration_status = bank_forks.migration_status();
+        panic!(
+            "Timed out waiting for Alpenglow migration: migration_status={migration_status:?}, \
+             root_slot={}, working_slot={}, feature_activation_slot={:?}, \
+             eligible_genesis_block={:?}, genesis_certificate={:?}",
+            root_bank.slot(),
+            bank_forks.working_bank().slot(),
+            root_bank.feature_set.activated_slot(&alpenglow::id()),
+            migration_status.eligible_genesis_block(),
+            migration_status.genesis_certificate(),
+        );
+    }
 
     #[test]
     fn get_health() {
@@ -1403,6 +1499,78 @@ mod test {
             .await;
         let rpc_client = test_validator.get_async_rpc_client();
         rpc_client.get_health().await.expect("health");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_all_features_active_except_alpenglow_by_default() {
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
+            .start_async()
+            .await;
+        let rpc_client = test_validator.get_async_rpc_client();
+
+        let active_features = FEATURE_NAMES
+            .keys()
+            .copied()
+            .filter(|feature| *feature != alpenglow::id())
+            .collect::<Vec<_>>();
+        assert_feature_accounts(&rpc_client, &active_features, &[alpenglow::id()]).await;
+        assert!(
+            test_validator
+                .bank_forks()
+                .read()
+                .unwrap()
+                .migration_status()
+                .is_pre_feature_activation()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_all_features_active_with_alpenglow_at_genesis() {
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
+            .activate_alpenglow()
+            .start_async()
+            .await;
+        let rpc_client = test_validator.get_async_rpc_client();
+
+        let active_features = FEATURE_NAMES.keys().copied().collect::<Vec<_>>();
+        assert_feature_accounts(&rpc_client, &active_features, &[]).await;
+        assert!(
+            test_validator
+                .bank_forks()
+                .read()
+                .unwrap()
+                .root_bank()
+                .get_alpenglow_genesis_certificate()
+                .is_some()
+        );
+        wait_for_alpenglow_enabled(&test_validator).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_pending_alpenglow_activation_migrates() {
+        let feature_lamports = Rent::default().minimum_balance(Feature::size_of()).max(1);
+        let (test_validator, _payer) = TestValidatorGenesis::default_for_tests()
+            .ticks_per_slot(8)
+            .epoch_schedule(EpochSchedule::custom(64, 64, false))
+            .add_account(
+                alpenglow::id(),
+                create_feature_account(&Feature::default(), feature_lamports),
+            )
+            .start_async()
+            .await;
+        let rpc_client = test_validator.get_async_rpc_client();
+
+        for _ in 0..120 {
+            let account = rpc_client.get_account(&alpenglow::id()).await.unwrap();
+            let feature_state = solana_feature_gate_interface::from_account(&account).unwrap();
+            if feature_state.activated_at.is_some() {
+                wait_for_alpenglow_enabled(&test_validator).await;
+                rpc_client.get_health().await.expect("health");
+                return;
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+        panic!("Timed out waiting for Alpenglow feature activation");
     }
 
     #[test]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -19,6 +19,7 @@ agave-unstable-api = []
 
 [dependencies]
 agave-cpu-utils = { workspace = true }
+agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -386,6 +386,18 @@ fn main() {
     });
 
     let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
+    if matches.is_present("alpenglow")
+        && features_to_deactivate.iter().any(|feature| {
+            *feature == agave_feature_set::alpenglow::id()
+                || *feature == agave_feature_set::validator_admission_ticket::id()
+        })
+    {
+        println!(
+            "Error: --alpenglow requires both the alpenglow and validator_admission_ticket \
+             features to be active"
+        );
+        exit(1);
+    }
 
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[
@@ -397,6 +409,7 @@ fn main() {
             ("slots_per_epoch", "--slots-per-epoch"),
             ("inflation_fixed", "--inflation-fixed"),
             ("faucet_sol", "--faucet-sol"),
+            ("alpenglow", "--alpenglow"),
             ("deactivate_feature", "--deactivate-feature"),
         ] {
             if matches.is_present(name) {
@@ -493,8 +506,7 @@ fn main() {
         .unwrap_or_else(|e| {
             println!("Error: add_accounts_from_directories failed: {e}");
             exit(1);
-        })
-        .deactivate_features(&features_to_deactivate);
+        });
 
     genesis.rpc_config(JsonRpcConfig {
         enable_rpc_transaction_history: true,
@@ -565,6 +577,12 @@ fn main() {
             exit(1);
         }
     }
+
+    if matches.is_present("alpenglow") {
+        genesis.activate_alpenglow();
+    }
+
+    genesis.deactivate_features(&features_to_deactivate);
 
     if let Some(warp_slot) = warp_slot {
         genesis.warp_slot(warp_slot);

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -844,6 +844,15 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .help("Enables external processes to connect and manage block production"),
         )
         .arg(
+            Arg::with_name("alpenglow")
+                .long("alpenglow")
+                .takes_value(false)
+                .help(
+                    "Activate Alpenglow at genesis. The validator_admission_ticket feature must \
+                     remain active",
+                ),
+        )
+        .arg(
             Arg::with_name("deactivate_feature")
                 .long("deactivate-feature")
                 .takes_value(true)


### PR DESCRIPTION
#### Problem
`solana-test-validator` does not have an option to enable alpenglow

#### Summary of Changes
Add `--alpenglow` which activates alpenglow.
Derive the proper BLS pubkey (test-validator sets the authorized-voter to the vote account 😢 , can clean that up in a follow up)
Add tests for alpenglow and the migration pathway

#### Testing
Unit tests and locally running the test validator

Fixes #13172 
