### PR TITLE
Create CPI accounts VmSlice

### DIFF
--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -1,22 +1,25 @@
+#[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 use {
     crate::{
         IndexOfAccount, MAX_ACCOUNT_DATA_GROWTH_PER_TRANSACTION, MAX_ACCOUNT_DATA_LEN,
         MAX_ACCOUNTS_PER_TRANSACTION,
         instruction::{InstructionContext, InstructionFrame},
-        instruction_accounts::InstructionAccount,
         transaction_accounts::{KeyedAccountSharedData, TransactionAccounts},
         vm_addresses::{
-            GUEST_INSTRUCTION_DATA_BASE_ADDRESS, GUEST_REGION_SIZE, RETURN_DATA_SCRATCHPAD,
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS, GUEST_INSTRUCTION_DATA_BASE_ADDRESS,
+            GUEST_REGION_SIZE, RETURN_DATA_SCRATCHPAD,
         },
-        vm_slice::VmSlice,
     },
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
-    solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
     std::{borrow::Cow, cell::Cell, rc::Rc},
+};
+use {
+    crate::{instruction_accounts::InstructionAccount, vm_slice::VmSlice},
+    solana_pubkey::Pubkey,
 };
 
 /// Used only in fn `take_instruction_trace` for deconstructing TransactionContext
@@ -37,7 +40,9 @@ struct TransactionFrame {
     return_data_pubkey: Pubkey,
     return_data_scratchpad: VmSlice<u8>,
     /// Scratchpad for programs to write CPI instruction data
-    cpi_scratchpad: VmSlice<u8>,
+    pub cpi_data_scratchpad: VmSlice<u8>,
+    /// Scratchpad for programs to write CPI accounts
+    pub cpi_accounts_scratchpad: VmSlice<InstructionAccount>,
     /// Index of current executing instruction
     current_executing_instruction: u16,
     /// Number of instructions in the instruction trace (including top level and CPIs)
@@ -88,8 +93,14 @@ impl<'ix_data> TransactionContext<'ix_data> {
         let transaction_frame = TransactionFrame {
             return_data_pubkey: Pubkey::default(),
             return_data_scratchpad: VmSlice::new(RETURN_DATA_SCRATCHPAD, 0),
-            cpi_scratchpad: VmSlice::new(
+            cpi_data_scratchpad: VmSlice::new(
                 GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(
+                    GUEST_REGION_SIZE.saturating_mul(number_of_top_level_instructions as u64),
+                ),
+                0,
+            ),
+            cpi_accounts_scratchpad: VmSlice::new(
+                GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS.saturating_add(
                     GUEST_REGION_SIZE.saturating_mul(number_of_top_level_instructions as u64),
                 ),
                 0,
@@ -297,12 +308,18 @@ impl<'ix_data> TransactionContext<'ix_data> {
                 .total_number_of_instructions_in_trace
                 .saturating_add(1);
             instruction.index_of_caller_instruction = caller_index;
-            let next_ptr = self
+            let next_data_ptr = self
                 .transaction_frame
-                .cpi_scratchpad
+                .cpi_data_scratchpad
                 .ptr()
                 .saturating_add(GUEST_REGION_SIZE);
-            self.transaction_frame.cpi_scratchpad = VmSlice::new(next_ptr, 0);
+            self.transaction_frame.cpi_data_scratchpad = VmSlice::new(next_data_ptr, 0);
+            let next_accounts_ptr = self
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr()
+                .saturating_add(GUEST_REGION_SIZE);
+            self.transaction_frame.cpi_accounts_scratchpad = VmSlice::new(next_accounts_ptr, 0);
         }
 
         instruction.program_account_index_in_tx = program_index;
@@ -915,13 +932,35 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(2))
         );
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.len(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .len(),
             0,
         );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(2))
+        );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .len(),
+            0,
+        );
+
         assert_eq!(
             transaction_context.number_of_called_instructions_in_trace(),
             1
@@ -962,8 +1001,19 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(3))
+        );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(3))
         );
 
         // A nested CPI
@@ -991,8 +1041,19 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(4))
+        );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(4))
         );
 
         assert_eq!(
@@ -1057,9 +1118,21 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
         );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
+        );
+
         assert_eq!(
             transaction_context
                 .transaction_frame
@@ -1089,8 +1162,19 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
+        );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
         );
 
         assert_eq!(
@@ -1122,8 +1206,19 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
+        );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(5))
         );
 
         assert_eq!(
@@ -1175,9 +1270,21 @@ mod tests {
         );
 
         assert_eq!(
-            transaction_context.transaction_frame.cpi_scratchpad.ptr(),
+            transaction_context
+                .transaction_frame
+                .cpi_data_scratchpad
+                .ptr(),
             GUEST_INSTRUCTION_DATA_BASE_ADDRESS.saturating_add(GUEST_REGION_SIZE.saturating_mul(6))
         );
+        assert_eq!(
+            transaction_context
+                .transaction_frame
+                .cpi_accounts_scratchpad
+                .ptr(),
+            GUEST_INSTRUCTION_ACCOUNT_BASE_ADDRESS
+                .saturating_add(GUEST_REGION_SIZE.saturating_mul(6))
+        );
+
         assert_eq!(
             transaction_context
                 .transaction_frame


### PR DESCRIPTION
#### Problem

This is a cherry pick of https://github.com/anza-xyz/agave-runtime/pull/8 for the upstream agave repository to synchronize the non ABIv2 specific parts and decrease the rebase overhead.

#### Summary of Changes

1. Add a VmSlice field to `TransactionContext` for CPI accounts, named `cpi_accounts_scratchpad`.
2. Rename `cpi_scratchpad` to `cpi_data_scratchpad` for disambiguation.


#### Testing

Tests have been updated to check if the pointer update is correct.
