### PR TITLE
runtime: Refactor intermediate types for SIMD-0123

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1,10 +1,11 @@
 use {
     super::{
         Bank, CachedVoteAccounts, CalculateValidatorRewardsResult, EpochRewardCalculateParamInfo,
-        PartitionedRewardsCalculation, PartitionedStakeReward, PartitionedStakeRewards,
-        REWARD_CALCULATION_NUM_BLOCKS, RewardCommission, RewardCommissionAccounts,
-        RewardCommissionAccountsStorable, RewardCommissionLamportAmounts, RewardCommissions,
-        StakeRewardCalculation, epoch_rewards_hasher::hash_rewards_into_partitions,
+        InflationReward, PartitionedRewardsCalculation, PartitionedStakeReward,
+        PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS, RewardCommission,
+        RewardCommissionAccounts, RewardCommissionAccountsStorable, RewardCommissionLamportAmounts,
+        RewardCommissions, StakeRewardCalculation,
+        epoch_rewards_hasher::hash_rewards_into_partitions,
     },
     crate::{
         alpenglow_epoch_type::{AlpenglowEpochType, RewardEpochDelegatedStakes},
@@ -42,8 +43,8 @@ use {
 };
 
 #[derive(Debug)]
-struct DelegationRewards {
-    stake_reward: PartitionedStakeReward,
+struct InflationRewardWithCommission {
+    inflation: InflationReward,
     commission_pubkey: Pubkey,
     reward_commission: RewardCommission,
 }
@@ -535,7 +536,7 @@ impl Bank {
         ag_epoch_type: &AlpenglowEpochType,
         custom_commission_collector: bool,
         use_fixed_point_stake_math: bool,
-    ) -> Option<DelegationRewards> {
+    ) -> Option<InflationRewardWithCommission> {
         // curry closure to add the contextual stake_pubkey
         let reward_calc_tracer = reward_calc_tracer.as_ref().map(|outer| {
             // inner
@@ -550,7 +551,6 @@ impl Bank {
             distribution_epoch_vote_accounts,
         } = cached_vote_accounts;
 
-        let stake_pubkey = *stake_pubkey;
         let vote_pubkey = stake_account.delegation().voter_pubkey;
 
         let current_lamports = stake_account.lamports();
@@ -575,8 +575,7 @@ impl Bank {
                 );
                 if stake_was_adjusted {
                     debug!("delegation for stake {stake_pubkey} was adjusted");
-                    let stake_reward = PartitionedStakeReward {
-                        stake_pubkey,
+                    let inflation = InflationReward {
                         stake,
                         stake_reward: 0,
                         commission_bps: (!custom_commission_collector).then_some(0),
@@ -590,8 +589,8 @@ impl Bank {
                         burned_lamports: 0,
                         is_vote_account: false,
                     };
-                    return Some(DelegationRewards {
-                        stake_reward,
+                    return Some(InflationRewardWithCommission {
+                        inflation,
                         commission_pubkey: vote_pubkey,
                         reward_commission,
                     });
@@ -647,8 +646,7 @@ impl Bank {
             minimum_lamports,
         ) {
             Ok((stake_reward, commission_lamports, stake)) => {
-                let stake_reward = PartitionedStakeReward {
-                    stake_pubkey,
+                let inflation = InflationReward {
                     stake,
                     stake_reward,
                     commission_bps: (!custom_commission_collector).then_some(commission_bps),
@@ -667,8 +665,8 @@ impl Bank {
                     burned_lamports: 0,
                     is_vote_account,
                 };
-                Some(DelegationRewards {
-                    stake_reward,
+                Some(InflationRewardWithCommission {
+                    inflation,
                     commission_pubkey,
                     reward_commission,
                 })
@@ -741,14 +739,17 @@ impl Bank {
 
                     let (stake_reward, maybe_reward_record) = match maybe_reward_record {
                         Some(res) => {
-                            let DelegationRewards {
-                                stake_reward,
+                            let InflationRewardWithCommission {
+                                inflation,
                                 commission_pubkey,
                                 reward_commission,
                             } = res;
-                            let stakers_reward = stake_reward.stake_reward;
+                            let stakers_reward = inflation.stake_reward;
                             (
-                                Some(stake_reward),
+                                Some(PartitionedStakeReward {
+                                    stake_pubkey: **stake_pubkey,
+                                    inflation,
+                                }),
                                 Some((stakers_reward, commission_pubkey, reward_commission)),
                             )
                         }
@@ -2074,10 +2075,12 @@ mod tests {
             stake.credits_observed = vote_state.credits();
             stake.delegation.stake += stake_reward;
             PartitionedStakeReward {
-                stake,
                 stake_pubkey,
-                stake_reward,
-                commission_bps: None,
+                inflation: InflationReward {
+                    stake,
+                    stake_reward,
+                    commission_bps: None,
+                },
             }
         };
         assert_eq!(
@@ -2443,8 +2446,8 @@ mod tests {
         assert_eq!(original_rewards.len(), 2);
         let (paid_index, paid_reward) = original_rewards[0];
         let (unpaid_index, unpaid_reward) = original_rewards[1];
-        assert!(paid_reward.stake_reward > 0);
-        assert!(unpaid_reward.stake_reward > 0);
+        assert!(paid_reward.inflation.stake_reward > 0);
+        assert!(unpaid_reward.inflation.stake_reward > 0);
 
         // Force exactly one stake reward to be distributed before simulating
         // snapshot restore. That write updates StakesCache with a larger
@@ -2468,7 +2471,7 @@ mod tests {
             .expect("unpaid stake reward must still be pending after recalculation");
 
         assert_eq!(
-            unpaid_reward.stake_reward, recalculated_unpaid_reward.stake_reward,
+            unpaid_reward.inflation.stake_reward, recalculated_unpaid_reward.inflation.stake_reward,
             "recalculation after partial distribution must use the same AG delegated stake \
              denominator as the original epoch-boundary calculation"
         );

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -41,8 +41,8 @@ enum DistributionError {
 }
 
 struct DistributionResults {
-    lamports_distributed: u64,
-    lamports_burned: u64,
+    stake_reward_lamports_minted: u64,
+    stake_reward_lamports_burned: u64,
     updated_stake_rewards: StakeRewards,
 }
 
@@ -151,18 +151,21 @@ impl Bank {
         let pre_capitalization = self.capitalization();
         let (
             DistributionResults {
-                lamports_distributed,
-                lamports_burned,
+                stake_reward_lamports_minted,
+                stake_reward_lamports_burned,
                 updated_stake_rewards,
             },
             store_stake_accounts_us,
         ) = measure_us!(self.store_stake_accounts_in_partition(partition_rewards, partition_index));
 
         // increase total capitalization by the distributed rewards
-        self.capitalization.fetch_add(lamports_distributed, Relaxed);
+        self.capitalization
+            .fetch_add(stake_reward_lamports_minted, Relaxed);
 
         // decrease distributed capital from epoch rewards sysvar
-        self.update_epoch_rewards_sysvar(lamports_distributed + lamports_burned);
+        self.update_epoch_rewards_sysvar(
+            stake_reward_lamports_minted + stake_reward_lamports_burned,
+        );
 
         // update reward history for this partitioned distribution
         self.update_reward_history_in_partition(&updated_stake_rewards);
@@ -175,8 +178,8 @@ impl Bank {
             partition_index,
             store_stake_accounts_us,
             store_stake_accounts_count: updated_stake_rewards.len(),
-            distributed_rewards: lamports_distributed,
-            burned_rewards: lamports_burned,
+            distributed_rewards: stake_reward_lamports_minted,
+            burned_rewards: stake_reward_lamports_burned,
         };
 
         report_partitioned_reward_metrics(self, metrics);
@@ -219,12 +222,12 @@ impl Bank {
             )
         };
         account
-            .checked_add_lamports(partitioned_stake_reward.stake_reward)
+            .checked_add_lamports(partitioned_stake_reward.inflation.stake_reward)
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
         if adjust_delegations_for_rent {
             let minimum_balance = rent.minimum_balance(account.data().len());
             assert!(
-                partitioned_stake_reward.stake.delegation.stake
+                partitioned_stake_reward.inflation.stake.delegation.stake
                     <= account.lamports().saturating_sub(minimum_balance),
                 "stake reward delegation must be consistent with the updated stake account \
                  lamport balance"
@@ -233,9 +236,9 @@ impl Bank {
             let expected_delegation = stake
                 .delegation
                 .stake
-                .saturating_add(partitioned_stake_reward.stake_reward);
+                .saturating_add(partitioned_stake_reward.inflation.stake_reward);
             assert_eq!(
-                expected_delegation, partitioned_stake_reward.stake.delegation.stake,
+                expected_delegation, partitioned_stake_reward.inflation.stake.delegation.stake,
                 "stake reward delegation must be consistent with the updated stake account \
                  lamport balance"
             );
@@ -243,13 +246,13 @@ impl Bank {
         account
             .set_state(&StakeStateV2::Stake(
                 meta,
-                partitioned_stake_reward.stake,
+                partitioned_stake_reward.inflation.stake,
                 flags,
             ))
             .map_err(|_| DistributionError::UnableToSetState)?;
 
         let stake_at_distribution_epoch = delegation_effective_stake(
-            &partitioned_stake_reward.stake.delegation,
+            &partitioned_stake_reward.inflation.stake.delegation,
             distribution_epoch,
             stake_history,
             new_warmup_cooldown_rate_epoch,
@@ -264,9 +267,9 @@ impl Bank {
             stake_pubkey: partitioned_stake_reward.stake_pubkey,
             stake_reward_info: StakeRewardInfo {
                 reward_type,
-                lamports: i64::try_from(partitioned_stake_reward.stake_reward).unwrap(),
+                lamports: i64::try_from(partitioned_stake_reward.inflation.stake_reward).unwrap(),
                 post_balance: account.lamports(),
-                commission_bps: partitioned_stake_reward.commission_bps,
+                commission_bps: partitioned_stake_reward.inflation.commission_bps,
             },
             stake_account: account,
         })
@@ -292,8 +295,8 @@ impl Bank {
         let adjust_delegations_for_rent = feature_snapshot.relax_post_exec_min_balance_check;
         let use_fixed_point_stake_math = feature_snapshot.upgrade_bpf_stake_program_to_v5_1;
 
-        let mut lamports_distributed = 0;
-        let mut lamports_burned = 0;
+        let mut stake_reward_lamports_minted = 0;
+        let mut stake_reward_lamports_burned = 0;
         let indices = partition_rewards
             .partition_indices
             .get(partition_index as usize)
@@ -324,7 +327,8 @@ impl Bank {
                     panic!("partition reward {index} is empty");
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
-            let reward_amount = partitioned_stake_reward.stake_reward;
+            let stake_reward_amount = partitioned_stake_reward.inflation.stake_reward;
+
             match Self::build_updated_stake_reward(
                 self.epoch,
                 stake_history,
@@ -336,23 +340,23 @@ impl Bank {
                 use_fixed_point_stake_math,
             ) {
                 Ok(stake_reward) => {
-                    lamports_distributed += reward_amount;
+                    stake_reward_lamports_minted += stake_reward_amount;
                     updated_stake_rewards.push(stake_reward);
                 }
                 Err(err) => {
                     error!(
                         "bank::distribution::store_stake_accounts_in_partition() failed for \
-                         {stake_pubkey}, {reward_amount} lamports burned: {err:?}"
+                         {stake_pubkey}, {stake_reward_amount} lamports burned: {err:?}"
                     );
-                    lamports_burned += reward_amount;
+                    stake_reward_lamports_burned += stake_reward_amount;
                 }
             }
         }
         drop(stakes_cache);
         self.store_accounts((self.slot(), &updated_stake_rewards[..]));
         DistributionResults {
-            lamports_distributed,
-            lamports_burned,
+            stake_reward_lamports_minted,
+            stake_reward_lamports_burned,
             updated_stake_rewards,
         }
     }
@@ -365,7 +369,7 @@ mod tests {
         crate::{
             bank::{
                 partitioned_epoch_rewards::{
-                    PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS,
+                    InflationReward, PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS,
                     epoch_rewards_hasher::hash_rewards_into_partitions, tests::convert_rewards,
                 },
                 tests::create_genesis_config,
@@ -506,15 +510,15 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
 
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
-        let total_rewards = 1_000_000_000;
+        let inflation_rewards = 1_000_000_000;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
-        let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+        let total_points = (inflation_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
         bank.create_epoch_rewards_sysvar(
             0,
             42,
             num_partitions,
             &PointValue {
-                rewards: total_rewards,
+                rewards: inflation_rewards,
                 points: total_points,
             },
         );
@@ -553,7 +557,7 @@ mod tests {
 
         let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
             from_account(&post_epoch_rewards_account).unwrap();
-        assert_eq!(epoch_rewards.total_rewards, total_rewards);
+        assert_eq!(epoch_rewards.total_rewards, inflation_rewards);
         assert_eq!(epoch_rewards.distributed_rewards, rewards_to_distribute,);
 
         // Assert that the bank total capital changed by the amount of rewards
@@ -605,14 +609,14 @@ mod tests {
 
         for i in 0..num_partitions {
             let DistributionResults {
-                lamports_distributed,
+                stake_reward_lamports_minted,
                 updated_stake_rewards,
                 ..
             } = bank.store_stake_accounts_in_partition(&partitioned_rewards, i as u64);
             let num_history_updates =
                 bank.update_reward_history_in_partition(&updated_stake_rewards);
             assert_eq!(updated_stake_rewards.len(), num_history_updates);
-            total_rewards += lamports_distributed;
+            total_rewards += stake_reward_lamports_minted;
             total_num_updates += num_history_updates;
         }
 
@@ -715,9 +719,11 @@ mod tests {
         let nonexistent_account = Pubkey::new_unique();
         let partitioned_stake_reward = PartitionedStakeReward {
             stake_pubkey: nonexistent_account,
-            stake: new_stake,
-            stake_reward,
-            commission_bps: Some(commission_bps),
+            inflation: InflationReward {
+                stake: new_stake,
+                stake_reward,
+                commission_bps: Some(commission_bps),
+            },
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -753,9 +759,11 @@ mod tests {
         bank.store_account(&overflowing_account, &stake_account);
         let partitioned_stake_reward = PartitionedStakeReward {
             stake_pubkey: overflowing_account,
-            stake: new_stake,
-            stake_reward,
-            commission_bps: Some(commission_bps),
+            inflation: InflationReward {
+                stake: new_stake,
+                stake_reward,
+                commission_bps: Some(commission_bps),
+            },
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -801,9 +809,11 @@ mod tests {
         bank.store_account(&successful_account, &stake_account);
         let partitioned_stake_reward = PartitionedStakeReward {
             stake_pubkey: successful_account,
-            stake: new_stake,
-            stake_reward,
-            commission_bps: Some(commission_bps),
+            inflation: InflationReward {
+                stake: new_stake,
+                stake_reward,
+                commission_bps: Some(commission_bps),
+            },
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -883,9 +893,11 @@ mod tests {
         bank.store_account(&deactivating_account, &stake_account);
         let partitioned_stake_reward = PartitionedStakeReward {
             stake_pubkey: deactivating_account,
-            stake: deactivating_stake,
-            stake_reward,
-            commission_bps: Some(commission_bps),
+            inflation: InflationReward {
+                stake: deactivating_stake,
+                stake_reward,
+                commission_bps: Some(commission_bps),
+            },
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -957,7 +969,7 @@ mod tests {
 
         let expected_total = converted_rewards
             .enumerated_rewards_iter()
-            .map(|(_, stake_reward)| stake_reward.stake_reward)
+            .map(|(_, reward)| reward.inflation.stake_reward)
             .sum::<u64>();
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
@@ -967,10 +979,10 @@ mod tests {
         };
 
         let DistributionResults {
-            lamports_distributed,
+            stake_reward_lamports_minted,
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
-        assert_eq!(expected_total, lamports_distributed);
+        assert_eq!(expected_total, stake_reward_lamports_minted);
     }
 
     #[test]
@@ -987,10 +999,10 @@ mod tests {
         let expected_total = 0;
 
         let DistributionResults {
-            lamports_distributed,
+            stake_reward_lamports_minted,
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
-        assert_eq!(expected_total, lamports_distributed);
+        assert_eq!(expected_total, stake_reward_lamports_minted);
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -25,7 +25,7 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
-/// Total reward for a stake account, divided between inflation and block rewards
+/// Total reward for a stake account, currently just inflation rewards.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -25,10 +25,18 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
+/// Total reward for a stake account, divided between inflation and block rewards
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address
     pub stake_pubkey: Pubkey,
+    /// Inflation reward information
+    pub inflation: InflationReward,
+}
+
+/// Just the inflation portion of a partitioned stake reward
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct InflationReward {
     /// `Stake` state to be stored in account
     pub stake: Stake,
     /// Stake reward for recording in the Bank on distribution
@@ -450,9 +458,11 @@ mod tests {
             {
                 Some(Self {
                     stake_pubkey: stake_reward.stake_pubkey,
-                    stake,
-                    stake_reward: stake_reward.stake_reward_info.lamports as u64,
-                    commission_bps: stake_reward.stake_reward_info.commission_bps,
+                    inflation: InflationReward {
+                        stake,
+                        stake_reward: stake_reward.stake_reward_info.lamports as u64,
+                        commission_bps: stake_reward.stake_reward_info.commission_bps,
+                    },
                 })
             } else {
                 None


### PR DESCRIPTION
#### Problem

SIMD-0123 adds another step for block rewards during partitioned epoch rewards, but the current types only assume inflation rewards.

#### Summary of changes

For a cleaner separation of concerns, refactor some types lightly. This makes it easier to add block reward fields in the future.

#### Testing

Just a refactor, so existing unit tests and compiler is enough.