### PR TITLE
Verifies cert stake when verifying signatures on them

### DIFF
--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -14,6 +14,7 @@ use {
         signature::Signature as BlsSignature,
     },
     solana_hash::Hash,
+    std::num::NonZero,
 };
 
 // Creates random BLS keypairs for bench tests
@@ -159,10 +160,11 @@ fn bench_verify_cert(c: &mut Criterion) {
             BenchmarkId::new("Base2_Notarize", size),
             &size,
             |b, &total_validators| {
+                let total_stake = NonZero::new(TEST_STAKE * total_validators as u64).unwrap();
                 b.iter(|| {
                     // The rank_map closure simulates the Bank lookup.
                     // It adds stake (we use 1000 per validator) and returns the pubkey.
-                    let _stake = verify_certificate(&cert_base2, total_validators, |rank| {
+                    verify_certificate(&cert_base2, total_validators, total_stake, |rank| {
                         pubkeys_ref
                             .get(rank)
                             .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
@@ -182,8 +184,9 @@ fn bench_verify_cert(c: &mut Criterion) {
             BenchmarkId::new("Base3_NotarizeFallback", size),
             &size,
             |b, &total_validators| {
+                let total_stake = NonZero::new(TEST_STAKE * total_validators as u64).unwrap();
                 b.iter(|| {
-                    let _stake = verify_certificate(&cert_base3, total_validators, |rank| {
+                    verify_certificate(&cert_base3, total_validators, total_stake, |rank| {
                         pubkeys_ref
                             .get(rank)
                             .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -3,6 +3,7 @@ use qualifier_attr::qualifiers;
 use {
     agave_votor_messages::{
         certificate::{Certificate, CertificateType},
+        fraction::Fraction,
         vote::Vote,
     },
     bitvec::vec::BitVec,
@@ -14,6 +15,7 @@ use {
         signature::AsSignatureAffine,
     },
     solana_signer_store::{DecodeError, Decoded, decode},
+    std::num::NonZero,
     thiserror::Error,
 };
 
@@ -35,6 +37,12 @@ pub enum Error {
     WrongEncoding,
     #[error("overlapping primary and fallback bitmaps")]
     BitmapOverlap,
+    #[error("Not enough stake {aggregate_stake}: {cert_fraction} < {required_fraction}")]
+    NotEnoughStake {
+        aggregate_stake: u64,
+        cert_fraction: Fraction,
+        required_fraction: Fraction,
+    },
 }
 
 /// Verifies an Alpenglow `Certificate` and calculates the total signing stake.
@@ -61,21 +69,18 @@ pub enum Error {
 /// * `cert` - The certificate to verify.
 /// * `max_validators` - The maximum number of validators (used for decoding the bitmap).
 /// * `rank_map` - A closure that maps a validator's rank (index) to their stake and public key.
-///
-/// # Returns
-///
-/// On success, returns the total stake of validators present in the certificate.
 pub fn verify_certificate(
     cert: &Certificate,
     max_validators: usize,
+    total_stake: NonZero<u64>,
     mut rank_map: impl FnMut(usize) -> Option<(u64, PopVerified<BlsPubkeyAffine>)>,
-) -> Result<u64, Error> {
-    let mut total_stake = 0u64;
+) -> Result<(), Error> {
+    let mut aggregate_stake = 0u64;
 
     // Wrap the `rank_map` to accumulate stake as a side-effect
     let accumulating_rank_map = |ind: usize| {
         rank_map(ind).map(|(stake, pubkey)| {
-            total_stake = total_stake.saturating_add(stake);
+            aggregate_stake = aggregate_stake.saturating_add(stake);
             pubkey
         })
     };
@@ -102,8 +107,26 @@ pub fn verify_certificate(
             accumulating_rank_map,
         )
     }?;
+    verify_stake(cert, aggregate_stake, total_stake)?;
+    Ok(())
+}
 
-    Ok(total_stake)
+fn verify_stake(
+    cert: &Certificate,
+    aggregate_stake: u64,
+    total_stake: NonZero<u64>,
+) -> Result<(), Error> {
+    let (required_fraction, _) = cert.cert_type.limits_and_vote_types();
+    let cert_fraction = Fraction::new(aggregate_stake, total_stake);
+    if cert_fraction >= required_fraction {
+        Ok(())
+    } else {
+        Err(Error::NotEnoughStake {
+            aggregate_stake,
+            cert_fraction,
+            required_fraction,
+        })
+    }
 }
 
 fn get_vote_payloads(cert_type: CertificateType) -> (Vote, Option<Vote>) {
@@ -335,15 +358,58 @@ mod test {
             cert_type,
             &(0..6).collect::<Vec<_>>(),
         );
-        assert_eq!(
-            verify_certificate(&cert, 10, |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public))
-            })
-            .unwrap(),
-            600
-        );
+        verify_certificate(&cert, 10, NonZero::new(600).unwrap(), |rank| {
+            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+        })
+        .unwrap();
     }
 
+    #[test]
+    fn test_stake_verification() {
+        let bls_keypairs = create_bls_keypairs(10);
+        let cert_type = CertificateType::Notarize(Block {
+            slot: 10,
+            block_id: Hash::new_unique(),
+        });
+        let per_validator_stake = 100;
+        let num_validators = 10;
+        let total_stake = NonZero::new(per_validator_stake * num_validators as u64).unwrap();
+
+        // with enough stake should succeed.
+        let cert = create_signed_certificate_message(
+            &bls_keypairs,
+            cert_type,
+            &(0..6).collect::<Vec<_>>(),
+        );
+        verify_certificate(&cert, 10, total_stake, |rank| {
+            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+        })
+        .unwrap();
+
+        // not enough stake, should fail.
+        let cert = create_signed_certificate_message(
+            &bls_keypairs,
+            cert_type,
+            &(0..5).collect::<Vec<_>>(),
+        );
+        let Err(err) = verify_certificate(&cert, 10, total_stake, |rank| {
+            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+        }) else {
+            panic!("should fail");
+        };
+        match err {
+            Error::NotEnoughStake {
+                aggregate_stake,
+                cert_fraction,
+                required_fraction,
+            } => {
+                assert_eq!(aggregate_stake, 500);
+                assert_eq!(required_fraction, cert_type.limits_and_vote_types().0);
+                assert_eq!(cert_fraction, Fraction::new(500, total_stake));
+            }
+            rest => panic!("wrong variant {rest:?}"),
+        }
+    }
     #[test]
     fn test_verify_certificate_base3_valid() {
         let bls_keypairs = create_bls_keypairs(10);
@@ -370,13 +436,10 @@ mod test {
             .aggregate(&all_vote_messages)
             .expect("Failed to aggregate votes");
         let cert = builder.build().expect("Failed to build certificate");
-        assert_eq!(
-            verify_certificate(&cert, 10, |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public))
-            })
-            .unwrap(),
-            700
-        );
+        verify_certificate(&cert, 10, NonZero::new(700).unwrap(), |rank| {
+            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+        })
+        .unwrap();
     }
 
     #[test]
@@ -402,7 +465,7 @@ mod test {
             bitmap: encoded_bitmap,
         };
         assert_eq!(
-            verify_certificate(&cert, 10, |rank| {
+            verify_certificate(&cert, 10, NonZero::new(1000).unwrap(), |rank| {
                 bls_keypairs.get(rank).map(|kp| (100, kp.public))
             })
             .unwrap_err(),
@@ -427,15 +490,17 @@ mod test {
         builder.aggregate(&vote_msgs).unwrap();
         let cert = builder.build().unwrap();
         let per_validator_stake = 100;
-        assert_eq!(
-            verify_certificate(&cert, 10, |rank| {
+        verify_certificate(
+            &cert,
+            10,
+            NonZero::new(per_validator_stake * max_validators as u64).unwrap(),
+            |rank| {
                 bls_keypairs
                     .get(rank)
                     .map(|kp| (per_validator_stake, kp.public))
-            })
-            .unwrap(),
-            per_validator_stake * max_validators as u64
-        );
+            },
+        )
+        .unwrap();
     }
 
     #[test]
@@ -570,7 +635,8 @@ mod test {
         // Must fail at the signature stage (not via a decode / missing-rank path),
         // proving the extra validator cannot be smuggled in.
         assert_eq!(
-            verify_certificate(&cert, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
     }
@@ -588,7 +654,8 @@ mod test {
         cert.bitmap = encoded_base2_bitmap(&[0, 1, 2, 3, 4], 6);
 
         assert_eq!(
-            verify_certificate(&cert, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
     }
@@ -612,7 +679,8 @@ mod test {
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
     }
@@ -629,7 +697,8 @@ mod test {
 
         // An empty signer set cannot produce a valid aggregate signature.
         assert_eq!(
-            verify_certificate(&cert, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::EmptyAggregation)
         );
     }
@@ -644,7 +713,8 @@ mod test {
         let cert = unsigned_cert(CertificateType::Notarize(fresh_block(10)), bitmap);
 
         assert_eq!(
-            verify_certificate(&cert, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::WrongEncoding
         );
     }
@@ -659,7 +729,7 @@ mod test {
         let cert = create_signed_certificate_message(&keypairs, cert_type, &[0, 1, 2, 3, 4, 5]);
 
         // rank_map returns None for rank 3, simulating an unknown/unstaked validator.
-        let result = verify_certificate(&cert, 10, |rank| {
+        let result = verify_certificate(&cert, 10, NonZero::new(10).unwrap(), |rank| {
             if rank == 3 {
                 None
             } else {
@@ -684,7 +754,8 @@ mod test {
         );
 
         assert_eq!(
-            verify_certificate(&cert, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::Decode(DecodeError::CorruptDataPayload)
         );
     }
@@ -702,7 +773,8 @@ mod test {
             let cert = unsigned_cert(CertificateType::Notarize(fresh_block(10)), bitmap);
             // Must return (Ok/Err) without panicking; a zero signature can never
             // produce a valid certificate, so the result must be an error.
-            assert!(verify_certificate(&cert, 10, rank_map(&keypairs)).is_err());
+            verify_certificate(&cert, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err();
         }
     }
 
@@ -724,7 +796,8 @@ mod test {
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
     }
@@ -745,7 +818,8 @@ mod test {
         };
 
         assert_eq!(
-            verify_certificate(&forged, 10, rank_map(&keypairs)).unwrap_err(),
+            verify_certificate(&forged, 10, NonZero::new(10).unwrap(), rank_map(&keypairs))
+                .unwrap_err(),
             Error::VerifySig(BlsError::VerificationFailed)
         );
     }

--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -7,10 +7,7 @@ use {
         utils::send_certs_to_pool,
     },
     agave_bls_cert_verify::cert_verify::Error as BlsCertVerifyError,
-    agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
-        fraction::Fraction,
-    },
+    agave_votor_messages::certificate::{Certificate, CertificateType},
     crossbeam_channel::Sender,
     log::info,
     rayon::{
@@ -22,7 +19,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::nonblocking::simple_qos::SimpleQosBanlist,
-    std::{collections::HashSet, num::NonZero},
+    std::collections::HashSet,
     thiserror::Error,
 };
 
@@ -36,12 +33,6 @@ pub(super) struct CertPayload {
 enum CertVerifyError {
     #[error("Cert Verification Error {0}")]
     CertVerifyFailed(#[from] BlsCertVerifyError),
-    #[error("Not enough stake {aggregate_stake}: {cert_fraction} < {required_fraction}")]
-    NotEnoughStake {
-        aggregate_stake: u64,
-        cert_fraction: Fraction,
-        required_fraction: Fraction,
-    },
     #[error("discarding cert with slot {cert_slot} too far in future from root slot {root_slot}")]
     TooFarInFuture { cert_slot: Slot, root_slot: Slot },
 }
@@ -125,8 +116,7 @@ fn verify_certs(
             }
             Err(e) => {
                 match &e {
-                    CertVerifyError::NotEnoughStake { .. }
-                    | CertVerifyError::CertVerifyFailed(_) => {
+                    CertVerifyError::CertVerifyFailed(_) => {
                         if banlist.ban(cert_payload.sender_identity_pubkey, BAN_TIMEOUT) {
                             stats.already_banned += 1;
                         } else {
@@ -140,11 +130,8 @@ fn verify_certs(
                 }
 
                 match e {
-                    CertVerifyError::NotEnoughStake { .. } => {
-                        stats.stake_verification_failed += 1;
-                    }
                     CertVerifyError::CertVerifyFailed(_) => {
-                        stats.signature_verification_failed += 1;
+                        stats.certificate_verification_failed += 1;
                     }
                     CertVerifyError::TooFarInFuture { .. } => {
                         stats.too_far_in_future += 1;
@@ -166,25 +153,6 @@ fn verify_cert(cert: &Certificate, root_bank: &Bank) -> Result<(), CertVerifyErr
             root_slot,
         });
     }
-    let (aggregate_stake, total_stake) = root_bank.verify_certificate(cert)?;
-    debug_assert!(aggregate_stake <= total_stake.get());
-    verify_stake(cert, aggregate_stake, total_stake)
-}
-
-fn verify_stake(
-    cert: &Certificate,
-    aggregate_stake: u64,
-    total_stake: NonZero<u64>,
-) -> Result<(), CertVerifyError> {
-    let (required_fraction, _) = cert.cert_type.limits_and_vote_types();
-    let cert_fraction = Fraction::new(aggregate_stake, total_stake);
-    if cert_fraction >= required_fraction {
-        Ok(())
-    } else {
-        Err(CertVerifyError::NotEnoughStake {
-            aggregate_stake,
-            cert_fraction,
-            required_fraction,
-        })
-    }
+    root_bank.verify_certificate(cert)?;
+    Ok(())
 }

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -1039,37 +1039,6 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_certificate_base2_not_enough_stake() {
-        let mut ctx = TestContext::new();
-
-        // < 60% of validators sign the cert
-        assert!(ctx.validator_keypairs.len() >= 2);
-        let num_signers = (ctx.validator_keypairs.len() * 6) / 10 - 1;
-        let cert_type = CertificateType::Notarize(Block {
-            slot: 10,
-            block_id: Hash::new_unique(),
-        });
-        let cert = create_signed_certificate_message(
-            &ctx.validator_keypairs,
-            cert_type,
-            &(0..num_signers).collect::<Vec<_>>(),
-        );
-        let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
-
-        // The call still succeeds, but the packet is marked for discard.
-        ctx.verifier
-            .verify_and_send_batches(packet_batches)
-            .unwrap();
-        assert_eq!(
-            ctx.pool_receiver.try_iter().count(),
-            0,
-            "This certificate should be invalid"
-        );
-        assert_eq!(ctx.verifier.stats.cert_stats.stake_verification_failed.0, 1);
-    }
-
-    #[test]
     fn test_verify_certificate_base3_valid() {
         let mut ctx = TestContext::new();
 
@@ -1162,53 +1131,6 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_certificate_base3_not_enough_stake() {
-        let mut ctx = TestContext::new();
-
-        let slot = 20;
-        let block_hash = Hash::new_unique();
-        let block = Block {
-            slot,
-            block_id: block_hash,
-        };
-        let notarize_vote = Vote::new_notarization_vote(block);
-        let notarize_fallback_vote = Vote::new_notarization_fallback_vote(block);
-        let mut all_vote_messages = Vec::new();
-        (0..4).for_each(|i| {
-            all_vote_messages.push(create_signed_vote_message(
-                &ctx.validator_keypairs,
-                notarize_vote,
-                i,
-            ))
-        });
-        (4..5).for_each(|i| {
-            all_vote_messages.push(create_signed_vote_message(
-                &ctx.validator_keypairs,
-                notarize_fallback_vote,
-                i,
-            ))
-        });
-        let cert_type = CertificateType::NotarizeFallback(block);
-        let mut builder = CertificateBuilder::new(cert_type);
-        builder
-            .aggregate(&all_vote_messages)
-            .expect("Failed to aggregate votes");
-        let cert = builder.build().expect("Failed to build certificate");
-        let consensus_message = ConsensusMessage::Certificate(cert);
-        let packet_batches = messages_to_batches(&[consensus_message]);
-
-        ctx.verifier
-            .verify_and_send_batches(packet_batches)
-            .unwrap();
-        assert_eq!(
-            ctx.pool_receiver.try_iter().count(),
-            0,
-            "This certificate should be invalid"
-        );
-        assert_eq!(ctx.verifier.stats.cert_stats.stake_verification_failed.0, 1);
-    }
-
-    #[test]
     fn test_verify_certificate_invalid_signature() {
         let mut ctx = TestContext::new();
 
@@ -1243,7 +1165,7 @@ mod tests {
             ctx.verifier
                 .stats
                 .cert_stats
-                .signature_verification_failed
+                .certificate_verification_failed
                 .0,
             1
         );

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -195,10 +195,8 @@ pub(super) struct SigVerifyCertStats {
     /// Number of times we are banning a validator that was already banned.
     pub(super) already_banned: Saturating<u64>,
 
-    /// Number of times stake verification failed on a cert.
-    pub(super) stake_verification_failed: Saturating<u64>,
-    /// Number of times signature verification failed on a cert.
-    pub(super) signature_verification_failed: Saturating<u64>,
+    /// Number of times cert verification failed.
+    pub(super) certificate_verification_failed: Saturating<u64>,
     /// Number of times the cert was too far in the future and discarded.
     pub(super) too_far_in_future: Saturating<u64>,
 
@@ -220,8 +218,7 @@ impl SigVerifyCertStats {
             sig_verified_certs,
             unnecessary_certs_verified,
             already_banned,
-            stake_verification_failed,
-            signature_verification_failed,
+            certificate_verification_failed,
             too_far_in_future,
             pool_outstanding_msgs,
             pool_sent,
@@ -232,8 +229,7 @@ impl SigVerifyCertStats {
         self.sig_verified_certs += sig_verified_certs;
         self.unnecessary_certs_verified += unnecessary_certs_verified;
         self.already_banned += already_banned;
-        self.stake_verification_failed += stake_verification_failed;
-        self.signature_verification_failed += signature_verification_failed;
+        self.certificate_verification_failed += certificate_verification_failed;
         self.too_far_in_future += too_far_in_future;
         self.pool_outstanding_msgs += pool_outstanding_msgs;
         self.pool_sent += pool_sent;
@@ -248,8 +244,7 @@ impl SigVerifyCertStats {
             sig_verified_certs,
             unnecessary_certs_verified,
             already_banned,
-            stake_verification_failed,
-            signature_verification_failed,
+            certificate_verification_failed,
             too_far_in_future,
             pool_outstanding_msgs,
             pool_sent,
@@ -268,13 +263,8 @@ impl SigVerifyCertStats {
             ),
             ("already_banned", already_banned.0, i64),
             (
-                "stake_verification_failed",
-                stake_verification_failed.0,
-                i64
-            ),
-            (
-                "signature_verification_failed",
-                signature_verification_failed.0,
+                "certificate_verification_failed",
+                certificate_verification_failed.0,
                 i64
             ),
             ("too_far_in_future", too_far_in_future.0, i64),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5706,12 +5706,10 @@ impl Bank {
     }
 
     /// Verify a BLS certificate's signature using this bank's epoch stakes.
-    ///
-    /// Returns (stake present in certificate, total stake in validator set) on success.
     pub fn verify_certificate(
         &self,
         cert: &Certificate,
-    ) -> std::result::Result<(u64, NonZero<u64>), CertVerifyError> {
+    ) -> std::result::Result<(), CertVerifyError> {
         let slot = cert.cert_type.slot();
         let epoch_stakes = self
             .epoch_stakes_from_slot(slot)
@@ -5720,13 +5718,13 @@ impl Bank {
         let total_stake =
             NonZero::new(key_to_rank_map.total_stake()).expect("total stake cannot be 0");
 
-        let stake = cert_verify::verify_certificate(cert, key_to_rank_map.len(), |rank| {
+        cert_verify::verify_certificate(cert, key_to_rank_map.len(), total_stake, |rank| {
             key_to_rank_map
                 .get_pubkey_stake_entry(rank)
                 .map(|entry| (entry.stake, entry.bls_pubkey))
         })?;
 
-        Ok((stake, total_stake))
+        Ok(())
     }
 
     pub fn epoch_stakes_map(&self) -> &HashMap<Epoch, VersionedEpochStakes> {

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -11,10 +11,7 @@ use {
         validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
     },
     agave_votor_messages::{
-        certificate::Certificate,
-        consensus_message::ConsensusMessage,
-        fraction::Fraction,
-        migration::{GENESIS_VOTE_THRESHOLD, MigrationStatus},
+        certificate::Certificate, consensus_message::ConsensusMessage, migration::MigrationStatus,
     },
     crossbeam_channel::Sender,
     log::*,
@@ -288,23 +285,13 @@ impl BlockComponentProcessor {
         debug_assert!(cert.cert_type.is_genesis());
 
         let cert_slot = cert.cert_type.slot();
-        let (genesis_stake, total_stake) = bank.verify_certificate(cert).map_err(|_| {
+        bank.verify_certificate(cert).map_err(|_| {
             warn!(
                 "Failed to verify genesis certificate for slot {cert_slot} in bank slot {}",
                 bank.slot()
             );
             BlockComponentProcessorError::GenesisCertificateFailedVerification
         })?;
-
-        let genesis_percent = Fraction::new(genesis_stake, total_stake);
-        if genesis_percent < GENESIS_VOTE_THRESHOLD {
-            warn!(
-                "Received a genesis certificate for slot {cert_slot} in bank slot {} with \
-                 {genesis_percent} stake < {GENESIS_VOTE_THRESHOLD}",
-                bank.slot()
-            );
-            return Err(BlockComponentProcessorError::GenesisCertificateFailedVerification);
-        }
 
         Ok(())
     }

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -9,15 +9,13 @@ use {
     agave_votor_messages::{
         certificate::{Certificate, CertificateType},
         consensus_message::Block,
-        fraction::Fraction,
     },
-    log::warn,
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
     solana_entry::block_component::{BlockFinalizationCert, VotesAggregate},
     solana_pubkey::Pubkey,
     solana_signer_store::{DecodeError, Decoded, decode},
-    std::{collections::HashSet, num::NonZero},
+    std::collections::HashSet,
     thiserror::Error,
 };
 
@@ -29,16 +27,8 @@ pub enum BlockFinalizationCertError {
     BlsError(CertificateType, BlsError),
 
     /// Certificate signature verification failed
-    #[error("Certificate signature for {0:?} verification failed")]
-    SignatureVerificationFailed(CertificateType),
-
-    /// Insufficient stake for finalization
-    #[error("Insufficient stake for {cert:?}: got {got}, required {required}")]
-    InsufficientStake {
-        cert: CertificateType,
-        got: Fraction,
-        required: Fraction,
-    },
+    #[error("Certificate verification for {0:?} failed")]
+    CertificateVerificationFailed(CertificateType),
 
     /// Missing epoch stakes for slot
     #[error("Missing epoch stakes for {0:?}")]
@@ -122,41 +112,8 @@ impl ValidatedBlockFinalizationCert {
             };
 
             // Verify both certificates
-            let (notarize_stake, total_stake) = Self::verify_certificate(bank, &notarize_cert)?;
-            let (finalize_stake, _) = Self::verify_certificate(bank, &finalize_cert)?;
-
-            let notarize_percent = Fraction::new(notarize_stake, total_stake);
-            let finalize_percent = Fraction::new(finalize_stake, total_stake);
-            let notarize_threshold = notarize_cert.cert_type.limits_and_vote_types().0;
-            let finalize_threshold = finalize_cert.cert_type.limits_and_vote_types().0;
-
-            if notarize_percent < notarize_threshold {
-                warn!(
-                    "Received a slow finalization in the footer for block {block:?} in bank slot \
-                     {} with notarize {notarize_percent} stake expecting at least \
-                     {notarize_threshold}",
-                    bank.slot()
-                );
-                return Err(BlockFinalizationCertError::InsufficientStake {
-                    cert: notarize_cert_type,
-                    got: notarize_percent,
-                    required: notarize_threshold,
-                });
-            }
-
-            if finalize_percent < finalize_threshold {
-                warn!(
-                    "Received a slow finalization in the footer for block {block:?} in bank slot \
-                     {} with finalize {finalize_percent} stake expecting at least \
-                     {finalize_threshold}",
-                    bank.slot()
-                );
-                return Err(BlockFinalizationCertError::InsufficientStake {
-                    cert: finalize_cert_type,
-                    got: finalize_percent,
-                    required: finalize_threshold,
-                });
-            }
+            Self::verify_certificate(bank, &notarize_cert)?;
+            Self::verify_certificate(bank, &finalize_cert)?;
 
             let signers = Self::extract_signers(bank, &finalize_cert)?;
             Ok(Self {
@@ -181,24 +138,7 @@ impl ValidatedBlockFinalizationCert {
                 bitmap: block_final_cert.final_aggregate.into_bitmap(),
             };
 
-            let (finalize_stake, total_stake) =
-                Self::verify_certificate(bank, &fast_finalize_cert)?;
-
-            let finalize_percent = Fraction::new(finalize_stake, total_stake);
-            let finalize_threshold = fast_finalize_cert.cert_type.limits_and_vote_types().0;
-
-            if finalize_percent < finalize_threshold {
-                warn!(
-                    "Received a fast finalization in the footer for block {block:?} in bank slot \
-                     {} with {finalize_percent} stake expecting at least {finalize_threshold}",
-                    bank.slot()
-                );
-                return Err(BlockFinalizationCertError::InsufficientStake {
-                    cert: fast_finalize_cert_type,
-                    got: finalize_percent,
-                    required: finalize_threshold,
-                });
-            }
+            Self::verify_certificate(bank, &fast_finalize_cert)?;
 
             let signers = Self::extract_signers(bank, &fast_finalize_cert)?;
             Ok(Self {
@@ -359,9 +299,11 @@ impl ValidatedBlockFinalizationCert {
     fn verify_certificate(
         bank: &Bank,
         cert: &Certificate,
-    ) -> Result<(u64, NonZero<u64>), BlockFinalizationCertError> {
-        bank.verify_certificate(cert)
-            .map_err(|_| BlockFinalizationCertError::SignatureVerificationFailed(cert.cert_type))
+    ) -> Result<(), BlockFinalizationCertError> {
+        bank.verify_certificate(cert).map_err(|_| {
+            BlockFinalizationCertError::CertificateVerificationFailed(cert.cert_type)
+        })?;
+        Ok(())
     }
 
     fn extract_signers(
@@ -572,13 +514,14 @@ mod tests {
                 notar_aggregate: None,
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
+            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
+                .unwrap_err();
             assert!(
                 matches!(
-                    result,
-                    Err(BlockFinalizationCertError::InsufficientStake { .. })
+                    err,
+                    BlockFinalizationCertError::CertificateVerificationFailed { .. }
                 ),
-                "Fast finalize with insufficient stake should fail verification"
+                "Fast finalize with insufficient stake should fail verification.  {err:?}"
             );
         }
 
@@ -613,11 +556,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
+            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
+                .unwrap_err();
             assert!(
                 matches!(
-                    result,
-                    Err(BlockFinalizationCertError::InsufficientStake { .. })
+                    err,
+                    BlockFinalizationCertError::CertificateVerificationFailed { .. }
                 ),
                 "Slow finalize with insufficient notarize stake should fail verification"
             );
@@ -656,11 +600,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
+            let err = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
+                .unwrap_err();
             assert!(
                 matches!(
-                    result,
-                    Err(BlockFinalizationCertError::InsufficientStake { .. })
+                    err,
+                    BlockFinalizationCertError::CertificateVerificationFailed { .. }
                 ),
                 "Slow finalize with insufficient finalize stake should fail verification"
             );


### PR DESCRIPTION
#### Problem

bls-cert-verify is just verifying the signatures on the stake.  However, all the callers of this module need to additionally verify the aggregate stake as well.  This leads to a lot of duplicate checks and adds complexity to APIs.


#### Summary of Changes

- Updates bls-cert-verify to verify stake and signatures. 
- Updates all its callers


#### Testing

- since stake verification unit tests from bls-sigverify were removed, adds a new one to bls-cert-verify
