### PR TITLE
accounts-db: Consolidates metrics for flush

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -912,9 +912,6 @@ pub struct AccountsDb {
     /// Stats from storing accounts for shrink
     store_accounts_for_shrink_stats: StoreAccountsForShrinkStats,
 
-    /// Stats from storing accounts for flush
-    store_accounts_for_flush_stats: StoreAccountsForFlushStats,
-
     clean_accounts_stats: CleanAccountsStats,
 
     // Stats for purges called outside of clean_accounts()
@@ -1140,7 +1137,6 @@ impl AccountsDb {
             load_account_stats: LoadAccountsStats::default(),
             store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats::default(),
             store_accounts_for_shrink_stats: StoreAccountsForShrinkStats::default(),
-            store_accounts_for_flush_stats: StoreAccountsForFlushStats::default(),
             #[cfg(test)]
             load_delay: u64::default(),
             #[cfg(test)]
@@ -4479,19 +4475,28 @@ impl AccountsDb {
                 flush_stats.store_accounts_total_us.0,
                 i64
             ),
+            ("write_accounts_us", flush_stats.write_accounts_us.0, i64),
+            ("update_index_us", flush_stats.update_index_us.0, i64),
+            ("handle_reclaims_us", flush_stats.handle_reclaims_us.0, i64),
             (
-                "update_index_us",
-                flush_stats.store_accounts_timing.update_index_elapsed,
+                "mark_zero_lamport_single_ref_accounts_us",
+                flush_stats.mark_zero_lamport_single_ref_accounts_us.0,
                 i64
             ),
             (
-                "store_accounts_elapsed_us",
-                flush_stats.store_accounts_timing.store_accounts_elapsed,
+                "num_zero_lamport_single_ref_accounts_marked",
+                flush_stats.num_zero_lamport_single_ref_accounts_marked.0,
+                i64
+            ),
+            ("num_reclaims", flush_stats.num_reclaims.0, i64),
+            (
+                "num_obsolete_slots_removed",
+                flush_stats.num_obsolete_slots_removed.0,
                 i64
             ),
             (
-                "handle_reclaims_elapsed_us",
-                flush_stats.store_accounts_timing.handle_reclaims_elapsed,
+                "num_obsolete_bytes_removed",
+                flush_stats.num_obsolete_bytes_removed.0,
                 i64
             ),
             ("select_pubkeys_us", flush_stats.select_pubkeys_us.0, i64),
@@ -4678,15 +4683,15 @@ impl AccountsDb {
                 self.create_store(slot, flush_stats.num_bytes_flushed.0, "flush_slot_cache");
             self.storage.insert(Arc::clone(&flushed_store));
 
-            let (store_accounts_timing_inner, store_accounts_total_inner_us) =
+            let (store_accounts_for_flush_stats, store_accounts_for_flush_us) =
                 measure_us!(self.store_accounts_for_flush(
                     (slot, &accounts[..]),
                     &flushed_store,
                     reclaim_method,
                     UpdateIndexThreadSelection::PoolWithThreshold,
                 ));
-            flush_stats.store_accounts_timing = store_accounts_timing_inner;
-            flush_stats.store_accounts_total_us = Saturating(store_accounts_total_inner_us);
+            flush_stats.accumulate_store_accounts_for_flush(store_accounts_for_flush_stats);
+            flush_stats.store_accounts_total_us += Saturating(store_accounts_for_flush_us);
 
             // If the above sizing function is correct, just one AppendVec is enough to hold
             // all the data for the slot
@@ -5643,10 +5648,8 @@ impl AccountsDb {
         storage: &AccountStorageEntry,
         reclaim_handling: UpsertReclaim,
         update_index_thread_selection: UpdateIndexThreadSelection,
-    ) -> StoreAccountsTiming {
+    ) -> StoreAccountsForFlushStats {
         let slot = accounts.target_slot();
-        let num_accounts_stored = accounts.len();
-        let stats = &self.store_accounts_for_flush_stats;
 
         debug_assert!(self.accounts_index.is_alive_root(slot));
 
@@ -5676,8 +5679,11 @@ impl AccountsDb {
         // should skip handle_reclaims only when reclaims is empty. No need to
         // check the elements of reclaims are empty.
         let handle_reclaims_time = Measure::start("handle_reclaims");
+        let mut num_reclaims = 0;
+        let mut num_obsolete_slots_removed = 0;
+        let mut num_obsolete_bytes_removed = 0;
         if !reclaims.is_empty() {
-            let reclaims_len = reclaims.iter().map(|r| r.len()).sum::<usize>();
+            num_reclaims = reclaims.iter().map(|r| r.len() as u64).sum();
             let purge_stats = PurgeStats::default();
             self.handle_reclaims(
                 reclaims.iter().flatten(),
@@ -5686,47 +5692,23 @@ impl AccountsDb {
                 &purge_stats,
                 MarkAccountsObsolete::Yes(slot),
             );
-            stats.num_obsolete_slots_removed.fetch_add(
-                purge_stats.num_stored_slots_removed.load(Ordering::Relaxed),
-                Ordering::Relaxed,
-            );
-            stats.num_obsolete_bytes_removed.fetch_add(
-                purge_stats
-                    .total_removed_stored_bytes
-                    .load(Ordering::Relaxed),
-                Ordering::Relaxed,
-            );
-            stats
-                .num_reclaims
-                .fetch_add(reclaims_len as u64, Ordering::Relaxed);
+            num_obsolete_slots_removed =
+                purge_stats.num_stored_slots_removed.load(Ordering::Relaxed) as u64;
+            num_obsolete_bytes_removed = purge_stats
+                .total_removed_stored_bytes
+                .load(Ordering::Relaxed);
         }
         let handle_reclaims_us = handle_reclaims_time.end_as_us();
 
-        stats
-            .write_to_storage_us
-            .fetch_add(write_accounts_us, Ordering::Relaxed);
-        stats
-            .update_index_us
-            .fetch_add(update_index_us, Ordering::Relaxed);
-        stats
-            .mark_zero_lamport_single_ref_accounts_us
-            .fetch_add(mark_zero_lamport_us, Ordering::Relaxed);
-        stats
-            .handle_reclaims_us
-            .fetch_add(handle_reclaims_us, Ordering::Relaxed);
-        stats
-            .num_accounts_stored
-            .fetch_add(num_accounts_stored as u64, Ordering::Relaxed);
-        stats.num_zero_lamport_single_ref_accounts_marked.fetch_add(
+        StoreAccountsForFlushStats {
+            write_accounts_us,
+            update_index_us,
+            handle_reclaims_us,
+            mark_zero_lamport_single_ref_accounts_us: mark_zero_lamport_us,
             num_zero_lamport_single_ref_accounts_marked,
-            Ordering::Relaxed,
-        );
-        stats.report();
-
-        StoreAccountsTiming {
-            store_accounts_elapsed: write_accounts_us,
-            update_index_elapsed: update_index_us,
-            handle_reclaims_elapsed: handle_reclaims_us,
+            num_reclaims,
+            num_obsolete_slots_removed,
+            num_obsolete_bytes_removed,
         }
     }
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -163,78 +163,14 @@ impl StoreAccountsForShrinkStats {
 /// Stats from storing accounts for flush (i.e. flushing the write cache to a storage file)
 #[derive(Debug, Default)]
 pub struct StoreAccountsForFlushStats {
-    pub last_report: AtomicInterval,
-    pub write_to_storage_us: AtomicU64,
-    pub update_index_us: AtomicU64,
-    pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
-    pub handle_reclaims_us: AtomicU64,
-    pub num_accounts_stored: AtomicU64,
-    pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
-    pub num_reclaims: AtomicU64,
-    pub num_obsolete_slots_removed: AtomicUsize,
-    pub num_obsolete_bytes_removed: AtomicU64,
-}
-
-impl StoreAccountsForFlushStats {
-    const REPORT_INTERVAL_MS: u64 = Duration::from_secs(1).as_millis() as u64;
-
-    pub fn report(&self) {
-        let should_report = self.last_report.should_update(Self::REPORT_INTERVAL_MS);
-        if !should_report {
-            return;
-        }
-
-        datapoint_info!(
-            "accounts_db_store_accounts_for_flush",
-            (
-                "write_to_storage_us",
-                self.write_to_storage_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "update_index_us",
-                self.update_index_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "mark_zero_lamport_single_ref_accounts_us",
-                self.mark_zero_lamport_single_ref_accounts_us
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "handle_reclaims_us",
-                self.handle_reclaims_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_accounts_stored",
-                self.num_accounts_stored.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_zero_lamport_single_ref_accounts_marked",
-                self.num_zero_lamport_single_ref_accounts_marked
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_reclaims",
-                self.num_reclaims.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_obsolete_slots_removed",
-                self.num_obsolete_slots_removed.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_obsolete_bytes_removed",
-                self.num_obsolete_bytes_removed.swap(0, Ordering::Relaxed),
-                i64
-            ),
-        );
-    }
+    pub write_accounts_us: u64,
+    pub update_index_us: u64,
+    pub handle_reclaims_us: u64,
+    pub mark_zero_lamport_single_ref_accounts_us: u64,
+    pub num_zero_lamport_single_ref_accounts_marked: u64,
+    pub num_reclaims: u64,
+    pub num_obsolete_slots_removed: u64,
+    pub num_obsolete_bytes_removed: u64,
 }
 
 #[derive(Debug, Default)]
@@ -351,21 +287,54 @@ pub struct FlushStats {
     pub num_bytes_flushed: Saturating<u64>,
     pub num_accounts_purged: Saturating<usize>,
     pub num_bytes_purged: Saturating<u64>,
-    pub store_accounts_timing: StoreAccountsTiming,
     pub store_accounts_total_us: Saturating<u64>,
+    pub write_accounts_us: Saturating<u64>,
+    pub update_index_us: Saturating<u64>,
+    pub handle_reclaims_us: Saturating<u64>,
+    pub mark_zero_lamport_single_ref_accounts_us: Saturating<u64>,
+    pub num_zero_lamport_single_ref_accounts_marked: Saturating<u64>,
+    pub num_reclaims: Saturating<u64>,
+    pub num_obsolete_slots_removed: Saturating<u64>,
+    pub num_obsolete_bytes_removed: Saturating<u64>,
     pub select_pubkeys_us: Saturating<u64>,
     pub disk_index_write_through_us: Saturating<u64>,
 }
 
 impl FlushStats {
+    pub fn accumulate_store_accounts_for_flush(
+        &mut self,
+        store_accounts_stats: StoreAccountsForFlushStats,
+    ) {
+        self.write_accounts_us += Saturating(store_accounts_stats.write_accounts_us);
+        self.update_index_us += Saturating(store_accounts_stats.update_index_us);
+        self.handle_reclaims_us += Saturating(store_accounts_stats.handle_reclaims_us);
+        self.mark_zero_lamport_single_ref_accounts_us +=
+            Saturating(store_accounts_stats.mark_zero_lamport_single_ref_accounts_us);
+        self.num_zero_lamport_single_ref_accounts_marked +=
+            Saturating(store_accounts_stats.num_zero_lamport_single_ref_accounts_marked);
+        self.num_reclaims += Saturating(store_accounts_stats.num_reclaims);
+        self.num_obsolete_slots_removed +=
+            Saturating(store_accounts_stats.num_obsolete_slots_removed);
+        self.num_obsolete_bytes_removed +=
+            Saturating(store_accounts_stats.num_obsolete_bytes_removed);
+    }
+
     pub fn accumulate(&mut self, other: &Self) {
         self.num_accounts_flushed += other.num_accounts_flushed;
         self.num_bytes_flushed += other.num_bytes_flushed;
         self.num_accounts_purged += other.num_accounts_purged;
         self.num_bytes_purged += other.num_bytes_purged;
-        self.store_accounts_timing
-            .accumulate(&other.store_accounts_timing);
         self.store_accounts_total_us += other.store_accounts_total_us;
+        self.write_accounts_us += other.write_accounts_us;
+        self.update_index_us += other.update_index_us;
+        self.handle_reclaims_us += other.handle_reclaims_us;
+        self.mark_zero_lamport_single_ref_accounts_us +=
+            other.mark_zero_lamport_single_ref_accounts_us;
+        self.num_zero_lamport_single_ref_accounts_marked +=
+            other.num_zero_lamport_single_ref_accounts_marked;
+        self.num_reclaims += other.num_reclaims;
+        self.num_obsolete_slots_removed += other.num_obsolete_slots_removed;
+        self.num_obsolete_bytes_removed += other.num_obsolete_bytes_removed;
         self.select_pubkeys_us += other.select_pubkeys_us;
         self.disk_index_write_through_us += other.disk_index_write_through_us;
     }


### PR DESCRIPTION
#### Problem

There are two sets of metrics for flush. One is the top-level flush, and the other is incremental calls of store_accounts_for_flush(). One, this is confusing. Two, there's some overlap between the two. And three, the store_accounts_for_flush() stats need to use atomics to increment the stat counters.

For me, the main one is to have all the flush stats under one metric.


#### Summary of Changes

Change `store_accounts_for_flush()` to return a struct of stats that then get accumulated by the top-level flush, and reported there under the "accounts_db-flush_accounts_cache" datapoint.

Note that the store_accounts_for_flush() metric used to report once per second. Now, since they are in the top-level flush metric, it'll be per each `flush`. This ends up being around once a minute. So another benefit is less frequent metric pushes, especially since the old way pushed more often than flush actually ran.

Another note, I'd like to do this for shrink as well. That also helps since shrink and squash both update the same stats. Purposely not doing that here in this PR.


#### Testing

Ran on a dev box and compared with an edge canary and confirmed the stats look accurate.

<details><summary>Metrics Charts</summary>
<p>

There are two types of metrics affected by this PR. (1) where the metric moves from store_accounts_for_flush to top-level flush, and (2) where the metric was duplicated in both.

I ran this PR on 3XU and here are metrics showing the changeover.


First here's the time spent writing accounts to storage. This is an example of the metric moving from store_accounts_for_flush to top-level flush. In purple on the left is master, and on the right in blue is this PR.

<img width="927" height="448" alt="Screenshot 2026-06-25 at 8 42 36 AM" src="https://github.com/user-attachments/assets/827473fc-be05-4eec-8b15-eb21e2b17d94" />


Second is the time spent updating the index. This metric was duplicated in both. On the left in yellow shows the metric from store_accounts_for_flush, and the blue is the top-level flush version, which spans the whole time.

<img width="925" height="457" alt="Screenshot 2026-06-25 at 8 50 06 AM" src="https://github.com/user-attachments/assets/88c83b3e-11cd-445a-9459-513400b96357" />


</p>
</details> 