### PR TITLE
clippy(networking): fix for_kv_map

### DIFF
--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -606,7 +606,7 @@ impl RepairWeight {
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) -> Vec<ShredRepairType> {
         let mut repairs = Vec::default();
-        for (_slot, tree) in self.trees.iter() {
+        for tree in self.trees.values() {
             if repairs.len() >= max_new_repairs {
                 break;
             }
@@ -638,7 +638,7 @@ impl RepairWeight {
     ) -> (Vec<ShredRepairType>, /* processed slots */ usize) {
         let mut repairs = Vec::default();
         let mut total_processed_slots = 0;
-        for (_slot, tree) in self.trees.iter() {
+        for tree in self.trees.values() {
             if repairs.len() >= max_new_repairs {
                 break;
             }


### PR DESCRIPTION
#### Problem
Newer clippy detects another class of
https://rust-lang.github.io/rust-clippy/rust-1.67.0/index.html#for_kv_map

#### Summary of Changes
Switch to APIs fetching values only

#### Testing
CI
