### PR TITLE
test: Migrate off ConnectionCache::new_quic_for_tests

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3161,8 +3161,7 @@ async fn send_deploy_messages(
 
             let connection_cache = {
                 #[cfg(feature = "dev-context-only-utils")]
-                let cache =
-                    ConnectionCache::new_quic_for_tests("connection_cache_cli_program_quic", 1);
+                let cache = solana_client::connection_cache::ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
                 #[cfg(not(feature = "dev-context-only-utils"))]
                 let cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
                 cache

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -4630,7 +4630,7 @@ fn test_replay_stage_refresh_last_vote() {
         .unwrap();
 
     let connection_cache = if DEFAULT_VOTE_USE_QUIC {
-        ConnectionCache::new_quic_for_tests(
+        solana_client::connection_cache::ConnectionCache::new_quic(
             "connection_cache_vote_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         )
@@ -4735,7 +4735,7 @@ fn test_replay_stage_refresh_last_vote() {
         .unwrap();
 
     let connection_cache = if DEFAULT_VOTE_USE_QUIC {
-        ConnectionCache::new_quic_for_tests(
+        solana_client::connection_cache::ConnectionCache::new_quic(
             "connection_cache_vote_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         )
@@ -4864,7 +4864,7 @@ fn test_replay_stage_refresh_last_vote() {
         .recv_timeout(Duration::from_secs(1))
         .unwrap();
     let connection_cache = if DEFAULT_VOTE_USE_QUIC {
-        ConnectionCache::new_quic_for_tests(
+        solana_client::connection_cache::ConnectionCache::new_quic(
             "connection_cache_vote_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         )
@@ -5006,7 +5006,7 @@ fn send_vote_in_new_bank(
         .recv_timeout(Duration::from_secs(1))
         .unwrap();
     let connection_cache = if DEFAULT_VOTE_USE_QUIC {
-        ConnectionCache::new_quic_for_tests(
+        solana_client::connection_cache::ConnectionCache::new_quic(
             "connection_cache_vote_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         )

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -795,7 +795,7 @@ pub mod tests {
         let outstanding_repair_requests = Arc::<RwLock<OutstandingShredRepairs>>::default();
         let cluster_slots = Arc::new(ClusterSlots::default_for_tests());
         let connection_cache = if DEFAULT_VOTE_USE_QUIC {
-            ConnectionCache::new_quic_for_tests(
+            solana_client::connection_cache::ConnectionCache::new_quic(
                 "connection_cache_vote_quic",
                 DEFAULT_TPU_CONNECTION_POOL_SIZE,
             )
@@ -805,7 +805,7 @@ pub mod tests {
                 DEFAULT_TPU_CONNECTION_POOL_SIZE,
             )
         };
-        let bls_connection_cache = ConnectionCache::new_quic_for_tests(
+        let bls_connection_cache = solana_client::connection_cache::ConnectionCache::new_quic(
             "connection_cache_bls_quic",
             DEFAULT_TPU_CONNECTION_POOL_SIZE,
         );


### PR DESCRIPTION
Fixes #10206.

**Problem Statement:**
`ConnectionCache::new_quic_for_tests` is being phased out due to unfortunate design decisions.

**Technical Solution:**
- Replaced `ConnectionCache::new_quic_for_tests` with `solana_client::connection_cache::ConnectionCache::new_quic` in `cli/src/program.rs`.
- Replaced `ConnectionCache::new_quic_for_tests` with `solana_client::connection_cache::ConnectionCache::new_quic` in `core/src/tvu.rs` and `core/src/replay_stage/tests.rs`.

*(Note: Issue #10206 mentions migrating to `tpu-client-next` eventually, but the immediate goal was clearing `new_quic_for_tests`. I've started the rollout here by replacing the direct constructor calls).*

**Related Issue:**
Resolves #10206