### PR TITLE
Remove ability to purge stores from runtime

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3792,10 +3792,10 @@ impl AccountsDb {
         // P1 purge_slot()                        | N/A
         //          |                             |
         //          V                             |
-        // P2 purge_cached_slots()                | map of caches/stores (removes old entry)
+        // P2 purge_slots_from_cache()            | map of caches/stores (removes old entry)
         //          |                             |
         //          V                             |
-        // P3 purge_cached_slots()/               | index
+        // P3 purge_slots_from_cache()/           | index
         //       remove_dead_slots_metadata()     | (removes index roots metadata for cached slot)
         //       purge_slot_storage()/            |
         //          purge_keys_exact()            | (removes accounts index entries)
@@ -4101,72 +4101,68 @@ impl AccountsDb {
 
         self.purge_slots(std::iter::once(&slot));
     }
-    /// Removes `slot` from the write cache and its accounts-index entries. Returns whether the
-    /// slot was in the cache. Does not touch backing storage.
-    fn remove_cached_slot(&self, slot: Slot, purge_stats: &PurgeStats) -> bool {
-        let mut remove_cache_elapsed = Measure::start("remove_cache_elapsed");
-
-        // Early return if the slot is not in the cache
-        let Some(slot_cache) = self.accounts_cache.slot_cache(slot) else {
-            debug!("remove_cached_slot() called for slot {slot} which is not in the cache");
-            return false;
-        };
-
-        // Note: we cannot remove this slot from the slot cache until we've removed its
-        // entries from the accounts index first. This is because `scan_accounts()` relies on
-        // holding the index lock, finding the index entry, and then looking up the entry
-        // in the cache. If it fails to find that entry, it will panic in `get_loaded_account()`
-        let total_bytes = slot_cache.total_bytes();
-        self.remove_dead_slots_metadata(iter::once(&slot));
-        remove_cache_elapsed.stop();
-        // Nobody else should have removed the slot cache entry yet
-        let pubkeys_removed = self
-            .accounts_cache
-            .remove_slot(slot)
-            .expect("slot cache entry must still be present");
-        // Cache writes populate the secondary indexes but not the primary index, so a
-        // cache-only account dropped here without ever being flushed would leak its
-        // secondary entry.
-        // Explicitly ignore the return value as there is no need to purge the account
-        // from the primary index as well
-        //
-        // Narrow race: If a write re-adds the same pubkey key between `remove_slot` and
-        // `handle_dead_keys`, the new secondary entry will be dropped. Only
-        // secondary-index scans observe it (no consensus impact), and it self-heals: the
-        // entry is re-added when that slot flushes, or stays correctly removed if the slot
-        // is later purged.
-        if !self.account_indexes.is_empty() {
-            let _ = self
-                .accounts_index
-                .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
-        }
-        self.accounts_index.write_through_pubkeys(pubkeys_removed);
-
-        purge_stats
-            .remove_cache_elapsed
-            .fetch_add(remove_cache_elapsed.as_us(), Ordering::Relaxed);
-        purge_stats
-            .num_cached_slots_removed
-            .fetch_add(1, Ordering::Relaxed);
-        purge_stats
-            .total_removed_cached_bytes
-            .fetch_add(total_bytes, Ordering::Relaxed);
-        true
-    }
 
     /// Purges each slot in `removed_slots` from the write cache (and the accounts index). Slots
     /// no longer present in the cache are skipped. This never touches backing storage, so it
-    /// cannot delete a flushed (rooted) slot's data.
-    fn purge_cached_slots<'a>(
+    /// cannot delete a flushed (rooted) slot's data. Returns whether any slot was in the cache.
+    fn purge_slots_from_cache<'a>(
         &self,
         removed_slots: impl Iterator<Item = &'a Slot>,
         purge_stats: &PurgeStats,
-    ) {
-        // This function is only currently safe with respect to `flush_slot_cache()` because
-        // both functions run serially in AccountsBackgroundService.
+    ) -> bool {
+        let mut remove_cache_elapsed_across_slots = 0;
+        let mut num_cached_slots_removed = 0;
+        let mut total_removed_cached_bytes = 0;
         for remove_slot in removed_slots {
-            self.remove_cached_slot(*remove_slot, purge_stats);
+            // This function is only currently safe with respect to `flush_slot_cache()` because
+            // both functions run serially in AccountsBackgroundService.
+            let mut remove_cache_elapsed = Measure::start("remove_cache_elapsed");
+            // Note: we cannot remove this slot from the slot cache until we've removed its
+            // entries from the accounts index first. This is because `scan_accounts()` relies on
+            // holding the index lock, finding the index entry, and then looking up the entry
+            // in the cache. If it fails to find that entry, it will panic in `get_loaded_account()`
+            if let Some(slot_cache) = self.accounts_cache.slot_cache(*remove_slot) {
+                num_cached_slots_removed += 1;
+                total_removed_cached_bytes += slot_cache.total_bytes();
+                self.remove_dead_slots_metadata(iter::once(remove_slot));
+                remove_cache_elapsed.stop();
+                remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
+                // Nobody else should have removed the slot cache entry yet
+                let pubkeys_removed = self
+                    .accounts_cache
+                    .remove_slot(*remove_slot)
+                    .expect("slot cache entry must still be present");
+                // Cache writes populate the secondary indexes but not the primary index, so a
+                // cache-only account dropped here without ever being flushed would leak its
+                // secondary entry.
+                // Explicitly ignore the return value as there is no need to purge the account
+                // from the primary index as well
+                //
+                // Narrow race: If a write re-adds the same pubkey key between `remove_slot` and
+                // `handle_dead_keys`, the new secondary entry will be dropped. Only
+                // secondary-index scans observe it (no consensus impact), and it self-heals: the
+                // entry is re-added when that slot flushes, or stays correctly removed if the slot
+                // is later purged.
+                if !self.account_indexes.is_empty() {
+                    let _ = self
+                        .accounts_index
+                        .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
+                }
+                self.accounts_index.write_through_pubkeys(pubkeys_removed);
+            }
         }
+
+        purge_stats
+            .remove_cache_elapsed
+            .fetch_add(remove_cache_elapsed_across_slots, Ordering::Relaxed);
+        purge_stats
+            .num_cached_slots_removed
+            .fetch_add(num_cached_slots_removed, Ordering::Relaxed);
+        purge_stats
+            .total_removed_cached_bytes
+            .fetch_add(total_removed_cached_bytes, Ordering::Relaxed);
+
+        num_cached_slots_removed > 0
     }
 
     /// Purges every slot in `removed_slots` from both the cache and storage. This includes
@@ -4183,7 +4179,7 @@ impl AccountsDb {
             // Unlike the consensus purge paths, minimization may purge slots that have already
             // been flushed to storage, so fall back to purging storage for any slot that is no
             // longer in the cache.
-            if !self.remove_cached_slot(*remove_slot, &purge_stats) {
+            if !self.purge_slots_from_cache(iter::once(remove_slot), &purge_stats) {
                 self.purge_slot_storage(*remove_slot, &purge_stats);
             }
         }
@@ -4327,13 +4323,13 @@ impl AccountsDb {
             // Also note roots are never removed via `remove_unrooted_slot()`, so
             // it's safe to filter them out here as they won't need deletion from
             // self.scan_tracker.removed_bank_ids in
-            // `purge_cached_slots()`.
+            // `purge_slots_from_cache()`.
             .filter(|slot| !self.accounts_index.is_alive_root(**slot));
         safety_checks_elapsed.stop();
         self.external_purge_slots_stats
             .safety_checks_elapsed
             .fetch_add(safety_checks_elapsed.as_us(), Ordering::Relaxed);
-        self.purge_cached_slots(non_roots, &self.external_purge_slots_stats);
+        self.purge_slots_from_cache(non_roots, &self.external_purge_slots_stats);
         self.external_purge_slots_stats
             .report("external_purge_slots_stats", Some(1000));
     }
@@ -4358,7 +4354,7 @@ impl AccountsDb {
         }
 
         let remove_unrooted_purge_stats = PurgeStats::default();
-        self.purge_cached_slots(
+        self.purge_slots_from_cache(
             remove_slots.iter().map(|(slot, _)| slot),
             &remove_unrooted_purge_stats,
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4104,7 +4104,9 @@ impl AccountsDb {
 
     /// Purges each slot in `removed_slots` from the write cache (and the accounts index). Slots
     /// no longer present in the cache are skipped. This never touches backing storage, so it
-    /// cannot delete a flushed (rooted) slot's data. Returns whether any slot was in the cache.
+    /// cannot delete a flushed (rooted) slot's data. Returns whether any slot was actually
+    /// removed from the cache. This allows the snapshot minimizer to determine whether
+    /// it should purge the storage as well
     fn purge_slots_from_cache<'a>(
         &self,
         removed_slots: impl Iterator<Item = &'a Slot>,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3792,10 +3792,10 @@ impl AccountsDb {
         // P1 purge_slot()                        | N/A
         //          |                             |
         //          V                             |
-        // P2 purge_slots_from_cache_and_store()  | map of caches/stores (removes old entry)
+        // P2 purge_cached_slots()                | map of caches/stores (removes old entry)
         //          |                             |
         //          V                             |
-        // P3 purge_slots_from_cache_and_store()/ | index
+        // P3 purge_cached_slots()/               | index
         //       remove_dead_slots_metadata()     | (removes index roots metadata for cached slot)
         //       purge_slot_storage()/            |
         //          purge_keys_exact()            | (removes accounts index entries)
@@ -4101,72 +4101,72 @@ impl AccountsDb {
 
         self.purge_slots(std::iter::once(&slot));
     }
+    /// Removes `slot` from the write cache and its accounts-index entries. Returns whether the
+    /// slot was in the cache. Does not touch backing storage.
+    fn remove_cached_slot(&self, slot: Slot, purge_stats: &PurgeStats) -> bool {
+        let mut remove_cache_elapsed = Measure::start("remove_cache_elapsed");
 
-    /// Purges every slot in `removed_slots` from both the cache and storage. This includes
-    /// entries in the accounts index, cache entries, and any backing storage entries.
-    fn purge_slots_from_cache_and_store<'a>(
-        &self,
-        removed_slots: impl Iterator<Item = &'a Slot> + Clone,
-        purge_stats: &PurgeStats,
-    ) {
-        let mut remove_cache_elapsed_across_slots = 0;
-        let mut num_cached_slots_removed = 0;
-        let mut total_removed_cached_bytes = 0;
-        for remove_slot in removed_slots {
-            // This function is only currently safe with respect to `flush_slot_cache()` because
-            // both functions run serially in AccountsBackgroundService.
-            let mut remove_cache_elapsed = Measure::start("remove_cache_elapsed");
-            // Note: we cannot remove this slot from the slot cache until we've removed its
-            // entries from the accounts index first. This is because `scan_accounts()` relies on
-            // holding the index lock, finding the index entry, and then looking up the entry
-            // in the cache. If it fails to find that entry, it will panic in `get_loaded_account()`
-            if let Some(slot_cache) = self.accounts_cache.slot_cache(*remove_slot) {
-                // If the slot is still in the cache, remove the backing storages for
-                // the slot and from the Accounts Index
-                num_cached_slots_removed += 1;
-                total_removed_cached_bytes += slot_cache.total_bytes();
-                self.remove_dead_slots_metadata(iter::once(remove_slot));
-                remove_cache_elapsed.stop();
-                remove_cache_elapsed_across_slots += remove_cache_elapsed.as_us();
-                // Nobody else should have removed the slot cache entry yet
-                let pubkeys_removed = self
-                    .accounts_cache
-                    .remove_slot(*remove_slot)
-                    .expect("slot cache entry must still be present");
-                // Cache writes populate the secondary indexes but not the primary index, so a
-                // cache-only account dropped here without ever being flushed would leak its
-                // secondary entry.
-                // Explicitly ignore the return value as there is no need to purge the account
-                // from the primary index as well
-                //
-                // Narrow race: If a write re-adds the same pubkey key between `remove_slot` and
-                // `handle_dead_keys`, the new secondary entry will be dropped. Only
-                // secondary-index scans observe it (no consensus impact), and it self-heals: the
-                // entry is re-added when that slot flushes, or stays correctly removed if the slot
-                // is later purged.
-                if !self.account_indexes.is_empty() {
-                    let _ = self
-                        .accounts_index
-                        .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
-                }
-                self.accounts_index.write_through_pubkeys(pubkeys_removed);
-            } else {
-                self.purge_slot_storage(*remove_slot, purge_stats);
-            }
-            // It should not be possible that a slot is neither in the cache or storage. Even in
-            // a slot with all ticks, `Bank::new_from_parent()` immediately stores some sysvars
-            // on bank creation.
+        // Early return if the slot is not in the cache
+        let Some(slot_cache) = self.accounts_cache.slot_cache(slot) else {
+            debug!("remove_cached_slot() called for slot {slot} which is not in the cache");
+            return false;
+        };
+
+        // Note: we cannot remove this slot from the slot cache until we've removed its
+        // entries from the accounts index first. This is because `scan_accounts()` relies on
+        // holding the index lock, finding the index entry, and then looking up the entry
+        // in the cache. If it fails to find that entry, it will panic in `get_loaded_account()`
+        let total_bytes = slot_cache.total_bytes();
+        self.remove_dead_slots_metadata(iter::once(&slot));
+        remove_cache_elapsed.stop();
+        // Nobody else should have removed the slot cache entry yet
+        let pubkeys_removed = self
+            .accounts_cache
+            .remove_slot(slot)
+            .expect("slot cache entry must still be present");
+        // Cache writes populate the secondary indexes but not the primary index, so a
+        // cache-only account dropped here without ever being flushed would leak its
+        // secondary entry.
+        // Explicitly ignore the return value as there is no need to purge the account
+        // from the primary index as well
+        //
+        // Narrow race: If a write re-adds the same pubkey key between `remove_slot` and
+        // `handle_dead_keys`, the new secondary entry will be dropped. Only
+        // secondary-index scans observe it (no consensus impact), and it self-heals: the
+        // entry is re-added when that slot flushes, or stays correctly removed if the slot
+        // is later purged.
+        if !self.account_indexes.is_empty() {
+            let _ = self
+                .accounts_index
+                .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
         }
+        self.accounts_index.write_through_pubkeys(pubkeys_removed);
 
         purge_stats
             .remove_cache_elapsed
-            .fetch_add(remove_cache_elapsed_across_slots, Ordering::Relaxed);
+            .fetch_add(remove_cache_elapsed.as_us(), Ordering::Relaxed);
         purge_stats
             .num_cached_slots_removed
-            .fetch_add(num_cached_slots_removed, Ordering::Relaxed);
+            .fetch_add(1, Ordering::Relaxed);
         purge_stats
             .total_removed_cached_bytes
-            .fetch_add(total_removed_cached_bytes, Ordering::Relaxed);
+            .fetch_add(total_bytes, Ordering::Relaxed);
+        true
+    }
+
+    /// Purges each slot in `removed_slots` from the write cache (and the accounts index). Slots
+    /// no longer present in the cache are skipped. This never touches backing storage, so it
+    /// cannot delete a flushed (rooted) slot's data.
+    fn purge_cached_slots<'a>(
+        &self,
+        removed_slots: impl Iterator<Item = &'a Slot>,
+        purge_stats: &PurgeStats,
+    ) {
+        // This function is only currently safe with respect to `flush_slot_cache()` because
+        // both functions run serially in AccountsBackgroundService.
+        for remove_slot in removed_slots {
+            self.remove_cached_slot(*remove_slot, purge_stats);
+        }
     }
 
     /// Purges every slot in `removed_slots` from both the cache and storage. This includes
@@ -4176,10 +4176,17 @@ impl AccountsDb {
     #[cfg(feature = "dev-context-only-utils")]
     pub fn purge_slots_for_snapshot_minimizer<'a>(
         &self,
-        removed_slots: impl Iterator<Item = &'a Slot> + Clone,
+        removed_slots: impl Iterator<Item = &'a Slot>,
     ) {
-        let stats = PurgeStats::default();
-        self.purge_slots_from_cache_and_store(removed_slots, &stats);
+        let purge_stats = PurgeStats::default();
+        for remove_slot in removed_slots {
+            // Unlike the consensus purge paths, minimization may purge slots that have already
+            // been flushed to storage, so fall back to purging storage for any slot that is no
+            // longer in the cache.
+            if !self.remove_cached_slot(*remove_slot, &purge_stats) {
+                self.purge_slot_storage(*remove_slot, &purge_stats);
+            }
+        }
     }
 
     /// Purge the backing storage entries for the given slot, does not purge from
@@ -4246,6 +4253,7 @@ impl AccountsDb {
             .fetch_add(num_stored_slots_removed as u64, Ordering::Relaxed);
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     fn purge_slot_storage(&self, remove_slot: Slot, purge_stats: &PurgeStats) {
         // Because AccountsBackgroundService synchronously flushes from the accounts cache
         // and handles all Bank::drop() (the cleanup function that leads to this
@@ -4319,13 +4327,13 @@ impl AccountsDb {
             // Also note roots are never removed via `remove_unrooted_slot()`, so
             // it's safe to filter them out here as they won't need deletion from
             // self.scan_tracker.removed_bank_ids in
-            // `purge_slots_from_cache_and_store()`.
+            // `purge_cached_slots()`.
             .filter(|slot| !self.accounts_index.is_alive_root(**slot));
         safety_checks_elapsed.stop();
         self.external_purge_slots_stats
             .safety_checks_elapsed
             .fetch_add(safety_checks_elapsed.as_us(), Ordering::Relaxed);
-        self.purge_slots_from_cache_and_store(non_roots, &self.external_purge_slots_stats);
+        self.purge_cached_slots(non_roots, &self.external_purge_slots_stats);
         self.external_purge_slots_stats
             .report("external_purge_slots_stats", Some(1000));
     }
@@ -4350,7 +4358,7 @@ impl AccountsDb {
         }
 
         let remove_unrooted_purge_stats = PurgeStats::default();
-        self.purge_slots_from_cache_and_store(
+        self.purge_cached_slots(
             remove_slots.iter().map(|(slot, _)| slot),
             &remove_unrooted_purge_stats,
         );


### PR DESCRIPTION
#### Problem
Currently the production path follows purge_from_cache_and_store which purges from both. There is no use case to purge from store in production, but we end up attempting to purge from stores anyways

Proof:
This timer is only incremented when attempting to purge stores. The else case (if a slot is not present in the slot_cache) immediately attempts to purge the slot from the store. Best case this is wasted cycles. Worst case, actually removing a store would cause an issue, although other bugs would need to compound for this to occur.

<img width="1678" height="489" alt="image" src="https://github.com/user-attachments/assets/2e1e6619-1fa9-4844-a319-3c6c83090a7b" />

#### Summary of Changes
- Split the calls so that stores are never looked at for purge other than the snapshot minimizer

#### Testing


Fixes #
