### PR TITLE
clippy(tx-metadata): fix collapsible_if

### DIFF
--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -182,9 +182,10 @@ fn sanitize_instructions(
         }
 
         if let Some(max_accounts_per_instruction) = config.max_accounts_per_instruction
-            && instruction.accounts.len() > max_accounts_per_instruction {
-                return Err(TransactionViewError::SanitizeError);
-            }
+            && instruction.accounts.len() > max_accounts_per_instruction
+        {
+            return Err(TransactionViewError::SanitizeError);
+        }
     }
 
     Ok(())

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -181,11 +181,10 @@ fn sanitize_instructions(
             }
         }
 
-        if let Some(max_accounts_per_instruction) = config.max_accounts_per_instruction {
-            if instruction.accounts.len() > max_accounts_per_instruction {
+        if let Some(max_accounts_per_instruction) = config.max_accounts_per_instruction
+            && instruction.accounts.len() > max_accounts_per_instruction {
                 return Err(TransactionViewError::SanitizeError);
             }
-        }
     }
 
     Ok(())


### PR DESCRIPTION
#### Problem
We want to remove temporary allow for `clippy::collapsible_if` warning and fix all the occurrences in code-base.

#### Summary of Changes
Fix `tx-metadata` owned code (this is `clippy --fix` generated change) 

#### Testing
CI
