### PR TITLE
feat(gossip): remove redundant pubkey from PruneMessage

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1975,7 +1975,7 @@ impl ClusterInfo {
                         wallclock,
                     };
                     prune_data.sign(&self_keypair);
-                    let prune_message = Protocol::PruneMessage(self_pubkey, prune_data);
+                    let prune_message = Protocol::PruneMessage(prune_data);
                     (addr, prune_message)
                 })
                 .collect()
@@ -2092,7 +2092,7 @@ impl ClusterInfo {
                         push_messages.push((from, data));
                     }
                 }
-                Protocol::PruneMessage(_from, data) => prune_messages.push(data),
+                Protocol::PruneMessage(data) => prune_messages.push(data),
                 Protocol::PingMessage(ping) => ping_messages.push((from_addr, ping)),
                 Protocol::PongMessage(pong) => pong_messages.push((from_addr, pong)),
             }
@@ -2486,7 +2486,7 @@ fn discard_different_shred_version(
         // check_pull_request_shred_version).
         Protocol::PullRequest(..) => return,
         // No CRDS values in Prune, Ping and Pong messages.
-        Protocol::PruneMessage(_, _) | Protocol::PingMessage(_) | Protocol::PongMessage(_) => {
+        Protocol::PruneMessage(_) | Protocol::PingMessage(_) | Protocol::PongMessage(_) => {
             return;
         }
     };

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -37,7 +37,7 @@ pub(crate) const DUPLICATE_SHRED_MAX_PAYLOAD_SIZE: usize = PACKET_DATA_SIZE - 11
 pub(crate) const MAX_INCREMENTAL_SNAPSHOT_HASHES: usize = 25;
 /// Maximum number of origin nodes that a PruneData may contain, such that the
 /// serialized size of the PruneMessage stays below PACKET_DATA_SIZE.
-pub(crate) const MAX_PRUNE_DATA_NODES: usize = 32;
+pub(crate) const MAX_PRUNE_DATA_NODES: usize = 33;
 /// Prune data prefix for PruneMessage
 const PRUNE_DATA_PREFIX: &[u8] = b"\xffSOLANA_PRUNE_DATA";
 /// Number of bytes in the randomly generated token sent with ping messages.
@@ -75,7 +75,7 @@ pub(crate) enum Protocol {
     PushMessage(Pubkey, Vec<CrdsValue>),
     // TODO: Remove the redundant outer pubkey here,
     // and use the inner PruneData.pubkey instead.
-    PruneMessage(Pubkey, PruneData),
+    PruneMessage(PruneData),
     PingMessage(Ping),
     PongMessage(Pong),
     // Update count_packets_received if new variants are added here.
@@ -143,7 +143,7 @@ impl Protocol {
             Self::PushMessage(_, data) => {
                 data.iter().all(|value| value.verify_with_cache(vk_cache))
             }
-            Self::PruneMessage(_, data) => data.verify(),
+            Self::PruneMessage(data) => data.verify(),
             Self::PingMessage(ping) => ping.verify(),
             Self::PongMessage(pong) => pong.verify(),
         }
@@ -220,13 +220,7 @@ impl Sanitize for Protocol {
                 // other nodes that have inserted it into their Crds table
                 val.sanitize()
             }
-            Protocol::PruneMessage(from, val) => {
-                if *from != val.pubkey {
-                    Err(SanitizeError::InvalidValue)
-                } else {
-                    val.sanitize()
-                }
-            }
+            Protocol::PruneMessage(val) => val.sanitize(),
             Protocol::PingMessage(ping) => ping.sanitize(),
             Protocol::PongMessage(pong) => pong.sanitize(),
         }
@@ -540,12 +534,10 @@ pub fn gossip_decode_to_effects(input: &[u8]) -> protosol::protos::GossipEffects
                     values: values.iter().map(convert_crds_value).collect(),
                 })
             }
-            Protocol::PruneMessage(pubkey, data) => {
-                gossip_msg::Msg::PruneMessage(GossipPruneMessage {
-                    pubkey: pubkey.to_bytes().to_vec(),
-                    data: Some(convert_prune_data(data)),
-                })
-            }
+            Protocol::PruneMessage(data) => gossip_msg::Msg::PruneMessage(GossipPruneMessage {
+                pubkey: data.pubkey.to_bytes().to_vec(),
+                data: Some(convert_prune_data(data)),
+            }),
         }
     }
 
@@ -707,7 +699,7 @@ pub(crate) mod tests {
             let self_keypair = Keypair::new();
             let prune_data =
                 new_rand_prune_data(&mut rng, &self_keypair, Some(MAX_PRUNE_DATA_NODES));
-            let prune_message = Protocol::PruneMessage(self_keypair.pubkey(), prune_data);
+            let prune_message = Protocol::PruneMessage(prune_data);
             let socket = new_rand_socket_addr(&mut rng);
             assert!(Packet::from_data(Some(&socket), prune_message).is_ok());
         }
@@ -715,7 +707,7 @@ pub(crate) mod tests {
         let self_keypair = Keypair::new();
         let prune_data =
             new_rand_prune_data(&mut rng, &self_keypair, Some(MAX_PRUNE_DATA_NODES + 1));
-        let prune_message = Protocol::PruneMessage(self_keypair.pubkey(), prune_data);
+        let prune_message = Protocol::PruneMessage(prune_data);
         let socket = new_rand_socket_addr(&mut rng);
         assert!(Packet::from_data(Some(&socket), prune_message).is_err());
     }
@@ -998,7 +990,7 @@ pub(crate) mod tests {
             wallclock: MAX_WALLCLOCK,
             ..PruneData::default()
         };
-        let msg = Protocol::PruneMessage(Pubkey::default(), pd);
+        let msg = Protocol::PruneMessage(pd);
         assert_eq!(msg.sanitize(), Err(SanitizeError::ValueOutOfBounds));
     }
 
@@ -1013,10 +1005,8 @@ pub(crate) mod tests {
             wallclock: timestamp(),
         };
         prune_data.sign(&keypair);
-        let prune_message = Protocol::PruneMessage(keypair.pubkey(), prune_data.clone());
+        let prune_message = Protocol::PruneMessage(prune_data.clone());
         assert_eq!(prune_message.sanitize(), Ok(()));
-        let prune_message = Protocol::PruneMessage(Pubkey::new_unique(), prune_data);
-        assert_eq!(prune_message.sanitize(), Err(SanitizeError::InvalidValue));
     }
 
     #[test]
@@ -1165,7 +1155,7 @@ pub(crate) mod tests {
         for _ in 0..1000 {
             let keypair = Keypair::new();
             let prune_data = new_rand_prune_data(&mut rng, &keypair, None);
-            let protocol = Protocol::PruneMessage(keypair.pubkey(), prune_data);
+            let protocol = Protocol::PruneMessage(prune_data);
 
             let bincode_bytes = bincode::serialize(&protocol).unwrap();
             let wincode_bytes = wincode::serialize(&protocol).unwrap();

--- a/gossip/src/protocol.rs
+++ b/gossip/src/protocol.rs
@@ -73,8 +73,6 @@ pub(crate) enum Protocol {
     PullRequest(CrdsFilter, CrdsValue),
     PullResponse(Pubkey, Vec<CrdsValue>),
     PushMessage(Pubkey, Vec<CrdsValue>),
-    // TODO: Remove the redundant outer pubkey here,
-    // and use the inner PruneData.pubkey instead.
     PruneMessage(PruneData),
     PingMessage(Ping),
     PongMessage(Pong),

--- a/gossip/tests/conformance/fixtures.rs
+++ b/gossip/tests/conformance/fixtures.rs
@@ -55,29 +55,29 @@ fn generate_gossip_fixtures() {
     write_fixture(
         &dir,
         "prune_valid",
-        &make_prune_bytes(&pk, &pk, &[[0x22; 32]], &sig, &[0x33; 32], 1_000_000),
+        &make_prune_bytes(&pk, &[[0x22; 32]], &sig, &[0x33; 32], 1_000_000),
     );
     write_fixture(
         &dir,
         "prune_mismatched_pubkeys",
-        &make_prune_bytes(&[0xAA; 32], &[0xBB; 32], &[], &sig, &[0u8; 32], 1_000_000),
+        &make_prune_bytes(&[0xBB; 32], &[], &sig, &[0u8; 32], 1_000_000),
     );
     write_fixture(
         &dir,
         "prune_wallclock_at_max",
-        &make_prune_bytes(&pk, &pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK),
+        &make_prune_bytes(&pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK),
     );
     write_fixture(
         &dir,
         "prune_wallclock_below_max",
-        &make_prune_bytes(&pk, &pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK - 1),
+        &make_prune_bytes(&pk, &[], &sig, &[0u8; 32], super::MAX_WALLCLOCK - 1),
     );
     {
-        let prunes: Vec<[u8; 32]> = (0..32u8).map(|i| [i; 32]).collect();
+        let prunes: Vec<[u8; 32]> = (0..33u8).map(|i| [i; 32]).collect();
         write_fixture(
             &dir,
             "prune_many_nodes",
-            &make_prune_bytes(&pk, &pk, &prunes, &sig, &[0u8; 32], 1_000_000),
+            &make_prune_bytes(&pk, &prunes, &sig, &[0u8; 32], 1_000_000),
         );
     }
 

--- a/gossip/tests/conformance/helpers.rs
+++ b/gossip/tests/conformance/helpers.rs
@@ -53,7 +53,6 @@ pub(crate) fn make_pong_bytes(from: &[u8; 32], hash: &[u8; 32], signature: &[u8;
 
 /// Build a PruneMessage (variant 3) from raw fields.
 pub(crate) fn make_prune_bytes(
-    outer_pubkey: &[u8; 32],
     pubkey: &[u8; 32],
     prunes: &[[u8; 32]],
     signature: &[u8; 64],
@@ -62,7 +61,6 @@ pub(crate) fn make_prune_bytes(
 ) -> Vec<u8> {
     let mut buf = Vec::new();
     buf.extend_from_slice(&3u32.to_le_bytes());
-    buf.extend_from_slice(outer_pubkey);
     // PruneData
     buf.extend_from_slice(pubkey);
     buf.extend_from_slice(&(prunes.len() as u64).to_le_bytes());

--- a/gossip/tests/conformance/tests.rs
+++ b/gossip/tests/conformance/tests.rs
@@ -91,7 +91,7 @@ fn test_conformance_prune_valid() {
     let sig = [0u8; 64];
     let dest = [0x33; 32];
     let wc = 1_000_000u64;
-    let data = make_prune_bytes(&pk, &pk, &[prune_node], &sig, &dest, wc);
+    let data = make_prune_bytes(&pk, &[prune_node], &sig, &dest, wc);
     check(&data, true);
 
     let effects = get_effects(&data);
@@ -112,37 +112,24 @@ fn test_conformance_prune_valid() {
 }
 
 #[test]
-fn test_conformance_prune_mismatched_pubkeys() {
-    let data = make_prune_bytes(
-        &[0xAA; 32], // outer pubkey
-        &[0xBB; 32], // PruneData.pubkey (mismatch)
-        &[],
-        &[0u8; 64],
-        &[0u8; 32],
-        1_000_000,
-    );
-    check(&data, false);
-}
-
-#[test]
 fn test_conformance_prune_wallclock_at_max() {
     let pk = [0x11; 32];
-    let data = make_prune_bytes(&pk, &pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK);
+    let data = make_prune_bytes(&pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK);
     check(&data, false);
 }
 
 #[test]
 fn test_conformance_prune_wallclock_below_max() {
     let pk = [0x11; 32];
-    let data = make_prune_bytes(&pk, &pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK - 1);
+    let data = make_prune_bytes(&pk, &[], &[0u8; 64], &[0u8; 32], MAX_WALLCLOCK - 1);
     check(&data, true);
 }
 
 #[test]
 fn test_conformance_prune_many_nodes() {
     let pk = [0x11; 32];
-    let prunes: Vec<[u8; 32]> = (0..32u8).map(|i| [i; 32]).collect();
-    let data = make_prune_bytes(&pk, &pk, &prunes, &[0u8; 64], &[0u8; 32], 1_000_000);
+    let prunes: Vec<[u8; 32]> = (0..33u8).map(|i| [i; 32]).collect();
+    let data = make_prune_bytes(&pk, &prunes, &[0u8; 64], &[0u8; 32], 1_000_000);
     check(&data, true);
 
     let effects = get_effects(&data);
@@ -150,7 +137,7 @@ fn test_conformance_prune_many_nodes() {
     match msg {
         gossip_msg::Msg::PruneMessage(pm) => {
             let pd = pm.data.as_ref().unwrap();
-            assert_eq!(pd.prunes.len(), 32);
+            assert_eq!(pd.prunes.len(), 33);
             for (i, proto_prune) in pd.prunes.iter().enumerate() {
                 assert_eq!(proto_prune.as_slice(), &[i as u8; 32]);
             }
@@ -583,7 +570,7 @@ fn test_conformance_encode_prune() {
     let sig = [0u8; 64];
     let dest = [0x33; 32];
     let wc = 1_000_000u64;
-    let input = make_prune_bytes(&pk, &pk, &[prune_node], &sig, &dest, wc);
+    let input = make_prune_bytes(&pk, &[prune_node], &sig, &dest, wc);
     let encoded = encode_effects(&input);
 
     use prost::Message;


### PR DESCRIPTION
#### Problem
Pubkey field in `Protocol::PruneMessage(Pubkey, PruneData)` is redundant and can be reliably removed.

### Summery
- Removed `Pubkey` from `Protocol::PruneMessage`
- Changed `MAX_PRUNE_DATA_NODES` to `33`(new limit after removing `Pubkey`)
- Changed the tests inside `gossip/tests/conformance/tests.rs` and `/gossip/tests/conformance/fixtures.rs` to match the new structure of `PruneData` and `MAX_PRUNE_DATA_NODES` limit

### Tests
The already existing tests `test_max_prune_data_pubkeys` reliably tests that having any more then `33` prunes won't fit in the UDP packet limit