### PR TITLE
clippy(consensus): fix for_kv_map

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1998,7 +1998,7 @@ pub mod test {
 
         // Fill the BankForks according to the above fork structure
         vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
-        for (_, fork_progress) in vote_simulator.progress.iter_mut() {
+        for fork_progress in vote_simulator.progress.values_mut() {
             fork_progress.fork_stats.computed = true;
         }
 
@@ -3093,7 +3093,7 @@ pub mod test {
 
         // Fill the BankForks according to the above fork structure
         vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
-        for (_, fork_progress) in vote_simulator.progress.iter_mut() {
+        for fork_progress in vote_simulator.progress.values_mut() {
             fork_progress.fork_stats.computed = true;
         }
 
@@ -3182,7 +3182,7 @@ pub mod test {
 
         // Fill the BankForks according to the above fork structure
         vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
-        for (_, fork_progress) in vote_simulator.progress.iter_mut() {
+        for fork_progress in vote_simulator.progress.values_mut() {
             fork_progress.fork_stats.computed = true;
         }
 
@@ -3820,7 +3820,7 @@ pub mod test {
 
         // Fill the BankForks according to the above fork structure
         vote_simulator.fill_bank_forks(forks, &HashMap::new(), true);
-        for (_, fork_progress) in vote_simulator.progress.iter_mut() {
+        for fork_progress in vote_simulator.progress.values_mut() {
             fork_progress.fork_stats.computed = true;
         }
 


### PR DESCRIPTION
#### Problem
Newer clippy detects another class of
https://rust-lang.github.io/rust-clippy/rust-1.67.0/index.html#for_kv_map

#### Summary of Changes
Switch to APIs fetching values only

#### Testing
CI, the change only spans test code
