### PR TITLE
Stores validator and total stake as `NonZero<u64>`

### DIFF
--- a/bls-cert-verify/benches/cert_verify.rs
+++ b/bls-cert-verify/benches/cert_verify.rs
@@ -205,7 +205,7 @@ fn bench_verify_cert(c: &mut Criterion) {
                         verify_certificate(cert_base2, total_validators, total_stake, |rank| {
                             pubkeys_ref
                                 .get(rank)
-                                .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
+                                .map(|bls_pubkey| (NonZero::new(TEST_STAKE).unwrap(), *bls_pubkey))
                         })
                         .unwrap();
                     },
@@ -231,7 +231,7 @@ fn bench_verify_cert(c: &mut Criterion) {
                         verify_certificate(cert_base3, total_validators, total_stake, |rank| {
                             pubkeys_ref
                                 .get(rank)
-                                .map(|bls_pubkey| (TEST_STAKE, *bls_pubkey))
+                                .map(|bls_pubkey| (NonZero::new(TEST_STAKE).unwrap(), *bls_pubkey))
                         })
                         .unwrap();
                     },

--- a/bls-cert-verify/src/cert_verify.rs
+++ b/bls-cert-verify/src/cert_verify.rs
@@ -71,14 +71,14 @@ pub fn verify_certificate(
     cert: UnverifiedCertificate,
     max_validators: usize,
     total_stake: NonZero<u64>,
-    mut rank_map: impl FnMut(usize) -> Option<(u64, PopVerified<BlsPubkeyAffine>)>,
+    mut rank_map: impl FnMut(usize) -> Option<(NonZero<u64>, PopVerified<BlsPubkeyAffine>)>,
 ) -> Result<Certificate, Error> {
     let mut aggregate_stake = 0u64;
 
     // Wrap the `rank_map` to accumulate stake as a side-effect
     let accumulating_rank_map = |ind: usize| {
         rank_map(ind).map(|(stake, pubkey)| {
-            aggregate_stake = aggregate_stake.saturating_add(stake);
+            aggregate_stake = aggregate_stake.saturating_add(stake.get());
             pubkey
         })
     };
@@ -347,7 +347,9 @@ mod test {
             &(0..6).collect::<Vec<_>>(),
         );
         verify_certificate(cert, 10, NonZero::new(600).unwrap(), |rank| {
-            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+            bls_keypairs
+                .get(rank)
+                .map(|kp| (NonZero::new(100).unwrap(), kp.public))
         })
         .unwrap();
     }
@@ -372,7 +374,9 @@ mod test {
             &(0..6).collect::<Vec<_>>(),
         );
         verify_certificate(cert, 10, total_stake, |rank| {
-            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+            bls_keypairs
+                .get(rank)
+                .map(|kp| (NonZero::new(100).unwrap(), kp.public))
         })
         .unwrap();
 
@@ -384,7 +388,9 @@ mod test {
             &(0..5).collect::<Vec<_>>(),
         );
         let Err(err) = verify_certificate(cert, 10, total_stake, |rank| {
-            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+            bls_keypairs
+                .get(rank)
+                .map(|kp| (NonZero::new(100).unwrap(), kp.public))
         }) else {
             panic!("should fail");
         };
@@ -442,7 +448,9 @@ mod test {
         };
 
         verify_certificate(cert, 10, NonZero::new(700).unwrap(), |rank| {
-            bls_keypairs.get(rank).map(|kp| (100, kp.public))
+            bls_keypairs
+                .get(rank)
+                .map(|kp| (NonZero::new(100).unwrap(), kp.public))
         })
         .unwrap();
     }
@@ -473,7 +481,9 @@ mod test {
         };
         assert_eq!(
             verify_certificate(cert, 10, NonZero::new(1000).unwrap(), |rank| {
-                bls_keypairs.get(rank).map(|kp| (100, kp.public))
+                bls_keypairs
+                    .get(rank)
+                    .map(|kp| (NonZero::new(100).unwrap(), kp.public))
             })
             .unwrap_err(),
             Error::VerifySig(BlsError::PointConversion)
@@ -511,7 +521,7 @@ mod test {
             |rank| {
                 bls_keypairs
                     .get(rank)
-                    .map(|kp| (per_validator_stake, kp.public))
+                    .map(|kp| (NonZero::new(per_validator_stake).unwrap(), kp.public))
             },
         )
         .unwrap();
@@ -555,7 +565,7 @@ mod test {
     // verification contract.
     // ----------------------------------------------------------------------------
 
-    const STAKE_PER_VALIDATOR: u64 = 100;
+    const STAKE_PER_VALIDATOR: NonZero<u64> = NonZero::new(100).unwrap();
 
     /// A `Block` for `slot` with a fresh, unique block id.
     fn fresh_block(slot: u64) -> Block {
@@ -594,7 +604,7 @@ mod test {
     /// Uniform `rank_map` over `keypairs`, each with `STAKE_PER_VALIDATOR` stake.
     fn rank_map(
         keypairs: &[BLSKeypair],
-    ) -> impl FnMut(usize) -> Option<(u64, PopVerified<BlsPubkeyAffine>)> + '_ {
+    ) -> impl FnMut(usize) -> Option<(NonZero<u64>, PopVerified<BlsPubkeyAffine>)> + '_ {
         move |rank| {
             keypairs
                 .get(rank)

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -69,7 +69,7 @@ impl PartialCert {
                     .ok_or(AddVoteError::InvalidRank)?;
                 self.signature.aggregate_with(std::iter::once(signature))?;
                 self.validators.push(entry.vote_account_pubkey);
-                self.stake = self.stake.saturating_add(entry.stake);
+                self.stake = self.stake.saturating_add(entry.stake.get());
                 *ind = true;
             }
         }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -199,7 +199,6 @@ use {
     std::{
         collections::{HashMap, HashSet},
         fmt,
-        num::NonZero,
         ops::AddAssign,
         path::PathBuf,
         slice,
@@ -5768,8 +5767,7 @@ impl Bank {
             .epoch_stakes_from_slot(slot)
             .ok_or(CertVerifyError::MissingRankMap)?;
         let key_to_rank_map = epoch_stakes.bls_pubkey_to_rank_map();
-        let total_stake =
-            NonZero::new(key_to_rank_map.total_stake()).expect("total stake cannot be 0");
+        let total_stake = key_to_rank_map.total_stake();
 
         let cert =
             cert_verify::verify_certificate(cert, key_to_rank_map.len(), total_stake, |rank| {

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -17,6 +17,7 @@ use {
     std::{
         collections::HashMap,
         fmt,
+        num::NonZero,
         sync::{Arc, OnceLock},
     },
 };
@@ -36,7 +37,7 @@ pub struct BLSPubkeyStakeEntry {
     /// The bls pubkey of the validator specified in the vote account
     pub bls_pubkey: PopVerified<BLSPubkeyAffine>,
     /// The stake of the validator
-    pub stake: u64,
+    pub stake: NonZero<u64>,
 }
 
 /// Container to store a mapping from validator [`BLSPubkeyAffine`] to rank.
@@ -49,7 +50,7 @@ pub struct BLSPubkeyToRankMap {
     rank_map: HashMap<BLSPubkeyCompressed, u16>,
     vote_pubkey_to_rank: HashMap<Pubkey, u16>,
     sorted_pubkeys: Vec<BLSPubkeyStakeEntry>,
-    total_stake: u64,
+    total_stake: NonZero<u64>,
 }
 
 // We cannot auto derive `AbiExample` for `BLSPubkeyToRankMap` because
@@ -61,7 +62,7 @@ impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
             rank_map: HashMap::new(),
             vote_pubkey_to_rank: HashMap::new(),
             sorted_pubkeys: Vec::new(),
-            total_stake: 0,
+            total_stake: NonZero::new(1).unwrap(),
         }
     }
 }
@@ -84,9 +85,9 @@ impl BLSPubkeyToRankMap {
         let mut bls_pubkey_counts = HashMap::new();
         let mut node_pubkey_counts = HashMap::new();
         for (&vote_account_pubkey, (stake, account)) in epoch_vote_accounts_hash_map {
-            if *stake == 0 {
+            let Some(stake) = NonZero::new(*stake) else {
                 continue;
-            }
+            };
             let node_pubkey = *account.vote_state_view().node_pubkey();
             let Some((bls_pubkey_compressed, bls_pubkey)) = account
                 .vote_state_view()
@@ -99,7 +100,7 @@ impl BLSPubkeyToRankMap {
                 vote_account_pubkey,
                 node_pubkey,
                 bls_pubkey,
-                stake: *stake,
+                stake,
             };
             *bls_pubkey_counts.entry(bls_pubkey_compressed).or_insert(0) += 1;
             *node_pubkey_counts.entry(node_pubkey).or_insert(0) += 1;
@@ -116,7 +117,10 @@ impl BLSPubkeyToRankMap {
                 .collect();
         let total_stake = keys_stake_entry_with_compressed
             .iter()
-            .fold(0u64, |stake, (entry, _)| stake.saturating_add(entry.stake));
+            .fold(0u64, |stake, (entry, _)| {
+                stake.saturating_add(entry.stake.get())
+            });
+        let total_stake = NonZero::new(total_stake).expect("total stakes should not be 0");
         keys_stake_entry_with_compressed.sort_by(
             |(a_entry, a_pubkey_compressed), (b_entry, b_pubkey_compressed)| {
                 b_entry
@@ -153,7 +157,7 @@ impl BLSPubkeyToRankMap {
         self.sorted_pubkeys.len()
     }
 
-    pub fn total_stake(&self) -> u64 {
+    pub fn total_stake(&self) -> NonZero<u64> {
         self.total_stake
     }
 
@@ -662,14 +666,13 @@ pub(crate) mod tests {
         }
     }
 
-    #[test_case(1; "single_vote_account")]
-    #[test_case(2; "multiple_vote_accounts")]
-    fn test_bls_pubkey_rank_map(num_vote_accounts_per_node: usize) {
+    #[test]
+    fn test_bls_pubkey_rank_map() {
         agave_logger::setup();
         let num_nodes = 10;
-        let num_vote_accounts = num_nodes * num_vote_accounts_per_node;
+        let num_vote_accounts = num_nodes;
 
-        let vote_accounts_map = new_vote_accounts(num_nodes, num_vote_accounts_per_node, true);
+        let vote_accounts_map = new_vote_accounts(num_nodes, 1, true);
         let node_id_to_stake_map = vote_accounts_map
             .keys()
             .enumerate()
@@ -680,18 +683,13 @@ pub(crate) mod tests {
         });
         let epoch_stakes = VersionedEpochStakes::new_for_tests(epoch_vote_accounts.clone(), 0);
         let bls_pubkey_to_rank_map = epoch_stakes.bls_pubkey_to_rank_map();
-        let expected_num_vote_accounts = if num_vote_accounts_per_node == 1 {
-            num_vote_accounts
-        } else {
-            0
-        };
+        let expected_num_vote_accounts = num_vote_accounts;
         assert_eq!(bls_pubkey_to_rank_map.len(), expected_num_vote_accounts);
-        let expected_total_stake = if num_vote_accounts_per_node == 1 {
-            epoch_stakes.total_stake()
-        } else {
-            0
-        };
-        assert_eq!(bls_pubkey_to_rank_map.total_stake(), expected_total_stake);
+        let expected_total_stake = epoch_stakes.total_stake();
+        assert_eq!(
+            bls_pubkey_to_rank_map.total_stake().get(),
+            expected_total_stake
+        );
         for (vote_account_pubkey, (stake, vote_account)) in epoch_vote_accounts {
             let vote_state_view = vote_account.vote_state_view();
             let (_comp, bls_pubkey) = bls_pubkey_compressed_bytes_to_bls_pubkey(
@@ -699,15 +697,6 @@ pub(crate) mod tests {
             )
             .unwrap();
             let node_pubkey = *vote_state_view.node_pubkey();
-            if num_vote_accounts_per_node > 1 {
-                assert!(bls_pubkey_to_rank_map.get_rank(&bls_pubkey).is_none());
-                assert!(
-                    bls_pubkey_to_rank_map
-                        .get_rank_for_vote_pubkey(&vote_account_pubkey)
-                        .is_none()
-                );
-                continue;
-            }
             let index = bls_pubkey_to_rank_map.get_rank(&bls_pubkey).unwrap();
             assert!(index >= &0 && index < &(expected_num_vote_accounts as u16));
             assert_eq!(
@@ -716,7 +705,7 @@ pub(crate) mod tests {
                     vote_account_pubkey,
                     node_pubkey,
                     bls_pubkey,
-                    stake,
+                    stake: NonZero::new(stake).unwrap(),
                 })
             );
         }
@@ -729,6 +718,25 @@ pub(crate) mod tests {
             .expect("Epoch stakes should exist");
         let bls_pubkey_to_rank_map2 = epoch_stakes.bls_pubkey_to_rank_map();
         assert_eq!(bls_pubkey_to_rank_map2, bls_pubkey_to_rank_map);
+    }
+
+    #[test]
+    #[should_panic(expected = "total stakes should not be 0")]
+    fn test_multiple_vote_accounts_panics() {
+        agave_logger::setup();
+        let num_nodes = 10;
+
+        let vote_accounts_map = new_vote_accounts(num_nodes, 2, true);
+        let node_id_to_stake_map = vote_accounts_map
+            .keys()
+            .enumerate()
+            .map(|(index, node_id)| (*node_id, ((index + 1) * 100) as u64))
+            .collect::<HashMap<_, _>>();
+        let epoch_vote_accounts = new_epoch_vote_accounts(&vote_accounts_map, |node_id| {
+            *node_id_to_stake_map.get(node_id).unwrap()
+        });
+        let epoch_stakes = VersionedEpochStakes::new_for_tests(epoch_vote_accounts.clone(), 0);
+        epoch_stakes.bls_pubkey_to_rank_map();
     }
 
     #[test]
@@ -865,7 +873,7 @@ pub(crate) mod tests {
         let rank_map = BLSPubkeyToRankMap::new(&epoch_vote_accounts);
 
         assert_eq!(rank_map.len(), 3);
-        assert_eq!(rank_map.total_stake(), 250);
+        assert_eq!(rank_map.total_stake().get(), 250);
         for bls_pubkey in [
             duplicate_bls_pubkey,
             duplicate_node_bls_pubkey,
@@ -905,7 +913,7 @@ pub(crate) mod tests {
                     vote_account_pubkey,
                     node_pubkey,
                     bls_pubkey,
-                    stake: 100,
+                    stake: NonZero::new(100).unwrap(),
                 })
             );
         }
@@ -921,7 +929,7 @@ pub(crate) mod tests {
                 vote_account_pubkey: unique_vote_pubkey,
                 node_pubkey: unique_node_pubkey,
                 bls_pubkey: unique_bls_pubkey,
-                stake: 50,
+                stake: NonZero::new(50).unwrap(),
             })
         );
         assert!(rank_map.get_pubkey_stake_entry(rank_map.len()).is_none());

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -74,13 +74,8 @@ fn get_key_and_stakes(
     };
     Ok((
         entry.vote_account_pubkey,
-        NonZero::new(entry.stake).unwrap_or_else(|| {
-            panic!(
-                "Validator stake is zero for pubkey: {}",
-                entry.vote_account_pubkey,
-            )
-        }),
-        NonZero::new(rank_map.total_stake()).expect("expect rank-map total stake to not be 0"),
+        entry.stake,
+        rank_map.total_stake(),
     ))
 }
 


### PR DESCRIPTION
#### Problem

We already assert in some places that the stakes values in the epoch stakes cannot be zero and I am adding a bunch of code that will also have to make the same assertion.  It will be nice if type guarantees for it.


#### Summary of Changes

Updates epoch stakes to store validator and total stake as `NonZero<u64>`


#### Testing

Just CI