### PR TITLE
tpu-client-next: introduce worker cache interface

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -545,6 +545,7 @@ impl TpuClientNextClient {
             skip_check_transaction_age: true,
             worker_channel_size: 2,
             max_reconnect_attempts: 4,
+            workers_cache: None,
             // Send to the next leader only, but verify that connections exist
             // for the leaders of the next `4 * NUM_CONSECUTIVE_SLOTS`.
             leaders_fanout: Fanout {

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -178,6 +178,7 @@ impl TpuClientNextClient {
             // experimentally found parameter values
             worker_channel_size: 64,
             max_reconnect_attempts: 4,
+            workers_cache: None,
             // We open connection to one more leader in advance, which time-wise means ~1.6s
             leaders_fanout: Fanout {
                 connect: leader_forward_count + 1,

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -48,6 +48,7 @@ use {
         },
         leader_updater::LeaderUpdater,
         transaction_batch::TransactionBatch,
+        workers_cache::WorkersCacheInterface,
     },
     solana_keypair::Keypair,
     std::{future::Future, net::UdpSocket, num::NonZeroUsize, pin::Pin, sync::Arc},
@@ -85,6 +86,7 @@ pub struct ClientBuilder {
     sender_channel_size: usize,
     worker_channel_size: usize,
     max_reconnect_attempts: usize,
+    workers_cache: Option<Box<dyn WorkersCacheInterface>>,
     broadcaster: Box<dyn WorkersBroadcaster>,
     report_fn: Option<ReportFn>,
     cancel_scheduler: CancellationToken,
@@ -105,6 +107,7 @@ impl ClientBuilder {
             worker_channel_size: 2,
             sender_channel_size: 64,
             max_reconnect_attempts: 2,
+            workers_cache: None,
             broadcaster: Box::new(NonblockingBroadcaster),
             report_fn: None,
             cancel_scheduler: CancellationToken::new(),
@@ -140,7 +143,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Set the maximum number of cached connections.
+    /// Set the maximum number of cached connections used by the default LRU cache.
     pub fn max_cache_size(mut self, num_connections: NonZeroUsize) -> Self {
         self.num_connections = num_connections;
         self
@@ -188,6 +191,14 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the cache implementation used to store connection workers.
+    ///
+    /// When this is set, [`Self::max_cache_size`] does not affect the provided cache.
+    pub fn workers_cache(mut self, workers_cache: impl WorkersCacheInterface + 'static) -> Self {
+        self.workers_cache = Some(Box::new(workers_cache));
+        self
+    }
+
     /// Set the broadcaster used by the scheduler.
     pub fn broadcaster(mut self, broadcaster: impl WorkersBroadcaster + 'static) -> Self {
         self.broadcaster = Box::new(broadcaster);
@@ -218,6 +229,7 @@ impl ClientBuilder {
             skip_check_transaction_age: self.skip_check_transaction_age,
             worker_channel_size: self.worker_channel_size,
             max_reconnect_attempts: self.max_reconnect_attempts,
+            workers_cache: self.workers_cache,
             // We open connection to one more leader in advance, which time-wise means ~1.6s
             leaders_fanout: Fanout {
                 connect: self.leader_send_fanout.saturating_add(1),

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -48,6 +48,7 @@ use {
         },
         leader_updater::LeaderUpdater,
         transaction_batch::TransactionBatch,
+        workers_cache::ConnectionWorkerCache,
     },
     solana_keypair::Keypair,
     std::{future::Future, net::UdpSocket, num::NonZeroUsize, pin::Pin, sync::Arc},
@@ -85,6 +86,7 @@ pub struct ClientBuilder {
     sender_channel_size: usize,
     worker_channel_size: usize,
     max_reconnect_attempts: usize,
+    workers_cache: Option<Box<dyn FnOnce(NonZeroUsize) -> Box<dyn ConnectionWorkerCache> + Send>>,
     broadcaster: Box<dyn WorkersBroadcaster>,
     report_fn: Option<ReportFn>,
     cancel_scheduler: CancellationToken,
@@ -105,6 +107,7 @@ impl ClientBuilder {
             worker_channel_size: 2,
             sender_channel_size: 64,
             max_reconnect_attempts: 2,
+            workers_cache: None,
             broadcaster: Box::new(NonblockingBroadcaster),
             report_fn: None,
             cancel_scheduler: CancellationToken::new(),
@@ -188,6 +191,20 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the cache implementation used to store connection workers.
+    ///
+    /// The configured [`Self::max_cache_size`] is passed to this factory.
+    pub fn workers_cache<C>(
+        mut self,
+        workers_cache: impl FnOnce(NonZeroUsize) -> C + Send + 'static,
+    ) -> Self
+    where
+        C: ConnectionWorkerCache + 'static,
+    {
+        self.workers_cache = Some(Box::new(move |capacity| Box::new(workers_cache(capacity))));
+        self
+    }
+
     /// Set the broadcaster used by the scheduler.
     pub fn broadcaster(mut self, broadcaster: impl WorkersBroadcaster + 'static) -> Self {
         self.broadcaster = Box::new(broadcaster);
@@ -218,6 +235,7 @@ impl ClientBuilder {
             skip_check_transaction_age: self.skip_check_transaction_age,
             worker_channel_size: self.worker_channel_size,
             max_reconnect_attempts: self.max_reconnect_attempts,
+            workers_cache: self.workers_cache,
             // We open connection to one more leader in advance, which time-wise means ~1.6s
             leaders_fanout: Fanout {
                 connect: self.leader_send_fanout.saturating_add(1),

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -11,9 +11,10 @@ use {
             QuicClientCertificate, QuicError, create_client_config, create_client_endpoint,
         },
         transaction_batch::TransactionBatch,
-        workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
+        workers_cache::{WorkersCache, WorkersCacheError, WorkersCacheInterface, shutdown_worker},
     },
     async_trait::async_trait,
+    lru::LruCache,
     quinn::{ClientConfig, Endpoint},
     solana_keypair::Keypair,
     std::{
@@ -98,6 +99,11 @@ pub struct ConnectionWorkersSchedulerConfig {
     /// The maximum number of reconnection attempts allowed in case of
     /// connection failure.
     pub max_reconnect_attempts: usize,
+
+    /// Optional cache implementation used to store connection workers.
+    ///
+    /// If not provided, the scheduler uses an LRU cache with [`Self::num_connections`] capacity.
+    pub workers_cache: Option<Box<dyn WorkersCacheInterface>>,
 
     /// Configures the number of leaders to connect to and send transactions to.
     pub leaders_fanout: Fanout,
@@ -218,6 +224,7 @@ impl ConnectionWorkersScheduler {
             skip_check_transaction_age,
             worker_channel_size,
             max_reconnect_attempts,
+            workers_cache,
             leaders_fanout,
             override_initial_congestion_window: initial_congestion_window,
         }: ConnectionWorkersSchedulerConfig,
@@ -233,7 +240,9 @@ impl ConnectionWorkersScheduler {
         let mut endpoint = setup_endpoint(bind, stake_identity, initial_congestion_window)?;
 
         debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
-        let mut workers = WorkersCache::new(num_connections, cancel.clone());
+        let workers_cache =
+            workers_cache.unwrap_or_else(|| Box::new(LruCache::new(num_connections)));
+        let mut workers = WorkersCache::new(workers_cache, cancel.clone());
 
         let mut last_error = None;
         // flag to ensure that the section handling

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -11,9 +11,10 @@ use {
             QuicClientCertificate, QuicError, create_client_config, create_client_endpoint,
         },
         transaction_batch::TransactionBatch,
-        workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
+        workers_cache::{ConnectionWorkerCache, WorkersCache, WorkersCacheError, shutdown_worker},
     },
     async_trait::async_trait,
+    lru::LruCache,
     quinn::{ClientConfig, Endpoint},
     solana_keypair::Keypair,
     std::{
@@ -98,6 +99,13 @@ pub struct ConnectionWorkersSchedulerConfig {
     /// The maximum number of reconnection attempts allowed in case of
     /// connection failure.
     pub max_reconnect_attempts: usize,
+
+    /// Optional cache factory used to store connection workers.
+    ///
+    /// If not provided, the scheduler uses an LRU cache. In both cases, [`Self::num_connections`]
+    /// is passed as the cache capacity.
+    pub workers_cache:
+        Option<Box<dyn FnOnce(NonZeroUsize) -> Box<dyn ConnectionWorkerCache> + Send>>,
 
     /// Configures the number of leaders to connect to and send transactions to.
     pub leaders_fanout: Fanout,
@@ -218,6 +226,7 @@ impl ConnectionWorkersScheduler {
             skip_check_transaction_age,
             worker_channel_size,
             max_reconnect_attempts,
+            workers_cache,
             leaders_fanout,
             override_initial_congestion_window: initial_congestion_window,
         }: ConnectionWorkersSchedulerConfig,
@@ -233,7 +242,10 @@ impl ConnectionWorkersScheduler {
         let mut endpoint = setup_endpoint(bind, stake_identity, initial_congestion_window)?;
 
         debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
-        let mut workers = WorkersCache::new(num_connections, cancel.clone());
+        let workers_cache: Box<dyn ConnectionWorkerCache> = workers_cache
+            .map(|create_workers_cache| create_workers_cache(num_connections))
+            .unwrap_or_else(|| Box::new(LruCache::new(num_connections)));
+        let mut workers = WorkersCache::new(workers_cache, cancel.clone());
 
         let mut last_error = None;
         // flag to ensure that the section handling

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
     client_builder::{Client, ClientBuilder, ClientError, TransactionSender},
     connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
     send_transaction_stats::SendTransactionStats,
+    workers_cache::WorkersCacheInterface,
 };
 pub(crate) mod quic_networking;
 pub(crate) use crate::quic_networking::QuicError;

--- a/tpu-client-next/src/lib.rs
+++ b/tpu-client-next/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
     client_builder::{Client, ClientBuilder, ClientError, TransactionSender},
     connection_workers_scheduler::{ConnectionWorkersScheduler, ConnectionWorkersSchedulerError},
     send_transaction_stats::SendTransactionStats,
+    workers_cache::ConnectionWorkerCache,
 };
 pub(crate) mod quic_networking;
 pub(crate) use crate::quic_networking::QuicError;

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -11,7 +11,7 @@ use {
     },
     lru::LruCache,
     quinn::Endpoint,
-    std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration},
+    std::{net::SocketAddr, sync::Arc, time::Duration},
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::TrySendError},
@@ -19,6 +19,37 @@ use {
     },
     tokio_util::sync::CancellationToken,
 };
+
+/// Interface for storing connection workers.
+pub trait WorkersCacheInterface: Send {
+    fn contains(&self, key: &SocketAddr) -> bool;
+    fn get(&mut self, key: &SocketAddr) -> Option<&WorkerInfo>;
+    fn push(&mut self, key: SocketAddr, value: WorkerInfo) -> Option<(SocketAddr, WorkerInfo)>;
+    fn pop(&mut self, key: &SocketAddr) -> Option<WorkerInfo>;
+    fn pop_next(&mut self) -> Option<(SocketAddr, WorkerInfo)>;
+}
+
+impl WorkersCacheInterface for LruCache<SocketAddr, WorkerInfo> {
+    fn contains(&self, key: &SocketAddr) -> bool {
+        LruCache::contains(self, key)
+    }
+
+    fn get(&mut self, key: &SocketAddr) -> Option<&WorkerInfo> {
+        LruCache::get(self, key)
+    }
+
+    fn push(&mut self, key: SocketAddr, value: WorkerInfo) -> Option<(SocketAddr, WorkerInfo)> {
+        LruCache::push(self, key, value)
+    }
+
+    fn pop(&mut self, key: &SocketAddr) -> Option<WorkerInfo> {
+        LruCache::pop(self, key)
+    }
+
+    fn pop_next(&mut self) -> Option<(SocketAddr, WorkerInfo)> {
+        LruCache::pop_lru(self)
+    }
+}
 
 /// [`WorkerInfo`] holds information about a worker responsible for sending
 /// transaction batches.
@@ -108,10 +139,9 @@ pub fn spawn_worker(
     WorkerInfo::new(txs_sender, handle, cancel)
 }
 
-/// [`WorkersCache`] manages and caches workers. It uses an LRU cache to store and
-/// manage workers. It also tracks transaction statistics for each peer.
+/// [`WorkersCache`] manages and caches workers using the provided cache implementation.
 pub struct WorkersCache {
-    workers: LruCache<SocketAddr, WorkerInfo>,
+    workers: Box<dyn WorkersCacheInterface>,
 
     /// Indicates that the `WorkersCache` is been `shutdown()`, interrupting any outstanding
     /// `send_transactions_to_address()` invocations.
@@ -138,11 +168,8 @@ pub enum WorkersCacheError {
 }
 
 impl WorkersCache {
-    pub fn new(capacity: NonZeroUsize, cancel: CancellationToken) -> Self {
-        Self {
-            workers: LruCache::new(capacity),
-            cancel,
-        }
+    pub fn new(workers: Box<dyn WorkersCacheInterface>, cancel: CancellationToken) -> Self {
+        Self { workers, cancel }
     }
 
     /// Checks if the worker for a given peer exists and it hasn't been
@@ -298,7 +325,7 @@ impl WorkersCache {
     /// Flushes the cache and asynchronously shuts down all workers. This method
     /// doesn't wait for the completion of all the shutdown tasks.
     pub(crate) fn flush(&mut self) {
-        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+        while let Some((peer, current_worker)) = self.workers.pop_next() {
             shutdown_worker(ShutdownWorker {
                 leader: peer,
                 worker: current_worker,
@@ -316,7 +343,7 @@ impl WorkersCache {
         self.cancel.cancel();
 
         let mut tasks = JoinSet::new();
-        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+        while let Some((peer, current_worker)) = self.workers.pop_next() {
             let shutdown_worker = ShutdownWorker {
                 leader: peer,
                 worker: current_worker,
@@ -371,6 +398,7 @@ mod tests {
             transaction_batch::TransactionBatch,
             workers_cache::{WorkersCache, WorkersCacheError, spawn_worker},
         },
+        lru::LruCache,
         quinn::Endpoint,
         solana_net_utils::sockets::{bind_to_localhost_unique, unique_port_range_for_tests},
         solana_tls_utils::QuicClientCertificate,
@@ -462,7 +490,10 @@ mod tests {
         let endpoint = create_test_endpoint();
 
         let cancel = CancellationToken::new();
-        let mut cache = WorkersCache::new(NonZeroUsize::new(10).unwrap(), cancel.clone());
+        let mut cache = WorkersCache::new(
+            Box::new(LruCache::new(NonZeroUsize::new(10).unwrap())),
+            cancel.clone(),
+        );
 
         let port_range = unique_port_range_for_tests(2);
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
@@ -481,17 +512,28 @@ mod tests {
         );
         assert!(cache.push(peer, worker).is_none());
 
-        let worker_info = cache.workers.peek(&peer).unwrap();
         // wait until sender is closed which happens when task has finished.
         let start = Instant::now();
-        while !worker_info.sender.is_closed() {
+        while !cache
+            .workers
+            .get(&peer)
+            .map(|worker| worker.sender.is_closed())
+            .unwrap_or(true)
+        {
             if start.elapsed() > TEST_MAX_TIME {
                 panic!("Sender did not close in {TEST_MAX_TIME:?}");
             }
             sleep(Duration::from_millis(500)).await;
         }
 
-        assert!(!worker_info.is_active(), "Worker should be inactive");
+        assert!(
+            !cache
+                .workers
+                .get(&peer)
+                .map(|worker| worker.is_active())
+                .unwrap_or(false),
+            "Worker should be inactive"
+        );
 
         // try to send to this worker — should fail and remove the worker
         let result = cache

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -516,8 +516,9 @@ mod tests {
         while !cache
             .workers
             .get(&peer)
-            .map(|worker| worker.sender.is_closed())
-            .unwrap_or(true)
+            .expect("Worker should remain in cache")
+            .sender
+            .is_closed()
         {
             if start.elapsed() > TEST_MAX_TIME {
                 panic!("Sender did not close in {TEST_MAX_TIME:?}");
@@ -526,11 +527,7 @@ mod tests {
         }
 
         assert!(
-            !cache
-                .workers
-                .get(&peer)
-                .map(|worker| worker.is_active())
-                .unwrap_or(false),
+            !cache.workers.get(&peer).unwrap().is_active(),
             "Worker should be inactive"
         );
 

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -11,7 +11,7 @@ use {
     },
     lru::LruCache,
     quinn::Endpoint,
-    std::{net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration},
+    std::{net::SocketAddr, sync::Arc, time::Duration},
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::TrySendError},
@@ -19,6 +19,36 @@ use {
     },
     tokio_util::sync::CancellationToken,
 };
+
+pub trait ConnectionWorkerCache: Send {
+    fn contains(&self, key: &SocketAddr) -> bool;
+    fn get(&mut self, key: &SocketAddr) -> Option<&WorkerInfo>;
+    fn push(&mut self, key: SocketAddr, value: WorkerInfo) -> Option<(SocketAddr, WorkerInfo)>;
+    fn pop(&mut self, key: &SocketAddr) -> Option<WorkerInfo>;
+    fn pop_next(&mut self) -> Option<(SocketAddr, WorkerInfo)>;
+}
+
+impl ConnectionWorkerCache for LruCache<SocketAddr, WorkerInfo> {
+    fn contains(&self, key: &SocketAddr) -> bool {
+        LruCache::contains(self, key)
+    }
+
+    fn get(&mut self, key: &SocketAddr) -> Option<&WorkerInfo> {
+        LruCache::get(self, key)
+    }
+
+    fn push(&mut self, key: SocketAddr, value: WorkerInfo) -> Option<(SocketAddr, WorkerInfo)> {
+        LruCache::push(self, key, value)
+    }
+
+    fn pop(&mut self, key: &SocketAddr) -> Option<WorkerInfo> {
+        LruCache::pop(self, key)
+    }
+
+    fn pop_next(&mut self) -> Option<(SocketAddr, WorkerInfo)> {
+        LruCache::pop_lru(self)
+    }
+}
 
 /// [`WorkerInfo`] holds information about a worker responsible for sending
 /// transaction batches.
@@ -108,10 +138,9 @@ pub fn spawn_worker(
     WorkerInfo::new(txs_sender, handle, cancel)
 }
 
-/// [`WorkersCache`] manages and caches workers. It uses an LRU cache to store and
-/// manage workers. It also tracks transaction statistics for each peer.
+/// [`WorkersCache`] manages and caches workers using the provided cache implementation.
 pub struct WorkersCache {
-    workers: LruCache<SocketAddr, WorkerInfo>,
+    workers: Box<dyn ConnectionWorkerCache>,
 
     /// Indicates that the `WorkersCache` is been `shutdown()`, interrupting any outstanding
     /// `send_transactions_to_address()` invocations.
@@ -138,11 +167,8 @@ pub enum WorkersCacheError {
 }
 
 impl WorkersCache {
-    pub fn new(capacity: NonZeroUsize, cancel: CancellationToken) -> Self {
-        Self {
-            workers: LruCache::new(capacity),
-            cancel,
-        }
+    pub fn new(workers: Box<dyn ConnectionWorkerCache>, cancel: CancellationToken) -> Self {
+        Self { workers, cancel }
     }
 
     /// Checks if the worker for a given peer exists and it hasn't been
@@ -298,7 +324,7 @@ impl WorkersCache {
     /// Flushes the cache and asynchronously shuts down all workers. This method
     /// doesn't wait for the completion of all the shutdown tasks.
     pub(crate) fn flush(&mut self) {
-        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+        while let Some((peer, current_worker)) = self.workers.pop_next() {
             shutdown_worker(ShutdownWorker {
                 leader: peer,
                 worker: current_worker,
@@ -316,7 +342,7 @@ impl WorkersCache {
         self.cancel.cancel();
 
         let mut tasks = JoinSet::new();
-        while let Some((peer, current_worker)) = self.workers.pop_lru() {
+        while let Some((peer, current_worker)) = self.workers.pop_next() {
             let shutdown_worker = ShutdownWorker {
                 leader: peer,
                 worker: current_worker,
@@ -371,6 +397,7 @@ mod tests {
             transaction_batch::TransactionBatch,
             workers_cache::{WorkersCache, WorkersCacheError, spawn_worker},
         },
+        lru::LruCache,
         quinn::Endpoint,
         solana_net_utils::sockets::{bind_to_localhost_unique, unique_port_range_for_tests},
         solana_tls_utils::QuicClientCertificate,
@@ -462,7 +489,10 @@ mod tests {
         let endpoint = create_test_endpoint();
 
         let cancel = CancellationToken::new();
-        let mut cache = WorkersCache::new(NonZeroUsize::new(10).unwrap(), cancel.clone());
+        let mut cache = WorkersCache::new(
+            Box::new(LruCache::new(NonZeroUsize::new(10).unwrap())),
+            cancel.clone(),
+        );
 
         let port_range = unique_port_range_for_tests(2);
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
@@ -481,17 +511,28 @@ mod tests {
         );
         assert!(cache.push(peer, worker).is_none());
 
-        let worker_info = cache.workers.peek(&peer).unwrap();
         // wait until sender is closed which happens when task has finished.
         let start = Instant::now();
-        while !worker_info.sender.is_closed() {
+        while !cache
+            .workers
+            .get(&peer)
+            .map(|worker| worker.sender.is_closed())
+            .unwrap_or(true)
+        {
             if start.elapsed() > TEST_MAX_TIME {
                 panic!("Sender did not close in {TEST_MAX_TIME:?}");
             }
             sleep(Duration::from_millis(500)).await;
         }
 
-        assert!(!worker_info.is_active(), "Worker should be inactive");
+        assert!(
+            !cache
+                .workers
+                .get(&peer)
+                .map(|worker| worker.is_active())
+                .unwrap_or(false),
+            "Worker should be inactive"
+        );
 
         // try to send to this worker — should fail and remove the worker
         let result = cache

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -64,6 +64,7 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
         // the speed of fastest leader.
         worker_channel_size: 100,
         max_reconnect_attempts: 4,
+        workers_cache: None,
         leaders_fanout: Fanout {
             send: 1,
             connect: 1,

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -17,17 +17,18 @@ use {
         streamer::StakedNodes,
     },
     solana_tpu_client_next::{
-        ClientBuilder, ConnectionWorkersScheduler, ConnectionWorkersSchedulerError,
-        SendTransactionStats,
+        ClientBuilder, ConnectionWorkerCache, ConnectionWorkersScheduler,
+        ConnectionWorkersSchedulerError, SendTransactionStats,
         connection_workers_scheduler::{
             BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
         leader_updater::create_pinned_leader_updater,
         send_transaction_stats::SendTransactionStatsNonAtomic,
         transaction_batch::TransactionBatch,
+        workers_cache::WorkerInfo,
     },
     std::{
-        collections::HashMap,
+        collections::{HashMap, VecDeque},
         net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
         num::{NonZeroUsize, Saturating},
         sync::{
@@ -855,10 +856,16 @@ async fn test_proactive_connection_close_detection() {
     );
 }
 
-#[tokio::test]
-async fn test_client_builder() {
+struct ClientBuilderTestContext {
+    builder: ClientBuilder,
+    receiver: CrossbeamReceiver<PacketBatch>,
+    server_handle: JoinHandle<()>,
+    cancel: CancellationToken,
+}
+
+fn setup_client_builder_test() -> ClientBuilderTestContext {
     let SpawnTestServerResult {
-        join_handle: server_handle,
+        join_handle,
         receiver,
         server_address,
         stats: _stats,
@@ -868,9 +875,6 @@ async fn test_client_builder() {
         QuicStreamerConfig::default_for_tests(),
         SwQosConfig::default(),
     );
-
-    let _drop_guard = cancel.clone().drop_guard();
-    let successfully_sent = Arc::new(AtomicU64::new(0));
 
     let port_range = localhost_port_range_for_tests();
     let socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
@@ -884,25 +888,45 @@ async fn test_client_builder() {
         .leader_send_fanout(1)
         .identity(None)
         .max_cache_size(NonZeroUsize::new(1).unwrap())
-        .worker_channel_size(100)
-        .metric_reporter({
-            let successfully_sent = successfully_sent.clone();
-            |stats: Arc<SendTransactionStats>, cancel: CancellationToken| async move {
-                let mut interval = interval(Duration::from_millis(10));
-                cancel
-                    .run_until_cancelled(async {
-                        loop {
-                            interval.tick().await;
-                            let view = stats.read_and_reset();
-                            successfully_sent.fetch_add(view.successfully_sent, Ordering::Relaxed);
-                        }
-                    })
-                    .await;
-                // update right after the cancel
-                let view = stats.read_and_reset();
-                successfully_sent.fetch_add(view.successfully_sent, Ordering::Relaxed);
-            }
-        });
+        .worker_channel_size(100);
+
+    ClientBuilderTestContext {
+        builder,
+        receiver,
+        server_handle: join_handle,
+        cancel,
+    }
+}
+
+#[tokio::test]
+async fn test_client_builder() {
+    let ClientBuilderTestContext {
+        builder,
+        receiver,
+        server_handle,
+        cancel,
+    } = setup_client_builder_test();
+
+    let _drop_guard = cancel.clone().drop_guard();
+    let successfully_sent = Arc::new(AtomicU64::new(0));
+    let builder = builder.metric_reporter({
+        let successfully_sent = successfully_sent.clone();
+        |stats: Arc<SendTransactionStats>, cancel: CancellationToken| async move {
+            let mut interval = interval(Duration::from_millis(10));
+            cancel
+                .run_until_cancelled(async {
+                    loop {
+                        interval.tick().await;
+                        let view = stats.read_and_reset();
+                        successfully_sent.fetch_add(view.successfully_sent, Ordering::Relaxed);
+                    }
+                })
+                .await;
+            // update right after the cancel
+            let view = stats.read_and_reset();
+            successfully_sent.fetch_add(view.successfully_sent, Ordering::Relaxed);
+        }
+    });
 
     let (tx_sender, client) = builder
         .build()
@@ -921,18 +945,15 @@ async fn test_client_builder() {
         .try_send_transactions_in_batch(txs.clone())
         .expect("Client should accept the transaction batch");
 
-    // Check results
     let now = Instant::now();
     let mut actual_num_packets = 0;
     while actual_num_packets < expected_num_txs {
-        {
-            let elapsed = now.elapsed();
-            assert!(
-                elapsed < TEST_MAX_TIME,
-                "Failed to send {expected_num_txs} transaction in {elapsed:?}. Only sent \
-                 {actual_num_packets}",
-            );
-        }
+        let elapsed = now.elapsed();
+        assert!(
+            elapsed < TEST_MAX_TIME,
+            "Failed to send {expected_num_txs} transaction in {elapsed:?}. Only sent \
+             {actual_num_packets}",
+        );
 
         let Ok(packets) = receiver.try_recv() else {
             sleep(Duration::from_millis(10)).await;
@@ -941,7 +962,7 @@ async fn test_client_builder() {
 
         actual_num_packets += packets.len();
         for p in packets.iter() {
-            assert_eq!(p.meta().size, 1);
+            assert_eq!(p.meta().size, tx_size);
         }
     }
 
@@ -956,6 +977,116 @@ async fn test_client_builder() {
     );
 
     // Stop server
+    cancel.cancel();
+    server_handle.await.unwrap();
+}
+
+struct FifoWorkersCache {
+    capacity: usize,
+    workers: HashMap<SocketAddr, WorkerInfo>,
+    order: VecDeque<SocketAddr>,
+}
+
+impl FifoWorkersCache {
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            capacity: capacity.get(),
+            workers: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+}
+
+impl ConnectionWorkerCache for FifoWorkersCache {
+    fn contains(&self, key: &SocketAddr) -> bool {
+        self.workers.contains_key(key)
+    }
+
+    fn get(&mut self, key: &SocketAddr) -> Option<&WorkerInfo> {
+        self.workers.get(key)
+    }
+
+    fn push(&mut self, key: SocketAddr, value: WorkerInfo) -> Option<(SocketAddr, WorkerInfo)> {
+        if let Some(worker) = self.workers.insert(key, value) {
+            return Some((key, worker));
+        }
+
+        self.order.push_back(key);
+        if self.workers.len() > self.capacity {
+            return self.pop_next();
+        }
+
+        None
+    }
+
+    fn pop(&mut self, key: &SocketAddr) -> Option<WorkerInfo> {
+        self.order.retain(|addr| addr != key);
+        self.workers.remove(key)
+    }
+
+    fn pop_next(&mut self) -> Option<(SocketAddr, WorkerInfo)> {
+        while let Some(key) = self.order.pop_front() {
+            if let Some(worker) = self.workers.remove(&key) {
+                return Some((key, worker));
+            }
+        }
+        None
+    }
+}
+
+#[tokio::test]
+async fn test_client_builder_with_custom_workers_cache() {
+    let ClientBuilderTestContext {
+        builder,
+        receiver,
+        server_handle,
+        cancel,
+    } = setup_client_builder_test();
+
+    let _drop_guard = cancel.clone().drop_guard();
+    let cache_factory_calls = Arc::new(AtomicU64::new(0));
+
+    let builder = builder.workers_cache({
+        let cache_factory_calls = cache_factory_calls.clone();
+        move |capacity| {
+            cache_factory_calls.fetch_add(1, Ordering::Relaxed);
+            FifoWorkersCache::new(capacity)
+        }
+    });
+
+    let (tx_sender, client) = builder
+        .build()
+        .expect("Client should be built successfully.");
+
+    tx_sender
+        .send_transactions_in_batch(vec![vec![0_u8; 1]])
+        .await
+        .expect("Client should accept the transaction batch");
+
+    let now = Instant::now();
+    loop {
+        assert!(
+            now.elapsed() < TEST_MAX_TIME,
+            "Failed to send transaction in {:?}",
+            now.elapsed(),
+        );
+
+        let Ok(packets) = receiver.try_recv() else {
+            sleep(Duration::from_millis(10)).await;
+            continue;
+        };
+
+        assert_eq!(packets.len(), 1);
+        assert_eq!(packets.iter().next().unwrap().meta().size, 1);
+        break;
+    }
+
+    client
+        .shutdown()
+        .await
+        .expect("Client should shutdown successfully.");
+    assert_eq!(cache_factory_calls.load(Ordering::Relaxed), 1);
+
     cancel.cancel();
     server_handle.await.unwrap();
 }


### PR DESCRIPTION
#### Issue

Currently, there is no choice over caching implementation as lru cache is the only supported.

#### Summary of Changes
- added connection worker cache interface
- added implementation for default lru cache
- extracted worker builder in tests (reusability)
- added test with custom fifo cache & and the fifo cache implementation

Fixes #10098
