### PR TITLE
accounts-db: Removes unused metrics

### DIFF
--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -552,7 +552,6 @@ pub struct ShrinkStats {
     pub accounts_loaded: AtomicU64,
     pub initial_candidates_count: AtomicU64,
     pub purged_zero_lamports: AtomicU64,
-    pub accounts_not_found_in_index: AtomicU64,
     pub num_ancient_slots_shrunk: AtomicU64,
     pub ancient_slots_added_to_shrink: AtomicU64,
     pub ancient_bytes_added_to_shrink: AtomicU64,
@@ -688,11 +687,6 @@ impl ShrinkStats {
                 (
                     "num_ancient_slots_shrunk",
                     self.num_ancient_slots_shrunk.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "accounts_not_found_in_index",
-                    self.accounts_not_found_in_index.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -937,13 +931,6 @@ impl ShrinkAncientStats {
                 "purged_zero_lamports_count",
                 self.shrink_stats
                     .purged_zero_lamports
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "accounts_not_found_in_index",
-                self.shrink_stats
-                    .accounts_not_found_in_index
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -993,7 +993,6 @@ pub struct WriteAccountsToCacheStats {
 pub struct LoadAccountsStats {
     pub num_loaded_from_write_cache: AtomicU64,
     pub num_loaded_from_read_cache: AtomicU64,
-    pub num_loaded_from_index_cache: AtomicU64,
     pub num_loaded_from_index_storage: AtomicU64,
 }
 
@@ -1009,11 +1008,6 @@ impl LoadAccountsStats {
             (
                 "num_loaded_from_read_cache",
                 self.num_loaded_from_read_cache.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_loaded_from_index_cache",
-                self.num_loaded_from_index_cache.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -491,7 +491,6 @@ pub struct ShrinkAncientStats {
     pub select_slots_us: AtomicU64,
     pub random_shrink: AtomicU64,
     pub slots_considered: AtomicU64,
-    pub ancient_scanned: AtomicU64,
     pub bytes_ancient_created: AtomicU64,
     pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
@@ -879,11 +878,6 @@ impl ShrinkAncientStats {
             (
                 "slots_considered",
                 self.slots_considered.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "ancient_scanned",
-                self.ancient_scanned.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("total_us", self.total_us.swap(0, Ordering::Relaxed), i64),

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -374,7 +374,6 @@ impl FlushStats {
 #[derive(Debug, Default)]
 pub struct LatestAccountsIndexRootsStats {
     pub roots_len: AtomicUsize,
-    pub uncleaned_roots_len: AtomicUsize,
     pub roots_range: AtomicU64,
     pub rooted_cleaned_count: AtomicUsize,
     pub unrooted_cleaned_count: AtomicUsize,
@@ -386,9 +385,6 @@ impl LatestAccountsIndexRootsStats {
     pub fn update(&self, accounts_index_roots_stats: &AccountsIndexRootsStats) {
         if let Some(value) = accounts_index_roots_stats.roots_len {
             self.roots_len.store(value, Ordering::Relaxed);
-        }
-        if let Some(value) = accounts_index_roots_stats.uncleaned_roots_len {
-            self.uncleaned_roots_len.store(value, Ordering::Relaxed);
         }
         if let Some(value) = accounts_index_roots_stats.roots_range {
             self.roots_range.store(value, Ordering::Relaxed);
@@ -415,11 +411,6 @@ impl LatestAccountsIndexRootsStats {
         datapoint_info!(
             "accounts_index_roots_len",
             ("roots_len", self.roots_len.load(Ordering::Relaxed), i64),
-            (
-                "uncleaned_roots_len",
-                self.uncleaned_roots_len.load(Ordering::Relaxed),
-                i64
-            ),
             (
                 "roots_range_width",
                 self.roots_range.load(Ordering::Relaxed),

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -195,7 +195,6 @@ pub fn default_num_flush_threads() -> NonZeroUsize {
 #[derive(Debug, Default)]
 pub struct AccountsIndexRootsStats {
     pub roots_len: Option<usize>,
-    pub uncleaned_roots_len: Option<usize>,
     pub roots_range: Option<u64>,
     pub rooted_cleaned_count: usize,
     pub unrooted_cleaned_count: usize,

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1616,8 +1616,6 @@ struct DiskFlushStats {
     num_not_flushed_ref_count: u64,
     /// Number of entries not flushed because slot list len != 1
     num_not_flushed_slot_list_len: u64,
-    /// Number of entries not flushed because slot list contained a cached entry
-    num_not_flushed_slot_list_cached: u64,
 }
 
 impl DiskFlushStats {
@@ -1640,10 +1638,6 @@ impl DiskFlushStats {
         Self::update_stat(
             &stats.held_in_mem.slot_list_len,
             self.num_not_flushed_slot_list_len,
-        );
-        Self::update_stat(
-            &stats.held_in_mem.slot_list_cached,
-            self.num_not_flushed_slot_list_cached,
         );
     }
 

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -23,7 +23,6 @@ pub struct HeldInMemStats {
     pub age: AtomicU64,
     pub ref_count: AtomicU64,
     pub slot_list_len: AtomicU64,
-    pub slot_list_cached: AtomicU64,
 }
 
 #[derive(Debug, Default)]
@@ -266,8 +265,6 @@ impl Stats {
             let held_in_mem_ref_count = self.held_in_mem.ref_count.swap(0, Ordering::Relaxed);
             let held_in_mem_slot_list_len =
                 self.held_in_mem.slot_list_len.swap(0, Ordering::Relaxed);
-            let held_in_mem_slot_list_cached =
-                self.held_in_mem.slot_list_cached.swap(0, Ordering::Relaxed);
             // If an entry is held in-mem due to ref count or slot list length,
             // then assume it has two slot list entries.
             // Since `approx_size_of_one_entry()` assumes 'regular' entries
@@ -318,11 +315,6 @@ impl Stats {
                 (
                     "num_not_flushed_slot_list_len",
                     held_in_mem_slot_list_len,
-                    i64
-                ),
-                (
-                    "num_not_flushed_slot_list_cached",
-                    held_in_mem_slot_list_cached,
                     i64
                 ),
                 ("min_in_bin_disk", disk_stats.0, i64),


### PR DESCRIPTION
#### Problem

There are multiple metrics in accounts-db that are never updated. They can be removed.


#### Summary of Changes

Each commit removes one metric. They are:

- num_loaded_from_index_cache
- accounts_not_found_in_index
- ancient_scanned
- uncleaned_roots_len
- num_not_flushed_slot_list_cached

It may be simpler to review commit-by-commit to see each metric removal in isolation.


#### Testing

Nothing additional.