### PR TITLE
Introduces finalized slot

### DIFF
--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -907,11 +907,11 @@ mod tests {
         .unwrap();
 
         let handle = vote_state_from_bank(&bank, &target_vote_pubkey);
-        assert_eq!(handle.root_slot(), Some(final_cert.slot()));
+        assert_eq!(handle.root_slot(), Some(final_cert.slot().slot()));
         assert_eq!(handle.votes().len(), 1);
         assert_eq!(
             handle.votes().front().unwrap().lockout.slot(),
-            final_cert.slot().max(reward_slot)
+            final_cert.slot().slot().max(reward_slot)
         );
     }
 

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -9,6 +9,7 @@ use {
     agave_votor_messages::{
         certificate::{Certificate, CertificateType},
         consensus_message::Block,
+        finalized_slot::FinalizedSlot,
     },
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
@@ -199,7 +200,7 @@ impl ValidatedBlockFinalizationCert {
     }
 
     /// Returns the slot that is finalized.
-    pub fn slot(&self) -> Slot {
+    pub fn slot(&self) -> FinalizedSlot {
         match &self.kind {
             ValidatedBlockFinalizationCertKind::Finalize {
                 finalize_cert,
@@ -209,10 +210,10 @@ impl ValidatedBlockFinalizationCert {
                     finalize_cert.cert_type.slot(),
                     notarize_cert.cert_type.slot()
                 );
-                finalize_cert.cert_type.slot()
+                FinalizedSlot::Slow(finalize_cert.cert_type.slot())
             }
             ValidatedBlockFinalizationCertKind::FastFinalize(certificate) => {
-                certificate.cert_type.slot()
+                FinalizedSlot::Fast(certificate.cert_type.slot())
             }
         }
     }
@@ -255,7 +256,7 @@ impl ValidatedBlockFinalizationCert {
 
     /// Returns the data needed to calculating and paying vote rewards.
     pub fn vote_rewards_input(&self) -> (&HashSet<Pubkey>, Slot) {
-        (&self.signers, self.slot())
+        (&self.signers, self.slot().slot())
     }
 
     /// Consumes self and returns the contained certificates and the signers.

--- a/votor-messages/src/finalized_slot.rs
+++ b/votor-messages/src/finalized_slot.rs
@@ -1,0 +1,68 @@
+//! A module to define FinalizedSlot
+use {solana_clock::Slot, std::cmp::Ordering};
+
+/// A slot can be finalized if the node has a fast finalization cert for it (fast finalization) or
+/// it has a notar and a finalization cert for it (slow finalization).  We prefer fast finalization
+/// certs above slow finalization for the same slot.  This enum helps in comparing two different
+/// finalized slots while preferring fast finalization over slow for the same slot.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FinalizedSlot {
+    /// The slot was slow finalized.
+    Slow(Slot),
+    /// The slot was fast finalized.
+    Fast(Slot),
+}
+
+impl FinalizedSlot {
+    /// Returns the actual slot.
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Slow(slot) | Self::Fast(slot) => *slot,
+        }
+    }
+}
+
+impl Ord for FinalizedSlot {
+    /// Overloading the cmp operators to prefer fast finalization over slow for the same slot.
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.slot().cmp(&other.slot()) {
+            Ordering::Equal => match (self, other) {
+                (Self::Fast(_), Self::Slow(_)) => Ordering::Greater,
+                (Self::Slow(_), Self::Fast(_)) => Ordering::Less,
+                _ => Ordering::Equal,
+            },
+            ordering => ordering,
+        }
+    }
+}
+
+impl PartialOrd for FinalizedSlot {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn validation() {
+        assert!(FinalizedSlot::Slow(5) < FinalizedSlot::Slow(6));
+        assert!(FinalizedSlot::Slow(5) == FinalizedSlot::Slow(5));
+        assert!(FinalizedSlot::Slow(5) > FinalizedSlot::Slow(4));
+
+        assert!(FinalizedSlot::Fast(5) < FinalizedSlot::Fast(6));
+        assert!(FinalizedSlot::Fast(5) == FinalizedSlot::Fast(5));
+        assert!(FinalizedSlot::Fast(5) > FinalizedSlot::Fast(4));
+
+        assert!(FinalizedSlot::Slow(5) < FinalizedSlot::Fast(6));
+        assert!(FinalizedSlot::Slow(5) < FinalizedSlot::Fast(5));
+        assert!(FinalizedSlot::Slow(5) > FinalizedSlot::Fast(4));
+
+        assert!(FinalizedSlot::Fast(5) < FinalizedSlot::Slow(6));
+        assert!(FinalizedSlot::Fast(5) > FinalizedSlot::Slow(5));
+        assert!(FinalizedSlot::Fast(5) > FinalizedSlot::Slow(4));
+    }
+}

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -11,6 +11,7 @@ use {
 
 pub mod certificate;
 pub mod consensus_message;
+pub mod finalized_slot;
 pub mod fraction;
 pub mod metric_types;
 pub mod migration;

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -17,6 +17,7 @@ use {
     agave_votor_messages::{
         certificate::{Certificate, CertificateType},
         consensus_message::{Block, ConsensusMessage, VoteMessage},
+        finalized_slot::FinalizedSlot,
         fraction::Fraction,
         migration::MigrationStatus,
         vote::{Vote, VoteType},
@@ -306,7 +307,10 @@ impl ConsensusPool {
                     // It's fine to set FastFinalization to false here, because
                     // we will report correctly as long as we have FastFinalization cert.
                     events.push(VotorEvent::Finalized(block, false));
-                    if self.highest_finalized_slot().is_none_or(|s| s < block.slot) {
+                    if self
+                        .highest_finalized_slot()
+                        .is_none_or(|s| s < FinalizedSlot::Slow(block.slot))
+                    {
                         self.highest_finalized_slot_cert =
                             Some(ValidatedBlockFinalizationCert::from_validated_slow(
                                 Arc::unwrap_or_clone(finalize_cert.clone()),
@@ -320,7 +324,10 @@ impl ConsensusPool {
                 if let Some(notarize_cert) = self.get_notarize_cert(slot) {
                     let block = notarize_cert.cert_type.to_block().unwrap();
                     events.push(VotorEvent::Finalized(block, false));
-                    if self.highest_finalized_slot().is_none_or(|s| s < slot) {
+                    if self
+                        .highest_finalized_slot()
+                        .is_none_or(|s| s < FinalizedSlot::Slow(slot))
+                    {
                         self.highest_finalized_slot_cert =
                             Some(ValidatedBlockFinalizationCert::from_validated_slow(
                                 Arc::unwrap_or_clone(cert),
@@ -334,10 +341,9 @@ impl ConsensusPool {
                 events.push(VotorEvent::Finalized(block, true));
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger(block, events);
-                // Use <= for FastFinalize since it supersedes standard finalization at the same slot
                 if self
                     .highest_finalized_slot()
-                    .is_none_or(|s| s <= block.slot)
+                    .is_none_or(|s| s < FinalizedSlot::Fast(block.slot))
                 {
                     self.highest_finalized_slot_cert =
                         Some(ValidatedBlockFinalizationCert::from_validated_fast(
@@ -383,7 +389,10 @@ impl ConsensusPool {
         } else {
             None
         };
-        Ok((new_finalized_slot, new_certficates_to_send))
+        Ok((
+            new_finalized_slot.map(|s| s.slot()),
+            new_certficates_to_send,
+        ))
     }
 
     fn add_vote(
@@ -491,7 +500,7 @@ impl ConsensusPool {
     }
 
     /// Get the highest finalized slot (slow or fast)
-    pub(crate) fn highest_finalized_slot(&self) -> Option<Slot> {
+    pub(crate) fn highest_finalized_slot(&self) -> Option<FinalizedSlot> {
         self.highest_finalized_slot_cert.as_ref().map(|c| c.slot())
     }
 
@@ -629,11 +638,10 @@ impl ConsensusPool {
     }
 
     pub(crate) fn get_certs_for_standstill(&self) -> Vec<Arc<Certificate>> {
-        let highest_slot = self
-            .highest_finalized_slot_cert
-            .as_ref()
-            .map(ValidatedBlockFinalizationCert::slot)
-            .unwrap_or(0);
+        let highest_slot = match &self.highest_finalized_slot_cert {
+            Some(c) => c.slot().slot(),
+            None => 0,
+        };
         self.completed_certificates
             .iter()
             .filter_map(|(cert_type, cert)| {
@@ -749,7 +757,7 @@ mod tests {
                 Vote::Skip(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
                 Vote::SkipFallback(vote) => assert_eq!(self.pool.highest_skip_slot(), vote.slot),
                 Vote::Finalize(vote) => assert_eq!(
-                    self.pool.highest_finalized_slot().unwrap_or_default(),
+                    self.pool.highest_finalized_slot().unwrap().slot(),
                     vote.slot
                 ),
                 Vote::Genesis(_genesis_vote) => (),
@@ -1078,9 +1086,11 @@ mod tests {
         }
 
         let highest_slot_fn = match &vote {
-            Vote::Finalize(_) => {
-                |pool: &ConsensusPool| pool.highest_finalized_slot().unwrap_or_default()
-            }
+            Vote::Finalize(_) => |pool: &ConsensusPool| {
+                pool.highest_finalized_slot()
+                    .map(|s| s.slot())
+                    .unwrap_or_default()
+            },
             Vote::Notarize(_) => |pool: &ConsensusPool| pool.highest_notarized_slot(),
             Vote::NotarizeFallback(_) => |pool: &ConsensusPool| pool.highest_notarized_slot(),
             Vote::Skip(_) => |pool: &ConsensusPool| pool.highest_skip_slot(),

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -357,6 +357,7 @@ impl ConsensusPoolService {
                     events.push(VotorEvent::Standstill(
                         consensus_pool
                             .highest_finalized_slot()
+                            .map(|s| s.slot())
                             .unwrap_or(ctx.sharable_banks.root().slot()),
                     ));
                 }
@@ -568,7 +569,10 @@ impl ConsensusPoolService {
             }
         }
 
-        let highest_finalized = consensus_pool.highest_finalized_slot().unwrap_or(0);
+        let highest_finalized = consensus_pool
+            .highest_finalized_slot()
+            .map(|s| s.slot())
+            .unwrap_or(0);
 
         pending_safe_to_notar.retain(|&block| {
             // Discard if slot is at or below highest finalized

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -357,7 +357,7 @@ impl VotingService {
         };
 
         if let Some((highest_finalized_slot, certificates)) = highest_finalized_slot_and_certs {
-            standstill_queue.prune(highest_finalized_slot);
+            standstill_queue.prune(highest_finalized_slot.slot());
 
             // Refresh the latest finalization (either Finalize + Notarize or FastFinalize)
             for certificate in certificates {


### PR DESCRIPTION
#### Problem

For the same slot, we prefer the fast finalization cert over slow finalization.  We have code in various places where we check for the cert type when comparing slots.  But https://github.com/anza-xyz/agave/issues/13057 noted that we are missing this check in some places.



#### Summary of Changes

- To make it easier to perform the check, introduces a FinalizedSlot type with a custom Ord implementation that prefers fast finalization over slow.
- Uses this type in various places removing old code to do complicated comparison.


#### Testing

- Added new unit tests to ensure that the Ord implementation is correct.
- CI


Fixes #13057 

Note that even though this PR does not change it, ConsensusPool::add_message() should now correctly return Some(slot) when the slow finalization cert was observed before the fast finalization.