### PR TITLE
accounts-db: stop upserting the accounts index on cache writes

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4267,7 +4267,7 @@ impl AccountsDb {
                 // the slot and from the Accounts Index
                 num_cached_slots_removed += 1;
                 total_removed_cached_bytes += slot_cache.total_bytes();
-                self.remove_dead_slots_metadata(std::iter::once(remove_slot));
+                self.remove_dead_slots_metadata(iter::once(remove_slot));
                 remove_cache_elapsed.stop();
                 remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
                 // Nobody else should have removed the slot cache entry yet
@@ -4280,6 +4280,12 @@ impl AccountsDb {
                 // secondary entry.
                 // Explicitly ignore the return value as there is no need to purge the account
                 // from the primary index as well
+                //
+                // Narrow race: If a write re-adds the same pubkey key between `remove_slot` and
+                // `handle_dead_keys`, the new secondary entry will be dropped. Only
+                // secondary-index scans observe it (no consensus impact), and it self-heals: the
+                // entry is re-added when that slot flushes, or stays correctly removed if the slot
+                // is later purged.
                 if !self.account_indexes.is_empty() {
                     let _ = self
                         .accounts_index
@@ -4839,7 +4845,7 @@ impl AccountsDb {
         } else {
             // Every account in this slot was superseded by a newer root, so it flushes to no
             // storage. Drop the now-dead slot from the index roots metadata
-            self.remove_dead_slots_metadata(std::iter::once(&slot));
+            self.remove_dead_slots_metadata(iter::once(&slot));
         }
 
         // Remove this slot from the cache, which will to AccountsDb's new readers should look like an

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3819,8 +3819,7 @@ impl AccountsDb {
         //          |                             |
         //          V                             |
         // P3 purge_slots_from_cache_and_store()/ | index
-        //       purge_slot_cache()/              |
-        //          purge_slot_cache_pubkeys()    | (removes existing store_id, offset for cache)
+        //       remove_dead_slots_metadata()     | (removes index roots metadata for cached slot)
         //       purge_slot_storage()/            |
         //          purge_keys_exact()            | (removes accounts index entries)
         //          handle_reclaims()             | (removes storage entries)
@@ -4268,7 +4267,7 @@ impl AccountsDb {
                 // the slot and from the Accounts Index
                 num_cached_slots_removed += 1;
                 total_removed_cached_bytes += slot_cache.total_bytes();
-                self.purge_slot_cache(*remove_slot, &slot_cache);
+                self.remove_dead_slots_metadata(std::iter::once(remove_slot));
                 remove_cache_elapsed.stop();
                 remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
                 // Nobody else should have removed the slot cache entry yet
@@ -4276,6 +4275,16 @@ impl AccountsDb {
                     .accounts_cache
                     .remove_slot(*remove_slot)
                     .expect("slot cache entry must still be present");
+                // Cache writes populate the secondary indexes but not the primary index, so a
+                // cache-only account dropped here without ever being flushed would leak its
+                // secondary entry.
+                // Explicitly ignore the return value as there is no need to purge the account
+                // from the primary index as well
+                if !self.account_indexes.is_empty() {
+                    let _ = self
+                        .accounts_index
+                        .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
+                }
                 self.accounts_index.write_through_pubkeys(pubkeys_removed);
             } else {
                 self.purge_slot_storage(*remove_slot, purge_stats);
@@ -4371,34 +4380,6 @@ impl AccountsDb {
         self.stats
             .dropped_stores
             .fetch_add(num_stored_slots_removed as u64, Ordering::Relaxed);
-    }
-
-    fn purge_slot_cache(&self, purged_slot: Slot, slot_cache: &SlotCache) {
-        let pubkeys = slot_cache.iter().map(|account| *account.key());
-        self.purge_slot_cache_pubkeys(purged_slot, pubkeys, true);
-    }
-
-    fn purge_slot_cache_pubkeys(
-        &self,
-        purged_slot: Slot,
-        pubkeys: impl IntoIterator<Item = Pubkey>,
-        is_dead: bool,
-    ) {
-        // Slot purged from cache should not exist in the backing store
-        assert!(
-            self.storage
-                .get_slot_storage_entry_shrinking_in_progress_ok(purged_slot)
-                .is_none()
-        );
-        let mut num_purged_keys = 0;
-        let (reclaims, _) = self.purge_keys_exact(pubkeys.into_iter().map(|key| {
-            num_purged_keys += 1;
-            (key, purged_slot)
-        }));
-        assert_eq!(reclaims.len(), num_purged_keys);
-        if is_dead {
-            self.remove_dead_slots_metadata(std::iter::once(&purged_slot));
-        }
     }
 
     fn purge_slot_storage(&self, remove_slot: Slot, purge_stats: &PurgeStats) {
@@ -4796,7 +4777,6 @@ impl AccountsDb {
         debug_assert!(self.accounts_index.is_alive_root(slot));
         let mut flush_stats = FlushStats::default();
         let iter_items: Vec<_> = slot_cache.iter().collect();
-        let mut purged_pubkeys: Vec<Pubkey> = vec![];
 
         let accounts: Vec<(&Pubkey, &AccountSharedData)> = iter_items
             .iter()
@@ -4813,9 +4793,7 @@ impl AccountsDb {
                     flush_stats.num_accounts_flushed += 1;
                     Some((key, account))
                 } else {
-                    // If we don't flush, we have to remove the entry from the
-                    // index, since it's equivalent to purging
-                    purged_pubkeys.push(*key);
+                    // A newer version wins, so this one isn't written
                     flush_stats.num_bytes_purged +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
                     flush_stats.num_accounts_purged += 1;
@@ -4823,11 +4801,6 @@ impl AccountsDb {
                 }
             })
             .collect();
-
-        let is_dead_slot = accounts.is_empty();
-        // Remove the account index entries from earlier roots that are outdated by later roots.
-        // Safe because queries to the index will be reading updates from later roots.
-        self.purge_slot_cache_pubkeys(slot, purged_pubkeys, is_dead_slot);
 
         // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning.
         // Cleaning is enabled if pubkeys_to_flush is PubkeysToFlush::Only
@@ -4839,7 +4812,7 @@ impl AccountsDb {
             PubkeysToFlush::All => UpsertReclaim::IgnoreReclaims,
         };
 
-        if !is_dead_slot {
+        if !accounts.is_empty() {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
             // will be able to find the account in storage
@@ -4863,6 +4836,10 @@ impl AccountsDb {
             // all the data for the slot
             assert!(self.storage.get_slot_storage_entry(slot).is_some());
             self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
+        } else {
+            // Every account in this slot was superseded by a newer root, so it flushes to no
+            // storage. Drop the now-dead slot from the index roots metadata
+            self.remove_dead_slots_metadata(std::iter::once(&slot));
         }
 
         // Remove this slot from the cache, which will to AccountsDb's new readers should look like an
@@ -4902,8 +4879,8 @@ impl AccountsDb {
     }
 
     /// `pubkeys_to_flush` selects which accounts are written to storage: `Only(set)` flushes
-    /// just the pubkeys in the set (purging the rest from the index), while `All` flushes
-    /// every account in the slot.
+    /// just the pubkeys in the set, dropping the rest with the cache, while `All` flushes every
+    /// account in the slot.
     fn flush_slot_cache(
         &self,
         slot: Slot,
@@ -5162,60 +5139,54 @@ impl AccountsDb {
         }
     }
 
-    /// Updates the accounts index with the given accounts. If store_account is false, skip storing
-    /// the account in the index as the account was not stored in the cache
+    /// Updates the secondary index with the given accounts. If store_account is false, skip storing
+    /// the account in the secondary index as the account was not stored in the cache
     /// Used for cached accounts only.
-    fn update_index_cached_accounts<'a>(
+    fn update_secondary_index_cached_accounts<'a>(
         &self,
         accounts: &impl StorableAccounts<'a>,
         store_account: &BitVec,
         update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
-        let target_slot = accounts.target_slot();
-        let len = accounts.len();
-        assert_eq!(accounts.len() as u64, store_account.len());
+        if !self.account_indexes.is_empty() {
+            let len = accounts.len();
+            assert_eq!(accounts.len() as u64, store_account.len());
 
-        let update = |start, end| {
-            (start..end).for_each(|i| {
-                if store_account[i as u64] {
-                    accounts.account(i, |account| {
-                        let info =
-                            AccountInfo::new(StorageLocation::Cached, account.is_zero_lamport());
-                        self.accounts_index.upsert(
-                            target_slot,
-                            target_slot,
-                            account.pubkey(),
-                            info,
-                            ReclaimsSlotList::default().as_mut(),
-                            UpsertReclaim::PreviousSlotEntryWasCached,
-                        );
-                        self.accounts_index.update_secondary_indexes(
-                            account.pubkey(),
-                            &account,
-                            &self.account_indexes,
-                        );
-                    });
-                }
-            });
-        };
+            // Cache writes do not upsert the accounts index; it only ever holds storage entries,
+            // populated on flush. Readers find cache-only accounts through the write cache. Only
+            // the secondary indexes are updated here.
+            let update = |start, end| {
+                (start..end).for_each(|i| {
+                    if store_account[i as u64] {
+                        accounts.account(i, |account| {
+                            self.accounts_index.update_secondary_indexes(
+                                account.pubkey(),
+                                &account,
+                                &self.account_indexes,
+                            );
+                        });
+                    }
+                });
+            };
 
-        let threshold = 1;
-        if matches!(
-            update_index_thread_selection,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        ) && len > threshold
-        {
-            let chunk_size = len.div_ceil(self.thread_pool_foreground.current_num_threads());
-            let batches = 1 + len / chunk_size;
-            self.thread_pool_foreground.install(|| {
-                (0..batches).into_par_iter().for_each(|batch| {
-                    let start = batch * chunk_size;
-                    let end = std::cmp::min(start + chunk_size, len);
-                    update(start, end)
-                })
-            });
-        } else {
-            update(0, len);
+            let threshold = 1;
+            if matches!(
+                update_index_thread_selection,
+                UpdateIndexThreadSelection::PoolWithThreshold,
+            ) && len > threshold
+            {
+                let chunk_size = len.div_ceil(self.thread_pool_foreground.current_num_threads());
+                let batches = 1 + len / chunk_size;
+                self.thread_pool_foreground.install(|| {
+                    (0..batches).into_par_iter().for_each(|batch| {
+                        let start = batch * chunk_size;
+                        let end = std::cmp::min(start + chunk_size, len);
+                        update(start, end)
+                    })
+                });
+            } else {
+                update(0, len);
+            }
         }
     }
 
@@ -5701,9 +5672,13 @@ impl AccountsDb {
             self.write_accounts_to_cache(accounts.target_slot(), &accounts, ancestors);
         let write_accounts_us = write_accounts_time.end_as_us();
 
-        // Update the index
+        // Update the secondary index
         let update_index_time = Measure::start("update_index");
-        self.update_index_cached_accounts(&accounts, &store_account, update_index_thread_selection);
+        self.update_secondary_index_cached_accounts(
+            &accounts,
+            &store_account,
+            update_index_thread_selection,
+        );
         let update_index_us = update_index_time.end_as_us();
 
         let stats = &self.store_accounts_unfrozen_stats;

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         accounts_file::AccountsFileProvider,
         accounts_index::{
-            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountSecondaryIndexesIncludeExclude,
+            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountIndex, AccountSecondaryIndexesIncludeExclude,
             AccountsIndexConfig, IndexLimit, IndexLimitThreshold, test_utils::*,
         },
         append_vec::{AppendVec, test_utils::TempFile},
@@ -814,6 +814,48 @@ define_accounts_db_test!(test_remove_unrooted_slot_cached, |db| {
     db.assert_load_account(unrooted_slot, key, 2);
 });
 
+/// Cache writes populate the secondary indexes but not the primary index. When a cache-only
+/// account is dropped via `remove_unrooted_slots` before it is ever flushed, its secondary-index
+/// entry must be reclaimed; otherwise it leaks because there is no primary entry to drive the
+/// usual `handle_dead_keys` purge.
+#[test]
+fn test_remove_unrooted_slot_purges_secondary_index_for_cache_only_account() {
+    let db = AccountsDb {
+        account_indexes: program_id_index_enabled(),
+        ..AccountsDb::new_with_config(
+            Vec::new(),
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+    };
+
+    let owner = Pubkey::new_unique();
+    let pubkey = Pubkey::new_unique();
+    let slot = 1;
+    let bank_id = 0;
+    let account = AccountSharedData::new(1, 0, &owner);
+
+    // Write only to the cache at an unrooted slot: this populates the secondary index keyed by
+    // the account owner, but leaves the primary index untouched.
+    db.store_for_tests((slot, &[(&pubkey, &account)][..]));
+    assert!(!db.accounts_index.contains(&pubkey));
+    assert_eq!(
+        db.accounts_index
+            .get_index_key_size(&AccountIndex::ProgramId, &owner),
+        Some(1)
+    );
+
+    // Dropping the unrooted slot must reclaim the secondary entry, not leak it.
+    db.remove_unrooted_slots(&[(slot, bank_id)]);
+    assert!(!db.accounts_cache.contains_pubkey(&pubkey));
+    assert_eq!(
+        db.accounts_index
+            .get_index_key_size(&AccountIndex::ProgramId, &owner),
+        None
+    );
+}
+
 // Test that removing a rooted storage works correctly. This is behaviour specific to
 // the snapshot minimizer
 define_accounts_db_test!(test_remove_slot_snapshot_minimizer, |db| {
@@ -1162,7 +1204,9 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
         accounts.accounts_index.get_and_then(&pubkey_zero, |entry| {
             let expected_ref_count = if pass < 2 { 1 } else { 2 };
             assert_eq!(entry.unwrap().ref_count(), expected_ref_count, "{pass}");
-            let expected_slot_list = if pass < 1 { 1 } else { 2 };
+            // The index holds only flushed writes: one entry at `slot` for passes 0 and 1,
+            // and a second at `slot + 1` for pass 2.
+            let expected_slot_list = if pass < 2 { 1 } else { 2 };
             assert_eq!(entry.unwrap().slot_list_lock_read_len(), expected_slot_list);
             (false, ())
         });
@@ -1186,23 +1230,14 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
                     assert!(entry.is_none(), "{pass}");
                 }
                 1 => {
-                    // alive only in slot + 1
-                    assert_eq!(entry.unwrap().slot_list_lock_read_len(), 1);
-                    assert_eq!(
-                        entry
-                            .unwrap()
-                            .slot_list_read_lock()
-                            .first()
-                            .map(|(s, _)| s)
-                            .cloned()
-                            .unwrap(),
-                        slot + 1
-                    );
-                    let expected_ref_count = 0;
-                    assert_eq!(
-                        entry.map(|e| e.ref_count()),
-                        Some(expected_ref_count),
-                        "{pass}"
+                    // The single-ref entry at `slot` is removed; pass 1's cache-only write at
+                    // `slot + 1` stays in the write cache.
+                    assert!(entry.is_none(), "{pass}");
+                    assert!(
+                        accounts
+                            .accounts_cache
+                            .load(slot + 1, &pubkey_zero)
+                            .is_some()
                     );
                 }
                 2 => {
@@ -4122,6 +4157,33 @@ fn test_accounts_db_cache_clean_dead_slots() {
     }
 }
 
+/// A rooted slot whose accounts are all superseded by a newer rooted slot flushes to no storage.
+/// It must be dropped from the index roots metadata: cache writes no longer upsert the index, so
+/// the old per-pubkey purge that used to remove such a dead root is gone, and the flush path must
+/// drop it explicitly. Otherwise it lingers in `alive_roots` as a root with no backing storage.
+#[test]
+fn test_flush_dead_slot_removed_from_alive_roots() {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // The same pubkey written to two rooted slots, both still in the write cache.
+    db.store_for_tests((0, &[(&pubkey, &account)][..]));
+    db.add_root(0);
+    db.store_for_tests((1, &[(&pubkey, &account)][..]));
+    db.add_root(1);
+
+    // Cleaning flush dedups newest-first: slot 1 keeps the account, slot 0 flushes empty.
+    db.flush_accounts_cache(true, None);
+
+    // Slot 1 holds the surviving version in storage and remains a root.
+    assert!(db.storage.get_slot_storage_entry(1).is_some());
+    assert!(db.accounts_index.is_alive_root(1));
+    // Slot 0 produced no storage and is dead; it must be gone from the roots metadata.
+    assert!(db.storage.get_slot_storage_entry(0).is_none());
+    assert!(!db.accounts_index.is_alive_root(0));
+}
+
 #[test]
 fn test_accounts_db_cache_clean() {
     let (accounts_db, keys, slots, _) = setup_accounts_db_cache_clean(10, None, None);
@@ -6466,61 +6528,6 @@ fn test_handle_dropped_roots_for_ancient_assert() {
     db.handle_dropped_roots_for_ancient(dropped_roots.into_iter());
 }
 
-/// Test that `clean` respects rooted vs unrooted slots w.r.t. reclaims
-///
-/// When an account is in multiple slots, and the latest is unrooted, `clean` should *not* reclaim
-/// all the rooted versions.
-#[test]
-fn test_clean_old_storages_with_reclaims_unrooted() {
-    let accounts_db = AccountsDb::new_single_for_tests();
-    let pubkey = Pubkey::new_unique();
-    let old_slot = 11;
-    let new_slot = 22;
-    let slots = [old_slot, new_slot];
-    for &slot in &slots {
-        let account = AccountSharedData::new(slot, 0, &Pubkey::new_unique());
-        // store `pubkey` into multiple slots, and also store another unique pubkey
-        // to prevent the whole storage from being marked as dead by `clean`.
-        accounts_db.store_for_tests((
-            slot,
-            [(&pubkey, &account), (&Pubkey::new_unique(), &account)].as_slice(),
-        ));
-    }
-
-    // only `old_slot` should be rooted, not `new_slot`
-    accounts_db.add_root_and_flush_write_cache(old_slot);
-    assert!(accounts_db.accounts_index.is_alive_root(old_slot));
-    assert!(!accounts_db.accounts_index.is_alive_root(new_slot));
-
-    // ensure `old_slot` is in uncleaned_pubkeys (but not dirty_stores) so it'll be cleaned
-    assert!(accounts_db.uncleaned_pubkeys.contains_key(&old_slot));
-    assert!(!accounts_db.dirty_stores.contains_key(&old_slot));
-    // and `new_slot` should be in neither
-    assert!(!accounts_db.uncleaned_pubkeys.contains_key(&new_slot));
-    assert!(!accounts_db.dirty_stores.contains_key(&new_slot));
-
-    // ensure the slot list for `pubkey` has both the old and new slots
-    let slot_list = accounts_db
-        .accounts_index
-        .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
-        .unwrap();
-    assert_eq!(slot_list.len(), slots.len());
-    assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
-
-    // `clean` should *not* reclaim the account in `old_slot` because `new_slot` is not a root
-    accounts_db.clean_accounts_for_tests();
-
-    // ensure we have NOT reclaimed the account in `old_slot`
-    let slot_list = accounts_db
-        .accounts_index
-        .get_bin(&pubkey)
-        .slot_list_mut(&pubkey, |slot_list| slot_list.clone_list())
-        .unwrap();
-    assert_eq!(slot_list.len(), slots.len());
-    assert!(slot_list.iter().map(|(slot, _)| slot).eq(slots.iter()));
-}
-
 /// Ensure the calculating capitalization produces the correct value
 #[test]
 fn test_calculate_capitalization_simple() {
@@ -6753,7 +6760,9 @@ fn test_new_zero_lamport_accounts_skipped() {
             .unwrap()
             .contains_key(&pubkey1)
     );
-    assert!(accounts_db.accounts_index.contains(&pubkey2));
+    // pubkey2 and pubkey3 are in the write cache but not the index; cache writes reach the
+    // index only on flush.
+    assert!(!accounts_db.accounts_index.contains(&pubkey2));
     assert!(
         accounts_db
             .accounts_cache
@@ -6761,7 +6770,7 @@ fn test_new_zero_lamport_accounts_skipped() {
             .unwrap()
             .contains_key(&pubkey2)
     );
-    assert!(accounts_db.accounts_index.contains(&pubkey3));
+    assert!(!accounts_db.accounts_index.contains(&pubkey3));
     assert!(
         accounts_db
             .accounts_cache
@@ -6770,18 +6779,26 @@ fn test_new_zero_lamport_accounts_skipped() {
             .contains_key(&pubkey3)
     );
 
-    // 3. Insert a zero-lamport update for an already-indexed pubkey (pubkey2).
-    //    Verify pubkey2 remains in the index and gets added to the slot cache.
+    // 3. Insert a zero-lamport update for pubkey2, which already has a non-zero entry in the
+    //    write cache. The update is stored rather than skipped, overwriting the cache entry
+    //    with zero lamports.
     accounts_db.store_accounts_unfrozen(
         (slot, [(&pubkey2, &zero_account)].as_slice()),
         UpdateIndexThreadSelection::Inline,
         &ancestors,
     );
-    assert!(accounts_db.accounts_index.contains(&pubkey2));
-    assert!(accounts_db.accounts_cache.contains_pubkey(&pubkey2));
+    assert_eq!(
+        accounts_db
+            .accounts_cache
+            .load(slot, &pubkey2)
+            .unwrap()
+            .account
+            .lamports(),
+        0
+    );
 
-    // 4. Flush the slot to simulate write-cache -> storage transition and verify
-    //    pubkey1 is still not present while pubkey2 remains indexed but is now zero-lamport.
+    // 4. Flush the slot (write cache -> storage). pubkey1 (only ever written as zero) is
+    //    absent; pubkey2 and pubkey3 are now in the index.
     accounts_db.add_root_and_flush_write_cache(slot);
     assert!(!accounts_db.contains(&pubkey1));
     assert!(accounts_db.contains(&pubkey2));
@@ -6794,7 +6811,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     }));
 
     // 5. Add a non-zero lamport account for a pubkey that was previously only written as zero
-    //    (pubkey1) and verify the pubkey is added to the index.
+    //    (pubkey1) and verify the pubkey is added to the write cache.
     let slot = slot + 1;
     ancestors.insert(slot);
     accounts_db.store_accounts_unfrozen(
@@ -6802,7 +6819,7 @@ fn test_new_zero_lamport_accounts_skipped() {
         UpdateIndexThreadSelection::Inline,
         &ancestors,
     );
-    assert!(accounts_db.accounts_index.contains(&pubkey1));
+    assert!(accounts_db.accounts_cache.contains_pubkey(&pubkey1));
 
     // 6. Set pubkey3 to zero lamports and flush. Verify pubkey3 is present in the index with
     // a zero-lamport AccountInfo after flushing.
@@ -7036,6 +7053,28 @@ fn test_is_ancestor_zero_lamport_cache_over_storage() {
 
     let ancestors = Ancestors::from(vec![cache_slot, storage_slot]);
     assert_eq!(db.is_ancestor_zero_lamport(&pubkey, &ancestors), Some(true));
+}
+
+/// A cache-only pubkey has no accounts-index entry (cache writes don't upsert the index),
+/// yet `do_load` must still return it — `load_latest` finds it in the write cache before
+/// the index is consulted.
+#[test]
+fn test_do_load_returns_cache_value_for_cache_only_pubkey() {
+    let db = AccountsDb::new_single_for_tests();
+    let pubkey = Pubkey::new_unique();
+    let slot = 5;
+
+    let account = AccountSharedData::new(100, 0, &Pubkey::default());
+    db.accounts_cache.store(slot, &pubkey, account.clone());
+    db.accounts_cache.add_root(slot);
+    assert!(!db.accounts_index.contains(&pubkey));
+
+    let ancestors = Ancestors::from(vec![slot]);
+    assert_eq!(
+        db.do_load_for_tests(&ancestors, &pubkey)
+            .map(|(loaded, loaded_slot)| (loaded.lamports(), loaded_slot)),
+        Some((account.lamports(), slot))
+    );
 }
 
 /// loading an account through an older bank must not return

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1236,6 +1236,14 @@ pub(crate) mod test_utils {
         super::{AccountIndex, secondary::AccountSecondaryIndexes},
         std::collections::HashSet,
     };
+    pub fn program_id_index_enabled() -> AccountSecondaryIndexes {
+        let mut account_indexes = HashSet::new();
+        account_indexes.insert(AccountIndex::ProgramId);
+        AccountSecondaryIndexes {
+            indexes: account_indexes,
+            keys: None,
+        }
+    }
     pub fn spl_token_mint_index_enabled() -> AccountSecondaryIndexes {
         let mut account_indexes = HashSet::new();
         account_indexes.insert(AccountIndex::SplTokenMint);


### PR DESCRIPTION
#### Problem
Now that accounts are tracked in the cache, they no longer need to be tracked in the index

#### Summary of Changes
- Remove them from being tracked in the index

#### Testing
RoryP is running the change in all graphs, it has the inline lt hash changes as well
Load/Store Times: 
Store times go down significantly since they no longer touch the index. Load times drop a little, but I think that's mainly noise.
<img width="918" height="318" alt="image" src="https://github.com/user-attachments/assets/254a70ab-a122-43bf-9e7a-ae62827990de" />

Flush Times:
Large reduction in flush times. Why?

<img width="918" height="318" alt="image" src="https://github.com/user-attachments/assets/6b5d04da-18bd-4959-aac3-e1ec54125e2d" />

Because we no longer need to purge keys on the flush path. This isn't measured directly on the flush path, so showing the total purge key time
<img width="918" height="318" alt="image" src="https://github.com/user-attachments/assets/3d1d30bc-29d9-4ddd-bae0-1a3d0656fa10" />


Fixes #
