### PR TITLE
Uses wire version of Certificate for rpc

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -10,7 +10,7 @@ use {
             writeln_transaction,
         },
     },
-    agave_votor_messages::{certificate::Certificate, migration::AG_MIGRATION_EPOCH_CREDIT},
+    agave_votor_messages::{migration::AG_MIGRATION_EPOCH_CREDIT, wire::WireBlockCertMessage},
     base64::{Engine, prelude::BASE64_STANDARD},
     bitvec::vec::BitVec,
     chrono::{Local, TimeZone, Utc},
@@ -1808,13 +1808,13 @@ pub enum VotesObserved {
 }
 
 impl VotesObserved {
-    pub fn new(vote_state: &VoteStateV4, ag_genesis_cert: &Option<Certificate>) -> Self {
+    pub fn new(vote_state: &VoteStateV4, ag_genesis_cert: &Option<WireBlockCertMessage>) -> Self {
         match ag_genesis_cert {
             None => Self::Tower(vote_state.votes.iter().map(CliLandedVote::from).collect()),
             Some(cert) => match vote_state.votes.iter().last() {
                 None => Self::Alpenglow(None),
                 Some(vote) => {
-                    if vote.lockout.slot() <= cert.cert_type.slot() {
+                    if vote.lockout.slot() <= cert.block.slot {
                         Self::Tower(vote_state.votes.iter().map(CliLandedVote::from).collect())
                     } else {
                         Self::Alpenglow(Some(CliLandedVote::from(vote)))
@@ -2006,7 +2006,7 @@ pub struct AgEpochHistory {
 pub fn get_epoch_history(
     epoch_schedule: &EpochSchedule,
     vote_state: &VoteStateV4,
-    ag_genesis_cert: &Option<Certificate>,
+    ag_genesis_cert: &Option<WireBlockCertMessage>,
     tvc_activation_epoch: Option<Epoch>,
 ) -> Vec<CliEpochVotingHistory> {
     let mut ret = vec![];
@@ -2027,7 +2027,7 @@ pub fn get_epoch_history(
         let tower_or_ag = match ag_genesis_cert {
             None => TowerOrAg::Tower(slots_in_epoch),
             Some(cert) => {
-                let migration_slot = cert.cert_type.slot();
+                let migration_slot = cert.block.slot;
                 let migration_epoch = epoch_schedule.get_epoch(migration_slot);
                 match epoch.cmp(&migration_epoch) {
                     Ordering::Less => TowerOrAg::Tower(slots_in_epoch),

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -3,7 +3,7 @@ use {
         cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
         feature::get_feature_activation_epoch,
     },
-    agave_votor_messages::certificate::Certificate,
+    agave_votor_messages::wire::WireBlockCertMessage,
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand, value_t, value_t_or_exit},
     console::style,
     serde::{Deserialize, Serialize},
@@ -1092,26 +1092,21 @@ pub async fn process_get_ag_genesis_info(
     let cert = rpc_client.get_ag_genesis_cert().await?;
     let ag_genesis_info = match cert {
         None => CliAgGenesisInfo::Tower,
-        Some(Certificate {
-            cert_type,
-            signature,
-            bitmap,
-        }) => {
-            debug_assert!(cert_type.is_genesis());
+        Some(WireBlockCertMessage { block, signature }) => {
             let epoch_schedule = rpc_client.get_epoch_schedule().await?;
-            let epoch = epoch_schedule.get_epoch(cert_type.slot());
+            let epoch = epoch_schedule.get_epoch(block.slot);
             const MAX_VALIDATORS: usize = 4096;
-            let Decoded::Base2(bitvec) = decode(&bitmap, MAX_VALIDATORS)
+            let Decoded::Base2(bitvec) = decode(&signature.bitmap, MAX_VALIDATORS)
                 .map_err(|_| Box::new(CliError::InvalidAgGenesisCert))?
             else {
                 return Err(Box::new(CliError::InvalidAgGenesisCert));
             };
             CliAgGenesisInfo::Ag(CliAgGenesisInfoPayload {
                 epoch,
-                slot: cert_type.slot(),
-                block_id: cert_type.to_block().unwrap().block_id,
+                slot: block.slot,
+                block_id: block.block_id,
                 bitvec,
-                signature,
+                signature: signature.signature,
             })
         }
     };

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -3,8 +3,8 @@
 use {
     crate::rpc_sender::*,
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
         consensus_message::Block,
+        wire::{WireBlockCertMessage, WireCertSignature},
     },
     async_trait::async_trait,
     base64::{Engine, prelude::BASE64_STANDARD},
@@ -178,10 +178,12 @@ impl RpcSender for MockSender {
                 transaction_count: Some(123),
             })?,
             "getAgGenesisCert" => {
-                let cert = Certificate {
-                    cert_type: CertificateType::Genesis(Block { slot: 0, block_id: Hash::default() }),
-                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-                    bitmap: Vec::default(),
+                let cert = WireBlockCertMessage {
+                    block: Block { slot: 0, block_id: Hash::default() },
+                    signature: WireCertSignature {
+                        signature:  BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                        bitmap: vec![],
+                     }
                 };
                 serde_json::to_value(Some(cert))?
             }

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -19,7 +19,7 @@ use {
         },
         rpc_sender::*,
     },
-    agave_votor_messages::certificate::Certificate,
+    agave_votor_messages::wire::WireBlockCertMessage,
     base64::{Engine, prelude::BASE64_STANDARD},
     futures::join,
     log::*,
@@ -2117,7 +2117,7 @@ impl RpcClient {
     /// # })?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub async fn get_ag_genesis_cert(&self) -> ClientResult<Option<Certificate>> {
+    pub async fn get_ag_genesis_cert(&self) -> ClientResult<Option<WireBlockCertMessage>> {
         self.send(RpcRequest::GetAgGenesisCert, Value::Null).await
     }
 

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -17,7 +17,7 @@ use {
         nonblocking::{self, rpc_client::get_rpc_request_str},
         rpc_sender::*,
     },
-    agave_votor_messages::certificate::Certificate,
+    agave_votor_messages::wire::WireBlockCertMessage,
     serde_json::Value,
     solana_account::{Account, ReadableAccount},
     solana_account_decoder::UiAccount,
@@ -1846,7 +1846,7 @@ impl RpcClient {
     /// let cert = rpc_client.get_ag_genesis_cert()?;
     /// # Ok::<(), Error>(())
     /// ```
-    pub fn get_ag_genesis_cert(&self) -> ClientResult<Option<Certificate>> {
+    pub fn get_ag_genesis_cert(&self) -> ClientResult<Option<WireBlockCertMessage>> {
         self.invoke((self.rpc_client.as_ref()).get_ag_genesis_cert())
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8,7 +8,7 @@ use {
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
     },
     agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig},
-    agave_votor_messages::certificate::Certificate,
+    agave_votor_messages::wire::{WireBlockCertMessage, WireCertSignature},
     base64::{Engine, prelude::BASE64_STANDARD},
     crossbeam_channel::{Receiver, Sender, unbounded},
     jsonrpc_core::{
@@ -921,9 +921,16 @@ impl JsonRpcRequestProcessor {
         bank.epoch_schedule().clone()
     }
 
-    pub fn get_ag_genesis_cert(&self) -> Option<Certificate> {
+    pub fn get_ag_genesis_cert(&self) -> Option<WireBlockCertMessage> {
         let bank = self.bank(Some(CommitmentConfig::finalized()));
         bank.get_alpenglow_genesis_certificate()
+            .map(|c| WireBlockCertMessage {
+                block: c.cert_type.to_block().unwrap(),
+                signature: WireCertSignature {
+                    signature: c.signature,
+                    bitmap: c.bitmap,
+                },
+            })
     }
 
     pub fn get_balance(
@@ -2990,7 +2997,7 @@ pub mod rpc_minimal {
 // RPC interface that only depends on immediate Bank data
 // Expected to be provided by API nodes
 pub mod rpc_bank {
-    use super::*;
+    use {super::*, agave_votor_messages::wire::WireBlockCertMessage};
     #[rpc]
     pub trait BankData {
         type Metadata;
@@ -3032,7 +3039,8 @@ pub mod rpc_bank {
         ) -> Result<Vec<String>>;
 
         #[rpc(meta, name = "getAgGenesisCert")]
-        fn get_ag_genesis_cert(&self, meta: Self::Metadata) -> Result<Option<Certificate>>;
+        fn get_ag_genesis_cert(&self, meta: Self::Metadata)
+        -> Result<Option<WireBlockCertMessage>>;
 
         #[rpc(meta, name = "getBlockProduction")]
         fn get_block_production(
@@ -3109,7 +3117,10 @@ pub mod rpc_bank {
                 .collect())
         }
 
-        fn get_ag_genesis_cert(&self, meta: Self::Metadata) -> Result<Option<Certificate>> {
+        fn get_ag_genesis_cert(
+            &self,
+            meta: Self::Metadata,
+        ) -> Result<Option<WireBlockCertMessage>> {
             debug!("get_ag_genesis_cert rpc request received");
             Ok(meta.get_ag_genesis_cert())
         }

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -8,26 +8,17 @@ use {
         vote::{Vote, VoteType},
         wire::get_vote_payload_to_sign,
     },
-    serde::{Deserialize, Serialize},
     solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
-    wincode::{SchemaRead, SchemaWrite, pod_wrapper},
 };
-
-// Use `BLSSignature` directly once `BLSSignature` wincode support
-// is released in solana-sdk.
-pod_wrapper! {
-    unsafe struct PodBLSSignature(BLSSignature);
-}
 
 /// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
 /// BLS vote message, we need rank to look up pubkey
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SchemaWrite, SchemaRead)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Certificate {
     /// The certificate type.
     pub cert_type: CertificateType,
     /// The aggregate signature.
-    #[wincode(with = "PodBLSSignature")]
     pub signature: BLSSignature,
     /// A rank bitmap for validators' signatures included in the aggregate.
     /// See solana-signer-store for encoding format.
@@ -35,20 +26,7 @@ pub struct Certificate {
 }
 
 /// The different types of certificates and their relevant state.
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Deserialize,
-    Serialize,
-    SchemaWrite,
-    SchemaRead,
-)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CertificateType {
     /// Finalize certificate
     Finalize(Slot),

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -46,7 +46,7 @@ use {
         consensus_message::{Block, ConsensusMessage, VoteMessage},
         vote::Vote,
     },
-    serde::Serialize,
+    serde::{Deserialize, Serialize},
     solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     wincode::{SchemaRead, SchemaWrite, pod_wrapper},
@@ -102,7 +102,7 @@ pub(crate) struct WireSlotVoteMessage {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
 /// Signature on a wire cert message
 pub struct WireCertSignature {
     #[cfg_attr(
@@ -133,7 +133,7 @@ pub(crate) struct WireSlotCertMessage {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize, Deserialize)]
 /// A wire cert message that holds a block.
 pub struct WireBlockCertMessage {
     /// the block the cert is certifying.


### PR DESCRIPTION
#### Problem

We are currently sending `Certificate` in response to rpc requests.  `Certificate` is supposed to be an internal type and exposing it publicly will make it difficult to update it.  


#### Summary of Changes

- Uses `WireBlockCertMessage` instead.
- removes various derives from `Certificate` and `CertType` that are used for serializing and deserializing.


#### Testing

Just CI
