### PR TITLE
chore(deps): bump solana-frozen-abi from 3.6.0 to 3.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8550,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47b47faa2099702dc4c764bd70806ac07166a2c81fd0c5154ed04c6e57e2b93"
+checksum = "038494fd91f75199a233ff12bc922b8e02da04bd6dd8fed26e710572733d39d5"
 dependencies = [
  "bincode",
  "boxcar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -403,7 +403,7 @@ solana-fee = { path = "fee", version = "=4.2.0-alpha.0", features = ["agave-unst
 solana-fee-calculator = "3.2.2"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.4"
-solana-frozen-abi = "3.6.0"
+solana-frozen-abi = "3.7.0"
 solana-frozen-abi-macro = "3.6.0"
 solana-genesis = { path = "genesis", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"


### PR DESCRIPTION
#### Problem
- frozen-abi was updated to support smart pointers (Arc, Rc, Box)
- this is wanted to avoid a manual impl in different PR

#### Summary of Changes
- bump solana-frozen-abi from 3.6.0 to 3.7.0

#### Testing
- CI

Fixes #
