### PR TITLE
ci: add conformance test-vectors dispatcher stub

### DIFF
--- a/.github/workflows/conformance-dispatch.yml
+++ b/.github/workflows/conformance-dispatch.yml
@@ -36,9 +36,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           entries=$(cargo run --quiet --manifest-path ci/xtask/Cargo.toml -- \
-            conformance-table --pr-number ${{ github.event.pull_request.number }})
+            conformance-table --pr-number "$PR_NUMBER")
           echo "entries=$entries" >> "$GITHUB_OUTPUT"
 
   run:
@@ -51,6 +52,9 @@ jobs:
         entry: ${{ fromJSON(needs.detect.outputs.entries) }}
     steps:
       - name: Log (stub)
+        env:
+          HARNESS: ${{ matrix.entry.harness }}
+          FIXTURES_DIR: ${{ matrix.entry.fixtures_dir }}
         run: |
-          echo "stub: would run harness '${{ matrix.entry.harness }}' on fixtures '${{ matrix.entry.fixtures_dir }}'"
+          echo "stub: would run harness '$HARNESS' on fixtures '$FIXTURES_DIR'"
           echo "No fixtures downloaded or executed yet."

--- a/.github/workflows/conformance-dispatch.yml
+++ b/.github/workflows/conformance-dispatch.yml
@@ -1,0 +1,56 @@
+name: Conformance Dispatch
+
+on:
+  pull_request:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+
+    paths:
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/conformance-dispatch.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: detect affected fixture sets
+    if: github.repository_owner == 'anza-xyz'
+    runs-on: ubuntu-24.04
+    outputs:
+      entries: ${{ steps.table.outputs.entries }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Setup Rust
+        shell: bash
+        run: |
+          source ci/rust-version.sh stable
+          rustup default "$rust_stable"
+
+      - id: table
+        name: Build conformance table
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          entries=$(cargo run --quiet --manifest-path ci/xtask/Cargo.toml -- \
+            conformance-table --pr-number ${{ github.event.pull_request.number }})
+          echo "entries=$entries" >> "$GITHUB_OUTPUT"
+
+  run:
+    name: "stub: ${{ matrix.entry.harness }}"
+    needs: detect
+    if: needs.detect.outputs.entries != '[]'
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        entry: ${{ fromJSON(needs.detect.outputs.entries) }}
+    steps:
+      - name: Log (stub)
+        run: |
+          echo "stub: would run harness '${{ matrix.entry.harness }}' on fixtures '${{ matrix.entry.fixtures_dir }}'"
+          echo "No fixtures downloaded or executed yet."

--- a/ci/xtask/src/commands.rs
+++ b/ci/xtask/src/commands.rs
@@ -1,4 +1,5 @@
 pub mod channel_info;
+pub mod conformance_table;
 pub mod generate_pipeline;
 pub mod hello;
 pub mod xdp_test;

--- a/ci/xtask/src/commands/conformance_table.rs
+++ b/ci/xtask/src/commands/conformance_table.rs
@@ -1,0 +1,268 @@
+use {
+    crate::github::{self, Repo},
+    anyhow::Result,
+    clap::Args,
+    log::info,
+    serde::Serialize,
+    std::{
+        collections::{HashMap, HashSet},
+        process::Command,
+    },
+};
+
+#[derive(Args)]
+pub struct CommandArgs {
+    /// The pull request number to inspect for changed files.
+    #[arg(long)]
+    pub pr_number: u64,
+}
+
+/// One row of the conformance dispatch table.
+#[derive(Serialize)]
+pub struct TableEntry {
+    pub harness: String,
+    pub fixtures_dir: String,
+}
+
+/// Static fixture-set table: (fixtures_dir, anchor_crate, harness_binary).
+const FIXTURE_ANCHORS: &[(&str, &str, &str)] = &[
+    ("instr", "solana-svm", "sol_compat_instr_v1"),
+    ("txn", "solana-runtime", "sol_compat_txn_v1"),
+    ("block", "solana-ledger", "sol_compat_block_v1"),
+    (
+        "elf_loader",
+        "solana-program-runtime",
+        "sol_compat_elf_loader_v1",
+    ),
+    ("syscall", "solana-program-runtime", "sol_compat_syscall_v1"),
+    (
+        "vm_serialization",
+        "solana-program-runtime",
+        "sol_compat_vm_serialization_v1",
+    ),
+    ("cost", "solana-cost-model", "sol_compat_cost_v1"),
+    ("shred", "solana-core", "sol_compat_shred_v1"),
+    ("gossip", "solana-gossip", "sol_compat_gossip_v1"),
+];
+
+/// Map changed file paths to workspace crate names using `cargo metadata`.
+fn changed_files_to_crates(changed_files: &[String]) -> Result<HashSet<String>> {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`cargo metadata` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let meta: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    let workspace_root = meta["workspace_root"]
+        .as_str()
+        .unwrap_or("")
+        .trim_end_matches('/');
+
+    // Build (dir_prefix, crate_name) pairs sorted longest-prefix first so the
+    // first match wins (handles nested crates like accounts-db/store-histogram).
+    let mut crate_dirs: Vec<(String, String)> = meta["packages"]
+        .as_array()
+        .unwrap_or(&vec![])
+        .iter()
+        .filter_map(|pkg| {
+            let manifest = pkg["manifest_path"].as_str()?;
+            let dir = manifest
+                .strip_suffix("/Cargo.toml")?
+                .strip_prefix(workspace_root)?
+                .trim_start_matches('/');
+            let name = pkg["name"].as_str()?;
+            Some((dir.to_string(), name.to_string()))
+        })
+        .collect();
+    crate_dirs.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.len()));
+
+    let mut result = HashSet::new();
+    for file in changed_files {
+        for (dir, name) in &crate_dirs {
+            if dir.is_empty() || file == dir || file.starts_with(&format!("{dir}/")) {
+                result.insert(name.clone());
+                break;
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Get the direct normal dependencies of an anchor crate using `cargo tree`.
+fn anchor_direct_deps(anchor: &str) -> Result<HashSet<String>> {
+    let output = Command::new("cargo")
+        .args([
+            "tree",
+            "--package",
+            anchor,
+            "--edges",
+            "normal",
+            "--depth",
+            "1",
+            "--prefix",
+            "none",
+        ])
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "`cargo tree` failed for {anchor}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let deps = String::from_utf8(output.stdout)?
+        .lines()
+        .filter_map(|line| line.split_whitespace().next().map(str::to_string))
+        .collect();
+    Ok(deps)
+}
+
+/// Pure selection logic: returns entries for fixture sets whose anchor or any
+/// of its direct normal deps appear in `changed_crates`.
+/// Extracted as a pure function so it can be unit-tested without I/O.
+pub fn select_entries(
+    changed_crates: &HashSet<String>,
+    anchor_deps: &HashMap<String, HashSet<String>>,
+) -> Vec<TableEntry> {
+    let mut entries = Vec::new();
+    for &(fixtures_dir, anchor, harness) in FIXTURE_ANCHORS {
+        let empty = HashSet::new();
+        let deps = anchor_deps.get(anchor).unwrap_or(&empty);
+        let matched = changed_crates.iter().any(|c| deps.contains(c));
+        if matched {
+            info!("selected: {fixtures_dir} (harness={harness})");
+            entries.push(TableEntry {
+                harness: harness.to_string(),
+                fixtures_dir: fixtures_dir.to_string(),
+            });
+        }
+    }
+    entries
+}
+
+pub async fn run(args: CommandArgs) -> Result<()> {
+    let repo = Repo::from_env();
+    let changed_files = github::get_changed_files(&repo, args.pr_number).await?;
+
+    if changed_files.is_empty() {
+        println!("[]");
+        return Ok(());
+    }
+
+    let changed_crates = changed_files_to_crates(&changed_files)?;
+    info!("changed crates: {changed_crates:?}");
+
+    // Precompute dep sets for each unique anchor (deduplicated).
+    let mut anchor_deps: HashMap<String, HashSet<String>> = HashMap::new();
+    for &(_, anchor, _) in FIXTURE_ANCHORS {
+        anchor_deps
+            .entry(anchor.to_string())
+            .or_insert_with(|| anchor_direct_deps(anchor).unwrap_or_default());
+    }
+
+    let entries = select_entries(&changed_crates, &anchor_deps);
+    println!("{}", serde_json::to_string(&entries)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, pretty_assertions::assert_eq};
+
+    fn deps(anchor: &str, crates: &[&str]) -> (String, HashSet<String>) {
+        (
+            anchor.to_string(),
+            crates.iter().map(|s| s.to_string()).collect(),
+        )
+    }
+
+    fn make_anchor_deps(pairs: &[(&str, &[&str])]) -> HashMap<String, HashSet<String>> {
+        pairs
+            .iter()
+            .map(|(anchor, crates)| deps(anchor, crates))
+            .collect()
+    }
+
+    fn fixture_dirs(entries: &[TableEntry]) -> Vec<&str> {
+        entries.iter().map(|e| e.fixtures_dir.as_str()).collect()
+    }
+
+    #[test]
+    fn test_no_changes_selects_nothing() {
+        let changed = HashSet::new();
+        let anchor_deps = make_anchor_deps(&[("solana-svm", &["solana-svm", "some-dep"])]);
+        let entries = select_entries(&changed, &anchor_deps);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_anchor_itself_selects_fixture() {
+        let changed = ["solana-svm".to_string()].into();
+        let anchor_deps = make_anchor_deps(&[("solana-svm", &["solana-svm", "some-dep"])]);
+        let entries = select_entries(&changed, &anchor_deps);
+        assert_eq!(fixture_dirs(&entries), vec!["instr"]);
+    }
+
+    #[test]
+    fn test_direct_dep_selects_fixture() {
+        let changed = ["some-dep".to_string()].into();
+        let anchor_deps = make_anchor_deps(&[("solana-svm", &["solana-svm", "some-dep"])]);
+        let entries = select_entries(&changed, &anchor_deps);
+        assert_eq!(fixture_dirs(&entries), vec!["instr"]);
+    }
+
+    #[test]
+    fn test_unrelated_crate_selects_nothing() {
+        let changed = ["totally-unrelated-crate".to_string()].into();
+        let anchor_deps = make_anchor_deps(&[("solana-svm", &["solana-svm", "some-dep"])]);
+        let entries = select_entries(&changed, &anchor_deps);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_shared_anchor_selects_multiple_fixtures() {
+        // elf_loader, syscall, vm_serialization all anchor on solana-program-runtime
+        let changed = ["solana-program-runtime".to_string()].into();
+        let anchor_deps = make_anchor_deps(&[(
+            "solana-program-runtime",
+            &["solana-program-runtime", "dep-a"],
+        )]);
+        let entries = select_entries(&changed, &anchor_deps);
+        let dirs = fixture_dirs(&entries);
+        assert!(dirs.contains(&"elf_loader"), "expected elf_loader");
+        assert!(dirs.contains(&"syscall"), "expected syscall");
+        assert!(
+            dirs.contains(&"vm_serialization"),
+            "expected vm_serialization"
+        );
+    }
+
+    #[test]
+    fn test_multiple_changed_crates_selects_multiple_fixtures() {
+        let changed = ["solana-svm".to_string(), "solana-runtime".to_string()].into();
+        let anchor_deps = make_anchor_deps(&[
+            ("solana-svm", &["solana-svm"]),
+            ("solana-runtime", &["solana-runtime"]),
+        ]);
+        let entries = select_entries(&changed, &anchor_deps);
+        let dirs = fixture_dirs(&entries);
+        assert!(dirs.contains(&"instr"), "expected instr");
+        assert!(dirs.contains(&"txn"), "expected txn");
+    }
+
+    #[test]
+    fn test_entry_json_shape() {
+        let entry = TableEntry {
+            harness: "sol_compat_instr_v1".to_string(),
+            fixtures_dir: "instr".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert_eq!(
+            json,
+            r#"{"harness":"sol_compat_instr_v1","fixtures_dir":"instr"}"#
+        );
+    }
+}

--- a/ci/xtask/src/commands/conformance_table.rs
+++ b/ci/xtask/src/commands/conformance_table.rs
@@ -143,6 +143,27 @@ pub fn select_entries(
     entries
 }
 
+/// Every fixture set, used when a change is workspace-wide and can't be
+/// attributed to a single crate (e.g. the workspace manifest or lockfile).
+fn all_entries() -> Vec<TableEntry> {
+    FIXTURE_ANCHORS
+        .iter()
+        .map(|&(fixtures_dir, _, harness)| TableEntry {
+            harness: harness.to_string(),
+            fixtures_dir: fixtures_dir.to_string(),
+        })
+        .collect()
+}
+
+/// A change to the workspace manifest or lockfile can affect any crate, so it
+/// can't be attributed to one anchor. These are the repo-root `Cargo.toml` and
+/// `Cargo.lock` (no directory prefix); nested manifests map to their own crate.
+fn is_workspace_wide_change(changed_files: &[String]) -> bool {
+    changed_files
+        .iter()
+        .any(|f| f == "Cargo.toml" || f == "Cargo.lock")
+}
+
 pub async fn run(args: CommandArgs) -> Result<()> {
     let repo = Repo::from_env();
     let changed_files = github::get_changed_files(&repo, args.pr_number).await?;
@@ -152,18 +173,24 @@ pub async fn run(args: CommandArgs) -> Result<()> {
         return Ok(());
     }
 
-    let changed_crates = changed_files_to_crates(&changed_files)?;
-    info!("changed crates: {changed_crates:?}");
+    let entries = if is_workspace_wide_change(&changed_files) {
+        info!("workspace manifest/lockfile changed; dispatching all fixture sets");
+        all_entries()
+    } else {
+        let changed_crates = changed_files_to_crates(&changed_files)?;
+        info!("changed crates: {changed_crates:?}");
 
-    // Precompute dep sets for each unique anchor (deduplicated).
-    let mut anchor_deps: HashMap<String, HashSet<String>> = HashMap::new();
-    for &(_, anchor, _) in FIXTURE_ANCHORS {
-        anchor_deps
-            .entry(anchor.to_string())
-            .or_insert_with(|| anchor_direct_deps(anchor).unwrap_or_default());
-    }
+        // Precompute dep sets for each unique anchor (deduplicated).
+        let mut anchor_deps: HashMap<String, HashSet<String>> = HashMap::new();
+        for &(_, anchor, _) in FIXTURE_ANCHORS {
+            if !anchor_deps.contains_key(anchor) {
+                anchor_deps.insert(anchor.to_string(), anchor_direct_deps(anchor)?);
+            }
+        }
 
-    let entries = select_entries(&changed_crates, &anchor_deps);
+        select_entries(&changed_crates, &anchor_deps)
+    };
+
     println!("{}", serde_json::to_string(&entries)?);
     Ok(())
 }
@@ -264,5 +291,24 @@ mod tests {
             json,
             r#"{"harness":"sol_compat_instr_v1","fixtures_dir":"instr"}"#
         );
+    }
+
+    #[test]
+    fn test_all_entries_covers_every_fixture() {
+        assert_eq!(all_entries().len(), FIXTURE_ANCHORS.len());
+    }
+
+    #[test]
+    fn test_workspace_root_manifest_and_lockfile_are_workspace_wide() {
+        assert!(is_workspace_wide_change(&["Cargo.toml".to_string()]));
+        assert!(is_workspace_wide_change(&["Cargo.lock".to_string()]));
+    }
+
+    #[test]
+    fn test_nested_manifest_is_not_workspace_wide() {
+        assert!(!is_workspace_wide_change(&[
+            "svm/Cargo.toml".to_string(),
+            "programs/sbf/Cargo.lock".to_string(),
+        ]));
     }
 }

--- a/ci/xtask/src/main.rs
+++ b/ci/xtask/src/main.rs
@@ -33,6 +33,8 @@ enum Commands {
     ChannelInfo(commands::channel_info::CommandArgs),
     #[command(about = "Run XDP integration tests")]
     XdpTest(commands::xdp_test::CommandArgs),
+    #[command(about = "Emit conformance fixture dispatch table as JSON")]
+    ConformanceTable(commands::conformance_table::CommandArgs),
 }
 
 #[derive(Args, Debug)]
@@ -88,6 +90,9 @@ async fn try_main(xtask: Xtask) -> Result<()> {
         }
         Commands::XdpTest(args) => {
             commands::xdp_test::run(args)?;
+        }
+        Commands::ConformanceTable(args) => {
+            commands::conformance_table::run(args).await?;
         }
     }
 


### PR DESCRIPTION
### conformance: initial test-vectors CI dispatcher (stub)

Closes #13387

#### Problem

As conformance harnesses migrate into the Agave codebase, there is no mechanism linking a pull request to the test-vector fixture sets it affects. Running every fixture set against every PR wastes CI resources.

#### Approach

A **PR-scoped dispatcher** that maps changed crates to the conformance fixture sets they affect, then emits a JSON matrix that a GitHub Actions `run` job fans out over. This is a **stub**: it identifies what *would* run and logs it — no fixtures are downloaded or executed. Real execution lands once the test-vectors project publishes release artifacts.

**Anchor-crate model:** each fixture set declares one anchor crate. A fixture set is selected when any changed crate is the anchor *or one of its direct normal dependencies*. Direct deps are read from the live cargo graph (`cargo tree --edges normal --depth 1`), so they stay correct as dependencies evolve. The graph is walked only one level deep on purpose — a full transitive closure would pull low-level crates (e.g. `solana-program-runtime`) into nearly every anchor and select almost everything.

| fixtures_dir | anchor crate | harness |
|---|---|---|
| instr | solana-svm | sol_compat_instr_v1 |
| txn | solana-runtime | sol_compat_txn_v1 |
| block | solana-ledger | sol_compat_block_v1 |
| elf_loader | solana-program-runtime | sol_compat_elf_loader_v1 |
| syscall | solana-program-runtime | sol_compat_syscall_v1 |
| vm_serialization | solana-program-runtime | sol_compat_vm_serialization_v1 |
| cost | solana-cost-model | sol_compat_cost_v1 |
| shred | solana-core | sol_compat_shred_v1 |
| gossip | solana-gossip | sol_compat_gossip_v1 |

#### Implementation

Detection lives in a new **`xtask` subcommand** rather than a standalone script, so it reuses the existing "PR changed-set → what runs" machinery instead of maintaining a parallel git-diff path (per @mircea-c's review):

- **`cargo xtask conformance-table --pr-number <N>`** (`ci/xtask/src/commands/conformance_table.rs`) — resolves changed files via the GitHub API, maps them to workspace crates (`cargo metadata`), computes anchor dep sets (`cargo tree`), and emits a serde-typed JSON array of `{ harness, fixtures_dir }` to stdout. The selection core (`select_entries`) is a pure function with unit tests.
- **`ci/xtask/src/commands/github.rs`** (new shared module) — extracted `Repo` + `get_changed_files()` out of `generate_pipeline.rs` so both commands share one source of truth. Their existing tests moved with them; added `Repo::from_env` coverage.
- **`.github/workflows/conformance-dispatch.yml`** — two jobs: `detect` runs the subcommand and captures its JSON as a step output; `run` fans out over `fromJSON(...)` as a matrix and logs the stub action. Scoped to `pull_request` only (detection is PR-number-keyed), passes `GH_TOKEN`.

#### Example

A PR changing `solana-accounts-db` + `solana-runtime` (real run against #13549) emits:

```json
[{"harness":"sol_compat_txn_v1","fixtures_dir":"txn"},{"harness":"sol_compat_block_v1","fixtures_dir":"block"},{"harness":"sol_compat_shred_v1","fixtures_dir":"shred"}]
```

#### Testing

- `cargo test --manifest-path ci/xtask/Cargo.toml` — unit tests on anchor selection (anchor match, dep-only match, no match, shared anchor → multiple fixtures) and repo resolution.
- Verified end-to-end against a live PR: valid JSON on stdout, logs on stderr, matrix fans out correctly.