### PR TITLE
Use ahash for hot HashMap / HashSets in repair

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -6,6 +6,7 @@ use {
         latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
         progress_map::ProgressMap, tree_diff::TreeDiff,
     },
+    ahash::AHashMap,
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
@@ -183,7 +184,7 @@ impl PartialEq for ForkInfo {
 
 #[derive(Debug, Clone)]
 pub struct HeaviestSubtreeForkChoice {
-    fork_infos: HashMap<SlotHashKey, ForkInfo>,
+    fork_infos: AHashMap<SlotHashKey, ForkInfo>,
     latest_votes: HashMap<Pubkey, SlotHashKey>,
     tree_root: SlotHashKey,
     last_root_time: Instant,
@@ -220,7 +221,7 @@ impl HeaviestSubtreeForkChoice {
             tree_root,
             // Doesn't implement default because `root` must
             // exist in all the fields
-            fork_infos: HashMap::new(),
+            fork_infos: AHashMap::new(),
             latest_votes: HashMap::new(),
             last_root_time: Instant::now(),
         };
@@ -608,7 +609,7 @@ impl HeaviestSubtreeForkChoice {
         self.process_update_operations(update_operations);
 
         // Remove node + all children and add to new tree
-        let mut split_tree_fork_infos = HashMap::new();
+        let mut split_tree_fork_infos = AHashMap::new();
         let mut to_visit = vec![*slot_hash_key];
         while let Some(current_node) = to_visit.pop() {
             let current_fork_info = self
@@ -1381,13 +1382,13 @@ impl ForkChoice for HeaviestSubtreeForkChoice {
 
 struct AncestorIterator<'a> {
     current_slot_hash_key: SlotHashKey,
-    fork_infos: &'a HashMap<SlotHashKey, ForkInfo>,
+    fork_infos: &'a AHashMap<SlotHashKey, ForkInfo>,
 }
 
 impl<'a> AncestorIterator<'a> {
     fn new(
         start_slot_hash_key: SlotHashKey,
-        fork_infos: &'a HashMap<SlotHashKey, ForkInfo>,
+        fork_infos: &'a AHashMap<SlotHashKey, ForkInfo>,
     ) -> Self {
         Self {
             current_slot_hash_key: start_slot_hash_key,

--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -6,10 +6,11 @@ use {
             serve_repair::ShredRepairType,
         },
     },
+    ahash::{AHashMap, AHashSet},
     solana_clock::Slot,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMetaRepair},
-    std::collections::{HashMap, HashSet},
+    std::collections::HashMap,
 };
 
 struct GenericTraversal<'a> {
@@ -51,8 +52,8 @@ impl Iterator for GenericTraversal<'_> {
 pub fn get_unknown_last_index(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
-    processed_slots: &mut HashSet<Slot>,
+    slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+    processed_slots: &mut AHashSet<Slot>,
     limit: usize,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
 ) -> Vec<ShredRepairType> {
@@ -97,8 +98,8 @@ pub fn get_unknown_last_index(
 fn get_unrepaired_path(
     start_slot: Slot,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
-    visited: &mut HashSet<Slot>,
+    slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+    visited: &mut AHashSet<Slot>,
 ) -> Vec<Slot> {
     let mut path = Vec::new();
     let mut slot = start_slot;
@@ -126,8 +127,8 @@ pub fn get_closest_completion(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
     root_slot: Slot,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
-    processed_slots: &mut HashSet<Slot>,
+    slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+    processed_slots: &mut AHashSet<Slot>,
     limit: usize,
     repair_eligibility: &mut RepairEligibility,
     outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -186,7 +187,7 @@ pub fn get_closest_completion(
     }
     slot_dists.sort_by_key(|(_, d)| *d);
 
-    let mut visited = HashSet::from([root_slot]);
+    let mut visited = AHashSet::from([root_slot]);
     let mut repairs = Vec::new();
     let mut total_processed_slots = 0;
     for (slot, _) in slot_dists {
@@ -232,8 +233,8 @@ pub mod test {
     fn test_get_unknown_last_index() {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
-        let mut slot_meta_cache = HashMap::default();
-        let mut processed_slots = HashSet::default();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         let mut outstanding_requests = HashMap::new();
         let repairs = get_unknown_last_index(
             &heaviest_subtree_fork_choice,
@@ -267,8 +268,8 @@ pub mod test {
     #[test]
     fn test_get_closest_completion() {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
-        let mut slot_meta_cache = HashMap::default();
-        let mut processed_slots = HashSet::default();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         let mut outstanding_requests = HashMap::new();
         let (repairs, _) = get_closest_completion(
             &heaviest_subtree_fork_choice,
@@ -295,8 +296,8 @@ pub mod test {
             Hash::default(),
         );
         let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_tree(forks);
-        let mut slot_meta_cache = HashMap::default();
-        let mut processed_slots = HashSet::default();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         outstanding_requests = HashMap::new();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -18,6 +18,7 @@ use {
         },
     },
     agave_votor_messages::{VerifiedVoterSlotsReceiver, migration::MigrationStatus},
+    ahash::AHashMap,
     bytes::Bytes,
     crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender},
     lazy_lru::LruCache,
@@ -139,7 +140,7 @@ impl SlotRepairFecTimes {
 /// probing.
 #[derive(Debug, Default)]
 pub struct RepairEligibility {
-    slots: HashMap<Slot, SlotRepairFecTimes>,
+    slots: AHashMap<Slot, SlotRepairFecTimes>,
 }
 
 impl RepairEligibility {

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -9,6 +9,7 @@ use {
         },
         replay_stage::DUPLICATE_THRESHOLD,
     },
+    ahash::{AHashMap, AHashSet},
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
@@ -214,8 +215,8 @@ impl RepairWeight {
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
         let mut repairs = vec![];
-        let mut processed_slots = HashSet::from([self.root]);
-        let mut slot_meta_cache = HashMap::default();
+        let mut processed_slots = AHashSet::from([self.root]);
+        let mut slot_meta_cache = AHashMap::default();
 
         let mut get_best_orphans_us = Measure::start("get_best_orphans_us");
         // Find the best orphans in order from heaviest stake to least heavy
@@ -501,7 +502,7 @@ impl RepairWeight {
     fn get_best_shreds(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
+        slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
         repair_eligibility: &mut RepairEligibility,
@@ -522,7 +523,7 @@ impl RepairWeight {
     fn get_best_orphans(
         &mut self,
         blockstore: &Blockstore,
-        processed_slots: &mut HashSet<Slot>,
+        processed_slots: &mut AHashSet<Slot>,
         repairs: &mut Vec<ShredRepairType>,
         epoch_stakes: &HashMap<Epoch, VersionedEpochStakes>,
         epoch_schedule: &EpochSchedule,
@@ -599,8 +600,8 @@ impl RepairWeight {
     fn get_best_unknown_last_index(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
-        processed_slots: &mut HashSet<Slot>,
+        slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+        processed_slots: &mut AHashSet<Slot>,
         max_new_repairs: usize,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
@@ -629,8 +630,8 @@ impl RepairWeight {
     fn get_best_closest_completion(
         &mut self,
         blockstore: &Blockstore,
-        slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
-        processed_slots: &mut HashSet<Slot>,
+        slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+        processed_slots: &mut AHashSet<Slot>,
         max_new_repairs: usize,
         repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
@@ -1508,7 +1509,7 @@ mod test {
         // should prioritize smaller orphan first
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
-        let mut processed_slots: HashSet<Slot> = vec![repair_weight.root].into_iter().collect();
+        let mut processed_slots: AHashSet<Slot> = vec![repair_weight.root].into_iter().collect();
         repair_weight.get_best_orphans(
             &blockstore,
             &mut processed_slots,
@@ -1661,7 +1662,7 @@ mod test {
         // exactly one more of the remaining two
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
-        let mut processed_slots: HashSet<Slot> = vec![repair_weight.root].into_iter().collect();
+        let mut processed_slots: AHashSet<Slot> = vec![repair_weight.root].into_iter().collect();
         blockstore.add_tree(tr(100) / (tr(101)), true, true, 2, Hash::default());
         repair_weight.get_best_orphans(
             &blockstore,

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -6,10 +6,11 @@ use {
             serve_repair::ShredRepairType,
         },
     },
+    ahash::{AHashMap, AHashSet},
     solana_clock::Slot,
     solana_hash::Hash,
     solana_ledger::{blockstore::Blockstore, blockstore_meta::SlotMetaRepair},
-    std::collections::{HashMap, HashSet},
+    std::collections::HashMap,
 };
 
 #[derive(Debug, PartialEq, Eq)]
@@ -85,7 +86,7 @@ impl Iterator for RepairWeightTraversal<'_> {
 pub fn get_best_repair_shreds(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &Blockstore,
-    slot_meta_cache: &mut HashMap<Slot, Option<SlotMetaRepair>>,
+    slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
     repair_eligibility: &mut RepairEligibility,
@@ -97,7 +98,7 @@ pub fn get_best_repair_shreds(
         return;
     }
     let weighted_iter = RepairWeightTraversal::new(tree);
-    let mut visited_set = HashSet::new();
+    let mut visited_set = AHashSet::new();
     for next in weighted_iter {
         if repairs.len() >= max_repairs {
             break;
@@ -239,7 +240,7 @@ pub mod test {
         // return repairs for all slots (none are completed) in order of traversal
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
-        let mut slot_meta_cache = HashMap::default();
+        let mut slot_meta_cache = AHashMap::default();
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
@@ -266,7 +267,7 @@ pub mod test {
         // repairing those new leaves before trying other branches
         repairs = vec![];
         outstanding_repairs = HashMap::new();
-        slot_meta_cache = HashMap::default();
+        slot_meta_cache = AHashMap::default();
         let best_overall_slot = heaviest_subtree_fork_choice.best_overall_slot().0;
         assert_eq!(best_overall_slot, 4);
         blockstore.add_tree(
@@ -299,7 +300,7 @@ pub mod test {
         // Completing slots should remove them from the repair list
         repairs = vec![];
         outstanding_repairs = HashMap::new();
-        slot_meta_cache = HashMap::default();
+        slot_meta_cache = AHashMap::default();
         let keypair = Keypair::new();
         let reed_solomon_cache = ReedSolomonCache::default();
 
@@ -347,7 +348,7 @@ pub mod test {
         // the parents are complete should still be repaired
         repairs = vec![];
         outstanding_repairs = HashMap::new();
-        slot_meta_cache = HashMap::default();
+        slot_meta_cache = AHashMap::default();
         blockstore.add_tree(tr(2) / (tr(8)), true, false, 2, Hash::default());
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=8);
@@ -390,7 +391,7 @@ pub mod test {
 
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
-        let mut slot_meta_cache = HashMap::default();
+        let mut slot_meta_cache = AHashMap::default();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
@@ -418,7 +419,7 @@ pub mod test {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
-        let mut slot_meta_cache = HashMap::default();
+        let mut slot_meta_cache = AHashMap::default();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
 


### PR DESCRIPTION
#### Problem

siphash shows up prominently in `identify_repairs`.

<img width="1939" height="738" alt="image" src="https://github.com/user-attachments/assets/25ff1a83-85cc-45f9-a38a-d7ef6e1777c4" />


These HashMaps / HashSets are local traversal/cache bookkeeping, not externally supplied peer/request identifiers, so ahash should be sufficient.

#### Summary of Changes

Converts these HashMaps and HashSets to use `ahash::RandomState`.

Roughly 15-20% reduction in `get-best-shred-elapsed` time.

<img width="1862" height="550" alt="image" src="https://github.com/user-attachments/assets/4c932d70-dc9c-4f49-8876-0501b40f893f" />

<img width="1870" height="529" alt="image" src="https://github.com/user-attachments/assets/0a7a16e0-17bb-4a15-bae4-327064ab4353" />
