### PR TITLE
vote history: store votes for refresh as VotePayloadToSign

### DIFF
--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -106,13 +106,15 @@ mod tests {
         crate::block_creation_loop::rewards::certs_builder::entry::tests::{
             get_rank_map_keypairs, new_vote, validate_bitmap,
         },
-        agave_votor_messages::{consensus_message::VoteMessage, vote::Vote},
+        agave_votor_messages::{
+            consensus_message::VoteMessage, vote::Vote, wire::get_vote_payload_to_sign,
+        },
         rand::Rng,
         solana_bls_signatures::Keypair as BlsKeypair,
     };
 
     fn new_invalid_vote(vote: Vote, rank: usize) -> VoteMessage {
-        let serialized = wincode::serialize(&vote).unwrap();
+        let serialized = get_vote_payload_to_sign(vote, 0);
         let keypair = BlsKeypair::new();
         let signature = keypair.sign(&serialized).into();
         VoteMessage {

--- a/votor-messages/src/consensus_message.rs
+++ b/votor-messages/src/consensus_message.rs
@@ -52,19 +52,18 @@ pub struct Block {
 }
 
 /// A consensus vote.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct VoteMessage {
     /// The type of the vote.
     pub vote: Vote,
     /// The signature.
-    #[wincode(with = "PodBLSSignature")]
     pub signature: BLSSignature,
     /// The rank of the validator.
     pub rank: u16,
 }
 
 /// A consensus message sent between validators.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(clippy::large_enum_variant)]
 pub enum ConsensusMessage {
     /// A vote from a single party.

--- a/votor-messages/src/vote.rs
+++ b/votor-messages/src/vote.rs
@@ -1,22 +1,9 @@
 //! Vote data types for use by clients
-use {
-    crate::consensus_message::Block,
-    serde::{Deserialize, Serialize},
-    solana_clock::Slot,
-    solana_hash::Hash,
-    wincode::{SchemaRead, SchemaWrite},
-};
+use {crate::consensus_message::Block, solana_clock::Slot, solana_hash::Hash};
 
 /// Enum that clients can use to parse and create the vote
 /// structures expected by the program
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor),
-    frozen_abi(digest = "Fd13KXQMkc1mCJEoHwyXWkcewqBCdRcAiMhS7Aqe4sm1")
-)]
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Vote {
     /// A notarization vote
     Notarize(NotarizationVote),
@@ -182,48 +169,14 @@ impl From<GenesisVote> for Vote {
 }
 
 /// A notarization vote
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "F9veHPmSwMyrYNSVuBLcvLGYSLgc7voTD3kUhxUHUTRU")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct NotarizationVote {
     /// The block this vote is cast for
     pub block: Block,
 }
 
 /// A finalization vote
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "2XQ5N6YLJjF28w7cMFFUQ9SDgKuf9JpJNtAiXSPA8vR2")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct FinalizationVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
@@ -232,96 +185,28 @@ pub struct FinalizationVote {
 /// A skip vote
 /// Represents a range of slots to skip
 /// inclusive on both ends
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "G8Nrx3sMYdnLpHsCNark3BGA58BmW2sqNnqjkYhQHtN")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct SkipVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
 }
 
 /// A notarization fallback vote
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "6UW4zutbRvyri4z8WAyKx8aUZkJrZX4XoiqC4XMUnUZk")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct NotarizationFallbackVote {
     /// The block this vote is cast for
     pub block: Block,
 }
 
 /// A skip fallback vote
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "WsUNum8V62gjRU1yAnPuBMAQui4YvMwD1RwrzHeYkeF")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct SkipFallbackVote {
     /// The slot this vote is cast for.
     pub slot: Slot,
 }
 
 /// A genesis vote. Only used during the migration from TowerBFT
-#[cfg_attr(
-    feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "8ty2gETfpyVGPNMYrEFS1YXeDRprfZaisSAmJwoAYusb")
-)]
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    Default,
-    Serialize,
-    Deserialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
 pub struct GenesisVote {
     /// The block this vote is cast for
     pub block: Block,

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -441,6 +441,22 @@ impl VotePayloadToSign {
     }
 }
 
+impl From<VotePayloadToSign> for Vote {
+    /// Converts a `VotePayloadToSign` back into a `Vote`, dropping the shred version.
+    fn from(vote_payload: VotePayloadToSign) -> Self {
+        match vote_payload {
+            VotePayloadToSign::Notar { block, .. } => Self::new_notarization_vote(block),
+            VotePayloadToSign::Finalize { slot, .. } => Self::new_finalization_vote(slot),
+            VotePayloadToSign::Skip { slot, .. } => Self::new_skip_vote(slot),
+            VotePayloadToSign::NotarFallback { block, .. } => {
+                Self::new_notarization_fallback_vote(block)
+            }
+            VotePayloadToSign::SkipFallback { slot, .. } => Self::new_skip_fallback_vote(slot),
+            VotePayloadToSign::Genesis { block, .. } => Self::new_genesis_vote(block),
+        }
+    }
+}
+
 /// Returns the appropriate vote payload to sign.
 pub fn get_vote_payload_to_sign(vote: Vote, shred_version: u16) -> Vec<u8> {
     let vote_to_sign = VotePayloadToSign::new_from_vote(vote, shred_version);

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -2,8 +2,7 @@ use {
     super::vote_history_storage::{
         Result, SavedVoteHistory, SavedVoteHistoryVersions, VoteHistoryStorage,
     },
-    agave_votor_messages::{consensus_message::Block, vote::Vote},
-    serde::{Deserialize, Serialize},
+    agave_votor_messages::{consensus_message::Block, vote::Vote, wire::VotePayloadToSign},
     solana_clock::Slot,
     solana_hash::Hash,
     solana_keypair::Keypair,
@@ -13,7 +12,11 @@ use {
     wincode::{SchemaRead, SchemaWrite},
 };
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+// Dummy shred version used for persisted votes - will be re-signed with the
+// correct shred version when performing the refresh
+const VOTE_HISTORY_SHRED_VERSION: u16 = 0;
+
+#[derive(Debug, SchemaRead, SchemaWrite, PartialEq, Clone)]
 pub enum VoteHistoryVersions {
     Current(VoteHistory),
 }
@@ -31,10 +34,13 @@ impl VoteHistoryVersions {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "BdNXvHhpPUTEba3DfDCLqirLoLXAmja2jyhroicM63bT")
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "MYpTecggZfULsn6SC1bojefNFK1R5kjBZg7wE8H8dHF",
+        abi_serializer = "wincode"
+    )
 )]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Default, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Default, SchemaWrite, SchemaRead)]
 pub struct VoteHistory {
     /// The validator identity that cast votes
     pub node_pubkey: Pubkey,
@@ -64,7 +70,7 @@ pub struct VoteHistory {
     its_over: HashSet<Slot>,
 
     /// All votes cast for a `slot`, for use in refresh
-    votes_cast: HashMap<Slot, Vec<Vote>>,
+    votes_cast: HashMap<Slot, Vec<VotePayloadToSign>>,
 
     /// Blocks which have a notarization certificate via the certificate pool
     notarized_blocks: HashSet<Block>,
@@ -131,7 +137,8 @@ impl VoteHistory {
             .iter()
             .filter(|&(&s, _)| s > slot)
             .flat_map(|(_, votes)| votes.iter())
-            .cloned()
+            .copied()
+            .map(Vote::from)
             .collect()
     }
 
@@ -203,7 +210,13 @@ impl VoteHistory {
                 // votor, we do not need to insert anything here.
             }
         }
-        self.votes_cast.entry(vote.slot()).or_default().push(vote);
+        self.votes_cast
+            .entry(vote.slot())
+            .or_default()
+            .push(VotePayloadToSign::new_from_vote(
+                vote,
+                VOTE_HISTORY_SHRED_VERSION,
+            ));
     }
 
     /// Add a new notarized block


### PR DESCRIPTION
#### Problem
We store the recently casted votes in vote history in case we ever need to refresh our votes during standstill.

These are stored as the internal type `Vote` which should not be part of frozen-abi


#### Summary of Changes
Instead store the `VotePayloadToSign` and remove `Vote` / `VoteMessage` / `ConsensusMessage` from frozen-abi

Fixes #13330 
