### PR TITLE
ledger-tool: add bigtable support for alpenglow blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11408,6 +11408,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-instruction",
  "solana-loader-v2-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10729,6 +10729,7 @@ dependencies = [
  "serde",
  "smpl_jwt",
  "solana-clock",
+ "solana-entry",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash 4.5.0",
@@ -10749,6 +10750,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
+ "wincode",
  "zstd",
 ]
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "solana-account 4.3.1",
  "solana-account-decoder",
  "solana-accounts-db",
+ "solana-bls-signatures",
  "solana-clap-utils",
  "solana-cli-output",
  "solana-clock",
@@ -247,6 +248,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8796,6 +8796,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-instruction",
  "solana-loader-v2-interface",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8316,6 +8316,7 @@ dependencies = [
  "serde",
  "smpl_jwt",
  "solana-clock",
+ "solana-entry",
  "solana-message",
  "solana-metrics",
  "solana-pubkey 4.2.0",
@@ -8330,6 +8331,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
+ "wincode",
  "zstd",
 ]
 

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -71,6 +71,7 @@ signal-hook = "0.4.4"
 solana-account = "4.3.1"
 solana-account-decoder = { path = "../account-decoder", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
+solana-bls-signatures = { version = "3.3.0", features = ["serde"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-builtins = { path = "../builtins", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-clap-utils = { path = "../clap-utils", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
@@ -151,6 +152,7 @@ solana-vote-program = { path = "../programs/vote", version = "=4.3.0-alpha.2", d
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"
+wincode = { version = "0.5.5", features = ["derive"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -92,6 +92,7 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+wincode = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
@@ -101,6 +102,7 @@ signal-hook = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+solana-bls-signatures = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -92,7 +92,6 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-wincode = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
@@ -104,6 +103,7 @@ signal-hook = { workspace = true }
 assert_cmd = { workspace = true }
 solana-bls-signatures = { workspace = true }
 tempfile = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -255,19 +255,16 @@ struct BlockMarkers {
 
 fn classify_alpenglow_block_markers(
     slot: Slot,
-    marker_payloads: Vec<Vec<u8>>,
+    block_markers: Vec<VersionedBlockMarker>,
 ) -> Result<Option<BlockMarkers>, Box<dyn Error>> {
-    if marker_payloads.is_empty() {
+    if block_markers.is_empty() {
         return Ok(None);
     }
 
     let mut header = None;
     let mut genesis = None;
     let mut footer = None;
-    for (index, payload) in marker_payloads.into_iter().enumerate() {
-        let marker: VersionedBlockMarker = wincode::deserialize(&payload).map_err(|err| {
-            format!("Failed to deserialize block marker {index} for slot {slot}: {err}")
-        })?;
+    for marker in block_markers {
         let VersionedBlockMarker::V1(marker_v1) = &marker;
         let (marker_kind, destination) = match marker_v1 {
             BlockMarkerV1::BlockHeader(_) => ("header", &mut header),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -27,9 +27,12 @@ use {
         display::println_transaction,
     },
     solana_clock::Slot,
-    solana_entry::entry::{Entry, create_ticks},
+    solana_entry::{
+        block_component::{BlockComponent, BlockMarkerV1, VersionedBlockMarker},
+        entry::{Entry, create_ticks},
+    },
     solana_hash::Hash,
-    solana_keypair::keypair_from_seed,
+    solana_keypair::{Keypair, keypair_from_seed},
     solana_ledger::{
         bigtable_upload::ConfirmedBlockUploadConfig,
         blockstore::Blockstore,
@@ -40,10 +43,13 @@ use {
     solana_shred_version::compute_shred_version,
     solana_signature::Signature,
     solana_storage_bigtable::CredentialType,
-    solana_transaction_status::{ConfirmedBlock, UiTransactionEncoding, VersionedConfirmedBlock},
+    solana_transaction_status::{
+        ConfirmedBlock, EntrySummary, UiTransactionEncoding, VersionedConfirmedBlock,
+    },
     std::{
         cmp::min,
         collections::HashSet,
+        error::Error,
         path::Path,
         process::exit,
         result::Result,
@@ -241,6 +247,209 @@ fn get_shred_config_from_ledger(
     }
 }
 
+struct BlockMarkers {
+    header: VersionedBlockMarker,
+    genesis: Option<VersionedBlockMarker>,
+    footer: VersionedBlockMarker,
+}
+
+fn classify_alpenglow_block_markers(
+    slot: Slot,
+    marker_payloads: Vec<Vec<u8>>,
+) -> Result<Option<BlockMarkers>, Box<dyn Error>> {
+    if marker_payloads.is_empty() {
+        return Ok(None);
+    }
+
+    let mut header = None;
+    let mut genesis = None;
+    let mut footer = None;
+    for (index, payload) in marker_payloads.into_iter().enumerate() {
+        let marker: VersionedBlockMarker = wincode::deserialize(&payload).map_err(|err| {
+            format!("Failed to deserialize block marker {index} for slot {slot}: {err}")
+        })?;
+        let VersionedBlockMarker::V1(marker_v1) = &marker;
+        let (marker_kind, destination) = match marker_v1 {
+            BlockMarkerV1::BlockHeader(_) => ("header", &mut header),
+            BlockMarkerV1::GenesisCertificate(_) => ("genesis certificate", &mut genesis),
+            BlockMarkerV1::BlockFooter(_) => ("footer", &mut footer),
+            BlockMarkerV1::UpdateParent(_) => {
+                warn!(
+                    "Ignoring UpdateParent block marker for slot {slot} during shred \
+                     reconstruction"
+                );
+                continue;
+            }
+        };
+        if destination.is_some() {
+            return Err(
+                format!("Multiple {marker_kind} block markers found for slot {slot}").into(),
+            );
+        }
+        *destination = Some(marker);
+    }
+
+    let header =
+        header.ok_or_else(|| format!("Missing header block marker for Alpenglow slot {slot}"))?;
+    let footer =
+        footer.ok_or_else(|| format!("Missing footer block marker for Alpenglow slot {slot}"))?;
+    Ok(Some(BlockMarkers {
+        header,
+        genesis,
+        footer,
+    }))
+}
+
+fn entries_from_summaries(
+    slot: Slot,
+    block: &ConfirmedBlock,
+    entry_summaries: impl Iterator<Item = EntrySummary>,
+) -> Result<Vec<Entry>, std::string::String> {
+    entry_summaries
+        .enumerate()
+        .map(|(i, entry_summary)| {
+            let num_hashes = entry_summary.num_hashes;
+            let hash = entry_summary.hash;
+            let starting_transaction_index = entry_summary.starting_transaction_index;
+            let num_transactions = entry_summary.num_transactions as usize;
+
+            let Some(transactions) = block
+                .transactions
+                .get(starting_transaction_index..starting_transaction_index + num_transactions)
+            else {
+                let num_block_transactions = block.transactions.len();
+                return Err(format!(
+                    "Entry summary {i} for slot {slot} with starting_transaction_index \
+                     {starting_transaction_index} and num_transactions {num_transactions} is in \
+                     conflict with the block, which has {num_block_transactions} transactions"
+                ));
+            };
+            let transactions = transactions
+                .iter()
+                .map(|tx_with_meta| tx_with_meta.get_transaction())
+                .collect();
+
+            Ok(Entry {
+                num_hashes,
+                hash,
+                transactions,
+            })
+        })
+        .collect()
+}
+
+fn split_alpenglow_entries(
+    slot: Slot,
+    block: &ConfirmedBlock,
+    mut entries: Vec<Entry>,
+) -> Result<(Vec<Entry>, Entry), Box<dyn Error>> {
+    let Some(alpentick) = entries.pop() else {
+        return Err(format!("Missing alpentick entry for Alpenglow slot {slot}"))?;
+    };
+    if !alpentick.is_tick() {
+        Err(format!(
+            "Missing trailing alpentick entry for Alpenglow slot {slot}"
+        ))?;
+    }
+
+    if let Some((index, _)) = entries
+        .iter()
+        .enumerate()
+        .find(|(_, entry)| entry.is_tick())
+    {
+        Err(format!(
+            "Unexpected non-trailing tick entry at index {index} for Alpenglow slot {slot}"
+        ))?;
+    }
+
+    let blockhash = Hash::from_str(&block.blockhash)?;
+    if alpentick.hash != blockhash {
+        Err(format!(
+            "Alpentick hash {} does not match blockhash {} for Alpenglow slot {slot}",
+            alpentick.hash, blockhash
+        ))?;
+    }
+
+    Ok((entries, alpentick))
+}
+
+fn append_component_shreds(
+    data_shreds: &mut Vec<Shred>,
+    shredder: &Shredder,
+    keypair: &Keypair,
+    component: &BlockComponent,
+    is_last_in_slot: bool,
+    next_shred_index: &mut u32,
+    next_code_index: &mut u32,
+    chained_merkle_root: &mut Hash,
+    reed_solomon_cache: &ReedSolomonCache,
+) {
+    let shreds: Vec<_> = shredder
+        .make_merkle_shreds_from_component(
+            keypair,
+            component,
+            is_last_in_slot,
+            *chained_merkle_root,
+            *next_shred_index,
+            *next_code_index,
+            reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        )
+        .collect();
+    if let Some(last_data_shred) = shreds.iter().filter(|shred| shred.is_data()).last() {
+        *next_shred_index = last_data_shred.index() + 1;
+        *chained_merkle_root = last_data_shred
+            .merkle_root()
+            .expect("no more legacy shreds");
+    }
+    if let Some(last_code_shred) = shreds.iter().filter(|shred| shred.is_code()).last() {
+        *next_code_index = last_code_shred.index() + 1;
+    }
+    data_shreds.extend(shreds.into_iter().filter(Shred::is_data));
+}
+
+fn make_alpenglow_shreds(
+    slot: Slot,
+    block: &ConfirmedBlock,
+    markers: BlockMarkers,
+    entries: Vec<Entry>,
+    alpentick: Entry,
+    shred_config: &ShredConfig,
+    keypair: &Keypair,
+) -> Result<Vec<Shred>, Box<dyn Error>> {
+    let shredder = Shredder::new(slot, block.parent_slot, 0, shred_config.shred_version)?;
+    let mut chained_merkle_root = Hash::default();
+    let reed_solomon_cache = ReedSolomonCache::default();
+    let mut data_shreds = Vec::new();
+    let mut next_shred_index = 0;
+    let mut next_code_index = 0;
+
+    let mut components = vec![BlockComponent::new_block_marker(markers.header)];
+    components.extend(markers.genesis.map(BlockComponent::new_block_marker));
+    if !entries.is_empty() {
+        components.push(BlockComponent::EntryBatch(entries));
+    }
+    components.push(BlockComponent::new_block_marker(markers.footer));
+    components.push(BlockComponent::EntryBatch(vec![alpentick]));
+
+    let last_component_index = components.len().saturating_sub(1);
+    for (index, component) in components.iter().enumerate() {
+        append_component_shreds(
+            &mut data_shreds,
+            &shredder,
+            keypair,
+            component,
+            index == last_component_index,
+            &mut next_shred_index,
+            &mut next_code_index,
+            &mut chained_merkle_root,
+            &reed_solomon_cache,
+        );
+    }
+
+    Ok(data_shreds)
+}
+
 async fn shreds(
     blockstore: Arc<Blockstore>,
     starting_slot: Slot,
@@ -269,40 +478,36 @@ async fn shreds(
 
     for slot in slots.iter() {
         let block = bigtable.get_confirmed_block(*slot).await?;
+        let maybe_alpenglow_markers = match bigtable.get_block_markers(*slot).await {
+            Ok(marker_payloads) => classify_alpenglow_block_markers(*slot, marker_payloads)?,
+            Err(solana_storage_bigtable::Error::BlockNotFound(_)) => None,
+            Err(err) => return Err(err.into()),
+        };
         let entry_summaries = bigtable.get_entries(*slot).await;
 
+        if let Some(alpenglow_markers) = maybe_alpenglow_markers {
+            let entries = match entry_summaries {
+                Ok(entry_summaries) => entries_from_summaries(*slot, &block, entry_summaries)?,
+                Err(err) => {
+                    return Err(format!("No entry data for Alpenglow slot {slot}: {err}").into());
+                }
+            };
+            let (entries, alpentick) = split_alpenglow_entries(*slot, &block, entries)?;
+            let data_shreds = make_alpenglow_shreds(
+                *slot,
+                &block,
+                alpenglow_markers,
+                entries,
+                alpentick,
+                &shred_config,
+                &keypair,
+            )?;
+            blockstore.insert_shreds(data_shreds, false)?;
+            continue;
+        }
+
         let entries = match entry_summaries {
-            Ok(entry_summaries) => entry_summaries
-                .enumerate()
-                .map(|(i, entry_summary)| {
-                    let num_hashes = entry_summary.num_hashes;
-                    let hash = entry_summary.hash;
-                    let starting_transaction_index = entry_summary.starting_transaction_index;
-                    let num_transactions = entry_summary.num_transactions as usize;
-
-                    let Some(transactions) = block.transactions.get(
-                        starting_transaction_index..starting_transaction_index + num_transactions,
-                    ) else {
-                        let num_block_transactions = block.transactions.len();
-                        return Err(format!(
-                            "Entry summary {i} for slot {slot} with starting_transaction_index \
-                             {starting_transaction_index} and num_transactions {num_transactions} \
-                             is in conflict with the block, which has {num_block_transactions} \
-                             transactions"
-                        ));
-                    };
-                    let transactions = transactions
-                        .iter()
-                        .map(|tx_with_meta| tx_with_meta.get_transaction())
-                        .collect();
-
-                    Ok(Entry {
-                        num_hashes,
-                        hash,
-                        transactions,
-                    })
-                })
-                .collect::<Result<Vec<Entry>, std::string::String>>()?,
+            Ok(entry_summaries) => entries_from_summaries(*slot, &block, entry_summaries)?,
             Err(err) => {
                 let err_msg = format!("Failed to get PoH entries for {slot}: {err}");
                 let (num_hashes_per_tick, num_ticks_per_slot) =
@@ -1643,7 +1848,126 @@ fn missing_blocks(reference: &[Slot], owned: &[Slot]) -> MissingBlocksData {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+        solana_entry::block_component::{BlockFooterV1, BlockHeaderV1, GenesisCertBlockMarker},
+    };
+
+    fn deshred_batch(batch: &[Shred]) -> Vec<u8> {
+        Shredder::deshred(batch.iter().map(Shred::payload)).unwrap()
+    }
+
+    fn marker_is_header(marker: &VersionedBlockMarker) -> bool {
+        let VersionedBlockMarker::V1(marker_v1) = marker;
+        marker_v1.as_block_header().is_some()
+    }
+
+    fn marker_is_footer(marker: &VersionedBlockMarker) -> bool {
+        let VersionedBlockMarker::V1(marker_v1) = marker;
+        marker_v1.as_block_footer().is_some()
+    }
+
+    fn marker_is_genesis(marker: &VersionedBlockMarker) -> bool {
+        let VersionedBlockMarker::V1(marker_v1) = marker;
+        marker_v1.as_genesis_certificate().is_some()
+    }
+
+    #[test]
+    fn test_alpenglow_shreds_marker_ordering() {
+        let parent_slot = 41;
+        let blockhash = Hash::new_unique();
+        let block = ConfirmedBlock {
+            previous_blockhash: Hash::default().to_string(),
+            blockhash: blockhash.to_string(),
+            parent_slot,
+            transactions: vec![],
+            rewards: vec![],
+            num_partitions: None,
+            block_time: None,
+            block_height: None,
+        };
+        let markers = BlockMarkers {
+            header: VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+                parent_slot,
+                parent_block_id: Hash::default(),
+            }),
+            genesis: Some(VersionedBlockMarker::from_genesis_cert_block_marker(
+                GenesisCertBlockMarker {
+                    slot: 42,
+                    block_id: blockhash,
+                    bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                    bitmap: vec![1, 2, 3],
+                },
+            )),
+            footer: VersionedBlockMarker::from_block_footer(BlockFooterV1 {
+                bank_hash: Hash::new_unique(),
+                block_producer_time_nanos: 0,
+                block_user_agent: Vec::new(),
+                block_final_cert: None,
+                skip_reward_cert: None,
+                notar_reward_cert: None,
+            }),
+        };
+        let shred_config = ShredConfig {
+            shred_version: 0,
+            poh_generation_mode: ShredPohGenerationMode::RequireEntryData,
+        };
+        let keypair = keypair_from_seed(&[0; 64]).unwrap();
+
+        let alpentick = Entry {
+            num_hashes: 1,
+            hash: blockhash,
+            transactions: vec![],
+        };
+        let entry = Entry {
+            num_hashes: 0,
+            hash: Hash::new_unique(),
+            transactions: vec![],
+        };
+        let data_shreds = make_alpenglow_shreds(
+            42,
+            &block,
+            markers,
+            vec![entry.clone()],
+            alpentick,
+            &shred_config,
+            &keypair,
+        )
+        .unwrap();
+        let batches = data_shreds
+            .split_inclusive(|shred| shred.data_complete())
+            .collect::<Vec<_>>();
+        assert_eq!(batches.len(), 5);
+        assert!(!batches[0].last().unwrap().last_in_slot());
+        assert!(!batches[1].last().unwrap().last_in_slot());
+        assert!(!batches[2].last().unwrap().last_in_slot());
+        assert!(!batches[3].last().unwrap().last_in_slot());
+        assert!(batches[4].last().unwrap().last_in_slot());
+
+        let header_component: BlockComponent =
+            wincode::deserialize(&deshred_batch(batches[0])).unwrap();
+        assert!(header_component.as_marker().is_some_and(marker_is_header));
+
+        let genesis_component: BlockComponent =
+            wincode::deserialize(&deshred_batch(batches[1])).unwrap();
+        assert!(genesis_component.as_marker().is_some_and(marker_is_genesis));
+
+        let entry_component: BlockComponent =
+            wincode::deserialize(&deshred_batch(batches[2])).unwrap();
+        assert_eq!(entry_component, BlockComponent::EntryBatch(vec![entry]));
+
+        let footer_component: BlockComponent =
+            wincode::deserialize(&deshred_batch(batches[3])).unwrap();
+        assert!(footer_component.as_marker().is_some_and(marker_is_footer));
+
+        let alpentick_entries: Vec<Entry> =
+            wincode::deserialize(&deshred_batch(batches[4])).unwrap();
+        assert_eq!(alpentick_entries.len(), 1);
+        assert!(alpentick_entries[0].is_tick());
+        assert_eq!(alpentick_entries[0].num_hashes, 1);
+        assert_eq!(alpentick_entries[0].hash, blockhash);
+    }
 
     #[test]
     fn test_missing_blocks() {

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -950,7 +950,7 @@ pub fn output_slot(
 
     if verbose_level == 0 {
         if *output_format == OutputFormat::Display {
-            // Given that Blockstore::get_complete_block_with_entries() returned Ok(_), we know
+            // Given that Blockstore::get_complete_block_with_components() returned Ok(_), we know
             // that we have a full block so meta.consumed is the number of shreds in the block
             println!(
                 "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, is_full: \

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -5,6 +5,7 @@ use {
     crossbeam_channel::{bounded, unbounded},
     log::*,
     solana_clock::Slot,
+    solana_entry::block_component::VersionedBlockMarker,
     solana_measure::measure::Measure,
     solana_transaction_status::VersionedConfirmedBlockWithEntries,
     std::{
@@ -46,7 +47,7 @@ struct BlockstoreLoadStats {
 
 struct ConfirmedBlockUploadData {
     confirmed_block: VersionedConfirmedBlockWithEntries,
-    block_markers: Vec<Vec<u8>>,
+    block_markers: Vec<VersionedBlockMarker>,
 }
 
 fn get_confirmed_block_upload_data(
@@ -64,7 +65,7 @@ fn get_confirmed_block_upload_data(
             ConfirmedBlockComponent::BlockMarker(marker) => {
                 // Preserve every marker variant in Bigtable, even if shred reconstruction does not
                 // support it yet.
-                block_markers.push(wincode::serialize(&marker)?);
+                block_markers.push(marker);
             }
         }
     }

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -1,9 +1,12 @@
 use {
-    crate::blockstore::Blockstore,
+    crate::blockstore::{
+        Blockstore, ConfirmedBlockComponent, VersionedConfirmedBlockWithComponents,
+    },
     crossbeam_channel::{bounded, unbounded},
     log::*,
     solana_clock::Slot,
     solana_measure::measure::Measure,
+    solana_transaction_status::VersionedConfirmedBlockWithEntries,
     std::{
         cmp::{max, min},
         collections::HashSet,
@@ -39,6 +42,37 @@ impl Default for ConfirmedBlockUploadConfig {
 struct BlockstoreLoadStats {
     pub num_blocks_read: usize,
     pub elapsed: Duration,
+}
+
+struct ConfirmedBlockUploadData {
+    confirmed_block: VersionedConfirmedBlockWithEntries,
+    block_markers: Vec<Vec<u8>>,
+}
+
+fn get_confirmed_block_upload_data(
+    blockstore: &Blockstore,
+    slot: Slot,
+) -> Result<ConfirmedBlockUploadData, Box<dyn std::error::Error>> {
+    let VersionedConfirmedBlockWithComponents { block, components } =
+        blockstore.get_rooted_block_with_components(slot, true)?;
+    let mut entries = Vec::new();
+    let mut block_markers = Vec::new();
+
+    for component in components {
+        match component {
+            ConfirmedBlockComponent::EntryBatch(entry_batch) => entries.extend(entry_batch),
+            ConfirmedBlockComponent::BlockMarker(marker) => {
+                // Preserve every marker variant in Bigtable, even if shred reconstruction does not
+                // support it yet.
+                block_markers.push(wincode::serialize(&marker)?);
+            }
+        }
+    }
+
+    Ok(ConfirmedBlockUploadData {
+        confirmed_block: VersionedConfirmedBlockWithEntries { block, entries },
+        block_markers,
+    })
 }
 
 /// Uploads a range of blocks from a Blockstore to bigtable LedgerStorage
@@ -174,10 +208,10 @@ pub async fn upload_confirmed_blocks(
                                     break;
                                 }
 
-                                let _ = match blockstore.get_rooted_block_with_entries(slot, true) {
-                                    Ok(confirmed_block_with_entries) => {
+                                let _ = match get_confirmed_block_upload_data(&blockstore, slot) {
+                                    Ok(upload_data) => {
                                         num_blocks_read += 1;
-                                        sender.send((slot, Some(confirmed_block_with_entries)))
+                                        sender.send((slot, Some(upload_data)))
                                     }
                                     Err(err) => {
                                         warn!(
@@ -222,8 +256,12 @@ pub async fn upload_confirmed_blocks(
             Some(confirmed_block) => {
                 let bt = bigtable.clone();
                 Some(tokio::spawn(async move {
-                    bt.upload_confirmed_block_with_entries(slot, confirmed_block)
-                        .await
+                    bt.upload_confirmed_block_with_entries_and_markers(
+                        slot,
+                        confirmed_block.confirmed_block,
+                        confirmed_block.block_markers,
+                    )
+                    .await
                 }))
             }
         });

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -5,9 +5,8 @@ use {
     crossbeam_channel::{bounded, unbounded},
     log::*,
     solana_clock::Slot,
-    solana_entry::block_component::VersionedBlockMarker,
     solana_measure::measure::Measure,
-    solana_transaction_status::VersionedConfirmedBlockWithEntries,
+    solana_transaction_status::VersionedConfirmedBlockWithSplitComponents,
     std::{
         cmp::{max, min},
         collections::HashSet,
@@ -45,32 +44,26 @@ struct BlockstoreLoadStats {
     pub elapsed: Duration,
 }
 
-struct ConfirmedBlockUploadData {
-    confirmed_block: VersionedConfirmedBlockWithEntries,
-    block_markers: Vec<VersionedBlockMarker>,
-}
-
 fn get_confirmed_block_upload_data(
     blockstore: &Blockstore,
     slot: Slot,
-) -> Result<ConfirmedBlockUploadData, Box<dyn std::error::Error>> {
+) -> Result<VersionedConfirmedBlockWithSplitComponents, Box<dyn std::error::Error>> {
     let VersionedConfirmedBlockWithComponents { block, components } =
         blockstore.get_rooted_block_with_components(slot, true)?;
     let mut entries = Vec::new();
-    let mut block_markers = Vec::new();
+    let mut markers = Vec::new();
 
     for component in components {
         match component {
             ConfirmedBlockComponent::EntryBatch(entry_batch) => entries.extend(entry_batch),
-            ConfirmedBlockComponent::BlockMarker(marker) => {
-                block_markers.push(marker);
-            }
+            ConfirmedBlockComponent::BlockMarker(marker) => markers.push(marker),
         }
     }
 
-    Ok(ConfirmedBlockUploadData {
-        confirmed_block: VersionedConfirmedBlockWithEntries { block, entries },
-        block_markers,
+    Ok(VersionedConfirmedBlockWithSplitComponents {
+        block,
+        entries,
+        markers,
     })
 }
 
@@ -255,12 +248,8 @@ pub async fn upload_confirmed_blocks(
             Some(confirmed_block) => {
                 let bt = bigtable.clone();
                 Some(tokio::spawn(async move {
-                    bt.upload_confirmed_block_with_entries_and_markers(
-                        slot,
-                        confirmed_block.confirmed_block,
-                        confirmed_block.block_markers,
-                    )
-                    .await
+                    bt.upload_confirmed_block_with_split_components(slot, confirmed_block)
+                        .await
                 }))
             }
         });

--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -63,8 +63,6 @@ fn get_confirmed_block_upload_data(
         match component {
             ConfirmedBlockComponent::EntryBatch(entry_batch) => entries.extend(entry_batch),
             ConfirmedBlockComponent::BlockMarker(marker) => {
-                // Preserve every marker variant in Bigtable, even if shred reconstruction does not
-                // support it yet.
                 block_markers.push(marker);
             }
         }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4102,6 +4102,24 @@ impl Blockstore {
         Ok(VersionedConfirmedBlockWithEntries { block, entries })
     }
 
+    pub fn get_rooted_block_with_components(
+        &self,
+        slot: Slot,
+        require_previous_blockhash: bool,
+    ) -> Result<VersionedConfirmedBlockWithComponents> {
+        let _cleanup_guard = self.check_lowest_cleanup_slot(slot)?;
+
+        if self.is_root(slot) {
+            return self.do_get_complete_block_with_components(
+                slot,
+                require_previous_blockhash,
+                true,
+                /*allow_dead_slots:*/ false,
+            );
+        }
+        Err(BlockstoreError::SlotNotRooted)
+    }
+
     #[cfg(feature = "dev-context-only-utils")]
     pub fn get_complete_block_with_components(
         &self,
@@ -4118,7 +4136,6 @@ impl Blockstore {
         )
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
     fn do_get_complete_block_with_components(
         &self,
         slot: Slot,
@@ -4219,7 +4236,6 @@ impl Blockstore {
     }
 
     // Helper to build VersionConfirmedBlock from blockhash and transactions
-    #[cfg(feature = "dev-context-only-utils")]
     fn build_versioned_confirmed_block(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4113,8 +4113,8 @@ impl Blockstore {
             return self.do_get_complete_block_with_components(
                 slot,
                 require_previous_blockhash,
-                true,
-                /*allow_dead_slots:*/ false,
+                /* populate_components */ true,
+                /* allow_dead_slots */ false,
             );
         }
         Err(BlockstoreError::SlotNotRooted)

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -66,8 +66,7 @@ use {
     solana_transaction_status::{
         ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta, EntrySummary,
         RewardsAndNumPartitions, TransactionStatusMeta, TransactionWithStatusMeta,
-        VersionedConfirmedBlock, VersionedConfirmedBlockWithEntries,
-        VersionedTransactionWithStatusMeta,
+        VersionedConfirmedBlock, VersionedTransactionWithStatusMeta,
     },
     std::{
         borrow::Cow,
@@ -3941,165 +3940,13 @@ impl Blockstore {
         slot: Slot,
         require_previous_blockhash: bool,
     ) -> Result<VersionedConfirmedBlock> {
-        self.do_get_complete_block_with_entries(
+        self.do_get_complete_block_with_components(
             slot,
             require_previous_blockhash,
-            false,
-            /*allow_dead_slots:*/ false,
+            /* populate_components */ false,
+            /* allow_dead_slots */ false,
         )
         .map(|result| result.block)
-    }
-
-    pub fn get_rooted_block_with_entries(
-        &self,
-        slot: Slot,
-        require_previous_blockhash: bool,
-    ) -> Result<VersionedConfirmedBlockWithEntries> {
-        let _lock = self.check_lowest_cleanup_slot(slot)?;
-
-        if self.is_root(slot) {
-            return self.do_get_complete_block_with_entries(
-                slot,
-                require_previous_blockhash,
-                true,
-                /*allow_dead_slots:*/ false,
-            );
-        }
-        Err(BlockstoreError::SlotNotRooted)
-    }
-
-    #[cfg(feature = "dev-context-only-utils")]
-    pub fn get_complete_block_with_entries(
-        &self,
-        slot: Slot,
-        require_previous_blockhash: bool,
-        populate_entries: bool,
-        allow_dead_slots: bool,
-    ) -> Result<VersionedConfirmedBlockWithEntries> {
-        self.do_get_complete_block_with_entries(
-            slot,
-            require_previous_blockhash,
-            populate_entries,
-            allow_dead_slots,
-        )
-    }
-
-    fn do_get_complete_block_with_entries(
-        &self,
-        slot: Slot,
-        require_previous_blockhash: bool,
-        populate_entries: bool,
-        allow_dead_slots: bool,
-    ) -> Result<VersionedConfirmedBlockWithEntries> {
-        let Some(slot_meta) = self.meta_cf.get(slot)? else {
-            trace!("do_get_complete_block_with_entries() failed for {slot} (missing SlotMeta)");
-            return Err(BlockstoreError::SlotUnavailable);
-        };
-
-        if !slot_meta.is_full() {
-            trace!("do_get_complete_block_with_entries() failed for {slot} (slot not full)");
-            return Err(BlockstoreError::SlotUnavailable);
-        }
-
-        let (slot_entries, _, _) = self.get_slot_entries_with_shred_info(
-            slot,
-            /*shred_start_index:*/ 0,
-            allow_dead_slots,
-        )?;
-
-        if slot_entries.is_empty() {
-            trace!("do_get_complete_block_with_entries() failed for {slot} (no entries found)");
-            return Err(BlockstoreError::SlotUnavailable);
-        }
-
-        let blockhash = slot_entries
-            .last()
-            .map(|entry| entry.hash)
-            .unwrap_or_else(|| panic!("Rooted slot {slot:?} must have blockhash"));
-
-        let mut starting_transaction_index = 0;
-        let mut entries = if populate_entries {
-            Vec::with_capacity(slot_entries.len())
-        } else {
-            Vec::new()
-        };
-
-        let slot_transaction_iterator = slot_entries
-            .into_iter()
-            .flat_map(|entry| {
-                if populate_entries {
-                    entries.push(solana_transaction_status::EntrySummary {
-                        num_hashes: entry.num_hashes,
-                        hash: entry.hash,
-                        num_transactions: entry.transactions.len() as u64,
-                        starting_transaction_index,
-                    });
-                    starting_transaction_index += entry.transactions.len();
-                }
-                entry.transactions
-            })
-            .map(|transaction| {
-                if let Err(err) = transaction.sanitize() {
-                    warn!(
-                        "Blockstore::get_block sanitize failed: {err:?}, slot: {slot:?}, \
-                         {transaction:?}",
-                    );
-                }
-                transaction
-            });
-
-        let previous_blockhash = slot_meta.parent_slot.and_then(|parent_slot| {
-            self.get_slot_entries_with_shred_info(
-                parent_slot,
-                /*shred_start_index:*/ 0,
-                allow_dead_slots,
-            )
-            .ok()
-            .and_then(|(entries, _, is_full)| {
-                // The blockhash is specifically the final entry hash in a
-                // block so ensure the block is full
-                if is_full {
-                    entries.last().map(|entry| entry.hash)
-                } else {
-                    None
-                }
-            })
-        });
-        if previous_blockhash.is_none() && require_previous_blockhash {
-            return Err(BlockstoreError::ParentEntriesUnavailable);
-        }
-        let previous_blockhash = previous_blockhash.unwrap_or_else(Hash::default);
-
-        let RewardsAndNumPartitions {
-            rewards,
-            num_partitions,
-        } = self
-            .read_rewards(slot)?
-            .unwrap_or_else(|| RewardsAndNumPartitions {
-                rewards: Vec::new(),
-                num_partitions: None,
-            });
-
-        // The Blocktime and BlockHeight column families are updated asynchronously; they
-        // may not be written by the time the complete slot entries are available. In this
-        // case, these fields will be `None`.
-        let block_time = self.blocktime_cf.get(slot)?;
-        let block_height = self.block_height_cf.get(slot)?;
-
-        let block = VersionedConfirmedBlock {
-            previous_blockhash: previous_blockhash.to_string(),
-            blockhash: blockhash.to_string(),
-            // If the slot is full it should have parent_slot populated
-            // from shreds received.
-            parent_slot: slot_meta.parent_slot.unwrap(),
-            transactions: self.map_transactions_to_statuses(slot, slot_transaction_iterator)?,
-            rewards,
-            num_partitions,
-            block_time,
-            block_height,
-        };
-
-        Ok(VersionedConfirmedBlockWithEntries { block, entries })
     }
 
     pub fn get_rooted_block_with_components(

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -3013,6 +3013,7 @@ fn test_get_complete_block_with_block_markers() {
         .cloned()
         .collect();
     blockstore.insert_shreds(shreds, true).unwrap();
+    blockstore.set_roots([parent_slot, slot].iter()).unwrap();
 
     let (slot_entries, num_shreds, is_full) = blockstore
         .get_slot_entries_with_shred_info(slot, 0, false)
@@ -3051,6 +3052,36 @@ fn test_get_complete_block_with_block_markers() {
         entries.last().unwrap().hash.to_string()
     );
     assert!(complete_block.transactions.is_empty());
+
+    let VersionedConfirmedBlockWithComponents { block, components } = blockstore
+        .get_rooted_block_with_components(slot, true)
+        .unwrap();
+    assert_eq!(block, complete_block);
+    let [
+        ConfirmedBlockComponent::BlockMarker(header),
+        ConfirmedBlockComponent::EntryBatch(entry_summaries),
+        ConfirmedBlockComponent::BlockMarker(footer),
+    ] = components.as_slice()
+    else {
+        panic!("unexpected confirmed block components");
+    };
+    let VersionedBlockMarker::V1(header) = header;
+    assert!(header.as_block_header().is_some());
+    assert_eq!(entry_summaries.len(), entries.len());
+    for (summary, entry) in entry_summaries.iter().zip(&entries) {
+        assert_eq!(summary.num_hashes, entry.num_hashes);
+        assert_eq!(summary.hash, entry.hash);
+        assert_eq!(summary.num_transactions, 0);
+        assert_eq!(summary.starting_transaction_index, 0);
+    }
+    let VersionedBlockMarker::V1(footer) = footer;
+    assert!(footer.as_block_footer().is_some());
+
+    *blockstore.lowest_cleanup_slot.write().unwrap() = slot;
+    assert!(matches!(
+        blockstore.get_rooted_block_with_components(slot, true),
+        Err(BlockstoreError::SlotCleanedUp)
+    ));
 }
 
 #[test]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9879,6 +9879,7 @@ dependencies = [
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-instruction",
  "solana-loader-v2-interface",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9341,6 +9341,7 @@ dependencies = [
  "serde",
  "smpl_jwt",
  "solana-clock",
+ "solana-entry",
  "solana-message",
  "solana-metrics",
  "solana-pubkey 4.2.0",
@@ -9355,6 +9356,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost",
+ "wincode",
  "zstd",
 ]
 

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -44,6 +44,7 @@ prost-types = { workspace = true }
 serde = { workspace = true }
 smpl_jwt = { workspace = true }
 solana-clock = { workspace = true }
+solana-entry = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
@@ -64,6 +65,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["tls-ring", "transport"] }
 tonic-prost = { workspace = true }
+wincode = { workspace = true }
 zstd = { workspace = true }
 
 [dev-dependencies]

--- a/storage-bigtable/init-bigtable.sh
+++ b/storage-bigtable/init-bigtable.sh
@@ -16,7 +16,7 @@ if [[ -n $BIGTABLE_EMULATOR_HOST ]]; then
   cbt+=(-project emulator)
 fi
 
-for table in blocks entries tx tx-by-addr; do
+for table in blocks entries block-markers tx tx-by-addr; do
   (
     set -x
     "${cbt[@]}" createtable $table

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -7,6 +7,7 @@ use {
     log::*,
     serde::{Deserialize, Serialize},
     solana_clock::{Slot, UnixTimestamp},
+    solana_entry::block_component::VersionedBlockMarker,
     solana_message::v0::LoadedAddresses,
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
@@ -68,6 +69,9 @@ pub enum Error {
 
     #[error("tokio error")]
     TokioJoinError(JoinError),
+
+    #[error("Wincode serialization error: {0}")]
+    WincodeWrite(#[from] wincode::WriteError),
 }
 
 impl std::convert::From<bigtable::Error> for Error {
@@ -83,6 +87,31 @@ impl std::convert::From<std::io::Error> for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+fn deserialize_block_markers(
+    slot: Slot,
+    block_markers: Vec<Vec<u8>>,
+) -> Result<Vec<VersionedBlockMarker>> {
+    block_markers
+        .into_iter()
+        .enumerate()
+        .map(|(index, marker)| {
+            wincode::deserialize(&marker).map_err(|err| {
+                bigtable::Error::ObjectCorrupt(format!(
+                    "Failed to deserialize block marker {index} for slot {slot}: {err}"
+                ))
+                .into()
+            })
+        })
+        .collect()
+}
+
+fn serialize_block_markers(block_markers: &[VersionedBlockMarker]) -> Result<Vec<Vec<u8>>> {
+    block_markers
+        .iter()
+        .map(|marker| wincode::serialize(marker).map_err(Error::from))
+        .collect()
+}
 
 // Convert a slot to its bucket representation whereby lower slots are always lexically ordered
 // before higher slots
@@ -741,11 +770,11 @@ impl LedgerStorage {
         Ok(entries)
     }
 
-    pub async fn get_block_markers(&self, slot: Slot) -> Result<Vec<Vec<u8>>> {
+    pub async fn get_block_markers(&self, slot: Slot) -> Result<Vec<VersionedBlockMarker>> {
         trace!("LedgerStorage::get_block_markers request received: {slot:?}");
         self.stats.increment_num_block_markers_table_reads();
         let mut bigtable = self.connection.client();
-        bigtable
+        let block_markers = bigtable
             .get_bincode_cell::<Vec<Vec<u8>>>(
                 BLOCK_MARKERS_TABLE_NAME,
                 slot_to_block_markers_key(slot),
@@ -754,7 +783,8 @@ impl LedgerStorage {
             .map_err(|err| match err {
                 bigtable::Error::RowNotFound => Error::BlockNotFound(slot),
                 _ => err.into(),
-            })
+            })?;
+        deserialize_block_markers(slot, block_markers)
     }
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
@@ -1056,7 +1086,7 @@ impl LedgerStorage {
         &self,
         slot: Slot,
         confirmed_block: VersionedConfirmedBlockWithEntries,
-        block_markers: Vec<Vec<u8>>,
+        block_markers: Vec<VersionedBlockMarker>,
     ) -> Result<()> {
         trace!("LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}");
 
@@ -1128,6 +1158,7 @@ impl LedgerStorage {
             },
         );
         let num_block_markers = block_markers.len();
+        let block_markers = serialize_block_markers(&block_markers)?;
         let block_markers_cell = (slot_to_block_markers_key(slot), block_markers);
 
         let mut tasks = vec![];
@@ -1387,7 +1418,36 @@ impl LedgerStorage {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use {
+        super::*,
+        solana_entry::block_component::{BlockFooterV1, BlockHeaderV1},
+        solana_hash::Hash,
+    };
+
+    #[test]
+    fn test_block_marker_serialization() {
+        let slot = 42;
+        let block_markers = vec![
+            VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+                parent_slot: slot - 1,
+                parent_block_id: Hash::new_unique(),
+            }),
+            VersionedBlockMarker::from_block_footer(BlockFooterV1 {
+                bank_hash: Hash::new_unique(),
+                block_producer_time_nanos: 123,
+                block_user_agent: b"test".to_vec(),
+                block_final_cert: None,
+                skip_reward_cert: None,
+                notar_reward_cert: None,
+            }),
+        ];
+
+        let serialized = serialize_block_markers(&block_markers).unwrap();
+        assert_eq!(
+            deserialize_block_markers(slot, serialized).unwrap(),
+            block_markers
+        );
+    }
 
     #[test]
     fn test_slot_to_key() {

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -98,6 +98,10 @@ fn slot_to_entries_key(slot: Slot) -> String {
     slot_to_key(slot)
 }
 
+fn slot_to_block_markers_key(slot: Slot) -> String {
+    slot_to_key(slot)
+}
+
 fn slot_to_tx_by_addr_key(slot: Slot) -> String {
     slot_to_key(!slot)
 }
@@ -438,6 +442,7 @@ pub const DEFAULT_APP_PROFILE_ID: &str = "default";
 pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
 const BLOCKS_TABLE_NAME: &str = "blocks";
+const BLOCK_MARKERS_TABLE_NAME: &str = "block-markers";
 const ENTRIES_TABLE_NAME: &str = "entries";
 const TX_TABLE_NAME: &str = "tx";
 const TX_BY_ADDR_TABLE_NAME: &str = "tx-by-addr";
@@ -476,6 +481,7 @@ const METRICS_REPORT_INTERVAL_MS: u64 = 10_000;
 #[derive(Default)]
 struct LedgerStorageStats {
     num_blocks_table_reads: AtomicI64,
+    num_block_markers_table_reads: AtomicI64,
     num_entries_table_reads: AtomicI64,
     num_tx_table_reads: AtomicI64,
     num_tx_by_addr_table_reads: AtomicI64,
@@ -485,6 +491,12 @@ struct LedgerStorageStats {
 impl LedgerStorageStats {
     fn increment_num_blocks_table_reads(&self) {
         self.num_blocks_table_reads.fetch_add(1, Ordering::Relaxed);
+        self.maybe_report();
+    }
+
+    fn increment_num_block_markers_table_reads(&self) {
+        self.num_block_markers_table_reads
+            .fetch_add(1, Ordering::Relaxed);
         self.maybe_report();
     }
 
@@ -511,6 +523,12 @@ impl LedgerStorageStats {
                 (
                     "num_blocks_table_reads",
                     self.num_blocks_table_reads.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_block_markers_table_reads",
+                    self.num_block_markers_table_reads
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -721,6 +739,22 @@ impl LedgerStorage {
             })?;
         let entries = entry_cell_data.entries.into_iter().map(Into::into);
         Ok(entries)
+    }
+
+    pub async fn get_block_markers(&self, slot: Slot) -> Result<Vec<Vec<u8>>> {
+        trace!("LedgerStorage::get_block_markers request received: {slot:?}");
+        self.stats.increment_num_block_markers_table_reads();
+        let mut bigtable = self.connection.client();
+        bigtable
+            .get_bincode_cell::<Vec<Vec<u8>>>(
+                BLOCK_MARKERS_TABLE_NAME,
+                slot_to_block_markers_key(slot),
+            )
+            .await
+            .map_err(|err| match err {
+                bigtable::Error::RowNotFound => Error::BlockNotFound(slot),
+                _ => err.into(),
+            })
     }
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
@@ -1014,6 +1048,16 @@ impl LedgerStorage {
         slot: Slot,
         confirmed_block: VersionedConfirmedBlockWithEntries,
     ) -> Result<()> {
+        self.upload_confirmed_block_with_entries_and_markers(slot, confirmed_block, Vec::new())
+            .await
+    }
+
+    pub async fn upload_confirmed_block_with_entries_and_markers(
+        &self,
+        slot: Slot,
+        confirmed_block: VersionedConfirmedBlockWithEntries,
+        block_markers: Vec<Vec<u8>>,
+    ) -> Result<()> {
         trace!("LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}");
 
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
@@ -1083,6 +1127,8 @@ impl LedgerStorage {
                 entries: entries.into_iter().enumerate().map(Into::into).collect(),
             },
         );
+        let num_block_markers = block_markers.len();
+        let block_markers_cell = (slot_to_block_markers_key(slot), block_markers);
 
         let mut tasks = vec![];
 
@@ -1116,6 +1162,17 @@ impl LedgerStorage {
                         &[entry_cell],
                     )
                     .await
+            }));
+        }
+
+        if num_block_markers > 0 {
+            let conn = self.connection.clone();
+            tasks.push(tokio::spawn(async move {
+                conn.put_bincode_cells_with_retry::<Vec<Vec<u8>>>(
+                    BLOCK_MARKERS_TABLE_NAME,
+                    &[block_markers_cell],
+                )
+                .await
             }));
         }
 
@@ -1163,6 +1220,7 @@ impl LedgerStorage {
             ("slot", slot, i64),
             ("transactions", num_transactions, i64),
             ("entries", num_entries, i64),
+            ("block_markers", num_block_markers, i64),
             ("bytes", bytes_written, i64),
         );
         Ok(())
@@ -1268,6 +1326,12 @@ impl LedgerStorage {
             .row_key_exists(ENTRIES_TABLE_NAME, slot_to_entries_key(slot))
             .await
             .is_ok_and(|x| x);
+        let block_markers_exist = self
+            .connection
+            .client()
+            .row_key_exists(BLOCK_MARKERS_TABLE_NAME, slot_to_block_markers_key(slot))
+            .await
+            .is_ok_and(|x| x);
 
         if !dry_run {
             if !address_slot_rows.is_empty() {
@@ -1288,6 +1352,15 @@ impl LedgerStorage {
                     .await?;
             }
 
+            if block_markers_exist {
+                self.connection
+                    .delete_rows_with_retry(
+                        BLOCK_MARKERS_TABLE_NAME,
+                        &[slot_to_block_markers_key(slot)],
+                    )
+                    .await?;
+            }
+
             self.connection
                 .delete_rows_with_retry(BLOCKS_TABLE_NAME, &[slot_to_blocks_key(slot)])
                 .await?;
@@ -1295,12 +1368,17 @@ impl LedgerStorage {
 
         info!(
             "{}deleted ledger data for slot {}: {} transaction rows, {} address slot rows, {} \
-             entry row",
+             entry row, {} block marker row",
             if dry_run { "[dry run] " } else { "" },
             slot,
             tx_deletion_rows.len(),
             address_slot_rows.len(),
-            if entries_exist { "with" } else { "WITHOUT" }
+            if entries_exist { "with" } else { "WITHOUT" },
+            if block_markers_exist {
+                "with"
+            } else {
+                "WITHOUT"
+            }
         );
 
         Ok(())

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -21,8 +21,9 @@ use {
         ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
         ConfirmedTransactionWithStatusMeta, EntrySummary, Reward, TransactionByAddrInfo,
         TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
-        TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedConfirmedBlockWithEntries,
-        VersionedTransactionWithStatusMeta, extract_and_fmt_memos,
+        TransactionWithStatusMeta, VersionedConfirmedBlock,
+        VersionedConfirmedBlockWithSplitComponents, VersionedTransactionWithStatusMeta,
+        extract_and_fmt_memos,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -1063,37 +1064,32 @@ impl LedgerStorage {
     ) -> Result<()> {
         trace!("LedgerStorage::upload_confirmed_block request received: {slot:?}");
 
-        self.upload_confirmed_block_with_entries(
+        self.upload_confirmed_block_with_split_components(
             slot,
-            VersionedConfirmedBlockWithEntries {
+            VersionedConfirmedBlockWithSplitComponents {
                 block: confirmed_block,
                 entries: vec![],
+                markers: vec![],
             },
         )
         .await
     }
 
-    pub async fn upload_confirmed_block_with_entries(
+    pub async fn upload_confirmed_block_with_split_components(
         &self,
         slot: Slot,
-        confirmed_block: VersionedConfirmedBlockWithEntries,
+        confirmed_block: VersionedConfirmedBlockWithSplitComponents,
     ) -> Result<()> {
-        self.upload_confirmed_block_with_entries_and_markers(slot, confirmed_block, Vec::new())
-            .await
-    }
-
-    pub async fn upload_confirmed_block_with_entries_and_markers(
-        &self,
-        slot: Slot,
-        confirmed_block: VersionedConfirmedBlockWithEntries,
-        block_markers: Vec<VersionedBlockMarker>,
-    ) -> Result<()> {
-        trace!("LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}");
+        trace!(
+            "LedgerStorage::upload_confirmed_block_with_split_components request received: \
+             {slot:?}"
+        );
 
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
-        let VersionedConfirmedBlockWithEntries {
+        let VersionedConfirmedBlockWithSplitComponents {
             block: confirmed_block,
             entries,
+            markers,
         } = confirmed_block;
 
         let reserved_account_keys = ReservedAccountKeys::new_all_activated();
@@ -1157,8 +1153,8 @@ impl LedgerStorage {
                 entries: entries.into_iter().enumerate().map(Into::into).collect(),
             },
         );
-        let num_block_markers = block_markers.len();
-        let block_markers = serialize_block_markers(&block_markers)?;
+        let num_block_markers = markers.len();
+        let block_markers = serialize_block_markers(&markers)?;
         let block_markers_cell = (slot_to_block_markers_key(slot), block_markers);
 
         let mut tasks = vec![];

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-clock = { workspace = true }
+solana-entry = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-loader-v2-interface = { workspace = true, features = ["bincode"] }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -29,6 +29,7 @@ use {
     base64::{Engine, prelude::BASE64_STANDARD},
     serde::{Deserialize, Serialize},
     solana_clock::{Slot, UnixTimestamp},
+    solana_entry::block_component::VersionedBlockMarker,
     solana_hash::Hash,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,
     solana_message::{
@@ -393,11 +394,12 @@ impl ConfirmedBlock {
 }
 
 // Confirmed block with type guarantees that transaction metadata is always
-// present, as well as a list of the entry data needed to cryptographically
-// verify the block. Used for uploading to BigTable.
-pub struct VersionedConfirmedBlockWithEntries {
+// present, as well as the entry data and block markers needed to
+// cryptographically verify the block. Used for uploading to BigTable.
+pub struct VersionedConfirmedBlockWithSplitComponents {
     pub block: VersionedConfirmedBlock,
     pub entries: Vec<EntrySummary>,
+    pub markers: Vec<VersionedBlockMarker>,
 }
 
 // Data needed to reconstruct an Entry, given an ordered list of transactions in


### PR DESCRIPTION
#### Problem
Alpenglow blocks require a header and a footer block marker and can also contain other block markers.

Currently big table only uploads entries, meaning that we will be unable to reconstruct valid alpenglow blocks for local replay from bigtable entries.

#### Summary of Changes
Support a new table to store the block markers as well.
Modify upload logic to store the block markers in this new table.
Modify download and reconstruction of fake shreds logic to:
- Shred any block markers present for this slot
- Order them properly e.g. header -> entries -> footer

Note: although these shreds are replayable in isolation, they violate inter slot checks with existing *real* shreds for slots pre & post the fake shred range. When playing a mix of real and fake shreds one must use the `--skip-inter-slot-verification` option for ledger tool.

Note: this does not yet handle `UpdateParent`, this is purely for Alpenglow support without the FLH feature flag enabled. 

#### Testing
uploaded to test big table instance via ledger-tool
Also briefly ran the validator on the community cluster with `--enable-bigtable-ledger-upload` and verified that it would upload blocks

Fixes #13358 
