### PR TITLE
chore(deps): bump solana-stake-interface from 4.2.0 to 4.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10716,9 +10716,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "borsh",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,7 +491,7 @@ solana-signer-store = "0.1.0"
 solana-slot-hashes = "3.1.0"
 solana-slot-history = "3.0.1"
 solana-stable-layout = "3.0.1"
-solana-stake-interface = "4.2.0"
+solana-stake-interface = "4.3.0"
 solana-storage-bigtable = { path = "storage-bigtable", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-storage-proto = { path = "storage-proto", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "streamer", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8362,9 +8362,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "num-traits",
  "serde",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -125,7 +125,7 @@ solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.1", default-features = false }
 solana-signer = "3.0.1"
-solana-stake-interface = "4.2.0"
+solana-stake-interface = "4.3.0"
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "../streamer", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm = { path = "../svm", version = "=4.2.0-alpha.0", features = ["agave-unstable-api"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9338,9 +9338,9 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-interface"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f34562cda7df74d85fcb1f7063d8cdec3e14f3d402aa3062605c116d8b8115"
+checksum = "252b4291eb25a5a356149ed4d4a940d5f655186210fa84b5d0d8d55c3dd42a81"
 dependencies = [
  "num-traits",
  "serde",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -152,7 +152,7 @@ solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version
 solana-sdk-ids = "=3.1.0"
 solana-secp256k1-recover = "=3.1.1"
 solana-sha256-hasher = { version = "=3.1.0", features = ["sha2"] }
-solana-stake-interface = { version = "=4.2.0", features = ["bincode"] }
+solana-stake-interface = { version = "=4.3.0", features = ["bincode"] }
 solana-svm = { path = "../../svm", version = "=4.2.0-alpha.0" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=4.2.0-alpha.0" }
 solana-svm-timings = { path = "../../svm-timings", version = "=4.2.0-alpha.0" }
@@ -213,7 +213,7 @@ solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sbf-rust-realloc-invoke-dep = { workspace = true }
 solana-sdk-ids = "3.1.0"
 solana-signer = "3.0.0"
-solana-stake-interface = "4.2.0"
+solana-stake-interface = "4.3.0"
 solana-svm = { workspace = true, features = ["dev-context-only-utils"] }
 solana-svm-feature-set = { workspace = true }
 solana-svm-timings = { workspace = true }


### PR DESCRIPTION
#### Problem
4.3.0 has added `StableAbi` implementations

#### Summary of Changes
Bump in whole repository

#### Testing
CI
