### PR TITLE
Remove the is_cached trait

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         accounts_db::AccountsFileId,
         accounts_file::ALIGN_BOUNDARY_OFFSET,
-        accounts_index::{DiskIndexValue, IndexValue, IsCached},
+        accounts_index::{DiskIndexValue, IndexValue},
         is_zero_lamport::IsZeroLamport,
     },
     modular_bitfield::prelude::*,
@@ -69,12 +69,6 @@ const _: () = assert!(size_of::<AccountInfo>() == 8);
 impl IsZeroLamport for AccountInfo {
     fn is_zero_lamport(&self) -> bool {
         self.account_offset_and_flags.is_zero_lamport()
-    }
-}
-
-impl IsCached for AccountInfo {
-    fn is_cached(&self) -> bool {
-        false
     }
 }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -47,8 +47,8 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, AccountsIndexRootsStats,
-            AccountsIndexScanResult, IndexKey, IsCached, ReclaimsSlotList, RefCount, ScanFilter,
-            SlotList, Startup, UpsertReclaim, in_mem_accounts_index::StartupStats,
+            AccountsIndexScanResult, IndexKey, ReclaimsSlotList, RefCount, ScanFilter, SlotList,
+            Startup, UpsertReclaim, in_mem_accounts_index::StartupStats,
         },
         accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult, ScanTracker},
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
@@ -1995,13 +1995,6 @@ impl AccountsDb {
                     } else {
                         let mut key_set = HashSet::new();
                         key_set.insert(*pubkey);
-                        assert!(
-                            !account_info.is_cached(),
-                            "The Accounts Cache must be flushed first for this account info. \
-                             pubkey: {}, slot: {}",
-                            *pubkey,
-                            *slot
-                        );
                         let count = self
                             .storage
                             .get_account_storage_entry(*slot, account_info.store_id())
@@ -2780,7 +2773,7 @@ impl AccountsDb {
                         // Let's handle the special case - after unref, the result is a single ref zero lamport account.
                         if slot_list.len() == 1 && ref_count == 2 {
                             if let Some((slot_alive, acct_info)) = slot_list.first() {
-                                if acct_info.is_zero_lamport() && !acct_info.is_cached() {
+                                if acct_info.is_zero_lamport() {
                                     self.zero_lamport_single_ref_found(
                                         *slot_alive,
                                         acct_info.offset(),
@@ -5086,7 +5079,6 @@ impl AccountsDb {
 
             (start..end).for_each(|i| {
                 let info: AccountInfo = infos[i];
-                debug_assert!(!info.is_cached());
                 let old_slot = accounts.slot(i);
                 let pubkey = accounts.pubkey(i);
                 self.accounts_index.upsert(
@@ -5162,7 +5154,6 @@ impl AccountsDb {
         let update = |start, end| {
             (start..end).for_each(|i| {
                 let info: AccountInfo = infos[i];
-                debug_assert!(!info.is_cached());
                 let old_slot = accounts.slot(i);
                 let pubkey = accounts.pubkey(i);
                 self.accounts_index
@@ -5266,8 +5257,6 @@ impl AccountsDb {
         let mut new_shrink_candidates = ShrinkCandidates::default();
         let mut measure = Measure::start("remove");
         for (slot, account_info) in reclaims {
-            // No cached accounts should make it here
-            assert!(!account_info.is_cached());
             reclaimed_offsets
                 .entry(*slot)
                 .or_default()
@@ -5410,7 +5399,7 @@ impl AccountsDb {
                             // Let's handle the special case - after unref, the result is a single ref zero lamport account.
                             if slot_list.len() == 1 && ref_count == 2 {
                                 if let Some((slot_alive, acct_info)) = slot_list.first() {
-                                    if acct_info.is_zero_lamport() && !acct_info.is_cached() {
+                                    if acct_info.is_zero_lamport() {
                                         self.zero_lamport_single_ref_found(
                                             *slot_alive,
                                             acct_info.offset(),
@@ -5932,7 +5921,6 @@ impl AccountsDb {
                     (false, is_single_ref)
                 });
                 if is_single_ref {
-                    debug_assert!(!account_info.is_cached());
                     debug_assert_eq!(account_info.store_id(), storage.id());
                     if storage.insert_zero_lamport_single_ref_account_offset(account_info.offset())
                     {

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -125,8 +125,6 @@ pub enum ScanFilter {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// how accounts index 'upsert' should handle reclaims
 pub enum UpsertReclaim {
-    /// previous entry for this slot in the index is expected to be cached, so irrelevant to reclaims
-    PreviousSlotEntryWasCached,
     /// previous entry for this slot in the index may need to be reclaimed, so return it.
     /// reclaims is the only output of upsert, requiring a synchronous execution
     PopulateReclaims,
@@ -136,12 +134,7 @@ pub enum UpsertReclaim {
     // in the 'reclaims'
     ReclaimOldSlots,
 }
-
-pub trait IsCached {
-    fn is_cached(&self) -> bool;
-}
-
-pub trait IndexValue: 'static + IsCached + IsZeroLamport + DiskIndexValue {}
+pub trait IndexValue: 'static + IsZeroLamport + DiskIndexValue {}
 
 pub trait DiskIndexValue:
     'static + Clone + Debug + PartialEq + Copy + Default + Sync + Send
@@ -1031,7 +1024,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
                 max_clean_root_inclusive,
                 newest_root_in_slot_list,
                 *slot,
-            ) && !value.is_cached();
+            );
             if should_purge {
                 reclaims.push((*slot, *value));
             }
@@ -1393,11 +1386,6 @@ mod tests {
 
     impl IndexValue for AccountInfoTest {}
     impl DiskIndexValue for AccountInfoTest {}
-    impl IsCached for AccountInfoTest {
-        fn is_cached(&self) -> bool {
-            true
-        }
-    }
 
     impl IsZeroLamport for AccountInfoTest {
         fn is_zero_lamport(&self) -> bool {
@@ -1622,25 +1610,6 @@ mod tests {
         for store_raw in [false, true] {
             for to_raw_first in [false, true] {
                 let slot = 0;
-                // account_info type that IS cached
-                let account_info = AccountInfoTest::default();
-                let index = AccountsIndex::default_for_tests();
-
-                let new_entry = get_pre_allocated(
-                    slot,
-                    account_info,
-                    &index.storage.storage,
-                    store_raw,
-                    to_raw_first,
-                )
-                .into_account_map_entry(&index.storage.storage);
-                assert_eq!(new_entry.ref_count(), 0);
-                assert_eq!(new_entry.slot_list_lock_read_len(), 1);
-                assert_eq!(
-                    new_entry.slot_list_read_lock().to_vec(),
-                    vec![(slot, account_info)]
-                );
-
                 // account_info type that is NOT cached
                 let account_info = true;
                 let index = AccountsIndex::default_for_tests();
@@ -1693,17 +1662,9 @@ mod tests {
 
     fn test_new_entry_code_paths_helper<T: IndexValue>(
         account_infos: [T; 2],
-        is_cached: bool,
         upsert_method: Option<UpsertReclaim>,
         use_disk: bool,
     ) {
-        if is_cached && upsert_method.is_none() {
-            // This is an illegal combination when we are using queued lazy inserts.
-            // Cached items don't ever leave the in-mem cache.
-            // But the queued lazy insert code relies on there being nothing in the in-mem cache.
-            return;
-        }
-
         let slot0 = 0;
         let slot1 = 1;
         let key = solana_pubkey::new_rand();
@@ -1737,7 +1698,7 @@ mod tests {
         index.get_and_then(&key, |entry| {
             let entry = entry.unwrap();
             let slot_list = entry.slot_list_read_lock();
-            assert_eq!(entry.ref_count(), RefCount::from(!is_cached));
+            assert_eq!(entry.ref_count(), 1);
             assert_eq!(slot_list.as_ref(), &[(slot0, account_infos[0])]);
             let new_entry = PreAllocatedAccountMapEntry::new(
                 slot0,
@@ -1772,8 +1733,7 @@ mod tests {
         }
 
         // There should be reclaims if entries are uncached and old slots are being reclaimed
-        let should_have_reclaims =
-            upsert_method == Some(UpsertReclaim::ReclaimOldSlots) && !is_cached;
+        let should_have_reclaims = upsert_method == Some(UpsertReclaim::ReclaimOldSlots);
 
         if should_have_reclaims {
             assert!(!gc.is_empty());
@@ -1793,7 +1753,7 @@ mod tests {
                 assert_eq!(entry.ref_count(), 1);
                 assert_eq!(slot_list.as_ref(), &[(slot1, account_infos[1])],);
             } else {
-                assert_eq!(entry.ref_count(), if is_cached { 0 } else { 2 });
+                assert_eq!(entry.ref_count(), 2);
                 assert_eq!(
                     slot_list.as_ref(),
                     &[(slot0, account_infos[0]), (slot1, account_infos[1])],
@@ -1814,21 +1774,10 @@ mod tests {
 
     #[test_matrix(
         [false, true],
-        [None, Some(UpsertReclaim::PopulateReclaims), Some(UpsertReclaim::ReclaimOldSlots)],
-        [true, false]
+        [None, Some(UpsertReclaim::PopulateReclaims), Some(UpsertReclaim::ReclaimOldSlots)]
     )]
-    fn test_new_entry_and_update_code_paths(
-        use_disk: bool,
-        upsert_method: Option<UpsertReclaim>,
-        is_cached: bool,
-    ) {
-        if is_cached {
-            // account_info type that IS cached
-            test_new_entry_code_paths_helper([1.0, 2.0], true, upsert_method, use_disk);
-        } else {
-            // account_info type that is NOT cached
-            test_new_entry_code_paths_helper([1, 2], false, upsert_method, use_disk);
-        }
+    fn test_new_entry_and_update_code_paths(use_disk: bool, upsert_method: Option<UpsertReclaim>) {
+        test_new_entry_code_paths_helper([1, 2], upsert_method, use_disk);
     }
 
     #[test]
@@ -1910,7 +1859,6 @@ mod tests {
             let mut reclaims = ReclaimsSlotList::new();
             let slot = 0;
             let value = 1;
-            assert!(!value.is_cached());
             index.upsert(
                 slot,
                 slot,
@@ -1931,45 +1879,6 @@ mod tests {
             // reclaimed
             assert!(!reclaims.is_empty());
             reclaims.clear();
-            index.upsert(
-                slot,
-                slot,
-                &key,
-                value,
-                &mut reclaims,
-                // since IgnoreReclaims, we should expect reclaims to be empty
-                UpsertReclaim::IgnoreReclaims,
-            );
-            // reclaims is ignored
-            assert!(reclaims.is_empty());
-        }
-        {
-            // cached
-            let key = solana_pubkey::new_rand();
-            let index = AccountsIndex::<AccountInfoTest, AccountInfoTest>::default_for_tests();
-            let mut reclaims = ReclaimsSlotList::new();
-            let slot = 0;
-            let value = 1.0;
-            assert!(value.is_cached());
-            index.upsert(
-                slot,
-                slot,
-                &key,
-                value,
-                &mut reclaims,
-                UpsertReclaim::PopulateReclaims,
-            );
-            assert!(reclaims.is_empty());
-            index.upsert(
-                slot,
-                slot,
-                &key,
-                value,
-                &mut reclaims,
-                UpsertReclaim::PopulateReclaims,
-            );
-            // No reclaims, since the entry replaced was cached
-            assert!(reclaims.is_empty());
             index.upsert(
                 slot,
                 slot,
@@ -2224,28 +2133,10 @@ mod tests {
     #[test]
     fn test_upsert_reclaims() {
         let key = solana_pubkey::new_rand();
-        let index =
-            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
+        let index = AccountsIndex::<u64, u64>::default_for_tests();
         let mut reclaims = ReclaimsSlotList::new();
-        index.upsert(
-            0,
-            0,
-            &key,
-            CacheableIndexValueTest(true),
-            &mut reclaims,
-            UPSERT_RECLAIM_TEST_DEFAULT,
-        );
-        // No reclaims should be returned on the first item
-        assert!(reclaims.is_empty());
 
-        index.upsert(
-            0,
-            0,
-            &key,
-            CacheableIndexValueTest(false),
-            &mut reclaims,
-            UPSERT_RECLAIM_TEST_DEFAULT,
-        );
+        index.upsert(0, 0, &key, 0, &mut reclaims, UPSERT_RECLAIM_TEST_DEFAULT);
         // Cached item should not be reclaimed
         assert!(reclaims.is_empty());
 
@@ -2255,14 +2146,7 @@ mod tests {
         });
         assert_eq!(slot_list_len, 1);
 
-        index.upsert(
-            0,
-            0,
-            &key,
-            CacheableIndexValueTest(false),
-            &mut reclaims,
-            UPSERT_RECLAIM_TEST_DEFAULT,
-        );
+        index.upsert(0, 0, &key, 0, &mut reclaims, UPSERT_RECLAIM_TEST_DEFAULT);
 
         // Uncached item should be returned as reclaim
         assert!(!reclaims.is_empty());
@@ -2345,27 +2229,6 @@ mod tests {
         index.upsert(5, 5, &key, 100, &mut gc, UpsertReclaim::IgnoreReclaims);
         // No entry at slot 99 — replace must panic rather than silently appending.
         index.replace(10, 99, &key, 200);
-    }
-
-    #[test]
-    #[should_panic(expected = "Replace should only be used for uncached accounts")]
-    fn test_replace_cached_account_info_panics() {
-        // Shrink only ever rewrites uncached accounts; passing a cached AccountInfo to replace
-        // is a programming error and must trip the assertion.
-        let key = solana_pubkey::new_rand();
-        let index =
-            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
-        let mut gc = ReclaimsSlotList::new();
-
-        index.upsert(
-            5,
-            5,
-            &key,
-            CacheableIndexValueTest(false),
-            &mut gc,
-            UpsertReclaim::IgnoreReclaims,
-        );
-        index.replace(10, 5, &key, CacheableIndexValueTest(true));
     }
 
     fn account_maps_stats_len<T: IndexValue>(index: &AccountsIndex<T, T>) -> usize {
@@ -2597,85 +2460,6 @@ mod tests {
                 assert_eq!(account_info, account_value + 1);
             })
             .unwrap();
-    }
-
-    #[test]
-    fn test_reclaim_do_not_reclaim_cached_other_slot() {
-        agave_logger::setup();
-        let key = solana_pubkey::new_rand();
-        let index =
-            AccountsIndex::<CacheableIndexValueTest, CacheableIndexValueTest>::default_for_tests();
-        let mut gc = ReclaimsSlotList::new();
-
-        // Insert an uncached account at slot 0 and an cached account at slot 1
-        index.upsert(
-            0,
-            0,
-            &key,
-            CacheableIndexValueTest(false),
-            &mut gc,
-            UpsertReclaim::IgnoreReclaims,
-        );
-
-        index.upsert(
-            1,
-            1,
-            &key,
-            CacheableIndexValueTest(true),
-            &mut gc,
-            UpsertReclaim::IgnoreReclaims,
-        );
-
-        // Now insert a cached account at slot 2
-        index.upsert(
-            2,
-            2,
-            &key,
-            CacheableIndexValueTest(true),
-            &mut gc,
-            UpsertReclaim::IgnoreReclaims,
-        );
-
-        // Replace the cached account at slot 2 with a uncached account
-        index.upsert(
-            2,
-            2,
-            &key,
-            CacheableIndexValueTest(false),
-            &mut gc,
-            UpsertReclaim::ReclaimOldSlots,
-        );
-
-        // Verify that the slot list is length two and consists of the cached account at slot 1
-        // and the uncached account at slot 2
-        index.get_and_then(&key, |entry| {
-            let entry = entry.unwrap();
-            assert_eq!(entry.slot_list_lock_read_len(), 2);
-            assert_eq!(
-                entry.slot_list_read_lock()[0],
-                PreAllocatedAccountMapEntry::new(
-                    1,
-                    CacheableIndexValueTest(true),
-                    &index.storage.storage,
-                    false
-                )
-                .into()
-            );
-            assert_eq!(
-                entry.slot_list_read_lock()[1],
-                PreAllocatedAccountMapEntry::new(
-                    2,
-                    CacheableIndexValueTest(false),
-                    &index.storage.storage,
-                    false
-                )
-                .into()
-            );
-            // Verify that the uncached account at slot 0 was reclaimed
-            assert_eq!(gc.len(), 1);
-            assert_eq!(gc[0], (0, CacheableIndexValueTest(false)));
-            (false, ())
-        });
     }
 
     #[test]
@@ -3146,16 +2930,7 @@ mod tests {
     impl IndexValue for u64 {}
     impl DiskIndexValue for bool {}
     impl DiskIndexValue for u64 {}
-    impl IsCached for bool {
-        fn is_cached(&self) -> bool {
-            false
-        }
-    }
-    impl IsCached for u64 {
-        fn is_cached(&self) -> bool {
-            false
-        }
-    }
+
     impl IsZeroLamport for bool {
         fn is_zero_lamport(&self) -> bool {
             false
@@ -3163,24 +2938,6 @@ mod tests {
     }
 
     impl IsZeroLamport for u64 {
-        fn is_zero_lamport(&self) -> bool {
-            false
-        }
-    }
-
-    /// Type that supports caching for tests. Used to test upsert behaviour
-    /// when the slot list has mixed cached and uncached items.
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-    struct CacheableIndexValueTest(bool);
-    impl IndexValue for CacheableIndexValueTest {}
-    impl DiskIndexValue for CacheableIndexValueTest {}
-    impl IsCached for CacheableIndexValueTest {
-        fn is_cached(&self) -> bool {
-            // Return self value as whether the item is cached or not
-            self.0
-        }
-    }
-    impl IsZeroLamport for CacheableIndexValueTest {
         fn is_zero_lamport(&self) -> bool {
             false
         }

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -296,9 +296,8 @@ impl<T: IndexValue> PreAllocatedAccountMapEntry<T> {
         account_info: T,
         storage: &BucketMapHolder<T, U>,
     ) -> Box<AccountMapEntry<T>> {
-        let is_cached = account_info.is_cached();
-        let ref_count = RefCount::from(!is_cached);
-        let meta = AccountMapEntryMeta::new_dirty(storage, is_cached);
+        let ref_count = 1;
+        let meta = AccountMapEntryMeta::new_dirty(storage, false);
         Box::new(AccountMapEntry::new(
             SlotList::from([(slot, account_info)]),
             ref_count,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -498,10 +498,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             })
         });
         if let Some((slot, info)) = to_write {
-            debug_assert!(
-                !info.is_cached(),
-                "Cached entries should not be written through"
-            );
             self.write_through(pubkey, slot, info);
         }
     }
@@ -525,7 +521,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             let count = slot_list.retain_and_count(|(slot, value)| {
                 // keep the newest entry, and reclaim all others
                 if *slot < max_slot {
-                    assert!(!value.is_cached(), "Unsafe to reclaim cached entries");
                     reclaims.push((*slot, *value));
                     reclaim_count += 1;
                     false
@@ -549,20 +544,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         .expect("Expected entry to exist in accounts index");
     }
 
-    /// Insert a cached entry into the accounts index
-    /// If the entry is already present, just mark dirty and set the age to the future
-    fn cache_entry_at_slot(current: &AccountMapEntry<T>, new_value: SlotListItem<T>) {
-        let mut slot_list = current.slot_list_write_lock();
-        let (slot, new_entry) = new_value;
-        // Find and replace existing entry at this slot, or append if not found
-        if let Some(existing_entry) = slot_list.iter_mut().find(|(s, _)| *s == slot) {
-            existing_entry.1 = new_entry;
-        } else {
-            slot_list.push((slot, new_entry));
-        }
-        current.mark_dirty();
-    }
-
     pub fn upsert(
         &self,
         pubkey: &Pubkey,
@@ -572,22 +553,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         reclaim: UpsertReclaim,
     ) {
         let (slot, account_info) = new_value.into();
-        let is_cached = account_info.is_cached();
 
         self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {
-            if is_cached {
-                Self::cache_entry_at_slot(entry, (slot, account_info));
-                self.set_age_to_future(entry, true);
-            } else {
-                let slot_list_length = Self::lock_and_update_slot_list(
-                    entry,
-                    (slot, account_info),
-                    other_slot,
-                    reclaims,
-                    reclaim,
-                );
-                self.set_age_to_future(entry, slot_list_length > 1);
-            }
+            let slot_list_length = Self::lock_and_update_slot_list(
+                entry,
+                (slot, account_info),
+                other_slot,
+                reclaims,
+                reclaim,
+            );
+            self.set_age_to_future(entry, slot_list_length > 1);
         });
     }
 
@@ -596,10 +571,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// Panics if `old_slot` is not present in the slot list, or if more than one entry at
     /// `old_slot` is found (which would indicate prior corruption).
     pub fn replace(&self, pubkey: &Pubkey, new_item: SlotListItem<T>, old_slot: Slot) {
-        debug_assert!(
-            !new_item.1.is_cached(),
-            "Replace should only be used for uncached accounts"
-        );
         let mut should_write_through = false;
 
         self.get_or_create_index_entry_for_pubkey(pubkey, |entry| {
@@ -794,33 +765,21 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ) -> (i32, usize) {
         let mut ref_count_change = 1;
 
-        // Cached accounts are not expected by this function, use cache_entry_at_slot instead
-        assert!(!account_info.is_cached());
-
         let old_slot = other_slot.unwrap_or(slot);
 
         // If we find an existing account at old_slot, replace it rather than adding a new entry to the list
         let mut found_slot = false;
         let mut final_len = slot_list.retain_and_count(|cur_item| {
-            let (cur_slot, cur_account_info) = cur_item;
+            let (cur_slot, _) = cur_item;
             if *cur_slot == old_slot {
                 // Ensure we only find one!
                 assert!(!found_slot);
-                let is_cur_account_cached = cur_account_info.is_cached();
 
                 // Replace the item
                 let reclaim_item = mem::replace(cur_item, (slot, account_info));
                 match reclaim {
                     UpsertReclaim::ReclaimOldSlots | UpsertReclaim::PopulateReclaims => {
-                        // Reclaims are used to reclaim other versions of accounts when they are
-                        // rewritten elsewhere. Cached accounts are not in storage, so there is
-                        // no reason to store the reclaim.
-                        if !is_cur_account_cached {
-                            reclaims.push(reclaim_item);
-                        }
-                    }
-                    UpsertReclaim::PreviousSlotEntryWasCached => {
-                        assert!(is_cur_account_cached);
+                        reclaims.push(reclaim_item);
                     }
                     UpsertReclaim::IgnoreReclaims => {
                         // do nothing. nothing to assert. nothing to return in reclaims
@@ -829,13 +788,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
                 found_slot = true;
 
-                if !is_cur_account_cached {
-                    // current info at 'slot' is NOT cached, so we should NOT addref. This slot already has a ref count for this pubkey.
-                    ref_count_change -= 1
-                }
+                ref_count_change -= 1
             } else if reclaim == UpsertReclaim::ReclaimOldSlots {
-                let is_cur_account_cached = cur_account_info.is_cached();
-                if !is_cur_account_cached && *cur_slot < slot {
+                if *cur_slot < slot {
                     reclaims.push(*cur_item);
                     ref_count_change -= 1;
                     return false;
@@ -1091,12 +1046,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         // SAFETY: We just checked that the slot list len is 1
         let slot_list_elem = slot_list[0];
-
-        if slot_list_elem.1.is_cached() {
-            // we only flush regular entries, i.e. slot list does not contain any cached entries
-            entry.mark_dirty();
-            return ShouldFlush::No(ReasonToNotFlush::SlotListCached);
-        }
 
         // entry is ready to be flushed
         ShouldFlush::Yes(slot_list_elem)
@@ -1482,9 +1431,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                         ReasonToNotFlush::SlotListLen => {
                             flush_stats.num_not_flushed_slot_list_len += 1
                         }
-                        ReasonToNotFlush::SlotListCached => {
-                            flush_stats.num_not_flushed_slot_list_cached += 1
-                        }
                     }
                     continue;
                 }
@@ -1772,10 +1718,6 @@ enum ReasonToNotFlush {
     /// slot list len was != 1
     /// This account has versions in multiple locations, and will be cleaned/shrunk soon.
     SlotListLen,
-    /// slot list contained an item pointing to a cached account
-    /// An account in the write cache will be flushed soon, so do not flush this index entry yet,
-    /// as it will be modified soon.
-    SlotListCached,
 }
 
 #[cfg(test)]
@@ -1855,7 +1797,13 @@ mod tests {
             assert_eq!(entry.slot_list_lock_read_len(), 0);
             assert_eq!(entry.ref_count(), 0);
             assert!(entry.dirty());
-            InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
+            InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
+                entry,
+                (slot, 0),
+                None,
+                &mut ReclaimsSlotList::new(),
+                UpsertReclaim::IgnoreReclaims,
+            );
             callback_called = true;
         });
 
@@ -1924,7 +1872,13 @@ mod tests {
             assert_eq!(entry.slot_list_lock_read_len(), 1);
             assert_eq!(entry.ref_count(), 1);
             assert!(!entry.dirty()); // Entry loaded from disk should not be dirty
-            InMemAccountsIndex::<u64, u64>::cache_entry_at_slot(entry, (slot, 0));
+            InMemAccountsIndex::<u64, u64>::lock_and_update_slot_list(
+                entry,
+                (slot, 0),
+                None,
+                &mut ReclaimsSlotList::new(),
+                UpsertReclaim::IgnoreReclaims,
+            );
             callback_called = true;
         });
 
@@ -2562,23 +2516,6 @@ mod tests {
             assert_eq!(
                 entry_for_flush,
                 ShouldFlush::No(ReasonToNotFlush::SlotListLen),
-            );
-        }
-
-        // test: do not flush due to slot list cached
-        {
-            let bucket = new_for_test::<f64>();
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(0, 0f64)]), // <-- f64 acts as cached
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-            entry.mark_dirty();
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(
-                entry_for_flush,
-                ShouldFlush::No(ReasonToNotFlush::SlotListCached),
             );
         }
     }


### PR DESCRIPTION
#### Problem
It is no longer possible for accounts in the index to be cached.

#### Summary of Changes
- Remove the trait 

#### Testing
- Unit test and ran validator against mainnet. 

Fixes #
