### PR TITLE
feat(snapshots): add StableAbi for snapshot serde types

### DIFF
--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -30,6 +30,7 @@ impl HashInfo {
     frozen_abi(
         api_digest = "DZVVXt4saSgH1CWGrzBcX2sq5yswCuRqGx1Y1ZehtWT6",
         abi_digest = "5ojmBDhhu9AjKUc1LSHhZfXF6KeicvZpKP6XdLNaFAdy",
+        test_roundtrip = "eq_and_wire"
     )
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1051,7 +1051,7 @@ pub struct ProcessedTransactionCounts {
 
 /// Account stats for computing the bank hash
 /// This struct is serialized and stored in the snapshot.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BankHashStats {
     pub num_updated_accounts: u64,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -175,7 +175,7 @@ impl BLSPubkeyToRankMap {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq)]
 pub struct NodeVoteAccounts {
     pub vote_accounts: Vec<Pubkey>,
@@ -198,7 +198,10 @@ pub(crate) enum DeserializableVersionedEpochStakes {
 }
 
 #[derive(Clone, Debug, Serialize)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub enum VersionedEpochStakes {
     Current {
@@ -207,6 +210,7 @@ pub enum VersionedEpochStakes {
         total_stake: u64,
         node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
         epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+        #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
         #[serde(skip)]
         bls_pubkey_to_rank_map: OnceLock<Arc<BLSPubkeyToRankMap>>,
     },
@@ -369,7 +373,7 @@ impl VersionedEpochStakes {
 
 /// The current version of epoch stakes
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct EpochStakes {
     epoch: Epoch,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -95,7 +95,7 @@ pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, Hash)>,
 );
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UnusedIncrementalSnapshotPersistence {
@@ -106,7 +106,14 @@ pub struct UnusedIncrementalSnapshotPersistence {
     pub incremental_capitalization: u64,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "EcPdH21GSyYYTiSZbAN157YfrT3G8rKvDiNh7q1fw8Bc",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
     unused_accounts_delta_hash: [u8; 32],
@@ -114,7 +121,7 @@ struct BankHashInfo {
     stats: BankHashStats,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 struct UnusedAccounts {
     unused1: HashSet<Pubkey>,
@@ -201,6 +208,16 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
 
 // Serializable version of Bank, not Deserializable to avoid cloning by using refs.
 // Sync fields with DeserializableVersionedBank!
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi, StableAbiSample),
+    // Write-only type (its deserialize counterpart is `DeserializableVersionedBank`), so the abi
+    // digest only verifies the serialized wire format; there is no roundtrip.
+    frozen_abi(
+        abi_digest = "6sm6hSNiTsNBAbSAiNe2BSQgnum3UdeNBpZnZiX7aM9r",
+        test_roundtrip = "no"
+    )
+)]
 #[derive(Serialize)]
 struct SerializableVersionedBank {
     blockhash_queue: BlockhashQueue,
@@ -413,7 +430,16 @@ struct ExtraFieldsToDeserialize {
 /// ExtraFieldsToDeserialize with the exception that new "extra fields" should
 /// be added to the deserialize struct a minor release before they are added to
 /// this one.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    // Write-only type (its deserialize counterpart is `ExtraFieldsToDeserialize`), so the abi digest
+    // only verifies the serialized wire format; there is no roundtrip.
+    frozen_abi(
+        abi_digest = "726M1TRfibJsSAGcFqan4TSC8qKkJhDZfiK2P3h71eoo",
+        test_roundtrip = "no"
+    )
+)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Debug, Serialize)]
 pub struct ExtraFieldsToSerialize {

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -18,7 +18,12 @@ use {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p")
+    frozen_abi(
+        api_digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p",
+        abi_digest = "GuQrL8fa1SCkbNyctatMnKgxvVQFs47oR5nwAcLKCzXq",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire"
+    )
 )]
 type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
 type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
@@ -112,8 +117,8 @@ pub fn deserialize_status_cache(
 /// contain a string in the BorshIoError variant.
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
-    derive(AbiExample, AbiEnumVisitor)
+    frozen_abi(api_digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
 enum SerdeTransactionError {
@@ -304,7 +309,10 @@ impl From<SerdeTransactionError> for TransactionError {
 /// Copy of `InstructionError` type in which the `BorshIoError` variant
 /// contains a string.
 #[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
 enum SerdeInstructionError {
     GenericError,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -8,6 +8,14 @@ use {
 pub(crate) type SerializedAccountsFileId = usize;
 
 // Serializable version of AccountStorageEntry for snapshot format
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "CMckX3HiC6K5FSmFo4tH44wU1mvGfabNtYAs65uaGvGU",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SerializableAccountStorageEntry {
     id: SerializedAccountsFileId,

--- a/runtime/src/serde_snapshot/types.rs
+++ b/runtime/src/serde_snapshot/types.rs
@@ -4,7 +4,7 @@ use {
 };
 
 /// Snapshot serde-safe AccountsLtHash
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[serde_with::serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct SerdeAccountsLtHash(
@@ -26,7 +26,7 @@ impl From<AccountsLtHash> for SerdeAccountsLtHash {
 
 /// Snapshot serde-safe RentCollector, which is now unused
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct UnusedRentCollector {
     epoch: Epoch,

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
-#[cfg(feature = "frozen-abi")]
-use solana_frozen_abi::abi_example::AbiExample;
 use {
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_instruction::error::InstructionError,
@@ -13,16 +11,41 @@ use {
     std::marker::PhantomData,
     thiserror::Error,
 };
+#[cfg(feature = "frozen-abi")]
+use {
+    solana_frozen_abi::{abi_example::AbiExample, stable_abi::StableAbi},
+    solana_stake_interface::{stake_flags::StakeFlags, state::Meta},
+};
 
 /// An account and a stake state deserialized from the account.
 /// Generic type T enforces type-safety so that StakeAccount<Delegation> can
 /// only wrap a stake-state which is a Delegation; whereas StakeAccount<()>
 /// wraps any account with stake state.
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Default)]
 pub struct StakeAccount<T> {
+    // Skipped by the custom (delegation/stake-format) serializer; sample the default.
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     account: AccountSharedData,
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_delegated_stake_state(rng)")
+    )]
     stake_state: StakeStateV2,
     _phantom: PhantomData<T>,
+}
+
+/// Samples a random `StakeStateV2::Stake`; the delegation-format serializer unwraps
+/// `delegation_ref()`, which would panic on any other variant.
+#[cfg(feature = "frozen-abi")]
+fn sample_delegated_stake_state(
+    rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized),
+) -> StakeStateV2 {
+    StakeStateV2::Stake(
+        Meta::random(rng),
+        Stake::random(rng),
+        StakeFlags::random(rng),
+    )
 }
 
 #[derive(Debug, Error)]
@@ -108,13 +131,7 @@ impl<S, T> PartialEq<StakeAccount<S>> for StakeAccount<T> {
 #[cfg(feature = "frozen-abi")]
 impl AbiExample for StakeAccount<Delegation> {
     fn example() -> Self {
-        use {
-            solana_account::Account,
-            solana_stake_interface::{
-                stake_flags::StakeFlags,
-                state::{Meta, Stake},
-            },
-        };
+        use solana_account::Account;
         let stake_state =
             StakeStateV2::Stake(Meta::example(), Stake::example(), StakeFlags::example());
         let mut account = Account::example();

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -12,7 +12,7 @@ use {
 };
 
 /// The SDK's stake history with clone-on-write semantics
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct StakeHistory(Arc<StakeHistoryInner>);
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1,5 +1,7 @@
 //! Stakes serve as a cache of stake and vote accounts to derive
 //! node stakes
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi::stable_abi::{context::SequenceLenMax, sample_collection_sized};
 use {
     crate::{
         alpenglow_epoch_type::RewardEpochDelegatedStakes,
@@ -188,7 +190,7 @@ impl StakesCache {
 /// account and StakeStateV2 deserialized from the account. Doing so, will remove
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Debug, Serialize)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
@@ -206,9 +208,14 @@ pub struct Stakes<T: Clone> {
     vote_accounts: VoteAccounts,
 
     /// stake_delegations
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_collection_sized(rng, SequenceLenMax(1))")
+    )]
     stake_delegations: ImblHashMap<Pubkey, T>,
 
     /// current effective stake delegated to each vote account pubkey
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
     delegated_stakes: DelegatedStakes,
 

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -30,6 +30,8 @@ dev-context-only-utils = [
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-account/frozen-abi",
+    "solana-pubkey/frozen-abi",
     "solana-vote-interface/frozen-abi",
 ]
 

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -32,7 +32,7 @@ use {
     },
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VoteAccount(Arc<VoteAccountInner>);
 
@@ -44,15 +44,20 @@ pub enum Error {
     InvalidOwner(/*owner:*/ Pubkey),
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug)]
 struct VoteAccountInner {
     account: AccountSharedData,
+    // Skipped by the custom serializer, and hard to instantiate other than via `AbiExample`.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "solana_frozen_abi::abi_example::AbiExample::example()")
+    )]
     vote_state_view: VoteStateView,
 }
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
@@ -62,6 +67,7 @@ pub struct VoteAccounts {
     #[serde(deserialize_with = "deserialize_accounts_hash_map")]
     vote_accounts: Arc<VoteAccountsHashMap>,
     // Inner Arc is meant to implement copy-on-write semantics.
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
     staked_nodes: OnceLock<
         Arc<


### PR DESCRIPTION
#### Problem
We should ensure binary format of snapshot serialization stays stable.
This would also prepare for switching the snapshot serialization path to
wincode.

#### Summary of Changes
Annotate the bincode-serialized snapshot types with `StableAbi` /
`StableAbiSample` and lock the wire format with `frozen_abi(abi_digest)` on the
top-level serialized types, so the later wincode switch can prove byte-for-byte
compatibility by checking the same digest under both serializers.

- Bank-fields stream: abi_digest on the minimum top-level set: `BankHashInfo`,
  `SerializableAccountStorageEntry` (`test_roundtrip = "eq_and_wire"`);
  `SerializableVersionedBank`, `ExtraFieldsToSerialize` (write-only, so
  `test_roundtrip = "no"`); `BlockhashQueue` gains `eq_and_wire`.
- Status-cache stream (already wincode): abi_digest on `SerdeBankSlotDelta` with
  `abi_serializer = "wincode"`; StableAbi on `SerdeTransactionError` /
  `SerdeInstructionError`.
- Inner-transitive types get derives only (no digest): `HashInfo, BankHashStats,
  StakeHistory, UnusedAccounts, UnusedRentCollector,
  UnusedIncrementalSnapshotPersistence, SerdeAccountsLtHash, StakeAccount,
  Stakes, VoteAccount, VoteAccountInner, VoteAccounts, EpochStakes,
  NodeVoteAccounts, VersionedEpochStakes`.
- StableAbi sampling mirrors serialization.
  *  Fields a custom Serialize ignores use `stable_abi_sample(with = ...)`: the serde(skip) OnceLock caches and
  `StakeAccount::account` use `Default::default()`; `VoteAccountInner::vote_state_view`
  (never serialized, no Default) uses `AbiExample::example()`. 
  * The `StakeAccount<Delegation>` delegation invariant is upheld at the leaf by sampling a random `StakeStateV2::Stake` variant; 
  * the `imbl::HashMap` of stake delegations is sampled via `sample_collection_sized` capped at one element for deterministic ordering.

#### Testing
CI / this change adds tests, no functional changes
