### PR TITLE
runtime: Update epoch rewards sysvar for SIMD-0123

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -205,6 +205,7 @@ impl Bank {
             distribution_starting_block_height,
             num_partitions,
             point_value,
+            0, // block_rewards
         );
 
         datapoint_info!(

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -194,6 +194,7 @@ impl Bank {
         // decrease distributed capital from epoch rewards sysvar
         self.update_epoch_rewards_sysvar(
             stake_reward_lamports_minted + stake_reward_lamports_burned,
+            0, // debit_block_rewards
         );
 
         // update reward history for this partitioned distribution
@@ -548,6 +549,7 @@ mod tests {
 
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
         let inflation_rewards = 1_000_000_000;
+        let block_rewards = 0;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (inflation_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
         bank.create_epoch_rewards_sysvar(
@@ -558,6 +560,7 @@ mod tests {
                 rewards: inflation_rewards,
                 points: total_points,
             },
+            block_rewards,
         );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =
@@ -1051,6 +1054,7 @@ mod tests {
 
         // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
         let total_rewards = 10 * LAMPORTS_PER_SOL;
+        let block_rewards = 0;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
         bank.create_epoch_rewards_sysvar(
@@ -1061,6 +1065,7 @@ mod tests {
                 rewards: total_rewards,
                 points: total_points,
             },
+            block_rewards,
         );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =
@@ -1146,6 +1151,7 @@ mod tests {
 
         // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
         let total_rewards = 10 * LAMPORTS_PER_SOL;
+        let block_rewards = 0;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
         bank.create_epoch_rewards_sysvar(
@@ -1156,6 +1162,7 @@ mod tests {
                 rewards: total_rewards,
                 points: total_points,
             },
+            block_rewards,
         );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
         let expected_balance =

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -2,16 +2,19 @@ use {
     super::Bank,
     crate::inflation_rewards::points::PointValue,
     log::info,
-    solana_account::{create_account_shared_data_with_fields as create_account, from_account},
-    solana_sysvar as sysvar,
+    solana_account::{
+        ReadableAccount, WritableAccount, create_account_shared_data_with_fields as create_account,
+        from_account,
+    },
+    solana_clock::INITIAL_RENT_EPOCH,
+    solana_sysvar::{self as sysvar, epoch_rewards::EpochRewards},
 };
 
 impl Bank {
     /// Helper fn to log epoch_rewards sysvar
     fn log_epoch_rewards_sysvar(&self, prefix: &str) {
         if let Some(account) = self.get_account(&sysvar::epoch_rewards::id()) {
-            let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
-                from_account(&account).unwrap();
+            let epoch_rewards: EpochRewards = from_account(&account).unwrap();
             info!("{prefix} epoch_rewards sysvar: {epoch_rewards:?}");
         } else {
             info!("{prefix} epoch_rewards sysvar: none");
@@ -27,12 +30,13 @@ impl Bank {
         distribution_starting_block_height: u64,
         num_partitions: u64,
         point_value: &PointValue,
+        block_rewards: u64,
     ) {
         assert!(point_value.rewards >= distributed_rewards);
 
         let parent_blockhash = self.last_blockhash();
 
-        let epoch_rewards = sysvar::epoch_rewards::EpochRewards {
+        let epoch_rewards = EpochRewards {
             distribution_starting_block_height,
             num_partitions,
             parent_blockhash,
@@ -42,12 +46,27 @@ impl Bank {
             active: true,
         };
 
+        // Do the first store to create the account from scratch, update
+        // capitalization if needed, etc
         self.update_sysvar_account(&sysvar::epoch_rewards::id(), |account| {
             create_account(
                 &epoch_rewards,
                 self.inherit_specially_retained_account_fields(account),
             )
         });
+
+        // Now add the lamports separately without updating capitalization,
+        // since block reward lamports already existed
+        let mut account = self
+            .get_account_with_fixed_root(&sysvar::epoch_rewards::id())
+            .expect("created sysvar account exists");
+
+        // SAFETY: block rewards come from existing lamports, which cannot
+        // overflow
+        account
+            .checked_add_lamports(block_rewards)
+            .expect("block rewards and sysvar account rent exemption must fit in a u64");
+        self.store_account(&sysvar::epoch_rewards::id(), &account);
 
         self.log_epoch_rewards_sysvar("create");
     }
@@ -56,6 +75,7 @@ impl Bank {
     pub(in crate::bank::partitioned_epoch_rewards) fn update_epoch_rewards_sysvar(
         &self,
         distributed: u64,
+        debit_block_reward_lamports: u64,
     ) {
         let mut epoch_rewards = self.get_epoch_rewards_sysvar();
         assert!(epoch_rewards.active);
@@ -69,19 +89,48 @@ impl Bank {
             )
         });
 
+        // Debit the lamports separately without updating capitalization,
+        // since block reward lamports already existed
+        let mut account = self
+            .get_account_with_fixed_root(&sysvar::epoch_rewards::id())
+            .expect("created sysvar account exists");
+
+        // SAFETY: programmer error if we debit too many block rewards
+        account
+            .checked_sub_lamports(debit_block_reward_lamports)
+            .expect("epoch reward sysvar has enough lamports for distribution");
+        assert!(
+            account.lamports() >= self.get_minimum_balance_for_rent_exemption(account.data().len()),
+            "Sysvar account must have enough for rent exemption after debiting block rewards"
+        );
+        self.store_account(&sysvar::epoch_rewards::id(), &account);
+
         self.log_epoch_rewards_sysvar("update");
     }
 
-    /// Update EpochRewards sysvar with distributed rewards
+    /// Update EpochRewards sysvar with distributed rewards and burn any
+    /// remaining lamports over the rent-exempt reserve
     pub(in crate::bank::partitioned_epoch_rewards) fn set_epoch_rewards_sysvar_to_inactive(&self) {
+        const RENT_UNADJUSTED_INITIAL_BALANCE: u64 = 1;
+
         let mut epoch_rewards = self.get_epoch_rewards_sysvar();
         assert!(epoch_rewards.total_rewards >= epoch_rewards.distributed_rewards);
         epoch_rewards.active = false;
 
         self.update_sysvar_account(&sysvar::epoch_rewards::id(), |account| {
+            // Don't use `inherit_specially_retained_account_fields()` to
+            // ensure that any remaining lamports get burned, lamports are
+            // set to the rent-exempt minimum during `update_sysvar_account`,
+            // and capitalization is updated
             create_account(
                 &epoch_rewards,
-                self.inherit_specially_retained_account_fields(account),
+                (
+                    RENT_UNADJUSTED_INITIAL_BALANCE,
+                    account
+                        .as_ref()
+                        .map(|a| a.rent_epoch())
+                        .unwrap_or(INITIAL_RENT_EPOCH),
+                ),
             )
         });
 
@@ -92,7 +141,7 @@ impl Bank {
     /// account cannot be found or cannot be deserialized.
     pub(in crate::bank::partitioned_epoch_rewards) fn get_epoch_rewards_sysvar(
         &self,
-    ) -> sysvar::epoch_rewards::EpochRewards {
+    ) -> EpochRewards {
         from_account(
             &self
                 .get_account(&sysvar::epoch_rewards::id())
@@ -107,7 +156,6 @@ mod tests {
     use {
         super::*,
         crate::bank::{SlotLeader, tests::create_genesis_config},
-        solana_account::ReadableAccount,
         solana_epoch_schedule::EpochSchedule,
         solana_native_token::LAMPORTS_PER_SOL,
     };
@@ -131,8 +179,10 @@ mod tests {
             points: total_points,
         };
 
+        let first_block_rewards = 5_000_000_000;
+
         // create epoch rewards sysvar
-        let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
+        let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash: bank.last_blockhash(),
@@ -143,18 +193,33 @@ mod tests {
         };
 
         let epoch_rewards = bank.get_epoch_rewards_sysvar();
+        assert_eq!(epoch_rewards, EpochRewards::default());
+
+        let pre_capitalization = bank.capitalization();
+        bank.create_epoch_rewards_sysvar(10, 42, num_partitions, &point_value, first_block_rewards);
+        let post_capitalization = bank.capitalization();
+
+        let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let rent_exempt_reserve = bank.get_minimum_balance_for_rent_exemption(account.data().len());
+        let expected_balance = rent_exempt_reserve + first_block_rewards;
+        // Expected balance is the sysvar rent-exempt balance plus block rewards
+        assert_eq!(account.lamports(), expected_balance);
+
+        // Expect capitalization to only change by rent exempt minimum
         assert_eq!(
-            epoch_rewards,
-            sysvar::epoch_rewards::EpochRewards::default()
+            post_capitalization,
+            pre_capitalization + rent_exempt_reserve
         );
 
-        bank.create_epoch_rewards_sysvar(10, 42, num_partitions, &point_value);
-        let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
-        let expected_balance = bank.get_minimum_balance_for_rent_exemption(account.data().len());
-        // Expected balance is the sysvar rent-exempt balance
-        assert_eq!(account.lamports(), expected_balance);
-        let epoch_rewards: sysvar::epoch_rewards::EpochRewards = from_account(&account).unwrap();
+        let epoch_rewards: EpochRewards = from_account(&account).unwrap();
         assert_eq!(epoch_rewards, expected_epoch_rewards);
+
+        // Unsetting should burn all block rewards
+        bank.set_epoch_rewards_sysvar_to_inactive();
+        assert_eq!(
+            post_capitalization - first_block_rewards,
+            bank.capitalization()
+        );
 
         // Create a child bank to test parent_blockhash
         let parent_blockhash = bank.last_blockhash();
@@ -165,11 +230,26 @@ mod tests {
             SlotLeader::default(),
             parent_slot + 1,
         );
+        let second_block_rewards = 500_000_000;
+
         // Also note that running `create_epoch_rewards_sysvar()` against a bank
         // with an existing EpochRewards sysvar clobbers the previous values
-        bank.create_epoch_rewards_sysvar(10, 42, num_partitions, &point_value);
+        let pre_capitalization = bank.capitalization();
+        bank.create_epoch_rewards_sysvar(
+            10,
+            42,
+            num_partitions,
+            &point_value,
+            second_block_rewards,
+        );
+        let post_capitalization = bank.capitalization();
 
-        let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
+        // Capitalization shouldn't change this time, no new lamports minted
+        // since account already existed, but different amount of lamports on
+        // account
+        assert_eq!(post_capitalization, pre_capitalization);
+
+        let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash,
@@ -179,16 +259,31 @@ mod tests {
             active: true,
         };
 
+        let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let expected_balance = bank.get_minimum_balance_for_rent_exemption(account.data().len())
+            + second_block_rewards;
+        // Expected balance is the sysvar rent-exempt balance with new block rewards
+        assert_eq!(account.lamports(), expected_balance);
+
         let epoch_rewards = bank.get_epoch_rewards_sysvar();
         assert_eq!(epoch_rewards, expected_epoch_rewards);
 
         // make a distribution from epoch rewards sysvar
-        bank.update_epoch_rewards_sysvar(10);
+        let block_reward_distribution = 1_000_000;
+        bank.update_epoch_rewards_sysvar(10, block_reward_distribution);
         let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
-        // Balance should not change
-        assert_eq!(account.lamports(), expected_balance);
-        let epoch_rewards: sysvar::epoch_rewards::EpochRewards = from_account(&account).unwrap();
-        let expected_epoch_rewards = sysvar::epoch_rewards::EpochRewards {
+
+        // Balance should change
+        assert_eq!(
+            account.lamports(),
+            expected_balance - block_reward_distribution
+        );
+
+        // Capitalization should not
+        assert_eq!(post_capitalization, bank.capitalization());
+
+        let epoch_rewards: EpochRewards = from_account(&account).unwrap();
+        let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
             parent_blockhash,
@@ -198,5 +293,26 @@ mod tests {
             active: true,
         };
         assert_eq!(epoch_rewards, expected_epoch_rewards);
+
+        // Unsetting should burn the rest
+        bank.set_epoch_rewards_sysvar_to_inactive();
+        assert_eq!(
+            bank.capitalization(),
+            post_capitalization + block_reward_distribution - second_block_rewards
+        );
+
+        let account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
+        let epoch_rewards: EpochRewards = from_account(&account).unwrap();
+        let expected_epoch_rewards = EpochRewards {
+            distribution_starting_block_height: 42,
+            num_partitions,
+            parent_blockhash,
+            total_points,
+            total_rewards,
+            distributed_rewards: 20,
+            active: false,
+        };
+        assert_eq!(epoch_rewards, expected_epoch_rewards);
+        assert_eq!(account.lamports(), rent_exempt_reserve);
     }
 }

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -125,6 +125,7 @@ mod tests {
         // inject a reward sysvar for test
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = 42_000; // total_points is arbitrary for the purposes of this test
+        let block_rewards = 42_000_000; // block_rewards are arbitrary for this test
         let expected_epoch_rewards = EpochRewards {
             distribution_starting_block_height: 42,
             num_partitions,
@@ -142,6 +143,7 @@ mod tests {
                 rewards: 100,
                 points: total_points,
             },
+            block_rewards,
         );
 
         bank1


### PR DESCRIPTION
#### Problem

Once SIMD-0123 is active, the epoch-rewards sysvar will hold block reward lamports to be distributed, which is different from every other sysvar, which typically only hold rent-exemption.

#### Summary of changes

Update sysvar logic to handle credit and debit situations. The touchiest situations are capitalization updates, which must only occur for burning lamports.

This code deliberately does two separate stores of the epoch rewards sysvar to simplify the logic. Otherwise we'd need to copy a lot of the code from `update_sysvar_account`.

#### Testing

Expanded unit test for sysvar lifecycle management.