### PR TITLE
geyser: don't count block markers in entry index

### DIFF
--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -64,15 +64,12 @@ impl TpuEntryNotifier {
         let (bank, (entry_or_marker, tick_height)) =
             entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
-        let index = if slot != *current_slot {
+        if slot != *current_slot {
             *current_index = 0;
             *current_transaction_index = 0;
             *current_slot = slot;
-            0
-        } else {
-            *current_index += 1;
-            *current_index
         };
+        let index = *current_index;
 
         if let EntryOrMarker::Entry(ref entry) = entry_or_marker {
             let entry_summary = EntrySummary {
@@ -91,11 +88,11 @@ impl TpuEntryNotifier {
                      EntryNotifierService, error {err:?}",
                 );
             }
+            *current_index += 1;
             *current_transaction_index += entry.transactions.len();
         };
 
         if let Err(err) = broadcast_entry_sender.send((bank, (entry_or_marker, tick_height))) {
-            let index = *current_index;
             warn!(
                 "Failed to send slot {slot:?} entry/marker {index:?} from Tpu to BroadcastStage, \
                  error {err:?}",


### PR DESCRIPTION
#### Problem
Alpenglow block markers were counted when advancing the Geyser entry index.

#### Summary of Changes
Only advance the entry index for actual entries.

#### Testing
Ran `solana-test-validator --alpenglow` with a dummy Geyser plugin.

A part of #12370 
