### PR TITLE
chore: remove net/README.md with broken docs link

### DIFF
--- a/net/README.md
+++ b/net/README.md
@@ -1,1 +1,0 @@
-../docs/src/clusters/testnet.md


### PR DESCRIPTION
The file `net/README.md` contained only a broken link pointing to `../docs/src/clusters/testnet.md`.

The docs directory was removed in PR #13200, so this link is now invalid.
Since the file has no other useful content, removing it is the cleanest fix.

Fixes #13474