### PR TITLE
nit: do not return a reference to a Arc

### DIFF
--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -314,7 +314,7 @@ impl VersionedEpochStakes {
         }
     }
 
-    pub fn bls_pubkey_to_rank_map(&self) -> &Arc<BLSPubkeyToRankMap> {
+    pub fn bls_pubkey_to_rank_map(&self) -> &BLSPubkeyToRankMap {
         match self {
             Self::Current {
                 bls_pubkey_to_rank_map,


### PR DESCRIPTION
#### Problem

It is considered ergonomic to prefer `&T` over `&Arc<T>`

#### Summary of Changes

Updates return type of `bls_pubkey_to_rank_map` accordingly.


#### Testing

Just CI