### PR TITLE
feat(snapshots): support snapshot serialization with wincode schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7002,6 +7002,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -7190,6 +7191,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "tikv-jemallocator",
+ "wincode",
 ]
 
 [[package]]
@@ -8398,6 +8400,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -8809,6 +8812,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -8855,6 +8859,7 @@ dependencies = [
  "serde_derive",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
+ "wincode",
 ]
 
 [[package]]
@@ -9939,6 +9944,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -11664,6 +11670,7 @@ dependencies = [
  "solana-vote-interface",
  "static_assertions",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -13352,6 +13359,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
+ "smallvec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -62,14 +62,14 @@ solana-address-lookup-table-interface = { workspace = true, features = [
 solana-bucket-map = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-fee-calculator = { workspace = true }
+solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true, features = ["serde"] }
+solana-hash = { workspace = true, features = ["serde", "wincode"] }
 solana-keypair = { workspace = true, optional = true }
 solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
@@ -94,6 +94,7 @@ solana-vote-program = { workspace = true, optional = true }
 spl-generic-token = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/accounts-db/src/blockhash_queue.rs
+++ b/accounts-db/src/blockhash_queue.rs
@@ -7,10 +7,12 @@ use {
     solana_hash::Hash,
     solana_time_utils::timestamp,
     std::collections::HashMap,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
+#[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct HashInfo {
     fee_calculator: FeeCalculator,
     hash_index: u64,
@@ -30,10 +32,11 @@ impl HashInfo {
     frozen_abi(
         api_digest = "DZVVXt4saSgH1CWGrzBcX2sq5yswCuRqGx1Y1ZehtWT6",
         abi_digest = "5ojmBDhhu9AjKUc1LSHhZfXF6KeicvZpKP6XdLNaFAdy",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub struct BlockhashQueue {
     /// index of last hash to be registered
     last_hash_index: u64,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5782,6 +5782,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -5900,6 +5901,7 @@ dependencies = [
  "spl-generic-token",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -6701,6 +6703,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -6942,6 +6945,7 @@ checksum = "45406eccad36220e52988b024d8daa93e691e38d5d71ad5fec55410cc9cf427d"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -6983,6 +6987,7 @@ checksum = "ccf104167e42e747602b88e02b25cacfc5de699c3b7cbba60d3250437e6a22ed"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7731,6 +7736,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -9054,6 +9060,7 @@ dependencies = [
  "solana-transaction",
  "solana-vote-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -10458,6 +10465,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
+ "smallvec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5799,6 +5799,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-sdk-ids",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -5929,6 +5930,7 @@ dependencies = [
  "spl-generic-token",
  "tempfile",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -6819,6 +6821,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -7087,6 +7090,7 @@ checksum = "45406eccad36220e52988b024d8daa93e691e38d5d71ad5fec55410cc9cf427d"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7129,6 +7133,7 @@ checksum = "ccf104167e42e747602b88e02b25cacfc5de699c3b7cbba60d3250437e6a22ed"
 dependencies = [
  "serde",
  "serde_derive",
+ "wincode",
 ]
 
 [[package]]
@@ -7989,6 +7994,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -10085,6 +10091,7 @@ dependencies = [
  "solana-transaction",
  "solana-vote-interface",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -11616,6 +11623,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
+ "smallvec",
  "thiserror 2.0.18",
  "wincode-derive",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -110,10 +110,10 @@ solana-ed25519-program = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-info = { workspace = true }
 solana-epoch-rewards-hasher = { workspace = true }
-solana-epoch-schedule = { workspace = true }
+solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-feature-gate-interface = { workspace = true, features = ["bincode"] }
 solana-fee = { workspace = true }
-solana-fee-calculator = { workspace = true }
+solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
@@ -122,9 +122,9 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-genesis-config = { workspace = true, features = ["serde"] }
-solana-hard-forks = { workspace = true, features = ["serde"] }
-solana-hash = { workspace = true, features = ["atomic"] }
-solana-inflation = { workspace = true, features = ["serde"] }
+solana-hard-forks = { workspace = true, features = ["serde", "wincode"] }
+solana-hash = { workspace = true, features = ["atomic", "wincode"] }
+solana-inflation = { workspace = true, features = ["serde", "wincode"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, features = ["seed-derivable"] }
 solana-lattice-hash = { workspace = true }
@@ -144,7 +144,7 @@ solana-program-binaries = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, features = ["metrics"] }
 solana-pubkey = { workspace = true, features = ["rand", "wincode"] }
 solana-rayon-threadlimit = { workspace = true }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode"] }
 solana-reward-info = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
@@ -157,7 +157,7 @@ solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-slot-history = { workspace = true, features = ["wincode"] }
-solana-stake-interface = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-callback = { workspace = true }
 solana-svm-timings = { workspace = true }
@@ -183,7 +183,7 @@ strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-wincode = { workspace = true }
+wincode = { workspace = true, features = ["smallvec"] }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -215,6 +215,7 @@ use {
         time::{Duration, Instant},
     },
     thiserror::Error,
+    wincode::{SchemaRead, SchemaWrite},
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -1054,8 +1055,9 @@ pub struct ProcessedTransactionCounts {
 
 /// Account stats for computing the bank hash
 /// This struct is serialized and stored in the snapshot.
+#[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct BankHashStats {
     pub num_updated_accounts: u64,
     pub num_removed_accounts: u64,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -20,6 +20,7 @@ use {
         num::NonZero,
         sync::{Arc, OnceLock},
     },
+    wincode::{SchemaRead, SchemaWrite, WriteResult},
 };
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
@@ -176,7 +177,7 @@ impl BLSPubkeyToRankMap {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Serialize, Debug, Deserialize, Default, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub struct NodeVoteAccounts {
     pub vote_accounts: Vec<Pubkey>,
     pub total_stake: u64,
@@ -197,7 +198,7 @@ pub(crate) enum DeserializableVersionedEpochStakes {
     },
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, SchemaWrite)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
@@ -212,6 +213,7 @@ pub enum VersionedEpochStakes {
         epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
         #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
         #[serde(skip)]
+        #[wincode(skip)]
         bls_pubkey_to_rank_map: OnceLock<Arc<BLSPubkeyToRankMap>>,
     },
 }
@@ -392,29 +394,50 @@ impl EpochStakes {
 
 /// Customization of EpochStakes for snapshot serialization.
 ///
-/// Needed because snapshots require additional fields no longer present in EpochStakes.
+/// Needed because snapshots require additional fields no longer present in EpochStakes: the
+/// fields are reordered relative to `EpochStakes` and an always-empty `stake_delegations` list
+/// plus an unused `u64` are injected to match the historical wire format.
+#[derive(Serialize, SchemaWrite)]
+struct SerializableEpochStakes<'a> {
+    vote_accounts: &'a VoteAccounts,
+    stake_delegations: Vec<(Pubkey, Stake)>,
+    unused: u64,
+    epoch: Epoch,
+    stake_history: &'a StakeHistory,
+}
+
+impl<'a> From<&'a EpochStakes> for SerializableEpochStakes<'a> {
+    fn from(epoch_stakes: &'a EpochStakes) -> Self {
+        Self {
+            vote_accounts: &epoch_stakes.vote_accounts,
+            stake_delegations: Vec::new(), // do not serialize any stake delegations
+            unused: 0,
+            epoch: epoch_stakes.epoch,
+            stake_history: &epoch_stakes.stake_history,
+        }
+    }
+}
+
 impl Serialize for EpochStakes {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        #[derive(Serialize)]
-        struct SerializableEpochStakes<'a> {
-            vote_accounts: &'a VoteAccounts,
-            stake_delegations: Vec<(Pubkey, Stake)>,
-            unused: u64,
-            epoch: Epoch,
-            stake_history: &'a StakeHistory,
-        }
+        SerializableEpochStakes::from(self).serialize(serializer)
+    }
+}
 
-        SerializableEpochStakes {
-            vote_accounts: &self.vote_accounts,
-            stake_delegations: Vec::new(), // do not serialize any stake delegations
-            unused: 0,
-            epoch: self.epoch,
-            stake_history: &self.stake_history,
-        }
-        .serialize(serializer)
+// Mirror the `Serialize` impl above for wincode by delegating to the same `SerializableEpochStakes`
+// wire layout, so the snapshot bytes match bincode.
+unsafe impl<C: wincode::config::Config> SchemaWrite<C> for EpochStakes {
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <SerializableEpochStakes<'_> as SchemaWrite<C>>::size_of(&src.into())
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
+        <SerializableEpochStakes<'_> as SchemaWrite<C>>::write(writer, &src.into())
     }
 }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -43,6 +43,7 @@ use {
     solana_serde::default_on_eof,
     solana_stake_interface::state::Delegation,
     std::{
+        borrow::Borrow,
         collections::{HashMap, HashSet},
         io::{self, BufReader, Read, Write},
         path::PathBuf,
@@ -56,8 +57,10 @@ use {
     },
     types::{SerdeAccountsLtHash, UnusedRentCollector},
     wincode::{
-        SchemaReadOwned, SchemaWrite,
+        ReadResult, SchemaRead, SchemaReadOwned, SchemaWrite, WriteResult,
+        containers::FromIntoIterator,
         io::{Reader, std_write::WriteAdapter},
+        len::BincodeLen,
     },
 };
 
@@ -93,9 +96,10 @@ pub(crate) struct AccountsDbFields<T>(
     Vec<(Slot, Hash)>,
 );
 
+#[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, SchemaRead, SchemaWrite)]
 pub struct UnusedIncrementalSnapshotPersistence {
     pub full_slot: u64,
     pub full_hash: [u8; 32],
@@ -104,15 +108,17 @@ pub struct UnusedIncrementalSnapshotPersistence {
     pub incremental_capitalization: u64,
 }
 
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "EcPdH21GSyYYTiSZbAN157YfrT3G8rKvDiNh7q1fw8Bc",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, SchemaRead, SchemaWrite)]
 struct BankHashInfo {
     unused_accounts_delta_hash: [u8; 32],
     unused_accounts_hash: [u8; 32],
@@ -120,7 +126,7 @@ struct BankHashInfo {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 struct UnusedAccounts {
     unused1: HashSet<Pubkey>,
     unused2: HashSet<Pubkey>,
@@ -213,10 +219,11 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
     // digest only verifies the serialized wire format; there is no roundtrip.
     frozen_abi(
         abi_digest = "6sm6hSNiTsNBAbSAiNe2BSQgnum3UdeNBpZnZiX7aM9r",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "no"
     )
 )]
-#[derive(Serialize)]
+#[derive(Serialize, SchemaWrite)]
 struct SerializableVersionedBank {
     blockhash_queue: BlockhashQueue,
     unused_ancestors: HashMap<Slot, usize>,
@@ -359,7 +366,7 @@ impl<T> SnapshotAccountsDbFields<T> {
     }
 }
 
-pub(crate) fn serialize_into<W, T>(writer: W, value: &T) -> wincode::WriteResult<()>
+pub(crate) fn serialize_into<W, T>(writer: W, value: &T) -> WriteResult<()>
 where
     W: Write,
     T: SchemaWrite<MaxStreamSizeConfig, Src = T>,
@@ -367,7 +374,7 @@ where
     wincode::config::serialize_into(WriteAdapter::new(writer), value, MaxStreamSizeConfig::new())
 }
 
-pub(crate) fn deserialize_wincode_from<'a, R, T>(reader: R) -> wincode::ReadResult<T>
+pub(crate) fn deserialize_wincode_from<'a, R, T>(reader: R) -> ReadResult<T>
 where
     R: Reader<'a>,
     T: SchemaReadOwned<MaxStreamSizeConfig, Dst = T>,
@@ -432,11 +439,12 @@ struct ExtraFieldsToDeserialize {
     // only verifies the serialized wire format; there is no roundtrip.
     frozen_abi(
         abi_digest = "726M1TRfibJsSAGcFqan4TSC8qKkJhDZfiK2P3h71eoo",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "no"
     )
 )]
 #[cfg_attr(feature = "dev-context-only-utils", derive(Default, PartialEq))]
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, SchemaWrite)]
 pub struct ExtraFieldsToSerialize {
     pub lamports_per_signature: u64,
     pub unused_incremental_snapshot_persistence: Option<UnusedIncrementalSnapshotPersistence>,
@@ -626,7 +634,7 @@ pub fn serialize_bank_snapshot_into(
 // extra fields, in wire order. Generic over the account-storage-entries serializer `E` so the
 // runtime can stream the storage entries lazily (see `SerializableAccountsDb`).
 #[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
-#[derive(Serialize)]
+#[derive(Serialize, SchemaWrite)]
 struct SerializableBankSnapshot<E> {
     bank: SerializableVersionedBank,
     accounts_db: SerializableAccountsDb<E>,
@@ -640,6 +648,7 @@ struct SerializableBankSnapshot<E> {
 #[cfg(all(test, feature = "frozen-abi"))]
 #[frozen_abi(
     abi_digest = "E4waD1iVxUYi3x9xA5xQHhCEbhhGtV9bqmo2TJ9ZsqTw",
+    abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]
 type SerializableBankSnapshotForAbi =
@@ -744,7 +753,7 @@ impl<'a> From<SerializableBankAndStorageNoExtra<'a>> for SerializableBankAndStor
 // (see `SerializableAccountsDb::new`) without materializing a collection. Sync fields with
 // `AccountsDbFields`!
 #[cfg_attr(feature = "frozen-abi", derive(StableAbi, StableAbiSample))]
-#[derive(Serialize)]
+#[derive(Serialize, SchemaWrite)]
 struct SerializableAccountsDb<E> {
     /// account storage entries, serialized as a map of slot to its storage entries
     accounts_storage_entries: E,
@@ -758,9 +767,29 @@ struct SerializableAccountsDb<E> {
 }
 
 /// Adapts a cloneable, exact-size iterator into a value that serializes as a length-prefixed
-/// sequence, re-creating the iterator via `Clone` on each serialization so a locally built iterator
-/// can be written without first materializing it into a collection.
+/// sequence under *both* serde (bincode) and wincode, re-creating the iterator via `Clone` on each
+/// serialization so a locally built iterator can be written without first materializing it into a
+/// collection. serde maps/sequences and bincode/wincode sequences share the same wire encoding, so
+/// this matches the `slot -> [entry]` map shape read back by `AccountsDbFields`.
 struct SerializableExactIteratorView<I>(I);
+
+impl<I: Iterator> IntoIterator for SerializableExactIteratorView<I> {
+    type Item = I::Item;
+    type IntoIter = I;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0
+    }
+}
+
+impl<I: Iterator + Clone> IntoIterator for &SerializableExactIteratorView<I> {
+    type Item = I::Item;
+    type IntoIter = I;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.clone()
+    }
+}
 
 impl<I> Serialize for SerializableExactIteratorView<I>
 where
@@ -772,6 +801,28 @@ where
         S: serde::Serializer,
     {
         serializer.collect_seq(self.0.clone())
+    }
+}
+
+// Serialize the wrapped iterator as a length-prefixed sequence via `FromIntoIterator`, byte-for-byte
+// identical to the serde encoding above.
+unsafe impl<I, C: wincode::config::Config> SchemaWrite<C> for SerializableExactIteratorView<I>
+where
+    I: ExactSizeIterator + Clone,
+    I::Item: SchemaWrite<C> + Borrow<<I::Item as SchemaWrite<C>>::Src>,
+{
+    type Src = Self;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <FromIntoIterator<SerializableExactIteratorView<I>, BincodeLen> as SchemaWrite<C>>::size_of(
+            src,
+        )
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
+        <FromIntoIterator<SerializableExactIteratorView<I>, BincodeLen> as SchemaWrite<C>>::write(
+            writer, src,
+        )
     }
 }
 
@@ -822,6 +873,7 @@ impl SerializableAccountsDb<()> {
 #[cfg(all(test, feature = "frozen-abi"))]
 #[frozen_abi(
     abi_digest = "2TpwtsyrverM4ius4ykX3RRCGqeLfXJQbAvYHkxdUVrs",
+    abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]
 type SerializableAccountsDbForAbi =

--- a/runtime/src/serde_snapshot/storage.rs
+++ b/runtime/src/serde_snapshot/storage.rs
@@ -2,21 +2,26 @@ use {
     serde::{Deserialize, Serialize},
     solana_accounts_db::account_storage_entry::AccountStorageEntry,
     solana_clock::Slot,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// The serialized AccountsFileId type is fixed as usize
 pub(crate) type SerializedAccountsFileId = usize;
 
 // Serializable version of AccountStorageEntry for snapshot format
+#[repr(C)]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "CMckX3HiC6K5FSmFo4tH44wU1mvGfabNtYAs65uaGvGU",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire"
     )
 )]
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize, SchemaRead, SchemaWrite,
+)]
 pub struct SerializableAccountStorageEntry {
     id: SerializedAccountsFileId,
     accounts_current_len: usize,

--- a/runtime/src/serde_snapshot/types.rs
+++ b/runtime/src/serde_snapshot/types.rs
@@ -1,12 +1,18 @@
 use {
-    solana_accounts_db::accounts_hash::AccountsLtHash, solana_clock::Epoch,
-    solana_epoch_schedule::EpochSchedule, solana_lattice_hash::lt_hash::LtHash, solana_rent::Rent,
+    solana_accounts_db::accounts_hash::AccountsLtHash,
+    solana_clock::Epoch,
+    solana_epoch_schedule::EpochSchedule,
+    solana_lattice_hash::lt_hash::LtHash,
+    solana_rent::Rent,
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// Snapshot serde-safe AccountsLtHash
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[serde_with::serde_as]
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
+#[derive(
+    Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, SchemaRead, SchemaWrite,
+)]
 pub struct SerdeAccountsLtHash(
     // serde only has array support up to 32 elements; anything larger needs to be handled manually
     // see https://github.com/serde-rs/serde/issues/1937 for more information
@@ -27,7 +33,7 @@ impl From<AccountsLtHash> for SerdeAccountsLtHash {
 /// Snapshot serde-safe RentCollector, which is now unused
 #[repr(C)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, SchemaRead, SchemaWrite)]
 pub struct UnusedRentCollector {
     epoch: Epoch,
     epoch_schedule: EpochSchedule,

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -10,6 +10,7 @@ use {
     },
     std::marker::PhantomData,
     thiserror::Error,
+    wincode::SchemaWrite,
 };
 #[cfg(feature = "frozen-abi")]
 use {
@@ -33,6 +34,24 @@ pub struct StakeAccount<T> {
     )]
     stake_state: StakeStateV2,
     _phantom: PhantomData<T>,
+}
+
+// `StakeAccount<Delegation>` is only ever wincode-serialized as part of the snapshot's
+// `stake_delegations` map, which uses the delegation format: just the `Delegation` is written (see
+// `serialize_stake_accounts_to_delegation_format`). Mirror that here so the wincode bytes match
+// bincode; `FromIntoIterator` on the map picks up this per-value schema automatically.
+unsafe impl<C: wincode::config::Config> SchemaWrite<C> for StakeAccount<Delegation> {
+    type Src = Self;
+
+    const TYPE_META: wincode::TypeMeta = <Delegation as SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
+        <Delegation as SchemaWrite<C>>::size_of(src.delegation())
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> wincode::WriteResult<()> {
+        <Delegation as SchemaWrite<C>>::write(writer, src.delegation())
+    }
 }
 
 /// Samples a random `StakeStateV2::Stake`; the delegation-format serializer unwraps

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -43,7 +43,8 @@ pub struct StakeAccount<T> {
 unsafe impl<C: wincode::config::Config> SchemaWrite<C> for StakeAccount<Delegation> {
     type Src = Self;
 
-    const TYPE_META: wincode::TypeMeta = <Delegation as SchemaWrite<C>>::TYPE_META;
+    const TYPE_META: wincode::TypeMeta =
+        <Delegation as SchemaWrite<C>>::TYPE_META.keep_zero_copy(false);
 
     fn size_of(src: &Self::Src) -> wincode::WriteResult<usize> {
         <Delegation as SchemaWrite<C>>::size_of(src.delegation())

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -9,11 +9,12 @@ use {
         ops::{Deref, DerefMut},
         sync::Arc,
     },
+    wincode::{SchemaRead, SchemaWrite},
 };
 
 /// The SDK's stake history with clone-on-write semantics
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Deserialize, Serialize, SchemaRead, SchemaWrite)]
 pub struct StakeHistory(Arc<StakeHistoryInner>);
 
 impl Deref for StakeHistory {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -30,6 +30,7 @@ use {
         sync::{Arc, RwLock, RwLockReadGuard},
     },
     thiserror::Error,
+    wincode::{SchemaWrite, containers::FromIntoIterator, len::BincodeLen},
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -191,7 +192,7 @@ impl StakesCache {
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Debug, Serialize)]
+#[derive(Default, Clone, PartialEq, Debug, Serialize, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(
@@ -212,11 +213,13 @@ pub struct Stakes<T: Clone> {
         feature = "frozen-abi",
         stable_abi_sample(with = "sample_collection_sized(rng, SequenceLenMax(1))")
     )]
+    #[wincode(with = "FromIntoIterator<ImblHashMap<Pubkey, T>, BincodeLen>")]
     stake_delegations: ImblHashMap<Pubkey, T>,
 
     /// current effective stake delegated to each vote account pubkey
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
+    #[wincode(skip)]
     delegated_stakes: DelegatedStakes,
 
     /// unused

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -41,7 +41,7 @@ log = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { version = "0.9.4", optional = true }
 serde = { workspace = true, features = ["rc"] }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
@@ -55,7 +55,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-packet = { workspace = true }
-solana-pubkey = { workspace = true }
+solana-pubkey = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
 solana-serialize-utils = { workspace = true }
 solana-signature = { workspace = true }
@@ -64,6 +64,7 @@ solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -422,7 +422,8 @@ impl VoteAccounts {
 unsafe impl<C: wincode::config::Config> SchemaWrite<C> for VoteAccount {
     type Src = Self;
 
-    const TYPE_META: TypeMeta = <AccountSharedData as SchemaWrite<C>>::TYPE_META;
+    const TYPE_META: TypeMeta =
+        <AccountSharedData as SchemaWrite<C>>::TYPE_META.keep_zero_copy(false);
 
     fn size_of(src: &Self::Src) -> WriteResult<usize> {
         <AccountSharedData as SchemaWrite<C>>::size_of(&src.0.account)

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -9,6 +9,7 @@ use {
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
+    solana_transaction::SchemaWrite,
     std::{
         cmp::Ordering,
         collections::{HashMap, hash_map::Entry},
@@ -18,6 +19,7 @@ use {
         sync::{Arc, OnceLock},
     },
     thiserror::Error,
+    wincode::{TypeMeta, WriteResult},
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
@@ -44,6 +46,7 @@ pub enum Error {
     InvalidOwner(/*owner:*/ Pubkey),
 }
 
+// No `SchemaWrite`: `VoteAccount` has a custom impl that writes only `account` (see above).
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug)]
 struct VoteAccountInner {
@@ -58,7 +61,7 @@ struct VoteAccountInner {
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(vote_accounts(pub))
@@ -69,6 +72,7 @@ pub struct VoteAccounts {
     // Inner Arc is meant to implement copy-on-write semantics.
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
+    #[wincode(skip)]
     staked_nodes: OnceLock<
         Arc<
             HashMap<
@@ -409,6 +413,23 @@ impl VoteAccounts {
             }
             Ordering::Greater => *current_stake -= stake,
         }
+    }
+}
+
+// `VoteAccount` serializes only its `account` (see the `Serialize` impl below). Mirror that for
+// wincode so the snapshot wire format matches bincode: `vote_state_view` is a parsed view of the
+// account data, rebuilt on read, and is intentionally not written.
+unsafe impl<C: wincode::config::Config> SchemaWrite<C> for VoteAccount {
+    type Src = Self;
+
+    const TYPE_META: TypeMeta = <AccountSharedData as SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <AccountSharedData as SchemaWrite<C>>::size_of(&src.0.account)
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
+        <AccountSharedData as SchemaWrite<C>>::write(writer, &src.0.account)
     }
 }
 


### PR DESCRIPTION
#### Problem
In order to speed up snapshot serialization we need to switch to wincode. Required types lack schema annotations / implementation with proper conformance testing.

#### Summary of Changes
Add wincode (`SchemaRead`/`SchemaWrite` + `#[repr(C)]`) alongside bincode and extend
the frozen_abi checks with `abi_serializer = ["bincode", "wincode"]` so the wire
format is proven byte-for-byte identical under both serializers.

- Pull in the wincode dependency and enable the wincode feature on the relevant
  solana-* crates (solana-fee-calculator, solana-hash, ...) across the
  accounts-db, runtime and vote crates (and the Cargo.lock files).
- Derive SchemaRead/SchemaWrite and add #[repr(C)] on the snapshot serde types
  (`HashInfo, BlockhashQueue, SerializableAccountStorageEntry`, and the
  stake/vote/epoch-stakes transitive types).

This doesn't yet enable actual use of wincode in production, but it already tests
serialization conformance.


#### Testing
CI / frozen_abi tests are extended by this PR

Fixes #