### PR TITLE
test: explicitly generate u8 chunks for test_wincode_compatibility_duplicate_shred

### DIFF
--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -401,7 +401,7 @@ pub(crate) mod tests {
                 _unused_shred_type: rng.random(),
                 num_chunks: rng.random(),
                 chunk_index: rng.random(),
-                chunk: (0..chunk_len).map(|_| rng.random()).collect(),
+                chunk: (0..chunk_len).map(|_| rng.random::<u8>()).collect(),
             };
 
             let bincode_bytes = bincode::serialize(&dup).unwrap();


### PR DESCRIPTION
#### Problem

(split from https://github.com/anza-xyz/agave/pull/13389)

while we don't actively support Windows anymore, we still ship binaries, so they should at least be compilable on Windows 

#### Summary of Changes

fix this by explicitly generating u8 chunks

<img width="1030" height="835" alt="Screenshot 2026-06-24 at 13 50 22" src="https://github.com/user-attachments/assets/3b3e793c-f478-4804-9e4a-a20b8cef4a61" />
