### PR TITLE
Replaces --accounts-db-cache-limit-mb with --accounts-db-write-cache-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Release channels have their own copy of this changelog:
 * `--accounts-db-access-storages-method` is now deprecated and a no-op (the `mmap` value was
   deprecated in v4.0.0; mmap mode has now been removed entirely). The flag is still accepted for
   backward compatibility, but account storages are always accessed via file I/O.
+* `--accounts-db-cache-limit-mb` is now deprecated. Use `--accounts-db-write-cache-limit` instead.
 * `--experimental-poh-pinned-cpu-core` is now deprecated. Use `--poh-pinned-cpu-core` instead.
 #### Changes
 * Turbine shred ingestion now rejects shreds more than half an epoch in the future (previously up to 2 full epochs ahead was accepted).

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -99,7 +99,7 @@ use {
 };
 
 // when the accounts write cache exceeds this many bytes, we will flush it
-// this can be specified on the command line, too (--accounts-db-cache-limit-mb)
+// this can be specified on the command line, too (--accounts-db-write-cache-limit)
 const WRITE_CACHE_LIMIT_BYTES_DEFAULT: u64 = 15_000_000_000;
 const SCAN_SLOT_PAR_ITER_THRESHOLD: usize = 4000;
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -151,6 +151,20 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("No-op; account storages are always accessed via file I/O"),
     );
     add_arg!(
+        // deprecated in v4.2.0
+        Arg::with_name("accounts_db_cache_limit_mb")
+            .long("accounts-db-cache-limit-mb")
+            .value_name("MEGABYTES")
+            .validator(is_parsable::<u64>)
+            .takes_value(true)
+            .help(
+                "How large the write cache for account data can become. If this is exceeded, the \
+                 cache is flushed more aggressively.",
+            )
+            .conflicts_with("accounts_db_write_cache_limit"),
+        replaced_by: "accounts-db-write-cache-limit",
+    );
+    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -979,14 +979,16 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced()),
     )
     .arg(
-        Arg::with_name("accounts_db_cache_limit_mb")
-            .long("accounts-db-cache-limit-mb")
-            .value_name("MEGABYTES")
-            .validator(is_parsable::<u64>)
+        Arg::with_name("accounts_db_write_cache_limit")
+            .long("accounts-db-write-cache-limit")
+            .value_name("BYTES")
+            .validator(is_parsable::<ByteSize>)
             .takes_value(true)
-            .help(
-                "How large the write cache for account data can become. If this is exceeded, the \
-                 cache is flushed more aggressively.",
+            .help("How large the write cache for account data can become, in bytes")
+            .long_help(
+                "How large the write cache for account data can become, in bytes. If this is \
+                 exceeded, the write cache is flushed more aggressively. Accepts SI and IEC \
+                 prefixes, e.g. 17.1GB or 18Gi.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -683,6 +683,15 @@ pub fn execute(
         None
     };
 
+    let write_cache_limit_bytes =
+        value_of::<ByteSize>(matches, "accounts_db_write_cache_limit").map(|limit| limit.0);
+    // accounts-db-write-cache-limit-mb was deprecated in v4.2.0
+    let write_cache_limit_mb = value_t!(matches, "accounts_db_cache_limit_mb", u64)
+        .ok()
+        .map(|mb| mb * MB as u64);
+    // clap will enforce only one cli arg is provided, so pick whichever is Some
+    let write_cache_limit_bytes = write_cache_limit_bytes.or(write_cache_limit_mb);
+
     let scan_filter_for_shrinking = matches
         .value_of("accounts_db_scan_filter_for_shrinking")
         .map(|filter| match filter {
@@ -704,9 +713,7 @@ pub fn execute(
         read_cache_limit_bytes,
         read_cache_evict_sample_size: None,
         read_cache_num_shards: None,
-        write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
-            .ok()
-            .map(|mb| mb * MB as u64),
+        write_cache_limit_bytes,
         ancient_append_vec_offset: value_t!(matches, "accounts_db_ancient_append_vecs", i64).ok(),
         ancient_storage_ideal_size: value_t!(
             matches,


### PR DESCRIPTION
#### Problem

There are a multiple cli args that take a value as bytes. Some args are raw bytes, some are MB, some are MiB. Some say "mb" and are really "MiB"... It is inconsistent.

For this PR we're focusing on --accounts-db-cache-limit-mb.

Some issues:

1. There are two accounts-db caches. By looking only at the arg name, you cannot tell which one this refers to. Or maybe both!?
2. The arg name ends with "mb", but actually takes the value as MiB. Minimally I found this unexpected.
3. The accounts-db read cache limit now supports SI and IEC[^1], so there is a mismatch in these two args.

[^1]: As of #13219.

#### Summary of Changes

Replace --accounts-db-cache-limit-mb with --accounts-db-write-cache-limit.

The new arg accepts SI and IEC prefixes too. E.g. these are all valid:

```
--accounts-db-write-cache-limit 123456789
--accounts-db-write-cache-limit 15G
--accounts-db-write-cache-limit 16Gi
--accounts-db-write-cache-limit 17GiB
--accounts-db-write-cache-limit 18000m
--accounts-db-write-cache-limit 19000mib
```


#### Testing

Built locally and tried out the above args to confirm they worked.

Also tested the following bad values so that their bad parsing is caught and returned as an Error (and not a panic).

bad parsing:
```
$ --accounts-db-write-cache-limit 23nope
error: Invalid value for '--accounts-db-write-cache-limit <BYTES>': error parsing '23nope': couldn't parse "nope" into a known SI unit, Failed to parse unit "nop..."
```

conflicting args:
```
$ --accounts-db-write-cache-limit 23 --accounts-db-cache-limit-mb 17
error: The argument '--accounts-db-write-cache-limit <BYTES>' cannot be used with '--accounts-db-cache-limit-mb <MEGABYTES>'
```