### PR TITLE
bls sigverify: allow genesis vote on root slot

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -308,7 +308,10 @@ impl SigVerifier {
                 None
             })?;
         let ret = Some((entry.vote_account_pubkey, entry.bls_pubkey));
-        if vote.slot() > root_slot {
+        if vote.slot() > root_slot
+            // Genesis votes should be allowed on the TowerBFT root
+         || (vote.is_genesis_vote() && vote.slot() >= root_slot)
+        {
             return ret;
         }
         if rewards_wants_vote(&self.cluster_info, &self.leader_schedule, root_slot, vote) {


### PR DESCRIPTION
#### Problem
Although unlikely, if there is lots of packet loss or network delay during the migration we might end up reaching 32 slots and the genesis block gets rooted

The filter currently rejects votes for our root slot.

credits to @igor56D for finding this during invalidator testing

#### Summary of Changes
For genesis votes allow votes on the root slot