### PR TITLE
Optimize status cache signature storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Release channels have their own copy of this changelog:
 * `--disable-banking-trace` is now deprecated and a no-op (banking trace is disabled by
   default). The flag is still accepted for backward compatibility.
 #### Changes
+* Validators running without `--full-rpc-api` and with snapshot generation disabled no longer
+  store transaction signature keys in the status cache. Message hashes remain cached for duplicate
+  transaction detection.
 ### SDK
 #### Breaking
 * solana-program-test: syscall getters (e.g. `Rent::get()`, `Clock::get()`) and `solana_sysvar::get_sysvar()` now return

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -640,6 +640,7 @@ impl PartialEq for Bank {
         let Self {
             rc: _,
             status_cache: _,
+            store_transaction_signatures_in_status_cache,
             blockhash_queue,
             max_processing_age,
             partitioned_rewards_stake_account_stores_per_block,
@@ -712,7 +713,9 @@ impl PartialEq for Bank {
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
-        *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
+        *store_transaction_signatures_in_status_cache
+            == other.store_transaction_signatures_in_status_cache
+            && *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
             && *partitioned_rewards_stake_account_stores_per_block
                 == other.partitioned_rewards_stake_account_stores_per_block
@@ -862,6 +865,9 @@ pub struct Bank {
 
     /// A cache of signature statuses
     pub status_cache: Arc<RwLock<BankStatusCache>>,
+
+    /// Derived from RuntimeConfig::skip_transaction_signatures_in_status_cache.
+    store_transaction_signatures_in_status_cache: bool,
 
     /// FIFO queue of `recent_blockhash` items
     blockhash_queue: RwLock<BlockhashQueue>,
@@ -1214,6 +1220,8 @@ impl Bank {
         let mut bank = Self {
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            store_transaction_signatures_in_status_cache: !RuntimeConfig::default()
+                .skip_transaction_signatures_in_status_cache,
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             max_processing_age: MAX_PROCESSING_AGE,
             partitioned_rewards_stake_account_stores_per_block,
@@ -1319,6 +1327,8 @@ impl Bank {
         let mut bank = Self::default_with_accounts(accounts);
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
         bank.compute_budget = runtime_config.compute_budget;
+        bank.store_transaction_signatures_in_status_cache =
+            !runtime_config.skip_transaction_signatures_in_status_cache;
         if let Some(compute_budget) = &bank.compute_budget {
             bank.transaction_processor
                 .set_execution_cost(compute_budget.to_cost());
@@ -1458,6 +1468,8 @@ impl Bank {
         let mut new = Self {
             rc,
             status_cache,
+            store_transaction_signatures_in_status_cache: parent
+                .store_transaction_signatures_in_status_cache,
             slot,
             bank_id,
             epoch,
@@ -2133,6 +2145,8 @@ impl Bank {
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            store_transaction_signatures_in_status_cache: !runtime_config
+                .skip_transaction_signatures_in_status_cache,
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             max_processing_age: MAX_PROCESSING_AGE,
             partitioned_rewards_stake_account_stores_per_block,
@@ -3542,15 +3556,16 @@ impl Bank {
                     self.slot(),
                     processed_tx.status(),
                 );
-                // Add the transaction signature to the status cache so that transaction status
-                // can be queried by transaction signature over RPC. In the future, this should
-                // only be added for API nodes because voting validators don't need to do this.
-                status_cache.insert(
-                    tx.recent_blockhash(),
-                    tx.signature(),
-                    self.slot(),
-                    processed_tx.status(),
-                );
+                if self.store_transaction_signatures_in_status_cache {
+                    // Add the transaction signature to the status cache so that transaction
+                    // status can be queried by transaction signature over RPC.
+                    status_cache.insert(
+                        tx.recent_blockhash(),
+                        tx.signature(),
+                        self.slot(),
+                        processed_tx.status(),
+                    );
+                }
             }
         }
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -599,6 +599,7 @@ impl PartialEq for Bank {
         let Self {
             rc: _,
             status_cache: _,
+            disable_transaction_signatures_in_status_cache,
             blockhash_queue,
             max_processing_age,
             partitioned_rewards_stake_account_stores_per_block,
@@ -671,7 +672,9 @@ impl PartialEq for Bank {
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
         } = self;
-        *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
+        *disable_transaction_signatures_in_status_cache
+            == other.disable_transaction_signatures_in_status_cache
+            && *blockhash_queue.read().unwrap() == *other.blockhash_queue.read().unwrap()
             && *max_processing_age == other.max_processing_age
             && *partitioned_rewards_stake_account_stores_per_block
                 == other.partitioned_rewards_stake_account_stores_per_block
@@ -821,6 +824,9 @@ pub struct Bank {
 
     /// A cache of signature statuses
     pub status_cache: Arc<RwLock<BankStatusCache>>,
+
+    /// Mirrors RuntimeConfig::disable_transaction_signatures_in_status_cache.
+    disable_transaction_signatures_in_status_cache: bool,
 
     /// FIFO queue of `recent_blockhash` items
     blockhash_queue: RwLock<BlockhashQueue>,
@@ -1172,6 +1178,8 @@ impl Bank {
         let mut bank = Self {
             rc: BankRc::new(accounts),
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            disable_transaction_signatures_in_status_cache: RuntimeConfig::default()
+                .disable_transaction_signatures_in_status_cache,
             blockhash_queue: RwLock::<BlockhashQueue>::default(),
             max_processing_age: MAX_PROCESSING_AGE,
             partitioned_rewards_stake_account_stores_per_block,
@@ -1277,6 +1285,8 @@ impl Bank {
         let mut bank = Self::default_with_accounts(accounts);
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
         bank.compute_budget = runtime_config.compute_budget;
+        bank.disable_transaction_signatures_in_status_cache =
+            runtime_config.disable_transaction_signatures_in_status_cache;
         if let Some(compute_budget) = &bank.compute_budget {
             bank.transaction_processor
                 .set_execution_cost(compute_budget.to_cost());
@@ -1416,6 +1426,8 @@ impl Bank {
         let mut new = Self {
             rc,
             status_cache,
+            disable_transaction_signatures_in_status_cache: parent
+                .disable_transaction_signatures_in_status_cache,
             slot,
             bank_id,
             epoch,
@@ -2091,6 +2103,8 @@ impl Bank {
         let mut bank = Self {
             rc: bank_rc,
             status_cache: Arc::<RwLock<BankStatusCache>>::default(),
+            disable_transaction_signatures_in_status_cache: runtime_config
+                .disable_transaction_signatures_in_status_cache,
             blockhash_queue: RwLock::new(fields.blockhash_queue),
             max_processing_age: MAX_PROCESSING_AGE,
             partitioned_rewards_stake_account_stores_per_block,
@@ -3498,15 +3512,16 @@ impl Bank {
                     self.slot(),
                     processed_tx.status(),
                 );
-                // Add the transaction signature to the status cache so that transaction status
-                // can be queried by transaction signature over RPC. In the future, this should
-                // only be added for API nodes because voting validators don't need to do this.
-                status_cache.insert(
-                    tx.recent_blockhash(),
-                    tx.signature(),
-                    self.slot(),
-                    processed_tx.status(),
-                );
+                if !self.disable_transaction_signatures_in_status_cache {
+                    // Add the transaction signature to the status cache so that transaction
+                    // status can be queried by transaction signature over RPC.
+                    status_cache.insert(
+                        tx.recent_blockhash(),
+                        tx.signature(),
+                        self.slot(),
+                        processed_tx.status(),
+                    );
+                }
             }
         }
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2231,6 +2231,58 @@ fn test_tx_already_processed() {
     );
 }
 
+#[test]
+fn test_status_cache_signature_storage_config() {
+    let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+    let amount = genesis_config.rent.minimum_balance(0);
+
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let tx = system_transaction::transfer(
+        &mint_keypair,
+        &Keypair::new().pubkey(),
+        amount,
+        genesis_config.hash(),
+    );
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_signature_status(&tx.signatures[0]), Some(Ok(())));
+
+    let mut signature_skipping_bank = Bank::new_from_genesis(
+        &genesis_config,
+        Arc::new(RuntimeConfig {
+            skip_transaction_signatures_in_status_cache: true,
+            ..RuntimeConfig::default()
+        }),
+        vec![],
+        None,
+        BankTestConfig::default().accounts_db_config,
+        None,
+        None,
+        Arc::default(),
+        None,
+        None,
+    );
+    signature_skipping_bank.set_fee_structure(&FeeStructure {
+        lamports_per_signature: genesis_config.fee_rate_governor.lamports_per_signature,
+        ..FeeStructure::default()
+    });
+    let (bank, _bank_forks) = signature_skipping_bank.wrap_with_bank_forks_for_tests();
+
+    let mut tx = system_transaction::transfer(
+        &mint_keypair,
+        &Keypair::new().pubkey(),
+        amount,
+        genesis_config.hash(),
+    );
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_signature_status(&tx.signatures[0]), None);
+
+    tx.signatures[0] = Signature::default();
+    assert_eq!(
+        bank.process_transaction(&tx),
+        Err(TransactionError::AlreadyProcessed)
+    );
+}
+
 /// Verifies that last ids and status cache are correctly referenced from parent
 #[test]
 fn test_bank_parent_already_processed() {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2213,6 +2213,58 @@ fn test_tx_already_processed() {
     );
 }
 
+#[test]
+fn test_status_cache_signature_storage_config() {
+    let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+    let amount = genesis_config.rent.minimum_balance(0);
+
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let tx = system_transaction::transfer(
+        &mint_keypair,
+        &Keypair::new().pubkey(),
+        amount,
+        genesis_config.hash(),
+    );
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_signature_status(&tx.signatures[0]), Some(Ok(())));
+
+    let mut disabled_bank = Bank::new_from_genesis(
+        &genesis_config,
+        Arc::new(RuntimeConfig {
+            disable_transaction_signatures_in_status_cache: true,
+            ..RuntimeConfig::default()
+        }),
+        vec![],
+        None,
+        BankTestConfig::default().accounts_db_config,
+        None,
+        None,
+        Arc::default(),
+        None,
+        None,
+    );
+    disabled_bank.set_fee_structure(&FeeStructure {
+        lamports_per_signature: genesis_config.fee_rate_governor.lamports_per_signature,
+        ..FeeStructure::default()
+    });
+    let (bank, _bank_forks) = disabled_bank.wrap_with_bank_forks_for_tests();
+
+    let mut tx = system_transaction::transfer(
+        &mint_keypair,
+        &Keypair::new().pubkey(),
+        amount,
+        genesis_config.hash(),
+    );
+    assert_eq!(bank.process_transaction(&tx), Ok(()));
+    assert_eq!(bank.get_signature_status(&tx.signatures[0]), None);
+
+    tx.signatures[0] = Signature::default();
+    assert_eq!(
+        bank.process_transaction(&tx),
+        Err(TransactionError::AlreadyProcessed)
+    );
+}
+
 /// Verifies that last ids and status cache are correctly referenced from parent
 #[test]
 fn test_bank_parent_already_processed() {

--- a/runtime/src/runtime_config.rs
+++ b/runtime/src/runtime_config.rs
@@ -6,4 +6,7 @@ pub struct RuntimeConfig {
     pub compute_budget: Option<ComputeBudget>,
     pub log_messages_bytes_limit: Option<usize>,
     pub transaction_account_lock_limit: Option<usize>,
+    /// When true, skip storing transaction signature keys in the status cache.
+    /// Message hash keys are still stored for duplicate transaction detection.
+    pub skip_transaction_signatures_in_status_cache: bool,
 }

--- a/runtime/src/runtime_config.rs
+++ b/runtime/src/runtime_config.rs
@@ -6,4 +6,7 @@ pub struct RuntimeConfig {
     pub compute_budget: Option<ComputeBudget>,
     pub log_messages_bytes_limit: Option<usize>,
     pub transaction_account_lock_limit: Option<usize>,
+    /// When true, skip storing transaction signature keys in the status cache.
+    /// Message hash keys are still stored for duplicate transaction detection.
+    pub disable_transaction_signatures_in_status_cache: bool,
 }

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -1170,6 +1170,7 @@ impl TestValidator {
                 }),
             log_messages_bytes_limit: config.log_messages_bytes_limit,
             transaction_account_lock_limit: config.transaction_account_lock_limit,
+            ..RuntimeConfig::default()
         };
 
         let mut validator_config = ValidatorConfig {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -758,6 +758,15 @@ pub fn execute(
         UseSnapshotArchivesAtStartup
     );
 
+    let skip_transaction_signatures_in_status_cache =
+        !run_args.json_rpc_config.full_api && !snapshot_config.should_generate_snapshots();
+    if skip_transaction_signatures_in_status_cache {
+        info!(
+            "Transaction signatures will not be stored in the status cache because full RPC and \
+             snapshot generation are disabled"
+        );
+    }
+
     let mut validator_config = ValidatorConfig {
         log_config,
         require_tower: matches.is_present("require_tower"),
@@ -774,6 +783,11 @@ pub fn execute(
             .map(|s| Hash::from_str(s).unwrap()),
         expected_shred_version,
         new_hard_forks: hardforks_of(matches, "hard_forks"),
+        runtime_config: RuntimeConfig {
+            log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
+            skip_transaction_signatures_in_status_cache,
+            ..RuntimeConfig::default()
+        },
         rpc_config: run_args.json_rpc_config,
         on_start_geyser_plugin_config_files,
         geyser_plugin_always_enabled: matches.is_present("geyser_plugin_always_enabled"),
@@ -826,10 +840,6 @@ pub fn execute(
         snapshot_config,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         wait_to_vote_slot: None,
-        runtime_config: RuntimeConfig {
-            log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
-            ..RuntimeConfig::default()
-        },
         staked_nodes_overrides: staked_nodes_overrides.clone(),
         use_snapshot_archives_at_startup,
         ip_echo_server_threads,

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -775,6 +775,12 @@ pub fn execute(
             .map(|s| Hash::from_str(s).unwrap()),
         expected_shred_version,
         new_hard_forks: hardforks_of(matches, "hard_forks"),
+        runtime_config: RuntimeConfig {
+            log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
+            disable_transaction_signatures_in_status_cache: !run_args.json_rpc_config.full_api
+                && !snapshot_config.should_generate_snapshots(),
+            ..RuntimeConfig::default()
+        },
         rpc_config: run_args.json_rpc_config,
         on_start_geyser_plugin_config_files,
         geyser_plugin_always_enabled: matches.is_present("geyser_plugin_always_enabled"),
@@ -827,10 +833,6 @@ pub fn execute(
         snapshot_config,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
         wait_to_vote_slot: None,
-        runtime_config: RuntimeConfig {
-            log_messages_bytes_limit: value_of(matches, "log_messages_bytes_limit"),
-            ..RuntimeConfig::default()
-        },
         staked_nodes_overrides: staked_nodes_overrides.clone(),
         use_snapshot_archives_at_startup,
         ip_echo_server_threads,


### PR DESCRIPTION
## Summary

This change avoids storing transaction signature keys in the runtime status cache when a validator is not serving full RPC and is not generating snapshots. Signature-key insertion is skipped only for validators launched without `--full-rpc-api` and with snapshot generation disabled.

## Changes

- Add `disable_transaction_signatures_in_status_cache` to `RuntimeConfig`, defaulting to `false`.
- Gate only the transaction signature insert in `Bank::update_transaction_statuses`.
- Preserve transaction signature inserts whenever snapshot generation is enabled, even without full RPC, so generated snapshots keep signature entries.

## Benchmark Result

```text
    Finished `bench` profile [optimized] target(s) in 0.33s
     Running benches/status_cache_signature_storage.rs (target/release/deps/status_cache_signature_storage-c7104056f6ef5d5f)
Gnuplot not found, using plotters backend
Benchmarking status_cache_signature_storage_mainnet/average_slot/with_signatures
Benchmarking status_cache_signature_storage_mainnet/average_slot/with_signatures: Warming up for 1.0000 s
Benchmarking status_cache_signature_storage_mainnet/average_slot/with_signatures: Collecting 10 samples in estimated 3.0094 s (13k iterations)
Benchmarking status_cache_signature_storage_mainnet/average_slot/with_signatures: Analyzing
status_cache_signature_storage_mainnet/average_slot/with_signatures
                        time:   [158.74 µs 159.90 µs 161.35 µs]
                        thrpt:  [7.4371 Melem/s 7.5045 Melem/s 7.5595 Melem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking status_cache_signature_storage_mainnet/average_slot/message_hash_only
Benchmarking status_cache_signature_storage_mainnet/average_slot/message_hash_only: Warming up for 1.0000 s
Benchmarking status_cache_signature_storage_mainnet/average_slot/message_hash_only: Collecting 10 samples in estimated 3.0007 s (26k iterations)
Benchmarking status_cache_signature_storage_mainnet/average_slot/message_hash_only: Analyzing
status_cache_signature_storage_mainnet/average_slot/message_hash_only
                        time:   [81.266 µs 81.500 µs 81.800 µs]
                        thrpt:  [14.670 Melem/s 14.724 Melem/s 14.766 Melem/s]
Benchmarking status_cache_signature_storage_mainnet/high_slot/with_signatures
Benchmarking status_cache_signature_storage_mainnet/high_slot/with_signatures: Warming up for 1.0000 s
Benchmarking status_cache_signature_storage_mainnet/high_slot/with_signatures: Collecting 10 samples in estimated 3.0280 s (5390 iterations)
Benchmarking status_cache_signature_storage_mainnet/high_slot/with_signatures: Analyzing
status_cache_signature_storage_mainnet/high_slot/with_signatures
                        time:   [364.60 µs 366.96 µs 370.53 µs]
                        thrpt:  [7.0170 Melem/s 7.0853 Melem/s 7.1311 Melem/s]
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking status_cache_signature_storage_mainnet/high_slot/message_hash_only
Benchmarking status_cache_signature_storage_mainnet/high_slot/message_hash_only: Warming up for 1.0000 s
Benchmarking status_cache_signature_storage_mainnet/high_slot/message_hash_only: Collecting 10 samples in estimated 3.0139 s (11k iterations)
Benchmarking status_cache_signature_storage_mainnet/high_slot/message_hash_only: Analyzing
status_cache_signature_storage_mainnet/high_slot/message_hash_only
                        time:   [180.50 µs 181.20 µs 182.35 µs]
                        thrpt:  [14.259 Melem/s 14.349 Melem/s 14.404 Melem/s]
```

## Mainnet Validator Log Result

The deployed validator was restarted with `--full-rpc-api` disabled at `2026-06-18T17:07:22Z`. The comparison below uses `replay-slot-stats` from `sudo journalctl -u solana-validator` on equal 2-minute windows. With the snapshot-generation guard, the message-hash-only path is active only when snapshot generation is disabled too.

Equal 2-minute windows:

```text
before full-rpc-api on:  17:05:22-17:07:22Z
samples=242  avg_tx=1428.91  avg_update_transaction_statuses_us=10154.08  avg_us_per_tx=7.1637

after full-rpc-api off:  17:07:22-17:09:22Z
samples=370  avg_tx=1473.71  avg_update_transaction_statuses_us=3749.66   avg_us_per_tx=2.6313
```

Percentiles:

```text
before: p50=6.7297us/tx  p90=9.8804us/tx  p95=11.2363us/tx
after:  p50=2.2274us/tx  p90=4.3021us/tx  p95=5.2580us/tx
```


## Benchmark

Sizes were taken from a running mainnet validator:

```text
samples=1000 avg_total_transactions=1189 max_total_transactions=2587 avg_update_transaction_statuses_us=10523 max_update_transaction_statuses_us=40457 avg_us_per_tx=8.94 max_us_per_tx=38.64
```

- `1_200` transactions for an average mainnet slot.
- `2_600` transactions for a high mainnet slot.

```rust
use {
    criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput},
    rand::{rngs::SmallRng, Rng, SeedableRng},
    solana_clock::Slot,
    solana_hash::{Hash, HASH_BYTES},
    solana_runtime::bank::BankStatusCache,
    solana_signature::{Signature, SIGNATURE_BYTES},
    std::{
        hint::black_box,
        time::{Duration, Instant},
    },
};

const MAINNET_AVERAGE_SLOT_TRANSACTIONS: usize = 1_200;
const MAINNET_HIGH_SLOT_TRANSACTIONS: usize = 2_600;

fn make_status_cache_keys(batch_size: usize, seed: u64) -> Vec<(Hash, Signature)> {
    let mut rng = SmallRng::seed_from_u64(seed);
    (0..batch_size)
        .map(|_| {
            let mut hash_bytes = [0u8; HASH_BYTES];
            rng.fill(&mut hash_bytes);

            let mut signature_bytes = [0u8; SIGNATURE_BYTES];
            rng.fill(&mut signature_bytes);

            (
                Hash::new_from_array(hash_bytes),
                Signature::from(signature_bytes),
            )
        })
        .collect()
}

fn insert_status_cache_batch(
    status_cache: &mut BankStatusCache,
    blockhash: &Hash,
    slot: Slot,
    tx_keys: &[(Hash, Signature)],
    store_signatures: bool,
) {
    for (message_hash, signature) in tx_keys {
        status_cache.insert(blockhash, *message_hash, slot, Ok(()));
        if store_signatures {
            status_cache.insert(blockhash, *signature, slot, Ok(()));
        }
    }
}

fn mainnet_status_cache(store_signatures: bool) -> (BankStatusCache, Hash, Slot) {
    let mut status_cache = BankStatusCache::default();
    let max_root_entries = status_cache.max_root_entries() as Slot;
    let mut active_blockhash = Hash::default();

    for slot in 0..max_root_entries {
        let blockhash = Hash::new_unique();
        let tx_keys = make_status_cache_keys(MAINNET_AVERAGE_SLOT_TRANSACTIONS, slot);
        insert_status_cache_batch(
            &mut status_cache,
            &blockhash,
            slot,
            &tx_keys,
            store_signatures,
        );
        status_cache.add_root(slot);
        active_blockhash = blockhash;
    }

    (status_cache, active_blockhash, max_root_entries)
}

fn benchmark_status_cache_signature_storage(c: &mut Criterion) {
    let mut group = c.benchmark_group("status_cache_signature_storage_mainnet");

    for (batch_name, batch_size) in [
        ("average_slot", MAINNET_AVERAGE_SLOT_TRANSACTIONS),
        ("high_slot", MAINNET_HIGH_SLOT_TRANSACTIONS),
    ] {
        group.throughput(Throughput::Elements(batch_size as u64));

        for (variant_name, store_signatures) in
            [("with_signatures", true), ("message_hash_only", false)]
        {
            group.bench_with_input(
                BenchmarkId::new(batch_name, variant_name),
                &(batch_size, store_signatures),
                |bencher, &(batch_size, store_signatures)| {
                    let (mut status_cache, blockhash, slot) =
                        mainnet_status_cache(store_signatures);
                    let tx_keys = make_status_cache_keys(batch_size, u64::MAX);

                    bencher.iter_custom(|iterations| {
                        let mut elapsed = Duration::ZERO;
                        for _ in 0..iterations {
                            let start = Instant::now();
                            insert_status_cache_batch(
                                &mut status_cache,
                                &blockhash,
                                slot,
                                &tx_keys,
                                store_signatures,
                            );
                            black_box(&mut status_cache);
                            elapsed += start.elapsed();

                            status_cache.clear_slot_entries(slot);
                        }
                        elapsed
                    });
                },
            );
        }
    }

    group.finish();
}

criterion_group!(benches, benchmark_status_cache_signature_storage);
criterion_main!(benches);
```
