### PR TITLE
clippy(networking): fix question_mark

### DIFF
--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -206,18 +206,15 @@ impl AncestorRequestStatus {
         response_slot_hashes: Vec<(Slot, Hash)>,
         blockstore: &Blockstore,
     ) -> Option<DuplicateAncestorDecision> {
-        if let Some(did_get_response) = self.sampled_validators.get_mut(from_addr) {
-            if *did_get_response {
-                // If we've already received a response from this validator, return.
-                return None;
-            }
-            // Mark we got a response from this validator already
-            *did_get_response = true;
-            self.num_responses += 1;
-        } else {
-            // If this is not a response from one of the sampled validators, return.
+        // If this is not a response from one of the sampled validators, return.
+        let did_get_response = self.sampled_validators.get_mut(from_addr)?;
+        if *did_get_response {
+            // If we've already received a response from this validator, return.
             return None;
         }
+        // Mark we got a response from this validator already
+        *did_get_response = true;
+        self.num_responses += 1;
 
         let validators_with_same_response = self
             .ancestor_request_responses

--- a/net-utils/src/tooling_for_tests.rs
+++ b/net-utils/src/tooling_for_tests.rs
@@ -32,10 +32,7 @@ impl Iterator for PcapReader {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            let block = match self.reader.next_block() {
-                Some(block) => block.ok()?,
-                None => return None,
-            };
+            let block = self.reader.next_block()?.ok()?;
             let data = match block {
                 pcap_file::pcapng::Block::Packet(ref block) => {
                     &block.data[0..block.original_len as usize]


### PR DESCRIPTION
#### Problem
Newer clippy detects another class of
https://rust-lang.github.io/rust-clippy/master/#question_mark

#### Summary of Changes
Use `?` for simpler syntax.

Note: auto-fix was losing some code and creating pointless nesting, so this is hand updated change.

#### Testing
CI
