### PR TITLE
accounts-db: switch BlockhashQueue to derived implementations of StableAbi sampling

### DIFF
--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -9,7 +9,7 @@ use {
     std::collections::HashMap,
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct HashInfo {
     fee_calculator: FeeCalculator,
@@ -26,10 +26,10 @@ impl HashInfo {
 /// Low memory overhead, so can be cloned for every checkpoint
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi),
+    derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
         api_digest = "DZVVXt4saSgH1CWGrzBcX2sq5yswCuRqGx1Y1ZehtWT6",
-        abi_digest = "CGD97vsYSQpPbYkzYnHmrwRZc4BbHqTEvP5vz4jg8jzU"
+        abi_digest = "5ojmBDhhu9AjKUc1LSHhZfXF6KeicvZpKP6XdLNaFAdy",
     )
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -158,37 +158,6 @@ impl BlockhashQueue {
     }
 }
 
-#[cfg(feature = "frozen-abi")]
-impl solana_frozen_abi::rand::prelude::Distribution<BlockhashQueue>
-    for solana_frozen_abi::rand::distr::StandardUniform
-{
-    fn sample<R: solana_frozen_abi::rand::Rng + ?Sized>(&self, rng: &mut R) -> BlockhashQueue {
-        let seed1: u64 = rng.random();
-        let seed2: u64 = rng.random();
-        let seed3: u64 = rng.random();
-        let seed4: u64 = rng.random();
-
-        let mut hashes =
-            HashMap::with_hasher(ahash::RandomState::with_seeds(seed1, seed2, seed3, seed4));
-        hashes.insert(
-            Hash::new_from_array(rng.random()),
-            HashInfo {
-                fee_calculator: FeeCalculator {
-                    lamports_per_signature: rng.random(),
-                },
-                hash_index: rng.random(),
-                timestamp: rng.random(),
-            },
-        );
-
-        BlockhashQueue {
-            last_hash_index: rng.random(),
-            last_hash: Some(Hash::new_from_array(rng.random())),
-            hashes,
-            max_age: rng.random_range(0..MAX_RECENT_BLOCKHASHES),
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
     #[allow(deprecated)]


### PR DESCRIPTION
#### Description

As StableAbi functionality progressed, we are able to drop manual implementations of type sampling.

#### Summary of Changes
The `abi_digest` has changed due to derived implementation data seeding differences.

- Removed manual sample implementation
- Derived StableAbi/Sample for `HashInfo` and `BlockhashQueue`
- Adjusted `abi_digest`
