### PR TITLE
extract dead replay result handling

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3808,6 +3808,30 @@ impl ReplayStage {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn mark_replay_result_dead_slot(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        err: &BlockstoreProcessorError,
+        progress: &mut ProgressMap,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+    ) {
+        let root = process_active_banks_context
+            .bank_forks
+            .read()
+            .unwrap()
+            .root();
+        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
+            root,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs.as_deref_mut(),
+        );
+        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3854,14 +3878,15 @@ impl ReplayStage {
                         continue;
                     }
                     Err(err) => {
-                        let root = bank_forks.read().unwrap().root();
-                        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                            root,
+                        Self::mark_replay_result_dead_slot(
+                            process_active_banks_context,
+                            bank,
+                            err,
+                            progress,
                             duplicate_slots_to_repair,
                             purge_repair_slot_counter,
-                            tbft_structs.as_deref_mut(),
+                            &mut tbft_structs,
                         );
-                        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3930,14 +3955,15 @@ impl ReplayStage {
                     },
                 );
                 if let Err(err) = replay_res.and(verify_res) {
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
+                        bank,
+                        &err,
+                        progress,
                         duplicate_slots_to_repair,
                         purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
+                        &mut tbft_structs,
                     );
-                    mark_replay_dead_slot(bank, &err, progress, &mut dead_slot_context);
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
@@ -3994,14 +4020,8 @@ impl ReplayStage {
                         warn!("Unable to write bank hash details file: {err}");
                     }
 
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
-                    );
-                    mark_replay_dead_slot(
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
                         bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
@@ -4009,7 +4029,9 @@ impl ReplayStage {
                             computed_hash,
                         ),
                         progress,
-                        &mut dead_slot_context,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        &mut tbft_structs,
                     );
 
                     continue;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -280,11 +280,12 @@ impl ProcessActiveBanksContext {
     /// soft dead-slot transition.
     fn dead_slot_context<'a>(
         &'a self,
-        root: Slot,
         duplicate_slots_to_repair: &'a mut DuplicateSlotsToRepair,
         purge_repair_slot_counter: &'a mut PurgeRepairSlotCounter,
         tbft_structs: Option<&'a mut TowerBFTStructures>,
     ) -> DeadSlotContext<'a> {
+        let root = self.bank_forks.read().unwrap().root();
+
         DeadSlotContext {
             notifications: self.dead_slot_notifications(),
             duplicate: DeadSlotDuplicateContext {
@@ -3818,13 +3819,7 @@ impl ReplayStage {
         purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
         tbft_structs: &mut Option<&mut TowerBFTStructures>,
     ) {
-        let root = process_active_banks_context
-            .bank_forks
-            .read()
-            .unwrap()
-            .root();
         let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-            root,
             duplicate_slots_to_repair,
             purge_repair_slot_counter,
             tbft_structs.as_deref_mut(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3809,24 +3809,6 @@ impl ReplayStage {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn mark_replay_result_dead_slot(
-        process_active_banks_context: &ProcessActiveBanksContext,
-        bank: &BankWithScheduler,
-        err: &BlockstoreProcessorError,
-        progress: &mut ProgressMap,
-        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
-        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
-        tbft_structs: &mut Option<&mut TowerBFTStructures>,
-    ) {
-        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-            duplicate_slots_to_repair,
-            purge_repair_slot_counter,
-            tbft_structs.as_deref_mut(),
-        );
-        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
-    }
-
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3873,15 +3855,17 @@ impl ReplayStage {
                         continue;
                     }
                     Err(err) => {
-                        Self::mark_replay_result_dead_slot(
-                            process_active_banks_context,
+                        mark_replay_dead_slot(
                             bank,
                             err,
                             progress,
-                            duplicate_slots_to_repair,
-                            purge_repair_slot_counter,
-                            &mut tbft_structs,
+                            &mut process_active_banks_context.dead_slot_context(
+                                duplicate_slots_to_repair,
+                                purge_repair_slot_counter,
+                                tbft_structs.as_deref_mut(),
+                            ),
                         );
+
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3950,14 +3934,15 @@ impl ReplayStage {
                     },
                 );
                 if let Err(err) = replay_res.and(verify_res) {
-                    Self::mark_replay_result_dead_slot(
-                        process_active_banks_context,
+                    mark_replay_dead_slot(
                         bank,
                         &err,
                         progress,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
+                        &mut process_active_banks_context.dead_slot_context(
+                            duplicate_slots_to_repair,
+                            purge_repair_slot_counter,
+                            tbft_structs.as_deref_mut(),
+                        ),
                     );
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
@@ -4015,8 +4000,7 @@ impl ReplayStage {
                         warn!("Unable to write bank hash details file: {err}");
                     }
 
-                    Self::mark_replay_result_dead_slot(
-                        process_active_banks_context,
+                    mark_replay_dead_slot(
                         bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
@@ -4024,9 +4008,11 @@ impl ReplayStage {
                             computed_hash,
                         ),
                         progress,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        &mut tbft_structs,
+                        &mut process_active_banks_context.dead_slot_context(
+                            duplicate_slots_to_repair,
+                            purge_repair_slot_counter,
+                            tbft_structs.as_deref_mut(),
+                        ),
                     );
 
                     continue;

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3807,6 +3807,30 @@ impl ReplayStage {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn mark_replay_result_dead_slot(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        err: &BlockstoreProcessorError,
+        progress: &mut ProgressMap,
+        duplicate_slots_to_repair: &mut DuplicateSlotsToRepair,
+        purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
+        tbft_structs: &mut Option<&mut TowerBFTStructures>,
+    ) {
+        let root = process_active_banks_context
+            .bank_forks
+            .read()
+            .unwrap()
+            .root();
+        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
+            root,
+            duplicate_slots_to_repair,
+            purge_repair_slot_counter,
+            tbft_structs.as_deref_mut(),
+        );
+        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3853,14 +3877,15 @@ impl ReplayStage {
                         continue;
                     }
                     Err(err) => {
-                        let root = bank_forks.read().unwrap().root();
-                        let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                            root,
+                        Self::mark_replay_result_dead_slot(
+                            process_active_banks_context,
+                            bank,
+                            err,
+                            progress,
                             duplicate_slots_to_repair,
                             purge_repair_slot_counter,
-                            tbft_structs.as_deref_mut(),
+                            &mut tbft_structs,
                         );
-                        mark_replay_dead_slot(bank, err, progress, &mut dead_slot_context);
                         // don't try to run the below logic to check if the bank is completed
                         continue;
                     }
@@ -3929,14 +3954,15 @@ impl ReplayStage {
                     },
                 );
                 if let Err(err) = replay_res.and(verify_res) {
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
+                        bank,
+                        &err,
+                        progress,
                         duplicate_slots_to_repair,
                         purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
+                        &mut tbft_structs,
                     );
-                    mark_replay_dead_slot(bank, &err, progress, &mut dead_slot_context);
                     // don't try to run the remaining normal processing for the completed bank
                     continue;
                 }
@@ -3993,14 +4019,8 @@ impl ReplayStage {
                         warn!("Unable to write bank hash details file: {err}");
                     }
 
-                    let root = bank_forks.read().unwrap().root();
-                    let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-                        root,
-                        duplicate_slots_to_repair,
-                        purge_repair_slot_counter,
-                        tbft_structs.as_deref_mut(),
-                    );
-                    mark_replay_dead_slot(
+                    Self::mark_replay_result_dead_slot(
+                        process_active_banks_context,
                         bank,
                         &BlockstoreProcessorError::BankHashMismatch(
                             bank_slot,
@@ -4008,7 +4028,9 @@ impl ReplayStage {
                             computed_hash,
                         ),
                         progress,
-                        &mut dead_slot_context,
+                        duplicate_slots_to_repair,
+                        purge_repair_slot_counter,
+                        &mut tbft_structs,
                     );
 
                     continue;

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -344,9 +344,7 @@ pub(super) fn handle_abandoned_bank(
                 .is_some()
             });
     if !update_parent_ready {
-        let root = bank_forks.read().unwrap().root();
         let mut dead_slot_context = process_active_banks_context.dead_slot_context(
-            root,
             duplicate_slots_to_repair,
             purge_repair_slot_counter,
             tbft_structs,


### PR DESCRIPTION
#### Problem

Code are duplicated few places to handle dead slot in replay results
(part of #12895)

#### Summary of Changes

- extract duplicated code into `mark_replay_result_dead_slot()`

#### Testing
CI

Fixes #
