### PR TITLE
Updates accounts read-only cache default size

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1018,12 +1018,12 @@ impl AccountsDb {
     // If the cache size exceeds MAX_SIZE_HI, it'll evict entries until the size is <= MAX_SIZE_LO.
     //
     // These default values were chosen empirically to minimize evictions on mainnet-beta.
-    // As of 2025-08-15 on mainnet-beta, the read cache size's steady state is around 2.5 GB,
+    // As of 2026-06-22 on mainnet-beta, the read cache size's steady state is around 3.4 GB,
     // and add a bit more to buffer future growth.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO: usize = 3_000_000_000;
+    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_LO: usize = 4_000_000_000;
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI: usize = 3_100_000_000;
+    const DEFAULT_MAX_READ_ONLY_CACHE_DATA_SIZE_HI: usize = 4_100_000_000;
 
     // See AccountsDbConfig::read_cache_evict_sample_size.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]


### PR DESCRIPTION
#### Problem

The accounts read cache is undersized, which causes evictions.

We want the default size to never need (extra) evictions on the default agave configurations. 

Here's mce1 and mcex over 4 days, showing read cache evictions. Yes, they are infrequent, but non-zero:
<img width="921" height="500" alt="Screenshot 2026-06-22 at 11 06 49 AM" src="https://github.com/user-attachments/assets/3ded92b9-ec5b-4826-afa1-8e085c801cb9" />

Related: #7553 


#### Summary of Changes

Increases default size from 3 GB to 4 GB.


#### Testing

Ran dev nodes on mnb with high read cache sizes to observe their steady state. The graph above had mds3 with a larger read cache size, and there were no evictions.

Here's the read cache size over that same time. We can see that mds3 is using more than 3 GB (the current default):
<img width="932" height="480" alt="Screenshot 2026-06-22 at 11 05 57 AM" src="https://github.com/user-attachments/assets/01b9a73f-52ca-4e63-a19f-8fbc7677581d" />