### PR TITLE
bls-sigverifies votes of the same `Vote` in a single batch

### DIFF
--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -32,7 +32,7 @@ fn create_signed_vote_message(
     vote: Vote,
     rank: usize,
 ) -> VoteMessage {
-    let payload = get_vote_payload_to_sign(&vote, shred_version);
+    let payload = get_vote_payload_to_sign(vote, shred_version);
     let signature: BlsSignature = bls_keypair.sign(&payload).into();
     VoteMessage {
         vote,

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -297,7 +297,7 @@ mod test {
         rank: usize,
     ) -> VoteMessage {
         let bls_keypair = &bls_keypairs[rank];
-        let payload = get_vote_payload_to_sign(&vote, shred_version);
+        let payload = get_vote_payload_to_sign(vote, shred_version);
         let signature: BLSSignature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,

--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -12,8 +12,10 @@ use {
         stats::SigVerifyVoteStats,
     },
     agave_votor_messages::{
-        consensus_message::Block, unverified_vote_message::UnverifiedVoteMessage, vote::Vote,
-        wire::get_vote_payload_to_sign,
+        consensus_message::Block,
+        unverified_vote_message::UnverifiedVoteMessage,
+        vote::Vote,
+        wire::{VotePayloadToSign, get_vote_payload_to_sign},
     },
     criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     rayon::{ThreadPool, ThreadPoolBuilder},
@@ -21,10 +23,9 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_signer::Signer,
-    std::{hint::black_box, sync::Arc},
+    std::hint::black_box,
 };
 
-static MESSAGE_COUNTS: &[usize] = &[1, 2, 4, 8, 16];
 static BATCH_SIZES: &[usize] = &[8, 16, 32, 64, 128];
 
 fn get_thread_pool() -> ThreadPool {
@@ -35,67 +36,39 @@ fn get_thread_pool() -> ThreadPool {
         .unwrap()
 }
 
-fn get_matrix_params() -> impl Iterator<Item = (usize, usize)> {
-    BATCH_SIZES.iter().flat_map(|&batch_size| {
-        MESSAGE_COUNTS.iter().filter_map(move |&num_distinct| {
-            if num_distinct > batch_size {
-                None
-            } else {
-                Some((batch_size, num_distinct))
-            }
-        })
-    })
-}
-
 fn generate_test_data(
     shred_version: u16,
-    num_distinct_messages: usize,
     batch_size: usize,
-) -> Vec<UnverifiedVotePayload> {
-    assert!(
-        batch_size >= num_distinct_messages,
-        "Batch size must be >= distinct messages"
-    );
-
+) -> (VotePayloadToSign, Vec<UnverifiedVotePayload>) {
     // Pre-calculate the payloads to ensure exact distinctness
-    let base_payloads = (0..num_distinct_messages)
-        .map(|i| {
-            let slot = (i as u64).saturating_add(100);
-            let vote = Vote::new_notarization_vote(Block {
-                slot,
-                block_id: Hash::new_unique(),
-            });
-            let payload = get_vote_payload_to_sign(&vote, shred_version);
-            (vote, Arc::new(payload))
-        })
-        .collect::<Vec<_>>();
-
-    let mut votes_to_verify = Vec::with_capacity(batch_size);
-
-    for i in 0..batch_size {
-        let (vote, payload) = &base_payloads[i.rem_euclid(num_distinct_messages)];
-
-        let bls_keypair = BLSKeypair::new();
-
-        let signature = bls_keypair.sign(payload);
-
-        let vote_message = UnverifiedVoteMessage {
-            vote: *vote,
-            signature: signature.into(),
-            rank: 0,
-            shred_version,
-        };
-
-        votes_to_verify.push(UnverifiedVotePayload {
-            vote_message,
-            sender_bls_pubkey: bls_keypair.public,
-            sender_vote_account_pubkey: Keypair::new().pubkey(),
-            sender_identity_pubkey: Keypair::new().pubkey(),
-            prepared_payload: None,
-        });
-    }
-
-    votes_to_verify
+    let slot = 100;
+    let vote = Vote::new_notarization_vote(Block {
+        slot,
+        block_id: Hash::new_unique(),
+    });
+    let payload = get_vote_payload_to_sign(vote, shred_version);
+    (
+        VotePayloadToSign::new_from_vote(vote, shred_version),
+        (0..batch_size)
+            .map(|_| {
+                let bls_keypair = BLSKeypair::new();
+                let signature = bls_keypair.sign(&payload);
+                let vote_message = UnverifiedVoteMessage {
+                    vote,
+                    signature: signature.into(),
+                    rank: 0,
+                    shred_version,
+                };
+                UnverifiedVotePayload {
+                    vote_message,
+                    sender_bls_pubkey: bls_keypair.public,
+                    sender_vote_account_pubkey: Keypair::new().pubkey(),
+                    sender_identity_pubkey: Keypair::new().pubkey(),
+                    prepared_payload: None,
+                }
+            })
+            .collect(),
+    )
 }
 
 // Single Signature Verification
@@ -145,13 +118,18 @@ fn bench_verify_votes_optimistic(c: &mut Criterion) {
     let mut stats = SigVerifyVoteStats::default();
     let thread_pool = get_thread_pool();
 
-    for (batch_size, num_distinct) in get_matrix_params() {
-        let votes = generate_test_data(shred_version, num_distinct, batch_size);
-        let label = format!("msgs_{num_distinct}/batch_{batch_size}");
+    for &batch_size in BATCH_SIZES {
+        let (vote, mut unverified_votes) = generate_test_data(shred_version, batch_size);
+        let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {
             b.iter(|| {
-                let res = verify_votes_optimistic(black_box(&votes), &mut stats, &thread_pool);
+                let res = verify_votes_optimistic(
+                    vote,
+                    black_box(&mut unverified_votes),
+                    &mut stats,
+                    &thread_pool,
+                );
                 black_box(res);
             })
         });
@@ -165,21 +143,19 @@ fn bench_verify_votes_optimistic(c: &mut Criterion) {
 fn bench_aggregate_pubkeys(c: &mut Criterion) {
     let shred_version = 1234;
     let mut group = c.benchmark_group("aggregate_pubkeys");
-    let mut stats = SigVerifyVoteStats::default();
 
-    for (batch_size, num_distinct) in get_matrix_params() {
-        let votes = generate_test_data(shred_version, num_distinct, batch_size);
-        let label = format!("msgs_{num_distinct}/batch_{batch_size}");
+    for &batch_size in BATCH_SIZES {
+        let (vote, unverified_votes) = generate_test_data(shred_version, batch_size);
+        let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {
             b.iter(|| {
-                let res = aggregate_pubkeys_by_payload(black_box(&votes), &mut stats);
-                black_box(res).2.unwrap();
+                let res = aggregate_pubkeys_by_payload(vote, black_box(&unverified_votes));
+                black_box(res).1.unwrap();
             })
         });
     }
     group.finish();
-    black_box(stats);
 }
 
 // Signature Aggregation
@@ -191,12 +167,12 @@ fn bench_aggregate_signatures(c: &mut Criterion) {
     for &batch_size in BATCH_SIZES {
         // Use 1 distinct message just to generate valid data cheaply.
         // It doesn't affect signature aggregation performance.
-        let votes = generate_test_data(shred_version, 1, batch_size);
+        let (_, unverified_votes) = generate_test_data(shred_version, batch_size);
         let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {
             b.iter(|| {
-                let res = aggregate_signatures(black_box(&votes));
+                let res = aggregate_signatures(black_box(&unverified_votes));
                 black_box(res).unwrap();
             })
         });
@@ -213,15 +189,14 @@ fn bench_verify_individual_votes(c: &mut Criterion) {
 
     for &batch_size in BATCH_SIZES {
         // Distinctness doesn't affect the cost of N individual verifications.
-        let votes = generate_test_data(shred_version, 1, batch_size);
+        let (_vote, unverified_votes) = generate_test_data(shred_version, batch_size);
         let label = format!("batch_{batch_size}");
 
         group.bench_function(&label, |b| {
             b.iter_batched(
-                || votes.clone(),
+                || unverified_votes.clone(),
                 |votes| {
-                    let res =
-                        verify_individual_votes(black_box(votes), vec![], vec![], &thread_pool);
+                    let res = verify_individual_votes(black_box(votes), &thread_pool);
                     black_box(res);
                 },
                 BatchSize::SmallInput,

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -17,7 +17,8 @@ use {
         migration::MigrationStatus,
         reward_certificate::AddVoteMessage,
         unverified_vote_message::{DecodedWireConsensusMessage, UnverifiedVoteMessage},
-        wire::VersionedWireConsensusMessage,
+        vote::Vote,
+        wire::{VersionedWireConsensusMessage, VotePayloadToSign},
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, TryRecvError},
     log::error,
@@ -32,7 +33,7 @@ use {
     solana_runtime::{bank::Bank, bank_forks::SharableBanks},
     solana_streamer::{nonblocking::simple_qos::SimpleQosBanlist, packet::PacketBatch},
     std::{
-        collections::HashSet,
+        collections::{HashMap, HashSet},
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
@@ -211,10 +212,13 @@ impl SigVerifier {
         &mut self,
         batches: Vec<PacketBatch>,
         root_bank: &Bank,
-    ) -> (Vec<CertPayload>, Vec<UnverifiedVotePayload>) {
+    ) -> (
+        Vec<CertPayload>,
+        HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
+    ) {
         let root_slot = root_bank.slot();
         let mut certs = Vec::new();
-        let mut votes = Vec::new();
+        let mut votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>> = HashMap::new();
         let mut num_pkts = 0u64;
         let my_shred_version = self.cluster_info.my_shred_version();
         for packet in batches.iter().flatten() {
@@ -243,17 +247,23 @@ impl SigVerifier {
             };
 
             match decoded_msg {
-                DecodedWireConsensusMessage::Vote(vote) => {
+                DecodedWireConsensusMessage::Vote(unverified_vote) => {
                     if let Some((sender_vote_account_pubkey, sender_bls_pubkey)) =
-                        self.keep_vote(&vote, root_bank)
+                        self.keep_vote(&unverified_vote.vote, &unverified_vote, root_bank)
                     {
-                        votes.push(UnverifiedVotePayload {
-                            vote_message: vote,
-                            sender_bls_pubkey,
-                            sender_vote_account_pubkey,
-                            sender_identity_pubkey,
-                            prepared_payload: None,
-                        });
+                        let vote_payload_to_sign = VotePayloadToSign::new_from_vote(
+                            unverified_vote.vote,
+                            unverified_vote.shred_version,
+                        );
+                        votes.entry(vote_payload_to_sign).or_default().push(
+                            UnverifiedVotePayload {
+                                vote_message: unverified_vote,
+                                sender_bls_pubkey,
+                                sender_vote_account_pubkey,
+                                sender_identity_pubkey,
+                                prepared_payload: None,
+                            },
+                        );
                     }
                 }
                 DecodedWireConsensusMessage::Certificate(cert) => {
@@ -283,11 +293,12 @@ impl SigVerifier {
     /// If this vote should be verified, then returns the sender's Pubkey and BlsPubkey.
     fn keep_vote(
         &mut self,
+        vote: &Vote,
         msg: &UnverifiedVoteMessage,
         root_bank: &Bank,
     ) -> Option<(Pubkey, PopVerified<BlsPubkeyAffine>)> {
         let root_slot = root_bank.slot();
-        let Some(rank_map) = root_bank.get_rank_map(msg.vote.slot()) else {
+        let Some(rank_map) = root_bank.get_rank_map(vote.slot()) else {
             self.stats.discard_vote_no_epoch_stakes += 1;
             return None;
         };
@@ -298,15 +309,10 @@ impl SigVerifier {
                 None
             })?;
         let ret = Some((entry.vote_account_pubkey, entry.bls_pubkey));
-        if msg.vote.slot() > root_slot {
+        if vote.slot() > root_slot {
             return ret;
         }
-        if rewards_wants_vote(
-            &self.cluster_info,
-            &self.leader_schedule,
-            root_slot,
-            &msg.vote,
-        ) {
+        if rewards_wants_vote(&self.cluster_info, &self.leader_schedule, root_slot, vote) {
             return ret;
         }
         self.stats.num_old_votes_received += 1;
@@ -482,7 +488,7 @@ mod tests {
         rank: usize,
     ) -> VoteMessage {
         let bls_keypair = &validator_keypairs[rank].bls_keypair;
-        let payload = get_vote_payload_to_sign(&vote, shred_version);
+        let payload = get_vote_payload_to_sign(vote, shred_version);
         let signature: Signature = bls_keypair.sign(&payload).into();
         VoteMessage {
             vote,
@@ -822,7 +828,7 @@ mod tests {
         let mut packets = Vec::with_capacity(num_votes);
         let vote = Vote::new_skip_vote(42);
         let vote_payload =
-            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
 
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
@@ -915,13 +921,15 @@ mod tests {
             .verify_and_send_batches(packet_batches)
             .unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 1);
-        match &batches[0] {
-            SigVerifiedBatch::Votes(votes) => {
-                assert_eq!(votes.len(), num_votes);
-            }
-            rest => panic!("unexpected type: {rest:?}"),
-        }
+        assert_eq!(batches.len(), 2);
+        let total_votes_verified = batches
+            .into_iter()
+            .map(|batch| match batch {
+                SigVerifiedBatch::Votes(votes) => votes.len(),
+                rest => panic!("unexpected type: {rest:?}"),
+            })
+            .sum::<usize>();
+        assert_eq!(total_votes_verified, num_votes);
         assert_eq!(
             ctx.verifier.stats.vote_stats.distinct_votes_stats.count(),
             1
@@ -947,12 +955,12 @@ mod tests {
 
         let vote1 = Vote::new_skip_vote(42);
         let vote1_payload =
-            get_vote_payload_to_sign(&vote1, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote1, ctx.verifier.cluster_info.my_shred_version());
         let vote2 = Vote::new_skip_vote(43);
         let vote2_payload =
-            get_vote_payload_to_sign(&vote2, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote2, ctx.verifier.cluster_info.my_shred_version());
         let invalid_payload = get_vote_payload_to_sign(
-            &Vote::new_skip_vote(99),
+            Vote::new_skip_vote(99),
             ctx.verifier.cluster_info.my_shred_version(),
         );
 
@@ -990,27 +998,22 @@ mod tests {
             .verify_and_send_batches(packet_batches)
             .unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 1);
-        match &batches[0] {
-            SigVerifiedBatch::Votes(votes) => {
-                assert_eq!(votes.len(), num_votes - 1);
-            }
-            rest => panic!("unexpected type: {rest:?}"),
-        }
-
-        let mut found_msg = false;
-        match &batches[0] {
-            SigVerifiedBatch::Votes(votes) => {
-                for vote in votes {
-                    if vote.vote == vote2 && vote.rank == invalid_rank {
-                        found_msg = true;
-                        break;
+        assert_eq!(batches.len(), 2);
+        let total_votes_verified = batches
+            .into_iter()
+            .map(|batch| match batch {
+                SigVerifiedBatch::Votes(votes) => {
+                    for vote in &votes {
+                        if vote.vote == vote2 && vote.rank == invalid_rank {
+                            panic!("invalid vote verified");
+                        }
                     }
+                    votes.len()
                 }
-            }
-            rest => panic!("unexpected type: {rest:?}"),
-        }
-        assert!(!found_msg);
+                rest => panic!("unexpected type: {rest:?}"),
+            })
+            .sum::<usize>();
+        assert_eq!(total_votes_verified, num_votes - 1);
     }
 
     #[test]
@@ -1024,9 +1027,9 @@ mod tests {
 
         let vote = Vote::new_skip_vote(42);
         let valid_vote_payload =
-            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let invalid_vote_payload = get_vote_payload_to_sign(
-            &Vote::new_skip_vote(99),
+            Vote::new_skip_vote(99),
             ctx.verifier.cluster_info.my_shred_version(),
         );
 
@@ -1303,7 +1306,7 @@ mod tests {
 
         let vote = Vote::new_skip_vote(42);
         let vote_payload =
-            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         for (i, validator_keypair) in ctx.validator_keypairs.iter().enumerate().take(num_votes) {
             let rank = i as u16;
             let bls_keypair = &validator_keypair.bls_keypair;
@@ -1328,7 +1331,7 @@ mod tests {
         });
         let cert_original_vote = Vote::new_notarization_vote(cert_type.to_block().unwrap());
         let cert_payload = get_vote_payload_to_sign(
-            &cert_original_vote,
+            cert_original_vote,
             ctx.verifier.cluster_info.my_shred_version(),
         );
 
@@ -1393,7 +1396,7 @@ mod tests {
         let invalid_rank = 999;
         let vote = Vote::new_skip_vote(42);
         let vote_payload =
-            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let bls_keypair = &ctx.validator_keypairs[0].bls_keypair;
         let signature: Signature = bls_keypair.sign(&vote_payload).into();
 
@@ -1469,7 +1472,7 @@ mod tests {
 
         let vote = Vote::new_skip_vote(2);
         let vote_payload =
-            get_vote_payload_to_sign(&vote, sig_verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, sig_verifier.cluster_info.my_shred_version());
         let bls_keypair = &validator_keypairs[0].bls_keypair;
         let signature: Signature = bls_keypair.sign(&vote_payload).into();
         let consensus_message_vote = ConsensusMessage::Vote(VoteMessage {
@@ -1523,7 +1526,7 @@ mod tests {
         let cert_type = CertificateType::Notarize(block);
         let original_vote = Vote::new_notarization_vote(block);
         let signed_payload =
-            get_vote_payload_to_sign(&original_vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(original_vote, ctx.verifier.cluster_info.my_shred_version());
         let mut vote_messages: Vec<VoteMessage> = (0..num_signers)
             .map(|i| {
                 let signature = ctx.validator_keypairs[i].bls_keypair.sign(&signed_payload);
@@ -1615,9 +1618,9 @@ mod tests {
 
         let vote = Vote::new_skip_vote(42);
         let valid_payload =
-            get_vote_payload_to_sign(&vote, ctx.verifier.cluster_info.my_shred_version());
+            get_vote_payload_to_sign(vote, ctx.verifier.cluster_info.my_shred_version());
         let invalid_payload = get_vote_payload_to_sign(
-            &Vote::new_skip_vote(999),
+            Vote::new_skip_vote(999),
             ctx.verifier.cluster_info.my_shred_version(),
         );
         let invalid_indexes = [1usize, 3usize];

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -12,9 +12,12 @@ use {
         },
     },
     agave_votor_messages::{
-        consensus_message::VoteMessage, metric_types::ConsensusMetricsEvent,
-        reward_certificate::AddVoteMessage, unverified_vote_message::UnverifiedVoteMessage,
-        vote::Vote, wire::get_vote_payload_to_sign,
+        consensus_message::VoteMessage,
+        metric_types::ConsensusMetricsEvent,
+        reward_certificate::AddVoteMessage,
+        unverified_vote_message::UnverifiedVoteMessage,
+        vote::Vote,
+        wire::{VotePayloadToSign, get_vote_payload_to_sign},
     },
     log::info,
     rayon::{
@@ -44,10 +47,6 @@ fn into_vote_msg(msg: UnverifiedVoteMessage) -> VoteMessage {
     }
 }
 
-/// This is the percentage threshold of distinct votes among the total votes under which we will prepare a cache of
-/// prepared payloads for individual verification.
-const PREPARED_PAYLOAD_CACHE_DISTINCT_VOTE_THRESHOLD_PERCENT: usize = 90;
-
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 struct VerifiedVotePayload {
     vote_message: VoteMessage,
@@ -73,7 +72,7 @@ impl UnverifiedVotePayload {
                 .is_ok()
         } else {
             let payload =
-                get_vote_payload_to_sign(&self.vote_message.vote, self.vote_message.shred_version);
+                get_vote_payload_to_sign(self.vote_message.vote, self.vote_message.shred_version);
             self.sender_bls_pubkey
                 .verify_signature(&self.vote_message.signature, &payload)
                 .is_ok()
@@ -90,7 +89,7 @@ impl UnverifiedVotePayload {
 ///
 /// Any vote that fails fallback individual signature verification will have its sender banlisted.
 pub(super) fn verify_and_send_votes(
-    votes_to_verify: Vec<UnverifiedVotePayload>,
+    unverified_votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
@@ -100,20 +99,33 @@ pub(super) fn verify_and_send_votes(
 ) -> Result<SigVerifyVoteStats, SigVerifyVoteError> {
     let mut measure = Measure::start("verify_and_send_votes");
     let mut stats = SigVerifyVoteStats::default();
-    if votes_to_verify.is_empty() {
+    if unverified_votes.is_empty() {
         return Ok(stats);
     }
-    stats.votes_to_sig_verify += votes_to_verify.len() as u64;
-    let verified_votes = verify_votes(root_bank, votes_to_verify, &mut stats, banlist, thread_pool);
-    stats.sig_verified_votes += verified_votes.len() as u64;
+    stats
+        .distinct_votes_stats
+        .add_sample(unverified_votes.len() as u64);
 
-    let (votes_for_pool, msgs_for_repair, msg_for_reward, msg_for_metrics) =
-        process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
+    for (vote_payload_to_sign, unverified_votes) in unverified_votes {
+        stats.votes_to_sig_verify += unverified_votes.len() as u64;
+        let verified_votes = verify_votes(
+            root_bank,
+            vote_payload_to_sign,
+            unverified_votes,
+            &mut stats,
+            banlist,
+            thread_pool,
+        );
+        stats.sig_verified_votes += verified_votes.len() as u64;
 
-    send_votes_to_pool(votes_for_pool, &channels.channel_to_pool, &mut stats)?;
-    send_votes_to_repair(msgs_for_repair, &channels.channel_to_repair, &mut stats)?;
-    send_votes_to_rewards(msg_for_reward, &channels.channel_to_reward, &mut stats)?;
-    send_votes_to_metrics(msg_for_metrics, &channels.channel_to_metrics, &mut stats)?;
+        let (votes_for_pool, msgs_for_repair, msg_for_reward, msg_for_metrics) =
+            process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
+
+        send_votes_to_pool(votes_for_pool, &channels.channel_to_pool, &mut stats)?;
+        send_votes_to_repair(msgs_for_repair, &channels.channel_to_repair, &mut stats)?;
+        send_votes_to_rewards(msg_for_reward, &channels.channel_to_reward, &mut stats)?;
+        send_votes_to_metrics(msg_for_metrics, &channels.channel_to_metrics, &mut stats)?;
+    }
 
     measure.stop();
     stats
@@ -196,30 +208,30 @@ fn process_verified_votes(
     )
 }
 
-/// Sig verifies `votes_to_verify` and returns a `Vec` of votes that passed verification.
+/// Sig verifies `unverified_votes` and returns a `Vec` of votes that passed verification.
 fn verify_votes(
     root_bank: &Bank,
-    votes_to_verify: Vec<UnverifiedVotePayload>,
+    vote_payload_to_sign: VotePayloadToSign,
+    mut unverified_votes: Vec<UnverifiedVotePayload>,
     stats: &mut SigVerifyVoteStats,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
 ) -> Vec<VerifiedVotePayload> {
     // Filter votes too far in the future.
-    let len_before = votes_to_verify.len();
-    let votes_to_verify = votes_to_verify
-        .into_iter()
-        .filter(|v| {
-            v.vote_message.vote.slot() <= root_bank.slot().saturating_add(NUM_SLOTS_FOR_VERIFY)
-        })
-        .collect::<Vec<_>>();
-    let num_discarded = len_before.saturating_sub(votes_to_verify.len());
-    stats.too_far_in_future += num_discarded as u64;
+    if vote_payload_to_sign.slot() > root_bank.slot().saturating_add(NUM_SLOTS_FOR_VERIFY) {
+        stats.too_far_in_future += unverified_votes.len() as u64;
+        return vec![];
+    }
 
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
-    let (optimistic_result, distinct_votes, distinct_payloads) =
-        verify_votes_optimistic(&votes_to_verify, stats, thread_pool);
-    if matches!(optimistic_result, OptimisticVerificationResult::Verified) {
-        return votes_to_verify
+    let is_verified = verify_votes_optimistic(
+        vote_payload_to_sign,
+        &mut unverified_votes,
+        stats,
+        thread_pool,
+    );
+    if is_verified {
+        return unverified_votes
             .into_iter()
             .map(|v| VerifiedVotePayload {
                 vote_message: into_vote_msg(v.vote_message),
@@ -229,12 +241,8 @@ fn verify_votes(
     }
 
     // Fallback to individual verification
-    let ((verified_votes, invalid_remote_pubkeys), time_us) = measure_us!(verify_individual_votes(
-        votes_to_verify,
-        distinct_votes,
-        distinct_payloads,
-        thread_pool,
-    ));
+    let ((verified_votes, invalid_remote_pubkeys), time_us) =
+        measure_us!(verify_individual_votes(unverified_votes, thread_pool));
     for sender_identity_pubkey in invalid_remote_pubkeys {
         if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
             stats.already_banned += 1;
@@ -250,17 +258,6 @@ fn verify_votes(
     verified_votes
 }
 
-/// Outcome of optimistic aggregate vote verification.
-///
-/// `Failed` carries the number of distinct vote messages seen before falling
-/// back to individual verification.
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OptimisticVerificationResult {
-    Verified,
-    Failed { num_distinct_messages: usize },
-}
-
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 /// Attempts aggregate BLS verification across the full vote set.
 ///
@@ -273,15 +270,13 @@ enum OptimisticVerificationResult {
 /// Returns the optimistic verification outcome together with the distinct vote
 /// messages and their prepared payloads, which can be reused by the fallback
 /// path.
+#[must_use]
 fn verify_votes_optimistic(
-    votes: &[UnverifiedVotePayload],
+    vote_payload_to_sign: VotePayloadToSign,
+    unverified_votes: &mut Vec<UnverifiedVotePayload>,
     stats: &mut SigVerifyVoteStats,
     thread_pool: &ThreadPool,
-) -> (
-    OptimisticVerificationResult,
-    Vec<Vote>,
-    Vec<PreparedHashedMessage>,
-) {
+) -> bool {
     let mut measure = Measure::start("verify_votes_optimistic");
 
     // For BLS verification, minimizing the expensive pairing operation is key.
@@ -293,62 +288,34 @@ fn verify_votes_optimistic(
     //
     // By verifying the aggregated signature against the aggregated public keys,
     // the number of pairings required is reduced to (1 + number of distinct messages).
-    let (signature_result, (distinct_votes, distinct_payloads, pubkeys_result)) = thread_pool.join(
-        || aggregate_signatures(votes),
-        || aggregate_pubkeys_by_payload(votes, stats),
+    let (signature_result, (prepared_hash_msg, pubkey_result)) = thread_pool.join(
+        || aggregate_signatures(unverified_votes),
+        || aggregate_pubkeys_by_payload(vote_payload_to_sign, unverified_votes),
     );
 
     let Ok(aggregate_signature) = signature_result else {
-        return (
-            OptimisticVerificationResult::Failed {
-                num_distinct_messages: 0,
-            },
-            Vec::new(),
-            Vec::new(),
-        );
+        return false;
     };
 
-    let Ok(aggregate_pubkeys) = pubkeys_result else {
-        return (
-            OptimisticVerificationResult::Failed {
-                num_distinct_messages: distinct_payloads.len(),
-            },
-            distinct_votes,
-            distinct_payloads,
-        );
+    let Ok(aggregate_pubkey) = pubkey_result else {
+        return false;
     };
 
-    let verified = if distinct_payloads.len() == 1 {
-        // if one unique payload, just verify the aggregate signature for the single payload
-        // this requires (2 pairings)
-        aggregate_pubkeys[0]
-            .verify_signature_prepared(&aggregate_signature, &distinct_payloads[0])
-            .is_ok()
-    } else {
-        // if non-unique payload, we need to apply a pairing for each distinct message,
-        // which is done inside `par_verify_distinct_aggregated_prepared`.
-        thread_pool.install(|| {
-            SignatureProjective::par_verify_distinct_aggregated_prepared(
-                &aggregate_pubkeys,
-                &aggregate_signature,
-                &distinct_payloads,
-            )
-            .is_ok()
-        })
-    };
+    let verified = aggregate_pubkey
+        .verify_signature_prepared(&aggregate_signature, &prepared_hash_msg)
+        .is_ok();
 
     measure.stop();
     stats
         .fn_verify_votes_optimistic_stats
         .add_sample(measure.as_us());
-    let result = if verified {
-        OptimisticVerificationResult::Verified
-    } else {
-        OptimisticVerificationResult::Failed {
-            num_distinct_messages: distinct_payloads.len(),
+    if !verified {
+        let prepared_hash_msg = Arc::new(prepared_hash_msg);
+        for unverified_vote in unverified_votes {
+            unverified_vote.prepared_payload = Some(prepared_hash_msg.clone());
         }
-    };
-    (result, distinct_votes, distinct_payloads)
+    }
+    verified
 }
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -364,57 +331,23 @@ fn aggregate_signatures(votes: &[UnverifiedVotePayload]) -> Result<SignatureProj
     SignatureProjective::par_aggregate(signatures)
 }
 
-#[allow(clippy::type_complexity)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn aggregate_pubkeys_by_payload(
+    vote_payload_to_sign: VotePayloadToSign,
     votes: &[UnverifiedVotePayload],
-    stats: &mut SigVerifyVoteStats,
 ) -> (
-    Vec<Vote>,
-    Vec<PreparedHashedMessage>,
-    Result<Vec<PopVerified<PubkeyProjective>>, BlsError>,
+    PreparedHashedMessage,
+    Result<PopVerified<PubkeyProjective>, BlsError>,
 ) {
     debug_assert!(current_thread_index().is_some());
-    let mut grouped_votes: HashMap<Vote, (u16, Vec<&PopVerified<BlsPubkeyAffine>>)> =
-        HashMap::new();
-
-    for v in votes {
-        let shred_version = v.vote_message.shred_version;
-        grouped_votes
-            .entry(v.vote_message.vote)
-            .or_insert_with(|| (shred_version, Vec::new()))
-            .1
-            .push(&v.sender_bls_pubkey);
-    }
-
-    stats
-        .distinct_votes_stats
-        .add_sample(grouped_votes.len() as u64);
-
-    let distinct_grouped_votes = grouped_votes
-        .into_par_iter()
-        .map(|(vote, (shred_version, pubkeys))| {
-            let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
-            // converting aggregate pubkey to `PopVerified` is safe here
-            // since the pubkeys are all PoP verified in the vote account
-            let pubkey = PubkeyProjective::par_aggregate(pubkeys.into_par_iter())
-                .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
-            (vote, PreparedHashedMessage::new(&serialized_vote), pubkey)
-        })
-        .collect::<Vec<_>>();
-    let (distinct_votes, distinct_payloads, distinct_pubkeys_results): (Vec<_>, Vec<_>, Vec<_>) =
-        distinct_grouped_votes.into_iter().fold(
-            (Vec::new(), Vec::new(), Vec::new()),
-            |mut acc, (vote, payload, pubkey)| {
-                acc.0.push(vote);
-                acc.1.push(payload);
-                acc.2.push(pubkey);
-                acc
-            },
-        );
-    let aggregate_pubkeys_result = distinct_pubkeys_results.into_iter().collect();
-
-    (distinct_votes, distinct_payloads, aggregate_pubkeys_result)
+    let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
+    let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
+    // converting aggregate pubkey to `PopVerified` is safe here
+    // since the pubkeys are all PoP verified in the vote account
+    let pubkey =
+        PubkeyProjective::par_aggregate(votes.into_par_iter().map(|v| &v.sender_bls_pubkey))
+            .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
+    (prepared_hash_msg, pubkey)
 }
 
 /// Verifies votes individually on a thread pool.
@@ -424,52 +357,26 @@ fn aggregate_pubkeys_by_payload(
 /// - `Vec<Pubkey>`: senders' identity pubkeys for votes that failed verification.
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn verify_individual_votes(
-    mut votes_to_verify: Vec<UnverifiedVotePayload>,
-    distinct_votes: Vec<Vote>,
-    distinct_payloads: Vec<PreparedHashedMessage>,
+    unverified_votes: Vec<UnverifiedVotePayload>,
     thread_pool: &ThreadPool,
 ) -> (Vec<VerifiedVotePayload>, Vec<Pubkey>) {
-    if should_prepare_payload_cache(distinct_votes.len(), votes_to_verify.len()) {
-        let prepared_payloads: HashMap<_, _> = distinct_votes
-            .into_iter()
-            .zip(distinct_payloads)
-            .map(|(vote, payload)| (vote, Arc::new(payload)))
-            .collect();
-        for vote in &mut votes_to_verify {
-            vote.prepared_payload = prepared_payloads.get(&vote.vote_message.vote).cloned();
-        }
-    }
-
     thread_pool.install(|| {
-        votes_to_verify.into_par_iter().partition_map(|vote| {
-            let sender_identity_pubkey = vote.sender_identity_pubkey;
-            match vote.verify() {
-                Some(vote) => Either::Left(vote),
-                None => Either::Right(sender_identity_pubkey),
-            }
-        })
+        unverified_votes
+            .into_par_iter()
+            .partition_map(|unverified_vote| {
+                let sender_identity_pubkey = unverified_vote.sender_identity_pubkey;
+                match unverified_vote.verify() {
+                    Some(vote) => Either::Left(vote),
+                    None => Either::Right(sender_identity_pubkey),
+                }
+            })
     })
-}
-
-fn should_prepare_payload_cache(distinct_vote_count: usize, total_vote_count: usize) -> bool {
-    distinct_vote_count.saturating_mul(100)
-        <= total_vote_count.saturating_mul(PREPARED_PAYLOAD_CACHE_DISTINCT_VOTE_THRESHOLD_PERCENT)
 }
 
 #[cfg(test)]
 mod tests {
 
     use super::*;
-
-    #[test]
-    fn test_should_prepare_payload_cache() {
-        assert!(should_prepare_payload_cache(9, 10));
-        assert!(should_prepare_payload_cache(0, 0));
-        assert!(!should_prepare_payload_cache(1, 1));
-        assert!(!should_prepare_payload_cache(10, 10));
-        assert!(!should_prepare_payload_cache(91, 100));
-        assert!(should_prepare_payload_cache(90, 100));
-    }
 
     #[test]
     #[should_panic]
@@ -483,8 +390,12 @@ mod tests {
     #[should_panic]
     fn ensure_aggregate_pubkeys_by_payload_runs_on_thread_pool() {
         let votes = vec![];
-        let mut stats = SigVerifyVoteStats::default();
+        let shred_version = 1234;
+        let vote = Vote::new_skip_vote(1);
+        let vote_payload_to_sign = VotePayloadToSign::new_from_vote(vote, shred_version);
         // calling without a rayon thread pool should trigger a debug assert.
-        aggregate_pubkeys_by_payload(&votes, &mut stats).2.unwrap();
+        aggregate_pubkeys_by_payload(vote_payload_to_sign, &votes)
+            .1
+            .unwrap();
     }
 }

--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -149,7 +149,7 @@ mod tests {
         keypairs: &[BlsKeypair],
         shred_version: u16,
     ) -> VoteMessage {
-        let serialized = get_vote_payload_to_sign(&vote, shred_version);
+        let serialized = get_vote_payload_to_sign(vote, shred_version);
         let signature = keypairs[rank].sign(&serialized).into();
         VoteMessage {
             vote,

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -406,7 +406,7 @@ mod tests {
         signing_ranks: &[usize],
         validator_keypairs: &[ValidatorVoteKeypairs],
     ) -> Certificate {
-        let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
+        let serialized_vote = get_vote_payload_to_sign(vote, shred_version);
 
         // Aggregate signatures
         let mut signature = SignatureProjective::identity();

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -104,7 +104,7 @@ impl ValidatedRewardCert {
 
         if let Some(skip) = skip {
             let vote = Vote::new_skip_vote(skip.slot);
-            let payload = get_vote_payload_to_sign(&vote, shred_version);
+            let payload = get_vote_payload_to_sign(vote, shred_version);
             verify_base2(
                 &payload,
                 &skip.signature,
@@ -118,7 +118,7 @@ impl ValidatedRewardCert {
                 slot: notar.slot,
                 block_id: notar.block_id,
             });
-            let payload = get_vote_payload_to_sign(&vote, shred_version);
+            let payload = get_vote_payload_to_sign(vote, shred_version);
             verify_base2(
                 &payload,
                 &notar.signature,
@@ -201,7 +201,7 @@ mod tests {
     };
 
     fn new_vote(vote: Vote, rank: usize, keypair: &BlsKeypair, shred_version: u16) -> VoteMessage {
-        let payload = get_vote_payload_to_sign(&vote, shred_version);
+        let payload = get_vote_payload_to_sign(vote, shred_version);
         let signature = keypair.sign(&payload).into();
         VoteMessage {
             vote,

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -82,33 +82,30 @@ impl CertificateType {
         match self {
             Self::Notarize(block) | Self::FinalizeFast(block) => {
                 let vote = Vote::new_notarization_vote(*block);
-                (get_vote_payload_to_sign(&vote, shred_version), None)
+                (get_vote_payload_to_sign(vote, shred_version), None)
             }
             Self::Genesis(block) => {
                 let vote = Vote::new_genesis_vote(*block);
-                (get_vote_payload_to_sign(&vote, shred_version), None)
+                (get_vote_payload_to_sign(vote, shred_version), None)
             }
             Self::Finalize(slot) => {
                 let vote = Vote::new_finalization_vote(*slot);
-                (get_vote_payload_to_sign(&vote, shred_version), None)
+                (get_vote_payload_to_sign(vote, shred_version), None)
             }
             Self::Skip(slot) => {
                 let skip_vote = Vote::new_skip_vote(*slot);
                 let skip_fallback_vote = Vote::new_skip_fallback_vote(*slot);
                 (
-                    get_vote_payload_to_sign(&skip_vote, shred_version),
-                    Some(get_vote_payload_to_sign(&skip_fallback_vote, shred_version)),
+                    get_vote_payload_to_sign(skip_vote, shred_version),
+                    Some(get_vote_payload_to_sign(skip_fallback_vote, shred_version)),
                 )
             }
             Self::NotarizeFallback(block) => {
                 let notar_vote = Vote::new_notarization_vote(*block);
                 let notar_fallback_vote = Vote::new_notarization_fallback_vote(*block);
                 (
-                    get_vote_payload_to_sign(&notar_vote, shred_version),
-                    Some(get_vote_payload_to_sign(
-                        &notar_fallback_vote,
-                        shred_version,
-                    )),
+                    get_vote_payload_to_sign(notar_vote, shred_version),
+                    Some(get_vote_payload_to_sign(notar_fallback_vote, shred_version)),
                 )
             }
         }

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -346,48 +346,103 @@ impl VersionedWireConsensusMessage {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, SchemaWrite, SchemaRead)]
 #[wincode(tag_encoding = "u8")]
 /// Vote payload that must be signed
-enum VotePayloadToSign {
+pub enum VotePayloadToSign {
     #[wincode(tag = 1)]
-    Notar { block: Block, shred_version: u16 },
+    /// notar vote
+    Notar {
+        /// block
+        block: Block,
+        /// shred version
+        shred_version: u16,
+    },
     #[wincode(tag = 2)]
-    Finalize { slot: Slot, shred_version: u16 },
+    /// finalize vote
+    Finalize {
+        /// slot
+        slot: Slot,
+        /// shred version
+        shred_version: u16,
+    },
     #[wincode(tag = 3)]
-    Skip { slot: Slot, shred_version: u16 },
+    /// skip vote
+    Skip {
+        /// slot
+        slot: Slot,
+        /// shred version
+        shred_version: u16,
+    },
     #[wincode(tag = 4)]
-    NotarFallback { block: Block, shred_version: u16 },
+    /// notar fallback vote
+    NotarFallback {
+        /// block
+        block: Block,
+        /// shred version
+        shred_version: u16,
+    },
     #[wincode(tag = 5)]
-    SkipFallback { slot: Slot, shred_version: u16 },
+    /// skip fallback vote
+    SkipFallback {
+        /// slot
+        slot: Slot,
+        /// shred version
+        shred_version: u16,
+    },
     #[wincode(tag = 6)]
-    Genesis { block: Block, shred_version: u16 },
+    /// genesis vote
+    Genesis {
+        /// block
+        block: Block,
+        /// shred version
+        shred_version: u16,
+    },
+}
+
+impl VotePayloadToSign {
+    /// Converts a `Vote` into a `VotePayloadToSign`
+    pub fn new_from_vote(vote: Vote, shred_version: u16) -> Self {
+        match vote {
+            Vote::Notarize(v) => Self::Notar {
+                block: v.block,
+                shred_version,
+            },
+            Vote::NotarizeFallback(v) => Self::NotarFallback {
+                block: v.block,
+                shred_version,
+            },
+            Vote::Genesis(v) => Self::Genesis {
+                block: v.block,
+                shred_version,
+            },
+            Vote::Finalize(v) => Self::Finalize {
+                slot: v.slot,
+                shred_version,
+            },
+            Vote::Skip(v) => Self::Skip {
+                slot: v.slot,
+                shred_version,
+            },
+            Vote::SkipFallback(v) => Self::SkipFallback {
+                slot: v.slot,
+                shred_version,
+            },
+        }
+    }
+
+    /// Returns the slot the vote is for.
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Notar { block, .. }
+            | Self::NotarFallback { block, .. }
+            | Self::Genesis { block, .. } => block.slot,
+            Self::Finalize { slot, .. }
+            | Self::Skip { slot, .. }
+            | Self::SkipFallback { slot, .. } => *slot,
+        }
+    }
 }
 
 /// Returns the appropriate vote payload to sign.
-pub fn get_vote_payload_to_sign(vote: &Vote, shred_version: u16) -> Vec<u8> {
-    let vote_to_sign = match vote {
-        Vote::Notarize(v) => VotePayloadToSign::Notar {
-            block: v.block,
-            shred_version,
-        },
-        Vote::NotarizeFallback(v) => VotePayloadToSign::NotarFallback {
-            block: v.block,
-            shred_version,
-        },
-        Vote::Genesis(v) => VotePayloadToSign::Genesis {
-            block: v.block,
-            shred_version,
-        },
-        Vote::Finalize(v) => VotePayloadToSign::Finalize {
-            slot: v.slot,
-            shred_version,
-        },
-        Vote::Skip(v) => VotePayloadToSign::Skip {
-            slot: v.slot,
-            shred_version,
-        },
-        Vote::SkipFallback(v) => VotePayloadToSign::SkipFallback {
-            slot: v.slot,
-            shred_version,
-        },
-    };
+pub fn get_vote_payload_to_sign(vote: Vote, shred_version: u16) -> Vec<u8> {
+    let vote_to_sign = VotePayloadToSign::new_from_vote(vote, shred_version);
     wincode::serialize(&vote_to_sign).unwrap()
 }

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -777,7 +777,7 @@ mod tests {
         let bls_keypair =
             BLSKeypair::derive_from_signer(&keypairs[rank].vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
-        let payload = get_vote_payload_to_sign(vote, shred_version);
+        let payload = get_vote_payload_to_sign(*vote, shred_version);
         let signature: BLSSignature = bls_keypair.sign(&payload).into();
         ConsensusMessage::new_vote(*vote, signature, rank as u16)
     }
@@ -2231,7 +2231,7 @@ mod tests {
             BLSKeypair::derive_from_signer(validator_vote_keypair, BLS_KEYPAIR_DERIVE_SEED)
                 .unwrap();
 
-        let payload = get_vote_payload_to_sign(&vote, ctx.pool.cluster_info.my_shred_version());
+        let payload = get_vote_payload_to_sign(vote, ctx.pool.cluster_info.my_shred_version());
         vote_message
             .signature
             .verify(&bls_keypair.public, &payload)

--- a/votor/src/consensus_pool/certificate_builder.rs
+++ b/votor/src/consensus_pool/certificate_builder.rs
@@ -414,7 +414,7 @@ mod tests {
         let mut keypairs = Vec::new();
         let mut vote_messages = Vec::new();
         let vote = Vote::new_notarization_vote(block);
-        let serialized_vote = get_vote_payload_to_sign(&vote, shred_version);
+        let serialized_vote = get_vote_payload_to_sign(vote, shred_version);
 
         for i in 0..num_validators {
             let keypair = BLSKeypair::new();
@@ -459,7 +459,7 @@ mod tests {
         let mut all_pubkeys = Vec::new();
         // Group 1: Signs a Notarize vote.
         let notarize_vote = Vote::new_notarization_vote(block);
-        let serialized_notarize_vote = get_vote_payload_to_sign(&notarize_vote, shred_version);
+        let serialized_notarize_vote = get_vote_payload_to_sign(notarize_vote, shred_version);
         for i in 0..3 {
             let keypair = BLSKeypair::new();
             let signature = keypair.sign(&serialized_notarize_vote);
@@ -474,7 +474,7 @@ mod tests {
         // Group 2: Signs a NotarizeFallback vote.
         let notarize_fallback_vote = Vote::new_notarization_fallback_vote(block);
         let serialized_fallback_vote =
-            get_vote_payload_to_sign(&notarize_fallback_vote, shred_version);
+            get_vote_payload_to_sign(notarize_fallback_vote, shred_version);
         for i in 3..6 {
             let keypair = BLSKeypair::new();
             let signature = keypair.sign(&serialized_fallback_vote);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -814,7 +814,7 @@ mod tests {
             let bls_keypair =
                 BLSKeypair::derive_from_signer(vote_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
             let vote_serialized =
-                get_vote_payload_to_sign(&notarize_vote, ctx.ctx.cluster_info.my_shred_version());
+                get_vote_payload_to_sign(notarize_vote, ctx.ctx.cluster_info.my_shred_version());
             let message = ConsensusMessage::Vote(VoteMessage {
                 vote: notarize_vote,
                 signature: bls_keypair.sign(&vote_serialized).into(),

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1398,7 +1398,7 @@ mod tests {
 
         fn expected_vote_message(&self, expected_vote: &Vote) -> VoteMessage {
             let payload =
-                get_vote_payload_to_sign(expected_vote, self.cluster_info.my_shred_version());
+                get_vote_payload_to_sign(*expected_vote, self.cluster_info.my_shred_version());
             let signature: BLSSignature = self.my_bls_keypair.sign(&payload).into();
             VoteMessage {
                 vote: *expected_vote,

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -219,7 +219,7 @@ pub fn generate_vote_tx(
         return GenerateVoteTxResult::NonVoting;
     };
 
-    let vote_payload_to_sign = get_vote_payload_to_sign(&vote, shred_version);
+    let vote_payload_to_sign = get_vote_payload_to_sign(vote, shred_version);
     GenerateVoteTxResult::Vote(VoteMessage {
         vote,
         signature: bls_keypair.sign(&vote_payload_to_sign).into(),
@@ -363,7 +363,7 @@ mod tests {
         vote: Vote,
         my_bls_keypair: &BLSKeypair,
     ) -> VoteMessage {
-        let payload = get_vote_payload_to_sign(&vote, ctx.cluster_info.my_shred_version());
+        let payload = get_vote_payload_to_sign(vote, ctx.cluster_info.my_shred_version());
         let signature = my_bls_keypair.sign(&payload);
         VoteMessage {
             vote,


### PR DESCRIPTION
#### Problem

Part of https://github.com/anza-xyz/agave/issues/12760.  As discussed there, we can no longer verify votes of different types in the same batch.


#### Summary of Changes

This PR updates bls-sigverify to restrict vote verification to only verify votes of the same `Vote` in a single batch.


#### Testing

Just CI.