### PR TITLE
xdp: express XDP config as explicit queue->CPU bindings

### DIFF
--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -84,7 +84,8 @@ use {
 };
 #[cfg(target_os = "linux")]
 use {
-    agave_cpu_utils::cpu_affinity, agave_xdp::transmitter::XdpConfig,
+    agave_cpu_utils::cpu_affinity,
+    agave_xdp::transmitter::{QueueCpuBinding, XdpConfig},
     solana_clap_utils::input_parsers::parse_cpu_ranges,
 };
 
@@ -1451,7 +1452,16 @@ fn build_xdp_config(
     };
     Ok(cpus.map(|cpus| {
         info!("XDP enabled on CPU cores: {cpus:?}");
-        XdpConfig::new(xdp_interface, cpus, xdp_zero_copy)
+        // Map the CPU list onto hardware queues sequentially (queue i -> cpus[i]).
+        let queues = cpus
+            .into_iter()
+            .enumerate()
+            .map(|(queue, cpu)| QueueCpuBinding {
+                queue: queue as u32,
+                cpu,
+            })
+            .collect();
+        XdpConfig::new(xdp_interface, queues, xdp_zero_copy)
     }))
 }
 

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -35,10 +35,25 @@ use {
 #[cfg(target_os = "linux")]
 const ROUTE_MONITOR_UPDATE_INTERVAL: Duration = Duration::from_millis(50);
 
+/// Binding of a single NIC hardware TX queue to a CPU core.
+///
+/// Each binding becomes one TX worker thread, pinned to `cpu`, whose AF_XDP
+/// socket is bound to hardware queue `queue` on the configured interface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QueueCpuBinding {
+    /// NIC hardware TX queue id the AF_XDP socket binds to.
+    pub queue: u32,
+    /// Logical CPU core the worker thread is pinned to.
+    pub cpu: usize,
+}
+
 #[derive(Clone, Debug)]
 pub struct XdpConfig {
     pub interface: Option<String>,
-    pub cpus: Vec<usize>,
+    /// NIC-queue -> CPU-core bindings. One TX worker is created per entry, in
+    /// order. The queue id is taken explicitly from the binding rather than
+    /// inferred from position, so callers can target arbitrary hardware queues.
+    pub queues: Vec<QueueCpuBinding>,
     pub zero_copy: bool,
     // The capacity of the channel that sits between senders and each XDP thread that enqueues
     // packets to the NIC.
@@ -54,7 +69,7 @@ impl Default for XdpConfig {
     fn default() -> Self {
         Self {
             interface: None,
-            cpus: vec![],
+            queues: vec![],
             zero_copy: false,
             tx_channel_cap: Self::DEFAULT_TX_CHANNEL_CAP,
         }
@@ -62,10 +77,14 @@ impl Default for XdpConfig {
 }
 
 impl XdpConfig {
-    pub fn new(interface: Option<impl Into<String>>, cpus: Vec<usize>, zero_copy: bool) -> Self {
+    pub fn new(
+        interface: Option<impl Into<String>>,
+        queues: Vec<QueueCpuBinding>,
+        zero_copy: bool,
+    ) -> Self {
         Self {
             interface: interface.map(|s| s.into()),
-            cpus,
+            queues,
             zero_copy,
             tx_channel_cap: XdpConfig::DEFAULT_TX_CHANNEL_CAP,
         }
@@ -236,7 +255,7 @@ impl TransmitterBuilder {
         };
         let XdpConfig {
             interface: maybe_interface,
-            cpus,
+            queues,
             zero_copy,
             tx_channel_cap,
         } = config;
@@ -251,10 +270,9 @@ impl TransmitterBuilder {
         tx_loop_config_builder.zero_copy(zero_copy);
         let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
 
-        let reserved_cores = cpus
+        let reserved_cores = queues
             .iter()
-            .copied()
-            .map(CpuId::new)
+            .map(|binding| CpuId::new(binding.cpu))
             .collect::<io::Result<HashSet<_>>>()?;
         let unreserved_cores = cpu_affinity(None)?
             .into_iter()
@@ -265,15 +283,19 @@ impl TransmitterBuilder {
             return Err("all CPUs are reserved; no CPU available for the main thread".into());
         }
 
-        let mut tx_loop_builders = Vec::with_capacity(cpus.len());
-        for (i, cpu_id) in cpus.into_iter().enumerate() {
+        let mut tx_loop_builders = Vec::with_capacity(queues.len());
+        for binding in queues {
             // since we aren't necessarily allocating from the thread that we intend to run on,
             // temporarily switch to the target cpu for each TxLoop to ensure that the Umem region
             // is allocated to the correct numa node
-            let cpu = CpuId::new(cpu_id)?;
+            let cpu = CpuId::new(binding.cpu)?;
             set_cpu_affinity(None, [cpu])?;
-            let tx_loop_builder =
-                TxLoopBuilder::new(cpu_id, QueueId(i as u64), tx_loop_config.clone(), &dev);
+            let tx_loop_builder = TxLoopBuilder::new(
+                binding.cpu,
+                QueueId(binding.queue as u64),
+                tx_loop_config.clone(),
+                &dev,
+            );
             // migrate main thread back off of the last xdp reserved cpu
             set_cpu_affinity(None, unreserved_cores.iter().copied())?;
             tx_loop_builders.push(tx_loop_builder);


### PR DESCRIPTION


#### Problem

Prepare XDP for configuration file by making configuration slightly more flexible.

#### Summary of Changes

Replace `XdpConfig.cpus: Vec<usize>` with `queues: Vec<QueueCpuBinding>`, where each binding pairs a NIC hardware TX queue id with the CPU core its worker thread is pinned to. `TransmitterBuilder` now takes the queue id from the binding rather than inferring it from the CPU's position in the list, so callers can target arbitrary (non-contiguous) hardware queues.