### PR TITLE
clippy: fix byte_char_slices

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -5004,7 +5004,7 @@ mod tests {
          */
 
         // Prepare four top level instructions: A, B, C and D
-        let ixs = [b'A', b'B', b'C', b'D'];
+        let ixs = *b"ABCD";
         for (idx, ix) in ixs.iter().enumerate() {
             invoke_context
                 .transaction_context
@@ -5268,7 +5268,7 @@ mod tests {
         We are invoking the syscall from B5, B6, B8, C, C1 and C2 for comprehensive testing.
         */
 
-        let top_level = [b'A', b'B', b'C'];
+        let top_level = *b"ABC";
         for (idx, ix) in top_level.iter().enumerate() {
             invoke_context
                 .transaction_context


### PR DESCRIPTION
#### Problem
Newer clippy detects 
https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#byte_char_slices
in the codebase

#### Summary of Changes
Change byte array creation syntax

#### Testing
CI
