### PR TITLE
Reduce transaction hot-path allocations

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -5,7 +5,6 @@ use {
         qos_service::QosService,
         scheduler_messages::MaxAge,
     },
-    itertools::Itertools,
     solana_fee::FeeFeatures,
     solana_measure::measure_us,
     solana_poh::{
@@ -136,7 +135,7 @@ impl Consumer {
             true,
             &mut error_counters,
         );
-        let check_results: Vec<_> = check_results
+        let check_results = check_results
             .into_iter()
             .zip(txs.iter())
             .map(|(result, tx)| match result {
@@ -148,12 +147,12 @@ impl Consumer {
                     }
                 }
                 Err(err) => Err(err),
-            })
-            .collect();
+            });
+
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,
-            check_results.into_iter(),
+            check_results,
             ExecutionFlags {
                 drop_on_failure: false,
                 all_or_nothing: false,
@@ -351,20 +350,20 @@ impl Consumer {
         };
 
         let mut entry_bytes = SERIALIZED_ENTRIES_OVERHEAD;
-        let (processed_transactions, processing_results_to_transactions_us) = measure_us!(
-            processing_results
+        let (processed_transactions, processing_results_to_transactions_us) = measure_us!({
+            let mut processed_transactions =
+                Vec::with_capacity(processed_counts.processed_transactions_count as usize);
+            for (processing_result, tx) in processing_results
                 .iter()
                 .zip(batch.sanitized_transactions())
-                .filter_map(|(processing_result, tx)| {
-                    if processing_result.was_processed() {
-                        entry_bytes += tx.serialized_size() as u64;
-                        Some(tx.to_versioned_transaction())
-                    } else {
-                        None
-                    }
-                })
-                .collect_vec()
-        );
+            {
+                if processing_result.was_processed() {
+                    entry_bytes += tx.serialized_size() as u64;
+                    processed_transactions.push(tx.to_versioned_transaction());
+                }
+            }
+            processed_transactions
+        });
 
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -78,7 +78,7 @@ impl Bank {
 
         let lock_results = self.check_age_and_compute_budget_limits(
             sanitized_txs,
-            &lock_results,
+            lock_results,
             max_age,
             strict_nonce_size_check,
             error_counters,
@@ -91,32 +91,31 @@ impl Bank {
         )
     }
 
-    fn filter_v1_transactions<Tx: TransactionWithMeta>(
+    fn filter_v1_transactions<'a, Tx: TransactionWithMeta>(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: &[TransactionResult<()>],
-    ) -> Vec<TransactionResult<()>> {
+        sanitized_txs: &'a [impl core::borrow::Borrow<Tx>],
+        lock_results: &'a [TransactionResult<()>],
+    ) -> impl Iterator<Item = TransactionResult<()>> + 'a {
+        let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
         // Discard v1 transactions until feature gate is activated.
         sanitized_txs
             .iter()
             .zip(lock_results)
-            .map(|(tx, lock_result)| match lock_result {
+            .map(move |(tx, lock_result)| match lock_result {
                 Err(err) => Err(err.clone()),
                 Ok(())
-                    if !self.feature_set.snapshot().enable_tx_v1
-                        && tx.borrow().version() == TransactionVersion::Number(1) =>
+                    if !enable_tx_v1 && tx.borrow().version() == TransactionVersion::Number(1) =>
                 {
                     Err(TransactionError::UnsupportedVersion)
                 }
                 Ok(()) => Ok(()),
             })
-            .collect()
     }
 
     fn check_age_and_compute_budget_limits<Tx: TransactionWithMeta>(
         &self,
         sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: &[TransactionResult<()>],
+        lock_results: impl IntoIterator<Item = TransactionResult<()>>,
         max_age: usize,
         strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
@@ -182,7 +181,7 @@ impl Bank {
                         strict_nonce_size_check,
                     )
                 }
-                Err(e) => Err(e.clone()),
+                Err(e) => Err(e),
             })
             .collect()
     }
@@ -255,12 +254,11 @@ impl Bank {
     fn check_status_cache<Tx: TransactionWithMeta>(
         &self,
         sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: Vec<TransactionCheckResult>,
+        mut lock_results: Vec<TransactionCheckResult>,
         collect_processed_slots: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
         // Do allocation before acquiring the lock on the status cache.
-        let mut check_results = Vec::with_capacity(sanitized_txs.len());
         let mut processed_slots = if collect_processed_slots {
             Some(Vec::with_capacity(sanitized_txs.len()))
         } else {
@@ -268,27 +266,24 @@ impl Bank {
         };
         let rcache = self.status_cache.read().unwrap();
 
-        for (sanitized_tx_ref, lock_result) in sanitized_txs.iter().zip(lock_results) {
-            let sanitized_tx = sanitized_tx_ref.borrow();
-
-            let (result, processed_slot) = if lock_result.is_ok() {
-                if let Some(slot) = self.get_processed_slot(sanitized_tx, &rcache) {
-                    error_counters.already_processed += 1;
-                    (Err(TransactionError::AlreadyProcessed), Some(slot))
-                } else {
-                    (lock_result, None)
-                }
+        for (sanitized_tx_ref, lock_result) in sanitized_txs.iter().zip(lock_results.iter_mut()) {
+            let processed_slot = if lock_result.is_ok() {
+                self.get_processed_slot(sanitized_tx_ref.borrow(), &rcache)
             } else {
-                (lock_result, None)
+                None
             };
 
-            check_results.push(result);
+            if processed_slot.is_some() {
+                error_counters.already_processed += 1;
+                *lock_result = Err(TransactionError::AlreadyProcessed);
+            }
+
             if let Some(processed_slots) = processed_slots.as_mut() {
                 processed_slots.push(processed_slot)
             }
         }
 
-        (check_results, processed_slots)
+        (lock_results, processed_slots)
     }
 
     fn get_processed_slot(
@@ -578,15 +573,7 @@ mod tests {
 
         let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
 
-        assert!(matches!(filtered[0], Err(TransactionError::AccountInUse)));
-        assert!(matches!(
-            filtered[1],
-            Err(TransactionError::TooManyAccountLocks)
-        ));
-        assert!(matches!(
-            filtered[2],
-            Err(TransactionError::WouldExceedMaxBlockCostLimit)
-        ));
+        assert!(filtered.eq(lock_results.iter().cloned()));
     }
 
     #[test]
@@ -596,11 +583,7 @@ mod tests {
 
         let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
 
-        assert_eq!(filtered.len(), 1);
-        assert!(matches!(
-            filtered[0],
-            Err(TransactionError::UnsupportedVersion)
-        ));
+        assert!(filtered.eq([Err(TransactionError::UnsupportedVersion)]));
     }
 
     #[test]
@@ -612,7 +595,7 @@ mod tests {
 
         let filtered = bank.filter_v1_transactions(&txs, &lock_results);
 
-        assert_eq!(filtered, vec![Ok(())]);
+        assert!(filtered.eq([Ok(())]));
     }
 
     #[test]
@@ -625,7 +608,7 @@ mod tests {
 
         let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
 
-        assert_eq!(filtered, vec![Ok(()), Ok(())]);
+        assert!(filtered.eq([Ok(()), Ok(())]));
     }
 
     #[test]
@@ -645,15 +628,11 @@ mod tests {
 
         let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
 
-        assert!(matches!(filtered[0], Ok(())));
-        assert!(matches!(
-            filtered[1],
-            Err(TransactionError::UnsupportedVersion)
-        ));
-        assert!(matches!(filtered[2], Err(TransactionError::AccountInUse)));
-        assert!(matches!(
-            filtered[3],
-            Err(TransactionError::TooManyAccountLocks)
-        ));
+        assert!(filtered.eq([
+            Ok(()),
+            Err(TransactionError::UnsupportedVersion),
+            Err(TransactionError::AccountInUse),
+            Err(TransactionError::TooManyAccountLocks),
+        ]));
     }
 }


### PR DESCRIPTION
## Summary
- Stream v1 transaction filtering into age and compute-budget checks instead of allocating an intermediate result vector.
- Mutate status-cache check results in place instead of building a second result vector.
- Stream vote-only check-result filtering into execution instead of collecting a second check-results vector.
- Preallocate recorded processed transactions from the processed transaction count.

TLDR:
  - 1 intermediate v1-filter alloc, 1 second status-cache result alloc per checked batch.
  - 1 second vote-only check-results alloc per process-and-record batch.