### PR TITLE
bcp: enforce that the genesis block marker is right after the header

### DIFF
--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -49,6 +49,8 @@ pub enum BlockComponentProcessorError {
     GenesisCertificateOnNonChild,
     #[error("GenesisCertificate was invalid and failed to verify")]
     GenesisCertificateFailedVerification,
+    #[error("GenesisCertificate marker must immediately follow the block header")]
+    GenesisCertificateOutOfOrder,
     #[error("FinalizationCertificate was invalid or failed to verify {0}")]
     InvalidFinalizationCertificate(#[from] BlockFinalizationCertError),
     #[error("Missing block footer")]
@@ -95,6 +97,7 @@ impl BlockComponentProcessorError {
             | BlockComponentProcessorError::HeaderParentSlotMismatch { .. }
             | BlockComponentProcessorError::NanosecondClockOutOfBounds
             | BlockComponentProcessorError::UnexpectedInitialUpdateParent
+            | BlockComponentProcessorError::GenesisCertificateOutOfOrder
             | BlockComponentProcessorError::AbandonedBank(_)
             | BlockComponentProcessorError::InvalidRewardCerts(_)
             | BlockComponentProcessorError::UpdateBankFooter(_)
@@ -116,6 +119,7 @@ impl BlockComponentProcessorError {
 pub struct BlockComponentProcessor {
     has_header: bool,
     has_footer: bool,
+    has_entry_batch: bool,
     update_parent: Option<VersionedUpdateParent>,
 }
 
@@ -152,6 +156,7 @@ impl BlockComponentProcessor {
         slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
         if !migration_status.should_allow_block_markers(slot) {
+            self.has_entry_batch = true;
             return Ok(());
         }
 
@@ -160,6 +165,7 @@ impl BlockComponentProcessor {
             return Err(BlockComponentProcessorError::MissingParentMarker);
         }
 
+        self.has_entry_batch = true;
         Ok(())
     }
 
@@ -235,6 +241,7 @@ impl BlockComponentProcessor {
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
+        self.validate_genesis_cert_block_marker_position()?;
         self.process_genesis_cert_block_marker(
             bank,
             genesis_block_marker,
@@ -252,6 +259,20 @@ impl BlockComponentProcessor {
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
         self.process_genesis_cert_block_marker(bank, genesis_block_marker, migration_status, None)
+    }
+
+    fn validate_genesis_cert_block_marker_position(
+        &self,
+    ) -> Result<(), BlockComponentProcessorError> {
+        if !self.has_header {
+            return Err(BlockComponentProcessorError::MissingParentMarker);
+        }
+
+        if self.has_entry_batch || self.has_footer || self.update_parent.is_some() {
+            return Err(BlockComponentProcessorError::GenesisCertificateOutOfOrder);
+        }
+
+        Ok(())
     }
 
     /// Performs verification if `shred_version` is specified
@@ -595,6 +616,7 @@ mod tests {
             genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
         },
         rand::Rng,
+        solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE,
         solana_clock::DEFAULT_MS_PER_SLOT,
         solana_entry::block_component::{
             BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
@@ -629,6 +651,15 @@ mod tests {
         )
     }
 
+    fn test_genesis_cert_marker() -> GenesisCertBlockMarker {
+        GenesisCertBlockMarker {
+            slot: 0,
+            block_id: Hash::default(),
+            bls_signature: solana_bls_signatures::Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }
+    }
+
     #[test]
     fn test_missing_header_error_on_entry_batch() {
         let migration_status = MigrationStatus::post_migration_status();
@@ -639,6 +670,117 @@ mod tests {
         assert!(matches!(
             result,
             Err(BlockComponentProcessorError::MissingParentMarker)
+        ));
+    }
+
+    #[test]
+    fn test_missing_header_error_on_genesis_certificate() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let mut processor = BlockComponentProcessor::default();
+        let marker =
+            VersionedBlockMarker::from_genesis_cert_block_marker(test_genesis_cert_marker());
+
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
+
+        let result = processor.on_marker(
+            bank,
+            parent,
+            shred_version,
+            marker,
+            false,
+            None,
+            &migration_status,
+        );
+        assert!(matches!(
+            result,
+            Err(BlockComponentProcessorError::MissingParentMarker)
+        ));
+    }
+
+    #[test]
+    fn test_genesis_certificate_after_entry_batch_errors() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let mut processor = BlockComponentProcessor::default();
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
+
+        let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+            parent_slot: 0,
+            parent_block_id: Hash::default(),
+        });
+        processor
+            .on_marker(
+                bank.clone(),
+                parent.clone(),
+                shred_version,
+                header,
+                false,
+                None,
+                &migration_status,
+            )
+            .unwrap();
+        processor
+            .on_entry_batch(&migration_status, bank.slot())
+            .unwrap();
+
+        let marker =
+            VersionedBlockMarker::from_genesis_cert_block_marker(test_genesis_cert_marker());
+        let result = processor.on_marker(
+            bank,
+            parent,
+            shred_version,
+            marker,
+            false,
+            None,
+            &migration_status,
+        );
+        assert!(matches!(
+            result,
+            Err(BlockComponentProcessorError::GenesisCertificateOutOfOrder)
+        ));
+    }
+
+    #[test]
+    fn test_genesis_certificate_immediately_after_header_passes_order_check() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let mut processor = BlockComponentProcessor::default();
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let shred_version = rand::rng().random();
+
+        let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+            parent_slot: 0,
+            parent_block_id: Hash::default(),
+        });
+        processor
+            .on_marker(
+                bank.clone(),
+                parent.clone(),
+                shred_version,
+                header,
+                false,
+                None,
+                &migration_status,
+            )
+            .unwrap();
+
+        let marker =
+            VersionedBlockMarker::from_genesis_cert_block_marker(test_genesis_cert_marker());
+        let result = processor.on_marker(
+            bank,
+            parent,
+            shred_version,
+            marker,
+            false,
+            None,
+            &migration_status,
+        );
+        assert!(matches!(
+            result,
+            Err(BlockComponentProcessorError::GenesisCertificateInAlpenglowCluster)
         ));
     }
 


### PR DESCRIPTION
#### Problem
We are susceptible to a race condition on the first alpenglow block:
- Header
- Tower BFT vote
- Genesis block marker

The TowerBFT vote is processed asynchronously via the US.
Depending on the ordering and whether we've processed the genesis block marker, it will either be rejected or succeed here:
https://github.com/anza-xyz/agave/blob/2aef3c18b3932cb55325a0c2ac80ae325ff9d7dc/runtime/src/bank.rs#L3992

You can replace TowerBFT vote with something that reads the genesis certificate account for the same sort of attack.

#### Summary of Changes
Enforce that the Genesis block marker if present must immediately follow the header so it is processed before any entry batches

#### Testing
Unit tests