### PR TITLE
ledger-tool: Dedupe block output code

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -46,7 +46,7 @@ use {
         EncodedConfirmedBlock, EncodedTransaction, TransactionConfirmationStatus,
         UiTransactionStatusMeta,
     },
-    solana_transaction_status_client_types::UiTransactionError,
+    solana_transaction_status_client_types::{Rewards, UiTransactionError},
     solana_vote_program::{
         authorized_voters::AuthorizedVoters,
         vote_state::{
@@ -3106,35 +3106,33 @@ pub struct CliBlock {
     pub slot: Slot,
 }
 
-impl QuietDisplay for CliBlock {}
-impl VerboseDisplay for CliBlock {}
-
-impl fmt::Display for CliBlock {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "Slot: {}", self.slot)?;
-        writeln!(
-            f,
-            "Parent Slot: {}",
-            self.encoded_confirmed_block.parent_slot
-        )?;
-        writeln!(f, "Blockhash: {}", self.encoded_confirmed_block.blockhash)?;
-        writeln!(
-            f,
-            "Previous Blockhash: {}",
-            self.encoded_confirmed_block.previous_blockhash
-        )?;
-        if let Some(block_time) = self.encoded_confirmed_block.block_time {
+impl CliBlock {
+    pub fn display_block_meta(
+        f: &mut fmt::Formatter,
+        slot: Slot,
+        parent_slot: Slot,
+        blockhash: &str,
+        previous_blockhash: &str,
+        block_time: Option<i64>,
+        block_height: Option<u64>,
+        rewards: &Rewards,
+    ) -> fmt::Result {
+        writeln!(f, "Slot: {slot}")?;
+        writeln!(f, "Parent Slot: {parent_slot}")?;
+        writeln!(f, "Blockhash: {blockhash}")?;
+        writeln!(f, "Previous Blockhash: {previous_blockhash}")?;
+        if let Some(block_time) = block_time {
             writeln!(
                 f,
                 "Block Time: {:?}",
                 Local.timestamp_opt(block_time, 0).unwrap()
             )?;
         }
-        if let Some(block_height) = self.encoded_confirmed_block.block_height {
+        if let Some(block_height) = block_height {
             writeln!(f, "Block Height: {block_height:?}")?;
         }
-        if !self.encoded_confirmed_block.rewards.is_empty() {
-            let mut rewards = self.encoded_confirmed_block.rewards.clone();
+        if !rewards.is_empty() {
+            let mut rewards = rewards.clone();
             rewards.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
             let mut total_rewards = 0;
             writeln!(f, "Rewards:")?;
@@ -3189,6 +3187,26 @@ impl fmt::Display for CliBlock {
                 build_balance_message(total_rewards.unsigned_abs(), false, false)
             )?;
         }
+        Ok(())
+    }
+}
+
+impl QuietDisplay for CliBlock {}
+impl VerboseDisplay for CliBlock {}
+
+impl fmt::Display for CliBlock {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Self::display_block_meta(
+            f,
+            self.slot,
+            self.encoded_confirmed_block.parent_slot,
+            &self.encoded_confirmed_block.blockhash,
+            &self.encoded_confirmed_block.previous_blockhash,
+            self.encoded_confirmed_block.block_time,
+            self.encoded_confirmed_block.block_height,
+            &self.encoded_confirmed_block.rewards,
+        )?;
+
         for (index, transaction_with_meta) in
             self.encoded_confirmed_block.transactions.iter().enumerate()
         {

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -3,7 +3,6 @@ use {
         error::{LedgerToolError, Result},
         ledger_utils::get_program_ids,
     },
-    chrono::{Local, TimeZone},
     itertools::Either,
     pretty_hex::PrettyHex,
     serde::{
@@ -13,8 +12,8 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::is_loadable::IsLoadable as _,
     solana_cli_output::{
-        CliAccount, CliAccountNewConfig, OutputFormat, QuietDisplay, VerboseDisplay,
-        display::{build_balance_message, writeln_transaction},
+        CliAccount, CliAccountNewConfig, CliBlock, OutputFormat, QuietDisplay, VerboseDisplay,
+        display::writeln_transaction,
     },
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
@@ -208,84 +207,17 @@ impl VerboseDisplay for CliBlockWithEntries {}
 
 impl fmt::Display for CliBlockWithEntries {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "Slot: {}", self.slot)?;
-        writeln!(
+        CliBlock::display_block_meta(
             f,
-            "Parent Slot: {}",
-            self.encoded_confirmed_block.parent_slot
+            self.slot,
+            self.encoded_confirmed_block.parent_slot,
+            &self.encoded_confirmed_block.blockhash,
+            &self.encoded_confirmed_block.previous_blockhash,
+            self.encoded_confirmed_block.block_time,
+            self.encoded_confirmed_block.block_height,
+            &self.encoded_confirmed_block.rewards,
         )?;
-        writeln!(f, "Blockhash: {}", self.encoded_confirmed_block.blockhash)?;
-        writeln!(
-            f,
-            "Previous Blockhash: {}",
-            self.encoded_confirmed_block.previous_blockhash
-        )?;
-        if let Some(block_time) = self.encoded_confirmed_block.block_time {
-            writeln!(
-                f,
-                "Block Time: {:?}",
-                Local.timestamp_opt(block_time, 0).unwrap()
-            )?;
-        }
-        if let Some(block_height) = self.encoded_confirmed_block.block_height {
-            writeln!(f, "Block Height: {block_height:?}")?;
-        }
-        if !self.encoded_confirmed_block.rewards.is_empty() {
-            let mut rewards = self.encoded_confirmed_block.rewards.clone();
-            rewards.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
-            let mut total_rewards = 0;
-            writeln!(f, "Rewards:")?;
-            writeln!(
-                f,
-                "  {:<44}  {:^15}  {:<15}  {:<20}  {:>14}  {:>10}",
-                "Address", "Type", "Amount", "New Balance", "Percent Change", "Commission"
-            )?;
-            for reward in rewards {
-                let sign = if reward.lamports < 0 { "-" } else { "" };
 
-                total_rewards += reward.lamports;
-                #[allow(clippy::format_in_format_args)]
-                writeln!(
-                    f,
-                    "  {:<44}  {:^15}  {:>15}  {}  {}",
-                    reward.pubkey,
-                    if let Some(reward_type) = reward.reward_type {
-                        format!("{reward_type}")
-                    } else {
-                        "-".to_string()
-                    },
-                    format!(
-                        "{}◎{:<14.9}",
-                        sign,
-                        build_balance_message(reward.lamports.unsigned_abs(), false, false)
-                    ),
-                    if reward.post_balance == 0 {
-                        "          -                 -".to_string()
-                    } else {
-                        format!(
-                            "◎{:<19.9}  {:>13.9}%",
-                            build_balance_message(reward.post_balance, false, false),
-                            (reward.lamports.abs() as f64
-                                / (reward.post_balance as f64 - reward.lamports as f64))
-                                * 100.0
-                        )
-                    },
-                    reward
-                        .commission_bps
-                        .map(|bps| format!("{:>8}.{:02}%", bps / 100, bps % 100))
-                        .or_else(|| reward.commission.map(|c| format!("{c:>9}%")))
-                        .unwrap_or_else(|| "    -".to_string())
-                )?;
-            }
-
-            let sign = if total_rewards < 0 { "-" } else { "" };
-            writeln!(
-                f,
-                "Total Rewards: {}◎{:<12.9}",
-                sign,
-                build_balance_message(total_rewards.unsigned_abs(), false, false)
-            )?;
-        }
         for (index, entry) in self.encoded_confirmed_block.entries.iter().enumerate() {
             writeln_entry(f, index, &entry.into(), "")?;
             for (index, transaction_with_meta) in entry.transactions.iter().enumerate() {


### PR DESCRIPTION
#### Problem
Repeated code between `solana_cli_output::CliBlock` and `CliBlockWithEntries` type from `ledger-tool`; the `ledger-tool` type is made to mirror the CLI type but adds some extra information (entry information as the name suggests 😄). https://github.com/anza-xyz/agave/pull/12532 is looking to add another variant so moving the common output code into a reusable function seems like a win

#### Summary of Changes
Refactor code from CliBlock into a helper and use that

#### Testing
This change is straight forward refactoring; regardless, I ran `solana block` and compared output for current stable version against this branch.
```
$ solana --version
solana-cli 4.0.2 (src:1845f426; feat:6ff76655, client:Agave)
$ solana block 428831665 > 428831665.pre
// This branch
$ cargo run --release -- block 428831665 > 428831665.post
$ shasum -a 256 428831665.pre 
179290ad6d0dc3e2e8f27b48518cb13fdbb5312d6bbde799807c6cafdf9aa35e  428831665.pre
$ shasum -a 256 428831665.post 
179290ad6d0dc3e2e8f27b48518cb13fdbb5312d6bbde799807c6cafdf9aa35e  428831665.post
```