### PR TITLE
blockstore: Remove unused arg from insert_shreds()

### DIFF
--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -551,7 +551,7 @@ pub mod test {
             ))],
         )];
         let shreds = blockstore::entries_to_test_shreds(&entries, 11, 10, true, 0);
-        let completed_data_sets = blockstore.insert_shreds(shreds, None, true).unwrap();
+        let completed_data_sets = blockstore.insert_shreds(shreds, true).unwrap();
         assert_eq!(completed_data_sets.len(), 1);
         let completed_data_set = completed_data_sets[0].clone();
         sender.send(completed_data_sets).unwrap();
@@ -617,7 +617,7 @@ pub mod test {
             .collect();
         let shreds = blockstore::entries_to_test_shreds(&entries, 12, 11, true, 0);
         assert!(shreds.len() > 1);
-        let completed_data_sets = blockstore.insert_shreds(shreds, None, true).unwrap();
+        let completed_data_sets = blockstore.insert_shreds(shreds, true).unwrap();
         assert_eq!(completed_data_sets.len(), 1);
         let completed_data_set = completed_data_sets[0].clone();
         sender.send(completed_data_sets).unwrap();

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -3333,11 +3333,11 @@ pub mod test {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_slot_entries(1, 0, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(3, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(4, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         assert!(!blockstore.is_root(0));
         assert!(!blockstore.is_root(1));
         assert!(!blockstore.is_root(3));
@@ -3369,11 +3369,11 @@ pub mod test {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_slot_entries(1, 0, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(3, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(4, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         blockstore.set_roots(std::iter::once(&3)).unwrap();
         assert!(!blockstore.is_root(0));
         assert!(!blockstore.is_root(1));
@@ -3397,9 +3397,9 @@ pub mod test {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_slot_entries(1, 0, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(3, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         assert!(!blockstore.is_root(0));
         assert!(!blockstore.is_root(1));
         assert!(!blockstore.is_root(3));

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1270,7 +1270,7 @@ mod test {
                 5,
             );
             blockstore
-                .insert_shreds(shreds, None, false)
+                .insert_shreds(shreds, false)
                 .expect("Expect successful ledger write");
             let mut correct_bank_hashes = HashMap::new();
             for duplicate_confirmed_slot in
@@ -1423,7 +1423,7 @@ mod test {
         // Create slots [slot, slot + num_ancestors) with 5 shreds apiece
         let (shreds, _) = make_many_slot_entries(dead_slot, dead_slot, 5);
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful ledger write");
         for duplicate_confirmed_slot in 0..(dead_slot - 1) {
             let bank_hash = correct_bank_hashes

--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -388,7 +388,7 @@ pub mod test {
                 shreds.pop().unwrap();
                 shreds.push(shred);
 
-                blockstore.insert_shreds(shreds, None, false).unwrap();
+                blockstore.insert_shreds(shreds, false).unwrap();
             }
             walk.forward();
         }

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -333,7 +333,6 @@ mod tests {
                     .into_iter()
                     .chain(parent_coding_shreds)
                     .collect::<Vec<_>>(),
-                None,
                 true,
             )
             .unwrap();
@@ -356,7 +355,6 @@ mod tests {
                     .into_iter()
                     .chain(coding_shreds)
                     .collect::<Vec<_>>(),
-                None,
                 true, // is_trusted
             )
             .unwrap();

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1480,7 +1480,7 @@ mod test {
         let (mut shreds, _) = make_slot_entries(1, 0, 1);
         let (shreds2, _) = make_slot_entries(5, 2, 1);
         shreds.extend(shreds2);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let mut repair_weight = RepairWeight::new(0);
         assert_eq!(
             repair_weight.get_best_weighted_repairs(
@@ -1511,7 +1511,7 @@ mod test {
 
         // Write this shred to slot 2, should chain to slot 0, which we haven't received
         // any shreds for
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let mut repair_weight = RepairWeight::new(0);
 
         // Check that repair tries to patch the empty slot
@@ -1560,9 +1560,7 @@ mod test {
                 missing_indexes_per_slot.insert(0, index);
             }
         }
-        blockstore
-            .insert_shreds(shreds_to_write, None, false)
-            .unwrap();
+        blockstore.insert_shreds(shreds_to_write, false).unwrap();
         let expected: Vec<ShredRepairType> = (0..num_slots)
             .flat_map(|slot| {
                 missing_indexes_per_slot
@@ -1652,7 +1650,6 @@ mod test {
                     shreds_by_index.get(&0).unwrap().clone(),
                     shreds_by_index.get(&(missing_index + 1)).unwrap().clone(),
                 ],
-                None,
                 false,
             )
             .unwrap();
@@ -1691,9 +1688,7 @@ mod test {
             .chain(std::iter::once(future_fec_start))
             .map(|index| shreds_by_index.get(&index).unwrap().clone())
             .collect();
-        blockstore
-            .insert_shreds(shreds_to_insert, None, false)
-            .unwrap();
+        blockstore.insert_shreds(shreds_to_insert, false).unwrap();
 
         let slot_meta = blockstore.meta_repair(slot).unwrap().unwrap();
         let mut repair_eligibility = RepairEligibility::default();
@@ -1741,7 +1736,7 @@ mod test {
         // Remove last shred (which is also last in slot) so that slot is not complete
         shreds.pop();
 
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         // We didn't get the last shred for this slot, so ask for the highest shred for that slot
         let expected: Vec<ShredRepairType> =
@@ -1794,7 +1789,7 @@ mod test {
             .collect();
 
         blockstore
-            .insert_shreds(vec![shreds_by_index.get(&0).unwrap().clone()], None, false)
+            .insert_shreds(vec![shreds_by_index.get(&0).unwrap().clone()], false)
             .unwrap();
         let mut repair_eligibility = RepairEligibility::default();
         let slot_meta = blockstore.meta_repair(0).unwrap().unwrap();
@@ -1811,7 +1806,7 @@ mod test {
         );
 
         blockstore
-            .insert_shreds(vec![shreds_by_index.get(&1).unwrap().clone()], None, false)
+            .insert_shreds(vec![shreds_by_index.get(&1).unwrap().clone()], false)
             .unwrap();
         let slot_meta = blockstore.meta_repair(0).unwrap().unwrap();
         assert_eq!(
@@ -1851,7 +1846,7 @@ mod test {
         let shreds = make_chaining_slot_entries(&slots, num_entries_per_slot, 0);
         for (mut slot_shreds, _) in shreds.into_iter() {
             slot_shreds.remove(0);
-            blockstore.insert_shreds(slot_shreds, None, false).unwrap();
+            blockstore.insert_shreds(slot_shreds, false).unwrap();
         }
 
         // Iterate through all possible combinations of start..end (inclusive on both
@@ -1905,7 +1900,7 @@ mod test {
                 num_entries_per_slot as u64,
             );
 
-            blockstore.insert_shreds(shreds, None, false).unwrap();
+            blockstore.insert_shreds(shreds, false).unwrap();
         }
 
         let end = 4;
@@ -1942,7 +1937,7 @@ mod test {
             num_entries_per_slot,
         );
         blockstore
-            .insert_shreds(shreds[..shreds.len() - 1].to_vec(), None, false)
+            .insert_shreds(shreds[..shreds.len() - 1].to_vec(), false)
             .unwrap();
         assert!(
             RepairService::generate_duplicate_repairs_for_slot(&blockstore, dead_slot,).is_some()
@@ -1950,7 +1945,7 @@ mod test {
 
         // SlotMeta is full, should make no repairs
         blockstore
-            .insert_shreds(vec![shreds.pop().unwrap()], None, false)
+            .insert_shreds(vec![shreds.pop().unwrap()], false)
             .unwrap();
         assert!(
             RepairService::generate_duplicate_repairs_for_slot(&blockstore, dead_slot,).is_none()
@@ -1990,7 +1985,7 @@ mod test {
         let num_entries_per_slot = max_ticks_per_n_shreds(1, None) + 1;
         let (mut shreds, _) = make_slot_entries(dead_slot, dead_slot - 1, num_entries_per_slot);
         blockstore
-            .insert_shreds(shreds[..shreds.len() - 1].to_vec(), None, false)
+            .insert_shreds(shreds[..shreds.len() - 1].to_vec(), false)
             .unwrap();
 
         duplicate_slot_repair_statuses.insert(dead_slot, duplicate_status);
@@ -2042,7 +2037,7 @@ mod test {
         // Insert rest of shreds. Slot is full, should get filtered from
         // `duplicate_slot_repair_statuses`
         blockstore
-            .insert_shreds(vec![shreds.pop().unwrap()], None, false)
+            .insert_shreds(vec![shreds.pop().unwrap()], false)
             .unwrap();
         RepairService::generate_and_send_duplicate_repairs(
             &mut duplicate_slot_repair_statuses,

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -2445,7 +2445,7 @@ mod test {
 
         // Simulate repair on 6 and 5
         for (shreds, _) in make_chaining_slot_entries(&[5, 6], 100, 0) {
-            blockstore.insert_shreds(shreds, None, true).unwrap();
+            blockstore.insert_shreds(shreds, true).unwrap();
         }
 
         // Verify orphans properly updated and chained

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -321,9 +321,7 @@ pub mod test {
                 shreds
             })
             .collect();
-        blockstore
-            .insert_shreds(completed_shreds, None, false)
-            .unwrap();
+        blockstore.insert_shreds(completed_shreds, false).unwrap();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -2505,7 +2505,7 @@ mod tests {
         shreds.truncate(1);
 
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful ledger write");
 
         let mut rv = handler
@@ -2668,7 +2668,7 @@ mod tests {
         let (shreds, _) = make_many_slot_entries(slot, num_slots, 5);
 
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful ledger write");
 
         // We don't have slot `slot + num_slots`, so we don't know how to service this request
@@ -2724,7 +2724,7 @@ mod tests {
         // covers packet size check in repair_response_packet_from_bytes.
         shreds.retain(|shred| shred.slot() != 1);
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful ledger write");
         let nonce = 42;
         // Make sure repair response is corrupted
@@ -2781,7 +2781,7 @@ mod tests {
         let (shreds, _) = make_many_slot_entries(slot, num_slots, 5);
 
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful ledger write");
 
         // We don't have slot `slot + num_slots`, so we return empty

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -217,7 +217,7 @@ fn insert_update_parent_slot(
         update_parent,
         replay_fec_set_index,
     ));
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 }
 
 /// Build the minimal dead-slot context needed by focused replay tests.
@@ -413,7 +413,7 @@ fn test_child_slots_of_same_parent() {
         1,                            // parent_slot
         8,                            // num_entries
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(
         bank_forks
             .read()
@@ -446,7 +446,7 @@ fn test_child_slots_of_same_parent() {
     // Insert shreds for slot 2 * NUM_CONSECUTIVE_LEADER_SLOTS,
     // chaining to slot 1
     let (shreds, _) = make_slot_entries(2 * NUM_CONSECUTIVE_LEADER_SLOTS, 1, 8);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(
         bank_forks
             .read()
@@ -1019,7 +1019,7 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
         };
         let entries = make_complete_slot_entries(&bank, vec![tx]);
         let shreds = entries_to_test_shreds(&entries, slot, bank.parent_slot(), true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let cluster_info = cluster_info_for_tests();
 
         ReplaySlotFromBlockstore {
@@ -1234,7 +1234,7 @@ where
             &validator_keypairs.values().next().unwrap().node_keypair,
             bank1.clone(),
         );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let exit = Arc::new(AtomicBool::new(false));
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
@@ -2702,13 +2702,13 @@ fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
         1, // parent_slot
         8, // num_entries
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let (shreds, _) = make_slot_entries(
         5, // slot
         3, // parent_slot
         8, // num_entries
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     let rpc_subscriptions = Some(rpc_subscriptions);
 
@@ -2939,7 +2939,7 @@ fn test_headerless_update_parent() {
         64,
         true,
     ));
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     let slot_meta = blockstore.meta(slot).unwrap().unwrap();
     assert!(blockstore.is_full(slot), "{slot_meta:?}");
     assert!(slot_meta.has_update_parent());
@@ -3252,7 +3252,7 @@ fn test_before_update_soft_dead() {
     let mut shreds = block_marker_shreds(slot, 0, header, 0);
     shreds.retain(|shred| !shred.is_data() || shred.index() != 0);
     shreds.extend(block_marker_shreds(slot, 0, update_parent, 32));
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     assert!(blockstore.meta(slot).unwrap().unwrap().has_update_parent());
 
     let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
@@ -6285,7 +6285,7 @@ fn test_skip_leader_slot_for_existing_slot() {
     let initial_slot = working_bank.slot();
     let num_entries = 10;
     let (shreds, _) = make_slot_entries(dummy_slot, initial_slot, num_entries);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     // Reset PoH recorder to the completed bank to ensure consistent state
     ReplayStage::reset_poh_recorder(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -467,7 +467,6 @@ impl Tvu {
                 exit.clone(),
                 repair_info,
                 window_service_channels,
-                leader_schedule_cache.clone(),
                 tvu_config.shred_version,
                 outstanding_repair_requests,
                 tvu_config.repair_xdp_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2857,7 +2857,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
             for (slot, _meta) in slot_meta_iterator {
                 let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
-                let _ = backup_blockstore.insert_cow_shreds(shreds, None, true);
+                let _ = backup_blockstore.insert_cow_shreds(shreds, true);
                 num_slots_copied += 1;
 
                 if print_timer.elapsed() > PRINT_INTERVAL {
@@ -3375,7 +3375,7 @@ mod tests {
                 true,  // is_full_slot
                 1,     // version
             );
-            blockstore.insert_shreds(shreds, None, true).unwrap();
+            blockstore.insert_shreds(shreds, true).unwrap();
         }
 
         // No check as all blockstore data is newer than latest hard fork
@@ -3466,7 +3466,7 @@ mod tests {
                 true,  // is_full_slot
                 1,     // version
             );
-            blockstore.insert_shreds(shreds, None, true).unwrap();
+            blockstore.insert_shreds(shreds, true).unwrap();
         }
 
         // this purges and compacts all slots greater than or equal to 5

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -21,7 +21,6 @@ use {
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
         blockstore_meta::BlockLocation,
-        leader_schedule_cache::LeaderScheduleCache,
         shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
     solana_measure::measure::Measure,
@@ -217,7 +216,6 @@ fn run_insert<F>(
     verified_receiver: &Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     blockstore: &Blockstore,
     shred_recovery_context: &mut ShredRecoveryContext,
-    leader_schedule_cache: &LeaderScheduleCache,
     handle_duplicate: F,
     metrics: &mut BlockstoreInsertionMetrics,
     ws_metrics: &mut WindowServiceMetrics,
@@ -252,7 +250,6 @@ where
     ws_metrics.num_shreds_received += shreds.len();
     let completed_data_sets = blockstore.insert_shreds_at_location_handle_duplicate(
         shreds,
-        Some(leader_schedule_cache),
         false, // is_trusted
         shred_recovery_context,
         &handle_duplicate,
@@ -312,7 +309,6 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         repair_info: RepairInfo,
         window_service_channels: WindowServiceChannels,
-        leader_schedule_cache: Arc<LeaderScheduleCache>,
         shred_version: u16,
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
         repair_xdp_sender: Option<PinnedXdpSender>,
@@ -366,7 +362,6 @@ impl WindowService {
             exit,
             blockstore,
             sharable_banks,
-            leader_schedule_cache,
             shred_version,
             verified_receiver,
             duplicate_sender,
@@ -413,7 +408,6 @@ impl WindowService {
         exit: Arc<AtomicBool>,
         blockstore: Arc<Blockstore>,
         sharable_banks: SharableBanks,
-        leader_schedule_cache: Arc<LeaderScheduleCache>,
         shred_version: u16,
         verified_receiver: Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
         check_duplicate_sender: Sender<PossibleDuplicateShred>,
@@ -456,7 +450,6 @@ impl WindowService {
                         &verified_receiver,
                         &blockstore,
                         &mut shred_recovery_context,
-                        &leader_schedule_cache,
                         handle_duplicate,
                         &mut metrics,
                         &mut ws_metrics,
@@ -560,7 +553,7 @@ mod test {
         let mut shreds = local_entries_to_shred(&original_entries, 0, 0, &Keypair::new());
         shreds.reverse();
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expect successful processing of shred");
 
         assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), original_entries);
@@ -575,9 +568,7 @@ mod test {
         let (sender, receiver) = bounded(1024);
         let (duplicate_slot_sender, duplicate_slot_receiver) = bounded(1024);
         let (shreds, _) = make_many_slot_entries(5, 5, 10);
-        blockstore
-            .insert_shreds(shreds.clone(), None, false)
-            .unwrap();
+        blockstore.insert_shreds(shreds.clone(), false).unwrap();
         let duplicate_index = 0;
         let original_shred = shreds[duplicate_index].clone();
         let duplicate_shred = {
@@ -666,7 +657,6 @@ mod test {
             blockstore
                 .insert_shreds_handle_duplicate(
                     shreds,
-                    None,
                     false, // is_trusted
                     &mut ShredRecoveryContext::new(
                         ReedSolomonCache::default(),

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -392,7 +392,7 @@ async fn shreds(
             )
             .filter(Shred::is_data)
             .collect();
-        blockstore.insert_shreds(data_shreds, None, false)?;
+        blockstore.insert_shreds(data_shreds, false)?;
     }
     Ok(())
 }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -642,7 +642,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 }
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
-                if target.insert_cow_shreds(shreds, None, true).is_err() {
+                if target.insert_cow_shreds(shreds, true).is_err() {
                     warn!("error inserting shreds for slot {slot}");
                 }
             }
@@ -1009,7 +1009,7 @@ pub mod tests {
         let num_slots = 5;
         let entries_per_shred = 5;
         let (shreds, _) = make_many_slot_entries(start_slot, num_slots, entries_per_shred);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         // Mark even shreds as optimistically confirmed
         (0..num_slots).step_by(2).for_each(|slot| {

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -51,7 +51,7 @@ fn insert_test_shreds(ledger_path: &Path, ending_slot: u64) {
         ending_slot,
         /*entries_per_slot:*/ 10,
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 }
 
 #[test]

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -40,7 +40,7 @@ fn setup_read_bench(
         0,                      // version
     );
     blockstore
-        .insert_shreds(shreds, None, false)
+        .insert_shreds(shreds, false)
         .expect("Expected successful insertion of shreds into ledger");
 }
 
@@ -55,7 +55,7 @@ fn bench_write_shreds(bench: &mut Bencher) {
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
     bench.iter(move || {
         let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
     });
 }
 
@@ -123,7 +123,7 @@ fn bench_insert_data_shred(bench: &mut Bencher) {
     let entries = create_ticks(num_entries, 0, Hash::default());
     bench.iter(move || {
         let shreds = entries_to_test_shreds(&entries, 0, 0, true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
     });
 }
 

--- a/ledger/src/ancestor_iterator.rs
+++ b/ledger/src/ancestor_iterator.rs
@@ -121,11 +121,11 @@ mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_slot_entries(0, 0, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(1, 0, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (shreds, _) = make_slot_entries(2, 1, 42);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         assert_eq!(
             AncestorIterator::new(2, &blockstore).collect::<Vec<Slot>>(),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -15,7 +15,6 @@ use {
         blockstore_options::{
             BLOCKSTORE_DIRECTORY_ROCKS_LEVEL, BlockstoreOptions, LedgerColumnOptions,
         },
-        leader_schedule_cache::LeaderScheduleCache,
         next_slots_iterator::NextSlotsIterator,
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Payload, ProcessShredsStats,
@@ -756,7 +755,7 @@ impl Blockstore {
                 if let Some(last_shred) = shreds.last() {
                     merkle_roots.insert(slot, last_shred.merkle_root().unwrap());
                 }
-                self.insert_shreds(shreds, None, false).unwrap();
+                self.insert_shreds(shreds, false).unwrap();
             }
             walk.forward();
         }
@@ -1556,7 +1555,6 @@ impl Blockstore {
             IntoIter: ExactSizeIterator,
         >,
         is_trusted: bool,
-        leader_schedule: Option<&LeaderScheduleCache>,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) {
@@ -1577,7 +1575,6 @@ impl Blockstore {
                         location,
                         shred_insertion_tracker,
                         is_trusted,
-                        leader_schedule,
                         shred_source,
                     ) {
                         Err(InsertDataShredError::Exists) => {
@@ -1718,7 +1715,6 @@ impl Blockstore {
     /// Note: We only perform recovery for the Original shred column
     fn handle_shred_recovery(
         &self,
-        leader_schedule: Option<&LeaderScheduleCache>,
         shred_recovery_context: &mut ShredRecoveryContext,
         shred_insertion_tracker: &mut ShredInsertionTracker,
         is_trusted: bool,
@@ -1741,7 +1737,6 @@ impl Blockstore {
                 BlockLocation::Original,
                 shred_insertion_tracker,
                 is_trusted,
-                leader_schedule,
                 ShredSource::Recovered,
             ) {
                 Err(InsertDataShredError::Exists) => &mut metrics.num_recovered_exists,
@@ -2177,7 +2172,6 @@ impl Blockstore {
     /// Arguments:
     ///  - `shreds`: the shreds to be inserted, alongside their repaired flag and
     ///    insertion location.
-    ///  - `leader_schedule`: the leader schedule
     ///  - `is_trusted`: whether the shreds come from a trusted source. If this
     ///    is set to true, then the function will skip the shred duplication and
     ///    integrity checks.
@@ -2194,7 +2188,6 @@ impl Blockstore {
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
         // When inserting own shreds during leader slots, we shouldn't try to
         // recover shreds. If shreds are not to be recovered we don't need the
@@ -2215,7 +2208,6 @@ impl Blockstore {
         let result = self.do_insert_shreds_locked(
             &lock,
             shreds,
-            leader_schedule,
             is_trusted,
             shred_recovery_context,
             metrics,
@@ -2236,7 +2228,6 @@ impl Blockstore {
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
         shred_recovery_context: Option<&mut ShredRecoveryContext>,
         metrics: &mut BlockstoreInsertionMetrics,
@@ -2245,16 +2236,9 @@ impl Blockstore {
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(shreds.len(), self.get_write_batch()?);
 
-        self.attempt_shred_insertion(
-            shreds,
-            is_trusted,
-            leader_schedule,
-            &mut shred_insertion_tracker,
-            metrics,
-        );
+        self.attempt_shred_insertion(shreds, is_trusted, &mut shred_insertion_tracker, metrics);
         if let Some(shred_recovery_context) = shred_recovery_context {
             self.handle_shred_recovery(
-                leader_schedule,
                 shred_recovery_context,
                 &mut shred_insertion_tracker,
                 is_trusted,
@@ -2309,7 +2293,6 @@ impl Blockstore {
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool),
             IntoIter: ExactSizeIterator,
         >,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
         shred_recovery_context: &mut ShredRecoveryContext,
         handle_duplicate: &F,
@@ -2322,7 +2305,6 @@ impl Blockstore {
             shreds
                 .into_iter()
                 .map(|(shred, is_repaired)| (shred, is_repaired, BlockLocation::Original)),
-            leader_schedule,
             is_trusted,
             shred_recovery_context,
             handle_duplicate,
@@ -2341,7 +2323,6 @@ impl Blockstore {
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
         shred_recovery_context: &mut ShredRecoveryContext,
         handle_duplicate: &F,
@@ -2353,13 +2334,7 @@ impl Blockstore {
         let InsertResults {
             completed_data_set_infos,
             duplicate_shreds,
-        } = self.do_insert_shreds(
-            shreds,
-            leader_schedule,
-            is_trusted,
-            Some(shred_recovery_context),
-            metrics,
-        )?;
+        } = self.do_insert_shreds(shreds, is_trusted, Some(shred_recovery_context), metrics)?;
 
         for shred in duplicate_shreds {
             handle_duplicate(shred);
@@ -2446,7 +2421,6 @@ impl Blockstore {
         self.do_insert_shreds_locked(
             lock,
             shreds,
-            None, // leader_schedule
             true, // is_trusted
             None, // should_recover_shreds
             &mut BlockstoreInsertionMetrics::default(),
@@ -2540,7 +2514,6 @@ impl Blockstore {
     pub fn insert_cow_shreds<'a>(
         &self,
         shreds: impl IntoIterator<Item = Cow<'a, Shred>, IntoIter: ExactSizeIterator>,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let shreds = shreds
@@ -2548,7 +2521,6 @@ impl Blockstore {
             .map(|shred| (shred, /*is_repaired:*/ false, BlockLocation::Original));
         let insert_results = self.do_insert_shreds(
             shreds,
-            leader_schedule,
             is_trusted,
             None, // Skip recovery for locally produced shreds.
             &mut BlockstoreInsertionMetrics::default(),
@@ -2560,19 +2532,14 @@ impl Blockstore {
     pub fn insert_shreds(
         &self,
         shreds: impl IntoIterator<Item = Shred, IntoIter: ExactSizeIterator>,
-        leader_schedule: Option<&LeaderScheduleCache>,
         is_trusted: bool,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let shreds = shreds.into_iter().map(Cow::Owned);
-        self.insert_cow_shreds(shreds, leader_schedule, is_trusted)
+        self.insert_cow_shreds(shreds, is_trusted)
     }
 
     #[cfg(test)]
-    fn insert_shred_return_duplicate(
-        &self,
-        shred: Shred,
-        leader_schedule: &LeaderScheduleCache,
-    ) -> Vec<PossibleDuplicateShred> {
+    fn insert_shred_return_duplicate(&self, shred: Shred) -> Vec<PossibleDuplicateShred> {
         let insert_results = self
             .do_insert_shreds(
                 [(
@@ -2580,7 +2547,6 @@ impl Blockstore {
                     /*is_repaired:*/ false,
                     BlockLocation::Original,
                 )],
-                Some(leader_schedule),
                 false,
                 None, // Skip recovery for this direct insertion path.
                 &mut BlockstoreInsertionMetrics::default(),
@@ -2826,18 +2792,13 @@ impl Blockstore {
     ///   data.
     /// - `is_trusted`: if false, this function will check whether the
     ///   input shred is duplicate.
-    /// - `handle_duplicate`: the function that handles duplication.
-    /// - `leader_schedule`: the leader schedule will be used to check
-    ///   whether it is okay to insert the input shred.
     /// - `shred_source`: the source of the shred.
-    #[allow(clippy::too_many_arguments)]
     fn check_insert_data_shred<'a>(
         &self,
         shred: Cow<'a, Shred>,
         location: BlockLocation,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         is_trusted: bool,
-        leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
     ) -> std::result::Result<(), InsertDataShredError> {
         let slot = shred.slot();
@@ -2903,7 +2864,6 @@ impl Blockstore {
                 slot_meta,
                 just_inserted_shreds,
                 self.max_root(),
-                leader_schedule,
                 shred_source,
                 duplicate_shreds,
             ) {
@@ -3261,7 +3221,6 @@ impl Blockstore {
         slot_meta: &SlotMeta,
         just_inserted_shreds: &HashMap<(BlockLocation, ShredId), Cow<'_, Shred>>,
         max_root: Slot,
-        _leader_schedule: Option<&LeaderScheduleCache>,
         shred_source: ShredSource,
         duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
     ) -> bool {
@@ -3839,7 +3798,7 @@ impl Blockstore {
         // `write_entries` is a test helper that synthesizes local shreds.
         // Insert as trusted to avoid dead-slot marking from untrusted-path
         // filters (for example slot-0 coding shred checks).
-        self.insert_shreds(all_shreds, None, true)?;
+        self.insert_shreds(all_shreds, true)?;
         Ok(num_data)
     }
 
@@ -6147,7 +6106,7 @@ impl Blockstore {
     pub fn insert_shreds_for_bank(&self, bank: Arc<Bank>) {
         let entries = create_ticks(bank.ticks_per_slot(), 1, Hash::new_unique());
         let shreds = entries_to_test_shreds(&entries, bank.slot(), bank.parent_slot(), true, 0);
-        self.insert_shreds(shreds, None, false).unwrap();
+        self.insert_shreds(shreds, false).unwrap();
     }
 }
 
@@ -6375,7 +6334,7 @@ pub fn create_new_ledger(
     );
     assert!(shreds.last().unwrap().last_in_slot());
 
-    blockstore.insert_shreds(shreds, None, false)?;
+    blockstore.insert_shreds(shreds, false)?;
     blockstore.set_roots(std::iter::once(&0))?;
     // Explicitly close the blockstore before we create the archived genesis file
     drop(blockstore);

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -703,7 +703,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         blockstore.purge_slots(0, 5, PurgeType::Exact).unwrap();
         all_columns_empty_or_greater_than_slot(&blockstore, 6);
@@ -777,7 +777,7 @@ pub mod tests {
                 true,                // is_full_slot
                 0,                   // version
             );
-            blockstore.insert_shreds(shreds, None, false).unwrap();
+            blockstore.insert_shreds(shreds, false).unwrap();
             let signature = entries
                 .iter()
                 .filter(|entry| !entry.is_tick())
@@ -821,7 +821,7 @@ pub mod tests {
                 true, // is_full_slot
                 0,    // version
             );
-            blockstore.insert_shreds(shreds, None, false).unwrap();
+            blockstore.insert_shreds(shreds, false).unwrap();
 
             for transaction in entries.into_iter().flat_map(|entry| entry.transactions) {
                 assert_eq!(transaction.signatures.len(), 1);
@@ -992,7 +992,7 @@ pub mod tests {
             true,     // is_full_slot
             0,        // version
         );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         let mut write_batch = blockstore.get_write_batch().unwrap();
         blockstore
@@ -1060,7 +1060,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_many_slot_entries(0, 10, 5);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         assert!(matches!(
             blockstore.purge_slot_cleanup_chaining(11).unwrap_err(),
@@ -1074,11 +1074,11 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
         let (shreds, _) = make_many_slot_entries(0, 10, 5);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         let (slot_11, _) = make_slot_entries(11, 4, 5);
-        blockstore.insert_shreds(slot_11, None, false).unwrap();
+        blockstore.insert_shreds(slot_11, false).unwrap();
         let (slot_12, _) = make_slot_entries(12, 5, 5);
-        blockstore.insert_shreds(slot_12, None, false).unwrap();
+        blockstore.insert_shreds(slot_12, false).unwrap();
 
         blockstore.purge_slot_cleanup_chaining(5).unwrap();
 

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -14,7 +14,6 @@ use {
     solana_entry::entry::next_entry_mut,
     solana_genesis_utils::{MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, open_genesis_config},
     solana_hash::Hash,
-    solana_leader_schedule::{FixedSchedule, LeaderSchedule, SlotLeader},
     solana_message::{compiled_instruction::CompiledInstruction, v0::LoadedAddresses},
     solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
@@ -27,7 +26,7 @@ use {
     solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionError,
     solana_transaction_status::{InnerInstruction, InnerInstructions},
-    std::{cmp::Ordering, num::NonZeroUsize, time::Duration},
+    std::{cmp::Ordering, time::Duration},
     test_case::{test_case, test_matrix},
 };
 
@@ -55,7 +54,7 @@ fn make_and_insert_slot(blockstore: &Blockstore, slot: Slot, parent_slot: Slot) 
         parent_slot,
         100, // num_entries
     );
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     let meta = blockstore.meta(slot).unwrap().unwrap();
     assert_eq!(slot, meta.slot);
@@ -236,7 +235,7 @@ fn test_insert_get_bytes() {
     let last_shred = shreds.pop().unwrap();
     assert!(last_shred.index() > 0);
     blockstore
-        .insert_shreds(vec![last_shred.clone()], None, false)
+        .insert_shreds(vec![last_shred.clone()], false)
         .unwrap();
 
     let serialized_shred = blockstore
@@ -432,7 +431,7 @@ fn test_read_shred_bytes() {
 
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     let mut buf = [0; 4096];
     let (_, bytes) = blockstore.get_data_shreds(slot, 0, 1, &mut buf).unwrap();
@@ -486,7 +485,7 @@ fn test_shred_cleanup_check() {
 
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     let mut buf = [0; 4096];
     assert!(blockstore.get_data_shreds(slot, 0, 1, &mut buf).is_ok());
@@ -521,9 +520,7 @@ fn test_insert_data_shreds_basic() {
     // shreds starting from slot 0, index 0 should exist.
     assert!(shreds.len() > 1);
     let last_shred = shreds.pop().unwrap();
-    blockstore
-        .insert_shreds(vec![last_shred], None, false)
-        .unwrap();
+    blockstore.insert_shreds(vec![last_shred], false).unwrap();
     assert!(blockstore.get_slot_entries(0, 0).unwrap().is_empty());
 
     let meta = blockstore
@@ -533,7 +530,7 @@ fn test_insert_data_shreds_basic() {
     assert!(meta.consumed == 0 && meta.received == num_shreds);
 
     // Insert the other shreds, check for consecutive returned entries
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let result = blockstore.get_slot_entries(0, 0).unwrap();
 
     assert_eq!(result, entries);
@@ -567,7 +564,7 @@ fn test_insert_data_shreds_reverse() {
     // Insert shreds in reverse, check for consecutive returned shreds
     for i in (0..num_shreds).rev() {
         let shred = shreds.pop().unwrap();
-        blockstore.insert_shreds(vec![shred], None, false).unwrap();
+        blockstore.insert_shreds(vec![shred], false).unwrap();
         let result = blockstore.get_slot_entries(0, 0).unwrap();
 
         let meta = blockstore
@@ -599,7 +596,7 @@ fn test_get_slot_entries1() {
     let entries = create_ticks(8, 0, Hash::default());
     let shreds = entries_to_test_shreds(&entries[0..4], 1, 0, false, 0);
     blockstore
-        .insert_shreds(shreds, None, false)
+        .insert_shreds(shreds, false)
         .expect("Expected successful write of shreds");
 
     assert_eq!(
@@ -626,7 +623,7 @@ fn test_get_slot_entries3() {
         let shreds = entries_to_test_shreds(&entries, slot, slot.saturating_sub(1), false, 0);
         assert!(shreds.len() as u64 >= shreds_per_slot);
         blockstore
-            .insert_shreds(shreds, None, false)
+            .insert_shreds(shreds, false)
             .expect("Expected successful write of shreds");
         assert_eq!(blockstore.get_slot_entries(slot, 0).unwrap(), entries);
     }
@@ -658,7 +655,7 @@ fn test_insert_data_shreds_consecutive() {
             }
         }
 
-        blockstore.insert_shreds(odd_shreds, None, false).unwrap();
+        blockstore.insert_shreds(odd_shreds, false).unwrap();
 
         assert_eq!(blockstore.get_slot_entries(slot, 0).unwrap(), vec![]);
 
@@ -676,7 +673,7 @@ fn test_insert_data_shreds_consecutive() {
             assert_eq!(meta.last_index, None);
         }
 
-        blockstore.insert_shreds(even_shreds, None, false).unwrap();
+        blockstore.insert_shreds(even_shreds, false).unwrap();
 
         assert_eq!(
             blockstore.get_slot_entries(slot, 0).unwrap(),
@@ -706,13 +703,13 @@ fn test_data_set_completed_on_insert() {
     assert!(num_shreds > 1);
     assert!(
         blockstore
-            .insert_shreds(shreds[1..].to_vec(), None, false)
+            .insert_shreds(shreds[1..].to_vec(), false)
             .unwrap()
             .is_empty()
     );
     assert_eq!(
         blockstore
-            .insert_shreds(vec![shreds[0].clone()], None, false)
+            .insert_shreds(vec![shreds[0].clone()], false)
             .unwrap(),
         vec![CompletedDataSetInfo {
             slot,
@@ -720,12 +717,7 @@ fn test_data_set_completed_on_insert() {
         }]
     );
     // Inserting shreds again doesn't trigger notification
-    assert!(
-        blockstore
-            .insert_shreds(shreds, None, false)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(blockstore.insert_shreds(shreds, false).unwrap().is_empty());
 }
 
 #[test]
@@ -750,19 +742,19 @@ fn test_new_shreds_signal() {
     // Insert second shred, but we're missing the first shred, so no consecutive
     // shreds starting from slot 0, index 0 should exist.
     blockstore
-        .insert_shreds(vec![shreds.remove(1)], None, false)
+        .insert_shreds(vec![shreds.remove(1)], false)
         .unwrap();
     let timer = Duration::from_secs(1);
     assert!(recvr.recv_timeout(timer).is_err());
     // Insert first shred, now we've made a consecutive block
     blockstore
-        .insert_shreds(vec![shreds.remove(0)], None, false)
+        .insert_shreds(vec![shreds.remove(0)], false)
         .unwrap();
     // Wait to get notified of update, should only be one update
     assert!(recvr.recv_timeout(timer).is_ok());
     assert!(recvr.try_recv().is_err());
     // Insert the rest of the ticks
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // Wait to get notified of update, should only be one update
     assert!(recvr.recv_timeout(timer).is_ok());
     assert!(recvr.try_recv().is_err());
@@ -785,7 +777,7 @@ fn test_new_shreds_signal() {
     }
 
     // Should be no updates, since no new chains from block 0 were formed
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(recvr.recv_timeout(timer).is_err());
 
     // For slots 1..num_slots/2, fill in the holes in one batch insertion,
@@ -793,17 +785,13 @@ fn test_new_shreds_signal() {
     let missing_shreds2 = missing_shreds
         .drain((num_slots / 2) as usize..)
         .collect_vec();
-    blockstore
-        .insert_shreds(missing_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(missing_shreds, false).unwrap();
     assert!(recvr.recv_timeout(timer).is_ok());
     assert!(recvr.try_recv().is_err());
 
     // Fill in the holes for each of the remaining slots,
     // we should get a single update
-    blockstore
-        .insert_shreds(missing_shreds2, None, false)
-        .unwrap();
+    blockstore.insert_shreds(missing_shreds2, false).unwrap();
 
     assert!(recvr.recv_timeout(timer).is_ok());
     assert!(recvr.try_recv().is_err());
@@ -826,11 +814,11 @@ fn test_completed_shreds_signal() {
 
     let shred0 = shreds.remove(0);
     // Insert all but the first shred in the slot, should not be considered complete
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(recvr.try_recv().is_err());
 
     // Insert first shred, slot should now be considered complete
-    blockstore.insert_shreds(vec![shred0], None, false).unwrap();
+    blockstore.insert_shreds(vec![shred0], false).unwrap();
     assert_eq!(recvr.try_recv().unwrap(), vec![0]);
 }
 
@@ -856,25 +844,23 @@ fn test_completed_shreds_signal_orphans() {
 
     // Insert all but the first shred in the slot, should not be considered complete
     let orphan_child0 = orphan_child.remove(0);
-    blockstore.insert_shreds(orphan_child, None, false).unwrap();
+    blockstore.insert_shreds(orphan_child, false).unwrap();
     assert!(recvr.try_recv().is_err());
 
     // Insert first shred, slot should now be considered complete
     blockstore
-        .insert_shreds(vec![orphan_child0], None, false)
+        .insert_shreds(vec![orphan_child0], false)
         .unwrap();
     assert_eq!(recvr.try_recv().unwrap(), vec![slots[2]]);
 
     // Insert the shreds for the orphan_slot
     let orphan_shred0 = orphan_shreds.remove(0);
-    blockstore
-        .insert_shreds(orphan_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(orphan_shreds, false).unwrap();
     assert!(recvr.try_recv().is_err());
 
     // Insert first shred, slot should now be considered complete
     blockstore
-        .insert_shreds(vec![orphan_shred0], None, false)
+        .insert_shreds(vec![orphan_shred0], false)
         .unwrap();
     assert_eq!(recvr.try_recv().unwrap(), vec![slots[1]]);
 }
@@ -909,7 +895,7 @@ fn test_completed_shreds_signal_many() {
         .collect();
 
     all_shreds.shuffle(&mut rng());
-    blockstore.insert_shreds(all_shreds, None, false).unwrap();
+    blockstore.insert_shreds(all_shreds, false).unwrap();
     let mut result = recvr.try_recv().unwrap();
     result.sort_unstable();
     slots.push(disconnected_slot);
@@ -933,7 +919,7 @@ fn test_handle_chaining_basic() {
     let shreds1 = shreds
         .drain(shreds_per_slot..2 * shreds_per_slot)
         .collect_vec();
-    blockstore.insert_shreds(shreds1, None, false).unwrap();
+    blockstore.insert_shreds(shreds1, false).unwrap();
     let meta1 = blockstore.meta(1).unwrap().unwrap();
     assert!(meta1.next_slots.is_empty());
     // Slot 1 is not connected because slot 0 hasn't been inserted yet
@@ -945,7 +931,7 @@ fn test_handle_chaining_basic() {
     let shreds2 = shreds
         .drain(shreds_per_slot..2 * shreds_per_slot)
         .collect_vec();
-    blockstore.insert_shreds(shreds2, None, false).unwrap();
+    blockstore.insert_shreds(shreds2, false).unwrap();
     let meta2 = blockstore.meta(2).unwrap().unwrap();
     assert!(meta2.next_slots.is_empty());
     // Slot 2 is not connected because slot 0 hasn't been inserted yet
@@ -963,7 +949,7 @@ fn test_handle_chaining_basic() {
 
     // 3) Write to the zeroth slot, check that every slot
     // is now part of the trunk
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     for slot in 0..3 {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         // The last slot will not chain to any other slots
@@ -995,7 +981,7 @@ fn test_handle_chaining_missing_slots() {
         shreds.into_iter().partition(|shred| shred.slot() % 2 == 0);
 
     // Write the odd slot shreds
-    blockstore.insert_shreds(odd_slots, None, false).unwrap();
+    blockstore.insert_shreds(odd_slots, false).unwrap();
 
     for slot in 0..num_slots {
         // The slots that were inserted (the odds) will ...
@@ -1021,7 +1007,7 @@ fn test_handle_chaining_missing_slots() {
     }
 
     // Write the even slot shreds that we did not earlier
-    blockstore.insert_shreds(even_slots, None, false).unwrap();
+    blockstore.insert_shreds(even_slots, false).unwrap();
 
     for slot in 0..num_slots {
         let meta = blockstore.meta(slot).unwrap().unwrap();
@@ -1068,9 +1054,7 @@ pub fn test_forward_chaining_is_connected() {
             let shred0 = shreds_for_slot.remove(0);
             missing_shreds.push(shred0);
         }
-        blockstore
-            .insert_shreds(shreds_for_slot, None, false)
-            .unwrap();
+        blockstore.insert_shreds(shreds_for_slot, false).unwrap();
     }
 
     // Check metadata
@@ -1101,7 +1085,7 @@ pub fn test_forward_chaining_is_connected() {
     for slot_index in 0..num_slots {
         if slot_index % 3 == 0 {
             let shred = missing_shreds.remove(0);
-            blockstore.insert_shreds(vec![shred], None, false).unwrap();
+            blockstore.insert_shreds(vec![shred], false).unwrap();
 
             for slot in 0..num_slots {
                 let meta = blockstore.meta(slot).unwrap().unwrap();
@@ -1157,7 +1141,7 @@ fn test_scan_and_fix_roots() {
             shreds.into_iter()
         })
         .collect();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     // Start slot must be a root
     let (start, end) = (Some(16), None);
@@ -1242,7 +1226,7 @@ fn test_set_and_chain_connected_on_root_and_next_slots() {
     // Insert some new slots and ensure they connect to the root correctly
     start_slot += 1;
     let (shreds, _) = make_many_slot_entries(start_slot, num_slots, entries_per_slot);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     for slot in start_slot..start_slot + num_slots {
         info!("Evaluating slot {slot}");
         let meta = blockstore.meta(slot).unwrap().unwrap();
@@ -1270,7 +1254,7 @@ fn test_set_and_chain_connected_on_root_and_next_slots() {
     let (shreds, missing_shreds): (Vec<_>, Vec<_>) = shreds
         .into_iter()
         .partition(|shred| shred.slot() != non_full_slot || shred.index() == 0);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // Chain method hasn't been called yet, so none of these connected yet
     for slot in start_slot..start_slot + num_slots {
         let meta = blockstore.meta(slot).unwrap().unwrap();
@@ -1303,9 +1287,7 @@ fn test_set_and_chain_connected_on_root_and_next_slots() {
     }
 
     // Insert the missing shreds and ensure all slots connected now
-    blockstore
-        .insert_shreds(missing_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(missing_shreds, false).unwrap();
     for slot in start_slot..start_slot + num_slots {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         assert!(meta.is_parent_connected());
@@ -1404,9 +1386,7 @@ fn test_orphans() {
     // Write slot 2, which chains to slot 1. We're missing slot 0,
     // so slot 1 is the orphan
     let shreds_for_slot = shreds.drain((shreds_per_slot * 2)..).collect_vec();
-    blockstore
-        .insert_shreds(shreds_for_slot, None, false)
-        .unwrap();
+    blockstore.insert_shreds(shreds_for_slot, false).unwrap();
     let meta = blockstore
         .meta(1)
         .expect("Expect database get to succeed")
@@ -1420,9 +1400,7 @@ fn test_orphans() {
     // Write slot 1 which chains to slot 0, so now slot 0 is the
     // orphan, and slot 1 is no longer the orphan.
     let shreds_for_slot = shreds.drain(shreds_per_slot..).collect_vec();
-    blockstore
-        .insert_shreds(shreds_for_slot, None, false)
-        .unwrap();
+    blockstore.insert_shreds(shreds_for_slot, false).unwrap();
     let meta = blockstore
         .meta(1)
         .expect("Expect database get to succeed")
@@ -1442,15 +1420,15 @@ fn test_orphans() {
     // nothing should change
     let (shred4, _) = make_slot_entries(4, 0, 1);
     let (shred5, _) = make_slot_entries(5, 1, 1);
-    blockstore.insert_shreds(shred4, None, false).unwrap();
-    blockstore.insert_shreds(shred5, None, false).unwrap();
+    blockstore.insert_shreds(shred4, false).unwrap();
+    blockstore.insert_shreds(shred5, false).unwrap();
     assert_eq!(
         blockstore.orphans_iterator(0).unwrap().collect::<Vec<_>>(),
         vec![0]
     );
 
     // Write zeroth slot, no more orphans
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     for i in 0..3 {
         let meta = blockstore
             .meta(i)
@@ -1480,11 +1458,11 @@ fn test_insert_data_shreds_slots(should_bulk_write: bool) {
     let num_shreds = shreds.len();
     // Write shreds to the database
     if should_bulk_write {
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
     } else {
         for _ in 0..num_shreds {
             let shred = shreds.remove(0);
-            blockstore.insert_shreds(vec![shred], None, false).unwrap();
+            blockstore.insert_shreds(vec![shred], false).unwrap();
         }
     }
 
@@ -1517,7 +1495,7 @@ fn test_find_missing_data_indexes() {
     shreds.retain(|s| (s.index() % gap as u32) == 0);
     let num_shreds = 2;
     shreds.truncate(num_shreds);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     // Index of the first shred is 0
     // Index of the second shred is "gap"
@@ -1680,7 +1658,7 @@ fn test_find_missing_data_indexes_sanity() {
     let shreds = vec![shreds.remove(OTHER as usize), shreds.remove(ONE as usize)];
 
     // Insert one shred at index = first_index
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     const STARTS: u64 = OTHER * 2;
     const END: u64 = OTHER * 3;
@@ -1712,7 +1690,7 @@ fn test_no_missing_shred_indexes() {
     let shreds = entries_to_test_shreds(&entries, slot, 0, true, 0);
     let num_shreds = shreds.len();
 
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     let empty: Vec<u64> = vec![];
     for i in 0..num_shreds as u64 {
@@ -1774,7 +1752,7 @@ fn test_should_insert_data_shred() {
 
     // Insert the first 5 shreds, we don't have a "is_last" shred yet
     blockstore
-        .insert_shreds(shreds[0..5].to_vec(), None, false)
+        .insert_shreds(shreds[0..5].to_vec(), false)
         .unwrap();
 
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
@@ -1801,7 +1779,6 @@ fn test_should_insert_data_shred() {
         &slot_meta,
         &HashMap::new(),
         max_root,
-        None,
         ShredSource::Repaired,
         &mut Vec::new(),
     ));
@@ -1811,7 +1788,6 @@ fn test_should_insert_data_shred() {
     blockstore
         .insert_shreds(
             shreds[term_last_idx + 2..term_last_idx + 3].iter().cloned(),
-            None,
             false,
         )
         .unwrap();
@@ -1826,7 +1802,6 @@ fn test_should_insert_data_shred() {
             &slot_meta,
             &HashMap::new(),
             max_root,
-            None,
             ShredSource::Repaired,
             &mut duplicate_shreds,
         ),
@@ -1841,7 +1816,7 @@ fn test_should_insert_data_shred() {
     assert_eq!(duplicate_shreds[0].slot(), 0);
     let last_idx = shreds.last().unwrap().index();
     // Insert all pending shreds
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
 
     let past_tail_shreds = shredder
@@ -1868,7 +1843,6 @@ fn test_should_insert_data_shred() {
             &slot_meta,
             &HashMap::new(),
             max_root,
-            None,
             ShredSource::Repaired,
             &mut duplicate_shreds,
         ),
@@ -1892,7 +1866,7 @@ fn test_is_data_shred_present() {
     let index_cf = &blockstore.index_cf;
 
     blockstore
-        .insert_shreds(shreds[0..5].to_vec(), None, false)
+        .insert_shreds(shreds[0..5].to_vec(), false)
         .unwrap();
     // Insert a shred less than `slot_meta.consumed`, check that
     // it already exists
@@ -1907,7 +1881,7 @@ fn test_is_data_shred_present() {
 
     // Insert a shred, check that it already exists
     blockstore
-        .insert_shreds(shreds[6..7].to_vec(), None, false)
+        .insert_shreds(shreds[6..7].to_vec(), false)
         .unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
     let index = index_cf.get(0).unwrap().unwrap();
@@ -1915,7 +1889,7 @@ fn test_is_data_shred_present() {
         &shreds[6],
         &slot_meta,
         index.data()
-    ),);
+    ));
 }
 
 #[test]
@@ -1926,7 +1900,7 @@ fn test_merkle_root_metas_coding() {
     let parent_slot = 0;
     let slot = 1;
     let index = 0;
-    let (_, coding_shreds, _) = setup_erasure_shreds(slot, parent_slot, 10);
+    let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let coding_shred = coding_shreds[index as usize].clone();
 
     let mut shred_insertion_tracker =
@@ -1981,7 +1955,7 @@ fn test_merkle_root_metas_coding() {
     blockstore.write_batch(write_batch).unwrap();
 
     // Add a shred with different merkle root and index
-    let (_, coding_shreds, _) = setup_erasure_shreds(slot, parent_slot, 10);
+    let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let new_coding_shred = coding_shreds[(index + 1) as usize].clone();
 
     let mut shred_insertion_tracker =
@@ -2049,7 +2023,7 @@ fn test_merkle_root_metas_coding() {
 
     // Add a shred from different fec set
     let new_index = index + 31;
-    let (_, coding_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, new_index);
+    let (_, coding_shreds) = setup_erasure_shreds_with_index(slot, parent_slot, 10, new_index);
     let new_coding_shred = coding_shreds[0].clone();
 
     blockstore
@@ -2112,7 +2086,7 @@ fn test_merkle_root_metas_data() {
     let slot = 1;
     let index = 11;
     let fec_set_index = 11;
-    let (data_shreds, _, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred = data_shreds[0].clone();
 
     let mut shred_insertion_tracker =
@@ -2123,7 +2097,6 @@ fn test_merkle_root_metas_data() {
             BlockLocation::Original,
             &mut shred_insertion_tracker,
             false,
-            None,
             ShredSource::Turbine,
         )
         .unwrap();
@@ -2168,7 +2141,7 @@ fn test_merkle_root_metas_data() {
     blockstore.write_batch(write_batch).unwrap();
 
     // Add a shred with different merkle root and index
-    let (data_shreds, _, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let new_data_shred = data_shreds[1].clone();
 
     let mut shred_insertion_tracker =
@@ -2179,7 +2152,6 @@ fn test_merkle_root_metas_data() {
         BlockLocation::Original,
         &mut shred_insertion_tracker,
         false,
-        None,
         ShredSource::Turbine,
     );
     assert_matches!(
@@ -2274,7 +2246,6 @@ fn test_merkle_root_metas_data() {
             BlockLocation::Original,
             &mut shred_insertion_tracker,
             false,
-            None,
             ShredSource::Turbine,
         )
         .unwrap();
@@ -2329,7 +2300,7 @@ fn test_check_insert_coding_shred() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     let slot = 1;
-    let (_data_shreds, code_shreds, _) =
+    let (_data_shreds, code_shreds) =
         setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
             slot,
             0,
@@ -2374,7 +2345,7 @@ fn test_should_insert_coding_shred() {
     let max_root = 0;
 
     let slot = 1;
-    let (_data_shreds, code_shreds, _) =
+    let (_data_shreds, code_shreds) =
         setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
             slot,
             0,
@@ -2391,7 +2362,7 @@ fn test_should_insert_coding_shred() {
     );
 
     blockstore
-        .insert_shreds(vec![coding_shred.clone()], None, false)
+        .insert_shreds(vec![coding_shred.clone()], false)
         .expect("Insertion should succeed");
 
     assert!(
@@ -2419,7 +2390,7 @@ fn test_insert_multiple_is_last() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
 
     assert_eq!(slot_meta.consumed, num_shreds);
@@ -2429,7 +2400,7 @@ fn test_insert_multiple_is_last() {
 
     let (shreds, _) = make_slot_entries(0, 0, 600);
     assert!(shreds.len() > num_shreds as usize);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
 
     assert_eq!(slot_meta.consumed, num_shreds);
@@ -2454,13 +2425,13 @@ fn test_mark_slot_dead_if_not_full() {
     let (mut shreds, _) = make_slot_entries(partial_slot, partial_slot - 1, 100);
     assert!(shreds.len() > 1);
     shreds.pop();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(!blockstore.meta(partial_slot).unwrap().unwrap().is_full());
 
     // Insert a full slot
     let full_slot = 10;
     let (shreds, _) = make_slot_entries(full_slot, full_slot - 1, 100);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     assert!(blockstore.meta(full_slot).unwrap().unwrap().is_full());
 
     let mut shred_insertion_tracker = ShredInsertionTracker::new(1, blockstore.db.batch().unwrap());
@@ -2487,7 +2458,7 @@ fn test_slot_data_iterator() {
     let all_shreds = make_chaining_slot_entries(&slots, shreds_per_slot, 0);
     let slot_8_shreds = all_shreds[2].0.clone();
     for (slot_shreds, _) in all_shreds {
-        blockstore.insert_shreds(slot_shreds, None, false).unwrap();
+        blockstore.insert_shreds(slot_shreds, false).unwrap();
     }
 
     // Slot doesn't exist, iterator should be empty
@@ -2627,7 +2598,7 @@ fn test_get_slot_entries_with_shred_count_corruption() {
     let shreds = entries_to_test_shreds(&entries, slot, 0, false, 0);
     let next_shred_index = shreds.len();
     blockstore
-        .insert_shreds(shreds, None, false)
+        .insert_shreds(shreds, false)
         .expect("Expected successful write of shreds");
     assert_eq!(
         blockstore.get_slot_entries(slot, 0).unwrap().len() as u64,
@@ -2658,7 +2629,7 @@ fn test_get_slot_entries_with_shred_count_corruption() {
     // With the corruption, nothing should be returned, even though an
     // earlier data block was valid
     blockstore
-        .insert_shreds(shreds, None, false)
+        .insert_shreds(shreds, false)
         .expect("Expected successful write of shreds");
     assert!(blockstore.get_slot_entries(slot, 0).is_err());
 }
@@ -2673,7 +2644,7 @@ fn test_no_insert_but_modify_slot_meta() {
 
     // Insert the first 5 shreds, we don't have a "is_last" shred yet
     blockstore
-        .insert_shreds(shreds0[0..5].to_vec(), None, false)
+        .insert_shreds(shreds0[0..5].to_vec(), false)
         .unwrap();
 
     // Insert a repetitive shred for slot 's', should get ignored, but also
@@ -2683,10 +2654,10 @@ fn test_no_insert_but_modify_slot_meta() {
     let (mut shreds3, _) = make_slot_entries(3, 0, 200);
     shreds2.push(shreds0[1].clone());
     shreds3.insert(0, shreds0[1].clone());
-    blockstore.insert_shreds(shreds2, None, false).unwrap();
+    blockstore.insert_shreds(shreds2, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
     assert_eq!(slot_meta.next_slots, vec![2]);
-    blockstore.insert_shreds(shreds3, None, false).unwrap();
+    blockstore.insert_shreds(shreds3, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
     assert_eq!(slot_meta.next_slots, vec![2, 3]);
 }
@@ -2704,13 +2675,13 @@ fn test_trusted_insert_shreds() {
 
     // Insert will fail, slot < root
     blockstore
-        .insert_shreds(shreds1[..].to_vec(), None, false)
+        .insert_shreds(shreds1[..].to_vec(), false)
         .unwrap();
     assert!(blockstore.get_data_shred(1, 0).unwrap().is_none());
 
     // Insert through trusted path will succeed
     blockstore
-        .insert_shreds(shreds1[..].to_vec(), None, true)
+        .insert_shreds(shreds1[..].to_vec(), true)
         .unwrap();
     assert!(blockstore.get_data_shred(1, 0).unwrap().is_some());
 }
@@ -2733,7 +2704,7 @@ fn test_get_first_available_block() {
             true,     // is_full_slot
             0,        // version
         );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         blockstore.set_roots([slot].iter()).unwrap();
     }
     assert_eq!(blockstore.get_first_available_block().unwrap(), 0);
@@ -2765,7 +2736,7 @@ fn test_get_rooted_block() {
         false,    // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // Root the partially full slot and its parent
     blockstore.set_roots([slot - 1, slot].iter()).unwrap();
     // An empty slot will return an error even if the slot is rooted
@@ -2788,7 +2759,7 @@ fn test_get_rooted_block() {
         true,     // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // Root both the full slot and its empty parent slot
     blockstore.set_roots([slot - 1, slot].iter()).unwrap();
     // A full slot will return an error if the previous blockhash is
@@ -2807,7 +2778,7 @@ fn test_get_rooted_block() {
         false,    // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let shreds = entries_to_test_shreds(
         &entries,
         slot,
@@ -2815,7 +2786,7 @@ fn test_get_rooted_block() {
         true,     // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // Root both the full slot and its partially full parent slot
     blockstore.set_roots([slot - 1, slot].iter()).unwrap();
     // A full root will return an error if the previous blockhash is
@@ -2834,7 +2805,7 @@ fn test_get_rooted_block() {
         true,     // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let shreds = entries_to_test_shreds(
         &entries,
         slot + 1,
@@ -2842,7 +2813,7 @@ fn test_get_rooted_block() {
         true, // is_full_slot
         0,    // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     let unrooted_shreds = entries_to_test_shreds(
         &entries,
         slot + 2,
@@ -2850,9 +2821,7 @@ fn test_get_rooted_block() {
         true,     // is_full_slot
         0,        // version
     );
-    blockstore
-        .insert_shreds(unrooted_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(unrooted_shreds, false).unwrap();
     blockstore.set_roots([slot, slot + 1].iter()).unwrap();
     let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
         .iter()
@@ -3041,7 +3010,6 @@ fn test_get_complete_block_with_block_markers() {
     blockstore
         .insert_shreds(
             entries_to_test_shreds(&parent_entries, parent_slot, parent_slot - 1, true, 0),
-            None,
             false,
         )
         .unwrap();
@@ -3083,7 +3051,7 @@ fn test_get_complete_block_with_block_markers() {
         .chain(block_footer_shreds.iter())
         .cloned()
         .collect();
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     let (slot_entries, num_shreds, is_full) = blockstore
         .get_slot_entries_with_shred_info(slot, 0, false)
@@ -3244,7 +3212,7 @@ fn test_persist_transaction_status() {
     .into();
     assert!(
         transaction_status_cf
-            .put_protobuf((Signature::from([2u8; 64]), 9), &status,)
+            .put_protobuf((Signature::from([2u8; 64]), 9), &status)
             .is_ok()
     );
 
@@ -3742,7 +3710,7 @@ fn test_get_rooted_transaction() {
     );
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     blockstore.set_roots([slot - 1, slot].iter()).unwrap();
 
     let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
@@ -3868,7 +3836,7 @@ fn test_get_complete_transaction() {
         true,     // is_full_slot
         0,        // version
     );
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     let expected_transactions: Vec<VersionedTransactionWithStatusMeta> = entries
         .iter()
@@ -3967,7 +3935,7 @@ fn test_get_complete_transaction() {
                 .unwrap(),
             None,
         );
-        assert_eq!(blockstore.get_rooted_transaction(signature).unwrap(), None,);
+        assert_eq!(blockstore.get_rooted_transaction(signature).unwrap(), None);
     }
 }
 
@@ -4080,7 +4048,7 @@ fn test_get_confirmed_signatures_for_address2() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     let (shreds, _) = make_slot_entries(1, 0, 4);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     fn make_slot_entries_with_transaction_addresses(addresses: &[Pubkey]) -> Vec<Entry> {
         let mut entries: Vec<Entry> = Vec::new();
@@ -4112,7 +4080,7 @@ fn test_get_confirmed_signatures_for_address2() {
             true,     // is_full_slot
             0,        // version
         );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         let mut counter = 0;
         for entry in entries.into_iter() {
@@ -4141,7 +4109,7 @@ fn test_get_confirmed_signatures_for_address2() {
         let entries =
             make_slot_entries_with_transaction_addresses(&[address0, address1, address0, address1]);
         let shreds = entries_to_test_shreds(&entries, slot, 8, true, 0);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         let mut counter = 0;
         for entry in entries.into_iter() {
@@ -4639,7 +4607,7 @@ fn test_lowest_slot() {
 
     for slot in 0..10 {
         let (shreds, _) = make_slot_entries(slot, 0, 1);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
     }
     assert_eq!(blockstore.lowest_slot(), 1);
     blockstore.purge_slots(0, 5, PurgeType::Exact).unwrap();
@@ -4655,7 +4623,7 @@ fn test_highest_slot() {
 
     for slot in 0..10 {
         let (shreds, _) = make_slot_entries(slot, 0, 1);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         assert_eq!(blockstore.highest_slot().unwrap(), Some(slot));
     }
     blockstore.purge_slots(5, 10, PurgeType::Exact).unwrap();
@@ -4671,7 +4639,7 @@ fn test_recovery() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     let slot = 1;
-    let (data_shreds, coding_shreds, leader_schedule_cache) = setup_erasure_shreds(slot, 0, 100);
+    let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
     let genesis_config = create_genesis_config(2).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
 
@@ -4686,7 +4654,6 @@ fn test_recovery() {
     blockstore
         .do_insert_shreds(
             coding_shreds,
-            Some(&leader_schedule_cache),
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
                 ReedSolomonCache::default(),
@@ -4719,7 +4686,7 @@ fn test_skip_alt_recovery() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     let slot = 1;
-    let (data_shreds, coding_shreds, leader_schedule_cache) = setup_erasure_shreds(slot, 0, 100);
+    let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
     let data_shred = data_shreds[0].clone();
     let data_shred_index = u64::from(data_shred.index());
 
@@ -4734,7 +4701,6 @@ fn test_skip_alt_recovery() {
                 /*is_repaired:*/ false,
                 BlockLocation::Original,
             )),
-            Some(&leader_schedule_cache),
             false, // is_trusted
             None,
             &mut BlockstoreInsertionMetrics::default(),
@@ -4756,7 +4722,6 @@ fn test_skip_alt_recovery() {
                 /*is_repaired:*/ true,
                 alternate_location,
             )),
-            Some(&leader_schedule_cache),
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
                 ReedSolomonCache::default(),
@@ -4798,7 +4763,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
     let root_bank = Arc::new(root_bank);
     let slot = root_bank.get_slots_in_epoch(root_bank.epoch());
     let reed_solomon_cache = ReedSolomonCache::default();
-    let (data_shreds, coding_shreds, leader_keypair, leader_schedule_cache) =
+    let (data_shreds, coding_shreds, leader_keypair) =
         setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
             slot,
             0,
@@ -4855,7 +4820,6 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
     blockstore
         .do_insert_shreds(
             shreds,
-            Some(&leader_schedule_cache),
             false, // is_trusted
             Some(&mut ShredRecoveryContext::new(
                 reed_solomon_cache,
@@ -4896,8 +4860,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
 fn test_index_integrity() {
     let slot = 1;
     let num_entries = 100;
-    let (data_shreds, coding_shreds, leader_schedule_cache) =
-        setup_erasure_shreds(slot, 0, num_entries);
+    let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, num_entries);
     assert!(data_shreds.len() > 3);
     assert!(coding_shreds.len() > 3);
 
@@ -4910,26 +4873,20 @@ fn test_index_integrity() {
         .cloned()
         .chain(coding_shreds.iter().cloned())
         .collect();
-    blockstore
-        .insert_shreds(all_shreds, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(all_shreds, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
     // Test inserting just the codes, enough for recovery
     blockstore
-        .insert_shreds(coding_shreds.clone(), Some(&leader_schedule_cache), false)
+        .insert_shreds(coding_shreds.clone(), false)
         .unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
     // Test inserting some codes, but not enough for recovery
     blockstore
-        .insert_shreds(
-            coding_shreds[..coding_shreds.len() - 1].to_vec(),
-            Some(&leader_schedule_cache),
-            false,
-        )
+        .insert_shreds(coding_shreds[..coding_shreds.len() - 1].to_vec(), false)
         .unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
@@ -4940,9 +4897,7 @@ fn test_index_integrity() {
         .cloned()
         .chain(coding_shreds[..coding_shreds.len() - 1].iter().cloned())
         .collect();
-    blockstore
-        .insert_shreds(shreds, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
@@ -4952,9 +4907,7 @@ fn test_index_integrity() {
         .cloned()
         .chain(coding_shreds[..coding_shreds.len() / 2 - 1].iter().cloned())
         .collect();
-    blockstore
-        .insert_shreds(shreds, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
@@ -4969,12 +4922,8 @@ fn test_index_integrity() {
         .cloned()
         .chain(coding_shreds[coding_shreds.len() / 2 - 1..].iter().cloned())
         .collect();
-    blockstore
-        .insert_shreds(shreds1, Some(&leader_schedule_cache), false)
-        .unwrap();
-    blockstore
-        .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(shreds1, false).unwrap();
+    blockstore.insert_shreds(shreds2, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
@@ -4994,12 +4943,8 @@ fn test_index_integrity() {
                 .cloned(),
         )
         .collect();
-    blockstore
-        .insert_shreds(shreds1, Some(&leader_schedule_cache), false)
-        .unwrap();
-    blockstore
-        .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(shreds1, false).unwrap();
+    blockstore.insert_shreds(shreds2, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 
@@ -5019,21 +4964,13 @@ fn test_index_integrity() {
                 .cloned(),
         )
         .collect();
-    blockstore
-        .insert_shreds(shreds1, Some(&leader_schedule_cache), false)
-        .unwrap();
-    blockstore
-        .insert_shreds(shreds2, Some(&leader_schedule_cache), false)
-        .unwrap();
+    blockstore.insert_shreds(shreds1, false).unwrap();
+    blockstore.insert_shreds(shreds2, false).unwrap();
     verify_index_integrity(&blockstore, slot);
     blockstore.purge_slots(0, slot, PurgeType::Exact).unwrap();
 }
 
-fn setup_erasure_shreds(
-    slot: u64,
-    parent_slot: u64,
-    num_entries: u64,
-) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
+fn setup_erasure_shreds(slot: u64, parent_slot: u64, num_entries: u64) -> (Vec<Shred>, Vec<Shred>) {
     setup_erasure_shreds_with_index(slot, parent_slot, num_entries, 0)
 }
 
@@ -5042,7 +4979,7 @@ fn setup_erasure_shreds_with_index(
     parent_slot: u64,
     num_entries: u64,
     fec_set_index: u32,
-) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
+) -> (Vec<Shred>, Vec<Shred>) {
     setup_erasure_shreds_with_index_and_chained_merkle(
         slot,
         parent_slot,
@@ -5058,7 +4995,7 @@ fn setup_erasure_shreds_with_index_and_chained_merkle(
     num_entries: u64,
     fec_set_index: u32,
     chained_merkle_root: Hash,
-) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
+) -> (Vec<Shred>, Vec<Shred>) {
     setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
         slot,
         parent_slot,
@@ -5076,8 +5013,8 @@ fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
     fec_set_index: u32,
     chained_merkle_root: Hash,
     is_last_in_slot: bool,
-) -> (Vec<Shred>, Vec<Shred>, Arc<LeaderScheduleCache>) {
-    let (data_shreds, coding_shreds, _, leader_schedule_cache) =
+) -> (Vec<Shred>, Vec<Shred>) {
+    let (data_shreds, coding_shreds, _) =
         setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
             slot,
             parent_slot,
@@ -5087,7 +5024,7 @@ fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
             is_last_in_slot,
         );
 
-    (data_shreds, coding_shreds, leader_schedule_cache)
+    (data_shreds, coding_shreds)
 }
 
 fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypair(
@@ -5097,12 +5034,7 @@ fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypa
     fec_set_index: u32,
     chained_merkle_root: Hash,
     is_last_in_slot: bool,
-) -> (
-    Vec<Shred>,
-    Vec<Shred>,
-    Arc<Keypair>,
-    Arc<LeaderScheduleCache>,
-) {
+) -> (Vec<Shred>, Vec<Shred>, Arc<Keypair>) {
     let entries = make_slot_entries_with_transactions(num_entries);
     let leader_keypair = Arc::new(Keypair::new());
     let shredder = Shredder::new(slot, parent_slot, 0, 0).unwrap();
@@ -5117,26 +5049,7 @@ fn setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot_and_keypa
         &mut ProcessShredsStats::default(),
     );
 
-    let genesis_config = create_genesis_config(2).genesis_config;
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
-    let mut leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
-    let fixed_schedule = FixedSchedule {
-        leader_schedule: Arc::new(LeaderSchedule::new_from_schedule(
-            vec![SlotLeader {
-                id: leader_keypair.pubkey(),
-                vote_address: Pubkey::new_unique(),
-            }],
-            NonZeroUsize::new(1).unwrap(),
-        )),
-    };
-    leader_schedule_cache.set_fixed_leader_schedule(Some(fixed_schedule));
-
-    (
-        data_shreds,
-        coding_shreds,
-        leader_keypair,
-        Arc::new(leader_schedule_cache),
-    )
+    (data_shreds, coding_shreds, leader_keypair)
 }
 
 fn verify_index_integrity(blockstore: &Blockstore, slot: u64) {
@@ -5208,7 +5121,7 @@ fn test_duplicate_slot() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     blockstore
-        .insert_shreds(vec![shred.clone()], None, false)
+        .insert_shreds(vec![shred.clone()], false)
         .unwrap();
 
     // No duplicate shreds exist yet
@@ -5257,7 +5170,7 @@ fn test_clear_unconfirmed_slot() {
         .into_iter()
         .flat_map(|x| x.0)
         .collect();
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     // There are 32 data shreds in slot 9.
     for index in 0..32 {
         assert_matches!(
@@ -5306,7 +5219,7 @@ fn test_clear_unconfirmed_slot_and_insert_again() {
     assert_eq!(unconfirmed_slot_shreds[0].slot(), unconfirmed_slot);
 
     // Insert into slot 9
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
 
     // Purge the slot
     blockstore.clear_unconfirmed_slot(unconfirmed_slot);
@@ -5321,7 +5234,7 @@ fn test_clear_unconfirmed_slot_and_insert_again() {
     // Re-add unconfirmed_slot and confirm that confirmed_slot only has
     // unconfirmed_slot in next_slots once
     blockstore
-        .insert_shreds(unconfirmed_slot_shreds, None, false)
+        .insert_shreds(unconfirmed_slot_shreds, false)
         .unwrap();
     assert_eq!(
         blockstore.meta(confirmed_slot).unwrap().unwrap().next_slots,
@@ -5455,11 +5368,11 @@ fn erasure_multiple_config() {
     }
     // insert all but 2 data shreds from first set (so it is not yet recoverable)
     blockstore
-        .insert_shreds(data1[..data1.len() - 2].to_vec(), None, false)
+        .insert_shreds(data1[..data1.len() - 2].to_vec(), false)
         .unwrap();
     // insert two coding shreds from conflicting FEC sets
     blockstore
-        .insert_shreds(vec![coding1[0].clone(), coding2[1].clone()], None, false)
+        .insert_shreds(vec![coding1[0].clone(), coding2[1].clone()], false)
         .unwrap();
     assert!(blockstore.has_duplicate_shreds_in_slot(slot));
 }
@@ -5486,7 +5399,7 @@ fn test_insert_data_shreds_same_slot_last_index() {
     // times
     for _ in 0..10 {
         blockstore
-            .insert_shreds(original_shreds.clone(), None, false)
+            .insert_shreds(original_shreds.clone(), false)
             .unwrap();
         let meta = blockstore.meta(0).unwrap().unwrap();
         assert!(!blockstore.is_dead(0));
@@ -5499,9 +5412,7 @@ fn test_insert_data_shreds_same_slot_last_index() {
     }
 
     let num_shreds = duplicate_shreds.len() as u64;
-    blockstore
-        .insert_shreds(duplicate_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(duplicate_shreds, false).unwrap();
 
     assert_eq!(blockstore.get_slot_entries(0, 0).unwrap(), original_entries);
 
@@ -5566,7 +5477,7 @@ fn test_duplicate_last_index() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     blockstore
-        .insert_shreds(vec![last_data1.clone(), last_data2.clone()], None, false)
+        .insert_shreds(vec![last_data1.clone(), last_data2.clone()], false)
         .unwrap();
 
     assert!(blockstore.get_duplicate_slot(slot).is_some());
@@ -5587,9 +5498,7 @@ fn test_duplicate_last_index_mark_dead() {
     let get_expected_slot_meta_and_index_meta =
         |blockstore: &Blockstore, shreds: Vec<Shred>| -> (SlotMeta, Index) {
             let slot = shreds[0].slot();
-            blockstore
-                .insert_shreds(shreds.clone(), None, false)
-                .unwrap();
+            blockstore.insert_shreds(shreds.clone(), false).unwrap();
             let meta = blockstore.meta(slot).unwrap().unwrap();
             assert_eq!(meta.consumed, shreds.len() as u64);
             let shreds_index = blockstore.get_index(slot).unwrap().unwrap();
@@ -5618,9 +5527,7 @@ fn test_duplicate_last_index_mark_dead() {
         &blockstore,
         shreds[..=smaller_last_shred_index].to_vec(),
     );
-    blockstore
-        .insert_shreds(shreds.clone(), None, false)
-        .unwrap();
+    blockstore.insert_shreds(shreds.clone(), false).unwrap();
     assert!(blockstore.get_duplicate_slot(slot).is_some());
     // Block is already full not marked dead
     assert!(!blockstore.is_dead(slot));
@@ -5644,9 +5551,7 @@ fn test_duplicate_last_index_mark_dead() {
     slot += 1;
     let mut shreds = setup_test_shreds(slot);
     shreds.reverse();
-    blockstore
-        .insert_shreds(shreds.clone(), None, false)
-        .unwrap();
+    blockstore.insert_shreds(shreds.clone(), false).unwrap();
     assert!(blockstore.is_dead(slot));
     // All the shreds other than the two last index shreds because those two
     // are marked as last, but less than the first received index == 10.
@@ -5682,7 +5587,7 @@ fn test_duplicate_last_index_mark_dead() {
     let mut shreds = setup_test_shreds(slot);
     shreds.reverse();
     for shred in shreds.clone() {
-        blockstore.insert_shreds(vec![shred], None, false).unwrap();
+        blockstore.insert_shreds(vec![shred], false).unwrap();
     }
     assert!(blockstore.is_dead(slot));
     // All the shreds will be inserted since dead slots can still be inserted into.
@@ -5750,7 +5655,7 @@ fn test_get_slot_entries_dead_slot_race() {
                     // Possible clippy bug, the lock is unused so clippy shouldn't care
                     // about read vs. write lock
                     let _lowest_cleanup_slot = blockstore.lowest_cleanup_slot.write().unwrap();
-                    blockstore.insert_shreds(shreds, None, false).unwrap();
+                    blockstore.insert_shreds(shreds, false).unwrap();
                     assert!(blockstore.get_duplicate_slot(slot).is_some());
                     assert!(blockstore.is_dead(slot));
                     signal_sender.send(Ok(())).unwrap();
@@ -5788,19 +5693,19 @@ fn test_previous_erasure_set() {
     let parent_slot = 0;
     let prev_slot = 1;
     let slot = 2;
-    let (data_shreds_0, coding_shreds_0, _) =
+    let (data_shreds_0, coding_shreds_0) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, 0);
     let erasure_set_0 = ErasureSetId::new(slot, 0);
     let erasure_meta_0 = ErasureMeta::from_coding_shred(coding_shreds_0.first().unwrap()).unwrap();
 
     let prev_fec_set_index = data_shreds_0.len() as u32;
-    let (data_shreds_prev, coding_shreds_prev, _) =
+    let (data_shreds_prev, coding_shreds_prev) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, prev_fec_set_index);
     let erasure_set_prev = ErasureSetId::new(slot, prev_fec_set_index);
     let erasure_meta_prev =
         ErasureMeta::from_coding_shred(coding_shreds_prev.first().unwrap()).unwrap();
 
-    let (_, coding_shreds_prev_slot, _) =
+    let (_, coding_shreds_prev_slot) =
         setup_erasure_shreds_with_index(prev_slot, parent_slot, 10, prev_fec_set_index);
     let erasure_set_prev_slot = ErasureSetId::new(prev_slot, prev_fec_set_index);
     let erasure_meta_prev_slot =
@@ -5930,21 +5835,21 @@ fn test_chained_merkle_root_consistency_backwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred.clone())
             .is_empty()
     );
 
     let merkle_root = coding_shred.merkle_root().unwrap();
 
     // Correctly chained merkle
-    let (data_shreds, coding_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
+    let (data_shreds, coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
         slot,
         parent_slot,
         10,
@@ -5955,12 +5860,12 @@ fn test_chained_merkle_root_consistency_backwards() {
     let coding_shred = coding_shreds[0].clone();
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
     assert!(
         blockstore
-            .insert_shred_return_duplicate(data_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(data_shred)
             .is_empty()
     );
 }
@@ -5974,14 +5879,14 @@ fn test_chained_merkle_root_consistency_forwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     // Correctly chained merkle
     let merkle_root = coding_shred.merkle_root().unwrap();
-    let (_, next_coding_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
+    let (_, next_coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
         slot,
         parent_slot,
         10,
@@ -5992,14 +5897,14 @@ fn test_chained_merkle_root_consistency_forwards() {
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(next_coding_shred)
             .is_empty()
     );
 
     // Insert previous FEC set
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
 }
@@ -6012,20 +5917,19 @@ fn test_chained_merkle_root_across_slots_backwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, _, leader_schedule) =
-        setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred = data_shreds[0].clone();
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(data_shred.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(data_shred.clone())
             .is_empty()
     );
 
     // Incorrectly chained merkle for next slot
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != data_shred.merkle_root().unwrap());
-    let (next_slot_data_shreds, next_slot_coding_shreds, leader_schedule) =
+    let (next_slot_data_shreds, next_slot_coding_shreds) =
         setup_erasure_shreds_with_index_and_chained_merkle(
             slot + 1,
             slot,
@@ -6037,12 +5941,12 @@ fn test_chained_merkle_root_across_slots_backwards() {
     let next_slot_coding_shred = next_slot_coding_shreds[0].clone();
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_slot_coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(next_slot_coding_shred)
             .is_empty()
     );
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_slot_data_shred, &leader_schedule)
+            .insert_shred_return_duplicate(next_slot_data_shred)
             .is_empty()
     );
 }
@@ -6055,33 +5959,31 @@ fn test_chained_merkle_root_across_slots_forwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (_, coding_shreds, _) =
-        setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let (_, coding_shreds) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred = coding_shreds[0].clone();
 
     // Incorrectly chained merkle for next slot
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred.merkle_root().unwrap());
-    let (next_slot_data_shreds, _, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot + 1,
-            slot,
-            10,
-            fec_set_index,
-            merkle_root,
-        );
+    let (next_slot_data_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot + 1,
+        slot,
+        10,
+        fec_set_index,
+        merkle_root,
+    );
     let next_slot_data_shred = next_slot_data_shreds[0].clone();
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_slot_data_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(next_slot_data_shred)
             .is_empty()
     );
 
     // Insert for previous slot
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
 }
@@ -6095,32 +5997,30 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred_previous = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred_previous.clone())
             .is_empty()
     );
 
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred_previous.merkle_root().unwrap());
-    let (data_shreds, coding_shreds, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (data_shreds, coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(coding_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
@@ -6130,7 +6030,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     // Should not check again, even though this shred conflicts as well
     assert!(
         blockstore
-            .insert_shred_return_duplicate(data_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(data_shred)
             .is_empty()
     );
 }
@@ -6144,33 +6044,31 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred_previous = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred_previous.clone())
             .is_empty()
     );
 
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred_previous.merkle_root().unwrap());
-    let (data_shreds, coding_shreds, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (data_shreds, coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
 
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(data_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(data_shred.clone());
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
@@ -6179,7 +6077,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
     // Should not check again, even though this shred conflicts as well
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
 }
@@ -6193,7 +6091,7 @@ fn test_chained_merkle_root_inconsistency_forwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
@@ -6201,25 +6099,23 @@ fn test_chained_merkle_root_inconsistency_forwards() {
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred.merkle_root().unwrap());
-    let (next_data_shreds, _, leader_schedule_next) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (next_data_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let next_data_shred = next_data_shreds[0].clone();
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_data_shred.clone(), &leader_schedule_next,)
+            .insert_shred_return_duplicate(next_data_shred.clone())
             .is_empty()
     );
 
     // Insert previous FEC set
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(coding_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
 
     assert_eq!(duplicate_shreds.len(), 2);
     assert!(
@@ -6245,20 +6141,19 @@ fn test_chained_merkle_root_inconsistency_data_shreds_only() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, _, leader_schedule) =
-        setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
+    let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred_previous = data_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(data_shred_previous.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(data_shred_previous.clone())
             .is_empty()
     );
 
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != data_shred_previous.merkle_root().unwrap());
-    let (data_shreds, _, leader_schedule) = setup_erasure_shreds_with_index_and_chained_merkle(
+    let (data_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
         slot,
         parent_slot,
         10,
@@ -6267,8 +6162,7 @@ fn test_chained_merkle_root_inconsistency_data_shreds_only() {
     );
     let data_shred = data_shreds[0].clone();
 
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(data_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(data_shred.clone());
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
@@ -6287,7 +6181,7 @@ fn test_chained_merkle_root_inconsistency_both() {
     let parent_slot = 0;
     let slot = 1;
     let prev_fec_set_index = 0;
-    let (prev_data_shreds, prev_coding_shreds, leader_schedule_prev) =
+    let (prev_data_shreds, prev_coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, prev_fec_set_index);
     let prev_coding_shred = prev_coding_shreds[0].clone();
     let fec_set_index = prev_fec_set_index + prev_data_shreds.len() as u32;
@@ -6295,14 +6189,13 @@ fn test_chained_merkle_root_inconsistency_both() {
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != prev_coding_shred.merkle_root().unwrap());
-    let (data_shreds, coding_shreds, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            fec_set_index,
-            merkle_root,
-        );
+    let (data_shreds, coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        fec_set_index,
+        merkle_root,
+    );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + prev_data_shreds.len() as u32;
@@ -6310,31 +6203,29 @@ fn test_chained_merkle_root_inconsistency_both() {
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != data_shred.merkle_root().unwrap());
-    let (next_data_shreds, _, leader_schedule_next) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (next_data_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let next_data_shred = next_data_shreds[0].clone();
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(prev_coding_shred.clone(), &leader_schedule_prev,)
+            .insert_shred_return_duplicate(prev_coding_shred.clone())
             .is_empty()
     );
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_data_shred.clone(), &leader_schedule_next)
+            .insert_shred_return_duplicate(next_data_shred.clone())
             .is_empty()
     );
 
     // Insert data shred
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(data_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(data_shred.clone());
 
     // Only the backwards check will be performed
     assert_eq!(duplicate_shreds.len(), 1);
@@ -6344,8 +6235,7 @@ fn test_chained_merkle_root_inconsistency_both() {
     );
 
     // Insert coding shred
-    let duplicate_shreds =
-        blockstore.insert_shred_return_duplicate(coding_shred.clone(), &leader_schedule);
+    let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
 
     // Now the forwards check will be performed
     assert_eq!(duplicate_shreds.len(), 1);
@@ -6364,14 +6254,14 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred_previous = coding_shreds[1].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred_previous.clone(), &leader_schedule,)
+            .insert_shred_return_duplicate(coding_shred_previous.clone())
             .is_empty()
     );
 
@@ -6401,24 +6291,23 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
     // we skip the duplicate check as the first received coding shred index shred is missing
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred_previous.merkle_root().unwrap());
-    let (data_shreds, coding_shreds, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (data_shreds, coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let data_shred = data_shreds[0].clone();
     let coding_shred = coding_shreds[0].clone();
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
     assert!(
         blockstore
-            .insert_shred_return_duplicate(data_shred, &leader_schedule,)
+            .insert_shred_return_duplicate(data_shred)
             .is_empty()
     );
 }
@@ -6432,7 +6321,7 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
     let parent_slot = 0;
     let slot = 1;
     let fec_set_index = 0;
-    let (data_shreds, coding_shreds, leader_schedule) =
+    let (data_shreds, coding_shreds) =
         setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let coding_shred = coding_shreds[0].clone();
     let next_fec_set_index = fec_set_index + data_shreds.len() as u32;
@@ -6440,19 +6329,18 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
     // Incorrectly chained merkle
     let merkle_root = Hash::new_unique();
     assert!(merkle_root != coding_shred.merkle_root().unwrap());
-    let (next_data_shreds, next_coding_shreds, leader_schedule_next) =
-        setup_erasure_shreds_with_index_and_chained_merkle(
-            slot,
-            parent_slot,
-            10,
-            next_fec_set_index,
-            merkle_root,
-        );
+    let (next_data_shreds, next_coding_shreds) = setup_erasure_shreds_with_index_and_chained_merkle(
+        slot,
+        parent_slot,
+        10,
+        next_fec_set_index,
+        merkle_root,
+    );
     let next_data_shred = next_data_shreds[0].clone();
 
     assert!(
         blockstore
-            .insert_shred_return_duplicate(next_data_shred, &leader_schedule_next,)
+            .insert_shred_return_duplicate(next_data_shred)
             .is_empty()
     );
 
@@ -6474,7 +6362,7 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
     // as the merkle root meta is missing.
     assert!(
         blockstore
-            .insert_shred_return_duplicate(coding_shred, &leader_schedule)
+            .insert_shred_return_duplicate(coding_shred)
             .is_empty()
     );
 }
@@ -6632,7 +6520,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     let num_entries = 200;
 
     // Create a set of shreds for a complete block
-    let (data_shreds, _, leader_schedule) = setup_erasure_shreds(slot, parent_slot, num_entries);
+    let (data_shreds, _) = setup_erasure_shreds(slot, parent_slot, num_entries);
 
     // Collect FEC set merkle roots for verification
     let mut fec_set_roots = [Hash::default(); 3];
@@ -6673,7 +6561,6 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     let insert_results = blockstore
         .do_insert_shreds(
             shreds,
-            Some(&leader_schedule),
             false,
             None,
             &mut BlockstoreInsertionMetrics::default(),
@@ -6742,15 +6629,14 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
 
     // Slot not full should return None
     let incomplete_slot = 1001;
-    let (partial_shreds, _, leader_schedule) =
-        setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
-            incomplete_slot,
-            slot, // parent is 1000
-            5,
-            0,
-            Hash::new_from_array(rand::random()),
-            false, // not last in slot
-        );
+    let (partial_shreds, _) = setup_erasure_shreds_with_index_and_chained_merkle_and_last_in_slot(
+        incomplete_slot,
+        slot, // parent is 1000
+        5,
+        0,
+        Hash::new_from_array(rand::random()),
+        false, // not last in slot
+    );
 
     let shreds = partial_shreds
         .iter()
@@ -6759,7 +6645,6 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     let insert_results = blockstore
         .do_insert_shreds(
             shreds,
-            Some(&leader_schedule),
             false,
             None,
             &mut BlockstoreInsertionMetrics::default(),
@@ -6797,8 +6682,7 @@ fn test_get_data_shreds_for_slot() {
 
     // Setup and insert shreds from 4 blocks into the columns for `slot`
     let data_shreds: [Vec<Shred>; 4] = std::array::from_fn(|i| {
-        let (data_shreds, _coding_shreds, leader_schedule_cache) =
-            setup_erasure_shreds(slot, parent_slot, num_entries);
+        let (data_shreds, _coding_shreds) = setup_erasure_shreds(slot, parent_slot, num_entries);
         let location = locations[i];
         let is_repaired = location != BlockLocation::Original;
         let shreds = data_shreds
@@ -6807,7 +6691,6 @@ fn test_get_data_shreds_for_slot() {
         let insert_results = blockstore
             .do_insert_shreds(
                 shreds,
-                Some(&leader_schedule_cache),
                 false,
                 None,
                 &mut BlockstoreInsertionMetrics::default(),
@@ -6883,7 +6766,7 @@ fn test_invalid_parent_info_marks_dead(block_header_first: bool, case: (u64, u64
     .filter(|s| s.is_data())
     .collect();
 
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     assert_eq!(
         blockstore.is_dead(slot),
@@ -6914,7 +6797,7 @@ fn test_invalid_block_header_parent_info_marks_dead() {
             block_header_parent_slot,
             Hash::new_unique(),
         );
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         assert!(
             blockstore.is_dead(slot),
@@ -6950,7 +6833,7 @@ fn test_invalid_update_parent_parent_info_marks_dead() {
         );
         shreds.extend(create_block_footer_shreds(slot, shred_parent_slot, 0));
 
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         assert!(
             blockstore.is_dead(slot),
@@ -6985,7 +6868,7 @@ fn test_update_parent_non_first_leader_window_marks_dead() {
         true,
     ));
 
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     let meta = blockstore.meta(slot).unwrap().unwrap();
     assert!(blockstore.is_dead(slot));
@@ -7001,7 +6884,7 @@ fn test_block_header_followed_by_update_parent() {
     let slot = 12;
     let parent_5_id = Hash::new_unique();
     blockstore
-        .insert_shreds(create_block_header_shreds(slot, 5, parent_5_id), None, true)
+        .insert_shreds(create_block_header_shreds(slot, 5, parent_5_id), true)
         .unwrap();
 
     assert_eq!(blockstore.meta(slot).unwrap().unwrap().parent_slot, Some(5));
@@ -7011,7 +6894,6 @@ fn test_block_header_followed_by_update_parent() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(slot, 5, 3, parent_3_id, 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7045,7 +6927,6 @@ fn test_post_update_orig_after() {
                 original_parent,
                 Hash::new_unique(),
             )),
-            None,
             false,
         )
         .unwrap();
@@ -7061,7 +6942,6 @@ fn test_post_update_orig_after() {
                 32,
                 false,
             )),
-            None,
             false,
         )
         .unwrap();
@@ -7075,7 +6955,6 @@ fn test_post_update_orig_after() {
     blockstore
         .insert_shreds(
             data_shreds(create_block_footer_shreds(slot, original_parent, 64)),
-            None,
             false,
         )
         .unwrap();
@@ -7113,7 +6992,7 @@ fn test_update_parent_shred_parent(update_parent_first: bool) {
 
     if update_parent_first {
         blockstore
-            .insert_shreds(update_parent_shreds, None, false)
+            .insert_shreds(update_parent_shreds, false)
             .unwrap();
         blockstore
             .insert_shreds(
@@ -7123,26 +7002,21 @@ fn test_update_parent_shred_parent(update_parent_first: bool) {
                     0,
                     false,
                 )),
-                None,
                 false,
             )
             .unwrap();
         assert!(blockstore.meta(slot).unwrap().unwrap().has_update_parent());
 
-        blockstore
-            .insert_shreds(bad_parent_shreds, None, false)
-            .unwrap();
+        blockstore.insert_shreds(bad_parent_shreds, false).unwrap();
     } else {
-        blockstore
-            .insert_shreds(bad_parent_shreds, None, false)
-            .unwrap();
+        blockstore.insert_shreds(bad_parent_shreds, false).unwrap();
         assert_eq!(
             blockstore.meta(slot).unwrap().unwrap().parent_slot,
             Some(bad_shred_parent)
         );
 
         blockstore
-            .insert_shreds(update_parent_shreds, None, false)
+            .insert_shreds(update_parent_shreds, false)
             .unwrap();
     }
 
@@ -7164,7 +7038,6 @@ fn test_marker_boundary_ooo() {
                 original_parent,
                 Hash::new_unique(),
             )),
-            None,
             false,
         )
         .unwrap();
@@ -7178,9 +7051,7 @@ fn test_marker_boundary_ooo() {
             false,
         )));
     }
-    blockstore
-        .insert_shreds(post_update_shreds, None, false)
-        .unwrap();
+    blockstore.insert_shreds(post_update_shreds, false).unwrap();
 
     let meta = blockstore.meta(slot).unwrap().unwrap();
     assert_eq!(meta.parent_slot, Some(original_parent));
@@ -7197,7 +7068,6 @@ fn test_marker_boundary_ooo() {
                 32,
                 false,
             )),
-            None,
             false,
         )
         .unwrap();
@@ -7225,7 +7095,7 @@ fn test_multiple_children_reparenting() {
     let parent_id = Hash::new_unique();
     for slot in [44, 40, 48] {
         blockstore
-            .insert_shreds(create_block_header_shreds(slot, 35, parent_id), None, true)
+            .insert_shreds(create_block_header_shreds(slot, 35, parent_id), true)
             .unwrap();
     }
     verify_next_slots(&blockstore, 35, &[40, 44, 48]);
@@ -7233,7 +7103,6 @@ fn test_multiple_children_reparenting() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(44, 35, 32, Hash::new_unique(), 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7243,7 +7112,6 @@ fn test_multiple_children_reparenting() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(40, 35, 33, Hash::new_unique(), 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7257,11 +7125,7 @@ fn test_interleaved_shred_arrival() {
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
     blockstore
-        .insert_shreds(
-            create_block_header_shreds(52, 48, Hash::new_unique()),
-            None,
-            true,
-        )
+        .insert_shreds(create_block_header_shreds(52, 48, Hash::new_unique()), true)
         .unwrap();
     assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(48));
 
@@ -7271,8 +7135,8 @@ fn test_interleaved_shred_arrival() {
     let mid = update_shreds.len() / 2;
     let first_half: Vec<_> = update_shreds.drain(..mid).collect();
 
-    blockstore.insert_shreds(first_half, None, true).unwrap();
-    blockstore.insert_shreds(update_shreds, None, true).unwrap();
+    blockstore.insert_shreds(first_half, true).unwrap();
+    blockstore.insert_shreds(update_shreds, true).unwrap();
 
     assert_eq!(blockstore.meta(52).unwrap().unwrap().parent_slot, Some(45));
     verify_next_slots(&blockstore, 48, &[]);
@@ -7296,7 +7160,7 @@ fn test_same_batch_block_header_then_update_parent() {
         true,
     ));
 
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     // UpdateParent should take precedence
     assert_eq!(blockstore.meta(60).unwrap().unwrap().parent_slot, Some(52));
@@ -7315,7 +7179,7 @@ fn test_same_batch_update_parent_then_block_header() {
         create_update_parent_shreds_with_shred_parent(72, 68, 65, Hash::new_unique(), 32, true);
     shreds.extend(create_block_header_shreds(72, 68, Hash::new_unique()));
 
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     // UpdateParent should take precedence regardless of insertion order
     assert_eq!(blockstore.meta(72).unwrap().unwrap().parent_slot, Some(65));
@@ -7332,7 +7196,6 @@ fn test_multiple_update_parents_out_of_order_marks_dead() {
     blockstore
         .insert_shreds(
             data_shreds(create_block_header_shreds(slot, 75, Hash::new_unique())),
-            None,
             true,
         )
         .unwrap();
@@ -7353,7 +7216,7 @@ fn test_multiple_update_parents_out_of_order_marks_dead() {
     // Insert the tail of the earlier FEC set so the later UpdateParent can
     // be parsed before this UpdateParent marker arrives.
     blockstore
-        .insert_shreds(first_update_parent_shreds, None, true)
+        .insert_shreds(first_update_parent_shreds, true)
         .unwrap();
 
     let second_update_parent_slot = 65;
@@ -7367,7 +7230,6 @@ fn test_multiple_update_parents_out_of_order_marks_dead() {
                 64,
                 false,
             )),
-            None,
             true,
         )
         .unwrap();
@@ -7381,7 +7243,7 @@ fn test_multiple_update_parents_out_of_order_marks_dead() {
     assert!(!blockstore.is_dead(slot));
 
     blockstore
-        .insert_shreds(vec![first_update_parent_marker], None, true)
+        .insert_shreds(vec![first_update_parent_marker], true)
         .unwrap();
     assert!(blockstore.is_dead(slot));
 }
@@ -7393,16 +7255,12 @@ fn test_update_parent_propagates_connectivity() {
 
     // Slot 0 is connected when full
     let (shreds, _) = make_slot_entries(0, 0, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
     // Slot 8 with BlockHeader pointing to disconnected parent
     blockstore
-        .insert_shreds(
-            create_block_header_shreds(8, 5, Hash::new_unique()),
-            None,
-            true,
-        )
+        .insert_shreds(create_block_header_shreds(8, 5, Hash::new_unique()), true)
         .unwrap();
     assert!(!blockstore.meta(8).unwrap().unwrap().is_connected());
 
@@ -7410,7 +7268,6 @@ fn test_update_parent_propagates_connectivity() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(8, 5, 0, Hash::new_unique(), 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7428,20 +7285,19 @@ fn test_update_parent_propagates_connectivity_to_descendants() {
 
     // Slot 0 is connected when full
     let (shreds, _) = make_slot_entries(0, 0, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     // Slot 100 starts incomplete with BlockHeader pointing to disconnected parent
     blockstore
         .insert_shreds(
             create_block_header_shreds(100, 50, Hash::new_unique()),
-            None,
             true,
         )
         .unwrap();
     // Slots 200 and 300 are full, chained to 100
     for (slot, parent) in [(200, 100), (300, 200)] {
         let (shreds, _) = make_slot_entries(slot, parent, 5);
-        blockstore.insert_shreds(shreds, None, true).unwrap();
+        blockstore.insert_shreds(shreds, true).unwrap();
     }
     for slot in [100, 200, 300] {
         assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
@@ -7451,7 +7307,6 @@ fn test_update_parent_propagates_connectivity_to_descendants() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(100, 50, 0, Hash::new_unique(), 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7471,31 +7326,26 @@ fn test_update_parent_clears_connectivity() {
 
     // Slot 0 and 5 are connected (full slots chained together)
     let (shreds, _) = make_slot_entries(0, 0, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     let (shreds, _) = make_slot_entries(5, 0, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     assert!(blockstore.meta(5).unwrap().unwrap().is_connected());
 
     // Slot 8 with BlockHeader pointing to connected parent 5
     blockstore
-        .insert_shreds(
-            create_block_header_shreds(8, 5, Hash::new_unique()),
-            None,
-            true,
-        )
+        .insert_shreds(create_block_header_shreds(8, 5, Hash::new_unique()), true)
         .unwrap();
     let meta = blockstore.meta(8).unwrap().unwrap();
     assert!(meta.is_parent_connected());
 
     // Slot 20 chains to slot 8
     let (shreds, _) = make_slot_entries(20, 8, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     // UpdateParent switches slot 8 to disconnected parent 3 (lower, doesn't exist)
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(8, 5, 3, Hash::new_unique(), 32, true),
-            None,
             true,
         )
         .unwrap();
@@ -7515,23 +7365,19 @@ fn test_connectivity_does_not_propagate_through_incomplete_slot() {
 
     // Slot 0 is the connected root
     let (shreds, _) = make_slot_entries(0, 0, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     assert!(blockstore.meta(0).unwrap().unwrap().is_connected());
 
     // Slot 48 incomplete, pointing to disconnected parent 40
     blockstore
-        .insert_shreds(
-            create_block_header_shreds(48, 40, Hash::new_unique()),
-            None,
-            true,
-        )
+        .insert_shreds(create_block_header_shreds(48, 40, Hash::new_unique()), true)
         .unwrap();
 
     // Full children chain from incomplete slot 48
     let (shreds, _) = make_slot_entries(60, 48, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
     let (shreds, _) = make_slot_entries(70, 60, 5);
-    blockstore.insert_shreds(shreds, None, true).unwrap();
+    blockstore.insert_shreds(shreds, true).unwrap();
 
     for slot in [48, 60, 70] {
         assert!(!blockstore.meta(slot).unwrap().unwrap().is_connected());
@@ -7541,7 +7387,6 @@ fn test_connectivity_does_not_propagate_through_incomplete_slot() {
     blockstore
         .insert_shreds(
             create_update_parent_shreds_with_shred_parent(48, 40, 0, Hash::new_unique(), 32, false),
-            None,
             true,
         )
         .unwrap();

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -300,7 +300,7 @@ mod tests {
         let total_num_shreds = shreds.len() as u64;
         let shreds_per_slot = (shreds.len() / num_slots as usize) as u64;
         assert!(shreds_per_slot > 1);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         // Initiate a flush so inserted shreds found by find_slots_to_clean()
         let blockstore = Arc::new(flush_blockstore_contents_to_disk(blockstore));
@@ -418,7 +418,7 @@ mod tests {
         let (sender, receiver) = bounded(1);
 
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
 
         // Initiate a flush so inserted shreds found by maybe_generate_automatic_cleanup_request()
         let blockstore = Arc::new(flush_blockstore_contents_to_disk(blockstore));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -6122,7 +6122,7 @@ pub mod tests {
         let mut all_shreds = header_shreds;
         all_shreds.extend(entry_shreds);
         all_shreds.extend(footer_shreds);
-        blockstore.insert_shreds(all_shreds, None, true).unwrap();
+        blockstore.insert_shreds(all_shreds, true).unwrap();
 
         let replay_tx_thread_pool = create_thread_pool(1);
 
@@ -6278,7 +6278,7 @@ pub mod tests {
                     )
                     .filter(Shred::is_data)
                     .collect();
-                blockstore.insert_shreds(shreds, None, true).unwrap();
+                blockstore.insert_shreds(shreds, true).unwrap();
             };
 
         // Create a genesis bank (slot 0) with all features active.

--- a/ledger/src/leader_schedule_cache.rs
+++ b/ledger/src/leader_schedule_cache.rs
@@ -457,7 +457,7 @@ mod tests {
         // Write a shred into slot 2 that chains to slot 1,
         // but slot 1 is empty so should not be skipped
         let (shreds, _) = make_slot_entries(2, 1, 1);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         assert_eq!(
             cache
                 .next_leader_slot(&pubkey, 0, &bank, Some(&blockstore), u64::MAX)
@@ -470,7 +470,7 @@ mod tests {
         let (shreds, _) = make_slot_entries(1, 0, 1);
 
         // Check that slot 1 and 2 are skipped
-        blockstore.insert_shreds(shreds, None, false).unwrap();
+        blockstore.insert_shreds(shreds, false).unwrap();
         assert_eq!(
             cache
                 .next_leader_slot(&pubkey, 0, &bank, Some(&blockstore), u64::MAX)

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -205,7 +205,7 @@ pub fn copy_blocks(end_slot: Slot, source: &Blockstore, dest: &Blockstore, is_tr
         assert!(source_meta.is_full());
 
         let shreds = source.get_data_shreds_for_slot(slot, 0).unwrap();
-        dest.insert_shreds(shreds, None, is_trusted).unwrap();
+        dest.insert_shreds(shreds, is_trusted).unwrap();
 
         let dest_meta = dest.meta(slot).unwrap().unwrap();
         assert!(dest_meta.is_full());

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4771,7 +4771,7 @@ fn test_duplicate_with_pruned_ancestor() {
         );
         let shreds =
             entries_to_test_shreds(&entries, last_majority_vote, last_minority_vote, true, 0);
-        our_blockstore.insert_shreds(shreds, None, false).unwrap();
+        our_blockstore.insert_shreds(shreds, false).unwrap();
     }
 
     // Actual test, `our_node` will replay the minority fork, then the majority fork which will

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4540,7 +4540,7 @@ pub fn populate_blockstore_for_tests(
     let parent_slot = bank.parent_slot();
     let shreds =
         solana_ledger::blockstore::entries_to_test_shreds(&entries, slot, parent_slot, true, 0);
-    blockstore.insert_shreds(shreds, None, false).unwrap();
+    blockstore.insert_shreds(shreds, false).unwrap();
     blockstore.set_roots(std::iter::once(&slot)).unwrap();
 
     let (transaction_status_sender, transaction_status_receiver) = bounded(1024);

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -801,12 +801,8 @@ pub mod test {
         assert!(num_data_shreds >= 10);
 
         // Insert all the shreds
-        blockstore
-            .insert_shreds(all_data_shreds, None, true)
-            .unwrap();
-        blockstore
-            .insert_shreds(all_coding_shreds, None, true)
-            .unwrap();
+        blockstore.insert_shreds(all_data_shreds, true).unwrap();
+        blockstore.insert_shreds(all_coding_shreds, true).unwrap();
 
         // Insert duplicate retransmit signal, blocks should
         // only be retransmitted once

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -445,7 +445,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
     fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {
         let (all_shreds, _) = receiver.recv()?;
         blockstore
-            .insert_shreds(all_shreds.to_vec(), None, true)
+            .insert_shreds(all_shreds.to_vec(), true)
             .expect("Failed to insert shreds in blockstore");
         Ok(())
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -446,7 +446,6 @@ impl StandardBroadcastRun {
             blockstore
                 .insert_cow_shreds(
                     [Cow::Borrowed(shred)],
-                    None, // leader_schedule
                     true, // is_trusted
                 )
                 .expect("Failed to insert shreds in blockstore");
@@ -536,9 +535,7 @@ impl StandardBroadcastRun {
         let num_shreds = shreds.len();
         let shreds = shreds.iter().skip(offset).map(Cow::Borrowed);
         blockstore
-            .insert_cow_shreds(
-                shreds, /*leader_schedule:*/ None, /*is_trusted:*/ true,
-            )
+            .insert_cow_shreds(shreds, /*is_trusted:*/ true)
             .expect("Failed to insert shreds in blockstore");
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
         let new_insert_shreds_stats = InsertShredsStats {


### PR DESCRIPTION
#### Problem
The LeaderScheduleCache argument is no longer used; follow-on to https://github.com/anza-xyz/agave/pull/13470

#### Summary of Changes
Update all callers of the various Blockstore insertion methods to no longer pass the argument

#### Testing
Nothing beyond CI; as the previous PR described, the `leader_schedule_cache` arg was purely for an error message so no "real" logic is touched here