### PR TITLE
add stable discriminant repr to SyscallError

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -60,6 +60,7 @@ mod sysvar;
 
 /// Error definitions
 #[derive(Debug, ThisError, PartialEq, Eq)]
+#[repr(C, u64)]
 pub enum SyscallError {
     #[error("{0}: {1:?}")]
     InvalidString(Utf8Error, Vec<u8>),

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -59,8 +59,10 @@ mod mem_ops;
 mod sysvar;
 
 /// Error definitions
+// Note: `#[repr(u64)]` is used for `Self::discriminant`, but the actual
+// memory layout of this enum's variants is not depended on by the VM.
 #[derive(Debug, ThisError, PartialEq, Eq)]
-#[repr(C, u64)]
+#[repr(u64)]
 pub enum SyscallError {
     #[error("{0}: {1:?}")]
     InvalidString(Utf8Error, Vec<u8>),
@@ -113,6 +115,15 @@ pub enum SyscallError {
     InvalidPointer,
     #[error("Arithmetic overflow")]
     ArithmeticOverflow,
+}
+
+impl SyscallError {
+    /// Returns the enum discriminant as a `u64`.
+    ///
+    /// This is sound only because of the `#[repr(u64)]` attribute on the enum.
+    pub fn discriminant(&self) -> u64 {
+        unsafe { *std::ptr::addr_of!(*self).cast::<u64>() }
+    }
 }
 
 impl From<MemoryTranslationError> for SyscallError {


### PR DESCRIPTION
#### Problem
As per discussion in https://github.com/anza-xyz/agave/pull/12921, we want to be able to get the variants for `SyscallError` as integers.

#### Summary of Changes
Add a `repr(u64)`.

#### Testing
I don't believe this change requires a test. These errors are not serialized.