### PR TITLE
alpenglow: separate fast leader handover to a separate feature flag

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1605,8 +1605,11 @@ impl ReplayStage {
             let bank_forks_r = bank_forks.read().unwrap();
             new_frozen_slots
                 .iter()
-                .filter(|slot| migration_status.should_allow_fast_leader_handover(**slot))
                 .filter_map(|slot| bank_forks_r.get(*slot))
+                .filter(|bank| {
+                    bank.feature_set.snapshot().alpenglow_fast_leader_handover
+                        && migration_status.should_allow_block_markers(bank.slot())
+                })
                 .collect_vec()
         };
         for bank in flh_candidate_banks {

--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -146,7 +146,8 @@ fn should_mark_soft_dead(
     migration_status: &MigrationStatus,
 ) -> bool {
     let slot = bank.slot();
-    if !migration_status.should_allow_fast_leader_handover(slot)
+    if !bank.feature_set.snapshot().alpenglow_fast_leader_handover
+        || !migration_status.should_allow_block_markers(slot)
         || blockstore.is_dead(slot)
         || !is_update_parent_recoverable_replay_error(err)
     {

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -64,13 +64,6 @@ pub(super) fn child_bank_replay_start(
     if !migration_status.should_allow_block_markers(child_slot) {
         return ChildBankReplayStart::FromStart;
     }
-    if !parent_bank
-        .feature_set
-        .snapshot()
-        .alpenglow_fast_leader_handover
-    {
-        return ChildBankReplayStart::FromStart;
-    }
 
     let Some(slot_meta) = blockstore
         .meta(child_slot)
@@ -142,10 +135,10 @@ fn try_restart_slot_from_update_parent(
     if bank.is_none() && !progress.contains_key(&slot) {
         return false;
     }
-    if bank
-        .as_ref()
-        .is_some_and(|bank| ReplayStage::leader_is_me(bank.leader_id(), my_pubkey))
-    {
+    if bank.as_ref().is_some_and(|bank| {
+        ReplayStage::leader_is_me(bank.leader_id(), my_pubkey)
+            || !bank.feature_set.snapshot().alpenglow_fast_leader_handover
+    }) {
         return false;
     }
     if progress.get(&slot).is_some_and(|progress| {

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -64,6 +64,13 @@ pub(super) fn child_bank_replay_start(
     if !migration_status.should_allow_block_markers(child_slot) {
         return ChildBankReplayStart::FromStart;
     }
+    if !parent_bank
+        .feature_set
+        .snapshot()
+        .alpenglow_fast_leader_handover
+    {
+        return ChildBankReplayStart::FromStart;
+    }
 
     let Some(slot_meta) = blockstore
         .meta(child_slot)
@@ -113,7 +120,7 @@ fn try_restart_slot_from_update_parent(
     migration_status: &MigrationStatus,
     source: &str,
 ) -> bool {
-    if !migration_status.should_allow_fast_leader_handover(slot) {
+    if !migration_status.should_allow_block_markers(slot) {
         return false;
     }
     if blockstore.is_dead(slot) {

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -52,6 +52,7 @@ pub struct FeatureSnapshot {
     pub fix_alt_bn128_multiplication_input_length: bool,
     pub formalize_loaded_transaction_data_size: bool,
     pub alpenglow: bool,
+    pub alpenglow_fast_leader_handover: bool,
     pub disable_zk_elgamal_proof_program: bool,
     pub reenable_zk_elgamal_proof_program: bool,
     pub raise_block_limits_to_100m: bool,
@@ -156,6 +157,7 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
                 &formalize_loaded_transaction_data_size::ID,
             ),
             alpenglow: is_active(&alpenglow::ID),
+            alpenglow_fast_leader_handover: is_active(&alpenglow_fast_leader_handover::ID),
             disable_zk_elgamal_proof_program: is_active(&disable_zk_elgamal_proof_program::ID),
             reenable_zk_elgamal_proof_program: is_active(&reenable_zk_elgamal_proof_program::ID),
             raise_block_limits_to_100m: is_active(&raise_block_limits_to_100m::ID),
@@ -1547,6 +1549,10 @@ pub mod upgrade_bpf_stake_program_to_v5_1 {
     }
 }
 
+pub mod alpenglow_fast_leader_handover {
+    solana_pubkey::declare_id!("FastLeaderHandover1111111111111111111111111");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2620,6 +2626,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             upgrade_bpf_stake_program_to_v5_1::id(),
             "SIMD-0391: Upgrade BPF Stake Program to v5.1.0 (fixed-point warmup/cooldown)",
+        ),
+        (
+            alpenglow_fast_leader_handover::id(),
+            "SIMD-0326: Alpenglow fast leader handover",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1827,8 +1827,7 @@ fn confirm_slot_with_components(
     // Only replay that starts at the persisted UpdateParent FEC set may accept
     // UpdateParent as its first parent marker. From-shred-zero replay still
     // requires a block header before UpdateParent.
-    let fast_leader_handover_active = bank.feature_set.snapshot().alpenglow_fast_leader_handover;
-    let replay_starts_at_update_parent = fast_leader_handover_active
+    let replay_starts_at_update_parent = bank.feature_set.snapshot().alpenglow_fast_leader_handover
         && migration_status.should_allow_block_markers(slot)
         && leader_slot_index(slot) == 0
         && blockstore

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1827,7 +1827,9 @@ fn confirm_slot_with_components(
     // Only replay that starts at the persisted UpdateParent FEC set may accept
     // UpdateParent as its first parent marker. From-shred-zero replay still
     // requires a block header before UpdateParent.
-    let replay_starts_at_update_parent = migration_status.should_allow_fast_leader_handover(slot)
+    let fast_leader_handover_active = bank.feature_set.snapshot().alpenglow_fast_leader_handover;
+    let replay_starts_at_update_parent = fast_leader_handover_active
+        && migration_status.should_allow_block_markers(slot)
         && leader_slot_index(slot) == 0
         && blockstore
             .meta(slot)
@@ -2490,7 +2492,8 @@ fn load_frozen_forks(
             // Live replay restarts UpdateParent slots from the marker's FEC set.
             // Startup replay must use the same offset or a restarted validator can
             // execute the obsolete optimistic-parent prefix.
-            if migration_status.should_allow_fast_leader_handover(slot)
+            if bank.feature_set.snapshot().alpenglow_fast_leader_handover
+                && migration_status.should_allow_block_markers(slot)
                 && leader_slot_index(slot) == 0
                 && meta.has_update_parent()
             {

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -130,12 +130,6 @@ impl BlockComponentProcessor {
             return Ok(());
         }
 
-        // If we encounter an UpdateParent when fast leader handover is disabled, error.
-        if !migration_status.should_allow_fast_leader_handover(slot) && self.update_parent.is_some()
-        {
-            return Err(BlockComponentProcessorError::SpuriousUpdateParent);
-        }
-
         // Post-migration: both header and footer are required
         if !self.has_footer {
             return Err(BlockComponentProcessorError::MissingBlockFooter);
@@ -190,6 +184,8 @@ impl BlockComponentProcessor {
 
         let markers_fully_enabled = migration_status.should_allow_block_markers(slot);
         let in_migration = migration_status.is_in_migration();
+        let fast_leader_handover_active =
+            bank.feature_set.snapshot().alpenglow_fast_leader_handover;
 
         match marker {
             // Header and genesis cert can be processed either:
@@ -218,8 +214,13 @@ impl BlockComponentProcessor {
                 finalization_cert_sender,
             ),
 
-            BlockMarkerV1::UpdateParent(update_parent) if markers_fully_enabled => {
+            BlockMarkerV1::UpdateParent(update_parent)
+                if markers_fully_enabled && fast_leader_handover_active =>
+            {
                 self.on_update_parent(slot, update_parent.inner(), allow_initial_update_parent)
+            }
+            BlockMarkerV1::UpdateParent(_) if markers_fully_enabled => {
+                Err(BlockComponentProcessorError::SpuriousUpdateParent)
             }
 
             // Any other combination means we saw a marker too early
@@ -1559,7 +1560,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO(ksn): Enable when fast leader handover is enabled in MigrationPhase::should_allow_fast_leader_handover
     fn test_workflow_with_update_parent() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -214,13 +214,12 @@ impl BlockComponentProcessor {
                 finalization_cert_sender,
             ),
 
-            BlockMarkerV1::UpdateParent(update_parent)
-                if markers_fully_enabled && fast_leader_handover_active =>
-            {
-                self.on_update_parent(slot, update_parent.inner(), allow_initial_update_parent)
-            }
-            BlockMarkerV1::UpdateParent(_) if markers_fully_enabled => {
-                Err(BlockComponentProcessorError::SpuriousUpdateParent)
+            BlockMarkerV1::UpdateParent(update_parent) if markers_fully_enabled => {
+                if fast_leader_handover_active {
+                    self.on_update_parent(slot, update_parent.inner(), allow_initial_update_parent)
+                } else {
+                    Err(BlockComponentProcessorError::SpuriousUpdateParent)
+                }
             }
 
             // Any other combination means we saw a marker too early

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -288,11 +288,6 @@ impl MigrationPhase {
     fn should_use_double_merkle_block_id(&self, slot: Slot) -> bool {
         self.is_alpenglow_block(slot)
     }
-
-    /// Should this block allow the UpdateParent marker, i.e., support fast leader handover?
-    fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool {
-        self.is_alpenglow_block(slot)
-    }
 }
 
 /// Keeps track of the current migration status
@@ -459,7 +454,6 @@ impl MigrationStatus {
     dispatch!(pub fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_have_alpenglow_ticks(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_block_markers(&self, slot: Slot) -> bool);
-    dispatch!(pub fn should_allow_fast_leader_handover(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_use_double_merkle_block_id(&self, slot: Slot) -> bool);
 
     /// The alpenglow feature flag has been activated in slot `slot`.


### PR DESCRIPTION
#### Problem
FLH is always turned on immediately when Alpenglow goes live

#### Summary of Changes
Separate to a different feature flag which gives us flexibility in deferring it.

Main guard points are in replay for notifying of an optimistic parent and in blockstore processor / bcp for processing the update parent