### PR TITLE
fix: generate docs correctly on docs.rs (part 3)

### DIFF
--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["lib"]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["lib"]

--- a/svm-callback/Cargo.toml
+++ b/svm-callback/Cargo.toml
@@ -9,6 +9,11 @@ license = { workspace = true }
 edition = { workspace = true }
 readme = false
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [features]
 agave-unstable-api = []
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["lib"]

--- a/transaction-context/src/lib.rs
+++ b/transaction-context/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "agave-unstable-api")]
 //! Data shared between program runtime and built-in programs as well as SBF programs.
 #![deny(clippy::indexing_slicing)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod instruction;
 pub mod instruction_accounts;


### PR DESCRIPTION
#### Problem

(part of #13137)

our crate doesn't generate documentation properly on docs.rs

#### Summary of Changes

- enable all-features in docs
- replace deprecated field