### PR TITLE
Includes staker rewards in total epoch rewards

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1832,7 +1832,7 @@ impl Bank {
 
         // Distribute rewards commission to vote accounts and cache stake rewards
         // for partitioned distribution in the upcoming slots.
-        let (epoch_validator_rewards, begin_partitioned_rewards_time_us) =
+        let (epoch_rewards, begin_partitioned_rewards_time_us) =
             measure_us!(self.begin_partitioned_rewards(
                 parent_epoch,
                 parent_slot,
@@ -1849,7 +1849,7 @@ impl Bank {
             EpochInflationAccountState::new_epoch_update_account(
                 self,
                 epoch_start_capitalization,
-                epoch_validator_rewards,
+                epoch_rewards,
             );
         }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -163,8 +163,9 @@ impl Bank {
     /// Begin the process of calculating and distributing rewards.
     /// This process can take multiple slots.
     ///
-    /// Returns the distributed epoch validator rewards, not including lamports
-    /// distributed to the incinerator.
+    /// Returns the total rewards that will be distributed in this epoch (to both validators and
+    /// stakers) minus rewards sent to the incinerator.  This is the total amount the capitalization
+    /// will increase by after all the rewards have been paid.
     pub(in crate::bank) fn begin_partitioned_rewards(
         &mut self,
         parent_epoch: Epoch,
@@ -217,6 +218,9 @@ impl Bank {
             ("parent_block_height", parent_block_height, i64),
         );
         distributed_lamports
+            + rewards_calculation
+                .stake_rewards
+                .total_stake_rewards_lamports
     }
 
     // Calculate rewards from previous epoch and distribute reward commissions
@@ -1366,6 +1370,74 @@ mod tests {
         );
 
         assert!(point_value.is_none());
+    }
+
+    #[test]
+    fn test_begin_partitioned_rewards_returns_total_capitalization_increase() {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000 * LAMPORTS_PER_SOL);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+
+        let commission_pubkey = Pubkey::new_unique();
+        {
+            let mut commission_account = AccountSharedData::default();
+            commission_account.set_lamports(1);
+            bank.store_account_and_update_capitalization(&commission_pubkey, &commission_account);
+        }
+
+        let commission_lamports = 123;
+        let stake_reward_lamports = 456;
+        let mut reward_commissions = RewardCommissions::default();
+        reward_commissions.insert(
+            commission_pubkey,
+            RewardCommission {
+                commission_bps: Some(0),
+                commission_lamports,
+                burned_lamports: 0,
+                is_vote_account: true,
+            },
+        );
+        let stake_rewards = [Some(PartitionedStakeReward {
+            stake_pubkey: Pubkey::new_unique(),
+            inflation: InflationReward {
+                stake: Stake {
+                    delegation: Delegation::default(),
+                    credits_observed: 0,
+                },
+                stake_reward: stake_reward_lamports,
+                commission_bps: Some(0),
+            },
+        })]
+        .into_iter()
+        .collect::<PartitionedStakeRewards>();
+        let rewards_calculation = PartitionedRewardsCalculation {
+            reward_commissions,
+            stake_rewards: StakeRewardCalculation {
+                stake_rewards: Arc::new(stake_rewards),
+                total_stake_rewards_lamports: stake_reward_lamports,
+            },
+            capitalization: bank.capitalization(),
+            point_value: PointValue {
+                rewards: commission_lamports + stake_reward_lamports,
+                points: 1,
+            },
+            num_filtered_vote_accounts: 1,
+        };
+        let mut rewards_metrics = RewardsMetrics::default();
+
+        let rewards = bank.begin_partitioned_rewards(
+            bank.epoch().saturating_sub(1),
+            bank.parent_slot(),
+            bank.block_height(),
+            &rewards_calculation,
+            &mut rewards_metrics,
+            &thread_pool,
+        );
+
+        assert_eq!(rewards, commission_lamports + stake_reward_lamports);
+        let epoch_rewards = bank.get_epoch_rewards_sysvar();
+        assert_eq!(epoch_rewards.distributed_rewards, commission_lamports);
+        assert_eq!(epoch_rewards.total_rewards, rewards);
     }
 
     struct EpochOperations {

--- a/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
+++ b/runtime/src/block_component_processor/vote_reward/epoch_inflation_account_state.rs
@@ -48,10 +48,10 @@ impl EpochInflationState {
     fn new_from_bank(
         bank: &Bank,
         epoch_start_capitalization: u64,
-        additional_validator_rewards: u64,
+        additional_rewards: u64,
     ) -> Self {
         let max_possible_validator_reward = bank.calculate_epoch_inflation_rewards(
-            epoch_start_capitalization + additional_validator_rewards,
+            epoch_start_capitalization + additional_rewards,
             bank.epoch(),
         );
         EpochInflationState {
@@ -135,19 +135,19 @@ impl EpochInflationAccountState {
     /// capitalization keeps increasing in the first slots of the epoch.  Vote rewards are
     /// calculated as a function of the capitalization and we do not want voting in the initial
     /// slots to earn less rewards than voting in the later rewards.  As such this function is
-    /// called with [`additional_validator_rewards`] which should be the total rewards that will
+    /// called with [`additional_rewards`] which should be the total rewards that will
     /// be paid by PER and we use the capitalization from the previous epoch plus this value to
     /// compute the vote rewards.
     pub(crate) fn new_epoch_update_account(
         bank: &Bank,
         epoch_start_capitalization: u64,
-        additional_validator_rewards: u64,
+        additional_rewards: u64,
     ) {
         let prev = Self::new_from_bank(bank).map(|s| s.current);
         let current = EpochInflationState::new_from_bank(
             bank,
             epoch_start_capitalization,
-            additional_validator_rewards,
+            additional_rewards,
         );
         let state = Self { prev, current };
         state.set_state(bank);


### PR DESCRIPTION
#### Problem

Also see https://github.com/anza-xyz/agave/issues/13420.

It turns out that we are only passing in the rewards that will be distributed to the validators `EpochInflationAccountState::new_epoch_update_account()` and not including staker rewards.  This will mean that we will continuously under rewards.

See https://github.com/anza-xyz/agave/issues/13420#issuecomment-4833489090 for reasoning.


#### Summary of Changes

Updates `begin_partitioned_rewards` to return total rewards earned by validators and stakers which is fed into `EpochInflationAccountState::new_epoch_update_account()`.


#### Testing

Just CI


Fixes #13420