### PR TITLE
Validates --accounts-db-read-cache-limit values

### DIFF
--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -5,6 +5,7 @@ use {
         commands::{FromClapArgMatches, Result},
     },
     agave_snapshots::{SUPPORTED_ARCHIVE_COMPRESSION, SnapshotVersion},
+    bytesize::ByteSize,
     clap::{App, Arg, ArgMatches, values_t},
     solana_accounts_db::utils::create_and_canonicalize_directory,
     solana_clap_utils::{
@@ -997,12 +998,13 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .max_values(2)
             .multiple(false)
             .require_delimiter(true)
+            .validator(is_parsable::<ByteSize>)
             .help("How large the read cache for account data can become, in bytes")
             .long_help(
                 "How large the read cache for account data can become, in bytes. The values will \
                  be the low and high watermarks for the cache. When the cache exceeds the high \
                  watermark, entries will be evicted until the size reaches the low watermark. \
-                 Accepts SI and IEC prefixes, e.g. 8.1GB,8.3GiB.",
+                 Accepts SI and IEC prefixes, e.g. 8.1GB,8.3GiB. LOW must be <= HIGH.",
             )
             .hidden(hidden_unless_forced()),
     )

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -660,22 +660,28 @@ pub fn execute(
 
     const MB: usize = 1_024 * 1_024;
 
-    let read_cache_limit_bytes =
-        if let Some(limits) = values_of::<ByteSize>(matches, "accounts_db_read_cache_limit") {
-            match limits.as_slice() {
-                [lo, hi] => {
-                    let lo = usize::try_from(lo.0)?;
-                    let hi = usize::try_from(hi.0)?;
-                    Some((lo, hi))
+    let read_cache_limit_bytes = if let Some(limits) =
+        values_of::<ByteSize>(matches, "accounts_db_read_cache_limit")
+    {
+        match limits.as_slice() {
+            [lo, hi] => {
+                let lo = usize::try_from(lo.0)?;
+                let hi = usize::try_from(hi.0)?;
+                if lo > hi {
+                    Err(format!(
+                        "invalid --accounts-db-read-cache-limit: LOW ({lo}) must be <= HIGH ({hi})",
+                    ))?;
                 }
-                _ => {
-                    // clap will enforce two values are given
-                    unreachable!("invalid number of values given to accounts-db-read-cache-limit")
-                }
+                Some((lo, hi))
             }
-        } else {
-            None
-        };
+            _ => {
+                // clap will enforce two values are given
+                unreachable!("invalid number of values given to accounts-db-read-cache-limit")
+            }
+        }
+    } else {
+        None
+    };
 
     let scan_filter_for_shrinking = matches
         .value_of("accounts_db_scan_filter_for_shrinking")


### PR DESCRIPTION
#### Problem

Following up from https://github.com/anza-xyz/agave/pull/13219, user input should not cause a panic.


#### Summary of Changes

Validate --accounts-db-read-cache-limit values and return suitable errors.


#### Testing

parsing value fails:
```
$ --accounts-db-read-cache-limit 2ebad-parse,123
error: Invalid value for '--accounts-db-read-cache-limit <LOW,HIGH>': error parsing '2ebad-parse': couldn't parse "ebad-parse" into a known SI unit, Failed to parse unit "eba..."
```

low > high:
```
$ --accounts-db-read-cache-limit 2.76312gi,2.911111g
Validator command failed: invalid --accounts-db-read-cache-limit: LOW (2966877508) must be <= HIGH (2911111000)
```