### PR TITLE
docs: update broken and outdated docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,12 +381,6 @@ confused with 3-letter acronyms.
 
 ## Design Proposals
 
-This Agave validator client's architecture is described by docs generated from markdown files in the `docs/src/`
-directory and viewable on the official [Agave Validator Client](https://docs.anza.xyz) documentation website.
-
-Current design proposals may be viewed on the docs site:
-
-1. [Accepted Proposals](https://docs.anza.xyz/proposals/accepted-design-proposals)
-2. [Implemented Proposals](https://docs.anza.xyz/implemented-proposals/implemented-proposals)
-
-New design proposals should follow this guide on [how to submit a design proposal](./docs/src/proposals.md#submit-a-design-proposal).
+Design proposals are now tracked as Solana Improvement Documents (SIMDs) in the
+[solana-foundation/solana-improvement-documents](https://github.com/solana-foundation/solana-improvement-documents)
+repository.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ ./cargo build
 ```
 
 > [!NOTE]
-> Note that this builds a debug version that is **not suitable for running a testnet or mainnet validator**. Please read [`docs/src/cli/install.md`](docs/src/cli/install.md#build-from-source) for instructions to build a release version for test and production uses.
+> Note that this builds a debug version that is **not suitable for running a testnet or mainnet validator**. Please read [the install guide](https://docs.anza.xyz/cli/install#build-from-source) for instructions to build a release version for test and production uses.
 
 ## **4. Grant capabilities for XDP (Linux-only).**
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -108,7 +108,7 @@ const UNREF_ACCOUNTS_BATCH_SIZE: usize = 10_000;
 const DEFAULT_NUM_DIRS: u32 = 4;
 
 // This value reflects recommended memory lock limit documented in the validator's
-// setup instructions at docs/src/operations/guides/validator-start.md allowing use of
+// setup instructions at https://docs.anza.xyz/operations/guides/validator-start allowing use of
 // several io_uring instances with fixed buffers for large disk IO operations.
 pub const TOTAL_IO_URING_BUFFERS_SIZE_LIMIT: usize = 2_000_000_000;
 

--- a/net/README.md
+++ b/net/README.md
@@ -1,1 +1,3 @@
-../docs/src/clusters/testnet.md
+# Network Management
+
+See the [Test Network Management](https://docs.anza.xyz/clusters/testnet) guide.

--- a/svm/doc/spec.md
+++ b/svm/doc/spec.md
@@ -28,7 +28,7 @@ We envision the following applications for SVM
     The SVM is currently viewed as realizing two stages of the
     Transaction Engine Execution pipeline as described in Solana
     Architecture documentation
-    [https://docs.solana.com/validator/runtime#execution](https://docs.solana.com/validator/runtime#execution),
+    [https://docs.anza.xyz/validator/runtime#execution](https://docs.anza.xyz/validator/runtime#execution),
     namely ‘load accounts’ and ‘execute’ stages.
 
 - **SVM Rollups**


### PR DESCRIPTION
#### Problem

we moved docs to another place in https://github.com/anza-xyz/agave/pull/13200. however, there are still some broken and outdated docs links in this repository. let's update them.

#### Summary of Changes

update docs

---

close #13474 