### PR TITLE
Do not store `Certificate` in genesis account

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -82,8 +82,10 @@ use {
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::snapshot_hash::SnapshotHash,
     agave_votor_messages::{
-        certificate::Certificate, migration::GENESIS_CERTIFICATE_ACCOUNT,
+        certificate::{Certificate, CertificateType},
+        migration::GENESIS_CERTIFICATE_ACCOUNT,
         unverified_vote_message::UnverifiedCertificate,
+        wire::{WireBlockCertMessage, WireCertSignature},
     },
     ahash::AHashSet,
     log::*,
@@ -3345,14 +3347,28 @@ impl Bank {
             // The address is known in advance, so the account could already exist if it was prefunded.
             // However this account cannot be written to except by us in `set_alpenglow_genesis_certificate`,
             // so this deserialize is safe if the account is non-empty
-            wincode::deserialize(acct.data())
-                .expect("Programmer error deserializing genesis certificate")
+            let cert: WireBlockCertMessage = wincode::deserialize(acct.data())
+                .expect("Programmer error deserializing genesis certificate");
+            Certificate {
+                cert_type: CertificateType::Genesis(cert.block),
+                signature: cert.signature.signature,
+                bitmap: cert.signature.bitmap,
+            }
         })
     }
 
     /// For use in the first Alpenglow block, set the genesis certificate.
     pub fn set_alpenglow_genesis_certificate(&self, cert: &Certificate) {
-        let data = wincode::serialize(cert).unwrap();
+        debug_assert!(cert.cert_type.is_genesis());
+        let block = cert.cert_type.to_block().unwrap();
+        let cert = WireBlockCertMessage {
+            block,
+            signature: WireCertSignature {
+                signature: cert.signature,
+                bitmap: cert.bitmap.clone(),
+            },
+        };
+        let data = wincode::serialize(&cert).unwrap();
         let lamports = Rent::default().minimum_balance(data.len());
         let mut cert_acct = AccountSharedData::new(lamports, data.len(), &system_program::ID);
         cert_acct.set_data_from_slice(&data);

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -789,6 +789,7 @@ mod tests {
             certificate::{Certificate, CertificateType},
             consensus_message::Block,
             migration::{GENESIS_CERTIFICATE_ACCOUNT, MIGRATION_SLOT_OFFSET},
+            wire::{WireBlockCertMessage, WireCertSignature},
         },
         assert_matches::assert_matches,
         crossbeam_channel::{Receiver, Sender, bounded},
@@ -992,8 +993,15 @@ mod tests {
         } = create_genesis_config(10_000);
         genesis_config.epoch_schedule = EpochSchedule::new(32);
 
-        if let Some(genesis_cert) = genesis_cert.as_ref() {
-            let cert_data = wincode::serialize(genesis_cert).unwrap();
+        if let Some(genesis_cert) = genesis_cert {
+            let cert = WireBlockCertMessage {
+                block: genesis_cert.cert_type.to_block().unwrap(),
+                signature: WireCertSignature {
+                    signature: genesis_cert.signature,
+                    bitmap: genesis_cert.bitmap,
+                },
+            };
+            let cert_data = wincode::serialize(&cert).unwrap();
             let lamports = Rent::default().minimum_balance(cert_data.len());
             let mut cert_account = Account::new(lamports, cert_data.len(), &system_program::ID);
             cert_account.data = cert_data;
@@ -1112,7 +1120,10 @@ mod tests {
         // Migration can still succeed
         let mut bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 10);
         let genesis_cert = Certificate {
-            cert_type: CertificateType::Finalize(1),
+            cert_type: CertificateType::Genesis(Block {
+                slot: 1,
+                block_id: Hash::new_unique(),
+            }),
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -9,9 +9,9 @@ use {
     agave_feature_set::{FEATURE_NAMES, FeatureSet},
     agave_votor_messages::{
         self,
-        certificate::{Certificate, CertificateType},
         consensus_message::{BLS_KEYPAIR_DERIVE_SEED, Block},
         migration::GENESIS_CERTIFICATE_ACCOUNT,
+        wire::{WireBlockCertMessage, WireCertSignature},
     },
     bincode::serialize,
     bitvec::vec::BitVec,
@@ -336,13 +336,15 @@ fn configure_alpenglow_at_genesis(genesis_config: &mut GenesisConfig) {
 
     // This is a dev cluster with alpenglow enabled at genesis. We don't want to test the migration pathway
     // so we add a fake genesis certificate.
-    let cert = Certificate {
-        cert_type: CertificateType::Genesis(Block {
+    let cert = WireBlockCertMessage {
+        block: Block {
             slot: 0,
             block_id: Hash::default(),
-        }),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        bitmap: encode_base2(&BitVec::new()).unwrap(),
+        },
+        signature: WireCertSignature {
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: encode_base2(&BitVec::new()).unwrap(),
+        },
     };
     let cert_size = bincode::serialized_size(&cert).unwrap();
     let lamports = Rent::default().minimum_balance(cert_size as usize);

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -103,14 +103,17 @@ pub(crate) struct WireSlotVoteMessage {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
-pub(crate) struct WireCertSignature {
+/// Signature on a wire cert message
+pub struct WireCertSignature {
     #[cfg_attr(
         feature = "frozen-abi",
         stable_abi_sample(with = "sample_bls_signature(rng)")
     )]
     #[wincode(with = "PodBLSSignature")]
-    pub(crate) signature: BLSSignature,
-    pub(crate) bitmap: Vec<u8>,
+    /// the aggregate signature
+    pub signature: BLSSignature,
+    /// bitmap of ranks of validators included in the aggregate.
+    pub bitmap: Vec<u8>,
 }
 
 impl From<Certificate> for WireCertSignature {
@@ -131,9 +134,12 @@ pub(crate) struct WireSlotCertMessage {
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
-pub(crate) struct WireBlockCertMessage {
-    pub(crate) block: Block,
-    pub(crate) signature: WireCertSignature,
+/// A wire cert message that holds a block.
+pub struct WireBlockCertMessage {
+    /// the block the cert is certifying.
+    pub block: Block,
+    /// the signature of the cert message.
+    pub signature: WireCertSignature,
 }
 
 #[cfg_attr(


### PR DESCRIPTION
#### Problem

Currently, we are storing `Certificate` in the alpenglow genesis account PDA.  This means that `Certificate` should have frozen abi on it.  Even though it was removed in #13138 and it should not have been removed till now.  `Certificate` is an internal representation and we should not require frozen abi on it.


#### Summary of Changes
- Instead of storing `Certificate`, stores `WireBlockCertMessage` in the PDA.

#### Testing

Just CI

Related: https://github.com/anza-xyz/agave/issues/13330