### PR TITLE
chore: Cleanup blockstore invalid shred search logs

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2768,16 +2768,23 @@ fn scan_blockstore_for_incorrect_shred_version(
     // Search for shreds with incompatible version in blockstore
     let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
 
-    info!("Searching blockstore for shred with incorrect version from slot {start_slot}");
+    info!(
+        "Blockstore search for shreds with incorrect version starting from slot {start_slot}; \
+         searching for 60s"
+    );
     for (slot, _meta) in slot_meta_iterator {
         let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
         for shred in &shreds {
             if shred.version() != expected_shred_version {
+                info!(
+                    "Blockstore search found shred with incorrect version {} in slot {slot}",
+                    shred.version()
+                );
                 return Ok(Some(shred.version()));
             }
         }
         if timer.elapsed() > TIMEOUT {
-            info!("Didn't find incorrect shreds after 60 seconds, aborting");
+            info!("Blockstore search did not find any shreds with incorrect version");
             break;
         }
     }


### PR DESCRIPTION
#### Problem
The logs could be a bit more informative / cleaner:
- The scan runs for 60s; that is quite a while so lead with that so operators searching their logs expect this wait
- Add a log for if we find a shred with wrong version
- Make log prefix (`Blockstore search`) consistent for these logs for easier searching

#### Summary of Changes
Add a bit more information and make the prefix consistent to allow for easier searching

#### Testing
Compilation (log only change)