### PR TITLE
core: drop invalid transactions early

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -314,7 +314,6 @@ impl TransactionViewReceiveAndBuffer {
                         .precheck_transaction_age(
                             transaction,
                             working_bank.max_processing_age(),
-                            true,
                             &mut error_counters,
                         )
                         .map(|details| details.nonce_address())
@@ -351,7 +350,7 @@ impl TransactionViewReceiveAndBuffer {
                             // If at capacity, run checks and remove invalid transactions.
                             if transaction_priority_ids.len() == EXTRA_CAPACITY {
                                 check_and_push_blockhash_batch_to_queue(
-                                    &working_bank,
+                                    working_bank,
                                     container,
                                     &mut transaction_priority_ids,
                                     &lock_results,
@@ -374,7 +373,7 @@ impl TransactionViewReceiveAndBuffer {
 
         // Any remaining packets undergo status/age checks
         check_and_push_blockhash_batch_to_queue(
-            &working_bank,
+            working_bank,
             container,
             &mut transaction_priority_ids,
             &lock_results,

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -357,14 +357,14 @@ impl TransactionViewReceiveAndBuffer {
                         .expect("transaction must exist")
                         .priority();
 
-                    let tx = container
+                    let transaction = container
                         .get_transaction(transaction_id)
                         .expect("transaction must exist");
 
                     // Pre-check this is a potentially valid transaction
                     match working_bank
                         .precheck_transaction_age(
-                            tx,
+                            transaction,
                             working_bank.max_processing_age(),
                             true,
                             &mut error_counters,
@@ -374,8 +374,25 @@ impl TransactionViewReceiveAndBuffer {
                         // Valid nonce transaction. Add to priority queue immediately.
                         // It is fine to skip StatusCache because "invalid nonce transactions"
                         // is a superset of "recently executed transactions".
-                        Ok(Some(nonce_address)) => {
-                            todo!()
+                        Ok(Some(_nonce_address)) => {
+                            match Consumer::check_fee_payer_unlocked(
+                                working_bank,
+                                transaction,
+                                &mut error_counters,
+                            ) {
+                                Ok(_) => {
+                                    // HANA perhaps a new stat for nonce-immediate? perhaps buffered *and* a new stat?
+                                    receiving_stats.num_buffered += 1;
+                                    receiving_stats.num_dropped_on_capacity += container
+                                        .push_ids_into_queue(std::iter::once(
+                                            TransactionPriorityId::new(priority, transaction_id),
+                                        ));
+                                }
+                                Err(_) => {
+                                    receiving_stats.num_dropped_on_fee_payer += 1;
+                                    container.remove_by_id(transaction_id);
+                                }
+                            }
                         }
 
                         // Potentially valid blockhash transaction. Put in our local batch.

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -38,7 +38,7 @@ use {
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     solana_svm_transaction::svm_message::SVMMessage,
     solana_transaction::sanitized::MessageHash,
-    solana_transaction_error::TransactionError,
+    solana_transaction_error::{TransactionError, TransactionResult},
     std::{collections::HashSet, sync::Arc, time::Instant},
 };
 
@@ -46,6 +46,7 @@ use {
 pub(crate) struct DisconnectedError;
 
 /// Stats/metrics returned by `receive_and_buffer_packets`.
+#[derive(Debug, Default)]
 pub(crate) struct ReceivingStats {
     pub num_received: usize,
     /// Count of packets that passed sigverify but were dropped
@@ -68,7 +69,48 @@ pub(crate) struct ReceivingStats {
     pub buffer_time_us: u64,
 }
 
+trait RecordReceiveError {
+    fn record(&self, receiving_stats: &mut ReceivingStats);
+}
+
+impl RecordReceiveError for PacketHandlingError {
+    fn record(&self, receiving_stats: &mut ReceivingStats) {
+        match self {
+            PacketHandlingError::Sanitization | PacketHandlingError::ALTResolution => {
+                receiving_stats.num_dropped_on_parsing_and_sanitization += 1;
+            }
+            PacketHandlingError::LockValidation => {
+                receiving_stats.num_dropped_on_lock_validation += 1;
+            }
+            PacketHandlingError::ComputeBudget => {
+                receiving_stats.num_dropped_on_compute_budget += 1;
+            }
+            PacketHandlingError::FilterKey => {
+                receiving_stats.num_dropped_on_filter_key += 1;
+            }
+        }
+    }
+}
+
+impl RecordReceiveError for TransactionError {
+    fn record(&self, receiving_stats: &mut ReceivingStats) {
+        match self {
+            TransactionError::BlockhashNotFound => {
+                receiving_stats.num_dropped_on_age += 1;
+            }
+            TransactionError::AlreadyProcessed => {
+                receiving_stats.num_dropped_on_already_processed += 1;
+            }
+            _ => {}
+        }
+    }
+}
+
 impl ReceivingStats {
+    fn record<E: RecordReceiveError>(&mut self, err: &E) {
+        err.record(self);
+    }
+
     fn accumulate(&mut self, other: ReceivingStats) {
         self.num_received += other.num_received;
         self.num_dropped_without_parsing += other.num_dropped_without_parsing;
@@ -253,83 +295,31 @@ impl TransactionViewReceiveAndBuffer {
         let mut transaction_priority_ids = ArrayVec::<_, EXTRA_CAPACITY>::new();
         let lock_results: [_; EXTRA_CAPACITY] = core::array::from_fn(|_| Ok(()));
         let mut error_counters = TransactionErrorMetrics::default();
-        let mut num_dropped_on_age = 0;
-        let mut num_dropped_on_already_processed = 0;
-        let mut num_dropped_on_fee_payer = 0;
-        let mut num_dropped_on_filter_key = 0;
-        let mut num_dropped_on_capacity = 0;
-        let mut num_buffered = 0;
+        let mut receiving_stats = ReceivingStats::default();
 
-        let mut check_and_push_to_queue =
-            |container: &mut TransactionViewStateContainer,
-             transaction_priority_ids: &mut ArrayVec<TransactionPriorityId, 64>| {
-                // Temporary scope so that transaction references are immediately
-                // dropped and transactions not passing
-                let mut check_results = {
-                    let mut transactions = ArrayVec::<_, EXTRA_CAPACITY>::new();
-                    transactions.extend(transaction_priority_ids.iter().map(|priority_id| {
-                        container
-                            .get_transaction(priority_id.id)
-                            .expect("transaction must exist")
-                    }));
-                    working_bank.check_transactions::<RuntimeTransaction<_>>(
-                        &transactions,
-                        &lock_results[..transactions.len()],
-                        working_bank.max_processing_age(),
-                        true,
-                        &mut error_counters,
-                    )
-                };
-
-                // Remove errored transactions
-                for (result, priority_id) in check_results
-                    .iter_mut()
-                    .zip(transaction_priority_ids.iter())
-                {
-                    if let Err(err) = result {
-                        match err {
-                            TransactionError::BlockhashNotFound => {
-                                num_dropped_on_age += 1;
-                            }
-                            TransactionError::AlreadyProcessed => {
-                                num_dropped_on_already_processed += 1;
-                            }
-                            _ => {}
-                        }
-                        container.remove_by_id(priority_id.id);
-                        continue;
-                    }
-                    let transaction = container
-                        .get_transaction(priority_id.id)
-                        .expect("transaction must exist");
-                    if let Err(err) = Consumer::check_fee_payer_unlocked(
-                        working_bank,
-                        transaction,
-                        &mut error_counters,
-                    ) {
-                        *result = Err(err);
-                        num_dropped_on_fee_payer += 1;
-                        container.remove_by_id(priority_id.id);
-                        continue;
-                    }
-
-                    num_buffered += 1;
-                }
-                // Push non-errored transaction into queue.
-                num_dropped_on_capacity += container.push_ids_into_queue(
-                    check_results
-                        .into_iter()
-                        .zip(transaction_priority_ids.drain(..))
-                        .filter(|(r, _)| r.is_ok())
-                        .map(|(_, id)| id),
-                );
-            };
-
-        let mut num_received = 0;
-        let mut num_dropped_without_parsing = 0;
-        let mut num_dropped_on_parsing_and_sanitization = 0;
-        let mut num_dropped_on_lock_validation = 0;
-        let mut num_dropped_on_compute_budget = 0;
+        // XXX HANA ok this is quite the difficult refactor. what happens already
+        // * loop through packets in packet batches. parse and do basic static validation
+        //   we implicitly discard anything that fails validation although we correctly log it
+        // * if it succeeded it goes in the slab. this gives us a usize id
+        // * get priority this is our priority-id. we push this into our 64-tx tmpbuffer
+        // * if we hit 64 we go to the next checks for the accumulated batch:
+        //   - check transactions. v1, age, nonce, status cache
+        //   - mut foreach over check results. check errors get removed from slap and logged
+        //   - then we check feepayer. mutate check result to err if err and remove from slab
+        //     if feepayer succeeded we log that we buffered something and otherwise do nothing in loop
+        //   - finally we filter errors, map to ids, and push into the real priority queue
+        //     the push fn returns a number of evictions which we also log
+        // * after we finish all packet batches we run the above lambda one final time to clear the rest
+        // * return all the logged stats. done
+        //
+        // so what im thinking is, i wrote a new fn to *just* check v1/age/nonce with no status cache
+        // i want to run this over each individual transaction. then we have three cases:
+        // * Ok(Some): valid nonce. check feepayer and push to queue immediately
+        // * Ok(None): valid blockhash. this goes into the 64-batch like normal, we still need to do status cache
+        // * Err: invalid nonce or blockhash. doesnt matter which, drop it
+        //   the present `check_transactions()` flow has to lock status cache and map over all txs
+        //   in this case we only pass valid blockhash txs through there, others never take the lock
+        // this improves further when we filter on nonce account because it drastically reduces *second* pass txs
 
         for packet_batch in packet_batch_message.iter() {
             for packet in packet_batch.iter() {
@@ -337,9 +327,9 @@ impl TransactionViewReceiveAndBuffer {
                     continue;
                 };
 
-                num_received += 1;
+                receiving_stats.num_received += 1;
                 if !should_parse {
-                    num_dropped_without_parsing += 1;
+                    receiving_stats.num_dropped_without_parsing += 1;
                     continue;
                 }
 
@@ -355,23 +345,8 @@ impl TransactionViewReceiveAndBuffer {
                             &self.filter_keys,
                         ) {
                             Ok(state) => Ok(state),
-                            Err(
-                                PacketHandlingError::Sanitization
-                                | PacketHandlingError::ALTResolution,
-                            ) => {
-                                num_dropped_on_parsing_and_sanitization += 1;
-                                Err(())
-                            }
-                            Err(PacketHandlingError::LockValidation) => {
-                                num_dropped_on_lock_validation += 1;
-                                Err(())
-                            }
-                            Err(PacketHandlingError::ComputeBudget) => {
-                                num_dropped_on_compute_budget += 1;
-                                Err(())
-                            }
-                            Err(PacketHandlingError::FilterKey) => {
-                                num_dropped_on_filter_key += 1;
+                            Err(ref err) => {
+                                receiving_stats.record(err);
                                 Err(())
                             }
                         }
@@ -381,35 +356,72 @@ impl TransactionViewReceiveAndBuffer {
                         .get_mut_transaction_state(transaction_id)
                         .expect("transaction must exist")
                         .priority();
-                    transaction_priority_ids
-                        .push(TransactionPriorityId::new(priority, transaction_id));
 
-                    // If at capacity, run checks and remove invalid transactions.
-                    if transaction_priority_ids.len() == EXTRA_CAPACITY {
-                        check_and_push_to_queue(container, &mut transaction_priority_ids);
+                    let tx = container
+                        .get_transaction(transaction_id)
+                        .expect("transaction must exist");
+
+                    // Pre-check this is a potentially valid transaction
+                    match working_bank
+                        .precheck_transaction_age(
+                            tx,
+                            working_bank.max_processing_age(),
+                            true,
+                            &mut error_counters,
+                        )
+                        .map(|details| details.nonce_address())
+                    {
+                        // Valid nonce transaction. Add to priority queue immediately.
+                        // It is fine to skip StatusCache because "invalid nonce transactions"
+                        // is a superset of "recently executed transactions".
+                        Ok(Some(nonce_address)) => {
+                            todo!()
+                        }
+
+                        // Potentially valid blockhash transaction. Put in our local batch.
+                        // We batch them to minimize the times we have to lock StatusCache.
+                        Ok(None) => {
+                            transaction_priority_ids
+                                .push(TransactionPriorityId::new(priority, transaction_id));
+
+                            // If at capacity, run checks and remove invalid transactions.
+                            if transaction_priority_ids.len() == EXTRA_CAPACITY {
+                                check_and_push_blockhash_batch_to_queue(
+                                    &working_bank,
+                                    container,
+                                    &mut transaction_priority_ids,
+                                    &lock_results,
+                                    &mut error_counters,
+                                    &mut receiving_stats,
+                                );
+                            }
+                        }
+
+                        // Invalid transaction, blockhash or nonce.
+                        // In this case we can drop it and never go to StatusCache.
+                        Err(err) => {
+                            receiving_stats.record(&err);
+                            container.remove_by_id(transaction_id);
+                        }
                     }
                 }
             }
         }
 
         // Any remaining packets undergo status/age checks
-        check_and_push_to_queue(container, &mut transaction_priority_ids);
+        check_and_push_blockhash_batch_to_queue(
+            &working_bank,
+            container,
+            &mut transaction_priority_ids,
+            &lock_results,
+            &mut error_counters,
+            &mut receiving_stats,
+        );
 
-        ReceivingStats {
-            num_received,
-            num_dropped_without_parsing,
-            num_dropped_on_parsing_and_sanitization,
-            num_dropped_on_lock_validation,
-            num_dropped_on_compute_budget,
-            num_dropped_on_age,
-            num_dropped_on_already_processed,
-            num_dropped_on_fee_payer,
-            num_dropped_on_filter_key,
-            num_dropped_on_capacity,
-            num_buffered,
-            receive_time_us: 0, // receive is outside this function
-            buffer_time_us: start.elapsed().as_micros() as u64,
-        }
+        // `receive_time_us` is set outside this function
+        receiving_stats.buffer_time_us = start.elapsed().as_micros() as u64;
+
+        receiving_stats
     }
 
     fn try_handle_packet(
@@ -448,6 +460,71 @@ impl TransactionViewReceiveAndBuffer {
 
         Ok(TransactionState::new(view, max_age, priority, cost))
     }
+}
+
+// Given a batch of plausibly valid blockhash transactions, fully validate and add to priority queue
+fn check_and_push_blockhash_batch_to_queue(
+    working_bank: &Bank,
+    container: &mut TransactionViewStateContainer,
+    transaction_priority_ids: &mut ArrayVec<TransactionPriorityId, 64>,
+    lock_results: &[TransactionResult<()>],
+    error_counters: &mut TransactionErrorMetrics,
+    receiving_stats: &mut ReceivingStats,
+) {
+    // Temporary scope so that transaction references are immediately
+    // dropped and transactions not passing
+    let mut check_results = {
+        let mut transactions = ArrayVec::<_, EXTRA_CAPACITY>::new();
+        transactions.extend(transaction_priority_ids.iter().map(|priority_id| {
+            container
+                .get_transaction(priority_id.id)
+                .expect("transaction must exist")
+        }));
+
+        working_bank.check_transactions::<RuntimeTransaction<_>>(
+            &transactions,
+            &lock_results[..transactions.len()],
+            working_bank.max_processing_age(),
+            true,
+            error_counters,
+        )
+    };
+
+    // Remove errored transactions
+    for (result, priority_id) in check_results
+        .iter_mut()
+        .zip(transaction_priority_ids.iter())
+    {
+        if let Err(err) = result {
+            receiving_stats.record(err);
+            container.remove_by_id(priority_id.id);
+            continue;
+        }
+
+        let transaction = container
+            .get_transaction(priority_id.id)
+            .expect("transaction must exist");
+
+        if let Err(err) =
+            Consumer::check_fee_payer_unlocked(working_bank, transaction, error_counters)
+        {
+            *result = Err(err);
+            receiving_stats.num_dropped_on_fee_payer += 1;
+            container.remove_by_id(priority_id.id);
+            continue;
+        }
+
+        receiving_stats.num_buffered += 1;
+    }
+
+    // Push non-errored transaction into queue.
+    receiving_stats.num_dropped_on_capacity += container.push_ids_into_queue(
+        check_results
+            .into_iter()
+            .zip(transaction_priority_ids.drain(..))
+            .filter(|(r, _)| r.is_ok())
+            .map(|(_, id)| id),
+    );
 }
 
 /// Perform sanitization checks and transition from data to an executable

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -169,21 +169,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         let start = Instant::now();
 
         let mut received_message = false;
-        let mut stats = ReceivingStats {
-            num_received: 0,
-            num_dropped_without_parsing: 0,
-            num_dropped_on_parsing_and_sanitization: 0,
-            num_dropped_on_lock_validation: 0,
-            num_dropped_on_compute_budget: 0,
-            num_dropped_on_age: 0,
-            num_dropped_on_already_processed: 0,
-            num_dropped_on_fee_payer: 0,
-            num_dropped_on_filter_key: 0,
-            num_dropped_on_capacity: 0,
-            num_buffered: 0,
-            receive_time_us: 0,
-            buffer_time_us: 0,
-        };
+        let mut stats = ReceivingStats::default();
 
         // If not leader/unknown, do a blocking-receive initially. This lets
         // the thread sleep until a message is received, or until the timeout.
@@ -247,21 +233,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             }
         }
 
-        Ok(ReceivingStats {
-            num_received: stats.num_received,
-            num_dropped_without_parsing: stats.num_dropped_without_parsing,
-            num_dropped_on_parsing_and_sanitization: stats.num_dropped_on_parsing_and_sanitization,
-            num_dropped_on_lock_validation: stats.num_dropped_on_lock_validation,
-            num_dropped_on_compute_budget: stats.num_dropped_on_compute_budget,
-            num_dropped_on_age: stats.num_dropped_on_age,
-            num_dropped_on_already_processed: stats.num_dropped_on_already_processed,
-            num_dropped_on_fee_payer: stats.num_dropped_on_fee_payer,
-            num_dropped_on_filter_key: stats.num_dropped_on_filter_key,
-            num_dropped_on_capacity: stats.num_dropped_on_capacity,
-            num_buffered: stats.num_buffered,
-            receive_time_us: stats.receive_time_us,
-            buffer_time_us: stats.buffer_time_us,
-        })
+        Ok(stats)
     }
 }
 
@@ -296,30 +268,6 @@ impl TransactionViewReceiveAndBuffer {
         let lock_results: [_; EXTRA_CAPACITY] = core::array::from_fn(|_| Ok(()));
         let mut error_counters = TransactionErrorMetrics::default();
         let mut receiving_stats = ReceivingStats::default();
-
-        // XXX HANA ok this is quite the difficult refactor. what happens already
-        // * loop through packets in packet batches. parse and do basic static validation
-        //   we implicitly discard anything that fails validation although we correctly log it
-        // * if it succeeded it goes in the slab. this gives us a usize id
-        // * get priority this is our priority-id. we push this into our 64-tx tmpbuffer
-        // * if we hit 64 we go to the next checks for the accumulated batch:
-        //   - check transactions. v1, age, nonce, status cache
-        //   - mut foreach over check results. check errors get removed from slap and logged
-        //   - then we check feepayer. mutate check result to err if err and remove from slab
-        //     if feepayer succeeded we log that we buffered something and otherwise do nothing in loop
-        //   - finally we filter errors, map to ids, and push into the real priority queue
-        //     the push fn returns a number of evictions which we also log
-        // * after we finish all packet batches we run the above lambda one final time to clear the rest
-        // * return all the logged stats. done
-        //
-        // so what im thinking is, i wrote a new fn to *just* check v1/age/nonce with no status cache
-        // i want to run this over each individual transaction. then we have three cases:
-        // * Ok(Some): valid nonce. check feepayer and push to queue immediately
-        // * Ok(None): valid blockhash. this goes into the 64-batch like normal, we still need to do status cache
-        // * Err: invalid nonce or blockhash. doesnt matter which, drop it
-        //   the present `check_transactions()` flow has to lock status cache and map over all txs
-        //   in this case we only pass valid blockhash txs through there, others never take the lock
-        // this improves further when we filter on nonce account because it drastically reduces *second* pass txs
 
         for packet_batch in packet_batch_message.iter() {
             for packet in packet_batch.iter() {
@@ -381,7 +329,6 @@ impl TransactionViewReceiveAndBuffer {
                                 &mut error_counters,
                             ) {
                                 Ok(_) => {
-                                    // HANA perhaps a new stat for nonce-immediate? perhaps buffered *and* a new stat?
                                     receiving_stats.num_buffered += 1;
                                     receiving_stats.num_dropped_on_capacity += container
                                         .push_ids_into_queue(std::iter::once(

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -91,11 +91,13 @@ impl Bank {
         )
     }
 
+    // NOTE this function can only be used for block production,
+    // because it enforces `strict_nonce_size_check` unconditionally.
+    // introducing this into replay requires a feature gate
     pub fn precheck_transaction_age(
         &self,
         tx: &impl TransactionWithMeta,
         max_age: usize,
-        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionCheckResult {
         let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
@@ -116,7 +118,7 @@ impl Bank {
             &hash_queue,
             error_counters,
             compute_budget_and_limits,
-            strict_nonce_size_check,
+            true, // strict_nonce_size_check
         )
     }
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -91,6 +91,35 @@ impl Bank {
         )
     }
 
+    pub fn precheck_transaction_age(
+        &self,
+        tx: &impl TransactionWithMeta,
+        max_age: usize,
+        strict_nonce_size_check: bool,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> TransactionCheckResult {
+        let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
+        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
+            return Err(TransactionError::UnsupportedVersion);
+        }
+
+        let hash_queue = self.blockhash_queue.read().unwrap();
+        let last_blockhash = hash_queue.last_hash();
+        let next_durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
+
+        let compute_budget_and_limits = self.get_compute_budget_and_limits(tx, error_counters)?;
+
+        self.check_transaction_age(
+            tx,
+            max_age,
+            &next_durable_nonce,
+            &hash_queue,
+            error_counters,
+            compute_budget_and_limits,
+            strict_nonce_size_check,
+        )
+    }
+
     fn filter_v1_transactions<'a, Tx: TransactionWithMeta>(
         &self,
         sanitized_txs: &'a [impl core::borrow::Borrow<Tx>],
@@ -124,53 +153,14 @@ impl Bank {
         let last_blockhash = hash_queue.last_hash();
         let next_durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
 
-        let feature_set: &FeatureSet = &self.feature_set;
-        let feature_snapshot = feature_set.snapshot();
-        let fee_features = FeeFeatures::from(feature_set);
-
-        let raise_cpi_limit = feature_snapshot.raise_cpi_nesting_limit_to_8;
-
         sanitized_txs
             .iter()
             .zip(lock_results)
             .map(|(tx, lock_res)| match lock_res {
                 Ok(()) => {
-                    let compute_budget_and_limits = tx
-                        .borrow()
-                        .transaction_configuration(feature_set)
-                        .map(|config| {
-                            let fee_details = calculate_fee_details(
-                                tx.borrow(),
-                                self.fee_structure.lamports_per_signature,
-                                config.priority_fee_lamports,
-                                fee_features,
-                            );
-                            if let Some(compute_budget) = self.compute_budget {
-                                // This block of code is only necessary to retain legacy behavior of the code.
-                                // It should be removed along with the change to favor transaction's compute budget limits
-                                // over configured compute budget in Bank.
-                                compute_budget.get_compute_budget_and_limits(
-                                    config.loaded_accounts_data_size_limit,
-                                    fee_details,
-                                )
-                            } else {
-                                SVMTransactionExecutionAndFeeBudgetLimits {
-                                    budget: SVMTransactionExecutionBudget {
-                                        compute_unit_limit: u64::from(config.compute_unit_limit),
-                                        heap_size: config.updated_heap_bytes,
-                                        ..SVMTransactionExecutionBudget::new_with_defaults(
-                                            raise_cpi_limit,
-                                        )
-                                    },
-                                    loaded_accounts_data_size_limit: config
-                                        .loaded_accounts_data_size_limit,
-                                    fee_details,
-                                }
-                            }
-                        })
-                        .inspect_err(|_err| {
-                            error_counters.invalid_compute_budget += 1;
-                        })?;
+                    let compute_budget_and_limits =
+                        self.get_compute_budget_and_limits(tx.borrow(), error_counters)?;
+
                     self.check_transaction_age(
                         tx.borrow(),
                         max_age,
@@ -296,6 +286,49 @@ impl Bank {
         status_cache
             .get_status(key, transaction_blockhash, &self.ancestors)
             .map(|status| status.0)
+    }
+
+    fn get_compute_budget_and_limits(
+        &self,
+        tx: &impl TransactionWithMeta,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> Result<SVMTransactionExecutionAndFeeBudgetLimits, TransactionError> {
+        let feature_set: &FeatureSet = &self.feature_set;
+        let feature_snapshot = feature_set.snapshot();
+        let fee_features = FeeFeatures::from(feature_set);
+        let raise_cpi_limit = feature_snapshot.raise_cpi_nesting_limit_to_8;
+
+        tx.transaction_configuration(feature_set)
+            .map(|config| {
+                let fee_details = calculate_fee_details(
+                    tx,
+                    self.fee_structure.lamports_per_signature,
+                    config.priority_fee_lamports,
+                    fee_features,
+                );
+                if let Some(compute_budget) = self.compute_budget {
+                    // This block of code is only necessary to retain legacy behavior of the code.
+                    // It should be removed along with the change to favor transaction's compute budget limits
+                    // over configured compute budget in Bank.
+                    compute_budget.get_compute_budget_and_limits(
+                        config.loaded_accounts_data_size_limit,
+                        fee_details,
+                    )
+                } else {
+                    SVMTransactionExecutionAndFeeBudgetLimits {
+                        budget: SVMTransactionExecutionBudget {
+                            compute_unit_limit: u64::from(config.compute_unit_limit),
+                            heap_size: config.updated_heap_bytes,
+                            ..SVMTransactionExecutionBudget::new_with_defaults(raise_cpi_limit)
+                        },
+                        loaded_accounts_data_size_limit: config.loaded_accounts_data_size_limit,
+                        fee_details,
+                    }
+                }
+            })
+            .inspect_err(|_err| {
+                error_counters.invalid_compute_budget += 1;
+            })
     }
 }
 

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -102,6 +102,10 @@ impl CheckedTransactionDetails {
             compute_budget_and_limits,
         }
     }
+
+    pub fn nonce_address(&self) -> Option<Pubkey> {
+        self.nonce_address
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]


### PR DESCRIPTION
#### Problem
the central scheduler parses and sanitizes incoming packets in a loop, pushing successfully resolved transactions into a len-64 buffer. this buffer, when full, is then given to `check_transactions()`, which checks blockhash age, nonce validity, and `StatusCache` presence/absence. the `StatusCache` lock is highly contended between (on the read side) the scheduler thread and worker threads executing batches, and (on the write side) worker threads committing batches

`check_transactions()` has to take the `StatusCache` lock on every batch regardless of whether any or all transactions already failed to validate. this is actually a material number: according to jito, some 45% of incoming transactions already have invalid blockhashes or nonces

#### Summary of Changes

this pr introduces a new function, `precheck_transaction_age()`, which checks blockhash and nonce validity for a single transaction, and does not perform the subsequent `StatusCache` check. we refactor the central scheduler to run this on all transactions after parsing them, resulting in three cases:
* the good: valid blockhash transactions. their ids go in the 64-item staging buffer to run as a batch through the full `check_transactions()` function, same as current behavior
* the bad: invalid transactions. these are immediately dropped
* the ugly: valid nonce transactions. these are immediately added to the priority queue. we dont need to check `StatusCache` because a) by definition if the nonce transaction had executed it would already be invalid, and b) we still do the `StatusCache` check in the second validation pass in `Bank`

perf concerns:
* this entails many more read locks on `BlockhashQueue`, but i assume this to be ~free because it is only updated once per slot
* this does not result in any new accounts-db loads because `check_transaction_age()` checks the hash queue before attempting to load a nonce
* this eliminates 45-55% of read locks on `StatusCache` during block production

this is a refactor to prep for a pr to address same-account different-transaction nonce spam. by identifying valid nonce transaction in the `Ok(Some(_nonce_address)) => { ... }` arm, we can do the rescheduling work right there, and will just need a mechanism to track which nonce accounts have queued transactions already

#### Testing
TODO
