### PR TITLE
Shrink based on storages

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -128,6 +128,20 @@ impl AccountStorage {
         self.map.iter().map(|iter_item| *iter_item.key()).collect()
     }
 
+    /// All slots with a storage entry below `max_slot_exclusive`.
+    pub(crate) fn slots_less_than(&self, max_slot_exclusive: Slot) -> Vec<Slot> {
+        assert!(
+            self.no_shrink_in_progress(),
+            "shrink is in progress! slots: {:?}",
+            self.shrink_in_progress_map.read().unwrap().keys(),
+        );
+        self.map
+            .iter()
+            .map(|iter_item| *iter_item.key())
+            .filter(|slot| *slot < max_slot_exclusive)
+            .collect()
+    }
+
     /// returns true if there is no entry for 'slot'
     #[cfg(test)]
     pub(crate) fn is_empty_entry(&self, slot: Slot) -> bool {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3165,20 +3165,13 @@ impl AccountsDb {
         (shrink_slots, shrink_slots_next_batch)
     }
 
-    fn get_roots_less_than(&self, slot: Slot) -> Vec<Slot> {
-        self.accounts_index
-            .roots_tracker
-            .read()
-            .unwrap()
-            .alive_roots
-            .get_all_less_than(slot)
-    }
-
     /// return all slots that are more than one epoch old and thus could already be an ancient append vec
     /// or which could need to be combined into a new or existing ancient append vec
     /// offset is used to combine newer slots than we normally would. This is designed to be used for testing.
     fn get_sorted_potential_ancient_slots(&self, oldest_non_ancient_slot: Slot) -> Vec<Slot> {
-        let mut ancient_slots = self.get_roots_less_than(oldest_non_ancient_slot);
+        // Only storages can be combined into ancient append vecs, so the storage map is the
+        // source of truth here.
+        let mut ancient_slots = self.storage.slots_less_than(oldest_non_ancient_slot);
         ancient_slots.sort_unstable();
         ancient_slots
     }
@@ -3192,7 +3185,11 @@ impl AccountsDb {
 
         let oldest_non_ancient_slot = self.get_oldest_non_ancient_slot(epoch_schedule);
         let can_randomly_shrink = true;
-        let sorted_slots = self.get_sorted_potential_ancient_slots(oldest_non_ancient_slot);
+        let (sorted_slots, select_slots_us) =
+            measure_us!(self.get_sorted_potential_ancient_slots(oldest_non_ancient_slot));
+        self.shrink_ancient_stats
+            .select_slots_us
+            .fetch_add(select_slots_us, Ordering::Relaxed);
         self.combine_ancient_slots_packed(sorted_slots, can_randomly_shrink);
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6526,6 +6526,10 @@ impl AccountsDb {
             self.accounts_index.add_root(storage.slot());
         }
 
+        // Roots added above bypass `add_root`, so seed `max_root` from the index's highest root.
+        self.max_root
+            .fetch_max(self.accounts_index.max_root_inclusive(), Ordering::Relaxed);
+
         self.set_storage_count_and_alive_bytes(total_accum.storage_info, &mut timings);
 
         let mut mark_obsolete_accounts_time = Measure::start("mark_obsolete_accounts_time");

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6526,10 +6526,6 @@ impl AccountsDb {
             self.accounts_index.add_root(storage.slot());
         }
 
-        // Roots added above bypass `add_root`, so seed `max_root` from the index's highest root.
-        self.max_root
-            .fetch_max(self.accounts_index.max_root_inclusive(), Ordering::Relaxed);
-
         self.set_storage_count_and_alive_bytes(total_accum.storage_info, &mut timings);
 
         let mut mark_obsolete_accounts_time = Measure::start("mark_obsolete_accounts_time");

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -488,6 +488,7 @@ pub struct ShrinkAncientStats {
     pub shrink_stats: ShrinkStats,
     pub ancient_append_vecs_shrunk: AtomicU64,
     pub total_us: AtomicU64,
+    pub select_slots_us: AtomicU64,
     pub random_shrink: AtomicU64,
     pub slots_considered: AtomicU64,
     pub ancient_scanned: AtomicU64,
@@ -892,6 +893,11 @@ impl ShrinkAncientStats {
                 i64
             ),
             ("total_us", self.total_us.swap(0, Ordering::Relaxed), i64),
+            (
+                "select_slots_us",
+                self.select_slots_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
             (
                 "bytes_ancient_created",
                 self.bytes_ancient_created.swap(0, Ordering::Relaxed),

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -5898,8 +5898,10 @@ define_accounts_db_test!(test_get_sorted_potential_ancient_slots, |db| {
     );
     let root1 = DEFAULT_MAX_ANCIENT_STORAGES as u64 + ancient_append_vec_offset as u64 + 1;
     db.add_root(root1);
+    db.create_and_insert_store(root1, 4096, "test");
     let root2 = root1 + 1;
     db.add_root(root2);
+    db.create_and_insert_store(root2, 4096, "test");
     let oldest_non_ancient_slot = db.get_oldest_non_ancient_slot(&epoch_schedule);
     assert!(
         db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot)
@@ -5937,12 +5939,7 @@ define_accounts_db_test!(test_get_sorted_potential_ancient_slots, |db| {
         db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot),
         vec![root1, root2]
     );
-    db.accounts_index
-        .roots_tracker
-        .write()
-        .unwrap()
-        .alive_roots
-        .remove(&root1);
+    db.storage.remove(&root1, false);
     let oldest_non_ancient_slot = db.get_oldest_non_ancient_slot(&epoch_schedule);
     assert_eq!(
         db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot),

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -295,26 +295,6 @@ impl RollingBitField {
         self.max_exclusive.saturating_sub(1)
     }
 
-    /// return all items < 'max_slot_exclusive'
-    pub fn get_all_less_than(&self, max_slot_exclusive: Slot) -> Vec<u64> {
-        let mut all = Vec::with_capacity(self.count);
-        self.excess.iter().for_each(|slot| {
-            if slot < &max_slot_exclusive {
-                all.push(*slot)
-            }
-        });
-        for key in self.min..self.max_exclusive {
-            if key >= max_slot_exclusive {
-                break;
-            }
-
-            if self.contains_assume_in_range(&key) {
-                all.push(key);
-            }
-        }
-        all
-    }
-
     /// return highest item < 'max_slot_exclusive'
     pub fn get_prior(&self, max_slot_exclusive: Slot) -> Option<Slot> {
         let mut slot = max_slot_exclusive.saturating_sub(1);
@@ -360,59 +340,6 @@ mod tests {
         pub fn clear(&mut self) {
             *self = Self::new(self.max_width);
         }
-    }
-
-    #[test]
-    fn test_get_all_less_than() {
-        agave_logger::setup();
-        let len = 16;
-        let mut bitfield = RollingBitField::new(len);
-        assert!(bitfield.get_all_less_than(0).is_empty());
-        bitfield.insert(0);
-        assert!(bitfield.get_all_less_than(0).is_empty());
-        assert_eq!(bitfield.get_all_less_than(1), vec![0]);
-        bitfield.insert(1);
-        assert_eq!(bitfield.get_all_less_than(1), vec![0]);
-        let last_item_not_in_excess = len - 1;
-        bitfield.insert(last_item_not_in_excess);
-        assert!(bitfield.excess.is_empty());
-        assert_eq!(
-            bitfield.get_all_less_than(last_item_not_in_excess),
-            vec![0, 1]
-        );
-        assert_eq!(
-            bitfield.get_all_less_than(last_item_not_in_excess + 1),
-            vec![0, 1, last_item_not_in_excess]
-        );
-        let first_item_in_excess = last_item_not_in_excess + 1;
-        bitfield.insert(first_item_in_excess);
-        assert!(bitfield.excess.contains(&0));
-        assert_eq!(
-            bitfield.get_all_less_than(last_item_not_in_excess),
-            vec![0, 1]
-        );
-        assert_eq!(
-            bitfield.get_all_less_than(last_item_not_in_excess + 1),
-            vec![0, 1, last_item_not_in_excess]
-        );
-        assert_eq!(
-            bitfield.get_all_less_than(first_item_in_excess + 1),
-            vec![0, 1, last_item_not_in_excess, first_item_in_excess]
-        );
-
-        bitfield.insert(len * 2);
-        let mut less = bitfield.get_all_less_than(len * 2);
-        less.sort_unstable();
-        assert_eq!(
-            vec![0, 1, last_item_not_in_excess, first_item_in_excess],
-            less
-        );
-        let mut less = bitfield.get_all_less_than(len * 2 + 1);
-        less.sort_unstable();
-        assert_eq!(
-            vec![0, 1, last_item_not_in_excess, first_item_in_excess, len * 2],
-            less
-        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Shrink Ancient currently uses the accounts index root tracker to find storages to shrink. This is weird coupling and should just be removed. 

#### Summary of Changes
- Just loop through all the storages instead. 

#### Testing
Ran testing. When there is only a single line (the first half or so of the graph), it is running base code. With the purple and blue line stacked, it is running with this change. 

I added the time to select into the total time for graphs, so this shows in effect total (before) vs total + select is roughly identical. Given that total doesn't include time to select, old measurement did not include select time. Based on that, this is a performance win as well as a cleanup

<img width="1601" height="365" alt="image" src="https://github.com/user-attachments/assets/1fe20d5b-fbc1-44e9-bcc2-ddbdc3638d23" />

Fixes #
