### PR TITLE
chore(deps): bump solana-transaction-error from 3.2.0 to 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8878,9 +8878,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "serde",
@@ -11382,9 +11382,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
+checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,7 +415,7 @@ solana-hash = "4.4.0"
 solana-hash-512 = "1.1.0"
 solana-inflation = "3.1.1"
 solana-instruction = "3.4.0"
-solana-instruction-error = "2.3.0"
+solana-instruction-error = "2.4.0"
 solana-instructions-sysvar = "3.0.0"
 solana-keccak-hasher = "3.1.0"
 solana-keypair = "3.1.2"
@@ -515,7 +515,7 @@ solana-tpu-client = { path = "tpu-client", version = "=4.2.0-alpha.0", default-f
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction = "4.1.3"
 solana-transaction-context = { path = "transaction-context", version = "=4.2.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-error = "3.2.1"
+solana-transaction-error = "3.3.0"
 solana-transaction-status = { path = "transaction-status", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7020,9 +7020,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "serde",
@@ -8828,9 +8828,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
+checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
 dependencies = [
  "serde",
  "serde_derive",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -97,7 +97,7 @@ solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=
 solana-hash = "4.4.0"
 solana-inflation = "3.1.1"
 solana-instruction = "3.4.0"
-solana-instruction-error = "2.3.0"
+solana-instruction-error = "2.4.0"
 solana-keypair = "3.1.2"
 solana-ledger = { path = "../ledger", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "7.0.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7170,9 +7170,9 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction-error"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b188842592fdf6cb96f55263ae1bf11713ab5114401d1d5a881ed7cc41bef6"
+checksum = "3b7d34343838343a3755b7dfb1e438d94c6db2263b519cfe3c2257af932b6e93"
 dependencies = [
  "num-traits",
  "serde",
@@ -9862,9 +9862,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441d6dcd51100e7d97c3fb3b723e08aa701066ff7afc00026fd8d8e222cb95b"
+checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
 dependencies = [
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -211,7 +211,7 @@ solana-system-interface = { workspace = true }
 solana-sysvar = "4.0.0"
 solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-transaction = "4.1.0"
-solana-transaction-error = "3.2.0"
+solana-transaction-error = "3.3.0"
 solana-vote = { workspace = true }
 solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -275,7 +275,7 @@ static NANOSECOND_CLOCK_ACCOUNT: LazyLock<Pubkey> = LazyLock::new(|| {
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "23uAyYmzMrmPvPDKf6SvF1YoojYstmEPmdkfAQDnpwsq")
+    frozen_abi(digest = "HvpA8mUc4TZAcDF3BpcynmYWYBK3scJRTem2qadCiF5Z")
 )]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -18,7 +18,7 @@ use {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "AardUUq1At4qq6oNNp9V2JZFsMR5k54RZmBmZkxUfk7m")
+    frozen_abi(digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p")
 )]
 type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
 type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
@@ -112,7 +112,7 @@ pub fn deserialize_status_cache(
 /// contain a string in the BorshIoError variant.
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "5pMgydVNgsYbg64Trhjxbftsug5La7fRDmooyrsHd4wy"),
+    frozen_abi(digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
     derive(AbiExample, AbiEnumVisitor)
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
@@ -156,6 +156,7 @@ enum SerdeTransactionError {
     UnbalancedTransaction,
     ProgramCacheHitMaxLimit,
     CommitCancelled,
+    InstructionsSysvarOverflow,
 }
 
 impl From<&TransactionError> for SerdeTransactionError {
@@ -224,6 +225,7 @@ impl From<&TransactionError> for SerdeTransactionError {
             TransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
             TransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
             TransactionError::CommitCancelled => Self::CommitCancelled,
+            TransactionError::InstructionsSysvarOverflow => Self::InstructionsSysvarOverflow,
         }
     }
 }
@@ -294,6 +296,7 @@ impl From<SerdeTransactionError> for TransactionError {
             SerdeTransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
             SerdeTransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
             SerdeTransactionError::CommitCancelled => Self::CommitCancelled,
+            SerdeTransactionError::InstructionsSysvarOverflow => Self::InstructionsSysvarOverflow,
         }
     }
 }

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -439,11 +439,13 @@ pub mod worker_message_types {
         pub const UNBALANCED_TRANSACTION: u8 = 100;
         /// Program cache hit max limit.
         pub const PROGRAM_CACHE_HIT_MAX_LIMIT: u8 = 101;
+        /// Instructions sysvar overflowed format.
+        pub const INSTRUCTIONS_SYSVAR_OVERFLOW: u8 = 102;
 
         // This error in agave is only internal, and to avoid updating the sdk
         // it is reused for mapping into `ALL_OR_NOTHING_BATCH_FAILURE`.
         // /// Commit cancelled internally.
-        // pub const COMMIT_CANCELLED: u8 = 102;
+        // pub const COMMIT_CANCELLED: u8 = 103;
     }
 
     /// Tag indicating [`CheckResponse`] inner message.

--- a/scheduling-utils/src/error.rs
+++ b/scheduling-utils/src/error.rs
@@ -87,6 +87,9 @@ pub fn transaction_error_to_not_included_reason(error: &TransactionError) -> u8 
         TransactionError::ProgramCacheHitMaxLimit => {
             not_included_reasons::PROGRAM_CACHE_HIT_MAX_LIMIT
         }
+        TransactionError::InstructionsSysvarOverflow => {
+            not_included_reasons::INSTRUCTIONS_SYSVAR_OVERFLOW
+        }
 
         // SPECIAL CASE - CommitCancelled is an internal error reused to avoid breaking sdk
         TransactionError::CommitCancelled => not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE,

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -64,6 +64,7 @@ enum TransactionErrorType {
     UNBALANCED_TRANSACTION = 36;
     PROGRAM_CACHE_HIT_MAX_LIMIT = 37;
     COMMIT_CANCELLED = 38;
+    INSTRUCTIONS_SYSVAR_OVERFLOW = 39;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -932,6 +932,7 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             36 => TransactionError::UnbalancedTransaction,
             37 => TransactionError::ProgramCacheHitMaxLimit,
             38 => TransactionError::CommitCancelled,
+            39 => TransactionError::InstructionsSysvarOverflow,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -1055,6 +1056,9 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::CommitCancelled => {
                     tx_by_addr::TransactionErrorType::CommitCancelled
+                }
+                TransactionError::InstructionsSysvarOverflow => {
+                    tx_by_addr::TransactionErrorType::InstructionsSysvarOverflow
                 }
             } as i32,
             instruction_error: match transaction_error {


### PR DESCRIPTION
#### Problem
- A new transaction error variant was added to support a change in solana-sysvar-instruction

#### Summary of Changes
- Bump solana-transaction-error from 3.2.0 to 3.3.0
- Bump solana-instruction-error from 2.3.0 to 2.4.0
	-  TransactionError now supports StableAbi, needed updated instruction-error that also supports StableAbi
- Fill matches with new transacation error variant

#### Testing
- CI

Fixes #
