### PR TITLE
blockstore: Disallow deshredded empty entry batches

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5017,9 +5017,17 @@ impl Blockstore {
         slot_meta: Option<&SlotMeta>,
     ) -> Result<Vec<Entry>> {
         self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
-            <WincodeVec<Entry, MaxDataShredsLen>>::deserialize(&payload).map_err(|e| {
-                BlockstoreError::InvalidShredData(format!("could not reconstruct entries: {e}"))
-            })
+            <WincodeVec<Entry, MaxDataShredsLen>>::deserialize(&payload)
+                .map_err(|e| {
+                    BlockstoreError::InvalidShredData(format!("could not reconstruct entries: {e}"))
+                })
+                .and_then(|entries| {
+                    if entries.is_empty() {
+                        Err(BlockstoreError::EmptyEntryBatch(slot))
+                    } else {
+                        Ok(entries)
+                    }
+                })
         })
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -394,8 +394,11 @@ impl Blockstore {
         }
 
         for slot in from_slot..=to_slot {
-            let (slot_entries, _, _) =
-                self.get_slot_entries_with_shred_info(slot, 0, true /* allow_dead_slots */)?;
+            let Ok((slot_entries, _, _)) =
+                self.get_slot_entries_with_shred_info(slot, 0, /*allow_dead_slots:*/ true)
+            else {
+                continue;
+            };
             let transactions = slot_entries
                 .into_iter()
                 .flat_map(|entry| entry.transactions);

--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -67,6 +67,8 @@ pub enum BlockstoreError {
     LegacyShred(Slot, u64),
     #[error("unable to read merkle root slot {0}, index {1}")]
     MissingMerkleRoot(Slot, u64),
+    #[error("block contains an empty entry batch for slot {0}")]
+    EmptyEntryBatch(Slot),
     #[error("unable to purge slots in range [{from_slot}, {to_slot}] {purge_type:?}: {inner:?}")]
     PurgeFailed {
         from_slot: Slot,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -998,17 +998,11 @@ mod test {
                 .is_none()
         );
 
-        // Try to fetch the incomplete ticks from blockstore, should succeed
-        assert_eq!(
-            blockstore.get_slot_entries(1, header_shred_offset).unwrap(),
-            ticks0
-        );
-        assert_eq!(
-            blockstore
-                .get_slot_entries(1, shred_multiplier * num_shreds_per_slot)
-                .unwrap(),
-            vec![],
-        );
+        // Try to fetch the incomplete ticks from blockstore, will fail because
+        // broadcast interruption serializes an empty entry batch into shreds
+        // which is an invalid block
+        assert!(blockstore.get_slot_entries(1, header_shred_offset).is_err());
+        assert!(blockstore.get_slot_entries(1, 0).is_err());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Empty entry batches are only created when a leader is abandoning a block and creates an invalid PoH block (too few ticks).

#### Summary of Changes
Add check to entry fetch function to fail faster

#### Testing
Updated unit tests