### PR TITLE
feat(snapshots): add StableAbi for snapshot serde types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7009,6 +7009,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -7196,6 +7197,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "tikv-jemallocator",
+ "wincode",
 ]
 
 [[package]]
@@ -8417,6 +8419,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -8828,6 +8831,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -8874,6 +8878,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -9940,6 +9945,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -11664,6 +11670,7 @@ dependencies = [
  "solana-vote-interface",
  "static_assertions",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -62,14 +62,14 @@ solana-address-lookup-table-interface = { workspace = true, features = [
 solana-bucket-map = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-fee-calculator = { workspace = true }
+solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true, features = ["serde"] }
+solana-hash = { workspace = true, features = ["serde", "wincode"] }
 solana-keypair = { workspace = true, optional = true }
 solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
@@ -94,6 +94,7 @@ solana-vote-program = { workspace = true, optional = true }
 spl-generic-token = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -30,6 +30,7 @@ impl HashInfo {
     frozen_abi(
         api_digest = "DZVVXt4saSgH1CWGrzBcX2sq5yswCuRqGx1Y1ZehtWT6",
         abi_digest = "5ojmBDhhu9AjKUc1LSHhZfXF6KeicvZpKP6XdLNaFAdy",
+        test_roundtrip = "eq_and_wire"
     )
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -7,10 +7,12 @@ use {
     solana_hash::Hash,
     solana_time_utils::timestamp,
     std::collections::HashMap,
+    wincode::SchemaWrite,
 };
 
+#[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, SchemaWrite)]
 pub struct HashInfo {
     fee_calculator: FeeCalculator,
     hash_index: u64,
@@ -33,7 +35,7 @@ impl HashInfo {
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaWrite)]
 pub struct BlockhashQueue {
     /// index of last hash to be registered
     last_hash_index: u64,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5798,6 +5798,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -5915,6 +5916,7 @@ dependencies = [
  "spl-generic-token",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -6735,6 +6737,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -6976,6 +6979,7 @@ checksum = "45406eccad36220e52988b024d8daa93e691e38d5d71ad5fec55410cc9cf427d"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7017,6 +7021,7 @@ checksum = "ccf104167e42e747602b88e02b25cacfc5de699c3b7cbba60d3250437e6a22ed"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7747,6 +7752,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -9069,6 +9075,7 @@ dependencies = [
  "solana-transaction",
  "solana-vote-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5818,6 +5818,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -5947,6 +5948,7 @@ dependencies = [
  "spl-generic-token",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -6856,6 +6858,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -7124,6 +7127,7 @@ checksum = "45406eccad36220e52988b024d8daa93e691e38d5d71ad5fec55410cc9cf427d"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7166,6 +7170,7 @@ checksum = "ccf104167e42e747602b88e02b25cacfc5de699c3b7cbba60d3250437e6a22ed"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -8008,6 +8013,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -10103,6 +10109,7 @@ dependencies = [
  "solana-transaction",
  "solana-vote-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -110,10 +110,10 @@ solana-ed25519-program = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-info = { workspace = true }
 solana-epoch-rewards-hasher = { workspace = true }
-solana-epoch-schedule = { workspace = true }
+solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-feature-gate-interface = { workspace = true, features = ["bincode"] }
 solana-fee = { workspace = true }
-solana-fee-calculator = { workspace = true }
+solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
@@ -122,9 +122,9 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-genesis-config = { workspace = true, features = ["serde"] }
-solana-hard-forks = { workspace = true, features = ["serde"] }
-solana-hash = { workspace = true, features = ["atomic"] }
-solana-inflation = { workspace = true, features = ["serde"] }
+solana-hard-forks = { workspace = true, features = ["serde", "wincode"] }
+solana-hash = { workspace = true, features = ["atomic", "wincode"] }
+solana-inflation = { workspace = true, features = ["serde", "wincode"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, features = ["seed-derivable"] }
 solana-lattice-hash = { workspace = true }
@@ -144,7 +144,7 @@ solana-program-binaries = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true, features = ["rand", "wincode"] }
 solana-rayon-threadlimit = { workspace = true }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode"] }
 solana-reward-info = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
@@ -157,7 +157,7 @@ solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-slot-history = { workspace = true, features = ["wincode"] }
-solana-stake-interface = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-callback = { workspace = true }
 solana-svm-timings = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1051,7 +1051,7 @@ pub struct ProcessedTransactionCounts {
 
 /// Account stats for computing the bank hash
 /// This struct is serialized and stored in the snapshot.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BankHashStats {
     pub num_updated_accounts: u64,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -215,6 +215,7 @@ use {
         time::{Duration, Instant},
     },
     thiserror::Error,
+    wincode::{SchemaRead, SchemaWrite},
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -1051,8 +1052,9 @@ pub struct ProcessedTransactionCounts {
 
 /// Account stats for computing the bank hash
 /// This struct is serialized and stored in the snapshot.
+#[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct BankHashStats {
     pub num_updated_accounts: u64,
     pub num_removed_accounts: u64,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -175,7 +175,7 @@ impl BLSPubkeyToRankMap {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq)]
 pub struct NodeVoteAccounts {
     pub vote_accounts: Vec<Pubkey>,
@@ -198,7 +198,10 @@ pub(crate) enum DeserializableVersionedEpochStakes {
 }
 
 #[derive(Clone, Debug, Serialize)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub enum VersionedEpochStakes {
     Current {
@@ -207,6 +210,7 @@ pub enum VersionedEpochStakes {
         total_stake: u64,
         node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
         epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+        #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
         #[serde(skip)]
         bls_pubkey_to_rank_map: OnceLock<Arc<BLSPubkeyToRankMap>>,
     },
@@ -369,7 +373,7 @@ impl VersionedEpochStakes {
 
 /// The current version of epoch stakes
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct EpochStakes {
     epoch: Epoch,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -57,7 +57,7 @@ use {
     },
     types::{SerdeAccountsLtHash, UnusedRentCollector},
     wincode::{
-        SchemaReadOwned, SchemaWrite,
+        SchemaRead, SchemaReadOwned, SchemaWrite,
         io::{Reader, std_write::WriteAdapter},
     },
 };
@@ -106,15 +106,17 @@ pub struct UnusedIncrementalSnapshotPersistence {
     pub incremental_capitalization: u64,
 }
 
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "EcPdH21GSyYYTiSZbAN157YfrT3G8rKvDiNh7q1fw8Bc",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct BankHashInfo {
     unused_accounts_delta_hash: [u8; 32],
     unused_accounts_hash: [u8; 32],
@@ -122,7 +124,7 @@ struct BankHashInfo {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, SchemaWrite)]
 struct UnusedAccounts {
     unused1: HashSet<Pubkey>,
     unused2: HashSet<Pubkey>,
@@ -215,10 +217,11 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
     // digest only verifies the serialized wire format; there is no roundtrip.
     frozen_abi(
         abi_digest = "6sm6hSNiTsNBAbSAiNe2BSQgnum3UdeNBpZnZiX7aM9r",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "no"
     )
 )]
-#[derive(Serialize)]
+#[derive(Serialize, SchemaWrite)]
 struct SerializableVersionedBank {
     blockhash_queue: BlockhashQueue,
     unused_ancestors: HashMap<Slot, usize>,

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -95,7 +95,7 @@ pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, Hash)>,
 );
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct UnusedIncrementalSnapshotPersistence {
@@ -106,7 +106,14 @@ pub struct UnusedIncrementalSnapshotPersistence {
     pub incremental_capitalization: u64,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "EcPdH21GSyYYTiSZbAN157YfrT3G8rKvDiNh7q1fw8Bc",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct BankHashInfo {
     unused_accounts_delta_hash: [u8; 32],
@@ -114,7 +121,7 @@ struct BankHashInfo {
     stats: BankHashStats,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 struct UnusedAccounts {
     unused1: HashSet<Pubkey>,
@@ -201,6 +208,16 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
 
 // Serializable version of Bank, not Deserializable to avoid cloning by using refs.
 // Sync fields with DeserializableVersionedBank!
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi, StableAbiSample),
+    // Write-only type (its deserialize counterpart is `DeserializableVersionedBank`), so the abi
+    // digest only verifies the serialized wire format; there is no roundtrip.
+    frozen_abi(
+        abi_digest = "6sm6hSNiTsNBAbSAiNe2BSQgnum3UdeNBpZnZiX7aM9r",
+        test_roundtrip = "no"
+    )
+)]
 #[derive(Serialize)]
 struct SerializableVersionedBank {
     blockhash_queue: BlockhashQueue,
@@ -413,7 +430,16 @@ struct ExtraFieldsToDeserialize {
 /// ExtraFieldsToDeserialize with the exception that new "extra fields" should
 /// be added to the deserialize struct a minor release before they are added to
 /// this one.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    // Write-only type (its deserialize counterpart is `ExtraFieldsToDeserialize`), so the abi digest
+    // only verifies the serialized wire format; there is no roundtrip.
+    frozen_abi(
+        abi_digest = "726M1TRfibJsSAGcFqan4TSC8qKkJhDZfiK2P3h71eoo",
+        test_roundtrip = "no"
+    )
+)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
 #[derive(Debug, Serialize)]
 pub struct ExtraFieldsToSerialize {

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -18,7 +18,12 @@ use {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p")
+    frozen_abi(
+        api_digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p",
+        abi_digest = "GuQrL8fa1SCkbNyctatMnKgxvVQFs47oR5nwAcLKCzXq",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire"
+    )
 )]
 type SerdeBankSlotDelta = SerdeSlotDelta<Result<(), SerdeTransactionError>>;
 type SerdeSlotDelta<T> = (Slot, bool, SerdeStatus<T>);
@@ -112,8 +117,8 @@ pub fn deserialize_status_cache(
 /// contain a string in the BorshIoError variant.
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
-    derive(AbiExample, AbiEnumVisitor)
+    frozen_abi(api_digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
 enum SerdeTransactionError {
@@ -304,7 +309,10 @@ impl From<SerdeTransactionError> for TransactionError {
 /// Copy of `InstructionError` type in which the `BorshIoError` variant
 /// contains a string.
 #[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
 enum SerdeInstructionError {
     GenericError,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -2,21 +2,26 @@ use {
     serde::{Deserialize, Serialize},
     solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// The serialized AccountsFileId type is fixed as usize
 pub(crate) type SerializedAccountsFileId = usize;
 
 // Serializable version of AccountStorageEntry for snapshot format
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "CMckX3HiC6K5FSmFo4tH44wU1mvGfabNtYAs65uaGvGU",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, SchemaRead, SchemaWrite,
+)]
 pub struct SerializableAccountStorageEntry {
     id: SerializedAccountsFileId,
     accounts_current_len: usize,

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -8,6 +8,14 @@ use {
 pub(crate) type SerializedAccountsFileId = usize;
 
 // Serializable version of AccountStorageEntry for snapshot format
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "CMckX3HiC6K5FSmFo4tH44wU1mvGfabNtYAs65uaGvGU",
+        test_roundtrip = "eq_and_wire"
+    )
+)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SerializableAccountStorageEntry {
     id: SerializedAccountsFileId,

--- a/runtime/src/serde_snapshot/types.rs
+++ b/runtime/src/serde_snapshot/types.rs
@@ -4,7 +4,7 @@ use {
 };
 
 /// Snapshot serde-safe AccountsLtHash
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[serde_with::serde_as]
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub struct SerdeAccountsLtHash(
@@ -26,7 +26,7 @@ impl From<AccountsLtHash> for SerdeAccountsLtHash {
 
 /// Snapshot serde-safe RentCollector, which is now unused
 #[repr(C)]
-#[cfg_attr(feature = "frozen-abi", derive(solana_frozen_abi_macro::AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct UnusedRentCollector {
     epoch: Epoch,

--- a/runtime/src/serde_snapshot/types.rs
+++ b/runtime/src/serde_snapshot/types.rs
@@ -1,6 +1,7 @@
 use {
     solana_accounts_db::accounts_hash::AccountsLtHash, solana_clock::Epoch,
     solana_epoch_schedule::EpochSchedule, solana_lattice_hash::lt_hash::LtHash, solana_rent::Rent,
+    wincode::SchemaWrite,
 };
 
 /// Snapshot serde-safe AccountsLtHash
@@ -27,7 +28,7 @@ impl From<AccountsLtHash> for SerdeAccountsLtHash {
 /// Snapshot serde-safe RentCollector, which is now unused
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, SchemaWrite)]
 pub struct UnusedRentCollector {
     epoch: Epoch,
     epoch_schedule: EpochSchedule,

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
-#[cfg(feature = "frozen-abi")]
-use solana_frozen_abi::abi_example::AbiExample;
 use {
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_instruction::error::InstructionError,
@@ -13,16 +11,41 @@ use {
     std::marker::PhantomData,
     thiserror::Error,
 };
+#[cfg(feature = "frozen-abi")]
+use {
+    solana_frozen_abi::{abi_example::AbiExample, stable_abi::StableAbi},
+    solana_stake_interface::{stake_flags::StakeFlags, state::Meta},
+};
 
 /// An account and a stake state deserialized from the account.
 /// Generic type T enforces type-safety so that StakeAccount<Delegation> can
 /// only wrap a stake-state which is a Delegation; whereas StakeAccount<()>
 /// wraps any account with stake state.
+#[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Default)]
 pub struct StakeAccount<T> {
+    // Skipped by the custom (delegation/stake-format) serializer; sample the default.
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     account: AccountSharedData,
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_delegated_stake_state(rng)")
+    )]
     stake_state: StakeStateV2,
     _phantom: PhantomData<T>,
+}
+
+/// Samples a random `StakeStateV2::Stake`; the delegation-format serializer unwraps
+/// `delegation_ref()`, which would panic on any other variant.
+#[cfg(feature = "frozen-abi")]
+fn sample_delegated_stake_state(
+    rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized),
+) -> StakeStateV2 {
+    StakeStateV2::Stake(
+        Meta::random(rng),
+        Stake::random(rng),
+        StakeFlags::random(rng),
+    )
 }
 
 #[derive(Debug, Error)]
@@ -108,13 +131,7 @@ impl<S, T> PartialEq<StakeAccount<S>> for StakeAccount<T> {
 #[cfg(feature = "frozen-abi")]
 impl AbiExample for StakeAccount<Delegation> {
     fn example() -> Self {
-        use {
-            solana_account::Account,
-            solana_stake_interface::{
-                stake_flags::StakeFlags,
-                state::{Meta, Stake},
-            },
-        };
+        use solana_account::Account;
         let stake_state =
             StakeStateV2::Stake(Meta::example(), Stake::example(), StakeFlags::example());
         let mut account = Account::example();

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -10,6 +10,7 @@ use {
     },
     std::marker::PhantomData,
     thiserror::Error,
+    wincode::SchemaWrite,
 };
 #[cfg(feature = "frozen-abi")]
 use {
@@ -33,6 +34,24 @@ pub struct StakeAccount<T> {
     )]
     stake_state: StakeStateV2,
     _phantom: PhantomData<T>,
+}
+
+// `StakeAccount<Delegation>` is only ever wincode-serialized as part of the snapshot's
+// `stake_delegations` map, which uses the delegation format: just the `Delegation` is written (see
+// `serialize_stake_accounts_to_delegation_format`). Mirror that here so the wincode bytes match
+// bincode; `FromIntoIterator` on the map picks up this per-value schema automatically.
+unsafe impl<C: wincode::config::Config> SchemaWrite<C> for StakeAccount<Delegation> {
+    type Src = Self;
+
+    const TYPE_META: wincode::TypeMeta = <Delegation as SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        <Delegation as SchemaWrite<C>>::size_of(src.delegation())
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        <Delegation as SchemaWrite<C>>::write(writer, src.delegation())
+    }
 }
 
 /// Samples a random `StakeStateV2::Stake`; the delegation-format serializer unwraps

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -12,7 +12,7 @@ use {
 };
 
 /// The SDK's stake history with clone-on-write semantics
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct StakeHistory(Arc<StakeHistoryInner>);
 

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -9,11 +9,12 @@ use {
         ops::{Deref, DerefMut},
         sync::Arc,
     },
+    wincode::SchemaWrite,
 };
 
 /// The SDK's stake history with clone-on-write semantics
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, SchemaWrite)]
 pub struct StakeHistory(Arc<StakeHistoryInner>);
 
 impl Deref for StakeHistory {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -1,5 +1,7 @@
 //! Stakes serve as a cache of stake and vote accounts to derive
 //! node stakes
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi::stable_abi::{context::SequenceLenMax, sample_collection_sized};
 use {
     crate::{
         alpenglow_epoch_type::RewardEpochDelegatedStakes,
@@ -188,7 +190,7 @@ impl StakesCache {
 /// account and StakeStateV2 deserialized from the account. Doing so, will remove
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Default, Clone, PartialEq, Debug, Serialize)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
@@ -206,9 +208,14 @@ pub struct Stakes<T: Clone> {
     vote_accounts: VoteAccounts,
 
     /// stake_delegations
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "sample_collection_sized(rng, SequenceLenMax(1))")
+    )]
     stake_delegations: ImblHashMap<Pubkey, T>,
 
     /// current effective stake delegated to each vote account pubkey
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
     delegated_stakes: DelegatedStakes,
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -30,6 +30,7 @@ use {
         sync::{Arc, RwLock, RwLockReadGuard},
     },
     thiserror::Error,
+    wincode::{SchemaWrite, containers::FromIntoIterator, len::BincodeLen},
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -191,7 +192,7 @@ impl StakesCache {
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Debug, Serialize)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(
@@ -212,11 +213,13 @@ pub struct Stakes<T: Clone> {
         feature = "frozen-abi",
         stable_abi_sample(with = "sample_collection_sized(rng, SequenceLenMax(1))")
     )]
+    #[wincode(with = "FromIntoIterator<ImblHashMap<Pubkey, T>, BincodeLen>")]
     stake_delegations: ImblHashMap<Pubkey, T>,
 
     /// current effective stake delegated to each vote account pubkey
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
+    #[wincode(skip)]
     delegated_stakes: DelegatedStakes,
 
     /// unused

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -30,6 +30,8 @@ dev-context-only-utils = [
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-account/frozen-abi",
+    "solana-pubkey/frozen-abi",
     "solana-vote-interface/frozen-abi",
 ]
 

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -41,7 +41,7 @@ log = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { version = "0.9.4", optional = true }
 serde = { workspace = true, features = ["rc"] }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
@@ -55,7 +55,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-packet = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
 solana-serialize-utils = { workspace = true }
 solana-signature = { workspace = true }
@@ -64,6 +64,7 @@ solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -32,7 +32,7 @@ use {
     },
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VoteAccount(Arc<VoteAccountInner>);
 
@@ -44,15 +44,20 @@ pub enum Error {
     InvalidOwner(/*owner:*/ Pubkey),
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug)]
 struct VoteAccountInner {
     account: AccountSharedData,
+    // Skipped by the custom serializer, and hard to instantiate other than via `AbiExample`.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "solana_frozen_abi::abi_example::AbiExample::example()")
+    )]
     vote_state_view: VoteStateView,
 }
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
@@ -62,6 +67,7 @@ pub struct VoteAccounts {
     #[serde(deserialize_with = "deserialize_accounts_hash_map")]
     vote_accounts: Arc<VoteAccountsHashMap>,
     // Inner Arc is meant to implement copy-on-write semantics.
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
     staked_nodes: OnceLock<
         Arc<

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -9,6 +9,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
+    solana_transaction::SchemaWrite,
     std::{
         cmp::Ordering,
         collections::{HashMap, hash_map::Entry},
@@ -36,6 +37,23 @@ use {
 #[derive(Clone, Debug, PartialEq)]
 pub struct VoteAccount(Arc<VoteAccountInner>);
 
+// `VoteAccount` serializes only its `account` (see the `Serialize` impl below). Mirror that for
+// wincode so the snapshot wire format matches bincode: `vote_state_view` is a parsed view of the
+// account data, rebuilt on read, and is intentionally not written.
+unsafe impl<C: wincode::config::Config> wincode::SchemaWrite<C> for VoteAccount {
+    type Src = Self;
+
+    const TYPE_META: wincode::TypeMeta = <AccountSharedData as wincode::SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        <AccountSharedData as wincode::SchemaWrite<C>>::size_of(&src.0.account)
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        <AccountSharedData as wincode::SchemaWrite<C>>::write(writer, &src.0.account)
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
@@ -44,6 +62,7 @@ pub enum Error {
     InvalidOwner(/*owner:*/ Pubkey),
 }
 
+// No `SchemaWrite`: `VoteAccount` has a custom impl that writes only `account` (see above).
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug)]
 struct VoteAccountInner {
@@ -58,7 +77,7 @@ struct VoteAccountInner {
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(vote_accounts(pub))
@@ -69,6 +88,7 @@ pub struct VoteAccounts {
     // Inner Arc is meant to implement copy-on-write semantics.
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
+    #[wincode(skip)]
     staked_nodes: OnceLock<
         Arc<
             HashMap<

--- a/vote/src/vote_state_view.rs
+++ b/vote/src/vote_state_view.rs
@@ -14,6 +14,7 @@ use {
     frame_v4::VoteStateFrameV4,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
+    solana_transaction::SchemaWrite,
     solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, BlockTimestamp, Lockout},
     std::sync::Arc,
 };
@@ -66,7 +67,7 @@ enum Simd185Field {
 /// This struct provides access to the VoteState data without
 /// deserializing it. This is done by parsing and caching metadata
 /// about the layout of the serialized VoteState.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub struct VoteStateView {
     data: Arc<Vec<u8>>,
@@ -257,7 +258,7 @@ impl From<VoteStateV4> for VoteStateView {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 enum VoteStateFrame {
     V1_14_11(VoteStateFrameV1_14_11),

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -2,6 +2,7 @@ use {
     super::{Result, VoteStateViewError, list_view::ListView},
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
+    solana_transaction::SchemaWrite,
     solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     std::io::{BufRead, Read},
 };
@@ -93,7 +94,8 @@ impl LockoutItem {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LockoutListFrame {
     pub(super) len: u8,
@@ -148,7 +150,8 @@ impl BlsPubkeyCompressedView<'_> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct BlsPubkeyCompressedFrame {
     pub(super) has_pubkey: bool,
@@ -182,7 +185,8 @@ impl BlsPubkeyCompressedFrame {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct LandedVotesListFrame {
     pub(super) len: u8,
@@ -227,7 +231,8 @@ impl ListFrame for LandedVotesListFrame {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct AuthorizedVotersListFrame {
     pub(super) len: u8,
@@ -284,7 +289,8 @@ pub struct EpochCreditsItem {
     prev_credits: [u8; 8],
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct EpochCreditsListFrame {
     pub(super) len: u8,
@@ -423,7 +429,8 @@ impl RootSlotView<'_> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct RootSlotFrame {
     pub(super) has_root_slot: bool,

--- a/vote/src/vote_state_view/frame_v1_14_11.rs
+++ b/vote/src/vote_state_view/frame_v1_14_11.rs
@@ -6,11 +6,12 @@ use {
         },
     },
     solana_pubkey::Pubkey,
+    solana_transaction::SchemaWrite,
     solana_vote_interface::state::BlockTimestamp,
     std::io::BufRead,
 };
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct VoteStateFrameV1_14_11 {
     pub(super) votes_frame: LockoutListFrame,

--- a/vote/src/vote_state_view/frame_v3.rs
+++ b/vote/src/vote_state_view/frame_v3.rs
@@ -9,9 +9,10 @@ use {
     solana_pubkey::Pubkey,
     solana_vote_interface::state::BlockTimestamp,
     std::io::BufRead,
+    wincode::SchemaWrite,
 };
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(super) struct VoteStateFrameV3 {
     pub(super) votes_frame: LandedVotesListFrame,

--- a/vote/src/vote_state_view/frame_v4.rs
+++ b/vote/src/vote_state_view/frame_v4.rs
@@ -7,9 +7,10 @@ use {
     solana_pubkey::Pubkey,
     solana_vote_interface::state::BlockTimestamp,
     std::io::BufRead,
+    wincode::SchemaWrite,
 };
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, SchemaWrite)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 pub(crate) struct VoteStateFrameV4 {
     pub(super) bls_pubkey_compressed_frame: BlsPubkeyCompressedFrame,


### PR DESCRIPTION
#### Problem
We should ensure binary format of snapshot serialization stays stable.
This would also prepare for switching the snapshot serialization path to
wincode.

#### Summary of Changes
Annotate the bincode-serialized snapshot types with StableAbi /
StableAbiSample and lock the wire format with frozen_abi(abi_digest) on the
top-level serialized types, so the later wincode switch can prove byte-for-byte
compatibility by checking the same digest under both serializers.

- Bank-fields stream: abi_digest on the minimum top-level set: BankHashInfo,
  SerializableAccountStorageEntry (test_roundtrip = "eq_and_wire");
  SerializableVersionedBank, ExtraFieldsToSerialize (write-only, so
  test_roundtrip = "no"); BlockhashQueue gains eq_and_wire.
- Status-cache stream (already wincode): abi_digest on SerdeBankSlotDelta with
  abi_serializer = "wincode"; StableAbi on SerdeTransactionError /
  SerdeInstructionError.
- Inner-transitive types get derives only (no digest): HashInfo, BankHashStats,
  StakeHistory, UnusedAccounts, UnusedRentCollector,
  UnusedIncrementalSnapshotPersistence, SerdeAccountsLtHash, StakeAccount,
  Stakes, VoteAccount, VoteAccountInner, VoteAccounts, EpochStakes,
  NodeVoteAccounts, VersionedEpochStakes.
- StableAbi sampling mirrors serialization. Fields a custom Serialize ignores
  use stable_abi_sample(with = ...): the serde(skip) OnceLock caches and
  StakeAccount::account use Default::default(); VoteAccountInner::vote_state_view
  (never serialized, no Default) uses AbiExample::example(). The
  StakeAccount<Delegation> delegation invariant is upheld at the leaf by sampling
  a random StakeStateV2::Stake variant; the imbl::HashMap of stake delegations is
  sampled via sample_collection_sized capped at one element for deterministic
  ordering.


#### Testing
CI / this change adds tests, no functional changes
