### PR TITLE
Vote transaction gets default compute-budget values

### DIFF
--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -311,9 +311,9 @@ mod tests {
 
         use {
             crate::block_cost_limits::INSTRUCTION_DATA_BYTES_COST,
-            solana_compute_budget::compute_budget_limits::{
-                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT,
-                MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
+            solana_runtime_transaction::transaction_meta::{
+                DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT,
+                DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT,
             },
         };
 
@@ -338,18 +338,11 @@ mod tests {
             let write_lock_cost = 2 * block_cost_limits::WRITE_LOCK_UNITS;
             let data_bytes_cost =
                 vote_transaction.instruction_data_len() / (INSTRUCTION_DATA_BYTES_COST as u16);
-            // Estimated execution cost depends on whether the Vote program is
-            // tracked in cost modeling as a builtin.
-            let programs_execution_cost = if simd_0387_enabled {
-                // SIMD-0387: Vote program removed from builtin cost modeling.
-                DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT as u64
-            } else {
-                MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT as u64
-            };
-            // and it has default loaded_account_data_size
+            let programs_execution_cost =
+                u64::from(DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT);
             let loaded_accounts_data_size_cost =
                 CostModel::calculate_loaded_accounts_data_size_cost(
-                    MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get(),
+                    DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT,
                     &feature_set,
                 );
             let vote_program_usage_details = UsageCostDetails {

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -57,7 +57,8 @@ impl RuntimeTransaction<SanitizedVersionedTransaction> {
         let versioned_transaction_config =
             VersionedTransactionConfiguration::try_from_sanitized_versioned_message(
                 sanitized_versioned_tx.get_message(),
-            )?;
+            )?
+            .with_simple_vote_defaults(is_simple_vote_tx);
 
         Ok(Self {
             transaction: sanitized_versioned_tx,
@@ -175,6 +176,10 @@ impl RuntimeTransaction<SanitizedTransaction> {
 mod tests {
     use {
         super::*,
+        crate::transaction_meta::{
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT,
+        },
         agave_feature_set::FeatureSet,
         agave_reserved_account_keys::ReservedAccountKeys,
         solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -216,8 +221,8 @@ mod tests {
         TestTransaction::new().to_sanitized_versioned_transaction()
     }
 
-    // Simple transfer transaction for testing, it does not support vote instruction
-    // because simple vote transaction will not request limits
+    // Simple transfer transaction for testing explicit compute-budget requests
+    // without applying the simple-vote default overrides.
     struct TestTransaction {
         from_keypair: Keypair,
         hash: Hash,
@@ -372,6 +377,32 @@ mod tests {
                 loaded_accounts_bytes,
                 transaction_configuration.loaded_accounts_data_size_limit
             );
+        }
+    }
+
+    #[test]
+    fn test_simple_vote_transaction_config_uses_vote_defaults() {
+        let runtime_transaction = RuntimeTransaction::<SanitizedVersionedTransaction>::try_from(
+            vote_sanitized_versioned_transaction(),
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+
+        assert!(runtime_transaction.is_simple_vote_transaction());
+        for feature_set in [FeatureSet::default(), FeatureSet::all_enabled()] {
+            let transaction_configuration = runtime_transaction
+                .transaction_configuration(&feature_set)
+                .unwrap();
+            assert_eq!(
+                transaction_configuration.compute_unit_limit,
+                DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT
+            );
+            assert_eq!(
+                transaction_configuration.loaded_accounts_data_size_limit,
+                DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+            );
+            assert_eq!(transaction_configuration.priority_fee_lamports, 0);
         }
     }
 

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -109,7 +109,8 @@ where
             VersionedTransactionConfiguration::LegacyAndV0(
                 ComputeBudgetInstructionDetails::try_from(transaction.program_instructions_iter())?,
             )
-        };
+        }
+        .with_simple_vote_defaults(is_simple_vote_tx);
 
     Ok(CachedTransactionMeta {
         message_hash,
@@ -256,14 +257,43 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
 mod tests {
     use {
         super::*,
+        crate::transaction_meta::{
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT,
+        },
+        agave_feature_set::FeatureSet,
         agave_reserved_account_keys::ReservedAccountKeys,
         solana_hash::Hash,
+        solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_message::{AddressLookupTableAccount, SimpleAddressLoader, v0},
+        solana_sdk_ids::vote,
         solana_signature::Signature,
+        solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_system_transaction as system_transaction,
+        solana_transaction::Transaction,
     };
+
+    fn serialized_simple_vote_transaction() -> Vec<u8> {
+        let block_hash = Hash::new_unique();
+        let vote_keypair = Keypair::new();
+        let node_keypair = Keypair::new();
+        let auth_keypair = Keypair::new();
+        let vote_ix = Instruction::new_with_bytes(
+            vote::id(),
+            &[],
+            vec![
+                AccountMeta::new(vote_keypair.pubkey(), false),
+                AccountMeta::new_readonly(auth_keypair.pubkey(), true),
+            ],
+        );
+        let mut vote_tx = Transaction::new_with_payer(&[vote_ix], Some(&node_keypair.pubkey()));
+        vote_tx.partial_sign(&[&node_keypair], block_hash);
+        vote_tx.partial_sign(&[&auth_keypair], block_hash);
+
+        wincode::serialize(&VersionedTransaction::from(vote_tx)).unwrap()
+    }
 
     #[test]
     fn test_advancing_transaction_type() {
@@ -302,6 +332,52 @@ mod tests {
 
         assert_eq!(hash, *dynamic_runtime_transaction.message_hash());
         assert!(!dynamic_runtime_transaction.is_simple_vote_transaction());
+    }
+
+    #[test]
+    fn test_simple_vote_transaction_config_uses_vote_defaults() {
+        let serialized_transaction = serialized_simple_vote_transaction();
+        let transaction =
+            SanitizedTransactionView::try_new_sanitized(&serialized_transaction[..], true).unwrap();
+        let static_runtime_transaction =
+            RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+                transaction,
+                MessageHash::Compute,
+                None,
+            )
+            .unwrap();
+
+        assert!(static_runtime_transaction.is_simple_vote_transaction());
+        let transaction_configuration = static_runtime_transaction
+            .transaction_configuration(&FeatureSet::all_enabled())
+            .unwrap();
+        assert_eq!(
+            transaction_configuration.compute_unit_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT
+        );
+        assert_eq!(
+            transaction_configuration.loaded_accounts_data_size_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+        );
+
+        let dynamic_runtime_transaction =
+            RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+                static_runtime_transaction,
+                None,
+                &ReservedAccountKeys::empty_key_set(),
+            )
+            .unwrap();
+        let transaction_configuration = dynamic_runtime_transaction
+            .transaction_configuration(&FeatureSet::all_enabled())
+            .unwrap();
+        assert_eq!(
+            transaction_configuration.compute_unit_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT
+        );
+        assert_eq!(
+            transaction_configuration.loaded_accounts_data_size_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+        );
     }
 
     #[test]

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -14,8 +14,8 @@
 use {
     agave_feature_set::FeatureSet,
     solana_compute_budget::compute_budget_limits::{
-        MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES, MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES,
-        MIN_HEAP_FRAME_BYTES,
+        MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT, MAX_HEAP_FRAME_BYTES,
+        MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, MIN_HEAP_FRAME_BYTES,
     },
     solana_compute_budget_instruction::compute_budget_instruction_details::ComputeBudgetInstructionDetails,
     solana_hash::Hash,
@@ -28,6 +28,14 @@ use {
     solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
     solana_transaction::TransactionError,
 };
+
+/// Default compute-unit limit used for simple vote transactions without
+/// compute-budget instructions.
+pub const DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT: u32 =
+    MAX_BUILTIN_ALLOCATION_COMPUTE_UNIT_LIMIT;
+/// Default loaded accounts data size limit used for simple vote transactions
+/// without compute-budget instructions.
+pub const DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT: u32 = 32 * 1024;
 
 pub trait TransactionMeta {
     fn message_hash(&self) -> &Hash;
@@ -60,6 +68,16 @@ pub struct TransactionConfiguration {
 }
 
 impl TransactionConfiguration {
+    pub fn default_for_simple_vote_transaction() -> Self {
+        Self {
+            updated_heap_bytes: MIN_HEAP_FRAME_BYTES,
+            compute_unit_limit: DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT,
+            priority_fee_lamports: 0,
+            loaded_accounts_data_size_limit:
+                DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT,
+        }
+    }
+
     pub fn try_from_sanitized_message(
         message: &SanitizedMessage,
         feature_set: &FeatureSet,
@@ -88,9 +106,18 @@ impl TransactionConfiguration {
 pub(crate) enum VersionedTransactionConfiguration {
     LegacyAndV0(ComputeBudgetInstructionDetails),
     V1(TransactionConfiguration),
+    SimpleVoteDefault,
 }
 
 impl VersionedTransactionConfiguration {
+    pub(crate) fn with_simple_vote_defaults(self, is_simple_vote_transaction: bool) -> Self {
+        if is_simple_vote_transaction {
+            Self::SimpleVoteDefault
+        } else {
+            self
+        }
+    }
+
     pub(crate) fn try_from_sanitized_message(
         message: &SanitizedMessage,
     ) -> Result<Self, TransactionError> {
@@ -174,6 +201,9 @@ impl VersionedTransactionConfiguration {
                         .min(MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get()),
                 })
             }
+            Self::SimpleVoteDefault => {
+                Ok(TransactionConfiguration::default_for_simple_vote_transaction())
+            }
         }
     }
 }
@@ -225,6 +255,26 @@ mod tests {
         assert_eq!(config.compute_unit_limit, 123_456);
         assert_eq!(config.priority_fee_lamports, 2 * 123_456);
         assert_eq!(config.loaded_accounts_data_size_limit, 456_789);
+    }
+
+    #[test]
+    fn test_try_into_config_simple_vote_defaults() {
+        let feature_set = FeatureSet::all_enabled();
+
+        let config = VersionedTransactionConfiguration::SimpleVoteDefault
+            .try_into_config(&feature_set)
+            .unwrap();
+
+        assert_eq!(config.updated_heap_bytes, HEAP_LENGTH as u32);
+        assert_eq!(
+            config.compute_unit_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_COMPUTE_UNIT_LIMIT
+        );
+        assert_eq!(config.priority_fee_lamports, 0);
+        assert_eq!(
+            config.loaded_accounts_data_size_limit,
+            DEFAULT_SIMPLE_VOTE_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE_LIMIT
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
- cost-model no longer treats vote transactions with static CU costs,
- vote program will be removed form built-in list;
- vote transaction does not come with CBP ixs,
- therefore vote transaction's estimated CU cost is way larger than it needs

#### Summary of Changes
- Changed runtime-transaction/src/transaction_meta.rs so simple vote transactions without compute-budget instructions gets default cbp values;
 - Wired that into both runtime transaction construction paths;


#### Testing


Fixes #
