### PR TITLE
blockstore: hide pre-UpdateParent slot contents

### DIFF
--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -3347,16 +3347,9 @@ fn test_headerless_update_parent() {
         bank_forks.read().unwrap().get(slot).is_some(),
         "headerless UpdateParent should create a replay bank from the marker"
     );
-    assert_eq!(
-        progress
-            .get(&slot)
-            .unwrap()
-            .replay_progress
-            .read()
-            .unwrap()
-            .num_shreds,
-        32
-    );
+    let replay_progress = progress.get(&slot).unwrap().replay_progress.read().unwrap();
+    assert_eq!(replay_progress.num_shreds, 32);
+    assert_eq!(replay_progress.num_txs, 0);
 }
 
 #[test]

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -21,7 +21,7 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{
-            Blockstore, PurgeType,
+            Blockstore, BlockstoreError, PurgeType,
             column::{Column, ColumnName},
         },
         blockstore_options::AccessType,
@@ -164,8 +164,12 @@ fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
 
 /// Returns true if the supplied slot contains any nonvote transactions
 fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
+    let Some(slot_meta) = blockstore.meta(slot).expect("Failed to get slot meta") else {
+        return false;
+    };
+
     let (entries, _, _) = blockstore
-        .get_slot_entries_with_shred_info(slot, 0, false)
+        .get_slot_entries_with_shred_info(slot, u64::from(slot_meta.replay_fec_set_index), false)
         .expect("Failed to get slot entries");
 
     entries
@@ -713,7 +717,14 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 .into_iter()
                 .rev()
             {
-                let blockhash = blockstore.get_slot_entries(slot, 0)?.last().unwrap().hash;
+                let slot_meta = blockstore
+                    .meta(slot)?
+                    .ok_or(BlockstoreError::SlotUnavailable)?;
+                let blockhash = blockstore
+                    .get_slot_entries(slot, u64::from(slot_meta.replay_fec_set_index))?
+                    .last()
+                    .unwrap()
+                    .hash;
                 println!("{slot}: {blockhash:?}");
             }
         }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -444,8 +444,13 @@ fn compute_slot_cost(
     slot: Slot,
     allow_dead_slots: bool,
 ) -> Result<(), String> {
+    let replay_fec_set_index = blockstore
+        .meta(slot)
+        .map_err(|err| format!("Slot: {slot}, Failed to load slot meta, err {err:?}"))?
+        .map_or(0, |slot_meta| u64::from(slot_meta.replay_fec_set_index));
+
     let (entries, _num_shreds, _is_full) = blockstore
-        .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+        .get_slot_entries_with_shred_info(slot, replay_fec_set_index, allow_dead_slots)
         .map_err(|err| format!("Slot: {slot}, Failed to load entries, err {err:?}"))?;
 
     let num_entries = entries.len();

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -885,7 +885,7 @@ pub fn output_slot(
             // entries and leave the metadata fields empty
             let (components, _, _) = blockstore.get_slot_components_with_shred_info(
                 slot,
-                /*shred_start_index:*/ 0,
+                u64::from(meta.replay_fec_set_index),
                 allow_dead_slots,
             )?;
 

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -890,7 +890,7 @@ pub fn output_slot(
             // entries and leave the metadata fields empty
             let (components, _, _) = blockstore.get_slot_components_with_shred_info(
                 slot,
-                /*shred_start_index:*/ 0,
+                u64::from(meta.replay_fec_set_index),
                 allow_dead_slots,
             )?;
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4077,30 +4077,11 @@ impl Blockstore {
             return Err(BlockstoreError::SlotUnavailable);
         }
 
-        // For UpdateParent slots, replay starts at the marker FEC set. Read
-        // components first so the marker can be skipped before returning entries.
-        let slot_entries = if slot_meta.has_update_parent() {
-            let (slot_components, _, _) = self.get_slot_components_with_shred_info(
-                slot,
-                u64::from(slot_meta.replay_fec_set_index),
-                allow_dead_slots,
-            )?;
-            slot_components
-                .into_iter()
-                .filter_map(|component| match component {
-                    BlockComponent::EntryBatch(entries) => Some(entries),
-                    BlockComponent::BlockMarker(_) => None,
-                })
-                .flatten()
-                .collect()
-        } else {
-            self.get_slot_entries_with_shred_info(
-                slot,
-                u64::from(slot_meta.replay_fec_set_index),
-                allow_dead_slots,
-            )?
-            .0
-        };
+        let (slot_entries, _, _) = self.get_slot_entries_with_shred_info(
+            slot,
+            u64::from(slot_meta.replay_fec_set_index),
+            allow_dead_slots,
+        )?;
 
         if slot_entries.is_empty() {
             trace!("do_get_complete_block_with_entries() failed for {slot} (no entries found)");

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4077,11 +4077,30 @@ impl Blockstore {
             return Err(BlockstoreError::SlotUnavailable);
         }
 
-        let (slot_entries, _, _) = self.get_slot_entries_with_shred_info(
-            slot,
-            /*shred_start_index:*/ 0,
-            allow_dead_slots,
-        )?;
+        // For UpdateParent slots, replay starts at the marker FEC set. Read
+        // components first so the marker can be skipped before returning entries.
+        let slot_entries = if slot_meta.has_update_parent() {
+            let (slot_components, _, _) = self.get_slot_components_with_shred_info(
+                slot,
+                u64::from(slot_meta.replay_fec_set_index),
+                allow_dead_slots,
+            )?;
+            slot_components
+                .into_iter()
+                .filter_map(|component| match component {
+                    BlockComponent::EntryBatch(entries) => Some(entries),
+                    BlockComponent::BlockMarker(_) => None,
+                })
+                .flatten()
+                .collect()
+        } else {
+            self.get_slot_entries_with_shred_info(
+                slot,
+                u64::from(slot_meta.replay_fec_set_index),
+                allow_dead_slots,
+            )?
+            .0
+        };
 
         if slot_entries.is_empty() {
             trace!("do_get_complete_block_with_entries() failed for {slot} (no entries found)");
@@ -4214,7 +4233,7 @@ impl Blockstore {
 
         let (slot_components, _, _) = self.get_slot_components_with_shred_info(
             slot,
-            /*start_index:*/ 0,
+            u64::from(slot_meta.replay_fec_set_index),
             allow_dead_slots,
         )?;
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4192,7 +4192,7 @@ impl Blockstore {
 
         let (slot_components, _, _) = self.get_slot_components_with_shred_info(
             slot,
-            /*start_index:*/ 0,
+            u64::from(slot_meta.replay_fec_set_index),
             allow_dead_slots,
         )?;
 
@@ -4283,9 +4283,10 @@ impl Blockstore {
         slot_transaction_iterator: impl Iterator<Item = VersionedTransaction>,
     ) -> Result<VersionedConfirmedBlock> {
         let previous_blockhash = slot_meta.parent_slot.and_then(|parent_slot| {
+            let parent_slot_meta = self.meta(parent_slot).ok().flatten()?;
             self.get_slot_components_with_shred_info(
                 parent_slot,
-                /*shred_start_index:*/ 0,
+                u64::from(parent_slot_meta.replay_fec_set_index),
                 allow_dead_slots,
             )
             .ok()
@@ -4613,15 +4614,17 @@ impl Blockstore {
     /// Finds a transaction by signature in the given slot and returns it along with its index.
     ///
     /// The index represents the transaction's 0-based position in the flattened list of all
-    /// transactions across all entries in this slot. This matches the `transaction_index`
-    /// stored in `AddressSignatures` when `write_transaction_status` is called during block
-    /// processing.
+    /// transactions across the entries in this slot, starting at `replay_fec_set_index` when the
+    /// slot has an UpdateParent marker. This matches the `transaction_index` stored in
+    /// `AddressSignatures` when `write_transaction_status` is called during block processing.
     fn find_transaction_in_slot(
         &self,
         slot: Slot,
         signature: Signature,
     ) -> Result<Option<(VersionedTransaction, u32)>> {
-        let slot_entries = self.get_slot_entries(slot, 0)?;
+        let slot_meta = self.meta(slot)?.ok_or(BlockstoreError::SlotUnavailable)?;
+        let slot_entries =
+            self.get_slot_entries(slot, u64::from(slot_meta.replay_fec_set_index))?;
         Ok(slot_entries
             .into_iter()
             .flat_map(|entry| entry.transactions)

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -460,34 +460,56 @@ impl Blockstore {
         }
 
         for slot in from_slot..=to_slot {
-            let Ok((slot_entries, _, _)) =
-                self.get_slot_entries_with_shred_info(slot, 0, /*allow_dead_slots:*/ true)
-            else {
+            let mut slot_components =
+                self.get_slot_components_with_shred_info(slot, 0, /*allow_dead_slots:*/ true);
+            if slot_components.is_err()
+                && let Ok(Some(slot_meta)) = self.meta(slot)
+                && slot_meta.has_update_parent()
+            {
+                slot_components = self.get_slot_components_with_shred_info(
+                    slot,
+                    u64::from(slot_meta.replay_fec_set_index),
+                    /*allow_dead_slots:*/ true,
+                );
+            }
+            let Ok((slot_components, _, _)) = slot_components else {
                 continue;
             };
-            let transactions = slot_entries
-                .into_iter()
-                .flat_map(|entry| entry.transactions);
-            for (i, transaction) in transactions.enumerate() {
-                if let Some(&signature) = transaction.signatures.first() {
-                    self.transaction_status_cf
-                        .delete_in_batch(batch, (signature, slot));
-                    self.transaction_memos_cf
-                        .delete_in_batch(batch, (signature, slot));
+            let mut transaction_index = 0usize;
+            for component in slot_components {
+                match component {
+                    BlockComponent::EntryBatch(entries) => {
+                        for transaction in entries.into_iter().flat_map(|entry| entry.transactions)
+                        {
+                            if let Some(&signature) = transaction.signatures.first() {
+                                self.transaction_status_cf
+                                    .delete_in_batch(batch, (signature, slot));
+                                self.transaction_memos_cf
+                                    .delete_in_batch(batch, (signature, slot));
 
-                    let meta = self.read_transaction_status((signature, slot))?;
-                    let loaded_addresses = meta.map(|meta| meta.loaded_addresses);
-                    let account_keys = AccountKeys::new(
-                        transaction.message.static_account_keys(),
-                        loaded_addresses.as_ref(),
-                    );
+                                let meta = self.read_transaction_status((signature, slot))?;
+                                let loaded_addresses = meta.map(|meta| meta.loaded_addresses);
+                                let account_keys = AccountKeys::new(
+                                    transaction.message.static_account_keys(),
+                                    loaded_addresses.as_ref(),
+                                );
 
-                    let transaction_index =
-                        u32::try_from(i).map_err(|_| BlockstoreError::TransactionIndexOverflow)?;
-                    for pubkey in account_keys.iter() {
-                        self.address_signatures_cf
-                            .delete_in_batch(batch, (*pubkey, slot, transaction_index, signature));
+                                let transaction_index = u32::try_from(transaction_index)
+                                    .map_err(|_| BlockstoreError::TransactionIndexOverflow)?;
+                                for pubkey in account_keys.iter() {
+                                    self.address_signatures_cf.delete_in_batch(
+                                        batch,
+                                        (*pubkey, slot, transaction_index, signature),
+                                    );
+                                }
+                            }
+                            transaction_index += 1;
+                        }
                     }
+                    BlockComponent::BlockMarker(marker) if marker.is_update_parent() => {
+                        transaction_index = 0;
+                    }
+                    BlockComponent::BlockMarker(_) => {}
                 }
             }
         }
@@ -533,7 +555,10 @@ pub mod tests {
     use {
         super::*,
         crate::{
-            blockstore::tests::make_slot_entries_with_transactions, get_tmp_ledger_path_auto_delete,
+            blockstore::tests::{
+                insert_complete_update_parent_slot, make_slot_entries_with_transactions,
+            },
+            get_tmp_ledger_path_auto_delete,
         },
         solana_entry::entry::next_entry_mut,
         solana_hash::Hash,
@@ -1038,6 +1063,51 @@ pub mod tests {
             .iter(IteratorMode::Start)
             .unwrap();
         assert_eq!(status_entry_iterator.next(), None);
+    }
+
+    #[test_case(false; "valid prefix")]
+    #[test_case(true; "invalid prefix")]
+    fn test_purge_update_parent_transaction_indexes(invalid_prefix: bool) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let slot = 104;
+        let fixture = insert_complete_update_parent_slot(&blockstore, slot, 103, 100);
+        if invalid_prefix {
+            blockstore
+                .data_shred_cf
+                .put_bytes((slot, 0), &[1, 1, 1])
+                .unwrap();
+            assert!(
+                blockstore
+                    .get_slot_components_with_shred_info(slot, 0, true)
+                    .is_err()
+            );
+        }
+        let address_signature = (
+            fixture.post_update_address,
+            slot,
+            0,
+            fixture.post_update_signatures[0],
+        );
+        assert!(
+            blockstore
+                .address_signatures_cf
+                .get(address_signature)
+                .unwrap()
+                .is_some()
+        );
+
+        blockstore
+            .purge_slots(slot, slot, PurgeType::Exact)
+            .unwrap();
+        assert!(
+            blockstore
+                .address_signatures_cf
+                .get(address_signature)
+                .unwrap()
+                .is_none()
+        );
     }
 
     fn purge_exact(blockstore: &Blockstore, oldest_slot: Slot) {

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -183,6 +183,30 @@ fn create_block_footer_shreds_with_last(
         .collect()
 }
 
+fn create_entry_batch_shreds(
+    slot: Slot,
+    parent_slot: Slot,
+    entries: Vec<Entry>,
+    shred_index: u32,
+    is_last_in_slot: bool,
+) -> Vec<Shred> {
+    let component = BlockComponent::new_entry_batch(entries).unwrap();
+
+    Shredder::new(slot, parent_slot, 0, 0)
+        .unwrap()
+        .make_merkle_shreds_from_component(
+            &Keypair::new(),
+            &component,
+            is_last_in_slot,
+            Hash::new_unique(),
+            shred_index,
+            shred_index,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        )
+        .collect()
+}
+
 fn data_shreds(shreds: Vec<Shred>) -> Vec<Shred> {
     shreds.into_iter().filter(Shred::is_data).collect()
 }
@@ -7085,6 +7109,264 @@ fn test_post_update_orig_after() {
     assert_eq!(meta.replay_fec_set_index, 32);
     assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
     assert!(!blockstore.is_dead(slot));
+}
+
+fn transaction_signatures(entries: &[Entry]) -> Vec<Signature> {
+    entries
+        .iter()
+        .flat_map(|entry| entry.transactions.iter())
+        .map(|transaction| transaction.signatures[0])
+        .collect()
+}
+
+fn write_transaction_statuses_for_entries(
+    blockstore: &Blockstore,
+    slot: Slot,
+    entries: &[Entry],
+) -> Vec<Signature> {
+    entries
+        .iter()
+        .flat_map(|entry| entry.transactions.iter())
+        .map(|transaction| {
+            let signature = transaction.signatures[0];
+            let account_count = transaction.message.static_account_keys().len();
+            let status = TransactionStatusMeta {
+                status: Ok(()),
+                fee: 42,
+                pre_balances: vec![0; account_count],
+                post_balances: vec![1; account_count],
+                inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
+                pre_token_balances: Some(vec![]),
+                post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
+                loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
+                compute_units_consumed: Some(12345),
+                cost_units: Some(6789),
+            }
+            .into();
+            blockstore
+                .transaction_status_cf
+                .put_protobuf((signature, slot), &status)
+                .unwrap();
+            signature
+        })
+        .collect()
+}
+
+struct UpdateParentSlotFixture {
+    previous_blockhash: String,
+    post_update_blockhash: String,
+    pre_update_signatures: Vec<Signature>,
+    post_update_signatures: Vec<Signature>,
+    post_update_starting_transaction_indexes: Vec<usize>,
+    post_update_num_entries: usize,
+    update_parent_fec_set_index: u32,
+}
+
+fn expected_starting_transaction_indexes(entries: &[Entry]) -> Vec<usize> {
+    let mut starting_transaction_index = 0;
+    entries
+        .iter()
+        .map(|entry| {
+            let current_index = starting_transaction_index;
+            starting_transaction_index += entry.transactions.len();
+            current_index
+        })
+        .collect()
+}
+
+fn insert_complete_update_parent_slot(
+    blockstore: &Blockstore,
+    slot: Slot,
+    original_parent: Slot,
+    update_parent: Slot,
+) -> UpdateParentSlotFixture {
+    let (parent_shreds, parent_entries) = make_slot_entries(update_parent, update_parent - 1, 5);
+    blockstore.insert_shreds(parent_shreds, None, true).unwrap();
+    let previous_blockhash = parent_entries.last().unwrap().hash.to_string();
+
+    let pre_update_entries = make_slot_entries_with_transactions(1);
+    let post_update_entries = make_slot_entries_with_transactions(2);
+    let pre_update_signatures = transaction_signatures(&pre_update_entries);
+    let post_update_signatures =
+        write_transaction_statuses_for_entries(blockstore, slot, &post_update_entries);
+    let post_update_blockhash = post_update_entries.last().unwrap().hash.to_string();
+    let post_update_starting_transaction_indexes =
+        expected_starting_transaction_indexes(&post_update_entries);
+    let post_update_num_entries = post_update_entries.len();
+
+    let fec_set_size = u32::try_from(DATA_SHREDS_PER_FEC_BLOCK).unwrap();
+    let update_parent_fec_set_index = fec_set_size * 2;
+    let post_update_fec_set_index = fec_set_size * 3;
+    let footer_fec_set_index = fec_set_size * 4;
+    let mut shreds = create_block_header_shreds(slot, original_parent, Hash::new_unique());
+    shreds.extend(create_entry_batch_shreds(
+        slot,
+        original_parent,
+        pre_update_entries,
+        fec_set_size,
+        false,
+    ));
+    shreds.extend(create_update_parent_shreds_with_shred_parent(
+        slot,
+        original_parent,
+        update_parent,
+        Hash::new_unique(),
+        update_parent_fec_set_index,
+        false,
+    ));
+    shreds.extend(create_entry_batch_shreds(
+        slot,
+        original_parent,
+        post_update_entries,
+        post_update_fec_set_index,
+        false,
+    ));
+    shreds.extend(create_block_footer_shreds(
+        slot,
+        original_parent,
+        footer_fec_set_index,
+    ));
+    blockstore.insert_shreds(shreds, None, true).unwrap();
+
+    UpdateParentSlotFixture {
+        previous_blockhash,
+        post_update_blockhash,
+        pre_update_signatures,
+        post_update_signatures,
+        post_update_starting_transaction_indexes,
+        post_update_num_entries,
+        update_parent_fec_set_index,
+    }
+}
+
+#[test]
+fn test_complete_block_with_entries_skips_pre_update_parent_entries() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 100;
+    let original_parent = 99;
+    let update_parent = 96;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    let meta = blockstore.meta(slot).unwrap().unwrap();
+    assert!(meta.is_full());
+    assert_eq!(meta.parent_slot, Some(update_parent));
+    assert_eq!(
+        meta.replay_fec_set_index,
+        fixture.update_parent_fec_set_index
+    );
+
+    let (raw_components, _, _) = blockstore
+        .get_slot_components_with_shred_info(slot, 0, false)
+        .unwrap();
+    assert_eq!(raw_components.len(), 5);
+    assert!(matches!(
+        &raw_components[1],
+        BlockComponent::EntryBatch(entries) if transaction_signatures(entries) == fixture.pre_update_signatures
+    ));
+
+    let complete_block = blockstore.get_complete_block(slot, true).unwrap();
+    assert_eq!(complete_block.parent_slot, update_parent);
+    assert_eq!(
+        complete_block.previous_blockhash,
+        fixture.previous_blockhash
+    );
+    assert_eq!(complete_block.blockhash, fixture.post_update_blockhash);
+    assert_eq!(
+        complete_block
+            .transactions
+            .iter()
+            .map(|tx| tx.transaction.signatures[0])
+            .collect::<Vec<_>>(),
+        fixture.post_update_signatures
+    );
+
+    let block_with_entries = blockstore
+        .get_complete_block_with_entries(
+            slot, /*require_previous_blockhash:*/ true, /*populate_entries:*/ true,
+            /*allow_dead_slots:*/ false,
+        )
+        .unwrap();
+    assert_eq!(
+        block_with_entries
+            .entries
+            .iter()
+            .map(|entry| entry.starting_transaction_index)
+            .collect::<Vec<_>>(),
+        fixture.post_update_starting_transaction_indexes
+    );
+    assert_eq!(
+        block_with_entries.entries.len(),
+        fixture.post_update_num_entries
+    );
+}
+
+#[test]
+fn test_complete_block_with_components_skips_pre_update_parent_components() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 104;
+    let original_parent = 103;
+    let update_parent = 100;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    let block_with_components = blockstore
+        .get_complete_block_with_components(
+            slot, /*require_previous_blockhash:*/ true, /*populate_components:*/ true,
+            /*allow_dead_slots:*/ false,
+        )
+        .unwrap();
+    assert_eq!(block_with_components.block.parent_slot, update_parent);
+    assert_eq!(
+        block_with_components.block.previous_blockhash,
+        fixture.previous_blockhash
+    );
+    assert_eq!(
+        block_with_components.block.blockhash,
+        fixture.post_update_blockhash
+    );
+    assert_eq!(
+        block_with_components
+            .block
+            .transactions
+            .iter()
+            .map(|tx| tx.transaction.signatures[0])
+            .collect::<Vec<_>>(),
+        fixture.post_update_signatures
+    );
+
+    assert_eq!(block_with_components.components.len(), 3);
+    assert!(matches!(
+        &block_with_components.components[0],
+        ConfirmedBlockComponent::BlockMarker(marker) if marker.is_update_parent()
+    ));
+    assert!(matches!(
+        &block_with_components.components[1],
+        ConfirmedBlockComponent::EntryBatch(entries)
+            if entries.len() == fixture.post_update_num_entries
+                && entries.iter().map(|entry| entry.starting_transaction_index).collect::<Vec<_>>()
+                    == fixture.post_update_starting_transaction_indexes
+    ));
+    assert!(matches!(
+        &block_with_components.components[2],
+        ConfirmedBlockComponent::BlockMarker(marker) if marker.is_footer()
+    ));
+
+    let raw_components = blockstore
+        .get_slot_components_with_shred_info(slot, 0, false)
+        .unwrap()
+        .0;
+    assert!(matches!(
+        &raw_components[1],
+        BlockComponent::EntryBatch(entries) if transaction_signatures(entries) == fixture.pre_update_signatures
+    ));
 }
 
 #[test_matrix([true, false])]

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -185,6 +185,30 @@ fn create_block_footer_shreds_with_last(
         .collect()
 }
 
+fn create_entry_batch_shreds(
+    slot: Slot,
+    parent_slot: Slot,
+    entries: Vec<Entry>,
+    shred_index: u32,
+    is_last_in_slot: bool,
+) -> Vec<Shred> {
+    let component = BlockComponent::new_entry_batch(entries).unwrap();
+
+    Shredder::new(slot, parent_slot, 0, 0)
+        .unwrap()
+        .make_merkle_shreds_from_component(
+            &Keypair::new(),
+            &component,
+            is_last_in_slot,
+            Hash::new_unique(),
+            shred_index,
+            shred_index,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        )
+        .collect()
+}
+
 fn data_shreds(shreds: Vec<Shred>) -> Vec<Shred> {
     shreds.into_iter().filter(Shred::is_data).collect()
 }
@@ -6993,6 +7017,299 @@ fn test_post_update_orig_after() {
     assert_eq!(meta.replay_fec_set_index, 32);
     assert!(blockstore.get_data_shred(slot, 64).unwrap().is_some());
     assert!(!blockstore.is_dead(slot));
+}
+
+fn transaction_signatures(entries: &[Entry]) -> Vec<Signature> {
+    entries
+        .iter()
+        .flat_map(|entry| entry.transactions.iter())
+        .map(|transaction| transaction.signatures[0])
+        .collect()
+}
+
+fn write_transaction_statuses_for_entries(
+    blockstore: &Blockstore,
+    slot: Slot,
+    entries: &[Entry],
+) -> Vec<Signature> {
+    entries
+        .iter()
+        .flat_map(|entry| entry.transactions.iter())
+        .enumerate()
+        .map(|(transaction_index, transaction)| {
+            let signature = transaction.signatures[0];
+            let account_count = transaction.message.static_account_keys().len();
+            let status = TransactionStatusMeta {
+                status: Ok(()),
+                fee: 42,
+                pre_balances: vec![0; account_count],
+                post_balances: vec![1; account_count],
+                inner_instructions: Some(vec![]),
+                log_messages: Some(vec![]),
+                pre_token_balances: Some(vec![]),
+                post_token_balances: Some(vec![]),
+                rewards: Some(vec![]),
+                loaded_addresses: LoadedAddresses::default(),
+                return_data: Some(TransactionReturnData::default()),
+                compute_units_consumed: Some(12345),
+                cost_units: Some(6789),
+            };
+            blockstore
+                .write_transaction_status(
+                    slot,
+                    signature,
+                    transaction
+                        .message
+                        .static_account_keys()
+                        .iter()
+                        .map(|key| (key, true)),
+                    status,
+                    transaction_index,
+                )
+                .unwrap();
+            signature
+        })
+        .collect()
+}
+
+pub(crate) struct UpdateParentSlotFixture {
+    previous_blockhash: String,
+    post_update_blockhash: String,
+    pub(crate) post_update_address: Pubkey,
+    pre_update_signatures: Vec<Signature>,
+    pub(crate) post_update_signatures: Vec<Signature>,
+    post_update_starting_transaction_indexes: Vec<usize>,
+    post_update_num_entries: usize,
+    update_parent_fec_set_index: u32,
+}
+
+fn expected_starting_transaction_indexes(entries: &[Entry]) -> Vec<usize> {
+    let mut starting_transaction_index = 0;
+    entries
+        .iter()
+        .map(|entry| {
+            let current_index = starting_transaction_index;
+            starting_transaction_index += entry.transactions.len();
+            current_index
+        })
+        .collect()
+}
+
+pub(crate) fn insert_complete_update_parent_slot(
+    blockstore: &Blockstore,
+    slot: Slot,
+    original_parent: Slot,
+    update_parent: Slot,
+) -> UpdateParentSlotFixture {
+    let (parent_shreds, parent_entries) = make_slot_entries(update_parent, update_parent - 1, 5);
+    blockstore.insert_shreds(parent_shreds, true).unwrap();
+    let previous_blockhash = parent_entries.last().unwrap().hash.to_string();
+
+    let pre_update_entries = make_slot_entries_with_transactions(1);
+    let post_update_entries = make_slot_entries_with_transactions(2);
+    let post_update_address = post_update_entries[0].transactions[0]
+        .message
+        .static_account_keys()[0];
+    let pre_update_signatures = transaction_signatures(&pre_update_entries);
+    let post_update_signatures =
+        write_transaction_statuses_for_entries(blockstore, slot, &post_update_entries);
+    let post_update_blockhash = post_update_entries.last().unwrap().hash.to_string();
+    let post_update_starting_transaction_indexes =
+        expected_starting_transaction_indexes(&post_update_entries);
+    let post_update_num_entries = post_update_entries.len();
+
+    let fec_set_size = u32::try_from(DATA_SHREDS_PER_FEC_BLOCK).unwrap();
+    let update_parent_fec_set_index = fec_set_size * 2;
+    let post_update_fec_set_index = fec_set_size * 3;
+    let footer_fec_set_index = fec_set_size * 4;
+    let mut shreds = create_block_header_shreds(slot, original_parent, Hash::new_unique());
+    shreds.extend(create_entry_batch_shreds(
+        slot,
+        original_parent,
+        pre_update_entries,
+        fec_set_size,
+        false,
+    ));
+    shreds.extend(create_update_parent_shreds_with_shred_parent(
+        slot,
+        original_parent,
+        update_parent,
+        Hash::new_unique(),
+        update_parent_fec_set_index,
+        false,
+    ));
+    shreds.extend(create_entry_batch_shreds(
+        slot,
+        original_parent,
+        post_update_entries,
+        post_update_fec_set_index,
+        false,
+    ));
+    shreds.extend(create_block_footer_shreds(
+        slot,
+        original_parent,
+        footer_fec_set_index,
+    ));
+    blockstore.insert_shreds(shreds, true).unwrap();
+
+    UpdateParentSlotFixture {
+        previous_blockhash,
+        post_update_blockhash,
+        post_update_address,
+        pre_update_signatures,
+        post_update_signatures,
+        post_update_starting_transaction_indexes,
+        post_update_num_entries,
+        update_parent_fec_set_index,
+    }
+}
+
+#[test]
+fn test_complete_block_skips_pre_update_parent_entries() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 100;
+    let original_parent = 99;
+    let update_parent = 96;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    let meta = blockstore.meta(slot).unwrap().unwrap();
+    assert!(meta.is_full());
+    assert_eq!(meta.parent_slot, Some(update_parent));
+    assert_eq!(
+        meta.replay_fec_set_index,
+        fixture.update_parent_fec_set_index
+    );
+
+    let (raw_components, _, _) = blockstore
+        .get_slot_components_with_shred_info(slot, 0, false)
+        .unwrap();
+    assert_eq!(raw_components.len(), 5);
+    assert!(matches!(
+        &raw_components[1],
+        BlockComponent::EntryBatch(entries) if transaction_signatures(entries) == fixture.pre_update_signatures
+    ));
+
+    let complete_block = blockstore.get_complete_block(slot, true).unwrap();
+    assert_eq!(complete_block.parent_slot, update_parent);
+    assert_eq!(
+        complete_block.previous_blockhash,
+        fixture.previous_blockhash
+    );
+    assert_eq!(complete_block.blockhash, fixture.post_update_blockhash);
+    assert_eq!(
+        complete_block
+            .transactions
+            .iter()
+            .map(|tx| tx.transaction.signatures[0])
+            .collect::<Vec<_>>(),
+        fixture.post_update_signatures
+    );
+}
+
+#[test]
+fn test_get_transaction_uses_post_update_parent_indexes() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 104;
+    let original_parent = 103;
+    let update_parent = 100;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    for (expected_index, signature) in fixture.post_update_signatures.iter().copied().enumerate() {
+        let transaction = blockstore
+            .get_complete_transaction(signature, slot)
+            .unwrap()
+            .unwrap();
+        assert_eq!(transaction.index, expected_index as u32);
+    }
+
+    blockstore.set_roots([slot].iter()).unwrap();
+    for (expected_index, signature) in fixture.post_update_signatures.iter().copied().enumerate() {
+        let transaction = blockstore
+            .get_rooted_transaction(signature)
+            .unwrap()
+            .unwrap();
+        assert_eq!(transaction.index, expected_index as u32);
+    }
+}
+
+#[test]
+fn test_find_transaction_in_slot_requires_slot_meta() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    assert_matches!(
+        blockstore.find_transaction_in_slot(1, Signature::new_unique()),
+        Err(BlockstoreError::SlotUnavailable)
+    );
+}
+
+#[test]
+fn test_complete_block_with_components_skips_pre_update_parent_components() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 104;
+    let original_parent = 103;
+    let update_parent = 100;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    let block_with_components = blockstore
+        .get_complete_block_with_components(
+            slot, /*require_previous_blockhash:*/ true, /*populate_components:*/ true,
+            /*allow_dead_slots:*/ false,
+        )
+        .unwrap();
+    assert_eq!(block_with_components.block.parent_slot, update_parent);
+    assert_eq!(
+        block_with_components.block.previous_blockhash,
+        fixture.previous_blockhash
+    );
+    assert_eq!(
+        block_with_components.block.blockhash,
+        fixture.post_update_blockhash
+    );
+    assert_eq!(
+        block_with_components
+            .block
+            .transactions
+            .iter()
+            .map(|tx| tx.transaction.signatures[0])
+            .collect::<Vec<_>>(),
+        fixture.post_update_signatures
+    );
+
+    assert_eq!(block_with_components.components.len(), 3);
+    assert!(matches!(
+        &block_with_components.components[0],
+        ConfirmedBlockComponent::BlockMarker(marker) if marker.is_update_parent()
+    ));
+    assert!(matches!(
+        &block_with_components.components[1],
+        ConfirmedBlockComponent::EntryBatch(entries)
+            if entries.len() == fixture.post_update_num_entries
+                && entries.iter().map(|entry| entry.starting_transaction_index).collect::<Vec<_>>()
+                    == fixture.post_update_starting_transaction_indexes
+    ));
+    assert!(matches!(
+        &block_with_components.components[2],
+        ConfirmedBlockComponent::BlockMarker(marker) if marker.is_footer()
+    ));
+
+    let raw_components = blockstore
+        .get_slot_components_with_shred_info(slot, 0, false)
+        .unwrap()
+        .0;
+    assert!(matches!(
+        &raw_components[1],
+        BlockComponent::EntryBatch(entries) if transaction_signatures(entries) == fixture.pre_update_signatures
+    ));
 }
 
 #[test_matrix([true, false])]


### PR DESCRIPTION
#### Problem
UpdateParent slots should expose only the replayed/canonical suffix of the slot. Currently, read-layer functions like ledger-tools `slot` and RPC `getBlock` show the entire slot.

See https://github.com/anza-xyz/agave/issues/12885 for FLH read layer plans overview/tracking

#### Summary of Changes
- Fixed `ledger/src/blockstore.rs:do_get_complete_block_with_entries` and `do_get_complete_block_with_components` to only read shreds starting at `slot_meta.replay_fec_set_index`.
- Fixed `ledger-tool/src/output.rs` to do the same
- Fixed `ledger/src/blockstore/blockstore_purge.rs` to count tx indexes correctly for lookups.

#### Testing
Added tests:
- `test_complete_block_skips_pre_update_parent_entries`
- `test_get_transaction_uses_post_update_parent_indexes`
- `test_purge_update_parent_transaction_indexes`
- `test_find_transaction_in_slot_requires_slot_meta`
- `test_complete_block_with_components_skips_pre_update_parent_components`

Example output of ledger-tool's `slot` command with UpdateParent:
```
Slot: 100
Parent Slot: 96
Blockhash: 9PUjT2qJ6Tf9nLGT3tGhaRx35Duf5SrGuk93ghmRbwFd
Previous Blockhash: 9UtpRQFh2wuVPQ6n2Q3EBRS7Mt5E9v1zrkpiFEWNP77W
Block Marker - UpdateParent: new_parent_slot: 96, new_parent_block_id: LX3EUdRUBUa3TbsYXLEUdj9J3prXkWXvLYSWyYyc2Jj
Entry 0 - num_hashes: 1, hash: 5w6wYxkXuZVtm56Nig3uzuAw93yo954QQtRSA9kW4EZC, transactions: 1, starting_transaction_index: 0
  Transaction 0:
    Version: legacy
    Recent Blockhash: 11111111111111111111111111111111
    Signature 0: KiKQJ1FZA7Zzhrg6isLq6vwsC1BCHcsicgJCug2KKubTXf2tqabsMYUCTrScNidZCUiqeTktzgRCsdrJCS5j4Dx
    Account 0: srw- CNXazAFprMxnKDXKpAHLBThaa3o3jZ3VRFogUTytJ4Rf (fee payer)
    Account 1: -r-x 8DYGSvQDrWXj5AvRau13wZ7ZktwFmu1RbbxHLheQCRuM
    Account 2: -r-- FZas2BZM8tENunbq8uCNQWP52Em8RA4qAAPTvmuBgLYC
    Instruction 0
      Program:   8DYGSvQDrWXj5AvRau13wZ7ZktwFmu1RbbxHLheQCRuM (1)
      Account 0: CNXazAFprMxnKDXKpAHLBThaa3o3jZ3VRFogUTytJ4Rf (0)
      Data: []
    Status: Ok
      Fee: ◎0.000000042
      Account 0 balance: ◎0 -> ◎0.000000001
      Account 1 balance: ◎0 -> ◎0.000000001
      Account 2 balance: ◎0 -> ◎0.000000001
    Compute Units Consumed: 12345
Entry 1 - num_hashes: 0, hash: CoRutESHXR94goeNsP5Za7RKyKrK8AYLQa4PwvT2934w, transactions: 0, starting_transaction_index: 1
Entry 2 - num_hashes: 1, hash: JBEgrV7UAeWuU3LRM1sBq8jGM9uNamUQQ5YKfTRh4haM, transactions: 1, starting_transaction_index: 1
  Transaction 0:
    Version: legacy
    Recent Blockhash: 11111111111111111111111111111111
    Signature 0: 4z4MTPEMf2qXCXPm4LMDQotuu5Fu1mBGKMUdEQ6ggxq5hE1vkV8EVVZsw2cmZWidJuuAezsQheasHYo5Ysm7Z4k1
    Account 0: srw- BQ12QTzH8jFQ7orempefZX2L8go2CE4k3WDSMHfBCLyH (fee payer)
    Account 1: -r-x 2m1abK4SXuGxxxnxkqWeCyAWuqkt3cYkp9bjXm4WsdMg
    Account 2: -r-- F3hFEjx5TVj1vDEgDb1EzTJmfZyFqPHtFHHzjqYuAb3b
    Instruction 0
      Program:   2m1abK4SXuGxxxnxkqWeCyAWuqkt3cYkp9bjXm4WsdMg (1)
      Account 0: BQ12QTzH8jFQ7orempefZX2L8go2CE4k3WDSMHfBCLyH (0)
      Data: []
    Status: Ok
      Fee: ◎0.000000042
      Account 0 balance: ◎0 -> ◎0.000000001
      Account 1 balance: ◎0 -> ◎0.000000001
      Account 2 balance: ◎0 -> ◎0.000000001
    Compute Units Consumed: 12345
Entry 3 - num_hashes: 0, hash: 9PUjT2qJ6Tf9nLGT3tGhaRx35Duf5SrGuk93ghmRbwFd, transactions: 0, starting_transaction_index: 2
Block Marker - BlockFooter: bank_hash: YEGAxog9gxiGXxo538aAQxq55XAebpFfwU72ZUxmSHm, block_producer_time_nanos: 0, block_user_agent:
  No finalization certificate
  SkipRewardCertificate: None
  NotarRewardCertificate: None
```
