### PR TITLE
program-runtime: remove obsolete VmMemoryPool default impl

### DIFF
--- a/program-runtime/src/mem_pool.rs
+++ b/program-runtime/src/mem_pool.rs
@@ -158,12 +158,6 @@ impl VmMemoryPool {
     }
 }
 
-impl Default for VmMemoryPool {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
#### Description

The `VmMemoryPool` have default implementation which is only calling `new()` and after all isn't used anywhere. 

#### Summary of Changes
- Removed default implementation of `VmMemoryPool`
