### PR TITLE
Drop incorrectly sized nonces on leader

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -930,6 +930,7 @@ pub(crate) mod external {
                     &[const { Ok(()) }; MAX_TRANSACTIONS_PER_MESSAGE],
                     working_bank.max_processing_age(),
                     true,
+                    true,
                     &mut error_counters,
                 );
             let included_slots = included_slots.expect("requested to collect processed slots");
@@ -3345,6 +3346,7 @@ mod tests {
                 &sanitized_txs,
                 &vec![Ok(()); sanitized_txs.len()],
                 bank.max_processing_age(),
+                true,
                 &mut TransactionErrorMetrics::default(),
             )
             .into_iter()

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -133,6 +133,7 @@ impl Consumer {
             txs,
             &pre_results,
             bank.max_processing_age(),
+            true,
             &mut error_counters,
         );
         let check_results: Vec<_> = check_results
@@ -331,6 +332,7 @@ impl Consumer {
                     ),
                     drop_on_failure: flags.drop_on_failure,
                     all_or_nothing: flags.all_or_nothing,
+                    strict_nonce_size_check: true,
                 }
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -275,6 +275,7 @@ impl TransactionViewReceiveAndBuffer {
                         &transactions,
                         &lock_results[..transactions.len()],
                         working_bank.max_processing_age(),
+                        true,
                         &mut error_counters,
                     )
                 };

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -415,6 +415,7 @@ where
             &txs,
             &lock_results,
             bank.max_processing_age(),
+            true,
             &mut error_counters,
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3260,7 +3260,7 @@ impl Bank {
             blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
         }
         .or_else(|| {
-            self.load_message_nonce_data(message)
+            self.load_message_nonce_data(message, false)
                 .map(|(_nonce_address, nonce_data)| nonce_data.get_lamports_per_signature())
         })?;
 
@@ -3749,6 +3749,7 @@ impl Bank {
                 },
                 drop_on_failure: false,
                 all_or_nothing: false,
+                strict_nonce_size_check: false,
             },
         );
 
@@ -3911,6 +3912,7 @@ impl Bank {
             sanitized_txs,
             batch.lock_results(),
             max_age,
+            processing_config.strict_nonce_size_check,
             error_counters,
         ));
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_us);
@@ -4483,6 +4485,7 @@ impl Bank {
                 recording_config,
                 drop_on_failure: false,
                 all_or_nothing: false,
+                strict_nonce_size_check: false,
             },
         );
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -6,7 +6,7 @@ use {
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_fee::{FeeFeatures, calculate_fee_details},
     solana_nonce::state::{Data as NonceData, DurableNonce},
-    solana_nonce_account as nonce_account,
+    solana_nonce_account::{self as nonce_account, SystemAccountKind, get_system_account_kind},
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -41,6 +41,7 @@ impl Bank {
             self.max_processing_age()
                 .saturating_sub(max_tx_fwd_delay)
                 .saturating_sub(forward_transactions_to_leader_at_slot_offset as usize),
+            false,
             &mut error_counters,
         )
     }
@@ -50,6 +51,7 @@ impl Bank {
         sanitized_txs: &[impl core::borrow::Borrow<Tx>],
         lock_results: &[TransactionResult<()>],
         max_age: usize,
+        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         self.check_transactions_with_processed_slots(
@@ -57,6 +59,7 @@ impl Bank {
             lock_results,
             max_age,
             false,
+            strict_nonce_size_check,
             error_counters,
         )
         .0
@@ -68,6 +71,7 @@ impl Bank {
         lock_results: &[TransactionResult<()>],
         max_age: usize,
         collect_processed_slots: bool,
+        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
         let lock_results = self.filter_v1_transactions(sanitized_txs, lock_results);
@@ -76,6 +80,7 @@ impl Bank {
             sanitized_txs,
             &lock_results,
             max_age,
+            strict_nonce_size_check,
             error_counters,
         );
         self.check_status_cache(
@@ -113,6 +118,7 @@ impl Bank {
         sanitized_txs: &[impl core::borrow::Borrow<Tx>],
         lock_results: &[TransactionResult<()>],
         max_age: usize,
+        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
         let hash_queue = self.blockhash_queue.read().unwrap();
@@ -173,6 +179,7 @@ impl Bank {
                         &hash_queue,
                         error_counters,
                         compute_budget_and_limits,
+                        strict_nonce_size_check,
                     )
                 }
                 Err(e) => Err(e.clone()),
@@ -188,6 +195,7 @@ impl Bank {
         hash_queue: &BlockhashQueue,
         error_counters: &mut TransactionErrorMetrics,
         compute_budget: SVMTransactionExecutionAndFeeBudgetLimits,
+        strict_nonce_size_check: bool,
     ) -> TransactionCheckResult {
         let recent_blockhash = tx.recent_blockhash();
         if hash_queue
@@ -196,7 +204,7 @@ impl Bank {
         {
             Ok(CheckedTransactionDetails::new(None, compute_budget))
         } else if let Some((nonce_address, _)) =
-            self.check_nonce_transaction_validity(tx, next_durable_nonce)
+            self.check_nonce_transaction_validity(tx, next_durable_nonce, strict_nonce_size_check)
         {
             Ok(CheckedTransactionDetails::new(
                 Some(nonce_address),
@@ -212,13 +220,15 @@ impl Bank {
         &self,
         message: &impl SVMMessage,
         next_durable_nonce: &DurableNonce,
+        strict_nonce_size_check: bool,
     ) -> Option<(Pubkey, u64)> {
         let nonce_is_advanceable = message.recent_blockhash() != next_durable_nonce.as_hash();
         if !nonce_is_advanceable {
             return None;
         }
 
-        let (nonce_address, nonce_data) = self.load_message_nonce_data(message)?;
+        let (nonce_address, nonce_data) =
+            self.load_message_nonce_data(message, strict_nonce_size_check)?;
         let previous_lamports_per_signature = nonce_data.get_lamports_per_signature();
 
         Some((nonce_address, previous_lamports_per_signature))
@@ -227,9 +237,15 @@ impl Bank {
     pub(super) fn load_message_nonce_data(
         &self,
         message: &impl SVMMessage,
+        strict_nonce_size_check: bool,
     ) -> Option<(Pubkey, NonceData)> {
         let nonce_address = message.get_durable_nonce()?;
         let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
+        if strict_nonce_size_check
+            && get_system_account_kind(&nonce_account) != Some(SystemAccountKind::Nonce)
+        {
+            return None;
+        }
         let nonce_data =
             nonce_account::verify_nonce_account(&nonce_account, message.recent_blockhash())?;
 
@@ -351,7 +367,7 @@ mod tests {
         bank.store_account(&nonce_pubkey, &nonce_account);
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce()),
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false),
             Some((nonce_pubkey, STALE_LAMPORTS_PER_SIGNATURE)),
         );
     }
@@ -373,7 +389,7 @@ mod tests {
             &nonce_hash,
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce())
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
                 .is_none()
         );
     }
@@ -399,6 +415,7 @@ mod tests {
             bank.check_nonce_transaction_validity(
                 &new_sanitized_message(message),
                 &bank.next_durable_nonce(),
+                false,
             )
             .is_none()
         );
@@ -423,7 +440,7 @@ mod tests {
             &nonce_hash,
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce())
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
                 .is_none()
         );
     }
@@ -444,7 +461,7 @@ mod tests {
             &Hash::default(),
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce())
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
                 .is_none()
         );
     }
@@ -502,7 +519,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce()),
+            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false),
             None,
         );
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4612,6 +4612,7 @@ fn test_check_ro_durable_nonce_fails() {
         bank.check_nonce_transaction_validity(
             &new_sanitized_message(tx.message().clone()),
             &bank.next_durable_nonce(),
+            false,
         ),
         None
     );

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -35,7 +35,7 @@ use {
         state::{DurableNonce, State as NonceState},
         versions::Versions as NonceVersions,
     },
-    solana_nonce_account::verify_nonce_account,
+    solana_nonce_account::{SystemAccountKind, get_system_account_kind, verify_nonce_account},
     solana_program_runtime::{
         execution_budget::{
             SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionCost,
@@ -140,6 +140,10 @@ pub struct TransactionProcessingConfig<'a> {
     /// failing transactions to be committed. If both flags are set then any
     /// failing transaction will cause all transactions to be aborted.
     pub all_or_nothing: bool,
+    /// Strictly require durable nonce accounts to have the canonical nonce account size.
+    ///
+    /// This is a leader-side filtering policy. It must not be enabled for replay.
+    pub strict_nonce_size_check: bool,
 }
 
 /// Runtime environment for transaction batch processing.
@@ -470,6 +474,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         environment.blockhash_lamports_per_signature,
                         &environment.rent,
                         environment.feature_set.relax_post_exec_min_balance_check,
+                        config.strict_nonce_size_check,
                         &mut error_metrics,
                     )
                 }));
@@ -675,6 +680,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         next_lamports_per_signature: u64,
         rent: &Rent,
         relax_post_exec_min_balance_check: bool,
+        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<ValidatedTransactionDetails> {
         let CheckedTransactionDetails {
@@ -693,6 +699,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                 nonce_address,
                 &next_durable_nonce,
                 next_lamports_per_signature,
+                strict_nonce_size_check,
                 error_counters,
             )?)
         } else {
@@ -772,6 +779,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         nonce_address: &Pubkey,
         next_durable_nonce: &DurableNonce,
         next_lamports_per_signature: u64,
+        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<NonceInfo> {
         // When SIMD83 is enabled, if the nonce has been used in this batch already, we must drop
@@ -787,6 +795,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             error_counters.account_not_found += 1;
             return Err(TransactionError::AccountNotFound);
         };
+
+        if strict_nonce_size_check
+            && get_system_account_kind(&nonce_account) != Some(SystemAccountKind::Nonce)
+        {
+            error_counters.blockhash_not_found += 1;
+            return Err(TransactionError::BlockhashNotFound);
+        }
 
         // This function verifies:
         // * Nonce account owner is SystemProgram
@@ -2096,6 +2111,7 @@ mod tests {
                 lamports_per_signature,
                 &rent,
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2148,6 +2164,7 @@ mod tests {
                 lamports_per_signature,
                 &Rent::default(),
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2189,6 +2206,7 @@ mod tests {
                 lamports_per_signature,
                 &Rent::default(),
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2234,6 +2252,7 @@ mod tests {
                 lamports_per_signature,
                 &rent,
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2277,6 +2296,7 @@ mod tests {
                 lamports_per_signature,
                 &Rent::default(),
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2371,6 +2391,7 @@ mod tests {
             &nonce_address,
             &next_durable_nonce,
             lamports_per_signature,
+            false,
             &mut error_counters,
         );
 
@@ -2464,6 +2485,7 @@ mod tests {
                 lamports_per_signature,
                 &rent,
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2525,6 +2547,7 @@ mod tests {
                 lamports_per_signature,
                 &rent,
                 mock_bank.feature_set.relax_post_exec_min_balance_check,
+                false,
                 &mut error_counters,
             );
 
@@ -2574,6 +2597,7 @@ mod tests {
             lamports_per_signature,
             &Rent::default(),
             mock_bank.feature_set.relax_post_exec_min_balance_check,
+            false,
             &mut TransactionErrorMetrics::default(),
         )
         .unwrap();


### PR DESCRIPTION
#### Summary of Changes
Drop these earlier to avoid wasting resources on something we won't pack

#### Testing
Updated unit tests