### PR TITLE
Rename secondary index update timer variable

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5663,21 +5663,21 @@ impl AccountsDb {
         let write_accounts_us = write_accounts_time.end_as_us();
 
         // Update the secondary index
-        let update_index_time = Measure::start("update_index");
+        let update_secondary_index_time = Measure::start("update_secondary_index");
         self.update_secondary_index_cached_accounts(
             &accounts,
             &store_account,
             update_index_thread_selection,
         );
-        let update_index_us = update_index_time.end_as_us();
+        let update_secondary_index_us = update_secondary_index_time.end_as_us();
 
         let stats = &self.store_accounts_unfrozen_stats;
         stats
             .write_to_cache_us
             .fetch_add(write_accounts_us, Ordering::Relaxed);
         stats
-            .update_index_us
-            .fetch_add(update_index_us, Ordering::Relaxed);
+            .update_secondary_index_us
+            .fetch_add(update_secondary_index_us, Ordering::Relaxed);
         stats
             .num_initial_accounts_to_store
             .fetch_add(write_stats.num_initial_accounts_to_store, Ordering::Relaxed);

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -26,8 +26,8 @@ pub struct StoreAccountsUnfrozenStats {
     pub last_report: AtomicInterval,
     /// time spent writing accounts to the write cache
     pub write_to_cache_us: AtomicU64,
-    /// time spend updating the accounts index
-    pub update_index_us: AtomicU64,
+    /// time spent updating the secondary indexes
+    pub update_secondary_index_us: AtomicU64,
     /// initial number of accounts to be stored
     pub num_initial_accounts_to_store: AtomicU64,
     /// number of accounts actually stored
@@ -59,8 +59,8 @@ impl StoreAccountsUnfrozenStats {
                 i64
             ),
             (
-                "update_index_us",
-                self.update_index_us.swap(0, Ordering::Relaxed),
+                "update_secondary_index_us",
+                self.update_secondary_index_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
During store accounts frozen, the accounts index is no longer updated, but the timer is named update_index_us

Follow up from https://github.com/anza-xyz/agave/pull/13254#discussion_r3428305570

#### Summary of Changes
- Rename to update_secondary_index_us

#### Testing
Compilation

Fixes #
