### PR TITLE
voting_service: add a refresh queue for standstill messages

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -35,7 +35,9 @@ use {
         event::{LatestSwitchRequest, LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
-        voting_service::{VotingService as BLSVotingService, VotingServiceOverride},
+        voting_service::{
+            VOTOR_RATE_LIMIT_PPS, VotingService as BLSVotingService, VotingServiceOverride,
+        },
         votor::{Votor, VotorConfig},
     },
     agave_votor_messages::{
@@ -311,7 +313,7 @@ impl Tvu {
                     ..Default::default()
                 };
                 let qos_config = SimpleQosConfig {
-                    max_streams_per_second: 30,
+                    max_streams_per_second: VOTOR_RATE_LIMIT_PPS,
                     // Cap by # of active validators (some overhead for epoch boundaries)
                     max_staked_connections: MAX_ALPENGLOW_VOTE_ACCOUNTS * 2,
                     // Two staked connection per validator to account for hotspares
@@ -522,7 +524,7 @@ impl Tvu {
             cluster_info: cluster_info.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
             consensus_metrics_sender,
-            highest_finalized,
+            highest_finalized: highest_finalized.clone(),
             bank_forks_controller,
             bls_sender: bls_sender.clone(),
             commitment_sender: votor_commitment_sender,
@@ -615,6 +617,7 @@ impl Tvu {
             vote_history_storage,
             bls_connection_cache,
             bank_forks.clone(),
+            highest_finalized,
             voting_service_test_override,
         );
 

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -239,6 +239,20 @@ impl ValidatedBlockFinalizationCert {
         )
     }
 
+    /// Returns cloned copies of the certificates that prove this finalization.
+    ///
+    /// For slow finalization this returns the finalize certificate followed by the notarize
+    /// certificate. For fast finalization this returns the single fast-finalize certificate.
+    pub fn clone_certificates(&self) -> Vec<Certificate> {
+        match &self.kind {
+            ValidatedBlockFinalizationCertKind::Finalize {
+                finalize_cert,
+                notarize_cert,
+            } => vec![finalize_cert.clone(), notarize_cert.clone()],
+            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => vec![cert.clone()],
+        }
+    }
+
     /// Returns the data needed to calculating and paying vote rewards.
     pub fn vote_rewards_input(&self) -> (&HashSet<Pubkey>, Slot) {
         (&self.signers, self.slot())
@@ -438,11 +452,10 @@ mod tests {
                 notar_aggregate: None,
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
-            assert!(
-                result.is_ok(),
-                "Valid fast finalize certificate should pass verification: {result:?}"
-            );
+            let validated =
+                ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
+                    .expect("Valid fast finalize certificate should pass verification");
+            assert_eq!(validated.clone_certificates(), vec![fast_finalize_cert]);
         }
 
         // Test 2: Slow finalize (requires 60% stake = 3300 for both certs)
@@ -475,10 +488,12 @@ mod tests {
                 notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
             };
 
-            let result = ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank);
-            assert!(
-                result.is_ok(),
-                "Valid slow finalize certificate should pass verification: {result:?}"
+            let validated =
+                ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank)
+                    .expect("Valid slow finalize certificate should pass verification");
+            assert_eq!(
+                validated.clone_certificates(),
+                vec![finalize_cert, notarize_cert]
             );
         }
     }

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -26,7 +26,7 @@ pod_wrapper! {
     derive(AbiExample),
     frozen_abi(digest = "5WqvPnvSnVXQFrAs9o29szFGDiCk45Pgk8K1evTZSrwo")
 )]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 pub struct Certificate {
     /// The certificate type.
     pub cert_type: CertificateType,

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -54,7 +54,7 @@ pub struct Block {
     derive(AbiExample),
     frozen_abi(digest = "CTiXEk2aQbpf6TS6PNKcaTsGkLruDvAYsTLFhHKW2vsm")
 )]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
@@ -71,7 +71,7 @@ pub struct VoteMessage {
     derive(AbiExample, AbiEnumVisitor),
     frozen_abi(digest = "CbPatwRWz8NyUAj3HeAxAAWAWTxJnHGAfekLspUQpMHN")
 )]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
     /// A vote from a single party.
@@ -101,6 +101,14 @@ impl ConsensusMessage {
             signature,
             bitmap,
         })
+    }
+
+    /// Returns the slot this message is for.
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Vote(vote) => vote.vote.slot(),
+            Self::Certificate(certificate) => certificate.cert_type.slot(),
+        }
     }
 }
 

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -28,7 +28,7 @@ use {
     solana_hash::Hash,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, validated_block_finalization::ValidatedBlockFinalizationCert},
-    std::{cmp::Ordering, collections::BTreeMap, num::NonZero, sync::Arc},
+    std::{collections::BTreeMap, num::NonZero, sync::Arc},
     thiserror::Error,
 };
 
@@ -629,33 +629,15 @@ impl ConsensusPool {
     }
 
     pub(crate) fn get_certs_for_standstill(&self) -> Vec<Arc<Certificate>> {
-        let (highest_slot, has_fast_finalize) = self
+        let highest_slot = self
             .highest_finalized_slot_cert
             .as_ref()
-            .map(|certs| (certs.slot(), certs.is_fast()))
-            .unwrap_or((0, false));
+            .map(ValidatedBlockFinalizationCert::slot)
+            .unwrap_or(0);
         self.completed_certificates
             .iter()
             .filter_map(|(cert_type, cert)| {
-                let cert_to_send = match (
-                    cert_type.slot().cmp(&highest_slot),
-                    cert_type,
-                    has_fast_finalize,
-                ) {
-                    (Ordering::Greater, _, _)
-                    | (
-                        Ordering::Equal,
-                        CertificateType::Finalize(_) | CertificateType::Notarize(_),
-                        false,
-                    )
-                    | (Ordering::Equal, CertificateType::FinalizeFast(_), true) => {
-                        Some(cert.clone())
-                    }
-                    (Ordering::Equal, CertificateType::FinalizeFast(_), false) => {
-                        panic!("Should not happen while certificate pool is single threaded")
-                    }
-                    _ => None,
-                };
+                let cert_to_send = (cert_type.slot() > highest_slot).then(|| cert.clone());
                 if cert_to_send.is_some() {
                     trace!(
                         "{}: Refreshing certificate {:?}",
@@ -1917,13 +1899,10 @@ mod tests {
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_5));
-        // Should return only FinalizeFast cert on 5
+        // Slot 5 is now the highest finalized slot, so standstill cert refresh only returns
+        // certificates for later slots.
         let certs = ctx.pool.get_certs_for_standstill();
-        assert_eq!(certs.len(), 1);
-        assert!(
-            certs[0].cert_type.slot() == 5
-                && matches!(certs[0].cert_type, CertificateType::FinalizeFast(_))
-        );
+        assert!(certs.is_empty());
 
         // Now add Notarize cert on 6
         let cert_6 = Certificate {
@@ -1935,11 +1914,9 @@ mod tests {
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6));
-        // Should return certs on 5 and 6
+        // Should return certs after highest finalized slot 5.
         let certs = ctx.pool.get_certs_for_standstill();
-        assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 5
-            && matches!(cert.cert_type, CertificateType::FinalizeFast(_))));
+        assert_eq!(certs.len(), 1);
         assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
             && matches!(cert.cert_type, CertificateType::Notarize(_))));
 
@@ -1960,14 +1937,10 @@ mod tests {
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_6_notarize_fallback));
-        // This should not be returned because 6 is the current highest finalized slot
-        // only Notarize/Finalze/FinalizeFast should be returned
+        // Slot 6 is now the current highest finalized slot, so no slot-6 certs should
+        // be returned by the queued refresh path.
         let certs = ctx.pool.get_certs_for_standstill();
-        assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
-            && matches!(cert.cert_type, CertificateType::Finalize(_))));
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
-            && matches!(cert.cert_type, CertificateType::Notarize(_))));
+        assert!(certs.is_empty());
 
         // Add another skip on 7
         let cert_7 = Certificate {
@@ -1976,13 +1949,9 @@ mod tests {
             bitmap: dummy_bitmap(),
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_7));
-        // Should return certs on 6 and 7
+        // Should return certs after highest finalized slot 6.
         let certs = ctx.pool.get_certs_for_standstill();
-        assert_eq!(certs.len(), 3);
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
-            && matches!(cert.cert_type, CertificateType::Finalize(_))));
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 6
-            && matches!(cert.cert_type, CertificateType::Notarize(_))));
+        assert_eq!(certs.len(), 1);
         assert!(
             certs.iter().any(|cert| cert.cert_type.slot() == 7
                 && matches!(cert.cert_type, CertificateType::Skip(_)))
@@ -2005,13 +1974,10 @@ mod tests {
         };
         ctx.add_message(ConsensusMessage::Certificate(cert_8_notarize));
 
-        // Should only return certs on 8 now
+        // Slot 8 is now the current highest finalized slot, so latest-finalization
+        // certs are refreshed from highest_finalized instead of this queue.
         let certs = ctx.pool.get_certs_for_standstill();
-        assert_eq!(certs.len(), 2);
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 8
-            && matches!(cert.cert_type, CertificateType::Finalize(_))));
-        assert!(certs.iter().any(|cert| cert.cert_type.slot() == 8
-            && matches!(cert.cert_type, CertificateType::Notarize(_))));
+        assert!(certs.is_empty());
     }
 
     #[test]

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -111,15 +111,21 @@ impl ConsensusPoolService {
         consensus_pool.maybe_prune(bank.slot());
         stats.prune_old_state_called += 1;
         // Send new certificates to peers
-        Self::send_certificates(ctx, new_certificates_to_send, stats)
+        Self::send_certificates(
+            ctx,
+            BLSOp::PushCertificates {
+                certificates: new_certificates_to_send,
+            },
+            stats,
+        )
     }
 
     fn send_certificates(
         ctx: &ConsensusPoolContext,
-        certificates_to_send: Vec<Arc<Certificate>>,
+        op: BLSOp,
         stats: &mut ConsensusPoolServiceStats,
     ) -> Result<(), ()> {
-        let num_certs = certificates_to_send.len();
+        let num_certs = Self::num_certificates(&op);
         if num_certs == 0 {
             return Ok(());
         }
@@ -130,7 +136,7 @@ impl ConsensusPoolService {
             stats.certificates_skipped_unstaked += num_certs;
             return Ok(());
         }
-        Self::enqueue_certificates(ctx, certificates_to_send, stats)
+        Self::enqueue_certificates(ctx, op, stats)
     }
 
     fn is_current_identity_staked(ctx: &ConsensusPoolContext) -> bool {
@@ -141,16 +147,22 @@ impl ConsensusPoolService {
             .is_some_and(|stake| *stake > 0)
     }
 
+    fn num_certificates(op: &BLSOp) -> usize {
+        match op {
+            BLSOp::PushCertificates { certificates }
+            | BLSOp::RefreshCertificates { certificates } => certificates.len(),
+            _ => unreachable!("expected a certificate BLSOp"),
+        }
+    }
+
     fn enqueue_certificates(
         ctx: &ConsensusPoolContext,
-        certificates: Vec<Arc<Certificate>>,
+        op: BLSOp,
         stats: &mut ConsensusPoolServiceStats,
     ) -> Result<(), ()> {
-        let num_certs = certificates.len();
-        match ctx
-            .bls_sender
-            .try_send(BLSOp::PushCertificates { certificates })
-        {
+        let num_certs = Self::num_certificates(&op);
+
+        match ctx.bls_sender.try_send(op) {
             Ok(()) => {
                 stats.certificates_sent += num_certs;
                 Ok(())
@@ -352,7 +364,9 @@ impl ConsensusPoolService {
                 standstill_timer = Instant::now();
                 match Self::send_certificates(
                     &ctx,
-                    consensus_pool.get_certs_for_standstill(),
+                    BLSOp::RefreshCertificates {
+                        certificates: consensus_pool.get_certs_for_standstill(),
+                    },
                     &mut stats,
                 ) {
                     Ok(()) => (),
@@ -1093,8 +1107,13 @@ mod tests {
         ];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result =
-            ConsensusPoolService::send_certificates(&ctx.ctx, certificates.clone(), &mut stats);
+        let result = ConsensusPoolService::send_certificates(
+            &ctx.ctx,
+            BLSOp::PushCertificates {
+                certificates: certificates.clone(),
+            },
+            &mut stats,
+        );
         assert!(result.is_ok());
         assert_eq!(stats.certificates_sent.0, 2);
 
@@ -1111,6 +1130,38 @@ mod tests {
         assert!(matches!(
             certificates[1].cert_type,
             CertificateType::Skip(2)
+        ));
+    }
+
+    #[test]
+    fn test_send_certificates_refresh() {
+        let ctx = TestContext::default();
+
+        let certificates = vec![Arc::new(Certificate {
+            cert_type: CertificateType::Skip(1),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        })];
+
+        let mut stats = ConsensusPoolServiceStats::new();
+        ConsensusPoolService::send_certificates(
+            &ctx.ctx,
+            BLSOp::RefreshCertificates {
+                certificates: certificates.clone(),
+            },
+            &mut stats,
+        )
+        .unwrap();
+        assert_eq!(stats.certificates_sent.0, 1);
+
+        let BLSOp::RefreshCertificates { certificates } = ctx.bls_receiver.try_recv().unwrap()
+        else {
+            panic!("invalid type");
+        };
+        assert_eq!(certificates.len(), 1);
+        assert!(matches!(
+            certificates[0].cert_type,
+            CertificateType::Skip(1)
         ));
     }
 
@@ -1133,7 +1184,12 @@ mod tests {
         let cluster_info = get_cluster_info(unstaked_identity);
         ctx.ctx.cluster_info = cluster_info;
         let mut stats = ConsensusPoolServiceStats::new();
-        ConsensusPoolService::send_certificates(&ctx.ctx, certificates, &mut stats).unwrap();
+        ConsensusPoolService::send_certificates(
+            &ctx.ctx,
+            BLSOp::PushCertificates { certificates },
+            &mut stats,
+        )
+        .unwrap();
         assert_eq!(stats.certificates_sent.0, 0);
         assert_eq!(stats.certificates_skipped_unstaked.0, 2);
         assert!(ctx.bls_receiver.try_recv().is_err());
@@ -1151,7 +1207,11 @@ mod tests {
         })];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result = ConsensusPoolService::send_certificates(&ctx.ctx, certificates, &mut stats);
+        let result = ConsensusPoolService::send_certificates(
+            &ctx.ctx,
+            BLSOp::PushCertificates { certificates },
+            &mut stats,
+        );
         assert_eq!(result.unwrap_err(), ());
     }
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1388,7 +1388,7 @@ mod tests {
                         found |= votes.len() != previous_len;
                         !votes.is_empty()
                     }
-                    BLSOp::PushCertificates { .. } => true,
+                    BLSOp::PushCertificates { .. } | BLSOp::RefreshCertificates { .. } => true,
                 });
                 assert!(found, "Did not find expected vote: {expected_message:?}");
             }
@@ -1420,7 +1420,7 @@ mod tests {
                     found |= votes.len() != previous_len;
                     !votes.is_empty()
                 }
-                BLSOp::PushCertificates { .. } => true,
+                BLSOp::PushCertificates { .. } | BLSOp::RefreshCertificates { .. } => true,
             });
             assert!(found, "Did not find expected vote: {expected_message:?}");
             // Also check own_vote_receiver

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -7,18 +7,21 @@ use {
         certificate::Certificate,
         consensus_message::{ConsensusMessage, VoteMessage},
     },
-    crossbeam_channel::Receiver,
+    crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_client::connection_cache::ConnectionCache,
     solana_clock::Slot,
     solana_connection_cache::client_connection::ClientConnection,
     solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
-    solana_runtime::bank_forks::BankForks,
+    solana_runtime::{
+        bank_forks::BankForks, validated_block_finalization::ValidatedBlockFinalizationCert,
+    },
     solana_transaction_error::TransportError,
     std::{
-        collections::HashMap,
+        collections::{BTreeMap, HashMap, HashSet},
         net::SocketAddr,
+        ops::Bound::{Excluded, Included, Unbounded},
         sync::{Arc, RwLock},
         thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
@@ -30,6 +33,22 @@ const STAKED_VALIDATORS_CACHE_TTL_S: u64 = 5;
 /// semantics, the cache may hold up to `2 * STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET` entries
 /// before evicting down to this target.
 const STAKED_VALIDATORS_CACHE_NUM_EPOCH_TARGET: usize = 3;
+
+/// The maximum amount of packets per second we expect from an honest node
+pub const VOTOR_RATE_LIMIT_PPS: u64 = 50;
+
+/// Max new packets per second in steady state:
+/// - Notarize + Finalize votes
+/// - NotarizeFallback + Notarize + FastFinalize + Finalize certificates
+///
+/// 200ms slots, 6 packets * 5 slots per second = 30 PPS
+const NEW_PACKETS_PER_SECOND: usize = 30;
+
+/// The amount of packets we should send per second from the standstill queue
+const STANDSTILL_REFRESH_BATCH_SIZE: usize = VOTOR_RATE_LIMIT_PPS as usize - NEW_PACKETS_PER_SECOND;
+
+/// How often we should refresh messages from the standstill queue
+const STANDSTILL_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 pub enum BLSOp {
@@ -43,6 +62,131 @@ pub enum BLSOp {
     RefreshVotes {
         votes: Vec<Arc<VoteMessage>>,
     },
+    RefreshCertificates {
+        certificates: Vec<Arc<Certificate>>,
+    },
+}
+
+#[derive(Debug)]
+/// Maintains a map of messages since the last finalization if we are in standstill.
+/// This queue is used to refresh the next `STANDSTILL_REFRESH_BATCH_SIZE` messages
+/// every `STANDSTILL_REFRESH_INTERVAL`.
+///
+/// When we are not in standstill the queue will be cleared as it's prune by the highest
+/// finalized slot.
+struct StandstillRefreshQueue {
+    messages: BTreeMap<Slot, HashSet<ConsensusMessage>>,
+    last_refresh: Instant,
+    cursor: Slot,
+}
+
+impl Default for StandstillRefreshQueue {
+    fn default() -> Self {
+        Self {
+            messages: BTreeMap::default(),
+            last_refresh: Instant::now(),
+            cursor: 0,
+        }
+    }
+}
+
+impl StandstillRefreshQueue {
+    fn insert(&mut self, message: ConsensusMessage) {
+        let slot = message.slot();
+        self.messages.entry(slot).or_default().insert(message);
+    }
+
+    /// Prune any state less than or equal to the highest finalized slot.
+    fn prune(&mut self, highest_finalized_slot: Slot) {
+        self.messages
+            .retain(|slot, _| *slot > highest_finalized_slot);
+        if self.cursor <= highest_finalized_slot {
+            self.cursor = highest_finalized_slot;
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+
+    /// Calls `handle_message` for up to the next `limit` messages from the queue,
+    /// updating the cursor as necessary.
+    fn for_next_n_messages(
+        &mut self,
+        limit: usize,
+        mut handle_message: impl FnMut(&ConsensusMessage),
+    ) -> usize {
+        if limit == 0 || self.is_empty() {
+            return 0;
+        }
+
+        let mut processed = 0usize;
+        let starting_cursor = self.cursor;
+        let mut reached_end = true;
+        for (slot, slot_messages) in self.messages.range((Excluded(self.cursor), Unbounded)) {
+            if limit.saturating_sub(processed) < slot_messages.len() {
+                // We cannot process this batch as it would put us over the limit
+                if processed == 0 {
+                    // However this is the very first batch! This should never happen
+                    // as the maximum number of possible votes & certificates for a slot is < 20.
+                    // But here we are, to avoid stalling the queue completely allow us to progress
+                    // at the risk of being rate limited
+                    error!(
+                        "First slot batch in the standstill queue exceeds votor rate limit: \
+                         {slot_messages:?}"
+                    );
+                } else {
+                    reached_end = false;
+                    break;
+                }
+            }
+
+            processed = processed.saturating_add(slot_messages.len());
+            self.cursor = *slot;
+            for message in slot_messages {
+                handle_message(message);
+            }
+        }
+
+        if reached_end && processed < limit && starting_cursor != 0 {
+            self.cursor = 0;
+            for (slot, slot_messages) in self
+                .messages
+                .range((Excluded(0), Included(starting_cursor)))
+            {
+                if limit.saturating_sub(processed) < slot_messages.len() {
+                    break;
+                }
+
+                processed = processed.saturating_add(slot_messages.len());
+                self.cursor = *slot;
+                for message in slot_messages {
+                    handle_message(message);
+                }
+            }
+        }
+
+        processed
+    }
+
+    /// Whether enough time has passed to refresh messages in the queue
+    fn should_refresh(&self) -> bool {
+        self.last_refresh.elapsed() >= STANDSTILL_REFRESH_INTERVAL
+    }
+
+    /// Reset the refresh timer
+    fn reset_refresh_timer(&mut self) {
+        self.last_refresh = Instant::now();
+    }
+
+    #[cfg(test)]
+    fn next_messages(&mut self, limit: usize) -> Vec<(Slot, ConsensusMessage)> {
+        let mut messages = Vec::new();
+        self.for_next_n_messages(limit, |message| {
+            messages.push((message.slot(), message.clone()));
+        });
+        messages
+    }
 }
 
 fn send_message(
@@ -127,6 +271,7 @@ impl VotingService {
         vote_history_storage: Arc<dyn VoteHistoryStorage>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
+        highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
         test_override: Option<VotingServiceOverride>,
     ) -> Self {
         let (additional_listeners, alpenglow_port_override) = match test_override {
@@ -136,6 +281,7 @@ impl VotingService {
                 alpenglow_port_override,
             }) => (additional_listeners, Some(alpenglow_port_override)),
         };
+        let mut standstill_queue = StandstillRefreshQueue::default();
 
         let thread_hdl = Builder::new()
             .name("solVotorVoteSvc".to_string())
@@ -149,7 +295,21 @@ impl VotingService {
                 );
 
                 info!("AlpenglowVotingService has started");
-                while let Ok(bls_op) = bls_receiver.recv() {
+                loop {
+                    Self::maybe_handle_standstill_queue(
+                        &mut standstill_queue,
+                        highest_finalized.as_ref(),
+                        &cluster_info,
+                        &connection_cache,
+                        &additional_listeners,
+                        &mut staked_validators_cache,
+                    );
+
+                    let bls_op = match bls_receiver.recv_timeout(STANDSTILL_REFRESH_INTERVAL) {
+                        Ok(bls_op) => bls_op,
+                        Err(RecvTimeoutError::Disconnected) => break,
+                        Err(RecvTimeoutError::Timeout) => continue,
+                    };
                     Self::handle_bls_op(
                         &cluster_info,
                         vote_history_storage.as_ref(),
@@ -157,6 +317,7 @@ impl VotingService {
                         &connection_cache,
                         &additional_listeners,
                         &mut staked_validators_cache,
+                        &mut standstill_queue,
                     );
                 }
                 info!("AlpenglowVotingService has stopped");
@@ -165,8 +326,69 @@ impl VotingService {
         Self { thread_hdl }
     }
 
+    /// If more than 1 second has passed, prune and send out messages from the queue
+    fn maybe_handle_standstill_queue(
+        standstill_queue: &mut StandstillRefreshQueue,
+        highest_finalized: &RwLock<Option<ValidatedBlockFinalizationCert>>,
+        cluster_info: &ClusterInfo,
+        connection_cache: &ConnectionCache,
+        additional_listeners: &[SocketAddr],
+        staked_validators_cache: &mut StakedValidatorsCache,
+    ) {
+        if !standstill_queue.should_refresh() {
+            return;
+        }
+
+        if standstill_queue.is_empty() {
+            standstill_queue.reset_refresh_timer();
+            return;
+        }
+
+        let mut num_sent_messages = 0usize;
+
+        let highest_finalized_slot_and_certs = {
+            let highest_finalized = highest_finalized.read().unwrap();
+            highest_finalized.as_ref().map(|highest_finalized| {
+                (
+                    highest_finalized.slot(),
+                    highest_finalized.clone_certificates(),
+                )
+            })
+        };
+
+        if let Some((highest_finalized_slot, certificates)) = highest_finalized_slot_and_certs {
+            standstill_queue.prune(highest_finalized_slot);
+
+            // Refresh the latest finalization (either Finalize + Notarize or FastFinalize)
+            for certificate in certificates {
+                let message = ConsensusMessage::Certificate(certificate);
+                Self::broadcast_consensus_message(
+                    cluster_info,
+                    &message,
+                    connection_cache,
+                    additional_listeners,
+                    staked_validators_cache,
+                );
+                num_sent_messages = num_sent_messages.saturating_add(1);
+            }
+        }
+
+        // Refresh the next messages from the queue while adhering to the budget
+        let remaining_budget = STANDSTILL_REFRESH_BATCH_SIZE.saturating_sub(num_sent_messages);
+        standstill_queue.for_next_n_messages(remaining_budget, |message| {
+            Self::broadcast_consensus_message(
+                cluster_info,
+                message,
+                connection_cache,
+                additional_listeners,
+                staked_validators_cache,
+            );
+        });
+
+        standstill_queue.reset_refresh_timer();
+    }
+
     fn broadcast_consensus_message(
-        slot: Slot,
         cluster_info: &ClusterInfo,
         message: &ConsensusMessage,
         connection_cache: &ConnectionCache,
@@ -182,7 +404,7 @@ impl VotingService {
         };
 
         let (staked_validator_alpenglow_sockets, _) = staked_validators_cache
-            .get_staked_validators_by_slot(slot, cluster_info, Instant::now());
+            .get_staked_validators_by_slot(message.slot(), cluster_info, Instant::now());
         let sockets = additional_listeners
             .iter()
             .chain(staked_validator_alpenglow_sockets.iter());
@@ -204,6 +426,7 @@ impl VotingService {
         connection_cache: &ConnectionCache,
         additional_listeners: &[SocketAddr],
         staked_validators_cache: &mut StakedValidatorsCache,
+        standstill_queue: &mut StandstillRefreshQueue,
     ) {
         match bls_op {
             BLSOp::PushVote {
@@ -217,10 +440,8 @@ impl VotingService {
                 }
                 measure.stop();
                 trace!("{measure}");
-                let slot = vote.vote.slot();
                 let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
                 Self::broadcast_consensus_message(
-                    slot,
                     cluster_info,
                     &msg,
                     connection_cache,
@@ -230,10 +451,8 @@ impl VotingService {
             }
             BLSOp::PushCertificates { certificates } => {
                 for certificate in certificates {
-                    let slot = certificate.cert_type.slot();
                     let message = ConsensusMessage::Certificate(Arc::unwrap_or_clone(certificate));
                     Self::broadcast_consensus_message(
-                        slot,
                         cluster_info,
                         &message,
                         connection_cache,
@@ -244,16 +463,14 @@ impl VotingService {
             }
             BLSOp::RefreshVotes { votes } => {
                 for vote in votes {
-                    let slot = vote.vote.slot();
                     let msg = ConsensusMessage::Vote(Arc::unwrap_or_clone(vote));
-                    Self::broadcast_consensus_message(
-                        slot,
-                        cluster_info,
-                        &msg,
-                        connection_cache,
-                        additional_listeners,
-                        staked_validators_cache,
-                    );
+                    standstill_queue.insert(msg);
+                }
+            }
+            BLSOp::RefreshCertificates { certificates } => {
+                for certificate in certificates {
+                    let message = ConsensusMessage::Certificate(Arc::unwrap_or_clone(certificate));
+                    standstill_queue.insert(message);
                 }
             }
         }
@@ -302,6 +519,87 @@ mod tests {
         tokio_util::sync::CancellationToken,
     };
 
+    fn test_vote_message(vote: Vote, rank: u16) -> ConsensusMessage {
+        ConsensusMessage::Vote(VoteMessage {
+            vote,
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            rank,
+        })
+    }
+
+    fn test_certificate_message(cert_type: CertificateType) -> ConsensusMessage {
+        ConsensusMessage::Certificate(Certificate {
+            cert_type,
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: Vec::new(),
+        })
+    }
+
+    #[test]
+    fn test_standstill_refresh_queue_cycles_by_slot() {
+        let mut queue = StandstillRefreshQueue::default();
+        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1);
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
+        let cert_6 = test_certificate_message(CertificateType::Finalize(6));
+
+        queue.insert(vote_6.clone());
+        queue.insert(cert_6.clone());
+        queue.insert(vote_5.clone());
+
+        assert_eq!(queue.next_messages(2), vec![(5, vote_5.clone())]);
+        let slot_6_messages = queue.next_messages(2);
+        assert_eq!(slot_6_messages.len(), 2);
+        assert!(slot_6_messages.contains(&(6, vote_6.clone())));
+        assert!(slot_6_messages.contains(&(6, cert_6.clone())));
+        assert_eq!(queue.next_messages(2), vec![(5, vote_5)]);
+    }
+
+    #[test]
+    fn test_standstill_refresh_queue_deduplicates_identical_messages() {
+        let mut queue = StandstillRefreshQueue::default();
+        let message = test_vote_message(Vote::new_skip_vote(8), 1);
+
+        queue.insert(message.clone());
+        queue.insert(message.clone());
+
+        assert_eq!(queue.next_messages(10), vec![(8, message)]);
+    }
+
+    #[test]
+    fn test_standstill_refresh_queue_wraps_to_fill_budget() {
+        let mut queue = StandstillRefreshQueue::default();
+        let vote_3 = test_vote_message(Vote::new_skip_vote(3), 1);
+        let vote_4 = test_vote_message(Vote::new_skip_vote(4), 1);
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
+
+        queue.insert(vote_3.clone());
+        queue.insert(vote_4.clone());
+        queue.insert(vote_6.clone());
+        queue.cursor = 5;
+
+        assert_eq!(
+            queue.next_messages(10),
+            vec![(6, vote_6), (3, vote_3), (4, vote_4)]
+        );
+    }
+
+    #[test]
+    fn test_standstill_refresh_queue_prunes_finalized_messages() {
+        let mut queue = StandstillRefreshQueue::default();
+        let vote_5 = test_vote_message(Vote::new_skip_vote(5), 1);
+        let cert_6 = test_certificate_message(CertificateType::Finalize(6));
+        let vote_6 = test_vote_message(Vote::new_skip_vote(6), 1);
+        let vote_7 = test_vote_message(Vote::new_skip_vote(7), 1);
+
+        queue.insert(vote_5);
+        queue.insert(cert_6);
+        queue.insert(vote_6);
+        queue.insert(vote_7.clone());
+
+        queue.prune(6);
+        assert_eq!(queue.next_messages(10), vec![(7, vote_7)]);
+    }
+
     fn create_voting_service(
         bls_receiver: Receiver<BLSOp>,
         listener: SocketAddr,
@@ -335,6 +633,7 @@ mod tests {
                     10,
                 )),
                 bank_forks,
+                Arc::new(RwLock::new(None)),
                 Some(VotingServiceOverride {
                     additional_listeners: vec![listener],
                     alpenglow_port_override: AlpenglowPortOverride::default(),


### PR DESCRIPTION
#### Problem
During standstill we might have a lot of votes / certificates to refresh.
Currently we just blast these out which leads to our messages being rate limited and ignored.

We saw on the community cluster where we had ~400 votes and certs to send out to 80 peers.

Even though we patched the bug which caused slots to be skipped in the first place, we were unable to make progress
after restarting, as nodes were in various states of stuck waiting for `SkipCertificate`s to be refreshed.
These certificates would never come, as they were dropped by the rate limit.

#### Summary of Changes

- Add a new `BLSOp::RefreshCertificates` in the same style of `BLSOp::RefreshVotes`
- Don't send the latest finalization certs anymore, just the certificates from the pool after that
- When receiving `RefreshCertificates` or `RefreshVotes` don't immediately broadcast, instead add any new messages to the standstill queue
- Every second if the queue is not empty, refresh the latest finalization + 20 messages from the queue
- We maintain a cursor into the queue so every vote / certificate will eventually get refreshed.
- Cursor starts from the earliest slot and wraps around
- Queue is pruned by the latest finalization

#### Testing
Unit tests
Will setup a standstill invalidator test soon

Fixes #13089
