### PR TITLE
votor-messages: Demote logs from warn to info

### DIFF
--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -418,7 +418,7 @@ impl MigrationStatus {
             }
         };
 
-        warn!("Pre startup initializing alpenglow migration from root bank: {phase:?}");
+        info!("Pre startup initializing alpenglow migration from root bank: {phase:?}");
         Self::new(phase)
     }
 
@@ -436,7 +436,7 @@ impl MigrationStatus {
     pub fn log_phase(&self) {
         let my_pubkey = self.my_pubkey();
         let phase = self.phase.read().unwrap();
-        warn!("{my_pubkey}: Alpenglow migration phase {phase:?}");
+        info!("{my_pubkey}: Alpenglow migration phase {phase:?}");
     }
 
     /// Record that PohService has started and must be coordinated with when enabling Alpenglow.
@@ -480,7 +480,7 @@ impl MigrationStatus {
             genesis_cert: None,
         };
 
-        warn!(
+        info!(
             "{}: Alpenglow feature flag was activated in {slot}, migration will start at \
              {migration_slot}",
             self.my_pubkey()
@@ -545,7 +545,7 @@ impl MigrationStatus {
             discovered_genesis_block.slot < *migration_slot,
             "Attempting to set a genesis block that is past the migration start"
         );
-        warn!(
+        info!(
             "{} Setting genesis block {discovered_genesis_block:?}",
             self.my_pubkey()
         );
@@ -604,7 +604,7 @@ impl MigrationStatus {
             block.slot < *migration_slot,
             "Attempting to set a genesis certificate past the migration start"
         );
-        warn!("{} Setting genesis cert for ({block:?})", self.my_pubkey());
+        info!("{} Setting genesis cert for ({block:?})", self.my_pubkey());
         *genesis_cert = Some(cert.clone());
 
         let Some(genesis_block) = genesis_block else {
@@ -639,14 +639,14 @@ impl MigrationStatus {
         self.wait_for_migration_or_exit(exit);
 
         if exit.load(Ordering::Relaxed) {
-            warn!(
+            info!(
                 "{}: Validator shutdown before Alpenglow could be enabled",
                 self.my_pubkey()
             );
             return;
         }
 
-        warn!("{}: Alpenglow enabled!", self.my_pubkey());
+        info!("{}: Alpenglow enabled!", self.my_pubkey());
     }
 
     /// PohService is shutting down after being asked to by replay_stage via `enable_alpenglow`.
@@ -672,7 +672,7 @@ impl MigrationStatus {
     ///
     /// Transition the phase from `ReadyToEnable` to `AlpenglowEnabled`
     pub fn enable_alpenglow_during_startup(&self) -> Slot {
-        warn!("{}: Enabling alpenglow during startup", self.my_pubkey());
+        info!("{}: Enabling alpenglow during startup", self.my_pubkey());
         let MigrationPhase::ReadyToEnable { genesis_cert } = self.phase.read().unwrap().clone()
         else {
             unreachable!(
@@ -697,7 +697,7 @@ impl MigrationStatus {
         let (is_alpenglow_enabled, _condvar) = &self.migration_wait;
         *is_alpenglow_enabled.lock().unwrap() = true;
         // No need to condvar as we're in startup and no one is waiting for us.
-        warn!(
+        info!(
             "{}: Alpenglow enabled during startup! Genesis slot {genesis_slot}",
             self.my_pubkey()
         );
@@ -721,7 +721,7 @@ impl MigrationStatus {
             full_alpenglow_epoch,
         };
 
-        warn!(
+        info!(
             "{}: Migration epoch has concluded, entering full alpenglow epoch {}!",
             self.my_pubkey(),
             full_alpenglow_epoch


### PR DESCRIPTION
#### Problem
These logs are in fact information and not warnings; if everything is warn then nothing is warn

#### Summary of Changes
Demote them

#### Testing
Compiles