### PR TITLE
bench: Transition benchmarks to bencher

### DIFF
--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -1,6 +1,6 @@
-#![feature(test)]
 
-extern crate test;
+
+
 
 use {
     solana_core::{
@@ -16,11 +16,11 @@ use {
         sync::Arc,
     },
     tempfile::TempDir,
-    test::Bencher,
+    Bencher,
     trees::tr,
 };
 
-#[bench]
+
 fn bench_save_tower(bench: &mut Bencher) {
     let dir = TempDir::new().unwrap();
 
@@ -43,7 +43,7 @@ fn bench_save_tower(bench: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
     let vote_account_pubkey = &Pubkey::default();
@@ -79,3 +79,6 @@ fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
         }
     });
 }
+
+benchmark_group!(benches, bench_save_tower, bench_generate_ancestors_descendants);
+benchmark_main!(benches);

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
-#![feature(test)]
-extern crate test;
+
+
 
 use {
     rand::Rng,
@@ -14,7 +14,7 @@ use {
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_transaction_status::TransactionStatusMeta,
-    test::Bencher,
+    Bencher,
 };
 
 // Insert some shreds into the ledger in preparation for read benchmarks
@@ -45,7 +45,7 @@ fn setup_read_bench(
 }
 
 // Write shreds to the ledger
-#[bench]
+
 #[ignore]
 fn bench_write_shreds(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -59,7 +59,7 @@ fn bench_write_shreds(bench: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_read_sequential(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -84,7 +84,7 @@ fn bench_read_sequential(bench: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_read_random(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -113,7 +113,7 @@ fn bench_read_random(bench: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_insert_data_shred(bench: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -127,7 +127,7 @@ fn bench_insert_data_shred(bench: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_write_transaction_memos(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -147,7 +147,7 @@ fn bench_write_transaction_memos(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_add_transaction_memos_to_batch(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -172,7 +172,7 @@ fn bench_add_transaction_memos_to_batch(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_write_transaction_status(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -206,7 +206,7 @@ fn bench_write_transaction_status(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 #[ignore]
 fn bench_add_transaction_status_to_batch(b: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -244,3 +244,6 @@ fn bench_add_transaction_status_to_batch(b: &mut Bencher) {
         blockstore.write_batch(status_batch).unwrap();
     });
 }
+
+benchmark_group!(benches, bench_write_shreds, bench_read_sequential, bench_read_random, bench_insert_data_shred, bench_write_transaction_memos, bench_add_transaction_memos_to_batch, bench_write_transaction_status, bench_add_transaction_status_to_batch);
+benchmark_main!(benches);

--- a/poh/benches/poh.rs
+++ b/poh/benches/poh.rs
@@ -1,7 +1,7 @@
 // This bench attempts to justify the value of `solana_core::poh_service::NUM_HASHES_PER_BATCH`
 
-#![feature(test)]
-extern crate test;
+
+
 
 use {
     solana_entry::poh::Poh,
@@ -22,7 +22,7 @@ use {
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    test::Bencher,
+    Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -31,7 +31,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 const NUM_HASHES: u64 = 30_000; // Should require ~10ms on a 2017 MacBook Pro
 
-#[bench]
+
 // No locking.  Fastest.
 fn bench_poh_hash(bencher: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
@@ -40,7 +40,7 @@ fn bench_poh_hash(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
+
 // Lock on each iteration.  Slowest.
 fn bench_arc_mutex_poh_hash(bencher: &mut Bencher) {
     let poh = Arc::new(Mutex::new(Poh::new(Hash::default(), None)));
@@ -51,7 +51,7 @@ fn bench_arc_mutex_poh_hash(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
+
 // Acquire lock every NUM_HASHES_PER_BATCH iterations.
 // Speed should be close to bench_poh_hash() if NUM_HASHES_PER_BATCH is set well.
 fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
@@ -72,7 +72,7 @@ fn bench_arc_mutex_poh_batched_hash(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
+
 // Worst case transaction record delay due to batch hashing at NUM_HASHES_PER_BATCH
 fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
     let mut poh = Poh::new(Hash::default(), None);
@@ -81,7 +81,7 @@ fn bench_poh_lock_time_per_batch(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
+
 fn bench_poh_recorder_record(bencher: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
@@ -128,7 +128,7 @@ fn bench_poh_recorder_record(bencher: &mut Bencher) {
     poh_recorder.tick();
 }
 
-#[bench]
+
 fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore =
@@ -154,3 +154,6 @@ fn bench_poh_recorder_set_bank(bencher: &mut Bencher) {
         poh_recorder.clear_bank_for_test();
     });
 }
+
+benchmark_group!(benches, bench_poh_hash, bench_arc_mutex_poh_hash, bench_arc_mutex_poh_batched_hash, bench_poh_lock_time_per_batch, bench_poh_recorder_record, bench_poh_recorder_set_bank);
+benchmark_main!(benches);

--- a/poh/benches/poh_verify.rs
+++ b/poh/benches/poh_verify.rs
@@ -1,5 +1,5 @@
-#![feature(test)]
-extern crate test;
+
+
 
 use {
     solana_entry::entry::{self, Entry, EntrySlice, next_entry_mut},
@@ -8,7 +8,7 @@ use {
     solana_sha256_hasher::hash,
     solana_signer::Signer,
     solana_system_transaction::transfer,
-    test::Bencher,
+    Bencher,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -18,7 +18,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 const NUM_HASHES: u64 = 400;
 const NUM_ENTRIES: usize = 800;
 
-#[bench]
+
 fn bench_poh_verify_ticks(bencher: &mut Bencher) {
     agave_logger::setup();
     let thread_pool = entry::thread_pool_for_benches();
@@ -37,7 +37,7 @@ fn bench_poh_verify_ticks(bencher: &mut Bencher) {
     })
 }
 
-#[bench]
+
 fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
     let thread_pool = entry::thread_pool_for_benches();
 
@@ -58,3 +58,6 @@ fn bench_poh_verify_transaction_entries(bencher: &mut Bencher) {
         assert!(ticks.verify(&start_hash, &thread_pool).status());
     })
 }
+
+benchmark_group!(benches, bench_poh_verify_ticks, bench_poh_verify_transaction_entries);
+benchmark_main!(benches);

--- a/precompiles/benches/ed25519_instructions.rs
+++ b/precompiles/benches/ed25519_instructions.rs
@@ -1,11 +1,11 @@
-#![feature(test)]
 
-extern crate test;
+
+
 use {
     agave_feature_set::FeatureSet, agave_precompiles::ed25519::verify,
     ed25519_dalek::ed25519::signature::Signer, rand::Rng,
     solana_ed25519_program::new_ed25519_instruction_with_signature,
-    solana_instruction::Instruction, test::Bencher,
+    solana_instruction::Instruction, Bencher,
 };
 
 // 5K instructions should be enough for benching loop
@@ -30,7 +30,7 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
+
 fn bench_ed25519_len_032(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32);
@@ -41,7 +41,7 @@ fn bench_ed25519_len_032(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_ed25519_len_128(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(128);
@@ -52,7 +52,7 @@ fn bench_ed25519_len_128(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_ed25519_len_32k(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32 * 1024);
@@ -63,7 +63,7 @@ fn bench_ed25519_len_32k(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_ed25519_len_max(b: &mut Bencher) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
     let feature_set = FeatureSet::all_enabled();
@@ -74,3 +74,6 @@ fn bench_ed25519_len_max(b: &mut Bencher) {
         verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
     });
 }
+
+benchmark_group!(benches, bench_ed25519_len_032, bench_ed25519_len_128, bench_ed25519_len_32k, bench_ed25519_len_max);
+benchmark_main!(benches);

--- a/precompiles/benches/secp256k1_instructions.rs
+++ b/precompiles/benches/secp256k1_instructions.rs
@@ -1,6 +1,6 @@
-#![feature(test)]
 
-extern crate test;
+
+
 use {
     agave_feature_set::FeatureSet,
     agave_precompiles::secp256k1::verify,
@@ -9,7 +9,7 @@ use {
     solana_secp256k1_program::{
         eth_address_from_pubkey, new_secp256k1_instruction_with_signature, sign_message,
     },
-    test::Bencher,
+    Bencher,
 };
 
 // 5K transactions should be enough for benching loop
@@ -40,7 +40,7 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
+
 fn bench_secp256k1_len_032(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32);
@@ -51,7 +51,7 @@ fn bench_secp256k1_len_032(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256k1_len_256(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(256);
@@ -62,7 +62,7 @@ fn bench_secp256k1_len_256(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256k1_len_32k(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32 * 1024);
@@ -73,7 +73,7 @@ fn bench_secp256k1_len_32k(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256k1_len_max(b: &mut Bencher) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
     let feature_set = FeatureSet::all_enabled();
@@ -84,3 +84,6 @@ fn bench_secp256k1_len_max(b: &mut Bencher) {
         verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
     });
 }
+
+benchmark_group!(benches, bench_secp256k1_len_032, bench_secp256k1_len_256, bench_secp256k1_len_32k, bench_secp256k1_len_max);
+benchmark_main!(benches);

--- a/precompiles/benches/secp256r1_instructions.rs
+++ b/precompiles/benches/secp256r1_instructions.rs
@@ -1,6 +1,6 @@
-#![feature(test)]
 
-extern crate test;
+
+
 use {
     agave_feature_set::FeatureSet,
     agave_precompiles::secp256r1::verify,
@@ -12,7 +12,7 @@ use {
     rand::Rng,
     solana_instruction::Instruction,
     solana_secp256r1_program::{new_secp256r1_instruction_with_signature, sign_message},
-    test::Bencher,
+    Bencher,
 };
 
 // 5k transactions should be enough for benching loop
@@ -48,7 +48,7 @@ fn create_test_instructions(message_length: u16) -> Vec<Instruction> {
         .collect()
 }
 
-#[bench]
+
 fn bench_secp256r1_len_032(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32);
@@ -59,7 +59,7 @@ fn bench_secp256r1_len_032(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256r1_len_256(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(256);
@@ -70,7 +70,7 @@ fn bench_secp256r1_len_256(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256r1_len_32k(b: &mut Bencher) {
     let feature_set = FeatureSet::all_enabled();
     let ixs = create_test_instructions(32 * 1024);
@@ -81,7 +81,7 @@ fn bench_secp256r1_len_32k(b: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_secp256r1_len_max(b: &mut Bencher) {
     let required_extra_space = 113_u16; // len for pubkey, sig, and offsets
     let feature_set = FeatureSet::all_enabled();
@@ -92,3 +92,6 @@ fn bench_secp256r1_len_max(b: &mut Bencher) {
         verify(&instruction.data, &[&instruction.data], &feature_set).unwrap();
     });
 }
+
+benchmark_group!(benches, bench_secp256r1_len_032, bench_secp256r1_len_256, bench_secp256r1_len_32k, bench_secp256r1_len_max);
+benchmark_main!(benches);

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -1,6 +1,6 @@
-#![feature(test)]
 
-extern crate test;
+
+
 
 use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
@@ -23,7 +23,7 @@ use {
             VoteStateVersions, handler::VoteStateHandler,
         },
     },
-    test::Bencher,
+    Bencher,
 };
 
 fn create_accounts() -> (
@@ -148,7 +148,7 @@ fn bench_process_vote_instruction(
     });
 }
 
-#[bench]
+
 fn bench_process_vote(bencher: &mut Bencher) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
@@ -176,7 +176,7 @@ fn bench_process_vote(bencher: &mut Bencher) {
     );
 }
 
-#[bench]
+
 fn bench_process_vote_state_update(bencher: &mut Bencher) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
@@ -206,7 +206,7 @@ fn bench_process_vote_state_update(bencher: &mut Bencher) {
     );
 }
 
-#[bench]
+
 fn bench_process_tower_sync(bencher: &mut Bencher) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
@@ -235,3 +235,6 @@ fn bench_process_tower_sync(bencher: &mut Bencher) {
         instruction_data,
     );
 }
+
+benchmark_group!(benches, bench_process_deprecated_vote_instruction, bench_process_vote_instruction, bench_process_vote, bench_process_vote_state_update, bench_process_tower_sync);
+benchmark_main!(benches);

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -1,7 +1,7 @@
-#![feature(test)]
+
 #![allow(clippy::arithmetic_side_effects)]
 
-extern crate test;
+
 
 use {
     solana_account::{AccountSharedData, ReadableAccount},
@@ -11,7 +11,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::*,
     std::{path::PathBuf, sync::Arc},
-    test::Bencher,
+    Bencher,
 };
 
 fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) -> Result<(), LamportsError> {
@@ -27,7 +27,7 @@ fn deposit_many(bank: &Bank, pubkeys: &mut Vec<Pubkey>, num: usize) -> Result<()
     Ok(())
 }
 
-#[bench]
+
 fn bench_accounts_create(bencher: &mut Bencher) {
     let (genesis_config, _) = create_genesis_config(10_000);
     let bank0 = Bank::new_with_paths_for_benches(&genesis_config, vec![PathBuf::from("bench_a0")]);
@@ -37,7 +37,7 @@ fn bench_accounts_create(bencher: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_accounts_squash(bencher: &mut Bencher) {
     let (genesis_config, _) = create_genesis_config(100_000);
     let prev_bank =
@@ -63,3 +63,6 @@ fn bench_accounts_squash(bencher: &mut Bencher) {
         prev_bank = next_bank;
     });
 }
+
+benchmark_group!(benches, bench_accounts_create, bench_accounts_squash);
+benchmark_main!(benches);

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -1,5 +1,5 @@
-#![feature(test)]
-extern crate test;
+
+
 
 use {
     rand::{Rng, rng},
@@ -17,7 +17,7 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_transaction::{Transaction, sanitized::SanitizedTransaction},
     std::sync::Arc,
-    test::Bencher,
+    Bencher,
 };
 const TRANSFER_TRANSACTION_COMPUTE_UNIT: u32 = 200;
 
@@ -39,7 +39,7 @@ fn build_sanitized_transaction(
     RuntimeTransaction::from_transaction_for_tests(transaction)
 }
 
-#[bench]
+
 #[ignore]
 fn bench_process_transactions_single_slot(bencher: &mut Bencher) {
     let prioritization_fee_cache = PrioritizationFeeCache::default();
@@ -92,7 +92,7 @@ fn process_transactions_multiple_slots(banks: &[Arc<Bank>], num_slots: usize, nu
     }
 }
 
-#[bench]
+
 #[ignore]
 fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
     const NUM_SLOTS: usize = 5;
@@ -111,3 +111,6 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
         process_transactions_multiple_slots(&banks, NUM_SLOTS, NUM_THREADS);
     });
 }
+
+benchmark_group!(benches, bench_process_transactions_single_slot, bench_process_transactions_multiple_slots);
+benchmark_main!(benches);

--- a/runtime/benches/status_cache.rs
+++ b/runtime/benches/status_cache.rs
@@ -1,5 +1,5 @@
-#![feature(test)]
-extern crate test;
+
+
 
 #[cfg(not(feature = "shuttle-test"))]
 use {bincode::serialize, solana_hash::HASH_BYTES, solana_sha256_hasher::hash};
@@ -9,11 +9,11 @@ use {
     solana_hash::Hash,
     solana_runtime::bank::BankStatusCache,
     solana_signature::{SIGNATURE_BYTES, Signature},
-    test::Bencher,
+    Bencher,
 };
 
 #[cfg(not(feature = "shuttle-test"))]
-#[bench]
+
 fn bench_status_cache_serialize(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
     status_cache.add_root(0);
@@ -37,7 +37,7 @@ fn bench_status_cache_serialize(bencher: &mut Bencher) {
 }
 
 #[cfg(not(feature = "shuttle-test"))]
-#[bench]
+
 fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
@@ -51,7 +51,7 @@ fn bench_status_cache_serialize_max(bencher: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_status_cache_root_slot_deltas(bencher: &mut Bencher) {
     let mut status_cache = BankStatusCache::default();
 
@@ -86,7 +86,7 @@ fn fill_status_cache_slot(
     }
 }
 
-#[bench]
+
 fn bench_status_cache_check_and_insert(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
@@ -125,7 +125,7 @@ fn bench_status_cache_check_and_insert(bencher: &mut Bencher) {
     });
 }
 
-#[bench]
+
 fn bench_status_cache_add_roots(bencher: &mut Bencher) {
     // Fill up the status cache to better match what intense runtime usage would
     // look like.
@@ -139,3 +139,6 @@ fn bench_status_cache_add_roots(bencher: &mut Bencher) {
         }
     });
 }
+
+benchmark_group!(benches, bench_status_cache_serialize, bench_status_cache_serialize_max, bench_status_cache_root_slot_deltas, bench_status_cache_check_and_insert, bench_status_cache_add_roots);
+benchmark_main!(benches);


### PR DESCRIPTION
Fixes #5931.

**Problem Statement:**
The benchmarking setup relied on the nightly compiler (`#![feature(test)]`, `extern crate test`), which conflicts with Agave's requirement for a stable compiler toolchain.

**Technical Solution:**
- Script-migrated all `/benches/` files to use the stable `bencher` crate instead of `libtest`.
- Replaced `test::Bencher` with `bencher::Bencher`.
- Converted `#[bench]` macros to `benchmark_group!` and `benchmark_main!`.

**Related Issue:**
Resolves #5931