### PR TITLE
svm: skip precompile signature verification in simulation when sigVerify is false

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -201,7 +201,12 @@ fn simulate_transaction(
         post_balances: _,
         pre_token_balances: _,
         post_token_balances: _,
-    } = bank.simulate_transaction_unchecked(&sanitized_transaction, true);
+    } = bank.simulate_transaction_unchecked(
+        &sanitized_transaction,
+        true,
+        // Verify precompiles (do not skip); BanksClient simulates signed transactions.
+        false,
+    );
 
     let simulation_details = TransactionSimulationDetails {
         logs,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -333,6 +333,8 @@ impl Consumer {
                     drop_on_failure: flags.drop_on_failure,
                     all_or_nothing: flags.all_or_nothing,
                     strict_nonce_size_check: true,
+                    // Committed execution must always verify precompiles.
+                    skip_precompile_verification: false,
                 }
             ));
         execute_and_commit_timings.load_execute_us = load_execute_us;

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -52,7 +52,7 @@ fn test_no_panic_banks_client() {
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank.simulate_transaction(&sanitized_tx, false, false);
     assert!(result.result.is_ok());
 }
 

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -96,7 +96,7 @@ fn test_syscall_get_epoch_stake() {
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank.simulate_transaction(&sanitized_tx, false, false);
 
     assert!(result.result.is_ok());
 

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -125,7 +125,7 @@ fn test_sysvar_syscalls() {
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
         let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-        let result = bank.simulate_transaction(&sanitized_tx, false);
+        let result = bank.simulate_transaction(&sanitized_tx, false, false);
         assert!(result.result.is_ok());
     }
 
@@ -143,6 +143,6 @@ fn test_sysvar_syscalls() {
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank.simulate_transaction(&sanitized_tx, false, false);
     assert!(result.result.is_err());
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3939,7 +3939,9 @@ pub mod rpc_full {
                 let simulation_result = if let Some(err) = verification_error {
                     TransactionSimulationResult::new_error(err)
                 } else {
-                    preflight_bank.simulate_transaction(&transaction, false)
+                    // Preflight simulates a fully-signed transaction, so
+                    // precompiles must be verified (do not skip).
+                    preflight_bank.simulate_transaction(&transaction, false, false)
                 };
 
                 if let TransactionSimulationResult {
@@ -4065,7 +4067,11 @@ pub mod rpc_full {
             let simulation_result = if let Some(err) = verification_error {
                 TransactionSimulationResult::new_error(err)
             } else {
-                bank.simulate_transaction(&transaction, enable_cpi_recording)
+                // When `sigVerify` is false, skip precompile signature
+                // verification so that transactions whose precompile
+                // instructions are not yet signed can still be simulated
+                // (restores pre-SIMD-0159 behavior).
+                bank.simulate_transaction(&transaction, enable_cpi_recording, !sig_verify)
             };
 
             let TransactionSimulationResult {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3749,18 +3749,30 @@ impl Bank {
         &self,
         transaction: &impl TransactionWithMeta,
         enable_cpi_recording: bool,
+        skip_precompile_verification: bool,
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
 
-        self.simulate_transaction_unchecked(transaction, enable_cpi_recording)
+        self.simulate_transaction_unchecked(
+            transaction,
+            enable_cpi_recording,
+            skip_precompile_verification,
+        )
     }
 
     /// Run transactions against a bank without committing the results; does not check if the bank
-    /// is frozen, enabling use in single-Bank test frameworks
+    /// is frozen, enabling use in single-Bank test frameworks.
+    ///
+    /// `skip_precompile_verification` should only be set when simulating on
+    /// behalf of `simulateTransaction` with `sigVerify: false`, so that a
+    /// transaction whose precompile instructions are not yet signed can still be
+    /// simulated. It must never be set for any path that mirrors committed
+    /// execution.
     pub fn simulate_transaction_unchecked(
         &self,
         transaction: &impl TransactionWithMeta,
         enable_cpi_recording: bool,
+        skip_precompile_verification: bool,
     ) -> TransactionSimulationResult {
         let account_keys = transaction.account_keys();
         let number_of_accounts = account_keys.len();
@@ -3795,6 +3807,7 @@ impl Bank {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 strict_nonce_size_check: false,
+                skip_precompile_verification,
             },
         );
 
@@ -4531,6 +4544,8 @@ impl Bank {
                 drop_on_failure: false,
                 all_or_nothing: false,
                 strict_nonce_size_check: false,
+                // Committed execution must always verify precompiles.
+                skip_precompile_verification: false,
             },
         );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11367,7 +11367,7 @@ fn test_failed_simulation_compute_units() {
 
     bank.freeze();
     let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(&sanitized, false);
+    let simulation = bank.simulate_transaction(&sanitized, false, false);
     assert_eq!(expected_consumed_units, simulation.units_consumed);
     assert_eq!(
         expected_loaded_program_account_data_size,
@@ -11395,7 +11395,7 @@ fn test_failed_simulation_load_error() {
     bank.freeze();
     let mint_balance = bank.get_account(&mint_keypair.pubkey()).unwrap().lamports();
     let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(&sanitized, false);
+    let simulation = bank.simulate_transaction(&sanitized, false, false);
     assert_eq!(
         simulation,
         TransactionSimulationResult {

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -106,6 +106,8 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
             &mut invoke_context,
             &mut timings,
             &mut compute_units_consumed,
+            // Conformance harness must verify precompiles like committed execution.
+            false,
         ) {
             Ok(()) => Ok(()),
             Err(TransactionError::InstructionError(_, err)) => Err(err),

--- a/svm/src/message_processor.rs
+++ b/svm/src/message_processor.rs
@@ -16,6 +16,7 @@ pub(crate) fn process_message<'ix_data>(
     invoke_context: &mut InvokeContext<'_, 'ix_data>,
     execute_timings: &mut ExecuteTimings,
     accumulated_consumed_units: &mut u64,
+    skip_precompile_verification: bool,
 ) -> Result<(), TransactionError> {
     invoke_context
         .prepare_top_level_instructions(message)
@@ -27,11 +28,22 @@ pub(crate) fn process_message<'ix_data>(
         let mut compute_units_consumed = 0;
         let (result, process_instruction_us) = measure_us!({
             if invoke_context.is_precompile(program_id) {
-                invoke_context.process_precompile(
-                    program_id,
-                    instruction.data,
-                    message.instructions_iter().map(|ix| ix.data),
-                )
+                // Precompile signature verification runs as part of execution
+                // (SIMD-0159). Simulation may skip it so that callers can
+                // simulate a transaction whose precompile instructions are not
+                // yet signed (e.g. passkey/secp256r1 smart wallets), matching
+                // the pre-SIMD-0159 behavior of `simulateTransaction` with
+                // `sigVerify: false`. This must never be skipped for committed
+                // execution, where it is consensus-relevant.
+                if skip_precompile_verification {
+                    Ok(())
+                } else {
+                    invoke_context.process_precompile(
+                        program_id,
+                        instruction.data,
+                        message.instructions_iter().map(|ix| ix.data),
+                    )
+                }
             } else {
                 invoke_context.process_instruction(&mut compute_units_consumed, execute_timings)
             }
@@ -240,6 +252,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert!(result.is_ok());
         assert_eq!(
@@ -298,6 +311,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert_eq!(
             result,
@@ -345,6 +359,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert_eq!(
             result,
@@ -480,6 +495,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert_eq!(
             result,
@@ -523,6 +539,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert!(result.is_ok());
 
@@ -562,6 +579,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
         assert!(result.is_ok());
         assert_eq!(
@@ -722,6 +740,7 @@ mod tests {
             &mut invoke_context,
             &mut ExecuteTimings::default(),
             &mut 0,
+            false,
         );
 
         assert_eq!(
@@ -735,5 +754,96 @@ mod tests {
             transaction_context.number_of_called_instructions_in_trace(),
             4
         );
+    }
+
+    // Regression test for issue #13252: `simulateTransaction` with
+    // `sigVerify: false` must be able to simulate a transaction whose precompile
+    // instructions are not yet signed. When `skip_precompile_verification` is
+    // set, a precompile whose signature would fail verification is treated as a
+    // no-op; otherwise it fails as usual.
+    #[test]
+    fn test_skip_precompile_verification() {
+        // A precompile callback that always reports an invalid signature,
+        // emulating an unsigned (placeholder) precompile instruction.
+        struct FailingPrecompileCallback;
+        impl InvokeContextCallback for FailingPrecompileCallback {
+            fn is_precompile(&self, program_id: &Pubkey) -> bool {
+                program_id == &solana_secp256r1_program::id()
+            }
+
+            fn process_precompile(
+                &self,
+                _program_id: &Pubkey,
+                _data: &[u8],
+                _instruction_datas: Vec<&[u8]>,
+            ) -> std::result::Result<(), PrecompileError> {
+                Err(PrecompileError::InvalidSignature)
+            }
+        }
+
+        let run = |skip_precompile_verification: bool| -> Result<(), TransactionError> {
+            let mut secp256r1_account = AccountSharedData::new(1, 0, &native_loader::id());
+            secp256r1_account.set_executable(true);
+            let fee_payer = Pubkey::new_unique();
+            let accounts_map: HashMap<Address, AccountSharedData> = HashMap::from([
+                (
+                    fee_payer,
+                    AccountSharedData::new(1, 0, &system_program::id()),
+                ),
+                (solana_secp256r1_program::id(), secp256r1_account),
+            ]);
+
+            let message = new_sanitized_message(Message::new(
+                &[secp256r1_instruction_for_test()],
+                Some(&fee_payer),
+            ));
+            let accounts = message
+                .account_keys()
+                .iter()
+                .map(|key| (*key, accounts_map.get(key).unwrap().clone()))
+                .collect();
+            let mut transaction_context =
+                TransactionContext::new(accounts, Rent::default(), 1, 1, 1);
+
+            let sysvar_cache = SysvarCache::default();
+            let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
+            let feature_set = SVMFeatureSet::all_enabled();
+            let program_runtime_environments = ProgramRuntimeEnvironments::mock();
+            let environment_config = EnvironmentConfig::new(
+                Hash::default(),
+                0,
+                false,
+                &FailingPrecompileCallback,
+                &feature_set,
+                &program_runtime_environments,
+                &sysvar_cache,
+            );
+            let mut invoke_context = InvokeContext::new(
+                &mut transaction_context,
+                &mut program_cache_for_tx_batch,
+                environment_config,
+                None,
+                SVMTransactionExecutionBudget::default(),
+                SVMTransactionExecutionCost::default(),
+            );
+            process_message(
+                &message,
+                &mut invoke_context,
+                &mut ExecuteTimings::default(),
+                &mut 0,
+                skip_precompile_verification,
+            )
+        };
+
+        // Without skipping, the invalid precompile signature fails simulation at
+        // the precompile instruction (index 0).
+        assert!(matches!(
+            run(false),
+            Err(TransactionError::InstructionError(0, _))
+        ));
+
+        // Skipping precompile verification lets the otherwise-unsigned
+        // transaction simulate cleanly.
+        assert_eq!(run(true), Ok(()));
     }
 }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -145,6 +145,16 @@ pub struct TransactionProcessingConfig<'a> {
     ///
     /// This is a leader-side filtering policy. It must not be enabled for replay.
     pub strict_nonce_size_check: bool,
+    /// Skip precompile (ed25519/secp256k1/secp256r1) signature verification
+    /// during execution.
+    ///
+    /// This must remain `false` for committed execution (replay, banking),
+    /// where precompile verification is consensus-relevant. It may be set to
+    /// `true` only for `simulateTransaction` with `sigVerify: false`, so that
+    /// callers can simulate a transaction whose precompile instructions are not
+    /// yet signed (e.g. passkey/secp256r1 smart wallets). The `Default` value
+    /// is `false` so verification is never skipped unless explicitly requested.
+    pub skip_precompile_verification: bool,
 }
 
 /// Runtime environment for transaction batch processing.
@@ -1055,6 +1065,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             &mut invoke_context,
             execute_timings,
             &mut executed_units,
+            config.skip_precompile_verification,
         );
         process_message_time.stop();
 

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2781,7 +2781,7 @@ mod tests {
             ));
         // make sure this tx is really a good one to execute.
         assert_matches!(
-            bank.simulate_transaction_unchecked(&good_tx_after_bad_tx, false)
+            bank.simulate_transaction_unchecked(&good_tx_after_bad_tx, false, false)
                 .result,
             Ok(_)
         );


### PR DESCRIPTION
Closes #13252.

Since SIMD-0159 (move_precompile_verification_to_svm), precompile signature
verification runs inside the SVM execution path that simulateTransaction uses,
with no sigVerify gate. Simulating a transaction with an ed25519/secp256k1/
secp256r1 precompile instruction therefore fails with Custom(2)
(PrecompileError::InvalidSignature) unless it already carries a valid
signature — even with sigVerify: false. This breaks pre-signing simulation for
smart wallets using non-ed25519 signers (e.g. passkeys/WebAuthn over secp256r1).

This restores the pre-SIMD-0159 behavior: simulateTransaction with
sigVerify: false skips precompile signature verification. Simulation-only,
never committed execution — not a consensus change.

- process_message takes skip_precompile_verification; when set, precompiles are a no-op.
- New TransactionProcessingConfig::skip_precompile_verification (default false);
  committed paths (banking stage, bank commit) set it false explicitly.
- Bank::simulate_transaction[_unchecked] take the flag; RPC passes !sig_verify
  (preflight always false).
- Adds test_skip_precompile_verification.
