### PR TITLE
TSS: invalidate transaction status on UpdateParent

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -120,8 +120,8 @@ use {
         DeadSlotContext, DeadSlotDuplicateContext, DeadSlotNotifications, mark_replay_dead_slot,
     },
     update_parent::{
-        ChildBankReplayStart, child_bank_replay_start, handle_abandoned_bank,
-        handle_update_parent_interrupts, process_soft_dead_slots,
+        ChildBankReplayStart, UpdateParentNotificationSenders, child_bank_replay_start,
+        handle_abandoned_bank, handle_update_parent_interrupts, process_soft_dead_slots,
     },
 };
 
@@ -967,6 +967,13 @@ impl ReplayStage {
                     break;
                 }
 
+                let update_parent_notification_senders = UpdateParentNotificationSenders::new(
+                    &replay_vote_sender,
+                    rpc_subscriptions.clone(),
+                    slot_status_notifier.clone(),
+                    transaction_status_sender.as_ref(),
+                );
+
                 handle_update_parent_interrupts(
                     &my_pubkey,
                     &blockstore,
@@ -974,7 +981,7 @@ impl ReplayStage {
                     &mut progress,
                     &mut async_verification_freelist,
                     &update_parent_receiver,
-                    &replay_vote_sender,
+                    &update_parent_notification_senders,
                     migration_status.as_ref(),
                 );
 
@@ -1060,11 +1067,9 @@ impl ReplayStage {
                         &my_pubkey,
                         &blockstore,
                         &bank_forks,
-                        &rpc_subscriptions,
-                        &slot_status_notifier,
                         &mut progress,
                         &mut async_verification_freelist,
-                        &replay_vote_sender,
+                        &update_parent_notification_senders,
                         migration_status.as_ref(),
                     );
                     Self::alpenglow_handle_newly_frozen_banks(

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -2853,11 +2853,19 @@ fn test_update_parent_restart() {
             parent_block_id,
             32,
         );
-        tx.send(UpdateParentSignal { slot }).unwrap();
+        tx.send(UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index: 32,
+            parent_slot: 0,
+            parent_block_id: Some(parent_block_id),
+        })
+        .unwrap();
     }
 
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -2866,7 +2874,7 @@ fn test_update_parent_restart() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -2986,9 +2994,17 @@ fn test_update_parent_tower_gated() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -2997,7 +3013,7 @@ fn test_update_parent_tower_gated() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &MigrationStatus::default(),
     );
 
@@ -3030,9 +3046,17 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(meta.parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3041,7 +3065,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3077,9 +3101,17 @@ fn test_update_parent_keeps_hard() {
     progress.insert(slot, p);
 
     let (tx, rx) = bounded(1024);
-    tx.send(UpdateParentSignal { slot }).unwrap();
+    tx.send(UpdateParentSignal {
+        slot,
+        update_parent_fec_set_index: 10,
+        parent_slot: 0,
+        parent_block_id: Some(parent_block_id),
+    })
+    .unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3088,7 +3120,7 @@ fn test_update_parent_keeps_hard() {
         &mut progress,
         &mut async_verification_freelist,
         &rx,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3299,16 +3331,16 @@ fn test_soft_dead_restarts() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
         &blockstore,
         &bank_forks,
-        &None,
-        &None,
         &mut progress,
         &mut async_verification_freelist,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 
@@ -3342,16 +3374,16 @@ fn test_full_soft_dead_hardens() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let update_parent_notification_senders =
+        UpdateParentNotificationSenders::new(&replay_vote_sender, None, None, None);
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
         &blockstore,
         &bank_forks,
-        &None,
-        &None,
         &mut progress,
         &mut async_verification_freelist,
-        &replay_vote_sender,
+        &update_parent_notification_senders,
         &post_migration_status_for_tests(),
     );
 

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -16,11 +16,13 @@ use {
     solana_clock::Slot,
     solana_entry::block_component::VersionedUpdateParent,
     solana_ledger::{
-        blockstore::{Blockstore, UpdateParentReceiver},
+        blockstore::{Blockstore, UpdateParentReceiver, UpdateParentSignal},
         blockstore_meta::SlotMeta,
-        blockstore_processor::AsyncVerificationProgress,
+        blockstore_processor::{AsyncVerificationProgress, TransactionStatusSender},
     },
+    solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
+    solana_rpc::{rpc_subscriptions::RpcSubscriptions, slot_status_notifier::SlotStatusNotifier},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, leader_schedule_utils::leader_slot_index,
         vote_sender_types::ReplayVoteSender,
@@ -178,6 +180,66 @@ fn try_restart_slot_from_update_parent(
     true
 }
 
+fn update_parent_signal_from_blockstore(
+    blockstore: &Blockstore,
+    slot: Slot,
+) -> Option<UpdateParentSignal> {
+    let slot_meta = blockstore.meta(slot).expect("Blockstore should not fail")?;
+    UpdateParentSignal::from_slot_meta(slot, &slot_meta)
+}
+
+pub(super) struct UpdateParentNotificationSenders<'a> {
+    replay_vote_sender: &'a ReplayVoteSender,
+    rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+    slot_status_notifier: Option<SlotStatusNotifier>,
+    transaction_status_sender: Option<&'a TransactionStatusSender>,
+}
+
+impl<'a> UpdateParentNotificationSenders<'a> {
+    pub(super) fn new(
+        replay_vote_sender: &'a ReplayVoteSender,
+        rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
+        slot_status_notifier: Option<SlotStatusNotifier>,
+        transaction_status_sender: Option<&'a TransactionStatusSender>,
+    ) -> Self {
+        Self {
+            replay_vote_sender,
+            rpc_subscriptions,
+            slot_status_notifier,
+            transaction_status_sender,
+        }
+    }
+
+    fn replay_vote_sender(&self) -> &ReplayVoteSender {
+        self.replay_vote_sender
+    }
+
+    fn dead_slot_notifications(&self, blockstore: Arc<Blockstore>) -> DeadSlotNotifications {
+        DeadSlotNotifications {
+            blockstore,
+            rpc_subscriptions: self.rpc_subscriptions.clone(),
+            slot_status_notifier: self.slot_status_notifier.clone(),
+            replay_vote_sender: self.replay_vote_sender.clone(),
+        }
+    }
+
+    fn notify_read_layer_consumers(&self, update_parent: &UpdateParentSignal) {
+        if let Some(transaction_status_sender) = self.transaction_status_sender {
+            transaction_status_sender.send_update_parent(update_parent.clone());
+        }
+        datapoint_info!(
+            "replay-stage-update-parent-read-layer-invalidation",
+            ("slot", update_parent.slot, i64),
+            (
+                "update_parent_fec_set_index",
+                update_parent.update_parent_fec_set_index,
+                i64
+            ),
+            ("parent_slot", update_parent.parent_slot, i64),
+        );
+    }
+}
+
 /// Revisit soft-dead slots as more shreds arrive.
 ///
 /// If an UpdateParent marker is now visible in SlotMeta, replay is restarted
@@ -187,11 +249,9 @@ pub(super) fn process_soft_dead_slots(
     my_pubkey: &Pubkey,
     blockstore: &Arc<Blockstore>,
     bank_forks: &RwLock<BankForks>,
-    rpc_subscriptions: &Option<Arc<solana_rpc::rpc_subscriptions::RpcSubscriptions>>,
-    slot_status_notifier: &Option<solana_rpc::slot_status_notifier::SlotStatusNotifier>,
     progress: &mut ProgressMap,
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
-    replay_vote_sender: &ReplayVoteSender,
+    notification_senders: &UpdateParentNotificationSenders,
     migration_status: &MigrationStatus,
 ) {
     let soft_dead_slots = progress
@@ -220,17 +280,24 @@ pub(super) fn process_soft_dead_slots(
             update_parent_replay_offset(slot, &slot_meta, bank_forks.read().unwrap().root());
 
         if replay_offset.is_some() {
-            try_restart_slot_from_update_parent(
+            let did_restart = try_restart_slot_from_update_parent(
                 my_pubkey,
                 blockstore.as_ref(),
                 bank_forks,
                 progress,
                 async_verification_freelist,
                 slot,
-                replay_vote_sender,
+                notification_senders.replay_vote_sender(),
                 migration_status,
                 "soft-dead scan",
             );
+            if did_restart {
+                if let Some(update_parent) =
+                    update_parent_signal_from_blockstore(blockstore.as_ref(), slot)
+                {
+                    notification_senders.notify_read_layer_consumers(&update_parent);
+                }
+            }
             continue;
         }
 
@@ -252,12 +319,8 @@ pub(super) fn process_soft_dead_slots(
             };
             let bank = bank_forks.read().unwrap().get(slot);
             if let Some(bank) = bank {
-                let notifications = DeadSlotNotifications {
-                    blockstore: blockstore.clone(),
-                    rpc_subscriptions: rpc_subscriptions.clone(),
-                    slot_status_notifier: slot_status_notifier.clone(),
-                    replay_vote_sender: replay_vote_sender.clone(),
-                };
+                let notifications =
+                    notification_senders.dead_slot_notifications(blockstore.clone());
                 mark_hard_dead_slot_notifications(&bank, err, log_level, progress, &notifications);
             }
         }
@@ -274,21 +337,28 @@ pub(super) fn handle_update_parent_interrupts(
     progress: &mut ProgressMap,
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     update_parent_receiver: &UpdateParentReceiver,
-    replay_vote_sender: &ReplayVoteSender,
+    notification_senders: &UpdateParentNotificationSenders,
     migration_status: &MigrationStatus,
 ) {
     while let Ok(signal) = update_parent_receiver.try_recv() {
-        try_restart_slot_from_update_parent(
+        let did_restart = try_restart_slot_from_update_parent(
             my_pubkey,
             blockstore,
             bank_forks,
             progress,
             async_verification_freelist,
             signal.slot,
-            replay_vote_sender,
+            notification_senders.replay_vote_sender(),
             migration_status,
             "UpdateParent signal",
         );
+        if did_restart {
+            if let Some(update_parent) =
+                update_parent_signal_from_blockstore(blockstore, signal.slot)
+            {
+                notification_senders.notify_read_layer_consumers(&update_parent);
+            }
+        }
     }
 }
 

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -8,6 +8,7 @@ use {
     log::*,
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_ledger::blockstore::UpdateParentSignal,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
     solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
@@ -72,6 +73,10 @@ impl TransactionNotifier for TransactionNotifierImpl {
                 }
             }
         }
+    }
+
+    fn notify_update_parent(&self, _update_parent: &UpdateParentSignal) {
+        // Will be addressed in a future commit
     }
 }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -131,14 +131,33 @@ type UpdateParentShredParentKey = (BlockLocation, Slot, u32);
 type UpdateParentShredParentCache =
     LruCache<UpdateParentShredParentKey, /* parent used for shred filtering */ Slot>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateParentSignal {
-    /// Slot whose parent metadata was updated by an UpdateParent marker.
-    ///
-    /// This is only a wakeup for replay. Consumers must re-read SlotMeta/dead
-    /// state from blockstore so stale queued signals cannot override newer
-    /// parent metadata or a durable dead-slot decision.
+    /// Slot whose same-slot prefix was invalidated by an UpdateParent marker.
     pub slot: Slot,
+    /// FEC set index of the UpdateParent marker. Read-layer consumers should
+    /// discard same-slot data observed before this boundary.
+    ///
+    /// Signals emitted by the TPU entry path use the marker's pre-shred stream
+    /// position as this boundary because no shred index has been assigned yet.
+    pub update_parent_fec_set_index: u32,
+    /// Parent slot selected by the UpdateParent marker.
+    pub parent_slot: Slot,
+    /// Parent block id selected by the UpdateParent marker, when available.
+    pub parent_block_id: Option<Hash>,
+}
+
+impl UpdateParentSignal {
+    pub fn from_slot_meta(slot: Slot, slot_meta: &SlotMeta) -> Option<Self> {
+        Some(Self {
+            slot,
+            update_parent_fec_set_index: slot_meta
+                .has_update_parent()
+                .then_some(slot_meta.replay_fec_set_index)?,
+            parent_slot: slot_meta.parent_slot?,
+            parent_block_id: Some(slot_meta.parent_block_id),
+        })
+    }
 }
 
 // Contiguous, sorted and non-empty ranges of shred indices:
@@ -4310,6 +4329,61 @@ impl Blockstore {
             .put_in_batch(db_write_batch, (*signature, slot), &memos)
     }
 
+    /// Delete transaction-status data for `slot`.
+    ///
+    /// This is used when an Alpenglow UpdateParent marker invalidates the
+    /// prefix of a same-slot block after read-layer data may already have been
+    /// emitted. Slot-scoped block metadata is deleted with the transaction
+    /// status rows so replacement replay can rewrite a coherent view.
+    pub fn delete_transaction_status_slot(&self, slot: Slot) -> Result<usize> {
+        let (_lowest_cleanup_slot, _) = self.ensure_lowest_cleanup_slot();
+
+        let mut signatures = HashSet::new();
+        let mut transaction_status_keys = Vec::new();
+        for ((signature, status_slot), _) in self.transaction_status_cf.iter(IteratorMode::Start)? {
+            if status_slot == slot {
+                signatures.insert(signature);
+                transaction_status_keys.push((signature, status_slot));
+            }
+        }
+
+        let mut transaction_memo_keys = Vec::new();
+        for ((signature, memo_slot), _) in self.transaction_memos_cf.iter(IteratorMode::Start)? {
+            if memo_slot == slot {
+                transaction_memo_keys.push((signature, memo_slot));
+            }
+        }
+
+        let mut address_signature_keys = Vec::new();
+        for ((address, address_slot, transaction_index, signature), _) in
+            self.address_signatures_cf.iter(IteratorMode::Start)?
+        {
+            if address_slot == slot {
+                address_signature_keys.push((address, address_slot, transaction_index, signature));
+            }
+        }
+
+        let mut write_batch = self.get_write_batch()?;
+        for key in transaction_status_keys {
+            self.transaction_status_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        for key in transaction_memo_keys {
+            self.transaction_memos_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        for key in address_signature_keys {
+            self.address_signatures_cf
+                .delete_in_batch(&mut write_batch, key);
+        }
+        self.blocktime_cf.delete_in_batch(&mut write_batch, slot);
+        self.block_height_cf.delete_in_batch(&mut write_batch, slot);
+        self.rewards_cf.delete_in_batch(&mut write_batch, slot);
+        self.write_batch(write_batch)?;
+
+        Ok(signatures.len())
+    }
+
     /// Acquires the `lowest_cleanup_slot` lock and returns a tuple of the held lock
     /// and lowest available slot.
     ///
@@ -5803,11 +5877,11 @@ impl Blockstore {
             // This signal is only used for replay, so we don't need to consider `Alternate` columns
             if location == BlockLocation::Original
                 && meta.has_update_parent()
-                && meta_backup
-                    .as_ref()
-                    .is_some_and(|m| m.populated_from_block_header())
+                && !meta_backup.as_ref().is_some_and(|m| m.has_update_parent())
             {
-                update_parent_signals.push(UpdateParentSignal { slot });
+                if let Some(update_parent) = UpdateParentSignal::from_slot_meta(slot, meta) {
+                    update_parent_signals.push(update_parent);
+                }
             }
         }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         block_error::BlockError,
-        blockstore::{Blockstore, BlockstoreError},
+        blockstore::{Blockstore, BlockstoreError, UpdateParentSignal},
         blockstore_meta::SlotMeta,
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,
@@ -22,7 +22,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{BlockComponent, VersionedUpdateParent},
         entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
@@ -1883,21 +1883,31 @@ fn confirm_slot_with_components(
                 if let Some(parent_bank) = bank.parent() {
                     let allow_initial_update_parent =
                         replay_starts_at_update_parent && marker.is_update_parent();
-                    processor
-                        .on_marker(
-                            bank.clone_without_scheduler(),
-                            parent_bank,
-                            marker,
-                            allow_initial_update_parent,
-                            finalization_cert_sender,
-                            migration_status,
-                        )
-                        .inspect_err(|err| {
-                            warn!(
-                                "BlockComponentProcessor::on_marker() for slot {slot} failed with \
-                                 {err}"
+                    if let Err(err) = processor.on_marker(
+                        bank.clone_without_scheduler(),
+                        parent_bank,
+                        marker,
+                        allow_initial_update_parent,
+                        finalization_cert_sender,
+                        migration_status,
+                    ) {
+                        warn!(
+                            "BlockComponentProcessor::on_marker() for slot {slot} failed with \
+                             {err}"
+                        );
+                        if let BlockComponentProcessorError::AbandonedBank(update_parent) = &err {
+                            let update_parent = update_parent_signal_from_marker(
+                                slot,
+                                completed_range.start,
+                                update_parent,
                             );
-                        })?;
+                            send_update_parent_transaction_status_notification(
+                                &update_parent,
+                                transaction_status_sender,
+                            );
+                        }
+                        return Err(err.into());
+                    }
                 }
                 progress.num_shreds += num_shreds as u64;
             }
@@ -2885,6 +2895,30 @@ pub fn process_single_slot(
     Ok(())
 }
 
+fn update_parent_signal_from_marker(
+    slot: Slot,
+    update_parent_fec_set_index: u32,
+    update_parent: &VersionedUpdateParent,
+) -> UpdateParentSignal {
+    match update_parent {
+        VersionedUpdateParent::V1(update_parent) => UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index,
+            parent_slot: update_parent.new_parent_slot,
+            parent_block_id: Some(update_parent.new_parent_block_id),
+        },
+    }
+}
+
+fn send_update_parent_transaction_status_notification(
+    update_parent: &UpdateParentSignal,
+    transaction_status_sender: Option<&TransactionStatusSender>,
+) {
+    if let Some(transaction_status_sender) = transaction_status_sender {
+        transaction_status_sender.send_update_parent(update_parent.clone());
+    }
+}
+
 type WorkSequence = u64;
 
 #[allow(clippy::large_enum_variant)]
@@ -2892,6 +2926,13 @@ type WorkSequence = u64;
 pub enum TransactionStatusMessage {
     Batch((TransactionStatusBatch, Option<WorkSequence>)),
     Freeze(Arc<Bank>),
+    /// Invalidate same-slot transaction-status data emitted before an
+    /// Alpenglow UpdateParent marker. Delivery is best-effort and follows the
+    /// same channel-drop behavior as other transaction-status messages.
+    UpdateParent {
+        update_parent: UpdateParentSignal,
+        work_sequence: Option<WorkSequence>,
+    },
 }
 
 #[derive(Debug)]
@@ -2950,6 +2991,25 @@ impl TransactionStatusSender {
         {
             let slot = bank.slot();
             warn!("Slot {slot} transaction_status send freeze message failed: {e:?}");
+        }
+    }
+
+    pub fn send_update_parent(&self, update_parent: UpdateParentSignal) {
+        let slot = update_parent.slot;
+        let work_sequence = self
+            .dependency_tracker
+            .as_ref()
+            .map(|dependency_tracker| dependency_tracker.declare_work());
+
+        if let Err(e) = self.sender.send(TransactionStatusMessage::UpdateParent {
+            update_parent,
+            work_sequence,
+        }) {
+            warn!("Slot {slot} transaction_status send UpdateParent failed: {e:?}");
+            datapoint_error!(
+                "transaction_status-update-parent-send-failed",
+                ("slot", slot, i64),
+            );
         }
     }
 }

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
-    solana_clock::Slot, solana_hash::Hash, solana_signature::Signature,
-    solana_transaction::versioned::VersionedTransaction,
+    solana_clock::Slot, solana_hash::Hash, solana_ledger::blockstore::UpdateParentSignal,
+    solana_signature::Signature, solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
 };
 
@@ -15,6 +15,12 @@ pub trait TransactionNotifier {
         transaction_status_meta: &TransactionStatusMeta,
         transaction: &VersionedTransaction,
     );
+
+    /// Called when an Alpenglow UpdateParent marker invalidates transaction
+    /// status data for the same slot that may have been emitted before the
+    /// marker boundary. Delivery is best-effort and ordered by the
+    /// TransactionStatusService message channel.
+    fn notify_update_parent(&self, update_parent: &UpdateParentSignal);
 }
 
 pub type TransactionNotifierArc = Arc<dyn TransactionNotifier + Sync + Send>;

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -12,6 +12,7 @@ use {
         blockstore::{Blockstore, BlockstoreError},
         blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
     },
+    solana_metrics::datapoint_info,
     solana_runtime::{
         bank::{Bank, KeyedRewardsAndNumPartitions},
         dependency_tracker::DependencyTracker,
@@ -272,6 +273,35 @@ impl TransactionStatusService {
                 Self::write_block_meta(&bank, blockstore)?;
                 max_complete_transaction_status_slot.fetch_max(bank.slot(), Ordering::SeqCst);
             }
+            TransactionStatusMessage::UpdateParent {
+                update_parent,
+                work_sequence,
+            } => {
+                let deleted_transaction_statuses =
+                    blockstore.delete_transaction_status_slot(update_parent.slot)?;
+                if let Some(transaction_notifier) = transaction_notifier.as_ref() {
+                    transaction_notifier.notify_update_parent(&update_parent);
+                }
+                datapoint_info!(
+                    "transaction_status-update-parent-invalidated",
+                    ("slot", update_parent.slot, i64),
+                    (
+                        "update_parent_fec_set_index",
+                        update_parent.update_parent_fec_set_index,
+                        i64
+                    ),
+                    (
+                        "deleted_transaction_statuses",
+                        deleted_transaction_statuses,
+                        i64
+                    ),
+                );
+                if let Some(dependency_tracker) = dependency_tracker.as_ref() {
+                    if let Some(work_id) = work_sequence {
+                        dependency_tracker.mark_this_and_all_previous_work_processed(work_id);
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -359,7 +389,10 @@ pub(crate) mod tests {
         solana_fee_structure::FeeDetails,
         solana_hash::Hash,
         solana_keypair::Keypair,
-        solana_ledger::{genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete},
+        solana_ledger::{
+            blockstore::UpdateParentSignal, blockstore_processor::TransactionStatusSender,
+            genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
+        },
         solana_message::SimpleAddressLoader,
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_nonce_account as nonce_account,
@@ -378,7 +411,7 @@ pub(crate) mod tests {
             TransactionStatusMeta, TransactionTokenBalance,
             token_balances::TransactionTokenBalancesSet,
         },
-        std::sync::{Arc, atomic::AtomicBool},
+        std::sync::{Arc, Mutex, atomic::AtomicBool},
     };
 
     #[derive(Eq, Hash, PartialEq)]
@@ -395,12 +428,14 @@ pub(crate) mod tests {
 
     struct TestTransactionNotifier {
         notifications: DashMap<TestNotifierKey, TestNotification>,
+        update_parents: Mutex<Vec<UpdateParentSignal>>,
     }
 
     impl TestTransactionNotifier {
         pub fn new() -> Self {
             Self {
                 notifications: DashMap::default(),
+                update_parents: Mutex::default(),
             }
         }
     }
@@ -427,6 +462,13 @@ pub(crate) mod tests {
                     transaction: transaction.clone(),
                 },
             );
+        }
+
+        fn notify_update_parent(&self, update_parent: &UpdateParentSignal) {
+            self.update_parents
+                .lock()
+                .unwrap()
+                .push(update_parent.clone());
         }
     }
 
@@ -692,6 +734,140 @@ pub(crate) mod tests {
         assert_eq!(
             expected_transaction2.message_hash(),
             &result2.transaction.message.hash(),
+        );
+    }
+
+    #[test]
+    fn test_update_parent_invalidates_transaction_status_storage() {
+        let genesis_config = create_genesis_config(2).genesis_config;
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(
+            Blockstore::open(ledger_path.path())
+                .expect("Expected to be able to open database ledger"),
+        );
+
+        let sanitize = |transaction: Transaction| {
+            SanitizedTransaction::try_create(
+                VersionedTransaction::from(transaction),
+                MessageHash::Compute,
+                None,
+                SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty_key_set(),
+            )
+            .unwrap()
+        };
+
+        let stale_transaction = sanitize(build_test_transaction_legacy());
+        let replacement_transaction = sanitize(build_test_transaction_legacy());
+        let stale_signature = *stale_transaction.signature();
+        let replacement_signature = *replacement_transaction.signature();
+
+        let commit_result = Ok(CommittedTransaction {
+            status: Ok(()),
+            log_messages: Some(vec!["log".to_string()]),
+            inner_instructions: None,
+            return_data: None,
+            executed_units: 1,
+            fee_details: FeeDetails::default(),
+            loaded_account_stats: TransactionLoadedAccountsStats::default(),
+            fee_payer_post_balance: 0,
+        });
+
+        let slot = bank.slot();
+        blockstore
+            .write_transaction_memos(&stale_signature, slot, "stale memo".to_string())
+            .unwrap();
+        blockstore.set_block_height(slot, 42).unwrap();
+        let test_notifier = Arc::new(TestTransactionNotifier::new());
+        let max_complete_transaction_status_slot = Arc::new(AtomicU64::new(99));
+        let dependency_tracker = Arc::new(DependencyTracker::default());
+        let exit = Arc::new(AtomicBool::new(false));
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            max_complete_transaction_status_slot.clone(),
+            true,
+            Some(test_notifier.clone()),
+            blockstore.clone(),
+            true,
+            Some(dependency_tracker.clone()),
+            exit.clone(),
+        );
+        let update_parent_sender = TransactionStatusSender {
+            sender: transaction_status_sender.clone(),
+            dependency_tracker: Some(dependency_tracker.clone()),
+        };
+
+        let make_batch = |transaction: SanitizedTransaction, index| TransactionStatusBatch {
+            slot,
+            transactions: vec![transaction],
+            commit_results: vec![commit_result.clone()],
+            balances: TransactionBalancesSet {
+                pre_balances: vec![vec![1]],
+                post_balances: vec![vec![2]],
+            },
+            token_balances: TransactionTokenBalancesSet {
+                pre_token_balances: vec![vec![]],
+                post_token_balances: vec![vec![]],
+            },
+            costs: vec![Some(3)],
+            transaction_indexes: vec![index],
+        };
+
+        let update_parent = UpdateParentSignal {
+            slot,
+            update_parent_fec_set_index: 32,
+            parent_slot: 0,
+            parent_block_id: Some(Hash::new_unique()),
+        };
+
+        transaction_status_sender
+            .send(TransactionStatusMessage::Batch((
+                make_batch(stale_transaction, 0),
+                None,
+            )))
+            .unwrap();
+        update_parent_sender.send_update_parent(update_parent.clone());
+        let update_parent_work = dependency_tracker.get_current_declared_work();
+        assert_eq!(update_parent_work, 1);
+        transaction_status_sender
+            .send(TransactionStatusMessage::Batch((
+                make_batch(replacement_transaction, 0),
+                None,
+            )))
+            .unwrap();
+
+        transaction_status_service.quiesce_and_join_for_tests(exit);
+        dependency_tracker.wait_for_dependency(update_parent_work);
+
+        assert!(
+            blockstore
+                .read_transaction_status((stale_signature, slot))
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            blockstore
+                .read_transaction_memos(stale_signature, slot)
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(blockstore.get_block_height(slot).unwrap(), None);
+        assert!(
+            blockstore
+                .read_transaction_status((replacement_signature, slot))
+                .unwrap()
+                .is_some()
+        );
+        assert_eq!(
+            max_complete_transaction_status_slot.load(Ordering::SeqCst),
+            99
+        );
+        assert_eq!(
+            *test_notifier.update_parents.lock().unwrap(),
+            vec![update_parent]
         );
     }
 }


### PR DESCRIPTION
Split from #13209 

#### Problem
In Alpenglow we allow a block producer to change the parent of their block midway in certain scenarios.
The accomplish this by transmitting an `UpdateParent` block marker. This marker indicates that all txs prior to the marker are no-ops.

However these transactions could have already been recorded by TSS and sent to the transaction notifier.

#### Summary of Changes
When the marker is observed, notify TSS so that the relevant no-op transactions are purged from blockstore. Add a trait fn to the transaction notifier for update parent. This will be filled in for geyser in a following commit

#### Testing
in progress

A part of #12885 