### PR TITLE
perf: cache delegated stake for vote account upsert

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -69,7 +69,9 @@ use {
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
             MaxAllowableDrift, calculate_stake_weighted_timestamp,
         },
-        stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache},
+        stakes::{
+            DelegatedStakes, DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache,
+        },
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
     },
@@ -1123,6 +1125,8 @@ struct NewEpochBundle {
     /// Vote accounts computed from the stakes cache for the current
     /// (distribution) epoch *before* applying any VAT filtering.
     unfiltered_distribution_vote_accounts: VoteAccounts,
+    /// Current effective stake delegated to each vote account pubkey.
+    delegated_stakes: DelegatedStakes,
     /// Vote accounts computed from the stakes cache for the current
     /// (distribution) epoch *after* applying VAT filtering (or an unfiltered
     /// clone when VAT is disabled).
@@ -1716,7 +1720,12 @@ impl Bank {
         let stakes = self.stakes_cache.stakes();
         let stake_delegations = stakes.stake_delegations_vec();
         let (
-            (stake_history, unfiltered_distribution_vote_accounts, reward_epoch_delegated_stakes),
+            (
+                stake_history,
+                unfiltered_distribution_vote_accounts,
+                delegated_stakes,
+                reward_epoch_delegated_stakes,
+            ),
             calculate_activated_stake_time_us,
         ) = measure_us!(stakes.calculate_activated_stake(
             self.epoch(),
@@ -1761,6 +1770,7 @@ impl Bank {
         NewEpochBundle {
             stake_history,
             unfiltered_distribution_vote_accounts,
+            delegated_stakes,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1789,6 +1799,7 @@ impl Bank {
         let NewEpochBundle {
             stake_history,
             unfiltered_distribution_vote_accounts,
+            delegated_stakes,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1804,6 +1815,7 @@ impl Bank {
             epoch,
             stake_history,
             unfiltered_distribution_vote_accounts,
+            delegated_stakes,
         );
 
         // Save a snapshot of stakes for use in consensus and stake weighted networking
@@ -5959,6 +5971,10 @@ impl Bank {
         }
 
         self.compute_and_apply_features_after_snapshot_restore();
+        self.stakes_cache.refresh_delegated_stakes(
+            self.new_warmup_cooldown_rate_epoch(),
+            self.use_fixed_point_stake_math(),
+        );
 
         self.recalculate_partitioned_rewards_if_active(rewards_thread_pool_builder);
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -66,6 +66,7 @@ pub enum InvalidCacheEntryReason {
 }
 
 type StakeAccount = stake_account::StakeAccount<Delegation>;
+pub(crate) type DelegatedStakes = ImblHashMap<Pubkey, u64>;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
@@ -118,12 +119,7 @@ impl StakesCache {
                         // drop the old account after releasing the lock
                         let _old_vote_account = {
                             let mut stakes = self.0.write().unwrap();
-                            stakes.upsert_vote_account(
-                                pubkey,
-                                vote_account,
-                                new_rate_activation_epoch,
-                                use_fixed_point_stake_math,
-                            )
+                            stakes.upsert_vote_account(pubkey, vote_account)
                         };
                     }
                     Err(_) => {
@@ -169,9 +165,19 @@ impl StakesCache {
         next_epoch: Epoch,
         stake_history: StakeHistory,
         vote_accounts: VoteAccounts,
+        delegated_stakes: DelegatedStakes,
     ) {
         let mut stakes = self.0.write().unwrap();
-        stakes.activate_epoch(next_epoch, stake_history, vote_accounts)
+        stakes.activate_epoch(next_epoch, stake_history, vote_accounts, delegated_stakes)
+    }
+
+    pub(crate) fn refresh_delegated_stakes(
+        &self,
+        new_rate_activation_epoch: Option<Epoch>,
+        use_fixed_point_stake_math: bool,
+    ) {
+        let mut stakes = self.0.write().unwrap();
+        stakes.refresh_delegated_stakes(new_rate_activation_epoch, use_fixed_point_stake_math);
     }
 }
 
@@ -189,6 +195,7 @@ impl StakesCache {
     field_qualifiers(
         vote_accounts(pub),
         stake_delegations(pub),
+        delegated_stakes(pub),
         unused(pub),
         epoch(pub),
         stake_history(pub),
@@ -200,6 +207,10 @@ pub struct Stakes<T: Clone> {
 
     /// stake_delegations
     stake_delegations: ImblHashMap<Pubkey, T>,
+
+    /// current effective stake delegated to each vote account pubkey
+    #[serde(skip)]
+    delegated_stakes: DelegatedStakes,
 
     /// unused
     unused: u64,
@@ -217,6 +228,7 @@ impl<T: Clone> Stakes<T> {
             vote_accounts,
             epoch,
             stake_delegations: ImblHashMap::new(),
+            delegated_stakes: DelegatedStakes::default(),
             unused: 0,
             stake_history: StakeHistory::default(),
         }
@@ -247,6 +259,7 @@ impl<T: Clone> Stakes<T> {
         let Self {
             vote_accounts,
             stake_delegations: _,
+            delegated_stakes: _,
             unused: _,
             epoch,
             stake_history,
@@ -263,7 +276,7 @@ impl Stakes<StakeAccount> {
     ) -> Self {
         let stake_history = StakeHistory::default();
         let mut vote_accounts = VoteAccountsHashMap::default();
-        let mut delegated_stakes: HashMap<Pubkey, u64> = HashMap::default();
+        let mut delegated_stakes = DelegatedStakes::default();
         let mut stake_delegations = ImblHashMap::new();
         let epoch = 0;
 
@@ -292,20 +305,23 @@ impl Stakes<StakeAccount> {
                         new_rate_activation_epoch,
                         use_fixed_point_stake_math,
                     );
-                    *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                    if stake != 0 {
+                        *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                    }
                     stake_delegations.insert(*pubkey, stake_account);
                 }
             }
         }
 
         let mut vote_accounts = VoteAccounts::from(Arc::new(vote_accounts));
-        for (vote_pubkey, stake) in delegated_stakes {
-            vote_accounts.add_stake(&vote_pubkey, stake);
+        for (vote_pubkey, stake) in &delegated_stakes {
+            vote_accounts.add_stake(vote_pubkey, *stake);
         }
 
         Self {
             vote_accounts,
             stake_delegations,
+            delegated_stakes,
             unused: 0,
             epoch,
             stake_history,
@@ -379,6 +395,7 @@ impl Stakes<StakeAccount> {
         Ok(Self {
             vote_accounts: stakes.vote_accounts.clone(),
             stake_delegations,
+            delegated_stakes: DelegatedStakes::default(),
             unused: stakes.unused,
             epoch: stakes.epoch,
             stake_history: stakes.stake_history,
@@ -391,12 +408,16 @@ impl Stakes<StakeAccount> {
         vote_accounts: VoteAccounts,
         stake_delegations: ImblHashMap<Pubkey, StakeAccount>,
     ) -> Self {
+        let stake_history = StakeHistory::default();
+        let delegated_stakes =
+            Self::calculate_delegated_stakes(&stake_delegations, epoch, &stake_history, None, true);
         Self {
             vote_accounts,
             stake_delegations,
+            delegated_stakes,
             unused: 0,
             epoch,
-            stake_history: StakeHistory::default(),
+            stake_history,
         }
     }
 
@@ -411,7 +432,12 @@ impl Stakes<StakeAccount> {
         new_rate_activation_epoch: Option<Epoch>,
         stake_delegations: &[(&Pubkey, &StakeAccount)],
         use_fixed_point_stake_math: bool,
-    ) -> (StakeHistory, VoteAccounts, RewardEpochDelegatedStakes) {
+    ) -> (
+        StakeHistory,
+        VoteAccounts,
+        DelegatedStakes,
+        RewardEpochDelegatedStakes,
+    ) {
         // Wrap up the prev epoch by adding new stake history entry for the
         // prev epoch.
         let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
@@ -448,7 +474,7 @@ impl Stakes<StakeAccount> {
         stake_history.add(self.epoch, stake_history_entry);
         // Refresh the stake distribution of vote accounts for the next epoch,
         // using new stake history.
-        let vote_accounts = refresh_vote_accounts(
+        let (vote_accounts, delegated_stakes) = refresh_vote_accounts(
             thread_pool,
             next_epoch,
             &self.vote_accounts,
@@ -461,7 +487,12 @@ impl Stakes<StakeAccount> {
             epoch: self.epoch,
             delegated_stakes: effective_delegated_stakes,
         };
-        (stake_history, vote_accounts, reward_epoch_delegated_stakes)
+        (
+            stake_history,
+            vote_accounts,
+            delegated_stakes,
+            reward_epoch_delegated_stakes,
+        )
     }
 
     pub(crate) fn activate_epoch(
@@ -469,35 +500,73 @@ impl Stakes<StakeAccount> {
         next_epoch: Epoch,
         stake_history: StakeHistory,
         vote_accounts: VoteAccounts,
+        delegated_stakes: DelegatedStakes,
     ) {
         self.epoch = next_epoch;
         self.stake_history = stake_history;
         self.vote_accounts = vote_accounts;
+        self.delegated_stakes = delegated_stakes;
     }
 
-    /// Sum the stakes that point to the given voter_pubkey
-    fn calculate_stake(
+    fn calculate_delegated_stakes(
         stake_delegations: &ImblHashMap<Pubkey, StakeAccount>,
-        voter_pubkey: &Pubkey,
         epoch: Epoch,
         stake_history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
-    ) -> u64 {
-        stake_delegations
-            .values()
-            .map(StakeAccount::delegation)
-            .filter(|delegation| &delegation.voter_pubkey == voter_pubkey)
-            .map(|delegation| {
-                delegation_effective_stake(
-                    delegation,
-                    epoch,
-                    stake_history,
-                    new_rate_activation_epoch,
-                    use_fixed_point_stake_math,
-                )
-            })
-            .sum()
+    ) -> DelegatedStakes {
+        let mut delegated_stakes = DelegatedStakes::new();
+        for stake_account in stake_delegations.values() {
+            let delegation = stake_account.delegation();
+            let stake = delegation_effective_stake(
+                delegation,
+                epoch,
+                stake_history,
+                new_rate_activation_epoch,
+                use_fixed_point_stake_math,
+            );
+            if stake != 0 {
+                *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+            }
+        }
+        delegated_stakes
+    }
+
+    fn refresh_delegated_stakes(
+        &mut self,
+        new_rate_activation_epoch: Option<Epoch>,
+        use_fixed_point_stake_math: bool,
+    ) {
+        self.delegated_stakes = Self::calculate_delegated_stakes(
+            &self.stake_delegations,
+            self.epoch,
+            &self.stake_history,
+            new_rate_activation_epoch,
+            use_fixed_point_stake_math,
+        );
+    }
+
+    fn add_delegated_stake(&mut self, voter_pubkey: Pubkey, stake: u64) {
+        if stake == 0 {
+            return;
+        }
+        *self.delegated_stakes.entry(voter_pubkey).or_default() += stake;
+    }
+
+    fn sub_delegated_stake(&mut self, voter_pubkey: &Pubkey, stake: u64) {
+        if stake == 0 {
+            return;
+        }
+        let current_stake = self
+            .delegated_stakes
+            .get_mut(voter_pubkey)
+            .expect("subtraction from missing delegated stake");
+        *current_stake = current_stake
+            .checked_sub(stake)
+            .expect("subtraction value exceeds delegated stake");
+        if *current_stake == 0 {
+            self.delegated_stakes.remove(voter_pubkey);
+        }
     }
 
     fn remove_vote_account(&mut self, vote_pubkey: &Pubkey) -> Option<VoteAccount> {
@@ -519,6 +588,7 @@ impl Stakes<StakeAccount> {
                 new_rate_activation_epoch,
                 use_fixed_point_stake_math,
             );
+            self.sub_delegated_stake(&removed_delegation.voter_pubkey, removed_stake);
             self.vote_accounts
                 .sub_stake(&removed_delegation.voter_pubkey, removed_stake);
         }
@@ -528,22 +598,17 @@ impl Stakes<StakeAccount> {
         &mut self,
         vote_pubkey: &Pubkey,
         vote_account: VoteAccount,
-        new_rate_activation_epoch: Option<Epoch>,
-        use_fixed_point_stake_math: bool,
     ) -> Option<VoteAccount> {
         debug_assert_ne!(vote_account.lamports(), 0u64);
 
-        let stake_delegations = &self.stake_delegations;
-        self.vote_accounts.insert(*vote_pubkey, vote_account, || {
-            Self::calculate_stake(
-                stake_delegations,
-                vote_pubkey,
-                self.epoch,
-                &self.stake_history,
-                new_rate_activation_epoch,
-                use_fixed_point_stake_math,
-            )
-        })
+        let calculate_delegated_stake = || {
+            self.delegated_stakes
+                .get(vote_pubkey)
+                .copied()
+                .unwrap_or_default()
+        };
+        self.vote_accounts
+            .insert(*vote_pubkey, vote_account, calculate_delegated_stake)
     }
 
     fn upsert_stake_delegation(
@@ -564,7 +629,10 @@ impl Stakes<StakeAccount> {
             use_fixed_point_stake_math,
         );
         match self.stake_delegations.insert(stake_pubkey, stake_account) {
-            None => self.vote_accounts.add_stake(&voter_pubkey, stake),
+            None => {
+                self.add_delegated_stake(voter_pubkey, stake);
+                self.vote_accounts.add_stake(&voter_pubkey, stake);
+            }
             Some(old_stake_account) => {
                 let old_delegation = old_stake_account.delegation();
                 let old_voter_pubkey = old_delegation.voter_pubkey;
@@ -576,6 +644,8 @@ impl Stakes<StakeAccount> {
                     use_fixed_point_stake_math,
                 );
                 if voter_pubkey != old_voter_pubkey || stake != old_stake {
+                    self.sub_delegated_stake(&old_voter_pubkey, old_stake);
+                    self.add_delegated_stake(voter_pubkey, stake);
                     self.vote_accounts.sub_stake(&old_voter_pubkey, old_stake);
                     self.vote_accounts.add_stake(&voter_pubkey, stake);
                 }
@@ -636,6 +706,7 @@ impl From<Stakes<StakeAccount>> for Stakes<Delegation> {
         Self {
             vote_accounts: stakes.vote_accounts,
             stake_delegations,
+            delegated_stakes: DelegatedStakes::default(),
             unused: stakes.unused,
             epoch: stakes.epoch,
             stake_history: stakes.stake_history,
@@ -656,6 +727,7 @@ impl From<Stakes<StakeAccount>> for Stakes<Stake> {
         Self {
             vote_accounts: stakes.vote_accounts,
             stake_delegations,
+            delegated_stakes: DelegatedStakes::default(),
             unused: stakes.unused,
             epoch: stakes.epoch,
             stake_history: stakes.stake_history,
@@ -676,6 +748,7 @@ impl From<Stakes<Stake>> for Stakes<Delegation> {
         Self {
             vote_accounts: stakes.vote_accounts,
             stake_delegations,
+            delegated_stakes: DelegatedStakes::default(),
             unused: stakes.unused,
             epoch: stakes.epoch,
             stake_history: stakes.stake_history,
@@ -704,15 +777,23 @@ fn refresh_vote_accounts(
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
     use_fixed_point_stake_math: bool,
-) -> VoteAccounts {
+) -> (VoteAccounts, DelegatedStakes) {
+    fn merge(mut stakes: DelegatedStakes, other: DelegatedStakes) -> DelegatedStakes {
+        if stakes.len() < other.len() {
+            return merge(other, stakes);
+        }
+        for (pubkey, stake) in other {
+            *stakes.entry(pubkey).or_default() += stake;
+        }
+        stakes
+    }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
             .par_iter()
             .fold(
-                HashMap::default,
+                DelegatedStakes::default,
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {
                     let delegation = stake_account.delegation();
-                    let entry = delegated_stakes.entry(delegation.voter_pubkey).or_default();
                     let stake = delegation_effective_stake(
                         delegation,
                         epoch,
@@ -720,13 +801,15 @@ fn refresh_vote_accounts(
                         new_rate_activation_epoch,
                         use_fixed_point_stake_math,
                     );
-                    *entry += stake;
+                    if stake != 0 {
+                        *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
+                    }
                     delegated_stakes
                 },
             )
-            .reduce(HashMap::default, merge_delegated_stakes)
+            .reduce(DelegatedStakes::default, merge)
     });
-    vote_accounts
+    let vote_accounts = vote_accounts
         .iter()
         .map(|(&vote_pubkey, vote_account)| {
             let delegated_stake = delegated_stakes
@@ -735,7 +818,8 @@ fn refresh_vote_accounts(
                 .unwrap_or_default();
             (vote_pubkey, (delegated_stake, vote_account.clone()))
         })
-        .collect()
+        .collect();
+    (vote_accounts, delegated_stakes)
 }
 
 #[cfg(test)]
@@ -758,6 +842,7 @@ pub(crate) mod tests {
             Self {
                 vote_accounts: stakes.vote_accounts,
                 stake_delegations: ImblHashMap::from_iter(stakes.stake_delegations),
+                delegated_stakes: DelegatedStakes::default(),
                 unused: stakes.unused,
                 epoch: stakes.epoch,
                 stake_history: stakes.stake_history,
@@ -1123,7 +1208,7 @@ pub(crate) mod tests {
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let next_epoch = 3;
-        let (stake_history, vote_accounts, effective_delegated_stakes) = {
+        let (stake_history, vote_accounts, delegated_stakes, effective_delegated_stakes) = {
             let stakes = stakes_cache.stakes();
             let stake_delegations = stakes.stake_delegations_vec();
             stakes.calculate_activated_stake(
@@ -1141,7 +1226,7 @@ pub(crate) mod tests {
                 .copied(),
             Some(initial_expected_stake)
         );
-        stakes_cache.activate_epoch(next_epoch, stake_history, vote_accounts);
+        stakes_cache.activate_epoch(next_epoch, stake_history, vote_accounts, delegated_stakes);
         {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -92,6 +92,7 @@ impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToDelegationFormat {
         let Stakes {
             vote_accounts,
             stake_delegations,
+            delegated_stakes: _,
             unused,
             epoch,
             stake_history,
@@ -112,6 +113,7 @@ impl From<Stakes<StakeAccount>> for SerdeStakeAccountsToStakeFormat {
         let Stakes {
             vote_accounts,
             stake_delegations,
+            delegated_stakes: _,
             unused,
             epoch,
             stake_history,
@@ -235,6 +237,7 @@ mod tests {
         let stake_account_stakes = Stakes {
             vote_accounts: VoteAccounts::default(),
             stake_delegations,
+            delegated_stakes: ImblHashMap::default(),
             unused: 0,
             epoch: 0,
             stake_history: StakeHistory::default(),

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -312,7 +312,8 @@ impl VoteAccounts {
                 Some(mem::replace(old_vote_account, new_vote_account))
             }
             Entry::Vacant(entry) => {
-                // This is a new vote account. We don't know the stake yet, so we need to compute it.
+                // This is a new vote account. Use the caller-provided stake for the initial
+                // cache entry.
                 let (stake, vote_account) = entry.insert((calculate_stake(), new_vote_account));
                 if let Some(staked_nodes) = self.staked_nodes.get_mut() {
                     Self::do_add_node_stake(staked_nodes, *stake, *vote_account.node_pubkey());


### PR DESCRIPTION
#### Problem
While working on https://github.com/anza-xyz/agave/pull/13187, I realized we can improve perf in the vote account pathway by similarly caching the current delegated stake for each vote account

#### Summary of Changes
Cache the current stake delegations for each vote account