### PR TITLE
Introduce Block Completion Time Buffer for Alpenglow

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -60,6 +60,12 @@ use {
 pub(crate) mod rewards;
 mod stats;
 
+// Imperically derived value estimating the time to drain and record the final batch of
+// transactions, produce the block footer, produce the 'alpentick', freeze the bank, shred the final
+// batches of the block, and broadcast. Recording stops this much before the slot timeout so
+// block completion has time to finish before the leader window deadline.
+const TIME_TO_COMPLETE_BLOCK_BROADCAST: Duration = Duration::from_millis(6);
+
 /// Source of a leader-window notification consumed by BCL.
 enum ParentSource {
     /// Parent from ParentReady event for this leader window is already known.
@@ -422,6 +428,7 @@ fn reset_poh_recorder(bank: &Arc<Bank>, ctx: &LeaderContext) {
 fn block_timeout(bank: &Bank, slot: Slot) -> Duration {
     Duration::from_nanos_u128(bank.ns_per_slot_at_slot(slot))
         .saturating_mul((leader_slot_index(slot) as u32).saturating_add(1))
+        .saturating_sub(TIME_TO_COMPLETE_BLOCK_BROADCAST)
 }
 
 /// Select the freshest leader-window notification within one source.
@@ -724,6 +731,8 @@ fn record_and_complete_block(
         return Err(PohRecorderError::WindowMovedOn(bank_slot));
     }
 
+    let block_completion_started_at = Instant::now();
+
     // Shutdown and clear any inflight records
     if !records_shutdown {
         shutdown_and_drain_record_receiver(&ctx.poh_recorder, &mut ctx.record_receiver, None)?;
@@ -786,7 +795,7 @@ fn record_and_complete_block(
 
     drop(bank);
     // Write the single tick for this slot
-    w_poh_recorder.tick_alpenglow(max_tick_height, footer)?;
+    w_poh_recorder.tick_alpenglow(max_tick_height, footer, block_completion_started_at)?;
     Ok(())
 }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -731,8 +731,6 @@ fn record_and_complete_block(
         return Err(PohRecorderError::WindowMovedOn(bank_slot));
     }
 
-    let block_completion_started_at = Instant::now();
-
     // Shutdown and clear any inflight records
     if !records_shutdown {
         shutdown_and_drain_record_receiver(&ctx.poh_recorder, &mut ctx.record_receiver, None)?;
@@ -795,7 +793,7 @@ fn record_and_complete_block(
 
     drop(bank);
     // Write the single tick for this slot
-    w_poh_recorder.tick_alpenglow(max_tick_height, footer, block_completion_started_at)?;
+    w_poh_recorder.tick_alpenglow(max_tick_height, footer)?;
     Ok(())
 }
 

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -60,10 +60,15 @@ use {
 pub(crate) mod rewards;
 mod stats;
 
-// Imperically derived value estimating the time to drain and record the final batch of
-// transactions, produce the block footer, produce the 'alpentick', freeze the bank, shred the final
-// batches of the block, and broadcast. Recording stops this much before the slot timeout so
-// block completion has time to finish before the leader window deadline.
+// Empirically derived value estimating the time to
+// - drain and record the final batch of transactions,
+// - produce the block footer,
+// - produce the 'alpentick',
+// - freeze the bank,
+// - shred the final batches of the block,
+// - broadcast.
+// Recording stops this much before the slot timeout so block completion has time to finish before
+// the leader window deadline.
 const TIME_TO_COMPLETE_BLOCK_BROADCAST: Duration = Duration::from_millis(6);
 
 /// Source of a leader-window notification consumed by BCL.

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1033,6 +1033,7 @@ impl PohRecorder {
         &mut self,
         slot_max_tick_height: u64,
         footer: BlockFooterV1,
+        block_completion_started_at: Instant,
     ) -> Result<()> {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
@@ -1062,10 +1063,24 @@ impl PohRecorder {
                     .load(Ordering::Acquire),
             ));
 
+            let bank_slot = self
+                .working_bank
+                .as_ref()
+                .map(|working_bank| working_bank.bank.slot())
+                .ok_or(PohRecorderError::MaxHeightReached)?;
             let (flush_res, flush_cache_and_tick_us) =
                 measure_us!(self.flush_cache(true, Some(footer)));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
             flush_res?;
+            datapoint_info!(
+                "block-completion-us",
+                ("slot", bank_slot, i64),
+                (
+                    "block_completion_elapsed_us",
+                    block_completion_started_at.elapsed().as_micros(),
+                    i64
+                ),
+            );
         }
         Ok(())
     }
@@ -1455,7 +1470,7 @@ mod tests {
         });
 
         let err = poh_recorder
-            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .tick_alpenglow(bank.max_tick_height(), test_footer(), Instant::now())
             .unwrap_err();
         freezer.join().unwrap();
 
@@ -1476,7 +1491,7 @@ mod tests {
             new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
 
         let err = poh_recorder
-            .tick_alpenglow(bank.max_tick_height(), test_footer())
+            .tick_alpenglow(bank.max_tick_height(), test_footer(), Instant::now())
             .unwrap_err();
 
         assert!(matches!(
@@ -1539,7 +1554,7 @@ mod tests {
             bank_to_freeze.freeze();
         });
         poh_recorder
-            .tick_alpenglow(child.max_tick_height(), test_footer())
+            .tick_alpenglow(child.max_tick_height(), test_footer(), Instant::now())
             .unwrap();
         freezer.join().unwrap();
         assert!(!poh_recorder.has_bank());

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -1033,7 +1033,6 @@ impl PohRecorder {
         &mut self,
         slot_max_tick_height: u64,
         footer: BlockFooterV1,
-        block_completion_started_at: Instant,
     ) -> Result<()> {
         let (poh_entry, tick_lock_contention_us) = measure_us!({
             let mut poh_l = self.poh.lock().unwrap();
@@ -1063,24 +1062,10 @@ impl PohRecorder {
                     .load(Ordering::Acquire),
             ));
 
-            let bank_slot = self
-                .working_bank
-                .as_ref()
-                .map(|working_bank| working_bank.bank.slot())
-                .ok_or(PohRecorderError::MaxHeightReached)?;
             let (flush_res, flush_cache_and_tick_us) =
                 measure_us!(self.flush_cache(true, Some(footer)));
             self.metrics.flush_cache_tick_us += flush_cache_and_tick_us;
             flush_res?;
-            datapoint_info!(
-                "block-completion-us",
-                ("slot", bank_slot, i64),
-                (
-                    "block_completion_elapsed_us",
-                    block_completion_started_at.elapsed().as_micros(),
-                    i64
-                ),
-            );
         }
         Ok(())
     }
@@ -1470,7 +1455,7 @@ mod tests {
         });
 
         let err = poh_recorder
-            .tick_alpenglow(bank.max_tick_height(), test_footer(), Instant::now())
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
             .unwrap_err();
         freezer.join().unwrap();
 
@@ -1491,7 +1476,7 @@ mod tests {
             new_alpenglow_recorder_for_bank(bank.clone(), blockstore);
 
         let err = poh_recorder
-            .tick_alpenglow(bank.max_tick_height(), test_footer(), Instant::now())
+            .tick_alpenglow(bank.max_tick_height(), test_footer())
             .unwrap_err();
 
         assert!(matches!(
@@ -1554,7 +1539,7 @@ mod tests {
             bank_to_freeze.freeze();
         });
         poh_recorder
-            .tick_alpenglow(child.max_tick_height(), test_footer(), Instant::now())
+            .tick_alpenglow(child.max_tick_height(), test_footer())
             .unwrap();
         freezer.join().unwrap();
         assert!(!poh_recorder.has_bank());


### PR DESCRIPTION
#### Problem
In TowerBFT we add a buffer (stop recording txs ~20ms early) to:
- Produce the block footer and final tick
- Freeze the bank (~5ms)
- Shred the last fec set(s)

The same should be done in Alpenglow. After profiling the time between after recording transactions and broadcast:

<img width="2860" height="831" alt="image" src="https://github.com/user-attachments/assets/156e8ca5-41f1-4b32-af69-eefe080e9eb3" />

Purple: average TPS load, divided by 10,
Blue: average time measured.

This yields a conservative upper bound on a block completion buffer to be ~6ms.

After implementing the buffer, here are block times under load:
<img width="3244" height="886" alt="image" src="https://github.com/user-attachments/assets/0dbb8c85-afe6-4c0c-abc2-57491d708e7e" />

#### Summary of Changes

- Introduces 6ms block completion buffer.


Fixes #13151 
