### PR TITLE
Do not remove from the read cache during shrink

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5570,6 +5570,37 @@ impl AccountsDb {
         self.report_store_timings();
     }
 
+    /// Store `accounts` into `storage`.
+    ///
+    /// This fn is to only be called by ancient squash.
+    pub(crate) fn store_accounts_for_squash<'a>(
+        &self,
+        accounts: impl StorableAccounts<'a>,
+        storage: &AccountStorageEntry,
+    ) -> StoreAccountsTiming {
+        let slot = accounts.target_slot();
+        // Flush the read cache if necessary
+        if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {
+            let flush_read_cache_time = Measure::start("flush_read_cache");
+            (0..accounts.len()).for_each(|index| {
+                // Based on the patterns of how a validator writes accounts, it is almost always
+                // the case that there is no read only cache entry for this pubkey and slot.
+                // So, we can give that hint to the `remove` for performance.
+                self.read_only_accounts_cache
+                    .remove_assume_not_present(accounts.pubkey(index));
+            });
+            self.store_accounts_for_shrink_stats
+                .flush_read_cache_us
+                .fetch_add(flush_read_cache_time.end_as_us(), Ordering::Relaxed);
+        }
+
+        self.store_accounts_for_shrink(
+            accounts,
+            storage,
+            UpdateIndexThreadSelection::PoolWithThreshold,
+        )
+    }
+
     /// Stores accounts in the storage and updates the index.
     /// This function is intended for accounts that are being shrunk (moving from one store to another)
     /// - `UpsertReclaims` is set to `IgnoreReclaims`. If the slot in `accounts` differs from the new slot,
@@ -5586,18 +5617,6 @@ impl AccountsDb {
         let stats = &self.store_accounts_for_shrink_stats;
 
         debug_assert!(self.accounts_index.is_alive_root(slot));
-
-        // Flush the read cache if necessary
-        let flush_read_cache_time = Measure::start("flush_read_cache");
-        if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {
-            (0..accounts.len()).for_each(|index| {
-                // based on the patterns of how a validator writes accounts, it is almost always the case that there is no read only cache entry
-                // for this pubkey and slot. So, we can give that hint to the `remove` for performance.
-                self.read_only_accounts_cache
-                    .remove_assume_not_present(accounts.pubkey(index));
-            });
-        }
-        let flush_read_cache_us = flush_read_cache_time.end_as_us();
 
         // Write the accounts to storage
         let write_accounts_time = Measure::start("write_accounts");
@@ -5618,9 +5637,6 @@ impl AccountsDb {
         );
         let update_index_us = update_index_time.end_as_us();
 
-        stats
-            .flush_read_cache_us
-            .fetch_add(flush_read_cache_us, Ordering::Relaxed);
         stats
             .write_to_storage_us
             .fetch_add(write_accounts_us, Ordering::Relaxed);

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -10,7 +10,7 @@ use {
         account_storage_entry::AccountStorageEntry,
         accounts_db::{
             AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
-            ShrinkCollectAliveSeparatedByRefs, UpdateIndexThreadSelection,
+            ShrinkCollectAliveSeparatedByRefs,
             stats::{ShrinkAncientStats, ShrinkStatsSub},
         },
         active_stats::ActiveStatItem,
@@ -563,12 +563,9 @@ impl AccountsDb {
             .expect("ancient shrink target slot must already have a storage");
         let (shrink_in_progress, create_and_insert_store_elapsed_us) =
             measure_us!(self.get_store_for_shrink(target_slot, old_store, bytes));
-        let (store_accounts_timing, rewrite_elapsed_us) =
-            measure_us!(self.store_accounts_for_shrink(
-                accounts_to_write,
-                shrink_in_progress.new_storage(),
-                UpdateIndexThreadSelection::PoolWithThreshold
-            ));
+        let (store_accounts_timing, rewrite_elapsed_us) = measure_us!(
+            self.store_accounts_for_squash(accounts_to_write, shrink_in_progress.new_storage())
+        );
 
         write_ancient_accounts.metrics.accumulate(&ShrinkStatsSub {
             store_accounts_timing,


### PR DESCRIPTION
#### Problem Overview

`shrink` removes accounts from the read cache unnecessarily.


#### Problem Details

`store_accounts_for_shrink()` unconditionally removes accounts from the read cache. There are three callers of `store_accounts_for_shrink()`, which have different needs. (1) is normal shrink, (2) is ancient squash, and (3) is snapshot minimizer.

For (1), normal shrink, we know the accounts being shrunk will remain in the same slot.
For (2), ancient squash, accounts may move slots.
For (3), snapshot minimizer, we're within ledger-tool and creating a snapshot.

Only in the case of (2) is it possible for the accounts in the new storage to end up in a different slot. In (1) and (3), the new storage will have the same slot, and thus the accounts too will stay in the same slot. Since the read cache only cares about slot, and not the storage id, we don't need to remove the accounts from the read cache when the accounts stay in the same slot.


#### Summary of Changes

Add a top-level fn for squash, that flushes the read cache. Remove flushing the read cache from `store_accounts_for_shrink()`.


#### Testing

Ran on a node against mnb, and it did not diverge.

Here's a chart of the read cache usage over the first hour-ish. We can see on mce1 the little saw tooths, which I believe are the read cache flushes during shrink. Whereas on Bnk it is smooth.
<img width="926" height="440" alt="Screenshot 2026-06-23 at 3 02 55 PM" src="https://github.com/user-attachments/assets/c5984005-3b80-4630-90cc-38e54696e151" />

---

Here's a 6-hr window after `3XU` hit the default (3.1GB) limit, vs mce1. We can see that 3XU actually gets to the max, then does evictions. Compared to mce1, which does not hit the limit in this window, but has its entries removed by `shrink`.

<img width="921" height="439" alt="Screenshot 2026-06-24 at 7 59 12 AM" src="https://github.com/user-attachments/assets/dacf492f-f29a-4981-8012-d7f8c7b4a810" />

And here's the read cache's miss rate in that window. It's not much, but `3XU` does appear to always have a slightly lower miss rate.

<img width="927" height="441" alt="Screenshot 2026-06-24 at 7 59 00 AM" src="https://github.com/user-attachments/assets/c058f931-5718-4316-8189-411e8ae0aa3e" />
