### PR TITLE
ci: add --bins for all coverage tests

### DIFF
--- a/ci/coverage/part-1.sh
+++ b/ci/coverage/part-1.sh
@@ -16,4 +16,5 @@ echo "--- coverage: root (part 1)"
   --features frozen-abi \
   --features dev-context-only-utils \
   --lib \
+  --bins \
   "${packages[@]}"

--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -15,4 +15,5 @@ echo "--- coverage: root (part 2)"
 "$git_root"/ci/test-coverage.sh \
   --features dev-context-only-utils \
   --lib \
+  --bins \
   "${packages[@]}"

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -21,6 +21,7 @@ echo "--- coverage: coverage (part 3)"
   --features dev-context-only-utils \
   --workspace \
   --lib \
+  --bins \
   "${exclude_packages[@]}"
 
 # Clean up


### PR DESCRIPTION
#### Problem

we missed bins tests in coverage reports

#### Summary of Changes

include them by adding `--bins`

