### PR TITLE
Fix verify_ref_counts with obsolete accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1791,6 +1791,17 @@ impl AccountsDb {
     // Only remove those accounts where the entire rooted history of the account
     // can be purged because there are no live append vecs in the ancestors
     pub fn clean_accounts(&self, max_clean_root_inclusive: Option<Slot>, is_startup: bool) {
+        if self.exhaustively_verify_refcounts {
+            //at startup use all cores to verify refcounts
+            if is_startup {
+                self.exhaustively_verify_refcounts(max_clean_root_inclusive);
+            } else {
+                // otherwise, use the background thread pool
+                self.thread_pool_background
+                    .install(|| self.exhaustively_verify_refcounts(max_clean_root_inclusive));
+            }
+        }
+
         let _guard = self.active_stats.activate(ActiveStatItem::Clean);
 
         let purges_old_accounts_count = AtomicU64::default();
@@ -6547,13 +6558,6 @@ impl AccountsDb {
         timings.report(self.accounts_index.get_startup_stats());
 
         self.accounts_index.log_secondary_indexes();
-
-        // Debug-only check: verify the freshly generated index has correct refcounts against every
-        // storage. Runs exactly once per boot, here, where the index is complete and no background
-        // flush is mutating storages. `None` means "verify all storages" (no slot bound).
-        if self.exhaustively_verify_refcounts {
-            self.exhaustively_verify_refcounts(None);
-        }
 
         // Now that the index is generated, get the total length and capacity of the in-mem maps
         // across all the bins and set the initial value for the stat.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1688,9 +1688,20 @@ impl AccountsDb {
             || Box::new(append_vec::new_scan_accounts_reader()),
             |reader, storage| {
                 let slot = storage.slot();
+                // Obsolete accounts are skipped during index generation, so they do not
+                // contribute to the index refcount. Skip them here too, otherwise we would count
+                // a physical copy the index never tracked and report a spurious mismatch.
+                let obsolete_accounts: IntSet<_> = storage
+                    .obsolete_accounts_read_lock()
+                    .filter_obsolete_accounts(None)
+                    .map(|(offset, _)| offset)
+                    .collect();
                 storage
                     .accounts
-                    .scan_accounts(reader.as_mut(), |_offset, account| {
+                    .scan_accounts(reader.as_mut(), |offset, account| {
+                        if obsolete_accounts.contains(&offset) {
+                            return;
+                        }
                         let pk = account.pubkey();
                         match pubkey_refcount.entry(*pk) {
                             dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
@@ -1780,17 +1791,6 @@ impl AccountsDb {
     // Only remove those accounts where the entire rooted history of the account
     // can be purged because there are no live append vecs in the ancestors
     pub fn clean_accounts(&self, max_clean_root_inclusive: Option<Slot>, is_startup: bool) {
-        if self.exhaustively_verify_refcounts {
-            //at startup use all cores to verify refcounts
-            if is_startup {
-                self.exhaustively_verify_refcounts(max_clean_root_inclusive);
-            } else {
-                // otherwise, use the background thread pool
-                self.thread_pool_background
-                    .install(|| self.exhaustively_verify_refcounts(max_clean_root_inclusive));
-            }
-        }
-
         let _guard = self.active_stats.activate(ActiveStatItem::Clean);
 
         let purges_old_accounts_count = AtomicU64::default();
@@ -6547,6 +6547,13 @@ impl AccountsDb {
         timings.report(self.accounts_index.get_startup_stats());
 
         self.accounts_index.log_secondary_indexes();
+
+        // Debug-only check: verify the freshly generated index has correct refcounts against every
+        // storage. Runs exactly once per boot, here, where the index is complete and no background
+        // flush is mutating storages. `None` means "verify all storages" (no slot bound).
+        if self.exhaustively_verify_refcounts {
+            self.exhaustively_verify_refcounts(None);
+        }
 
         // Now that the index is generated, get the total length and capacity of the in-mem maps
         // across all the bins and set the initial value for the stat.


### PR DESCRIPTION
#### Problem
Verify ref counts does not take into account obsolete accounts. This leads to tons of spam in the log (but no errors, as it only errors on the Greater branch

#### Summary of Changes
- Collect obsolete accounts for each storage
- ignore obsolete offsets for ref count purposes

#### Testing
- Started a validator with, forced ref count verify and passed in None for max_clean_root_inclusive 
- verified that "exhaustively_verify_refcounts: {} refcount too small: {}, should be: {}, {:?}, {:?}", was no longer seen


Fixes #
