### PR TITLE
chore: fix typos in comments

### DIFF
--- a/programs/sbf/rust/account_mem/src/lib.rs
+++ b/programs/sbf/rust/account_mem/src/lib.rs
@@ -30,7 +30,7 @@ pub fn process_instruction(
     unsafe {
         match instruction_data[0] {
             0 => {
-                // memcmp overlaps begining
+                // memcmp overlaps beginning
                 #[allow(clippy::manual_memcpy)]
                 for i in 0..500 {
                     buf[i] = too_early(8)[i];
@@ -39,7 +39,7 @@ pub fn process_instruction(
                 sol_memcmp(too_early(8), &buf, 500);
             }
             1 => {
-                // memcmp overlaps begining
+                // memcmp overlaps beginning
                 #[allow(clippy::manual_memcpy)]
                 for i in 0..12 {
                     buf[i] = too_early(9)[i];
@@ -48,7 +48,7 @@ pub fn process_instruction(
                 sol_memcmp(&buf, too_early(9), 12);
             }
             2 => {
-                // memcmp overlaps begining
+                // memcmp overlaps beginning
                 #[allow(clippy::manual_memcpy)]
                 for i in 0..3 {
                     buf[i] = too_early(2)[i];

--- a/programs/sbf/rust/account_mem_deprecated/src/lib.rs
+++ b/programs/sbf/rust/account_mem_deprecated/src/lib.rs
@@ -30,7 +30,7 @@ pub fn process_instruction(
     unsafe {
         match instruction_data[0] {
             0 => {
-                // memcmp overlaps begining
+                // memcmp overlaps beginning
                 #[allow(clippy::manual_memcpy)]
                 for i in 0..90 {
                     buf[i] = too_early(8)[i];
@@ -39,7 +39,7 @@ pub fn process_instruction(
                 sol_memcmp(too_early(8), &buf, 90);
             }
             1 => {
-                // memcmp overlaps begining
+                // memcmp overlaps beginning
                 #[allow(clippy::manual_memcpy)]
                 for i in 0..12 {
                     buf[i] = too_early(9)[i];

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -90,7 +90,7 @@ pub(crate) const MIN_RTT: Duration = Duration::from_millis(2);
 /// before considering stream to be "too late". 1.5 RTT should be enough
 /// for any reasonable fragmentation to be resolved, so the only way
 /// a stream reassembly would be delayed more is when something
-/// extraordinary has occured (congestion control or flow control blocking)
+/// extraordinary has occurred (congestion control or flow control blocking)
 const LATE_REASSEMBLY_THRESHOLD: f32 = 1.5;
 
 // A struct to accumulate the bytes making up


### PR DESCRIPTION
Fixes spelling mistakes in code comments. Comment-only — no functional changes.

| File | Before | After |
|---|---|---|
| `streamer/src/nonblocking/quic.rs` | occured | occurred |
| `programs/sbf/rust/account_mem/src/lib.rs` | begining | beginning |
| `programs/sbf/rust/account_mem_deprecated/src/lib.rs` | begining | beginning |

🤖 Generated with [Claude Code](https://claude.com/claude-code)