### PR TITLE
accounts-db: Removes duplicate total_removed_storage_entries metric

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4236,9 +4236,6 @@ impl AccountsDb {
             .num_stored_slots_removed
             .fetch_add(num_stored_slots_removed, Ordering::Relaxed);
         purge_stats
-            .total_removed_storage_entries
-            .fetch_add(num_stored_slots_removed, Ordering::Relaxed);
-        purge_stats
             .total_removed_stored_bytes
             .fetch_add(total_removed_stored_bytes, Ordering::Relaxed);
         self.stats
@@ -6633,8 +6630,7 @@ impl AccountsDb {
                 }
                 ObsoleteAccountsStats {
                     accounts_marked_obsolete: reclaims.len() as u64,
-                    slots_removed: stats.total_removed_storage_entries.load(Ordering::Relaxed)
-                        as u64,
+                    slots_removed: stats.num_stored_slots_removed.load(Ordering::Relaxed) as u64,
                 }
             })
             .sum();

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -246,7 +246,6 @@ pub struct PurgeStats {
     pub drop_storage_entries_elapsed: AtomicU64,
     pub num_cached_slots_removed: AtomicUsize,
     pub num_stored_slots_removed: AtomicUsize,
-    pub total_removed_storage_entries: AtomicUsize,
     pub total_removed_cached_bytes: AtomicU64,
     pub total_removed_stored_bytes: AtomicU64,
     pub scan_storages_elapsed: AtomicU64,
@@ -292,12 +291,6 @@ impl PurgeStats {
                 (
                     "num_stored_slots_removed",
                     self.num_stored_slots_removed.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "total_removed_storage_entries",
-                    self.total_removed_storage_entries
-                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem

`total_removed_storage_entries` is a duplicate of `num_stored_slots_removed`. Remove one.


#### Summary of Changes

Remove `total_removed_storage_entries`.

I picked removing `total_removed_storage_entries` because `num_stored_slots_removed` has a matching `num_cached_slots_removed`.


#### Testing

Nothing additional.
