### PR TITLE
Changes for sbpf 0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10409,7 +10409,8 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0f2767643b3609343f18b43c222a36aaae274940b86bee0553f898f83007a3"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10409,7 +10409,7 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10408,9 +10408,8 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
+version = "0.22.0"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,7 +468,7 @@ solana-rpc-client-types = { path = "rpc-client-types", version = "=4.3.0-alpha.0
 solana-runtime = { path = "runtime", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "runtime-transaction", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-sanitize = "3.0.1"
-solana-sbpf = { version = "=0.21.1", default-features = false }
+solana-sbpf = { version = "=0.22.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-secp256k1-program = "3.0.1"
 solana-secp256k1-recover = "3.1.1"
@@ -618,3 +618,4 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,4 +618,3 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
-solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8089,9 +8089,8 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
+version = "0.22.0"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1189,8 +1189,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -8090,7 +8090,7 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1189,8 +1189,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -8090,7 +8090,8 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0f2767643b3609343f18b43c222a36aaae274940b86bee0553f898f83007a3"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -184,6 +184,3 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-[patch.crates-io]
-solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -119,7 +119,7 @@ solana-rpc-client = { path = "../rpc-client", version = "=4.3.0-alpha.0", defaul
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.3.0-alpha.0" }
 solana-runtime = { path = "../runtime", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
-solana-sbpf = { version = "=0.21.1", default-features = false }
+solana-sbpf = { version = "=0.22.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
 solana-signature = { version = "3.4.1", default-features = false }
@@ -184,3 +184,6 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
+
+[patch.crates-io]
+solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -27,7 +27,7 @@ use {
     solana_runtime::bank::Bank,
     solana_sbpf::{
         assembler::assemble,
-        ebpf::MM_INPUT_START,
+        ebpf::{MM_HEAP_START, MM_INPUT_START, MM_RODATA_START, MM_STACK_START},
         elf::Executable,
         memory_region::{MemoryMapping, MemoryRegion},
         static_analysis::Analysis,
@@ -514,10 +514,14 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         )
         .unwrap();
 
-    let regions = vec![MemoryRegion::default(); 3]
-        .into_iter()
-        .chain(regions)
-        .collect();
+    let regions = [
+        MemoryRegion::new_empty(MM_RODATA_START),
+        MemoryRegion::new_empty(MM_STACK_START),
+        MemoryRegion::new_empty(MM_HEAP_START),
+    ]
+    .into_iter()
+    .chain(regions)
+    .collect();
     let program = matches.value_of("PROGRAM").unwrap();
     let verified_executable = load_program(Path::new(program), program_id, &invoke_context);
 

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1199,13 +1199,14 @@ unsafe fn update_caller_account_region(
             .find_region(caller_account.vm_data_addr)
             .ok_or_else(|| Box::new(InstructionError::MissingAccount) as Error)?;
         // vm_data_addr must always point to the beginning of the region
-        debug_assert_eq!(region.vm_addr, caller_account.vm_data_addr);
+        let region_start_vm_addr = region.vm_addr_range().start;
+        debug_assert_eq!(region_start_vm_addr, caller_account.vm_data_addr);
         let mut new_region;
         if !account_data_direct_mapping {
             new_region = region.clone();
             modify_memory_region_of_account(callee_account, &mut new_region);
         } else {
-            new_region = create_memory_region_of_account(callee_account, region.vm_addr)?;
+            new_region = create_memory_region_of_account(callee_account, region_start_vm_addr)?;
         }
         unsafe {
             // SAFETY: the lifetime invariants are delegated to the callers of this function. Both

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -1,9 +1,6 @@
 //! Memory translation utilities.
 
-use {
-    solana_sbpf::memory_region::MemoryMapping, solana_transaction_context::vm_slice::VmSlice,
-    std::mem::align_of,
-};
+use {solana_sbpf::memory_region::MemoryMapping, solana_transaction_context::vm_slice::VmSlice};
 
 /// Error types for memory translation operations.
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
@@ -12,13 +9,6 @@ pub enum MemoryTranslationError {
     UnalignedPointer,
     #[error("InvalidLength")]
     InvalidLength,
-}
-
-pub fn address_is_aligned<T>(address: usize) -> bool {
-    address
-        .checked_rem(align_of::<T>())
-        .map(|rem| rem == 0)
-        .expect("T to be non-zero aligned")
 }
 
 // Do not use this directly
@@ -47,7 +37,7 @@ macro_rules! translate_type_inner {
         let ptr = host_addr.ptr_mut().cast::<$T>();
         if !$check_aligned {
             Ok(unsafe { ptr.as_mut_unchecked() })
-        } else if !$crate::memory::address_is_aligned::<$T>(ptr.addr()) {
+        } else if !ptr.is_aligned() {
             Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
         } else {
             Ok(unsafe { ptr.as_mut_unchecked() })
@@ -64,7 +54,7 @@ macro_rules! translate_type_inner {
         let ptr = host_addr.ptr().cast::<$T>();
         if !$check_aligned {
             Ok(unsafe { ptr.as_ref_unchecked() })
-        } else if !$crate::memory::address_is_aligned::<$T>(ptr.addr()) {
+        } else if !ptr.is_aligned() {
             Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
         } else {
             Ok(unsafe { ptr.as_ref_unchecked() })
@@ -94,10 +84,7 @@ macro_rules! translate_slice_inner {
                     total_size
                 ) {
                     Err(e) => Err(e),
-                    Ok(host_buf)
-                        if $check_aligned
-                            && !$crate::memory::address_is_aligned::<$T>(host_buf.ptr().addr()) =>
-                    {
+                    Ok(host_buf) if $check_aligned && !host_buf.ptr().cast::<$T>().is_aligned() => {
                         Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
                     }
                     Ok(host_buf) => Ok(std::ptr::slice_from_raw_parts_mut(
@@ -127,10 +114,7 @@ macro_rules! translate_slice_inner {
                     total_size
                 ) {
                     Err(e) => Err(e),
-                    Ok(host_buf)
-                        if $check_aligned
-                            && !$crate::memory::address_is_aligned::<$T>(host_buf.ptr().addr()) =>
-                    {
+                    Ok(host_buf) if $check_aligned && !host_buf.ptr().cast::<$T>().is_aligned() => {
                         Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
                     }
                     Ok(host_buf) => Ok(std::ptr::slice_from_raw_parts(

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -35,9 +35,7 @@ macro_rules! translate_type_inner {
             size_of::<$T>() as u64
         )?;
         let ptr = host_addr.ptr_mut().cast::<$T>();
-        if !$check_aligned {
-            Ok(unsafe { ptr.as_mut_unchecked() })
-        } else if !ptr.is_aligned() {
+        if $check_aligned && !ptr.is_aligned() {
             Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
         } else {
             Ok(unsafe { ptr.as_mut_unchecked() })
@@ -52,9 +50,7 @@ macro_rules! translate_type_inner {
             size_of::<$T>() as u64
         )?;
         let ptr = host_addr.ptr().cast::<$T>();
-        if !$check_aligned {
-            Ok(unsafe { ptr.as_ref_unchecked() })
-        } else if !ptr.is_aligned() {
+        if $check_aligned && !ptr.is_aligned() {
             Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
         } else {
             Ok(unsafe { ptr.as_ref_unchecked() })

--- a/program-runtime/src/memory.rs
+++ b/program-runtime/src/memory.rs
@@ -1,8 +1,7 @@
 //! Memory translation utilities.
 
 use {
-    solana_sbpf::memory_region::{AccessType, MemoryMapping},
-    solana_transaction_context::vm_slice::VmSlice,
+    solana_sbpf::memory_region::MemoryMapping, solana_transaction_context::vm_slice::VmSlice,
     std::mem::align_of,
 };
 
@@ -15,8 +14,8 @@ pub enum MemoryTranslationError {
     InvalidLength,
 }
 
-pub fn address_is_aligned<T>(address: u64) -> bool {
-    (address as *mut T as usize)
+pub fn address_is_aligned<T>(address: usize) -> bool {
+    address
         .checked_rem(align_of::<T>())
         .map(|rem| rem == 0)
         .expect("T to be non-zero aligned")
@@ -26,7 +25,7 @@ pub fn address_is_aligned<T>(address: u64) -> bool {
 #[macro_export]
 macro_rules! translate_inner {
     ($memory_mapping:expr, $map:ident, $access_type:expr, $vm_addr:expr, $len:expr $(,)?) => {
-        Result::<u64, Box<dyn std::error::Error>>::from(
+        Result::<$crate::solana_sbpf::memory_region::HostBuffer, Box<dyn std::error::Error>>::from(
             $memory_mapping
                 .$map($access_type, $vm_addr, $len)
                 .map_err(|err| err.into()),
@@ -37,20 +36,38 @@ macro_rules! translate_inner {
 // Do not use this directly
 #[macro_export]
 macro_rules! translate_type_inner {
-    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+    ($memory_mapping:expr, AccessType::Store, $vm_addr:expr, $T:ty, $check_aligned:expr $(,)?) => {{
         let host_addr = $crate::translate_inner!(
             $memory_mapping,
             map,
-            $access_type,
+            $crate::solana_sbpf::memory_region::AccessType::Store,
             $vm_addr,
             size_of::<$T>() as u64
         )?;
+        let ptr = host_addr.ptr_mut().cast::<$T>();
         if !$check_aligned {
-            Ok(unsafe { std::mem::transmute::<u64, &mut $T>(host_addr) })
-        } else if !$crate::memory::address_is_aligned::<$T>(host_addr) {
+            Ok(unsafe { ptr.as_mut_unchecked() })
+        } else if !$crate::memory::address_is_aligned::<$T>(ptr.addr()) {
             Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
         } else {
-            Ok(unsafe { &mut *(host_addr as *mut $T) })
+            Ok(unsafe { ptr.as_mut_unchecked() })
+        }
+    }};
+    ($memory_mapping:expr, AccessType::Load, $vm_addr:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+        let host_addr = $crate::translate_inner!(
+            $memory_mapping,
+            map,
+            $crate::solana_sbpf::memory_region::AccessType::Load,
+            $vm_addr,
+            size_of::<$T>() as u64
+        )?;
+        let ptr = host_addr.ptr().cast::<$T>();
+        if !$check_aligned {
+            Ok(unsafe { ptr.as_ref_unchecked() })
+        } else if !$crate::memory::address_is_aligned::<$T>(ptr.addr()) {
+            Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
+        } else {
+            Ok(unsafe { ptr.as_ref_unchecked() })
         }
     }};
 }
@@ -58,7 +75,7 @@ macro_rules! translate_type_inner {
 // Do not use this directly
 #[macro_export]
 macro_rules! translate_slice_inner {
-    ($memory_mapping:expr, $access_type:expr, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+    ($memory_mapping:expr, AccessType::Store, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
         if $len == 0 {
             Ok(std::ptr::slice_from_raw_parts_mut(
                 std::ptr::dangling_mut::<$T>(),
@@ -72,19 +89,52 @@ macro_rules! translate_slice_inner {
                 match $crate::translate_inner!(
                     $memory_mapping,
                     map,
-                    $access_type,
+                    $crate::solana_sbpf::memory_region::AccessType::Store,
                     $vm_addr,
                     total_size
                 ) {
                     Err(e) => Err(e),
-                    Ok(host_addr)
+                    Ok(host_buf)
                         if $check_aligned
-                            && !$crate::memory::address_is_aligned::<$T>(host_addr) =>
+                            && !$crate::memory::address_is_aligned::<$T>(host_buf.ptr().addr()) =>
                     {
                         Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
                     }
-                    Ok(host_addr) => Ok(std::ptr::slice_from_raw_parts_mut(
-                        host_addr as *mut $T,
+                    Ok(host_buf) => Ok(std::ptr::slice_from_raw_parts_mut(
+                        host_buf.ptr_mut().cast(),
+                        $len as usize,
+                    )),
+                }
+            }
+        }
+    }};
+    ($memory_mapping:expr, AccessType::Load, $vm_addr:expr, $len:expr, $T:ty, $check_aligned:expr $(,)?) => {{
+        if $len == 0 {
+            Ok(std::ptr::slice_from_raw_parts(
+                std::ptr::dangling_mut::<$T>(),
+                0,
+            ))
+        } else {
+            let total_size = $len.saturating_mul(size_of::<$T>() as u64);
+            if isize::try_from(total_size).is_err() {
+                Err($crate::memory::MemoryTranslationError::InvalidLength.into())
+            } else {
+                match $crate::translate_inner!(
+                    $memory_mapping,
+                    map,
+                    $crate::solana_sbpf::memory_region::AccessType::Load,
+                    $vm_addr,
+                    total_size
+                ) {
+                    Err(e) => Err(e),
+                    Ok(host_buf)
+                        if $check_aligned
+                            && !$crate::memory::address_is_aligned::<$T>(host_buf.ptr().addr()) =>
+                    {
+                        Err($crate::memory::MemoryTranslationError::UnalignedPointer.into())
+                    }
+                    Ok(host_buf) => Ok(std::ptr::slice_from_raw_parts(
+                        host_buf.ptr().cast(),
                         $len as usize,
                     )),
                 }
@@ -99,7 +149,6 @@ pub fn translate_type<'a, T>(
     check_aligned: bool,
 ) -> Result<&'a T, Box<dyn std::error::Error>> {
     translate_type_inner!(memory_mapping, AccessType::Load, vm_addr, T, check_aligned)
-        .map(|value| &*value)
 }
 
 pub fn translate_slice<T>(

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -24,19 +24,19 @@ pub fn modify_memory_region_of_account(
     account: &mut BorrowedInstructionAccount<'_, '_>,
     region: &mut MemoryRegion,
 ) {
-    let host_ptr = match region.host_buffer() {
-        solana_sbpf::memory_region::HostBuffer::Mutable(p) => p.cast::<u8>(),
-        solana_sbpf::memory_region::HostBuffer::Immutable(p) => p.cast::<u8>(),
-    };
-    let host_len = account.get_data().len();
-    let vm_addr = region.vm_addr_range().start;
     if account.can_data_be_changed().is_ok() {
-        let host_slice = std::ptr::slice_from_raw_parts_mut(host_ptr.cast_mut(), host_len);
-        *region = MemoryRegion::new_gapped(host_slice, vm_addr, region.gap_size());
+        unsafe {
+            // SAFETY:
+            // Contract from `HostBuffer::mutable`: This host buffer must have been initially
+            // constructed with a mutable pointer.
+            // Evidence: this region must be pointing to a serialized data buffer which is known to
+            // be mutable.
+            region.redirect(region.host_buffer().mutable());
+        }
         region.access_violation_handler_payload = Some(account.get_index_in_transaction());
     } else {
-        let host_slice = std::ptr::slice_from_raw_parts(host_ptr, host_len);
-        *region = MemoryRegion::new_gapped(host_slice, vm_addr, region.gap_size());
+        region.make_immutable();
+        region.access_violation_handler_payload = None;
     }
 }
 
@@ -854,7 +854,10 @@ mod tests {
 
                 let (mut serialized, regions, _account_lengths, _instruction_data_offset) =
                     serialization_result.unwrap();
-                let mut serialized_regions = concat_regions(&regions);
+                let mut serialized_regions = unsafe {
+                    // SAFETY: test code, serialize_parameters should be constructing valid regions.
+                    concat_regions(&regions)
+                };
                 let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                     deserialize(
                         if !virtual_address_space_adjustments {
@@ -1008,7 +1011,10 @@ mod tests {
                 )
                 .unwrap();
 
-            let mut serialized_regions = concat_regions(&regions);
+            let mut serialized_regions = unsafe {
+                // SAFETY: test code, serialize_parameters should be constructing valid regions.
+                concat_regions(&regions)
+            };
             if !virtual_address_space_adjustments {
                 assert_eq!(serialized.as_slice(), serialized_regions.as_slice());
             }
@@ -1107,7 +1113,10 @@ mod tests {
                     direct_account_pointers_in_program_input,
                 )
                 .unwrap();
-            let mut serialized_regions = concat_regions(&regions);
+            let mut serialized_regions = unsafe {
+                // SAFETY: test code, serialize_parameters should be constructing valid regions.
+                concat_regions(&regions)
+            };
 
             let (de_program_id, de_accounts, de_instruction_data) = unsafe {
                 deserialize_for_abiv0(
@@ -1273,7 +1282,10 @@ mod tests {
             )
             .unwrap();
 
-        let mut serialized_regions = concat_regions(&regions);
+        let mut serialized_regions = unsafe {
+            // SAFETY: test code, serialize_parameters should be constructing valid regions.
+            concat_regions(&regions)
+        };
         let (_de_program_id, de_accounts, _de_instruction_data) = unsafe {
             deserialize(serialized_regions.as_slice_mut().first_mut().unwrap() as *mut u8)
         };
@@ -1305,7 +1317,10 @@ mod tests {
                 direct_account_pointers_in_program_input,
             )
             .unwrap();
-        let mut serialized_regions = concat_regions(&regions);
+        let mut serialized_regions = unsafe {
+            // SAFETY: test code, serialize_parameters should be constructing valid regions.
+            concat_regions(&regions)
+        };
 
         let (_de_program_id, de_accounts, _de_instruction_data) = unsafe {
             deserialize_for_abiv0(serialized_regions.as_slice_mut().first_mut().unwrap() as *mut u8)
@@ -1441,7 +1456,10 @@ mod tests {
         (program_id, accounts, instruction_data)
     }
 
-    fn concat_regions(regions: &[MemoryRegion]) -> AlignedMemory<HOST_ALIGN> {
+    /// # Safety
+    ///
+    /// All memory regions must be pointing to valid to dereference host buffers.
+    unsafe fn concat_regions(regions: &[MemoryRegion]) -> AlignedMemory<HOST_ALIGN> {
         let last_region = regions.last().unwrap();
         let last_region_vm_addr = last_region.vm_addr_range().start;
         let mut mem = AlignedMemory::zero_filled(
@@ -1449,12 +1467,15 @@ mod tests {
         );
         for region in regions {
             let vm_start = region.vm_addr_range().start;
-            let buffer = match region.host_buffer() {
-                solana_sbpf::memory_region::HostBuffer::Immutable(buf) => buf,
-                solana_sbpf::memory_region::HostBuffer::Mutable(buf) => buf.cast_const(),
-            };
+            let buffer = region.host_buffer().ptr();
             mem.as_slice_mut()[(vm_start - MM_INPUT_START) as usize..][..buffer.len()]
-                .copy_from_slice(unsafe { &*buffer })
+                .copy_from_slice(unsafe {
+                    // SAFETY:
+                    // Contract from `<*const [u8]>::as_ref_unchecked`: ensure that the pointer is
+                    // convertible to reference.
+                    // Evidence: The contract delegated to the callers.
+                    buffer.as_ref_unchecked()
+                })
         }
         mem
     }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -24,13 +24,19 @@ pub fn modify_memory_region_of_account(
     account: &mut BorrowedInstructionAccount<'_, '_>,
     region: &mut MemoryRegion,
 ) {
-    region.len = account.get_data().len() as u64;
+    let host_ptr = match region.host_buffer() {
+        solana_sbpf::memory_region::HostBuffer::Mutable(p) => p.cast::<u8>(),
+        solana_sbpf::memory_region::HostBuffer::Immutable(p) => p.cast::<u8>(),
+    };
+    let host_len = account.get_data().len();
+    let vm_addr = region.vm_addr_range().start;
     if account.can_data_be_changed().is_ok() {
-        region.writable = true;
+        let host_slice = std::ptr::slice_from_raw_parts_mut(host_ptr.cast_mut(), host_len);
+        *region = MemoryRegion::new_gapped(host_slice, vm_addr, region.gap_size());
         region.access_violation_handler_payload = Some(account.get_index_in_transaction());
     } else {
-        region.writable = false;
-        region.access_violation_handler_payload = None;
+        let host_slice = std::ptr::slice_from_raw_parts(host_ptr, host_len);
+        *region = MemoryRegion::new_gapped(host_slice, vm_addr, region.gap_size());
     }
 }
 
@@ -701,7 +707,7 @@ mod tests {
             cell::RefCell,
             mem::transmute,
             rc::Rc,
-            slice::{self, from_raw_parts, from_raw_parts_mut},
+            slice::{from_raw_parts, from_raw_parts_mut},
         },
         test_case::test_case,
     };
@@ -1437,15 +1443,18 @@ mod tests {
 
     fn concat_regions(regions: &[MemoryRegion]) -> AlignedMemory<HOST_ALIGN> {
         let last_region = regions.last().unwrap();
+        let last_region_vm_addr = last_region.vm_addr_range().start;
         let mut mem = AlignedMemory::zero_filled(
-            (last_region.vm_addr - MM_INPUT_START + last_region.len) as usize,
+            (last_region_vm_addr - MM_INPUT_START + last_region.len() as u64) as usize,
         );
         for region in regions {
-            let host_slice = unsafe {
-                slice::from_raw_parts(region.host_addr as *const u8, region.len as usize)
+            let vm_start = region.vm_addr_range().start;
+            let buffer = match region.host_buffer() {
+                solana_sbpf::memory_region::HostBuffer::Immutable(buf) => buf,
+                solana_sbpf::memory_region::HostBuffer::Mutable(buf) => buf.cast_const(),
             };
-            mem.as_slice_mut()[(region.vm_addr - MM_INPUT_START) as usize..][..region.len as usize]
-                .copy_from_slice(host_slice)
+            mem.as_slice_mut()[(vm_start - MM_INPUT_START) as usize..][..buffer.len()]
+                .copy_from_slice(unsafe { &*buffer })
         }
         mem
     }

--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -14,7 +14,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_program_entrypoint::{MAX_PERMITTED_DATA_INCREASE, SUCCESS},
     solana_sbpf::{
-        ebpf::{self, MM_HEAP_START, MM_STACK_START},
+        ebpf::{self, MM_HEAP_START, MM_RODATA_START, MM_STACK_START},
         elf::Executable,
         error::{EbpfError, ProgramResult},
         memory_region::{AccessType, MemoryMapping, MemoryRegion},
@@ -150,10 +150,14 @@ unsafe fn set_memory_context<'b>(
     account_data_direct_mapping: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let heap_size = invoke_context.get_compute_budget().heap_size;
-    let regions = vec![MemoryRegion::default(); 3]
-        .into_iter()
-        .chain(additional_initialized_regions)
-        .collect();
+    let regions = [
+        MemoryRegion::new_empty(MM_RODATA_START),
+        MemoryRegion::new_empty(MM_STACK_START),
+        MemoryRegion::new_empty(MM_HEAP_START),
+    ]
+    .into_iter()
+    .chain(additional_initialized_regions)
+    .collect();
     let memory_mapping = unsafe {
         // SAFETY: all memory regions are `default` (and thus implicitly valid) or valid by
         // delegating the safety invariant upon the caller.

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1159,8 +1159,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -9064,7 +9064,8 @@ dependencies = [
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0f2767643b3609343f18b43c222a36aaae274940b86bee0553f898f83007a3"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9063,9 +9063,8 @@ dependencies = [
 
 [[package]]
 name = "solana-sbpf"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d777d7a89267dd133e985113c7e7f820fb7cfd9123a4a350cf8b39ebae1920bc"
+version = "0.22.0"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1159,8 +1159,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "solana-sbpf"
 version = "0.22.0"
-source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#2482f5abbfadd4b63428f852468982705ce97716"
+source = "git+https://github.com/anza-xyz/sbpf?rev=refs%2Fpull%2F191%2Fhead#aa3c51173bed9c4332da053b5323f4d53f912b23"
 dependencies = [
  "byteorder",
  "combine 3.8.1",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -248,6 +248,3 @@ strip = true
 
 [lints]
 workspace = true
-
-[patch.crates-io]
-solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -248,3 +248,6 @@ strip = true
 
 [lints]
 workspace = true
+
+[patch.crates-io]
+solana-sbpf = { git = "https://github.com/anza-xyz/sbpf", rev = "refs/pull/191/head" }

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -147,9 +147,9 @@ pub(crate) fn push_and_serialize_parameters<'ix_data>(
 
 fn memory_region_to_proto(region: &MemoryRegion) -> ProtoVmInputMemoryRegion {
     ProtoVmInputMemoryRegion {
-        vm_address: region.vm_addr,
-        region_size: region.len,
-        is_writable: region.writable,
+        vm_address: region.vm_addr_range().start,
+        region_size: region.len() as u64,
+        is_writable: region.host_buffer().is_mutable(),
     }
 }
 

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -26,7 +26,7 @@ use {
             aligned_memory::AlignedMemory,
             ebpf::{HOST_ALIGN, MM_BYTECODE_START, MM_HEAP_START, MM_INPUT_START, MM_STACK_START},
             error::{ProgramResult, StableResult},
-            memory_region::{AccessViolationHandler, HostBuffer, MemoryMapping, MemoryRegion},
+            memory_region::{AccessViolationHandler, MemoryMapping, MemoryRegion},
             program::{BuiltinProgram, SBPFVersion},
             vm::{Config, ContextObject, EbpfVm},
         },
@@ -320,13 +320,7 @@ fn extract_input_data_regions(
 fn mem_region_to_input_data_region(region: &MemoryRegion) -> ProtoInputDataRegion {
     let host_buffer = region.host_buffer();
     ProtoInputDataRegion {
-        content: unsafe {
-            match host_buffer {
-                HostBuffer::Immutable(p) => &*p,
-                HostBuffer::Mutable(p) => &*p,
-            }
-            .to_vec()
-        },
+        content: unsafe { host_buffer.ptr().as_ref_unchecked().to_vec() },
         offset: region.vm_addr_range().start.saturating_sub(MM_INPUT_START),
         is_writable: host_buffer.is_mutable(),
     }

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -26,7 +26,7 @@ use {
             aligned_memory::AlignedMemory,
             ebpf::{HOST_ALIGN, MM_BYTECODE_START, MM_HEAP_START, MM_INPUT_START, MM_STACK_START},
             error::{ProgramResult, StableResult},
-            memory_region::{AccessViolationHandler, MemoryMapping, MemoryRegion},
+            memory_region::{AccessViolationHandler, HostBuffer, MemoryMapping, MemoryRegion},
             program::{BuiltinProgram, SBPFVersion},
             vm::{Config, ContextObject, EbpfVm},
         },
@@ -308,7 +308,7 @@ fn extract_input_data_regions(
             let mut regions: Vec<ProtoInputDataRegion> = mapping
                 .get_regions()
                 .iter()
-                .filter(|region| region.vm_addr >= MM_INPUT_START)
+                .filter(|region| region.vm_addr_range().start >= MM_INPUT_START)
                 .map(mem_region_to_input_data_region)
                 .collect();
             regions.sort_by_key(|region| region.offset);
@@ -318,12 +318,17 @@ fn extract_input_data_regions(
 }
 
 fn mem_region_to_input_data_region(region: &MemoryRegion) -> ProtoInputDataRegion {
+    let host_buffer = region.host_buffer();
     ProtoInputDataRegion {
         content: unsafe {
-            std::slice::from_raw_parts(region.host_addr as *const u8, region.len as usize).to_vec()
+            match host_buffer {
+                HostBuffer::Immutable(p) => &*p,
+                HostBuffer::Mutable(p) => &*p,
+            }
+            .to_vec()
         },
-        offset: region.vm_addr.saturating_sub(MM_INPUT_START),
-        is_writable: region.writable,
+        offset: region.vm_addr_range().start.saturating_sub(MM_INPUT_START),
+        is_writable: host_buffer.is_mutable(),
     }
 }
 

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -2694,7 +2694,6 @@ mod tests {
         solana_program_runtime::{
             execution_budget::MAX_HEAP_FRAME_BYTES,
             invoke_context::{BpfAllocator, InvokeContext},
-            memory::address_is_aligned,
             memory_context::MemoryContext,
             with_mock_invoke_context, with_mock_invoke_context_with_feature_set,
         },
@@ -3315,8 +3314,9 @@ mod tests {
             let result =
                 SyscallAllocFree::rust(&mut invoke_context, size_of::<T>() as u64, 0, 0, 0, 0);
             let address = result.unwrap();
+            let align = align_of::<T>() as u64;
             assert_ne!(address, 0);
-            assert!(address_is_aligned::<T>(address as usize));
+            assert!((address % align) == 0);
         }
         aligned::<u8>();
         aligned::<u16>();
@@ -6193,13 +6193,6 @@ mod tests {
     fn bytes_of_slice_mut<T>(val: &mut [T]) -> *mut [u8] {
         let size = val.len().wrapping_mul(mem::size_of::<T>());
         core::ptr::slice_from_raw_parts_mut(val.as_mut_ptr().cast(), size)
-    }
-
-    #[test]
-    fn test_address_is_aligned() {
-        for address in 0..std::mem::size_of::<u64>() {
-            assert_eq!(address_is_aligned::<u64>(address), address == 0);
-        }
     }
 
     #[test_case(0x100000004, 0x100000004, &[0x00, 0x00, 0x00, 0x00])] // Intra region match

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -577,7 +577,6 @@ fn translate_type<T>(
     check_aligned: bool,
 ) -> Result<&T, Error> {
     translate_type_inner!(memory_mapping, AccessType::Load, vm_addr, T, check_aligned)
-        .map(|value| &*value)
 }
 fn translate_slice<T>(
     memory_mapping: &MemoryMapping,
@@ -2804,7 +2803,7 @@ mod tests {
         const LENGTH: u64 = 1000;
 
         let data = vec![0u8; LENGTH as usize];
-        let addr = data.as_ptr() as u64;
+        let addr = data.as_ptr().addr();
         let config = Config::default();
         let memory_mapping = unsafe {
             MemoryMapping::new(
@@ -2821,21 +2820,28 @@ mod tests {
             (true, START, LENGTH, addr),
             (true, START + 1, LENGTH - 1, addr + 1),
             (false, START + 1, LENGTH, 0),
-            (true, START + LENGTH - 1, 1, addr + LENGTH - 1),
-            (true, START + LENGTH, 0, addr + LENGTH),
+            (true, START + LENGTH - 1, 1, addr + LENGTH as usize - 1),
+            (true, START + LENGTH, 0, addr + LENGTH as usize),
             (false, START + LENGTH, 1, 0),
             (false, START, LENGTH + 1, 0),
             (false, 0, 0, 0),
             (false, 0, 1, 0),
             (false, START - 1, 0, 0),
             (false, START - 1, 1, 0),
-            (true, START + LENGTH / 2, LENGTH / 2, addr + LENGTH / 2),
+            (
+                true,
+                START + LENGTH / 2,
+                LENGTH / 2,
+                addr + LENGTH as usize / 2,
+            ),
         ];
         for (ok, start, length, value) in cases {
             if ok {
                 assert_eq!(
                     translate_inner!(&memory_mapping, map, AccessType::Load, start, length)
-                        .unwrap(),
+                        .unwrap()
+                        .ptr()
+                        .addr(),
                     value
                 )
             } else {
@@ -3310,7 +3316,7 @@ mod tests {
                 SyscallAllocFree::rust(&mut invoke_context, size_of::<T>() as u64, 0, 0, 0, 0);
             let address = result.unwrap();
             assert_ne!(address, 0);
-            assert!(address_is_aligned::<T>(address));
+            assert!(address_is_aligned::<T>(address as usize));
         }
         aligned::<u8>();
         aligned::<u16>();
@@ -6192,7 +6198,7 @@ mod tests {
     #[test]
     fn test_address_is_aligned() {
         for address in 0..std::mem::size_of::<u64>() {
-            assert_eq!(address_is_aligned::<u64>(address as u64), address == 0);
+            assert_eq!(address_is_aligned::<u64>(address), address == 0);
         }
     }
 

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -14,7 +14,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
     solana_rent::Rent,
-    solana_sbpf::memory_region::{AccessType, AccessViolationHandler, HostBuffer, MemoryRegion},
+    solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
     std::{borrow::Cow, cell::Cell, rc::Rc},
 };
 use {
@@ -573,11 +573,6 @@ impl<'ix_data> TransactionContext<'ix_data> {
                     }
                     unsafe {
                         account.resize(new_len, 0);
-                        let data_ptr = match region.host_buffer() {
-                            HostBuffer::Immutable(p) => p.cast::<u8>().cast_mut(),
-                            HostBuffer::Mutable(p) => p.cast::<u8>(),
-                        };
-                        let data_slice = std::ptr::slice_from_raw_parts_mut(data_ptr, new_len);
                         // SAFETY:
                         //
                         // Contract from `MemoryRegion::redirect`: MemoryRegion must point to a
@@ -601,7 +596,12 @@ impl<'ix_data> TransactionContext<'ix_data> {
                         // writable (even though the HostBuffer might have been initially created as
                         // immutable.) In the direct mapping case we redirect the region to the
                         // buffer stored in the account later on.
-                        region.redirect(data_slice);
+                        //
+                        // Contract from `HostBuffer::mutable`: This host buffer must have been
+                        // initially constructed with a mutable pointer.
+                        // Evidence: See `create_memory_region_of_account`. Direct mapping case
+                        // later reconstructs this buffer from scratch. See below.
+                        region.redirect(region.host_buffer().mutable());
                     }
                 }
 

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -14,7 +14,7 @@ use {
     solana_instruction::error::InstructionError,
     solana_instructions_sysvar as instructions,
     solana_rent::Rent,
-    solana_sbpf::memory_region::{AccessType, AccessViolationHandler, MemoryRegion},
+    solana_sbpf::memory_region::{AccessType, AccessViolationHandler, HostBuffer, MemoryRegion},
     std::{borrow::Cow, cell::Cell, rc::Rc},
 };
 use {
@@ -529,8 +529,11 @@ impl<'ix_data> TransactionContext<'ix_data> {
                     // This region is not a writable account.
                     return;
                 };
-                let requested_length =
-                    vm_addr.saturating_add(len).saturating_sub(region.vm_addr) as usize;
+                let region_vm_addr_start = region.vm_addr_range().start;
+                let requested_length = vm_addr
+                    .saturating_add(len)
+                    .saturating_sub(region_vm_addr_start)
+                    as usize;
                 if requested_length > address_space_reserved_for_account as usize {
                     // Requested access goes further than the account region.
                     return;
@@ -552,7 +555,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
                     .saturating_sub(accounts.resize_delta())
                     .max(0) as usize;
 
-                if requested_length > region.len as usize {
+                if requested_length > region.len() {
                     // Realloc immediately here to fit the requested access,
                     // then later in CPI or deserialization realloc again to the
                     // account length the program stored in AccountInfo.
@@ -568,14 +571,46 @@ impl<'ix_data> TransactionContext<'ix_data> {
                     {
                         return;
                     }
-                    account.resize(new_len, 0);
-                    region.len = new_len as u64;
+                    unsafe {
+                        account.resize(new_len, 0);
+                        let data_ptr = match region.host_buffer() {
+                            HostBuffer::Immutable(p) => p.cast::<u8>().cast_mut(),
+                            HostBuffer::Mutable(p) => p.cast::<u8>(),
+                        };
+                        let data_slice = std::ptr::slice_from_raw_parts_mut(data_ptr, new_len);
+                        // SAFETY:
+                        //
+                        // Contract from `MemoryRegion::redirect`: MemoryRegion must point to a
+                        // valid object live for the duration of this `MemoryMapping`.
+                        //
+                        // Evidence: There are two distinct cases, when the account buffer is
+                        // serialized and when the account buffer is directly mapped.
+                        // * In the serialization case we continue pointing at the same buffer as
+                        // before, and the original buffer must have satisfied the liveness
+                        // condition before.
+                        // * In the direct mapping case `account.resize` invalidates the buffer this
+                        // region has been pointing at, but this is fixed up later in the "unshare"
+                        // branch later.
+                        //
+                        // Contract from `MemoryRegion::redirect`: For `MemoryRegion`s marked
+                        // writable, the host buffer must accept arbitrary bytes being overwritten
+                        // without it resulting in unsoundness.
+                        //
+                        // Evidence: The account payloads dont have any internal soundness
+                        // invariants. The buffer in the serialization case starts off and remains
+                        // writable (even though the HostBuffer might have been initially created as
+                        // immutable.) In the direct mapping case we redirect the region to the
+                        // buffer stored in the account later on.
+                        region.redirect(data_slice);
+                    }
                 }
 
                 // Potentially unshare / make the account shared data unique (CoW logic).
                 if virtual_address_space_adjustments && account_data_direct_mapping {
-                    region.host_addr = account.data_as_mut_slice().as_mut_ptr() as u64;
-                    region.writable = true;
+                    unsafe {
+                        // SAFETY: refer to the comment above.
+                        region.redirect(account.raw_mut_data_slice());
+                    }
                 }
             },
         )

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -98,6 +98,10 @@ impl TransactionAccountViewMut<'_> {
         Arc::make_mut(&mut self.private_fields.payload)
     }
 
+    pub(crate) fn raw_mut_data_slice(&mut self) -> *mut [u8] {
+        &raw mut self.data_mut()[..]
+    }
+
     pub(crate) fn resize(&mut self, new_len: usize, value: u8) {
         self.data_mut().resize(new_len, value);
         // SAFETY: We are synchronizing the lengths.


### PR DESCRIPTION
#### Problem

I'm making breaking API changes to the sbpf's `MemoryRegion` to better encapsulate its various invariants. 

#### Summary of Changes

This should be a NFC (non-functional-change) that adapts to the new APIs, although some of the concepts that were previously available no longer are (such as `MemoryRegion::default()` which creates memory regions without a specified `vm_addr`.)

#### Testing

Clippy and test suite passing has high signal for this to be a correct change.

#### Pending actions

This cannot land before sbpf 0.22.0 is released.