### PR TITLE
ci(docker): add cargo-build-sbf to ci image

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -90,6 +90,7 @@ RUN \
   cargo install svgbob_cli && \
   cargo install wasm-pack && \
   cargo install rustfilt && \
+  cargo install cargo-build-sbf@4.1.0 --locked && \
   rustup show && \
   rustc --version && \
   cargo --version && \


### PR DESCRIPTION
#### Problem

cargo-build-sbf is a standalone crate now. afaik it's very backward-compatible. it would be really useful if we could integrate it into our ci image

#### Summary of Changes

add `cargo-build-sbf@4.1.0` to our ci image