### PR TITLE
bls sigverify: reduce ban timeout to 10 secs

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -50,8 +50,8 @@ use {
 pub(super) const NUM_SLOTS_FOR_VERIFY: Slot = 90_000;
 
 /// If we receive an invalid certificate or vote from a QUIC connection, we ban the sender.
-/// We ban the sender for 2 days which roughly corresponds to an epoch
-pub(super) const BAN_TIMEOUT: Duration = Duration::from_hours(48);
+/// We ban the sender for 1 minute which prevents DoS but allows for recovery in case of instability.
+pub(super) const BAN_TIMEOUT: Duration = Duration::from_mins(1);
 
 pub struct SigVerifierContext {
     pub migration_status: Arc<MigrationStatus>,

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -61,10 +61,9 @@ fn max_admitted_vote_slot(root_slot: Slot, highest_parent_ready_slot: Slot) -> S
         .saturating_add(MAX_VOTE_SLOT_DISTANCE_FROM_PARENT_READY)
 }
 
-/// If we receive an invalid certificate or vote, we ban its attributed sender. For certificates
-/// received from blockstore, that sender is the scheduled leader for the carrier slot. We ban the
-/// sender for 2 days, which roughly corresponds to an epoch.
-pub(super) const BAN_TIMEOUT: Duration = Duration::from_hours(48);
+/// If we receive an invalid certificate or vote from a QUIC connection, we ban the sender.
+/// We ban the sender for 10 seconds which prevents DoS but allows for recovery in case of instability.
+pub(super) const BAN_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct SigVerifierContext {
     pub migration_status: Arc<MigrationStatus>,


### PR DESCRIPTION
#### Problem
We currently ban invalid vote/cert senders for a full epoch
This is not really necessary, 10s is plenty to prevent DoS and gives us a small chance of recovery for any critical bugs.

#### Summary of Changes
Change it to 10 seconds