### PR TITLE
fix: add no-op collect_local_ipv4_ips for windows

### DIFF
--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -272,7 +272,7 @@ impl QuicXdpSender {
 }
 
 /// Collects IPv4 addresses assigned to local network interfaces.
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
     use nix::ifaddrs::getifaddrs;
 
@@ -289,7 +289,7 @@ fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
     Ok(ips)
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(not(target_os = "linux"))]
 fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
     Ok(Vec::new())
 }

--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -7,7 +7,6 @@ use {
     },
     bytes::Bytes,
     crossbeam_channel::TrySendError,
-    nix::ifaddrs::getifaddrs,
     quinn::{
         AsyncUdpSocket, Runtime, TokioRuntime, UdpPoller,
         udp::{EcnCodepoint as QuinnEcnCodepoint, RecvMeta, Transmit},
@@ -273,7 +272,10 @@ impl QuicXdpSender {
 }
 
 /// Collects IPv4 addresses assigned to local network interfaces.
+#[cfg(not(target_os = "windows"))]
 fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
+    use nix::ifaddrs::getifaddrs;
+
     let mut ips = Vec::new();
     for ifa in getifaddrs().map_err(io::Error::other)? {
         let Some(addr) = ifa.address else { continue };
@@ -285,6 +287,11 @@ fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
         }
     }
     Ok(ips)
+}
+
+#[cfg(target_os = "windows")]
+fn collect_local_ipv4_ips() -> io::Result<Vec<Ipv4Addr>> {
+    Ok(Vec::new())
 }
 
 #[inline]


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/13389)

while we don't actively support Windows anymore, we still ship binaries, so they should at least be compilable on Windows 

#### Summary of Changes

fix this by adding a no-op function for windows

<img width="578" height="254" alt="Screenshot 2026-06-24 at 13 48 58" src="https://github.com/user-attachments/assets/a6092db1-eada-4d09-8eb3-bae419129e87" />


