### PR TITLE
bcl: when packing a rewards aggregate, choose by stake not size

### DIFF
--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -162,6 +162,14 @@ mod tests {
         max_validators: usize,
         slot: Slot,
     ) -> (Arc<BLSPubkeyToRankMap>, Vec<BlsKeypair>) {
+        get_rank_map_keypairs_with_stakes(vec![100; max_validators], slot)
+    }
+
+    pub(crate) fn get_rank_map_keypairs_with_stakes(
+        stakes: Vec<u64>,
+        slot: Slot,
+    ) -> (Arc<BLSPubkeyToRankMap>, Vec<BlsKeypair>) {
+        let max_validators = stakes.len();
         let validator_keypairs = (0..max_validators)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -177,7 +185,7 @@ mod tests {
         let mut genesis_config = create_genesis_config_with_alpenglow_vote_accounts(
             1_000_000_000,
             &validator_keypairs,
-            vec![100; validator_keypairs.len()],
+            stakes,
         )
         .genesis_config;
         genesis_config.epoch_schedule = EpochSchedule::without_warmup();

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -65,15 +65,13 @@ impl NotarEntry {
         self,
         reward_slot: Slot,
     ) -> Result<Option<(NotarRewardCertificate, Vec<Pubkey>)>, BuildRewardCertsRespError> {
-        // we can only submit one notar rewards certificate but different validators may vote for different blocks and we cannot combine notar votes for different blocks together in one cert.
-        // ideally we should pick the block_id with the most stake to maximum leader rewards.
-        // we expect this to be rare enough that picking the block_id with the most votes should be fine in most cases.
-
-        let res = self
+        // We can only submit one notar rewards certificate, but different validators may vote for
+        // different block ids. Pick the block id with the most stake to maximize leader rewards.
+        let selected = self
             .partials
             .into_iter()
-            .max_by_key(|(_block_id, partial)| partial.votes_seen());
-        let Some((block_id, partial)) = res else {
+            .max_by_key(|(_block_id, partial)| partial.stake());
+        let Some((block_id, partial)) = selected else {
             return Ok(None);
         };
         match partial.build_sig_bitmap() {
@@ -95,7 +93,7 @@ mod tests {
     use {
         super::*,
         crate::block_creation_loop::rewards::certs_builder::entry::tests::{
-            get_rank_map_keypairs, new_vote, validate_bitmap,
+            get_rank_map_keypairs, get_rank_map_keypairs_with_stakes, new_vote, validate_bitmap,
         },
         agave_votor_messages::{
             consensus_message::{Block, VoteMessage},
@@ -161,7 +159,8 @@ mod tests {
     fn validate_build_cert() {
         let slot = 123;
         let max_validators = 5;
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let (rank_map, keypairs) =
+            get_rank_map_keypairs_with_stakes(vec![1_000, 900, 10, 10, 10], slot);
         let shred_version = rand::rng().random();
 
         let mut entry = NotarEntry::new(max_validators);
@@ -204,7 +203,8 @@ mod tests {
         }
         let (notar_cert, _) = entry.build_cert(slot).unwrap().unwrap();
         assert_eq!(notar_cert.slot, slot);
-        assert_eq!(notar_cert.block_id, blockid1);
-        validate_bitmap(notar_cert.bitmap(), 3, 5);
+        // We should pick the block id with the most stake (not the most votes)
+        assert_eq!(notar_cert.block_id, blockid0);
+        validate_bitmap(notar_cert.bitmap(), 2, 5);
     }
 }

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -27,8 +27,8 @@ pub(super) struct PartialCert {
     signature: SignatureProjective,
     /// bitvec of ranks whose signatures is included in the aggregate above.
     bitvec: BitVec<u8, Lsb0>,
-    /// number of signatures in the aggregate above.
-    cnt: usize,
+    /// total stake represented by the signatures in the aggregate above.
+    stake: u64,
     validators: Vec<Pubkey>,
 }
 
@@ -38,7 +38,7 @@ impl PartialCert {
         Self {
             signature: SignatureProjective::identity(),
             bitvec: BitVec::repeat(false, max_validators),
-            cnt: 0,
+            stake: 0,
             validators: Vec::with_capacity(max_validators),
         }
     }
@@ -64,16 +64,15 @@ impl PartialCert {
                 if *ind {
                     return Err(AddVoteError::Duplicate);
                 }
-                let pubkey = rank_map
+                let entry = rank_map
                     .get_pubkey_stake_entry(rank.into())
-                    .unwrap()
-                    .vote_account_pubkey;
-                self.validators.push(pubkey);
+                    .ok_or(AddVoteError::InvalidRank)?;
                 self.signature.aggregate_with(std::iter::once(signature))?;
+                self.validators.push(entry.vote_account_pubkey);
+                self.stake = self.stake.saturating_add(entry.stake);
                 *ind = true;
             }
         }
-        self.cnt = self.cnt.saturating_add(1);
         Ok(())
     }
 
@@ -83,7 +82,7 @@ impl PartialCert {
     pub(super) fn build_sig_bitmap(
         self,
     ) -> Result<(BLSSignatureCompressed, Vec<u8>, Vec<Pubkey>), BuildSigBitmapError> {
-        if self.cnt == 0 {
+        if self.validators.is_empty() {
             return Err(BuildSigBitmapError::Empty);
         }
         let mut bitvec = self.bitvec.clone();
@@ -94,9 +93,9 @@ impl PartialCert {
         Ok((signature, bitmap, self.validators))
     }
 
-    /// Returns how many votes have been observed.
-    pub(super) fn votes_seen(&self) -> usize {
-        self.cnt
+    /// Returns how much stake has been observed.
+    pub(super) fn stake(&self) -> u64 {
+        self.stake
     }
 }
 
@@ -120,23 +119,6 @@ mod tests {
             vote,
             signature,
             rank: rank.try_into().unwrap(),
-        }
-    }
-
-    #[test]
-    fn validate_votes_seen() {
-        let slot = 123;
-        let max_validators = 2;
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
-        let shred_version = rand::rng().random();
-        let skip = Vote::new_skip_vote(7);
-        let mut partial_cert = PartialCert::new(max_validators);
-        for rank in 0..max_validators {
-            let vote = new_vote(skip, rank, &keypairs, shred_version);
-            partial_cert
-                .add_vote(&rank_map, vote.rank, &vote.signature)
-                .unwrap();
-            assert_eq!(partial_cert.votes_seen(), rank + 1);
         }
     }
 


### PR DESCRIPTION
#### Problem
During a duplicate block event there might be multiple blocks that get notarize votes.
When packing the rewards aggregate we choose the one with the most votes, not the most stake.

This means even without a duplicate block, enough malicious nodes (with low stake) can cause their aggregate to be choosen - resulting in the remaining nodes to not get rewards.

Not a big issue, but easy to fix.

#### Summary of Changes
Instead choose the max by stake.

#### Testing
Unit tests

Fixes #13235
