### PR TITLE
fix: generate docs correctly on docs.rs (part 5)

### DIFF
--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -11,6 +11,8 @@ edition = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 crate-type = ["lib"]

--- a/fee/Cargo.toml
+++ b/fee/Cargo.toml
@@ -9,6 +9,11 @@ homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
 [features]
 agave-unstable-api = []
 


### PR DESCRIPTION
#### Problem

(part of #13137)

our crate doesn't generate documentation properly on docs.rs

#### Summary of Changes

- enable all-features in docs
