### PR TITLE
Create version bump PRs as draft first

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -86,6 +86,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Bump version to ${process.env.NEW_VERSION}`,
+              draft: true,
               head: `version-bump-${process.env.NEW_VERSION}`,
               base: process.env.TARGET_BRANCH
             })


### PR DESCRIPTION
#### Problem

The procedures is that the release manager reviews a version bump PR, ensures CI passes, and only after that a backport reviewers stamps it. When a PR is opened as non-draft then backport reviewers are notified immediately however.

#### Summary of Changes

Create version bump PRs as drafts first. The releae manager should mark the PR as ready for review when tests passed and they reviewed it first.

#### Testing

Will be tested in the master by running the workflow to create a version bump PR.

Fixes #
