### PR TITLE
Prioritizes own messages over remote

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -25,7 +25,7 @@ use {
         consensus_message::{Block, ConsensusMessage},
         migration::MigrationStatus,
     },
-    crossbeam_channel::{Receiver, Sender, TrySendError, select},
+    crossbeam_channel::{Receiver, Sender, TrySendError, select_biased},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
@@ -389,19 +389,19 @@ impl ConsensusPoolService {
                 Duration::from_millis(20)
             };
 
-            let ret = select! {
-                recv(ctx.consensus_message_receiver) -> msg => {
-                    let Ok(first) = msg else {
-                        return Self::handle_channel_disconnected(&mut ctx, "consensus_message_receiver channel");
-                    };
-                    Self::handle_sig_verified_batch(&mut ctx, &mut consensus_pool, &mut events, &mut standstill_timer, first, &mut stats)
-                },
+            let ret = select_biased! {
                 recv(ctx.own_message_receiver) -> msg => {
                     let Ok(first) = msg else {
                         return Self::handle_channel_disconnected(&mut ctx, "own_message_receiver channel");
                     };
                     Self::handle_own_message(&mut ctx, &mut consensus_pool, &mut events, &mut standstill_timer, first, &mut stats)
                 }
+                recv(ctx.consensus_message_receiver) -> msg => {
+                    let Ok(first) = msg else {
+                        return Self::handle_channel_disconnected(&mut ctx, "consensus_message_receiver channel");
+                    };
+                    Self::handle_sig_verified_batch(&mut ctx, &mut consensus_pool, &mut events, &mut standstill_timer, first, &mut stats)
+                },
                 default(wait_timeout) => continue
             };
 


### PR DESCRIPTION
#### Problem

Currently when both remote messages receiver and own messages receiver become ready, we will pick one at "random".  We should be prioritising our own messages as those are probably going to help make consensus more progress.


#### Summary of Changes

Uses `select_biased` to prioritise our own msgs over remote.


#### Testing

Just standard CI

Related: #13268
