### PR TITLE
bls sigverify: remove optimistic vote verification

### DIFF
--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -4,13 +4,7 @@
 */
 
 use {
-    agave_bls_sigverify::{
-        bls_vote_sigverify::{
-            UnverifiedVotePayload, aggregate_pubkeys_by_payload, aggregate_signatures,
-            verify_individual_votes, verify_votes_optimistic,
-        },
-        stats::SigVerifyVoteStats,
-    },
+    agave_bls_sigverify::bls_vote_sigverify::{UnverifiedVotePayload, verify_individual_votes},
     agave_votor_messages::{
         consensus_message::Block,
         unverified_vote_message::UnverifiedVoteMessage,
@@ -64,7 +58,6 @@ fn generate_test_data(
                     sender_bls_pubkey: bls_keypair.public,
                     sender_vote_account_pubkey: Keypair::new().pubkey(),
                     sender_identity_pubkey: Keypair::new().pubkey(),
-                    prepared_payload: None,
                 }
             })
             .collect(),
@@ -110,76 +103,6 @@ fn bench_verify_single_signature_with_prepared_message(c: &mut Criterion) {
     group.finish();
 }
 
-// Optimistic Verification - aggregates the public keys and signatures first before verifying.
-// Depends on both batch size and message distinctness due to pairing checks.
-fn bench_verify_votes_optimistic(c: &mut Criterion) {
-    let shred_version = 1234;
-    let mut group = c.benchmark_group("verify_votes_optimistic");
-    let mut stats = SigVerifyVoteStats::default();
-    let thread_pool = get_thread_pool();
-
-    for &batch_size in BATCH_SIZES {
-        let (vote, mut unverified_votes) = generate_test_data(shred_version, batch_size);
-        let label = format!("batch_{batch_size}");
-
-        group.bench_function(&label, |b| {
-            b.iter(|| {
-                let res = verify_votes_optimistic(
-                    vote,
-                    black_box(&mut unverified_votes),
-                    &mut stats,
-                    &thread_pool,
-                );
-                black_box(res);
-            })
-        });
-    }
-    group.finish();
-    black_box(stats);
-}
-
-// Public Key Aggregation
-// Depends on message distinctness because keys are grouped by messages.
-fn bench_aggregate_pubkeys(c: &mut Criterion) {
-    let shred_version = 1234;
-    let mut group = c.benchmark_group("aggregate_pubkeys");
-
-    for &batch_size in BATCH_SIZES {
-        let (vote, unverified_votes) = generate_test_data(shred_version, batch_size);
-        let label = format!("batch_{batch_size}");
-
-        group.bench_function(&label, |b| {
-            b.iter(|| {
-                let res = aggregate_pubkeys_by_payload(vote, black_box(&unverified_votes));
-                black_box(res).1.unwrap();
-            })
-        });
-    }
-    group.finish();
-}
-
-// Signature Aggregation
-// Pure G1 addition - message distinctness is irrelevant.
-fn bench_aggregate_signatures(c: &mut Criterion) {
-    let shred_version = 1234;
-    let mut group = c.benchmark_group("aggregate_signatures");
-
-    for &batch_size in BATCH_SIZES {
-        // Use 1 distinct message just to generate valid data cheaply.
-        // It doesn't affect signature aggregation performance.
-        let (_, unverified_votes) = generate_test_data(shred_version, batch_size);
-        let label = format!("batch_{batch_size}");
-
-        group.bench_function(&label, |b| {
-            b.iter(|| {
-                let res = aggregate_signatures(black_box(&unverified_votes));
-                black_box(res).unwrap();
-            })
-        });
-    }
-    group.finish();
-}
-
 // Individual Verification - verifies each signatures in parallel threads
 // Message distinctness is irrelevant.
 fn bench_verify_individual_votes(c: &mut Criterion) {
@@ -210,9 +133,6 @@ criterion_group!(
     benches,
     bench_verify_single_signature,
     bench_verify_single_signature_with_prepared_message,
-    bench_verify_votes_optimistic,
-    bench_aggregate_pubkeys,
-    bench_aggregate_signatures,
     bench_verify_individual_votes
 );
 criterion_main!(benches);

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -261,7 +261,6 @@ impl SigVerifier {
                                 sender_bls_pubkey,
                                 sender_vote_account_pubkey,
                                 sender_identity_pubkey,
-                                prepared_payload: None,
                             },
                         );
                     }

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -21,13 +21,11 @@ use {
     },
     log::info,
     rayon::{
-        ThreadPool, current_thread_index,
-        iter::{Either, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
+        ThreadPool,
+        iter::{Either, IntoParallelIterator, ParallelIterator},
     },
-    solana_bls_signatures::{
-        BlsError, PreparedHashedMessage,
-        pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, PubkeyProjective, VerifySignature},
-        signature::SignatureProjective,
+    solana_bls_signatures::pubkey::{
+        PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature,
     },
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -36,7 +34,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::nonblocking::simple_qos::SimpleQosBanlist,
-    std::{collections::HashMap, sync::Arc},
+    std::collections::HashMap,
 };
 
 fn into_vote_msg(msg: UnverifiedVoteMessage) -> VoteMessage {
@@ -61,22 +59,16 @@ pub(super) struct UnverifiedVotePayload {
     pub sender_bls_pubkey: PopVerified<BlsPubkeyAffine>,
     pub sender_vote_account_pubkey: Pubkey,
     pub sender_identity_pubkey: Pubkey,
-    pub prepared_payload: Option<Arc<PreparedHashedMessage>>,
 }
 
 impl UnverifiedVotePayload {
     fn verify(self) -> Option<VerifiedVotePayload> {
-        let is_verified = if let Some(prepared_payload) = self.prepared_payload.as_deref() {
-            self.sender_bls_pubkey
-                .verify_signature_prepared(&self.vote_message.signature, prepared_payload)
-                .is_ok()
-        } else {
-            let payload =
-                get_vote_payload_to_sign(self.vote_message.vote, self.vote_message.shred_version);
-            self.sender_bls_pubkey
-                .verify_signature(&self.vote_message.signature, &payload)
-                .is_ok()
-        };
+        let payload =
+            get_vote_payload_to_sign(self.vote_message.vote, self.vote_message.shred_version);
+        let is_verified = self
+            .sender_bls_pubkey
+            .verify_signature(&self.vote_message.signature, &payload)
+            .is_ok();
         is_verified.then_some(VerifiedVotePayload {
             vote_message: into_vote_msg(self.vote_message),
             sender_vote_account_pubkey: self.sender_vote_account_pubkey,
@@ -212,7 +204,7 @@ fn process_verified_votes(
 fn verify_votes(
     root_bank: &Bank,
     vote_payload_to_sign: VotePayloadToSign,
-    mut unverified_votes: Vec<UnverifiedVotePayload>,
+    unverified_votes: Vec<UnverifiedVotePayload>,
     stats: &mut SigVerifyVoteStats,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
@@ -221,23 +213,6 @@ fn verify_votes(
     if vote_payload_to_sign.slot() > root_bank.slot().saturating_add(NUM_SLOTS_FOR_VERIFY) {
         stats.too_far_in_future += unverified_votes.len() as u64;
         return vec![];
-    }
-
-    // Try optimistic verification - fast to verify, but cannot identify invalid votes
-    let is_verified = verify_votes_optimistic(
-        vote_payload_to_sign,
-        &mut unverified_votes,
-        stats,
-        thread_pool,
-    );
-    if is_verified {
-        return unverified_votes
-            .into_iter()
-            .map(|v| VerifiedVotePayload {
-                vote_message: into_vote_msg(v.vote_message),
-                sender_vote_account_pubkey: v.sender_vote_account_pubkey,
-            })
-            .collect();
     }
 
     // Fallback to individual verification
@@ -256,98 +231,6 @@ fn verify_votes(
     stats.fn_verify_individual_votes_stats.add_sample(time_us);
 
     verified_votes
-}
-
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-/// Attempts aggregate BLS verification across the full vote set.
-///
-/// This fast path aggregates all vote signatures and the public keys for each
-/// distinct vote payload, minimizing the number of pairing operations needed
-/// for verification. When aggregation or aggregate verification fails, the
-/// caller falls back to individual vote verification so invalid votes can be
-/// identified precisely.
-///
-/// Returns the optimistic verification outcome together with the distinct vote
-/// messages and their prepared payloads, which can be reused by the fallback
-/// path.
-#[must_use]
-fn verify_votes_optimistic(
-    vote_payload_to_sign: VotePayloadToSign,
-    unverified_votes: &mut Vec<UnverifiedVotePayload>,
-    stats: &mut SigVerifyVoteStats,
-    thread_pool: &ThreadPool,
-) -> bool {
-    let mut measure = Measure::start("verify_votes_optimistic");
-
-    // For BLS verification, minimizing the expensive pairing operation is key.
-    // Each BLS signature verification requires two pairings.
-    //
-    // However, the BLS verification formula allows us to:
-    // 1. Aggregate all signatures into a single signature.
-    // 2. Aggregate public keys for each unique message.
-    //
-    // By verifying the aggregated signature against the aggregated public keys,
-    // the number of pairings required is reduced to (1 + number of distinct messages).
-    let (signature_result, (prepared_hash_msg, pubkey_result)) = thread_pool.join(
-        || aggregate_signatures(unverified_votes),
-        || aggregate_pubkeys_by_payload(vote_payload_to_sign, unverified_votes),
-    );
-
-    let Ok(aggregate_signature) = signature_result else {
-        return false;
-    };
-
-    let Ok(aggregate_pubkey) = pubkey_result else {
-        return false;
-    };
-
-    let verified = aggregate_pubkey
-        .verify_signature_prepared(&aggregate_signature, &prepared_hash_msg)
-        .is_ok();
-
-    measure.stop();
-    stats
-        .fn_verify_votes_optimistic_stats
-        .add_sample(measure.as_us());
-    if !verified {
-        let prepared_hash_msg = Arc::new(prepared_hash_msg);
-        for unverified_vote in unverified_votes {
-            unverified_vote.prepared_payload = Some(prepared_hash_msg.clone());
-        }
-    }
-    verified
-}
-
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn aggregate_signatures(votes: &[UnverifiedVotePayload]) -> Result<SignatureProjective, BlsError> {
-    debug_assert!(current_thread_index().is_some());
-    let signatures = votes.par_iter().map(|v| &v.vote_message.signature);
-    // TODO(sam): Currently, `par_aggregate` performs full validation
-    // (on-curve + subgroup check) for every signature. Since the subgroup
-    // check is expensive, we can use an `unchecked` deserialization here
-    // (performing only the cheap on-curve check) and rely on a single subgroup
-    // check on the final aggregated signature. This should save more than 80%
-    // of the time for signature aggregation.
-    SignatureProjective::par_aggregate(signatures)
-}
-
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn aggregate_pubkeys_by_payload(
-    vote_payload_to_sign: VotePayloadToSign,
-    votes: &[UnverifiedVotePayload],
-) -> (
-    PreparedHashedMessage,
-    Result<PopVerified<PubkeyProjective>, BlsError>,
-) {
-    debug_assert!(current_thread_index().is_some());
-    let serialized_vote = wincode::serialize(&vote_payload_to_sign).unwrap();
-    let prepared_hash_msg = PreparedHashedMessage::new(&serialized_vote);
-    // converting aggregate pubkey to `PopVerified` is safe here
-    // since the pubkeys are all PoP verified in the vote account
-    let pubkey =
-        PubkeyProjective::par_aggregate(votes.into_par_iter().map(|v| &v.sender_bls_pubkey))
-            .map(|agg| unsafe { PopVerified::new_unchecked(*agg) });
-    (prepared_hash_msg, pubkey)
 }
 
 /// Verifies votes individually on a thread pool.
@@ -371,31 +254,4 @@ fn verify_individual_votes(
                 }
             })
     })
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    #[should_panic]
-    fn ensure_aggregate_signatures_runs_on_thread_pool() {
-        let votes = vec![];
-        // calling without a rayon thread pool should trigger a debug assert.
-        aggregate_signatures(&votes).unwrap();
-    }
-
-    #[test]
-    #[should_panic]
-    fn ensure_aggregate_pubkeys_by_payload_runs_on_thread_pool() {
-        let votes = vec![];
-        let shred_version = 1234;
-        let vote = Vote::new_skip_vote(1);
-        let vote_payload_to_sign = VotePayloadToSign::new_from_vote(vote, shred_version);
-        // calling without a rayon thread pool should trigger a debug assert.
-        aggregate_pubkeys_by_payload(vote_payload_to_sign, &votes)
-            .1
-            .unwrap();
-    }
 }

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -320,8 +320,6 @@ pub(super) struct SigVerifyVoteStats {
 
     /// Stats for [`verify_and_send_votes`].
     pub(super) fn_verify_and_send_votes_stats: WelfordStats,
-    /// Stats for [`verify_votes_optimistic`].
-    pub(super) fn_verify_votes_optimistic_stats: WelfordStats,
     /// Stats for [`verify_individual_votes`].
     pub(super) fn_verify_individual_votes_stats: WelfordStats,
 
@@ -346,7 +344,6 @@ impl SigVerifyVoteStats {
             pool_sent,
             pool_channel_full,
             fn_verify_and_send_votes_stats,
-            fn_verify_votes_optimistic_stats,
             fn_verify_individual_votes_stats,
             distinct_votes_stats,
         } = other;
@@ -365,8 +362,6 @@ impl SigVerifyVoteStats {
         self.pool_channel_full += pool_channel_full;
         self.fn_verify_and_send_votes_stats
             .merge(fn_verify_and_send_votes_stats);
-        self.fn_verify_votes_optimistic_stats
-            .merge(fn_verify_votes_optimistic_stats);
         self.fn_verify_individual_votes_stats
             .merge(fn_verify_individual_votes_stats);
         self.distinct_votes_stats.merge(distinct_votes_stats);
@@ -388,7 +383,6 @@ impl SigVerifyVoteStats {
             pool_sent,
             pool_channel_full,
             fn_verify_and_send_votes_stats,
-            fn_verify_votes_optimistic_stats,
             fn_verify_individual_votes_stats,
             distinct_votes_stats,
         } = self;
@@ -415,16 +409,6 @@ impl SigVerifyVoteStats {
             (
                 "fn_verify_and_send_votes_mean",
                 fn_verify_and_send_votes_stats.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "fn_verify_votes_optimistic_count",
-                fn_verify_votes_optimistic_stats.count(),
-                i64
-            ),
-            (
-                "fn_verify_votes_optimistic_mean",
-                fn_verify_votes_optimistic_stats.mean().unwrap_or(0),
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem
Optimistic vote aggregation leads to extra complexity and malleability issues.
Metrics from the community cluster show that batches are very small anyway
<img width="3340" height="648" alt="image" src="https://github.com/user-attachments/assets/425b23ef-ed14-44c3-ba99-2811088ebdd4" />


#### Summary of Changes
Remove optimistic aggregation for now - we can look to reintroduce if the need arises