### PR TITLE
bcl: skip verification of leader certificate/aggregates

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -138,7 +138,6 @@ pub struct BlockCreationLoopConfig {
 
 struct LeaderContext {
     exit: Arc<AtomicBool>,
-    my_shred_version: u16,
     my_pubkey: Pubkey,
     /// Finalized leader-window notifications from Votor.
     leader_window_info_receiver: Receiver<LeaderWindowInfo>,
@@ -273,7 +272,6 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
 
     let mut ctx = LeaderContext {
         exit,
-        my_shred_version: cluster_info.my_shred_version(),
         my_pubkey,
         highest_parent_ready,
         leader_window_info_receiver,
@@ -763,9 +761,10 @@ fn record_and_complete_block(
         let RewardRespSucc {
             skip,
             notar,
-            validators: _,
+            validators,
         } = reward_certs;
-        let reward_cert = ValidatedRewardCert::try_new(&bank, ctx.my_shred_version, &skip, &notar)?;
+        let reward_cert =
+            ValidatedRewardCert::try_new_for_leader(bank.slot(), &skip, &notar, validators)?;
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
         let final_cert_input = guard.as_ref().map(|c| c.vote_rewards_input());
@@ -1321,9 +1320,8 @@ fn maybe_include_genesis_certificate(
     let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
     let processor = bank.block_component_processor.read().unwrap();
     processor
-        .on_genesis_cert_block_marker(
+        .on_genesis_cert_block_marker_leader(
             bank.clone(),
-            ctx.my_shred_version,
             ctx.genesis_cert_block_marker.clone(),
             &ctx.bank_forks.read().unwrap().migration_status(),
         )
@@ -1347,11 +1345,9 @@ mod tests {
         crossbeam_channel::bounded,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{block_component::VersionedUpdateParent, entry_or_marker::EntryOrMarker},
-        solana_gossip::node::Node,
         solana_keypair::Keypair,
         solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
         solana_ledger::{blockstore::Blockstore, get_tmp_ledger_path_auto_delete},
-        solana_net_utils::SocketAddrSpace,
         solana_poh::{
             poh_recorder::{PohRecorder, Record, WorkingBankEntryOrMarker},
             record_channels::record_channels,
@@ -1361,7 +1357,6 @@ mod tests {
             bank::Bank, bank_forks::BankForks, genesis_utils::create_genesis_config_with_leader,
             installed_scheduler_pool::BankWithScheduler,
         },
-        solana_signer::Signer,
         solana_system_transaction as system_transaction,
         std::num::NonZeroUsize,
     };
@@ -1396,20 +1391,6 @@ mod tests {
             leader_schedule: Arc::new(schedule),
         }));
         Arc::new(leader_schedule_cache)
-    }
-
-    fn test_cluster_info() -> (Pubkey, Arc<ClusterInfo>) {
-        let keypair = Arc::new(Keypair::new());
-        let my_pubkey = keypair.pubkey();
-        let contact_info = Node::new_localhost_with_pubkey(&my_pubkey).info;
-        (
-            my_pubkey,
-            Arc::new(ClusterInfo::new(
-                contact_info,
-                keypair,
-                SocketAddrSpace::Unspecified,
-            )),
-        )
     }
 
     struct TestBankForksController {
@@ -1530,7 +1511,7 @@ mod tests {
     fn test_abort_failed_working_bank() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (my_pubkey, cluster_info) = test_cluster_info();
+        let my_pubkey = Pubkey::new_unique();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1562,7 +1543,6 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
-            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1635,7 +1615,7 @@ mod tests {
     fn test_marker_send_clears_bank() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (my_pubkey, cluster_info) = test_cluster_info();
+        let my_pubkey = Pubkey::new_unique();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1681,7 +1661,6 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
-            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1725,7 +1704,7 @@ mod tests {
     fn test_moved_on_aborts() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (my_pubkey, cluster_info) = test_cluster_info();
+        let my_pubkey = Pubkey::new_unique();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.freeze();
@@ -1757,7 +1736,6 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
-            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,
@@ -1811,7 +1789,7 @@ mod tests {
     fn test_sad_leader_handover() {
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
-        let (my_pubkey, cluster_info) = test_cluster_info();
+        let my_pubkey = Pubkey::new_unique();
         let genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
         let root_bank = Bank::new_for_tests(&genesis.genesis_config);
         root_bank.set_block_id(Some(Hash::new_unique()));
@@ -1867,7 +1845,6 @@ mod tests {
 
         let mut ctx = LeaderContext {
             exit,
-            my_shred_version: cluster_info.my_shred_version(),
             my_pubkey,
             leader_window_info_receiver,
             pending_parent_ready: None,

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -227,12 +227,40 @@ impl BlockComponentProcessor {
         }
     }
 
+    /// Processes the genesis block marker with full verification
     pub fn on_genesis_cert_block_marker(
         &self,
         bank: Arc<Bank>,
         shred_version: u16,
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
+    ) -> Result<(), BlockComponentProcessorError> {
+        self.process_genesis_cert_block_marker(
+            bank,
+            genesis_block_marker,
+            migration_status,
+            Some(shred_version),
+        )
+    }
+
+    /// Processes a locally produced genesis certificate marker without
+    /// re-verifying the certificate signature.
+    pub fn on_genesis_cert_block_marker_leader(
+        &self,
+        bank: Arc<Bank>,
+        genesis_block_marker: GenesisCertBlockMarker,
+        migration_status: &MigrationStatus,
+    ) -> Result<(), BlockComponentProcessorError> {
+        self.process_genesis_cert_block_marker(bank, genesis_block_marker, migration_status, None)
+    }
+
+    /// Performs verification if `shred_version` is specified
+    fn process_genesis_cert_block_marker(
+        &self,
+        bank: Arc<Bank>,
+        genesis_block_marker: GenesisCertBlockMarker,
+        migration_status: &MigrationStatus,
+        shred_version: Option<u16>,
     ) -> Result<(), BlockComponentProcessorError> {
         // Genesis Certificate is only allowed for direct child of genesis
         if bank.parent_slot() == 0 {
@@ -252,16 +280,26 @@ impl BlockComponentProcessor {
             return Err(BlockComponentProcessorError::GenesisCertificateAlreadyPopulated);
         }
 
-        let unverified_genesis_cert = UnverifiedCertificate {
-            cert_type: CertificateType::Genesis(Block {
-                slot: genesis_block_marker.slot,
-                block_id: genesis_block_marker.block_id,
-            }),
-            signature: genesis_block_marker.bls_signature,
-            bitmap: genesis_block_marker.bitmap,
-            shred_version,
+        let genesis_cert_type = CertificateType::Genesis(Block {
+            slot: genesis_block_marker.slot,
+            block_id: genesis_block_marker.block_id,
+        });
+        let genesis_cert = match shred_version {
+            Some(shred_version) => {
+                let unverified_genesis_cert = UnverifiedCertificate {
+                    cert_type: genesis_cert_type,
+                    signature: genesis_block_marker.bls_signature,
+                    bitmap: genesis_block_marker.bitmap,
+                    shred_version,
+                };
+                Self::verify_genesis_certificate(&bank, unverified_genesis_cert)?
+            }
+            None => Certificate {
+                cert_type: genesis_cert_type,
+                signature: genesis_block_marker.bls_signature,
+                bitmap: genesis_block_marker.bitmap,
+            },
         };
-        let genesis_cert = Self::verify_genesis_certificate(&bank, unverified_genesis_cert)?;
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
         bank.set_hashes_per_tick(None);
 

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -136,6 +136,31 @@ impl ValidatedRewardCert {
         }))
     }
 
+    /// Constructs a [`ValidatedRewardCert`] for a block produced locally.
+    ///
+    /// The leader-side reward certificate builder receives verified votes and
+    /// tracks the validator set while aggregating them, so block production
+    /// only needs the reward slot and validator set for bank reward
+    /// calculation.
+    pub fn try_new_for_leader(
+        current_slot: Slot,
+        skip: &Option<SkipRewardCertificate>,
+        notar: &Option<NotarRewardCertificate>,
+        validators: impl IntoIterator<Item = Pubkey>,
+    ) -> Result<Option<Self>, Error> {
+        let Some(reward_slot) = extract_slot(current_slot, skip, notar)? else {
+            return Ok(None);
+        };
+        let validators: HashSet<_> = validators.into_iter().collect();
+        if validators.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            validators,
+            reward_slot,
+        }))
+    }
+
     pub(crate) fn slot(&self) -> Slot {
         self.reward_slot
     }


### PR DESCRIPTION
#### Problem
When packing these certificate / aggregates we reverify them even though they've already been verified

#### Summary of Changes
Remove the re-verification which allows us to remove shred version

#### Testing
Unit tests

Fixes #13329 