### PR TITLE
clippy: fix explicitly allowed collapsible_if cases

### DIFF
--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -500,7 +500,6 @@ impl SubscriptionsTracker {
         }
     }
 
-    #[allow(clippy::collapsible_if)]
     pub fn unsubscribe(&mut self, params: SubscriptionParams, id: SubscriptionId) {
         match &params {
             SubscriptionParams::Logs(params) => {
@@ -520,21 +519,18 @@ impl SubscriptionsTracker {
             }
             _ => {}
         }
-        if params.is_commitment_watcher() {
-            if self.commitment_watchers.remove(&id).is_none() {
+        if params.is_commitment_watcher()
+            && self.commitment_watchers.remove(&id).is_none() {
                 warn!("Subscriptions inconsistency (missing entry in commitment_watchers)");
             }
-        }
-        if params.is_gossip_watcher() {
-            if self.gossip_watchers.remove(&id).is_none() {
+        if params.is_gossip_watcher()
+            && self.gossip_watchers.remove(&id).is_none() {
                 warn!("Subscriptions inconsistency (missing entry in gossip_watchers)");
             }
-        }
-        if params.is_node_progress_watcher() {
-            if self.node_progress_watchers.remove(&params).is_none() {
+        if params.is_node_progress_watcher()
+            && self.node_progress_watchers.remove(&params).is_none() {
                 warn!("Subscriptions inconsistency (missing entry in node_progress_watchers)");
             }
-        }
     }
 
     pub fn by_signature(
@@ -571,7 +567,6 @@ impl fmt::Debug for SubscriptionTokenInner {
 }
 
 impl Drop for SubscriptionTokenInner {
-    #[allow(clippy::collapsible_if)]
     fn drop(&mut self) {
         match self.control.subscriptions.entry(self.params.clone()) {
             DashEntry::Vacant(_) => {

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -519,18 +519,17 @@ impl SubscriptionsTracker {
             }
             _ => {}
         }
-        if params.is_commitment_watcher()
-            && self.commitment_watchers.remove(&id).is_none() {
-                warn!("Subscriptions inconsistency (missing entry in commitment_watchers)");
-            }
-        if params.is_gossip_watcher()
-            && self.gossip_watchers.remove(&id).is_none() {
-                warn!("Subscriptions inconsistency (missing entry in gossip_watchers)");
-            }
+        if params.is_commitment_watcher() && self.commitment_watchers.remove(&id).is_none() {
+            warn!("Subscriptions inconsistency (missing entry in commitment_watchers)");
+        }
+        if params.is_gossip_watcher() && self.gossip_watchers.remove(&id).is_none() {
+            warn!("Subscriptions inconsistency (missing entry in gossip_watchers)");
+        }
         if params.is_node_progress_watcher()
-            && self.node_progress_watchers.remove(&params).is_none() {
-                warn!("Subscriptions inconsistency (missing entry in node_progress_watchers)");
-            }
+            && self.node_progress_watchers.remove(&params).is_none()
+        {
+            warn!("Subscriptions inconsistency (missing entry in node_progress_watchers)");
+        }
     }
 
     pub fn by_signature(

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -85,17 +85,14 @@ fn sanitize_config(
     view: &UnsanitizedTransactionView<impl TransactionData>,
     config: &SanitizeConfig,
 ) -> Result<()> {
-    #[allow(clippy::collapsible_if)]
     if let Some(requested_heap_bytes) = view
         .transaction_config()
         .and_then(|config| config.requested_heap_size())
-    {
-        if !(config.min_requested_heap_size..=config.max_requested_heap_size)
+        && (!(config.min_requested_heap_size..=config.max_requested_heap_size)
             .contains(&requested_heap_bytes)
-            || !requested_heap_bytes.is_multiple_of(1024)
-        {
-            return Err(TransactionViewError::SanitizeError);
-        }
+            || !requested_heap_bytes.is_multiple_of(1024))
+    {
+        return Err(TransactionViewError::SanitizeError);
     }
 
     Ok(())


### PR DESCRIPTION
#### Problem
`#[allow(clippy::collapsible_if)]` is no longer necessary

#### Summary of Changes
Remove `#[allow(clippy::collapsible_if)]` and fix nested ifs

#### Testing
CI
