### PR TITLE
v4.1: ignore quinn RUSTSEC-2026-0185

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -55,6 +55,17 @@ default_cargo_audit_extra_args=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+  # Crate:     quinn-proto
+  # Version:   0.11.14
+  # Title:     Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
+  # Date:      2026-06-22
+  # ID:        RUSTSEC-2026-0185
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0185
+  # Severity:  7.5 (high)
+  # Solution:  Upgrade to >=0.11.15
+  # AGAVE OK:  we read 1 stream at a time, bounded to tx size, for up to 2s
+  --ignore RUSTSEC-2026-0185
 )
 
 xtask_cargo_audit_extra_args=(


### PR DESCRIPTION
#### Problem
cargo audit trips on this quinn rustsec. but we are not vulnerable to this.

#### Summary of Changes
ignore RUSTSEC-2026-0185