### PR TITLE
runtime: Distribute block rewards to stakes for SIMD-0123

### DIFF
--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -140,10 +140,11 @@ impl StakeReward {
     }
 
     pub fn new_with_pre_stake_account(
-        reward_lamports: i64,
+        inflation_reward_lamports: i64,
+        block_reward_lamports: u64,
         stake_lamports: u64,
         rent: &Rent,
-    ) -> (AccountSharedData, Self) {
+    ) -> (AccountSharedData, Self, u64) {
         let vote_pubkey = Pubkey::new_unique();
         let node_pubkey = Pubkey::new_unique();
         let vote_account = vote_state::create_v4_account_with_authorized(
@@ -167,13 +168,16 @@ impl StakeReward {
             rent,
             rent_exempt_reserve + stake_lamports,
         );
-        let post_stake_account = create_stake_account(
+        let mut post_stake_account = create_stake_account(
             &stake_pubkey,
             &vote_pubkey,
             &vote_account,
             rent,
-            rent_exempt_reserve + stake_lamports + reward_lamports as u64,
+            rent_exempt_reserve + stake_lamports + inflation_reward_lamports as u64,
         );
+        post_stake_account
+            .checked_add_lamports(block_reward_lamports)
+            .unwrap();
 
         (
             pre_stake_account,
@@ -181,13 +185,13 @@ impl StakeReward {
                 stake_pubkey,
                 stake_reward_info: StakeRewardInfo {
                     reward_type: solana_reward_info::RewardType::Staking,
-                    lamports: reward_lamports,
+                    lamports: inflation_reward_lamports + block_reward_lamports as i64,
                     post_balance: 0,         /* unused atm */
                     commission_bps: Some(0), /* unused but tests require some value */
                 },
-
                 stake_account: post_stake_account,
             },
+            block_reward_lamports,
         )
     }
 

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -139,62 +139,6 @@ impl StakeReward {
         }
     }
 
-    pub fn new_with_pre_stake_account(
-        inflation_reward_lamports: i64,
-        block_reward_lamports: u64,
-        stake_lamports: u64,
-        rent: &Rent,
-    ) -> (AccountSharedData, Self, u64) {
-        let vote_pubkey = Pubkey::new_unique();
-        let node_pubkey = Pubkey::new_unique();
-        let vote_account = vote_state::create_v4_account_with_authorized(
-            &node_pubkey,
-            &vote_pubkey,
-            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
-            &vote_pubkey,
-            1000,
-            &vote_pubkey,
-            0,
-            &node_pubkey,
-            stake_lamports,
-        );
-
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let stake_pubkey = Pubkey::new_unique();
-        let pre_stake_account = create_stake_account(
-            &stake_pubkey,
-            &vote_pubkey,
-            &vote_account,
-            rent,
-            rent_exempt_reserve + stake_lamports,
-        );
-        let mut post_stake_account = create_stake_account(
-            &stake_pubkey,
-            &vote_pubkey,
-            &vote_account,
-            rent,
-            rent_exempt_reserve + stake_lamports + inflation_reward_lamports as u64,
-        );
-        post_stake_account
-            .checked_add_lamports(block_reward_lamports)
-            .unwrap();
-
-        (
-            pre_stake_account,
-            Self {
-                stake_pubkey,
-                stake_reward_info: StakeRewardInfo {
-                    reward_type: solana_reward_info::RewardType::Staking,
-                    lamports: inflation_reward_lamports + block_reward_lamports as i64,
-                    post_balance: 0,         /* unused atm */
-                    commission_bps: Some(0), /* unused but tests require some value */
-                },
-                stake_account: post_stake_account,
-            },
-            block_reward_lamports,
-        )
-    }
-
     pub fn credit(&mut self, amount: u64) {
         self.stake_reward_info.lamports = amount as i64;
         self.stake_reward_info.post_balance += amount;

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -181,6 +181,8 @@ pub(crate) struct RewardsStoreMetrics {
     pub(crate) total_stake_accounts_count: usize,
     pub(crate) distributed_rewards: u64,
     pub(crate) burned_rewards: u64,
+    pub(crate) distributed_block_rewards: u64,
+    pub(crate) burned_block_rewards: u64,
     pub(crate) pre_capitalization: u64,
     pub(crate) post_capitalization: u64,
 }
@@ -211,6 +213,12 @@ pub(crate) fn report_partitioned_reward_metrics(bank: &Bank, timings: RewardsSto
         ),
         ("distributed_rewards", timings.distributed_rewards, i64),
         ("burned_rewards", timings.burned_rewards, i64),
+        (
+            "distributed_block_rewards",
+            timings.distributed_block_rewards,
+            i64
+        ),
+        ("burned_block_rewards", timings.burned_block_rewards, i64),
         ("pre_capitalization", timings.pre_capitalization, i64),
         ("post_capitalization", timings.post_capitalization, i64),
     );

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -56,6 +56,16 @@ struct RewardsAccumulator {
     total_stake_rewards_lamports: u64,
 }
 
+/// Helper struct used with `RewardsAccumulator` to accumulate individual stake
+/// account rewards
+struct RewardAccumulation {
+    /// Inflation rewards earned by the stake account. May be 0.
+    stake_reward: u64,
+    /// If a stake account receives block rewards, but no stake rewards, there
+    /// isn't a commission entry
+    commission: Option<(Pubkey, RewardCommission)>,
+}
+
 /// Merge the lamport and `is_vote_account` fields of two `RewardCommission`s
 ///
 /// This pays special attention to the case where `is_vote_account` does not
@@ -112,22 +122,19 @@ fn accumulate_lamports(src: &RewardCommission, dst: &mut RewardCommission) {
 }
 
 impl RewardsAccumulator {
-    fn add_reward(
-        &mut self,
-        commission_pubkey: Pubkey,
-        reward_commission: RewardCommission,
-        stakers_reward: u64,
-    ) {
-        self.reward_commissions
-            .entry(commission_pubkey)
-            .and_modify(|dst_reward_commission| {
-                accumulate_lamports(&reward_commission, dst_reward_commission);
-            })
-            .or_insert(reward_commission);
+    fn add_reward(&mut self, reward: RewardAccumulation) {
         self.num_stake_rewards = self.num_stake_rewards.saturating_add(1);
         self.total_stake_rewards_lamports = self
             .total_stake_rewards_lamports
-            .saturating_add(stakers_reward);
+            .saturating_add(reward.stake_reward);
+        if let Some((commission_pubkey, reward_commission)) = reward.commission {
+            self.reward_commissions
+                .entry(commission_pubkey)
+                .and_modify(|dst_reward_commission| {
+                    accumulate_lamports(&reward_commission, dst_reward_commission);
+                })
+                .or_insert(reward_commission);
+        }
     }
 
     /// Merges two instances by combining their reward commissions and stake rewards.
@@ -752,40 +759,38 @@ impl Bank {
                                 commission_pubkey,
                                 reward_commission,
                             } = res;
-                            let stakers_reward = inflation.stake_reward;
+                            let stake_reward = inflation.stake_reward;
                             (
                                 Some(PartitionedStakeReward {
                                     stake_pubkey: **stake_pubkey,
                                     inflation,
                                     block_reward,
                                 }),
-                                Some((stakers_reward, commission_pubkey, reward_commission)),
+                                Some(RewardAccumulation {
+                                    stake_reward,
+                                    commission: Some((commission_pubkey, reward_commission)),
+                                }),
                             )
                         }
                         (_, None) => {
                             // Create a zero entry for distribution
                             let stake = *stake_account.stake();
                             let stake_reward = 0;
-                            let commission_pubkey = stake.delegation.voter_pubkey;
-                            let commission_bps = None;
-                            let reward_commission = RewardCommission {
-                                commission_bps,
-                                commission_lamports: 0,
-                                burned_lamports: 0,
-                                is_vote_account: true,
-                            };
                             (
                                 Some(PartitionedStakeReward {
                                     stake_pubkey: **stake_pubkey,
                                     inflation: InflationReward {
                                         stake,
                                         stake_reward,
-                                        commission_bps,
+                                        commission_bps: None,
                                     },
                                     block_reward,
                                 }),
                                 // Need a reward record for accumulator
-                                Some((stake_reward, commission_pubkey, reward_commission)),
+                                Some(RewardAccumulation {
+                                    stake_reward,
+                                    commission: None,
+                                }),
                             )
                         }
                     };
@@ -800,13 +805,8 @@ impl Bank {
                 })
                 .fold(
                     RewardsAccumulator::default,
-                    |mut rewards_accumulator,
-                     (stakers_reward, commission_pubkey, reward_commission)| {
-                        rewards_accumulator.add_reward(
-                            commission_pubkey,
-                            reward_commission,
-                            stakers_reward,
-                        );
+                    |mut rewards_accumulator, accumulation| {
+                        rewards_accumulator.add_reward(accumulation);
                         rewards_accumulator
                     },
                 )
@@ -2796,46 +2796,54 @@ mod tests {
         let commission_pubkey_b = Pubkey::new_unique();
         let commission_pubkey_c = Pubkey::new_unique();
 
-        accumulator1.add_reward(
-            commission_pubkey_a,
-            RewardCommission {
-                commission_bps: Some(1_000),
-                commission_lamports: 50,
-                burned_lamports: 0,
-                is_vote_account: true,
-            },
-            50,
-        );
-        accumulator1.add_reward(
-            commission_pubkey_b,
-            RewardCommission {
-                commission_bps: Some(1_000),
-                commission_lamports: 50,
-                burned_lamports: 0,
-                is_vote_account: true,
-            },
-            50,
-        );
-        accumulator2.add_reward(
-            commission_pubkey_b,
-            RewardCommission {
-                commission_bps: Some(1_000),
-                commission_lamports: 30,
-                burned_lamports: 0,
-                is_vote_account: true,
-            },
-            30,
-        );
-        accumulator2.add_reward(
-            commission_pubkey_c,
-            RewardCommission {
-                commission_bps: Some(1_000),
-                commission_lamports: 50,
-                burned_lamports: 0,
-                is_vote_account: true,
-            },
-            50,
-        );
+        accumulator1.add_reward(RewardAccumulation {
+            commission: Some((
+                commission_pubkey_a,
+                RewardCommission {
+                    commission_bps: Some(1_000),
+                    commission_lamports: 50,
+                    burned_lamports: 0,
+                    is_vote_account: true,
+                },
+            )),
+            stake_reward: 50,
+        });
+        accumulator1.add_reward(RewardAccumulation {
+            commission: Some((
+                commission_pubkey_b,
+                RewardCommission {
+                    commission_bps: Some(1_000),
+                    commission_lamports: 50,
+                    burned_lamports: 0,
+                    is_vote_account: true,
+                },
+            )),
+            stake_reward: 50,
+        });
+        accumulator2.add_reward(RewardAccumulation {
+            commission: Some((
+                commission_pubkey_b,
+                RewardCommission {
+                    commission_bps: Some(1_000),
+                    commission_lamports: 30,
+                    burned_lamports: 0,
+                    is_vote_account: true,
+                },
+            )),
+            stake_reward: 30,
+        });
+        accumulator2.add_reward(RewardAccumulation {
+            commission: Some((
+                commission_pubkey_c,
+                RewardCommission {
+                    commission_bps: Some(1_000),
+                    commission_lamports: 50,
+                    burned_lamports: 0,
+                    is_vote_account: true,
+                },
+            )),
+            stake_reward: 50,
+        });
 
         assert_eq!(accumulator1.num_stake_rewards, 2);
         assert_eq!(accumulator1.total_stake_rewards_lamports, 100);
@@ -2972,8 +2980,14 @@ mod tests {
             burned_lamports: 1_000,
             is_vote_account: right_is_vote_account,
         };
-        accumulator.add_reward(commission_pubkey, left_reward.clone(), 50);
-        accumulator.add_reward(commission_pubkey, right_reward.clone(), 50);
+        accumulator.add_reward(RewardAccumulation {
+            commission: Some((commission_pubkey, left_reward.clone())),
+            stake_reward: 50,
+        });
+        accumulator.add_reward(RewardAccumulation {
+            commission: Some((commission_pubkey, right_reward.clone())),
+            stake_reward: 50,
+        });
 
         check_accumulator(
             &accumulator,
@@ -3012,8 +3026,14 @@ mod tests {
             is_vote_account: right_is_vote_account,
         };
 
-        accumulator1.add_reward(commission_pubkey, left_reward.clone(), 50);
-        accumulator2.add_reward(commission_pubkey, right_reward.clone(), 50);
+        accumulator1.add_reward(RewardAccumulation {
+            commission: Some((commission_pubkey, left_reward.clone())),
+            stake_reward: 50,
+        });
+        accumulator2.add_reward(RewardAccumulation {
+            commission: Some((commission_pubkey, right_reward.clone())),
+            stake_reward: 50,
+        });
 
         let additional_commission_pubkey = Pubkey::new_unique();
         let additional_reward_commission = RewardCommission {
@@ -3023,17 +3043,15 @@ mod tests {
             is_vote_account: true,
         };
         if right_is_larger {
-            accumulator2.add_reward(
-                additional_commission_pubkey,
-                additional_reward_commission,
-                50,
-            );
+            accumulator2.add_reward(RewardAccumulation {
+                commission: Some((additional_commission_pubkey, additional_reward_commission)),
+                stake_reward: 50,
+            });
         } else {
-            accumulator1.add_reward(
-                additional_commission_pubkey,
-                additional_reward_commission,
-                50,
-            );
+            accumulator1.add_reward(RewardAccumulation {
+                commission: Some((additional_commission_pubkey, additional_reward_commission)),
+                stake_reward: 50,
+            });
         };
 
         let accumulator = accumulator1.accumulate_into_larger(accumulator2);

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -763,18 +763,29 @@ impl Bank {
                             )
                         }
                         (_, None) => {
+                            // Create a zero entry for distribution
                             let stake = *stake_account.stake();
+                            let stake_reward = 0;
+                            let commission_pubkey = stake.delegation.voter_pubkey;
+                            let commission_bps = None;
+                            let reward_commission = RewardCommission {
+                                commission_bps,
+                                commission_lamports: 0,
+                                burned_lamports: 0,
+                                is_vote_account: true,
+                            };
                             (
                                 Some(PartitionedStakeReward {
                                     stake_pubkey: **stake_pubkey,
                                     inflation: InflationReward {
                                         stake,
-                                        stake_reward: 0,
-                                        commission_bps: None,
+                                        stake_reward,
+                                        commission_bps,
                                     },
                                     block_reward,
                                 }),
-                                None, // No commission to consider
+                                // Need a reward record for accumulator
+                                Some((stake_reward, commission_pubkey, reward_commission)),
                             )
                         }
                     };

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -725,7 +725,8 @@ impl Bank {
                 .par_iter()
                 .zip(&mut stake_rewards.spare_capacity_mut()[..stake_delegations_len])
                 .with_min_len(500)
-                .filter_map(|((stake_pubkey, stake_account), stake_reward_ref)| {
+                .filter_map(|((stake_pubkey, stake_account), reward_ref)| {
+                    let block_reward = 0;
                     let maybe_reward_record = self.redeem_delegation_rewards(
                         rewarded_epoch,
                         stake_pubkey,
@@ -743,8 +744,9 @@ impl Bank {
                         use_fixed_point_stake_math,
                     );
 
-                    let (stake_reward, maybe_reward_record) = match maybe_reward_record {
-                        Some(res) => {
+                    let (reward, maybe_reward_record) = match (block_reward, maybe_reward_record) {
+                        (0, None) => (None, None),
+                        (_, Some(res)) => {
                             let InflationRewardWithCommission {
                                 inflation,
                                 commission_pubkey,
@@ -755,11 +757,26 @@ impl Bank {
                                 Some(PartitionedStakeReward {
                                     stake_pubkey: **stake_pubkey,
                                     inflation,
+                                    block_reward,
                                 }),
                                 Some((stakers_reward, commission_pubkey, reward_commission)),
                             )
                         }
-                        None => (None, None),
+                        (_, None) => {
+                            let stake = *stake_account.stake();
+                            (
+                                Some(PartitionedStakeReward {
+                                    stake_pubkey: **stake_pubkey,
+                                    inflation: InflationReward {
+                                        stake,
+                                        stake_reward: 0,
+                                        commission_bps: None,
+                                    },
+                                    block_reward,
+                                }),
+                                None, // No commission to consider
+                            )
+                        }
                     };
                     // It's important that for every stake delegation, we write
                     // a value to the cell of the stake rewards vector,
@@ -767,7 +784,7 @@ impl Bank {
                     // This allows us to pre-allocate the vector with the known
                     // size and avoid re-allocations, which were the bottleneck
                     // in this path.
-                    stake_reward_ref.write(stake_reward);
+                    reward_ref.write(reward);
                     maybe_reward_record
                 })
                 .fold(
@@ -1410,6 +1427,7 @@ mod tests {
                 stake_reward: stake_reward_lamports,
                 commission_bps: Some(0),
             },
+            block_reward: 0,
         })]
         .into_iter()
         .collect::<PartitionedStakeRewards>();
@@ -2157,6 +2175,7 @@ mod tests {
                     stake_reward,
                     commission_bps: None,
                 },
+                block_reward: 0,
             }
         };
         assert_eq!(

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -43,6 +43,8 @@ enum DistributionError {
 struct DistributionResults {
     stake_reward_lamports_minted: u64,
     stake_reward_lamports_burned: u64,
+    block_reward_lamports_distributed: u64,
+    block_reward_lamports_burned: u64,
     updated_stake_rewards: StakeRewards,
 }
 
@@ -182,6 +184,8 @@ impl Bank {
             DistributionResults {
                 stake_reward_lamports_minted,
                 stake_reward_lamports_burned,
+                block_reward_lamports_distributed,
+                block_reward_lamports_burned,
                 updated_stake_rewards,
             },
             store_stake_accounts_us,
@@ -194,7 +198,7 @@ impl Bank {
         // decrease distributed capital from epoch rewards sysvar
         self.update_epoch_rewards_sysvar(
             stake_reward_lamports_minted + stake_reward_lamports_burned,
-            0, // debit_block_rewards
+            block_reward_lamports_distributed + block_reward_lamports_burned,
         );
 
         // update reward history for this partitioned distribution
@@ -210,6 +214,8 @@ impl Bank {
             store_stake_accounts_count: updated_stake_rewards.len(),
             distributed_rewards: stake_reward_lamports_minted,
             burned_rewards: stake_reward_lamports_burned,
+            distributed_block_rewards: block_reward_lamports_distributed,
+            burned_block_rewards: block_reward_lamports_burned,
         };
 
         report_partitioned_reward_metrics(self, metrics);
@@ -253,6 +259,9 @@ impl Bank {
         };
         account
             .checked_add_lamports(partitioned_stake_reward.inflation.stake_reward)
+            .map_err(|_| DistributionError::ArithmeticOverflow)?;
+        account
+            .checked_add_lamports(partitioned_stake_reward.block_reward)
             .map_err(|_| DistributionError::ArithmeticOverflow)?;
 
         let mut new_stake = partitioned_stake_reward.inflation.stake;
@@ -301,7 +310,11 @@ impl Bank {
             stake_pubkey: partitioned_stake_reward.stake_pubkey,
             stake_reward_info: StakeRewardInfo {
                 reward_type,
-                lamports: i64::try_from(partitioned_stake_reward.inflation.stake_reward).unwrap(),
+                lamports: i64::try_from(
+                    partitioned_stake_reward.inflation.stake_reward
+                        + partitioned_stake_reward.block_reward,
+                )
+                .unwrap(),
                 post_balance: account.lamports(),
                 commission_bps: partitioned_stake_reward.inflation.commission_bps,
             },
@@ -331,6 +344,8 @@ impl Bank {
 
         let mut stake_reward_lamports_minted = 0;
         let mut stake_reward_lamports_burned = 0;
+        let mut block_reward_lamports_distributed = 0;
+        let mut block_reward_lamports_burned = 0;
         let indices = partition_rewards
             .partition_indices
             .get(partition_index as usize)
@@ -362,6 +377,7 @@ impl Bank {
                 });
             let stake_pubkey = partitioned_stake_reward.stake_pubkey;
             let stake_reward_amount = partitioned_stake_reward.inflation.stake_reward;
+            let block_reward_amount = partitioned_stake_reward.block_reward;
 
             match Self::build_updated_stake_reward(
                 self.epoch,
@@ -375,6 +391,7 @@ impl Bank {
             ) {
                 Ok(stake_reward) => {
                     stake_reward_lamports_minted += stake_reward_amount;
+                    block_reward_lamports_distributed += block_reward_amount;
                     updated_stake_rewards.push(stake_reward);
                 }
                 Err(err) => {
@@ -383,6 +400,7 @@ impl Bank {
                          {stake_pubkey}, {stake_reward_amount} lamports burned: {err:?}"
                     );
                     stake_reward_lamports_burned += stake_reward_amount;
+                    block_reward_lamports_burned += block_reward_amount;
                 }
             }
         }
@@ -396,6 +414,8 @@ impl Bank {
         DistributionResults {
             stake_reward_lamports_minted,
             stake_reward_lamports_burned,
+            block_reward_lamports_distributed,
+            block_reward_lamports_burned,
             updated_stake_rewards,
         }
     }
@@ -448,11 +468,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| {
-                Some(PartitionedStakeReward::new_random(
-                    &bank.rent_collector.rent,
-                ))
-            })
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices =
@@ -476,11 +492,7 @@ mod tests {
         let expected_num = 1;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| {
-                Some(PartitionedStakeReward::new_random(
-                    &bank.rent_collector.rent,
-                ))
-            })
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(
@@ -512,8 +524,11 @@ mod tests {
         bank.distribute_partitioned_epoch_rewards();
     }
 
-    fn populate_starting_stake_accounts_from_stake_rewards(bank: &Bank, rewards: &[StakeReward]) {
-        let rent = &bank.rent_collector.rent;
+    fn populate_starting_stake_accounts_from_stake_rewards(
+        bank: &Bank,
+        rent: &Rent,
+        rewards: &[PartitionedStakeReward],
+    ) {
         let validator_pubkey = Pubkey::new_unique();
         let validator_vote_pubkey = Pubkey::new_unique();
 
@@ -529,18 +544,18 @@ mod tests {
             20,
         );
 
-        for stake_reward in rewards.iter() {
-            // store account in Bank, since distribution now checks for account existence
-            let lamports = stake_reward.stake_account.lamports()
-                - stake_reward.stake_reward_info.lamports as u64;
+        for reward in rewards.iter() {
+            let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+            let pre_lamports = rent_exempt_reserve + reward.inflation.stake.delegation.stake
+                - reward.inflation.stake_reward;
             let validator_stake_account = stake_utils::create_stake_account(
-                &stake_reward.stake_pubkey,
+                &reward.stake_pubkey,
                 &validator_vote_pubkey,
                 &validator_vote_account,
                 rent,
-                lamports,
+                pre_lamports,
             );
-            bank.store_account(&stake_reward.stake_pubkey, &validator_stake_account);
+            bank.store_account(&reward.stake_pubkey, &validator_stake_account);
         }
     }
 
@@ -553,10 +568,30 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
 
         // Set up epoch_rewards sysvar with rewards with 1e9 lamports to distribute.
+        let expected_num = 100;
         let inflation_rewards = 1_000_000_000;
-        let block_rewards = 0;
+
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (inflation_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+
+        // Set up a partition of rewards to distribute
+        let stake_rewards = (0..expected_num)
+            .map(|_| PartitionedStakeReward::new_random())
+            .collect::<Vec<_>>();
+        let rewards_to_distribute = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.inflation.stake_reward)
+            .sum::<u64>();
+        let block_rewards = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.block_reward)
+            .sum::<u64>();
+        populate_starting_stake_accounts_from_stake_rewards(
+            &bank,
+            &bank.rent_collector.rent,
+            &stake_rewards,
+        );
+
         bank.create_epoch_rewards_sysvar(
             0,
             42,
@@ -568,26 +603,15 @@ mod tests {
             block_rewards,
         );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
-        let expected_balance =
-            bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());
+        let expected_balance = bank
+            .get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len())
+            + block_rewards;
         // Expected balance is the sysvar rent-exempt balance
         assert_eq!(pre_epoch_rewards_account.lamports(), expected_balance);
 
-        // Set up a partition of rewards to distribute
-        let expected_num = 100;
-        let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
-            .collect::<Vec<_>>();
-        let rewards_to_distribute = stake_rewards
-            .iter()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>() as u64;
-        populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
-        let all_rewards = convert_rewards(stake_rewards);
-
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            all_stake_rewards: Arc::new(all_rewards),
+            all_stake_rewards: Arc::new(stake_rewards.into_iter().collect()),
             partition_indices: vec![(0..expected_num as usize).collect::<Vec<_>>()],
         };
 
@@ -597,8 +621,12 @@ mod tests {
         let post_cap = bank.capitalization();
         let post_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
 
-        // Assert that epoch rewards sysvar lamports balance does not change
-        assert_eq!(post_epoch_rewards_account.lamports(), expected_balance);
+        // Assert that epoch rewards sysvar lamports balance changes by distributed
+        // amount
+        assert_eq!(
+            post_epoch_rewards_account.lamports(),
+            expected_balance - block_rewards
+        );
 
         let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
             from_account(&post_epoch_rewards_account).unwrap();
@@ -623,31 +651,40 @@ mod tests {
         let expected_num = 12345;
 
         let mut stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
-        populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
-
-        let expected_rewards = stake_rewards
+        let expected_block_rewards = stake_rewards
             .iter()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>() as u64;
+            .map(|reward| reward.block_reward)
+            .sum::<u64>();
+        populate_starting_stake_accounts_from_stake_rewards(
+            &bank,
+            &bank.rent_collector.rent,
+            &stake_rewards,
+        );
+
+        let expected_inflation_rewards = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.inflation.stake_reward)
+            .sum::<u64>();
 
         // Push extra StakeReward to simulate non-existent account
-        stake_rewards.push(StakeReward::new_random(&bank.rent_collector.rent));
+        stake_rewards.push(PartitionedStakeReward::new_random());
 
-        let stake_rewards = convert_rewards(stake_rewards);
+        let all_stake_rewards = Arc::new(stake_rewards.into_iter().collect());
 
         let partition_indices =
-            hash_rewards_into_partitions(&stake_rewards, &Hash::new_from_array([1; 32]), 100);
+            hash_rewards_into_partitions(&all_stake_rewards, &Hash::new_from_array([1; 32]), 100);
         let num_partitions = partition_indices.len();
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            all_stake_rewards: Arc::new(stake_rewards),
+            all_stake_rewards,
             partition_indices,
         };
 
         // Test partitioned stores
-        let mut total_rewards = 0;
+        let mut total_inflation_rewards = 0;
+        let mut total_block_rewards = 0;
         let mut total_num_updates = 0;
 
         let pre_update_history_len = bank.rewards.read().unwrap().len();
@@ -656,19 +693,22 @@ mod tests {
             let DistributionResults {
                 stake_reward_lamports_minted,
                 updated_stake_rewards,
+                block_reward_lamports_distributed,
                 ..
             } = bank.store_stake_accounts_in_partition(&partitioned_rewards, i as u64);
             let num_history_updates =
                 bank.update_reward_history_in_partition(&updated_stake_rewards);
             assert_eq!(updated_stake_rewards.len(), num_history_updates);
-            total_rewards += stake_reward_lamports_minted;
+            total_inflation_rewards += stake_reward_lamports_minted;
+            total_block_rewards += block_reward_lamports_distributed;
             total_num_updates += num_history_updates;
         }
 
         let post_update_history_len = bank.rewards.read().unwrap().len();
 
         // assert that all rewards are credited
-        assert_eq!(total_rewards, expected_rewards);
+        assert_eq!(total_inflation_rewards, expected_inflation_rewards);
+        assert_eq!(total_block_rewards, expected_block_rewards);
         assert_eq!(total_num_updates, expected_num);
         assert_eq!(
             total_num_updates,
@@ -759,6 +799,7 @@ mod tests {
             credits_observed: 42,
         };
         let stake_reward = 100;
+        let block_reward = 10_000;
         let commission_bps = 4_200;
 
         let nonexistent_account = Pubkey::new_unique();
@@ -769,6 +810,7 @@ mod tests {
                 stake_reward,
                 commission_bps: Some(commission_bps),
             },
+            block_reward,
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -790,7 +832,7 @@ mod tests {
 
         let overflowing_account = Pubkey::new_unique();
         let mut stake_account = AccountSharedData::new(
-            u64::MAX - stake_reward + 1,
+            u64::MAX - stake_reward - block_reward + 1,
             StakeStateV2::size_of(),
             &solana_stake_interface::program::id(),
         );
@@ -809,6 +851,7 @@ mod tests {
                 stake_reward,
                 commission_bps: Some(commission_bps),
             },
+            block_reward,
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -859,10 +902,11 @@ mod tests {
                 stake_reward,
                 commission_bps: Some(commission_bps),
             },
+            block_reward,
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
-        let expected_lamports = starting_lamports + stake_reward;
+        let expected_lamports = starting_lamports + stake_reward + block_reward;
         let mut expected_stake_account = AccountSharedData::new(
             expected_lamports,
             StakeStateV2::size_of(),
@@ -881,7 +925,7 @@ mod tests {
             stake_account: expected_stake_account,
             stake_reward_info: StakeRewardInfo {
                 reward_type: RewardType::Staking,
-                lamports: stake_reward as i64,
+                lamports: (stake_reward + block_reward) as i64,
                 post_balance: expected_lamports,
                 commission_bps: Some(commission_bps),
             },
@@ -943,6 +987,7 @@ mod tests {
                 stake_reward,
                 commission_bps: Some(commission_bps),
             },
+            block_reward: 0,
         };
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
@@ -1007,14 +1052,23 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| StakeReward::new_random(&bank.rent_collector.rent))
+            .map(|_| PartitionedStakeReward::new_random())
             .collect::<Vec<_>>();
-        populate_starting_stake_accounts_from_stake_rewards(&bank, &stake_rewards);
-        let converted_rewards = convert_rewards(stake_rewards);
+        populate_starting_stake_accounts_from_stake_rewards(
+            &bank,
+            &bank.rent_collector.rent,
+            &stake_rewards,
+        );
+        let converted_rewards: PartitionedStakeRewards = stake_rewards.into_iter().collect();
 
-        let expected_total = converted_rewards
+        let expected_minted_lamports = converted_rewards
             .enumerated_rewards_iter()
             .map(|(_, reward)| reward.inflation.stake_reward)
+            .sum::<u64>();
+
+        let expected_distributed_lamports = converted_rewards
+            .enumerated_rewards_iter()
+            .map(|(_, reward)| reward.block_reward)
             .sum::<u64>();
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
@@ -1025,9 +1079,14 @@ mod tests {
 
         let DistributionResults {
             stake_reward_lamports_minted,
+            block_reward_lamports_distributed,
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
-        assert_eq!(expected_total, stake_reward_lamports_minted);
+        assert_eq!(expected_minted_lamports, stake_reward_lamports_minted);
+        assert_eq!(
+            expected_distributed_lamports,
+            block_reward_lamports_distributed
+        );
     }
 
     #[test]
@@ -1045,9 +1104,11 @@ mod tests {
 
         let DistributionResults {
             stake_reward_lamports_minted,
+            block_reward_lamports_distributed,
             ..
         } = bank.store_stake_accounts_in_partition(&partitioned_rewards, 0);
         assert_eq!(expected_total, stake_reward_lamports_minted);
+        assert_eq!(expected_total, block_reward_lamports_distributed);
     }
 
     #[test]
@@ -1057,11 +1118,51 @@ mod tests {
         genesis_config.epoch_schedule = EpochSchedule::custom(432000, 432000, false);
         let bank = Bank::new_for_tests(&genesis_config);
 
+        // Use lower lamports per byte for creating, bank has higher amount
+        let mut lower_rent = bank.rent_collector.rent.clone();
+        lower_rent.lamports_per_byte /= 10;
+
+        // Set up a partition of rewards to distribute
+        let stake_rewards = [
+            // Zero stake -> destaked
+            PartitionedStakeReward::new_with_lamport_amounts(0, 0, 0),
+            // Below new minimum, small reward -> destaked
+            PartitionedStakeReward::new_with_lamport_amounts(1, 0, 1),
+            // Below new minimum, no reward -> delegation modified
+            PartitionedStakeReward::new_with_lamport_amounts(0, 0, LAMPORTS_PER_SOL),
+            // Below new minimum, small reward -> delegation modified
+            PartitionedStakeReward::new_with_lamport_amounts(1, 0, LAMPORTS_PER_SOL),
+            // Below new minimum, big reward -> delegation modified
+            PartitionedStakeReward::new_with_lamport_amounts(LAMPORTS_PER_SOL, 0, LAMPORTS_PER_SOL),
+            // Above new minimum, small reward -> delegation capped
+            PartitionedStakeReward::new_with_lamport_amounts(1, 0, LAMPORTS_PER_SOL),
+            // Above new minimum, big reward -> delegation capped
+            PartitionedStakeReward::new_with_lamport_amounts(LAMPORTS_PER_SOL, 0, LAMPORTS_PER_SOL),
+            // Block reward partially covers rent increase -> delegation modified
+            PartitionedStakeReward::new_with_lamport_amounts(1, 1, LAMPORTS_PER_SOL),
+            // Block reward totally covers rent increase
+            PartitionedStakeReward::new_with_lamport_amounts(1, LAMPORTS_PER_SOL, LAMPORTS_PER_SOL),
+        ]
+        .into_iter()
+        .collect::<Vec<_>>();
+        populate_starting_stake_accounts_from_stake_rewards(&bank, &lower_rent, &stake_rewards);
+
+        let expected_num = stake_rewards.len();
+        let inflation_rewards_minted = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.inflation.stake_reward)
+            .sum::<u64>();
+        let block_rewards = stake_rewards
+            .iter()
+            .map(|stake_reward| stake_reward.block_reward)
+            .sum::<u64>();
+        let all_stake_rewards = Arc::new(stake_rewards.into_iter().collect());
+
         // Set up epoch_rewards sysvar with rewards with 10e9 lamports to distribute.
         let total_rewards = 10 * LAMPORTS_PER_SOL;
-        let block_rewards = 0;
         let num_partitions = 2; // num_partitions is arbitrary and unimportant for this test
         let total_points = (total_rewards * 42) as u128; // total_points is arbitrary for the purposes of this test
+
         bank.create_epoch_rewards_sysvar(
             0,
             42,
@@ -1073,58 +1174,15 @@ mod tests {
             block_rewards,
         );
         let pre_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
-        let expected_balance =
-            bank.get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len());
+        let expected_balance = bank
+            .get_minimum_balance_for_rent_exemption(pre_epoch_rewards_account.data().len())
+            + block_rewards;
         // Expected balance is the sysvar rent-exempt balance
         assert_eq!(pre_epoch_rewards_account.lamports(), expected_balance);
 
-        // Use lower lamports per byte for creating, bank has higher amount
-        let mut lower_rent = bank.rent_collector.rent.clone();
-        lower_rent.lamports_per_byte /= 10;
-        let higher_rent = &bank.rent_collector.rent;
-
-        // Set up a partition of rewards to distribute
-        let stake_rewards = [
-            // Zero stake -> destaked
-            StakeReward::new_with_pre_stake_account(0, 0, &lower_rent),
-            // Below new minimum, small reward -> destaked
-            StakeReward::new_with_pre_stake_account(1, 1, &lower_rent),
-            // Below new minimum, no reward -> delegation modified
-            StakeReward::new_with_pre_stake_account(0, LAMPORTS_PER_SOL, &lower_rent),
-            // Below new minimum, small reward -> delegation modified
-            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, &lower_rent),
-            // Below new minimum, big reward -> delegation modified
-            StakeReward::new_with_pre_stake_account(
-                LAMPORTS_PER_SOL as i64,
-                LAMPORTS_PER_SOL,
-                &lower_rent,
-            ),
-            // Above new minimum, small reward -> delegation capped
-            StakeReward::new_with_pre_stake_account(1, LAMPORTS_PER_SOL, higher_rent),
-            // Above new minimum, big reward -> delegation capped
-            StakeReward::new_with_pre_stake_account(
-                LAMPORTS_PER_SOL as i64,
-                LAMPORTS_PER_SOL,
-                higher_rent,
-            ),
-        ]
-        .into_iter()
-        .map(|r| {
-            bank.store_account(&r.1.stake_pubkey, &r.0);
-            r.1
-        })
-        .collect::<Vec<_>>();
-
-        let expected_num = stake_rewards.len();
-        let rewards_to_distribute = stake_rewards
-            .iter()
-            .map(|stake_reward| stake_reward.stake_reward_info.lamports)
-            .sum::<i64>() as u64;
-        let all_rewards = convert_rewards(stake_rewards);
-
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            all_stake_rewards: Arc::new(all_rewards),
+            all_stake_rewards,
             partition_indices: vec![(0..expected_num).collect::<Vec<_>>()],
         };
 
@@ -1134,17 +1192,21 @@ mod tests {
         let post_cap = bank.capitalization();
         let post_epoch_rewards_account = bank.get_account(&sysvar::epoch_rewards::id()).unwrap();
 
-        // Assert that epoch rewards sysvar lamports balance does not change
-        assert_eq!(post_epoch_rewards_account.lamports(), expected_balance);
+        // Assert that epoch rewards sysvar lamports balance decreased by
+        // distributed reward amount
+        assert_eq!(
+            post_epoch_rewards_account.lamports(),
+            expected_balance - block_rewards
+        );
 
         let epoch_rewards: sysvar::epoch_rewards::EpochRewards =
             from_account(&post_epoch_rewards_account).unwrap();
         assert_eq!(epoch_rewards.total_rewards, total_rewards);
-        assert_eq!(epoch_rewards.distributed_rewards, rewards_to_distribute,);
+        assert_eq!(epoch_rewards.distributed_rewards, inflation_rewards_minted);
 
         // Assert that the bank total capital changed by the amount of rewards
         // distributed
-        assert_eq!(pre_cap + rewards_to_distribute, post_cap);
+        assert_eq!(pre_cap + inflation_rewards_minted, post_cap);
     }
 
     #[test]
@@ -1181,7 +1243,8 @@ mod tests {
 
         // Below new minimum, small reward, should normally be destaked
         let reward_lamports = 1;
-        let stake_reward = StakeReward::new_with_pre_stake_account(reward_lamports, 1, &lower_rent);
+        let stake_reward =
+            StakeReward::new_with_pre_stake_account(reward_lamports, 0, 1, &lower_rent);
         bank.store_account(&stake_reward.1.stake_pubkey, &stake_reward.0);
 
         let stake_pubkey = stake_reward.1.stake_pubkey;
@@ -1189,7 +1252,7 @@ mod tests {
 
         let expected_num = 1;
         let rewards_to_distribute = stake_reward.1.stake_reward_info.lamports as u64;
-        let all_rewards = convert_rewards(vec![stake_reward.1]);
+        let all_rewards = convert_rewards(vec![(stake_reward.1, stake_reward.2)]);
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -195,6 +195,10 @@ impl Bank {
         self.capitalization
             .fetch_add(stake_reward_lamports_minted, Relaxed);
 
+        // decrease total capitalization by burned block rewards
+        self.capitalization
+            .fetch_sub(block_reward_lamports_burned, Relaxed);
+
         // decrease distributed capital from epoch rewards sysvar
         self.update_epoch_rewards_sysvar(
             stake_reward_lamports_minted + stake_reward_lamports_burned,

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -434,7 +434,7 @@ mod tests {
             bank::{
                 partitioned_epoch_rewards::{
                     InflationReward, PartitionedStakeRewards, REWARD_CALCULATION_NUM_BLOCKS,
-                    epoch_rewards_hasher::hash_rewards_into_partitions, tests::convert_rewards,
+                    epoch_rewards_hasher::hash_rewards_into_partitions,
                 },
                 tests::create_genesis_config,
             },
@@ -1247,20 +1247,18 @@ mod tests {
 
         // Below new minimum, small reward, should normally be destaked
         let reward_lamports = 1;
-        let stake_reward =
-            StakeReward::new_with_pre_stake_account(reward_lamports, 0, 1, &lower_rent);
-        bank.store_account(&stake_reward.1.stake_pubkey, &stake_reward.0);
-
-        let stake_pubkey = stake_reward.1.stake_pubkey;
-        let mut stake_account = stake_reward.0;
+        let reward = PartitionedStakeReward::new_with_lamport_amounts(reward_lamports, 0, 1);
+        let rewards_to_distribute = reward.inflation.stake_reward;
+        let stake_pubkey = reward.stake_pubkey;
+        let stake_rewards = [reward];
+        populate_starting_stake_accounts_from_stake_rewards(&bank, &lower_rent, &stake_rewards);
+        let mut stake_account = bank.get_account(&stake_pubkey).unwrap();
 
         let expected_num = 1;
-        let rewards_to_distribute = stake_reward.1.stake_reward_info.lamports as u64;
-        let all_rewards = convert_rewards(vec![(stake_reward.1, stake_reward.2)]);
 
         let partitioned_rewards = StartBlockHeightAndPartitionedRewards {
             distribution_starting_block_height: bank.block_height() + REWARD_CALCULATION_NUM_BLOCKS,
-            all_stake_rewards: Arc::new(all_rewards),
+            all_stake_rewards: Arc::new(stake_rewards.into_iter().collect()),
             partition_indices: vec![(0..expected_num).collect::<Vec<_>>()],
         };
 
@@ -1292,7 +1290,7 @@ mod tests {
         let pre_stake_state: StakeStateV2 = stake_account.state().unwrap();
         assert_eq!(
             post_stake_state.delegation().unwrap().stake,
-            pre_stake_state.delegation().unwrap().stake + reward_lamports as u64
+            pre_stake_state.delegation().unwrap().stake + reward_lamports
         );
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/epoch_rewards_hasher.rs
@@ -34,7 +34,6 @@ mod tests {
         },
         solana_epoch_schedule::EpochSchedule,
         solana_native_token::LAMPORTS_PER_SOL,
-        solana_rent::Rent,
         std::sync::Arc,
     };
 
@@ -42,10 +41,9 @@ mod tests {
     fn test_hash_rewards_into_partitions() {
         // setup the expected number of stake rewards
         let expected_num = 12345;
-        let rent = Rent::default();
 
         let stake_rewards = (0..expected_num)
-            .map(|_| Some(PartitionedStakeReward::new_random(&rent)))
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = hash_rewards_into_partitions(&stake_rewards, &Hash::default(), 5);
@@ -81,11 +79,7 @@ mod tests {
         // simulate 40K - 1 rewards, the expected num of credit blocks should be 10.
         let expected_num = 40959;
         let stake_rewards = (0..expected_num)
-            .map(|_| {
-                Some(PartitionedStakeReward::new_random(
-                    &bank.rent_collector.rent,
-                ))
-            })
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices =

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -32,6 +32,8 @@ pub(crate) struct PartitionedStakeReward {
     pub stake_pubkey: Pubkey,
     /// Inflation reward information
     pub inflation: InflationReward,
+    /// Block rewards distributed
+    pub block_reward: u64,
 }
 
 /// Just the inflation portion of a partitioned stake reward
@@ -114,6 +116,18 @@ impl FromIterator<Option<PartitionedStakeReward>> for PartitionedStakeRewards {
         Self {
             rewards,
             num_rewards: len_some,
+        }
+    }
+}
+
+#[cfg(test)]
+impl FromIterator<PartitionedStakeReward> for PartitionedStakeRewards {
+    fn from_iter<T: IntoIterator<Item = PartitionedStakeReward>>(iter: T) -> Self {
+        let rewards = Vec::from_iter(iter.into_iter().map(Some));
+        let num_rewards = rewards.len();
+        Self {
+            rewards,
+            num_rewards,
         }
     }
 }
@@ -431,6 +445,7 @@ mod tests {
             stake_utils,
         },
         assert_matches::assert_matches,
+        rand::Rng,
         solana_account::{Account, state_traits::StateMut},
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
@@ -440,7 +455,6 @@ mod tests {
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_native_token::LAMPORTS_PER_SOL,
-        solana_rent::Rent,
         solana_reward_info::RewardType,
         solana_signer::Signer,
         solana_stake_interface::state::StakeStateV2,
@@ -452,7 +466,7 @@ mod tests {
     };
 
     impl PartitionedStakeReward {
-        fn maybe_from(stake_reward: &StakeReward) -> Option<Self> {
+        fn maybe_from(stake_reward: &StakeReward, block_reward: u64) -> Option<Self> {
             if let Ok(StakeStateV2::Stake(_meta, stake, _flags)) =
                 stake_reward.stake_account.state()
             {
@@ -463,14 +477,55 @@ mod tests {
                         stake_reward: stake_reward.stake_reward_info.lamports as u64,
                         commission_bps: stake_reward.stake_reward_info.commission_bps,
                     },
+                    block_reward,
                 })
             } else {
                 None
             }
         }
 
-        pub fn new_random(rent: &Rent) -> Self {
-            Self::maybe_from(&StakeReward::new_random(rent)).unwrap()
+        pub fn new_random() -> Self {
+            let mut rng = rand::rng();
+            let stake_reward = rng.random_range(1..200);
+            Self {
+                stake_pubkey: Pubkey::new_unique(),
+                inflation: InflationReward {
+                    stake: Stake {
+                        delegation: Delegation {
+                            voter_pubkey: Pubkey::new_unique(),
+                            stake: rng.random_range(1..200) + stake_reward,
+                            activation_epoch: 0,
+                            deactivation_epoch: u64::MAX,
+                            ..Default::default()
+                        },
+                        credits_observed: rng.random_range(1..200),
+                    },
+                    stake_reward,
+                    commission_bps: None,
+                },
+                block_reward: rng.random_range(0..10_000_000_000),
+            }
+        }
+
+        pub fn new_with_lamport_amounts(stake_reward: u64, block_reward: u64, stake: u64) -> Self {
+            Self {
+                stake_pubkey: Pubkey::new_unique(),
+                inflation: InflationReward {
+                    stake: Stake {
+                        delegation: Delegation {
+                            voter_pubkey: Pubkey::new_unique(),
+                            stake: stake + stake_reward,
+                            activation_epoch: 0,
+                            deactivation_epoch: u64::MAX,
+                            ..Default::default()
+                        },
+                        credits_observed: 0,
+                    },
+                    stake_reward,
+                    commission_bps: None,
+                },
+                block_reward,
+            }
         }
     }
 
@@ -492,11 +547,13 @@ mod tests {
     }
 
     pub fn convert_rewards(
-        stake_rewards: impl IntoIterator<Item = StakeReward>,
+        stake_rewards: impl IntoIterator<Item = (StakeReward, u64)>,
     ) -> PartitionedStakeRewards {
         stake_rewards
             .into_iter()
-            .map(|stake_reward| Some(PartitionedStakeReward::maybe_from(&stake_reward).unwrap()))
+            .map(|(stake_reward, block_reward)| {
+                Some(PartitionedStakeReward::maybe_from(&stake_reward, block_reward).unwrap())
+            })
             .collect()
     }
 
@@ -679,11 +736,7 @@ mod tests {
         let expected_num = 100;
 
         let stake_rewards = (0..expected_num)
-            .map(|_| {
-                Some(PartitionedStakeReward::new_random(
-                    &bank.rent_collector.rent,
-                ))
-            })
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         let partition_indices = vec![(0..expected_num).collect()];
@@ -741,11 +794,7 @@ mod tests {
             |num_stakes: u64, expected_num_reward_distribution_blocks: u64| {
                 // Given the short epoch, i.e. 32 slots, we should cap the number of reward distribution blocks to 32/10 = 3.
                 let stake_rewards = (0..num_stakes)
-                    .map(|_| {
-                        Some(PartitionedStakeReward::new_random(
-                            &bank.rent_collector.rent,
-                        ))
-                    })
+                    .map(|_| Some(PartitionedStakeReward::new_random()))
                     .collect::<PartitionedStakeRewards>();
 
                 assert_eq!(
@@ -783,11 +832,7 @@ mod tests {
         // Given 8k rewards, it will take 2 blocks to credit all the rewards
         let expected_num = 8192;
         let stake_rewards = (0..expected_num)
-            .map(|_| {
-                Some(PartitionedStakeReward::new_random(
-                    &bank.rent_collector.rent,
-                ))
-            })
+            .map(|_| Some(PartitionedStakeReward::new_random()))
             .collect::<PartitionedStakeRewards>();
 
         assert_eq!(bank.get_reward_distribution_num_blocks(&stake_rewards), 2);
@@ -822,9 +867,7 @@ mod tests {
                 if i % 4 == 0 {
                     None
                 } else {
-                    Some(PartitionedStakeReward::new_random(
-                        &bank.rent_collector.rent,
-                    ))
+                    Some(PartitionedStakeReward::new_random())
                 }
             })
             .collect::<PartitionedStakeRewards>();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct PartitionedStakeReward {
     pub stake_pubkey: Pubkey,
     /// Inflation reward information
     pub inflation: InflationReward,
-    /// Block rewards distributed
+    /// Block rewards due during distribution
     pub block_reward: u64,
 }
 
@@ -457,7 +457,6 @@ mod tests {
         solana_native_token::LAMPORTS_PER_SOL,
         solana_reward_info::RewardType,
         solana_signer::Signer,
-        solana_stake_interface::state::StakeStateV2,
         solana_system_transaction as system_transaction,
         solana_vote::vote_transaction,
         solana_vote_interface::state::{MAX_LOCKOUT_HISTORY, VoteStateV4, VoteStateVersions},
@@ -466,24 +465,6 @@ mod tests {
     };
 
     impl PartitionedStakeReward {
-        fn maybe_from(stake_reward: &StakeReward, block_reward: u64) -> Option<Self> {
-            if let Ok(StakeStateV2::Stake(_meta, stake, _flags)) =
-                stake_reward.stake_account.state()
-            {
-                Some(Self {
-                    stake_pubkey: stake_reward.stake_pubkey,
-                    inflation: InflationReward {
-                        stake,
-                        stake_reward: stake_reward.stake_reward_info.lamports as u64,
-                        commission_bps: stake_reward.stake_reward_info.commission_bps,
-                    },
-                    block_reward,
-                })
-            } else {
-                None
-            }
-        }
-
         pub fn new_random() -> Self {
             let mut rng = rand::rng();
             let stake_reward = rng.random_range(1..200);
@@ -544,17 +525,6 @@ mod tests {
                     .collect::<PartitionedStakeRewards>()
             })
             .collect::<Vec<_>>()
-    }
-
-    pub fn convert_rewards(
-        stake_rewards: impl IntoIterator<Item = (StakeReward, u64)>,
-    ) -> PartitionedStakeRewards {
-        stake_rewards
-            .into_iter()
-            .map(|(stake_reward, block_reward)| {
-                Some(PartitionedStakeReward::maybe_from(&stake_reward, block_reward).unwrap())
-            })
-            .collect()
     }
 
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -25,7 +25,7 @@ use {
 /// Distributing rewards to stake accounts begins AFTER this many blocks.
 const REWARD_CALCULATION_NUM_BLOCKS: u64 = 1;
 
-/// Total reward for a stake account, currently just inflation rewards.
+/// Total reward for a stake account, comprising inflation and block rewards.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PartitionedStakeReward {
     /// Stake account address

--- a/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/sysvar.rs
@@ -74,13 +74,13 @@ impl Bank {
     /// Update EpochRewards sysvar with distributed rewards
     pub(in crate::bank::partitioned_epoch_rewards) fn update_epoch_rewards_sysvar(
         &self,
-        distributed: u64,
+        inflation_reward_lamports_minted_and_burned: u64,
         debit_block_reward_lamports: u64,
     ) {
         let mut epoch_rewards = self.get_epoch_rewards_sysvar();
         assert!(epoch_rewards.active);
 
-        epoch_rewards.distribute(distributed);
+        epoch_rewards.distribute(inflation_reward_lamports_minted_and_burned);
 
         self.update_sysvar_account(&sysvar::epoch_rewards::id(), |account| {
             create_account(


### PR DESCRIPTION
#### Problem

As part of SIMD-0123, calculated block rewards must get distributed to stake accounts during the distribution phase of partitioned epoch rewards, but this logic hasn't been implemented yet.

#### Summary of changes

Distribute calculated block rewards during the distribution phase. This part assumes that `block_reward` has been calculated during the calculation phase, and moves that amount of lamports from the epoch rewards sysvar to the stake account.

#### Testing

Add block rewards to most distribution tests. Also, simplify a good amount of testing to reduce reliance on the `StakeReward` db type.