### PR TITLE
bcp: enforce that the first alpenglow block has a genesis block marker

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1329,7 +1329,7 @@ fn maybe_include_genesis_certificate(
 
     // Process the genesis certificate
     let bank = poh_recorder.bank().expect("Bank cannot have been cleared");
-    let processor = bank.block_component_processor.read().unwrap();
+    let mut processor = bank.block_component_processor.write().unwrap();
     processor
         .on_genesis_cert_block_marker_leader(
             bank.clone(),

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1313,7 +1313,7 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    solana_pubkey::declare_id!("a1penGLz8Vm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP");
+    solana_pubkey::declare_id!("a2penGLz8Vm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP");
 }
 
 pub mod disable_zk_elgamal_proof_program {

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1816,7 +1816,7 @@ pub fn confirm_slot(
         // Skip block component validation for genesis block. Slot 0 is handled specially,
         // since it won't have the required block markers.
         if is_final && slot != 0 {
-            processor.on_final(migration_status, slot)?;
+            processor.on_final(migration_status, slot, bank.parent_slot())?;
         }
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5278,9 +5278,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "4PhJip2GUR1cihJKUwGam9GeFChyU5S9KsxhB3kMSYgk"
+                    "5PG7F5xaWbdVbGqMK4swGStgw6Dc3CRBwg3aYcDmY9q"
                 } else {
-                    "BvPkQKe71uT4XBsSoBtw5ynydnrgPjEccbge235sXQiL"
+                    "BKPZ9wePLfR5995UW3zc487emH7KXh7fAMTG1unYBYbC"
                 },
             );
         }
@@ -5289,9 +5289,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "AHdJaAqajYELEDxx6iE9F6yc2MobHLNrrVZr2egARz9m"
+                    "6P7mQgYgfCKXJT4giFVG9AUTG1k2oqbEz9oaJkQFzaFZ"
                 } else {
-                    "H6wrFKB918yKMNe32rGuEML5aQP59o6pcUVJnm3vKGLr"
+                    "9X9n98FSzPHCrEns4We6giA6QnsQEeYXqbxxULT5tHL1"
                 },
             );
             break;

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -55,6 +55,8 @@ pub enum BlockComponentProcessorError {
     InvalidFinalizationCertificate(#[from] BlockFinalizationCertError),
     #[error("Missing block footer")]
     MissingBlockFooter,
+    #[error("Missing genesis certificate marker")]
+    MissingGenesisCertificateMarker,
     #[error("Missing parent marker (neither a header nor an update parent was present)")]
     MissingParentMarker,
     #[error("Multiple block footers detected")]
@@ -108,6 +110,7 @@ impl BlockComponentProcessorError {
             | BlockComponentProcessorError::GenesisCertificateOnNonChild
             | BlockComponentProcessorError::GenesisCertificateFailedVerification
             | BlockComponentProcessorError::MissingBlockFooter
+            | BlockComponentProcessorError::MissingGenesisCertificateMarker
             | BlockComponentProcessorError::MultipleUpdateParents
             | BlockComponentProcessorError::SpuriousUpdateParent
             | BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(_) => false,
@@ -120,6 +123,7 @@ pub struct BlockComponentProcessor {
     has_header: bool,
     has_footer: bool,
     has_entry_batch: bool,
+    has_genesis_certificate_marker: bool,
     update_parent: Option<VersionedUpdateParent>,
 }
 
@@ -128,7 +132,14 @@ impl BlockComponentProcessor {
         &self,
         migration_status: &MigrationStatus,
         slot: Slot,
+        parent_slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
+        if Self::requires_genesis_certificate_marker(migration_status, parent_slot)
+            && !self.has_genesis_certificate_marker
+        {
+            return Err(BlockComponentProcessorError::MissingGenesisCertificateMarker);
+        }
+
         // Only require block markers (header/footer) for slots where they should be present
         if !migration_status.should_allow_block_markers(slot) {
             return Ok(());
@@ -144,6 +155,22 @@ impl BlockComponentProcessor {
         }
 
         Ok(())
+    }
+
+    /// Check if `parent_slot` is the alpenglow genesis block for use in enforcing
+    /// that the block has a genesis block marker
+    ///
+    /// Note: We have an exemption for Dev clusters that have alpenglow active at slot 0,
+    /// as these clusters do not need a genesis block marker
+    fn requires_genesis_certificate_marker(
+        migration_status: &MigrationStatus,
+        parent_slot: Slot,
+    ) -> bool {
+        migration_status
+            .genesis_block()
+            .is_some_and(|genesis_block| {
+                genesis_block.slot != 0 && parent_slot == genesis_block.slot
+            })
     }
 
     /// Process an entry batch.
@@ -235,7 +262,7 @@ impl BlockComponentProcessor {
 
     /// Processes the genesis block marker with full verification
     pub fn on_genesis_cert_block_marker(
-        &self,
+        &mut self,
         bank: Arc<Bank>,
         shred_version: u16,
         genesis_block_marker: GenesisCertBlockMarker,
@@ -253,7 +280,7 @@ impl BlockComponentProcessor {
     /// Processes a locally produced genesis certificate marker without
     /// re-verifying the certificate signature.
     pub fn on_genesis_cert_block_marker_leader(
-        &self,
+        &mut self,
         bank: Arc<Bank>,
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
@@ -277,7 +304,7 @@ impl BlockComponentProcessor {
 
     /// Performs verification if `shred_version` is specified
     fn process_genesis_cert_block_marker(
-        &self,
+        &mut self,
         bank: Arc<Bank>,
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
@@ -323,6 +350,7 @@ impl BlockComponentProcessor {
         };
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
         bank.set_hashes_per_tick(None);
+        self.has_genesis_certificate_marker = true;
 
         if migration_status.is_alpenglow_enabled() {
             // We participated in the migration, nothing to do
@@ -616,7 +644,7 @@ mod tests {
             genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
         },
         rand::Rng,
-        solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::DEFAULT_MS_PER_SLOT,
         solana_entry::block_component::{
             BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
@@ -655,9 +683,29 @@ mod tests {
         GenesisCertBlockMarker {
             slot: 0,
             block_id: Hash::default(),
-            bls_signature: solana_bls_signatures::Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         }
+    }
+
+    fn post_migration_status_with_genesis_slot(genesis_slot: Slot) -> MigrationStatus {
+        let migration_status = MigrationStatus::default();
+        let migration_slot = migration_status.record_feature_activation(0);
+        assert!(genesis_slot < migration_slot);
+
+        let genesis_block = Block {
+            slot: genesis_slot,
+            block_id: Hash::default(),
+        };
+        migration_status.set_genesis_block(genesis_block);
+        migration_status.set_genesis_certificate(Arc::new(Certificate {
+            cert_type: CertificateType::Genesis(genesis_block),
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        }));
+        migration_status.enable_alpenglow_during_startup();
+
+        migration_status
     }
 
     #[test]
@@ -793,11 +841,65 @@ mod tests {
         };
 
         // Try to mark slot as full without footer - should fail
-        let result = processor.on_final(&migration_status, 1);
+        let result = processor.on_final(&migration_status, 1, 0);
         assert!(matches!(
             result,
             Err(BlockComponentProcessorError::MissingBlockFooter)
         ));
+    }
+
+    #[test]
+    fn test_first_alpenglow_block_requires_genesis_certificate_marker() {
+        let migration_status = post_migration_status_with_genesis_slot(1);
+        let processor = BlockComponentProcessor {
+            has_header: true,
+            has_footer: true,
+            ..BlockComponentProcessor::default()
+        };
+
+        let result = processor.on_final(&migration_status, 2, 1);
+        assert!(matches!(
+            result,
+            Err(BlockComponentProcessorError::MissingGenesisCertificateMarker)
+        ));
+    }
+
+    #[test]
+    fn test_first_alpenglow_block_with_genesis_certificate_marker_succeeds() {
+        let migration_status = post_migration_status_with_genesis_slot(1);
+        let (genesis_bank, bank_forks) = create_test_bank();
+        let parent = create_child_bank(&bank_forks, &genesis_bank, 1);
+        let parent_block_id = Hash::new_unique();
+        parent.set_block_id(Some(parent_block_id));
+        let bank = create_child_bank(&bank_forks, &parent, 2);
+        let genesis_marker = GenesisCertBlockMarker {
+            slot: parent.slot(),
+            block_id: parent_block_id,
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        };
+        let mut processor = BlockComponentProcessor {
+            has_header: true,
+            has_footer: true,
+            ..BlockComponentProcessor::default()
+        };
+
+        processor
+            .on_genesis_cert_block_marker_leader(bank, genesis_marker, &migration_status)
+            .unwrap();
+        assert!(processor.on_final(&migration_status, 2, 1).is_ok());
+    }
+
+    #[test]
+    fn test_first_alpenglow_block_genesis_slot_zero_skips_genesis_certificate_marker_check() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let processor = BlockComponentProcessor {
+            has_header: true,
+            has_footer: true,
+            ..BlockComponentProcessor::default()
+        };
+
+        assert!(processor.on_final(&migration_status, 1, 0).is_ok());
     }
 
     #[test]
@@ -1734,6 +1836,6 @@ mod tests {
             .on_footer(bank, parent, shred_version, footer, None)
             .unwrap();
 
-        assert!(processor.on_final(&migration_status, 1).is_ok());
+        assert!(processor.on_final(&migration_status, 1, 0).is_ok());
     }
 }


### PR DESCRIPTION
#### Problem
We don't enforce that the first alpenglow block(s) have the genesis block marker.

This means the genesis certificate account could fail to be initialized

#### Summary of Changes
Enforce that if the parent slot is the genesis block then the block contains a genesis block marker.

Add an exemption for dev clusters which have alpenglow active at slot 0 and need to genesis block marker