### PR TITLE
feat(transaction-status): Parse the permissioned burn ConfidentialBurn instruction

### DIFF
--- a/transaction-status/src/parse_token/extension/permissioned_burn.rs
+++ b/transaction-status/src/parse_token/extension/permissioned_burn.rs
@@ -1,9 +1,12 @@
 use {
     super::*,
     spl_token_2022_interface::{
-        extension::permissioned_burn::instruction::{
-            BurnCheckedInstructionData, BurnInstructionData, InitializeInstructionData,
-            PermissionedBurnInstruction,
+        extension::{
+            confidential_mint_burn::instruction::BurnInstructionData as ConfidentialBurnInstructionData,
+            permissioned_burn::instruction::{
+                BurnCheckedInstructionData, BurnInstructionData, InitializeInstructionData,
+                PermissionedBurnInstruction,
+            },
         },
         instruction::{decode_instruction_data, decode_instruction_type},
     },
@@ -84,9 +87,92 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
                 info: value,
             })
         }
-        PermissionedBurnInstruction::ConfidentialBurn => Err(
-            ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken),
-        ),
+        PermissionedBurnInstruction::ConfidentialBurn => {
+            check_num_token_accounts(account_indexes, 4)?;
+            let burn_data: ConfidentialBurnInstructionData =
+                *decode_instruction_data(instruction_data).map_err(|_| {
+                    ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
+                })?;
+            let mut value = json!({
+                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "newDecryptableAvailableBalance": burn_data.new_decryptable_available_balance.to_string(),
+                "equalityProofInstructionOffset": burn_data.equality_proof_instruction_offset,
+                "ciphertextValidityProofInstructionOffset": burn_data.ciphertext_validity_proof_instruction_offset,
+                "rangeProofInstructionOffset": burn_data.range_proof_instruction_offset,
+            });
+            let map = value.as_object_mut().unwrap();
+            // The permissioned burn authority and the owner/delegate are the
+            // trailing accounts; everything between the mint and them is optional
+            // proof material. Reserve those two when walking the proof accounts.
+            let mut offset = 2;
+            if offset < account_indexes.len() - 2
+                && (burn_data.equality_proof_instruction_offset != 0
+                    || burn_data.ciphertext_validity_proof_instruction_offset != 0
+                    || burn_data.range_proof_instruction_offset != 0)
+            {
+                map.insert(
+                    "instructionsSysvar".to_string(),
+                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                );
+                offset += 1;
+            }
+            // Assume that extra accounts are proof accounts and not multisig
+            // signers. This might be wrong, but it's the best possible option.
+            if offset < account_indexes.len() - 2 {
+                let label = if burn_data.equality_proof_instruction_offset == 0 {
+                    "equalityProofContextStateAccount"
+                } else {
+                    "equalityProofRecordAccount"
+                };
+                map.insert(
+                    label.to_string(),
+                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                );
+                offset += 1;
+            }
+            if offset < account_indexes.len() - 2 {
+                let label = if burn_data.ciphertext_validity_proof_instruction_offset == 0 {
+                    "ciphertextValidityProofContextStateAccount"
+                } else {
+                    "ciphertextValidityProofRecordAccount"
+                };
+                map.insert(
+                    label.to_string(),
+                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                );
+                offset += 1;
+            }
+            if offset < account_indexes.len() - 2 {
+                let label = if burn_data.range_proof_instruction_offset == 0 {
+                    "rangeProofContextStateAccount"
+                } else {
+                    "rangeProofRecordAccount"
+                };
+                map.insert(
+                    label.to_string(),
+                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                );
+                offset += 1;
+            }
+            map.insert(
+                "permissionedBurnAuthority".to_string(),
+                json!(account_keys[account_indexes[offset] as usize].to_string()),
+            );
+            offset += 1;
+            parse_signers(
+                map,
+                offset,
+                account_keys,
+                account_indexes,
+                "authority",
+                "multisigAuthority",
+            );
+            Ok(ParsedInstructionEnum {
+                instruction_type: "permissionedConfidentialBurn".to_string(),
+                info: value,
+            })
+        }
     }
 }
 
@@ -94,10 +180,38 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
 mod test {
     use {
         super::*,
+        bytemuck::Zeroable,
+        solana_instruction::{AccountMeta, Instruction},
         solana_message::Message,
         solana_pubkey::Pubkey,
-        spl_token_2022_interface::extension::permissioned_burn::instruction::{burn, initialize},
+        solana_zk_sdk_pod::encryption::{
+            auth_encryption::PodAeCiphertext, elgamal::PodElGamalCiphertext,
+        },
+        spl_token_2022_interface::{
+            extension::permissioned_burn::instruction::{
+                burn, confidential_burn_with_split_proofs, initialize,
+            },
+            solana_zk_elgamal_proof_interface::proof_data::{
+                BatchedGroupedCiphertext3HandlesValidityProofData, BatchedRangeProofU128Data,
+                CiphertextCommitmentEqualityProofData,
+            },
+        },
+        spl_token_confidential_transfer_proof_extraction::instruction::ProofLocation,
+        std::num::NonZero,
     };
+
+    fn check_no_panic(mut instruction: Instruction) {
+        let account_meta = AccountMeta::new_readonly(Pubkey::new_unique(), false);
+        for i in 0..20 {
+            instruction.accounts = vec![account_meta.clone(); i];
+            let message = Message::new(&[instruction.clone()], None);
+            let compiled_instruction = &message.instructions[0];
+            let _ = parse_token(
+                compiled_instruction,
+                &AccountKeys::new(&message.account_keys, None),
+            );
+        }
+    }
 
     #[test]
     fn test_parse_initialize_permissioned_burn_instruction() {
@@ -157,5 +271,47 @@ mod test {
                 })
             }
         );
+    }
+
+    #[test]
+    fn test_parse_permissioned_confidential_burn_instruction() {
+        for (equality_proof_location, ciphertext_validity_proof_location, range_proof_location) in [
+            (
+                ProofLocation::InstructionOffset(
+                    NonZero::new(1).unwrap(),
+                    &CiphertextCommitmentEqualityProofData::zeroed(),
+                ),
+                ProofLocation::InstructionOffset(
+                    NonZero::new(2).unwrap(),
+                    &BatchedGroupedCiphertext3HandlesValidityProofData::zeroed(),
+                ),
+                ProofLocation::InstructionOffset(
+                    NonZero::new(3).unwrap(),
+                    &BatchedRangeProofU128Data::zeroed(),
+                ),
+            ),
+            (
+                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
+                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
+                ProofLocation::ContextStateAccount(&Pubkey::new_unique()),
+            ),
+        ] {
+            let instructions = confidential_burn_with_split_proofs(
+                &spl_token_2022_interface::id(),
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &PodAeCiphertext::default(),
+                &PodElGamalCiphertext::default(),
+                &PodElGamalCiphertext::default(),
+                &Pubkey::new_unique(),
+                &[],
+                equality_proof_location,
+                ciphertext_validity_proof_location,
+                range_proof_location,
+            )
+            .unwrap();
+            check_no_panic(instructions[0].clone());
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #13504 (now merged), which migrated to spl-token-2022-interface 3.x and stubbed `PermissionedBurnInstruction::ConfidentialBurn` as not-parsable. This adds the parser.

#### Summary

Mirrors the existing confidential mint-burn `Burn` parser, since they share the `BurnInstructionData` layout (decryptable balance + the three proof instruction offsets), with the permissioned burn authority sitting between the optional proof accounts and the owner/delegate. Emits `permissionedConfidentialBurn`.

Optional proof material (instructions sysvar, equality / ciphertext-validity / range proof context-state or record accounts) is walked the same way as the confidential mint-burn parser, reserving the two trailing accounts (permissioned burn authority + owner) before handing off to `parse_signers`.

#### Tests

Adds a `check_no_panic` smoke test over the instruction built by `confidential_burn_with_split_proofs` (both instruction-offset and context-state-account proof locations), matching the confidential mint-burn test pattern.