### PR TITLE
test-validator: fix block subscription flag panic

### DIFF
--- a/validator/src/commands/run/args/pub_sub_config.rs
+++ b/validator/src/commands/run/args/pub_sub_config.rs
@@ -68,12 +68,25 @@ pub(crate) fn args<'a, 'b>(test_validator: bool) -> Vec<Arg<'a, 'b>> {
         )
     };
 
-    vec![
-        Arg::with_name("rpc_pubsub_enable_block_subscription")
-            .long("rpc-pubsub-enable-block-subscription")
+    let rpc_pubsub_enable_block_sub_value = Arg::with_name("rpc_pubsub_enable_block_subscription")
+        .long("rpc-pubsub-enable-block-subscription");
+
+    // enable_rpc_transaction_history is on by default in the configs
+    // for test_validator, while required by agave_validator if
+    // rpc_pubsub_enable_block_subscription is passed
+    let rpc_pubsub_enable_block_sub_value = if !test_validator {
+        rpc_pubsub_enable_block_sub_value
             .requires("enable_rpc_transaction_history")
             .takes_value(false)
-            .help("Enable the unstable RPC PubSub `blockSubscribe` subscription"),
+            .help("Enable the unstable RPC PubSub `blockSubscribe` subscription")
+    } else {
+        rpc_pubsub_enable_block_sub_value
+            .takes_value(false)
+            .help("Enable the unstable RPC PubSub `blockSubscribe` subscription")
+    };
+
+    vec![
+        rpc_pubsub_enable_block_sub_value,
         Arg::with_name("rpc_pubsub_enable_vote_subscription")
             .long("rpc-pubsub-enable-vote-subscription")
             .takes_value(false)


### PR DESCRIPTION
#### Problem
passing `--rpc-pubsub-enable-block-subscription` for `solana-test-validator` requires `enable_rpc_transaction_history` to be passed whose parsing is only supported in `agave-validator`, hence leading to a panic from `clap`, even though transaction history is on by default for test-validator:
```rust
genesis.rpc_config(JsonRpcConfig {
        enable_rpc_transaction_history: true,
        ....
```

#### Summary of Changes
changes how `rpc_pubsub_enable_block_sub_value` is parsed, requiring `enable_rpc_transaction_history` only if `!test_validator`

#### Testing
No additional tests added, but running the following command works successfully:
```bash 
solana-test-validator --reset --rpc-pubsub-enable-vote-subscription --rpc-pubsub-enable-block-subscription 
```

Fixes #13307