### PR TITLE
bench(cost-model): migrate benchmark to criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7964,6 +7964,7 @@ dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
  "ahash 0.8.12",
+ "criterion",
  "itertools 0.14.0",
  "log",
  "rand 0.9.4",

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -64,6 +64,7 @@ solana-vote-program = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+criterion = { workspace = true }
 itertools = { workspace = true }
 rand = { workspace = true }
 # See order-crates-for-publishing.py for using this unusual `path = "."`
@@ -82,6 +83,10 @@ solana-system-transaction = { workspace = true }
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
+
+[[bench]]
+name = "cost_model"
+harness = false
 
 [[bench]]
 name = "cost_tracker"

--- a/cost-model/benches/cost_model.rs
+++ b/cost-model/benches/cost_model.rs
@@ -1,7 +1,6 @@
-#![feature(test)]
-extern crate test;
 use {
     agave_feature_set::FeatureSet,
+    criterion::{Criterion, Throughput, criterion_group, criterion_main},
     solana_cost_model::cost_model::CostModel,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -11,7 +10,7 @@ use {
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
     solana_transaction::{Transaction, sanitized::SanitizedTransaction},
-    test::Bencher,
+    std::hint::black_box,
 };
 
 struct BenchSetup {
@@ -43,16 +42,22 @@ fn setup(num_transactions: usize) -> BenchSetup {
     }
 }
 
-#[bench]
-fn bench_cost_model(bencher: &mut Bencher) {
+fn bench_cost_model(c: &mut Criterion) {
     let BenchSetup {
         transactions,
         feature_set,
     } = setup(NUM_TRANSACTIONS_PER_ITER);
 
-    bencher.iter(|| {
-        for transaction in &transactions {
-            let _ = CostModel::calculate_cost(test::black_box(transaction), &feature_set);
-        }
-    });
+    c.benchmark_group("bench_cost_model")
+        .throughput(Throughput::Elements(NUM_TRANSACTIONS_PER_ITER as u64))
+        .bench_function("calculate_cost", |bencher| {
+            bencher.iter(|| {
+                for transaction in &transactions {
+                    let _ = CostModel::calculate_cost(black_box(transaction), &feature_set);
+                }
+            });
+        });
 }
+
+criterion_group!(benches, bench_cost_model);
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem

`cost-model/benches/cost_model.rs` used the unstable built-in `test` bench harness (`#![feature(test)]`), which requires a nightly toolchain.

#### Summary

Migrates the benchmark to Criterion — the framework already standard across the workspace (and in the sibling `compute-budget-instruction` crate). Removes the nightly dependency and adds stable statistical reporting (confidence intervals, throughput, regression tracking).

#### Testing
Benchmarked workload is identical; only the harness changed. 

| | Per-iter (1024 txns) | Spread |
|---|---|---|
| Before (`test`) | 446.55 µs | ± 69 µs (±15%) |
| After (criterion) | 488.85 µs | 95% CI [485.8, 492.0] µs |

The two estimates overlap within the old harness's noise band; Criterion's CI is far tighter (±0.6%).

Total wall-clock run grows from ~4.5 s to ~13.9 s (3 s warmup + ~7.5 s for 100 samples + analysis) — inherent to Criterion's methodology, not variance-driven sampling extension (2/100 outliers). 
