### PR TITLE
accounts-db: Consolidates metrics for shrink and squash

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -40,7 +40,7 @@ use {
         accounts_db::stats::{
             AccountsStats, CleanAccountsStats, FlushStats, LoadAccountsStats,
             ObsoleteAccountsStats, PurgeStats, ShrinkAncientStats, ShrinkStats, ShrinkStatsSub,
-            StoreAccountsForFlushStats, StoreAccountsForShrinkStats, StoreAccountsTiming,
+            StoreAccountsForFlushStats, StoreAccountsForShrinkStats, StoreAccountsForSquashStats,
             StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
         },
         accounts_file::{AccountsFile, AccountsFileProvider},
@@ -909,9 +909,6 @@ pub struct AccountsDb {
     /// Stats from storing accounts unfrozen
     store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats,
 
-    /// Stats from storing accounts for shrink
-    store_accounts_for_shrink_stats: StoreAccountsForShrinkStats,
-
     clean_accounts_stats: CleanAccountsStats,
 
     // Stats for purges called outside of clean_accounts()
@@ -1136,7 +1133,6 @@ impl AccountsDb {
             stats: AccountsStats::default(),
             load_account_stats: LoadAccountsStats::default(),
             store_accounts_unfrozen_stats: StoreAccountsUnfrozenStats::default(),
-            store_accounts_for_shrink_stats: StoreAccountsForShrinkStats::default(),
             #[cfg(test)]
             load_delay: u64::default(),
             #[cfg(test)]
@@ -2936,7 +2932,7 @@ impl AccountsDb {
         // mutating rooted slots; There should be no writers to them.
         let accounts = [(slot, &shrink_collect.alive_accounts.alive_accounts()[..])];
         let storable_accounts = StorableAccountsBySlot::new(slot, &accounts, self);
-        stats_sub.store_accounts_timing = self.store_accounts_for_shrink(
+        stats_sub.store_accounts_stats = self.store_accounts_for_shrink(
             storable_accounts,
             shrink_in_progress.new_storage(),
             UpdateIndexThreadSelection::PoolWithThreshold,
@@ -2961,46 +2957,8 @@ impl AccountsDb {
 
         self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
 
-        Self::update_shrink_stats(&self.shrink_stats, stats_sub, true);
+        self.shrink_stats.accumulate_sub_stats(stats_sub, true);
         self.shrink_stats.report();
-    }
-
-    pub(crate) fn update_shrink_stats(
-        shrink_stats: &ShrinkStats,
-        stats_sub: ShrinkStatsSub,
-        increment_count: bool,
-    ) {
-        if increment_count {
-            shrink_stats
-                .num_slots_shrunk
-                .fetch_add(1, Ordering::Relaxed);
-        }
-        shrink_stats.create_and_insert_store_elapsed.fetch_add(
-            stats_sub.create_and_insert_store_elapsed_us.0,
-            Ordering::Relaxed,
-        );
-        shrink_stats.store_accounts_elapsed.fetch_add(
-            stats_sub.store_accounts_timing.store_accounts_elapsed,
-            Ordering::Relaxed,
-        );
-        shrink_stats.update_index_elapsed.fetch_add(
-            stats_sub.store_accounts_timing.update_index_elapsed,
-            Ordering::Relaxed,
-        );
-        shrink_stats.handle_reclaims_elapsed.fetch_add(
-            stats_sub.store_accounts_timing.handle_reclaims_elapsed,
-            Ordering::Relaxed,
-        );
-        shrink_stats
-            .rewrite_elapsed
-            .fetch_add(stats_sub.rewrite_elapsed_us.0, Ordering::Relaxed);
-        shrink_stats
-            .unpackable_slots_count
-            .fetch_add(stats_sub.unpackable_slots_count.0 as u64, Ordering::Relaxed);
-        shrink_stats.newest_alive_packed_count.fetch_add(
-            stats_sub.newest_alive_packed_count.0 as u64,
-            Ordering::Relaxed,
-        );
     }
 
     /// get stores for 'slot'
@@ -5583,10 +5541,11 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a>,
         storage: &AccountStorageEntry,
-    ) -> StoreAccountsTiming {
+    ) -> StoreAccountsForSquashStats {
         let slot = accounts.target_slot();
+
         // Flush the read cache if necessary
-        if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {
+        let flush_read_cache_us = if self.read_only_accounts_cache.can_slot_be_in_cache(slot) {
             let flush_read_cache_time = Measure::start("flush_read_cache");
             (0..accounts.len()).for_each(|index| {
                 // Based on the patterns of how a validator writes accounts, it is almost always
@@ -5595,16 +5554,20 @@ impl AccountsDb {
                 self.read_only_accounts_cache
                     .remove_assume_not_present(accounts.pubkey(index));
             });
-            self.store_accounts_for_shrink_stats
-                .flush_read_cache_us
-                .fetch_add(flush_read_cache_time.end_as_us(), Ordering::Relaxed);
-        }
+            flush_read_cache_time.end_as_us()
+        } else {
+            0
+        };
 
-        self.store_accounts_for_shrink(
+        let store_accounts_for_shrink_stats = self.store_accounts_for_shrink(
             accounts,
             storage,
             UpdateIndexThreadSelection::PoolWithThreshold,
-        )
+        );
+        StoreAccountsForSquashStats {
+            store_accounts_for_shrink_stats,
+            flush_read_cache_us,
+        }
     }
 
     /// Stores accounts in the storage and updates the index.
@@ -5617,10 +5580,9 @@ impl AccountsDb {
         accounts: impl StorableAccounts<'a>,
         storage: &AccountStorageEntry,
         update_index_thread_selection: UpdateIndexThreadSelection,
-    ) -> StoreAccountsTiming {
+    ) -> StoreAccountsForShrinkStats {
         let slot = accounts.target_slot();
         let num_accounts_stored = accounts.len();
-        let stats = &self.store_accounts_for_shrink_stats;
 
         debug_assert!(self.accounts_index.is_alive_root(slot));
 
@@ -5643,28 +5605,12 @@ impl AccountsDb {
         );
         let update_index_us = update_index_time.end_as_us();
 
-        stats
-            .write_to_storage_us
-            .fetch_add(write_accounts_us, Ordering::Relaxed);
-        stats
-            .mark_zero_lamport_single_ref_accounts_us
-            .fetch_add(mark_zero_lamport_single_ref_us, Ordering::Relaxed);
-        stats
-            .update_index_us
-            .fetch_add(update_index_us, Ordering::Relaxed);
-        stats
-            .num_accounts_stored
-            .fetch_add(num_accounts_stored as u64, Ordering::Relaxed);
-        stats.num_zero_lamport_single_ref_accounts_marked.fetch_add(
+        StoreAccountsForShrinkStats {
+            write_accounts_us,
+            mark_zero_lamport_single_ref_accounts_us: mark_zero_lamport_single_ref_us,
+            update_index_us,
+            num_accounts_stored: num_accounts_stored as u64,
             num_zero_lamport_single_ref_accounts_marked,
-            Ordering::Relaxed,
-        );
-        stats.report();
-
-        StoreAccountsTiming {
-            store_accounts_elapsed: write_accounts_us,
-            update_index_elapsed: update_index_us,
-            handle_reclaims_elapsed: 0,
         }
     }
 

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -101,62 +101,40 @@ impl StoreAccountsUnfrozenStats {
     }
 }
 
-/// Stats from storing accounts for shrink (i.e. moving accounts between storage files)
+/// Stats from storing accounts for shrink (i.e. moving accounts into new storage file)
 #[derive(Debug, Default)]
 pub struct StoreAccountsForShrinkStats {
-    pub last_report: AtomicInterval,
-    pub flush_read_cache_us: AtomicU64,
-    pub write_to_storage_us: AtomicU64,
-    pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
-    pub update_index_us: AtomicU64,
-    pub num_accounts_stored: AtomicU64,
-    pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
+    pub write_accounts_us: u64,
+    pub mark_zero_lamport_single_ref_accounts_us: u64,
+    pub update_index_us: u64,
+    pub num_accounts_stored: u64,
+    pub num_zero_lamport_single_ref_accounts_marked: u64,
 }
 
 impl StoreAccountsForShrinkStats {
-    const REPORT_INTERVAL_MS: u64 = Duration::from_secs(1).as_millis() as u64;
+    pub fn accumulate(&mut self, other: &Self) {
+        self.write_accounts_us += other.write_accounts_us;
+        self.mark_zero_lamport_single_ref_accounts_us +=
+            other.mark_zero_lamport_single_ref_accounts_us;
+        self.update_index_us += other.update_index_us;
+        self.num_accounts_stored += other.num_accounts_stored;
+        self.num_zero_lamport_single_ref_accounts_marked +=
+            other.num_zero_lamport_single_ref_accounts_marked;
+    }
+}
 
-    pub fn report(&self) {
-        let should_report = self.last_report.should_update(Self::REPORT_INTERVAL_MS);
-        if !should_report {
-            return;
-        }
+/// Stats from storing accounts for squash (i.e. moving accounts between storage files)
+#[derive(Debug, Default)]
+pub struct StoreAccountsForSquashStats {
+    pub store_accounts_for_shrink_stats: StoreAccountsForShrinkStats,
+    pub flush_read_cache_us: u64,
+}
 
-        datapoint_info!(
-            "accounts_db_store_accounts_for_shrink",
-            (
-                "flush_read_cache_us",
-                self.flush_read_cache_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "write_to_storage_us",
-                self.write_to_storage_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "mark_zero_lamport_single_ref_accounts_us",
-                self.mark_zero_lamport_single_ref_accounts_us
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "update_index_us",
-                self.update_index_us.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_accounts_stored",
-                self.num_accounts_stored.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_zero_lamport_single_ref_accounts_marked",
-                self.num_zero_lamport_single_ref_accounts_marked
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-        );
+impl StoreAccountsForSquashStats {
+    pub fn accumulate(&mut self, other: &Self) {
+        self.store_accounts_for_shrink_stats
+            .accumulate(&other.store_accounts_for_shrink_stats);
+        self.flush_read_cache_us += other.flush_read_cache_us;
     }
 }
 
@@ -256,21 +234,6 @@ impl PurgeStats {
                 ),
             );
         }
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct StoreAccountsTiming {
-    pub store_accounts_elapsed: u64,
-    pub update_index_elapsed: u64,
-    pub handle_reclaims_elapsed: u64,
-}
-
-impl StoreAccountsTiming {
-    pub fn accumulate(&mut self, other: &Self) {
-        self.store_accounts_elapsed += other.store_accounts_elapsed;
-        self.update_index_elapsed += other.update_index_elapsed;
-        self.handle_reclaims_elapsed += other.handle_reclaims_elapsed;
     }
 }
 
@@ -456,27 +419,36 @@ pub struct ShrinkAncientStats {
     pub total_alive_bytes: AtomicU64,
     pub slot: AtomicU64,
     pub ideal_storage_size: AtomicU64,
+    pub flush_read_cache_us: AtomicU64,
 }
 
 #[derive(Debug, Default)]
 pub struct ShrinkStatsSub {
-    pub store_accounts_timing: StoreAccountsTiming,
+    pub store_accounts_stats: StoreAccountsForShrinkStats,
+    pub rewrite_elapsed_us: Saturating<u64>,
+    pub create_and_insert_store_elapsed_us: Saturating<u64>,
+}
+
+#[derive(Debug, Default)]
+pub struct SquashStatsSub {
+    pub store_accounts_stats: StoreAccountsForSquashStats,
     pub rewrite_elapsed_us: Saturating<u64>,
     pub create_and_insert_store_elapsed_us: Saturating<u64>,
     pub unpackable_slots_count: Saturating<usize>,
     pub newest_alive_packed_count: Saturating<usize>,
 }
 
-impl ShrinkStatsSub {
+impl SquashStatsSub {
     pub fn accumulate(&mut self, other: &Self) {
-        self.store_accounts_timing
-            .accumulate(&other.store_accounts_timing);
+        self.store_accounts_stats
+            .accumulate(&other.store_accounts_stats);
         self.rewrite_elapsed_us += other.rewrite_elapsed_us;
         self.create_and_insert_store_elapsed_us += other.create_and_insert_store_elapsed_us;
         self.unpackable_slots_count += other.unpackable_slots_count;
         self.newest_alive_packed_count += other.newest_alive_packed_count;
     }
 }
+
 #[derive(Debug, Default)]
 pub struct ShrinkStats {
     pub last_report: AtomicInterval,
@@ -484,9 +456,11 @@ pub struct ShrinkStats {
     pub storage_read_elapsed: AtomicU64,
     pub index_read_elapsed: AtomicU64,
     pub create_and_insert_store_elapsed: AtomicU64,
-    pub store_accounts_elapsed: AtomicU64,
-    pub update_index_elapsed: AtomicU64,
-    pub handle_reclaims_elapsed: AtomicU64,
+    pub write_accounts_us: AtomicU64,
+    pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
+    pub update_index_us: AtomicU64,
+    pub num_accounts_stored: AtomicU64,
+    pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
     pub remove_old_stores_shrink_us: AtomicU64,
     pub rewrite_elapsed: AtomicU64,
     pub unpackable_slots_count: AtomicU64,
@@ -514,6 +488,39 @@ pub struct ShrinkStats {
 }
 
 impl ShrinkStats {
+    pub fn accumulate_sub_stats(&self, stats_sub: ShrinkStatsSub, increment_count: bool) {
+        if increment_count {
+            self.num_slots_shrunk.fetch_add(1, Ordering::Relaxed);
+        }
+        self.create_and_insert_store_elapsed.fetch_add(
+            stats_sub.create_and_insert_store_elapsed_us.0,
+            Ordering::Relaxed,
+        );
+        self.rewrite_elapsed
+            .fetch_add(stats_sub.rewrite_elapsed_us.0, Ordering::Relaxed);
+        self.accumulate_store_accounts_for_shrink_stats(stats_sub.store_accounts_stats);
+    }
+
+    pub fn accumulate_store_accounts_for_shrink_stats(
+        &self,
+        store_accounts_stats: StoreAccountsForShrinkStats,
+    ) {
+        self.write_accounts_us
+            .fetch_add(store_accounts_stats.write_accounts_us, Ordering::Relaxed);
+        self.mark_zero_lamport_single_ref_accounts_us.fetch_add(
+            store_accounts_stats.mark_zero_lamport_single_ref_accounts_us,
+            Ordering::Relaxed,
+        );
+        self.update_index_us
+            .fetch_add(store_accounts_stats.update_index_us, Ordering::Relaxed);
+        self.num_accounts_stored
+            .fetch_add(store_accounts_stats.num_accounts_stored, Ordering::Relaxed);
+        self.num_zero_lamport_single_ref_accounts_marked.fetch_add(
+            store_accounts_stats.num_zero_lamport_single_ref_accounts_marked,
+            Ordering::Relaxed,
+        );
+    }
+
     pub fn report(&self) {
         if self.last_report.should_update(1000) {
             datapoint_info!(
@@ -567,18 +574,30 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "store_accounts_elapsed",
-                    self.store_accounts_elapsed.swap(0, Ordering::Relaxed),
+                    "write_accounts_us",
+                    self.write_accounts_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
-                    "update_index_elapsed",
-                    self.update_index_elapsed.swap(0, Ordering::Relaxed),
+                    "mark_zero_lamport_single_ref_accounts_us",
+                    self.mark_zero_lamport_single_ref_accounts_us
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
-                    "handle_reclaims_elapsed",
-                    self.handle_reclaims_elapsed.swap(0, Ordering::Relaxed),
+                    "update_index_us",
+                    self.update_index_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_accounts_stored",
+                    self.num_accounts_stored.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_zero_lamport_single_ref_accounts_marked",
+                    self.num_zero_lamport_single_ref_accounts_marked
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -676,6 +695,31 @@ impl ShrinkStats {
 }
 
 impl ShrinkAncientStats {
+    pub fn accumulate_sub_stats(&self, stats_sub: SquashStatsSub) {
+        let shrink_stats = &self.shrink_stats;
+        shrink_stats.create_and_insert_store_elapsed.fetch_add(
+            stats_sub.create_and_insert_store_elapsed_us.0,
+            Ordering::Relaxed,
+        );
+        shrink_stats
+            .rewrite_elapsed
+            .fetch_add(stats_sub.rewrite_elapsed_us.0, Ordering::Relaxed);
+        shrink_stats
+            .unpackable_slots_count
+            .fetch_add(stats_sub.unpackable_slots_count.0 as u64, Ordering::Relaxed);
+        shrink_stats.newest_alive_packed_count.fetch_add(
+            stats_sub.newest_alive_packed_count.0 as u64,
+            Ordering::Relaxed,
+        );
+        let StoreAccountsForSquashStats {
+            store_accounts_for_shrink_stats,
+            flush_read_cache_us,
+        } = stats_sub.store_accounts_stats;
+        self.flush_read_cache_us
+            .fetch_add(flush_read_cache_us, Ordering::Relaxed);
+        shrink_stats.accumulate_store_accounts_for_shrink_stats(store_accounts_for_shrink_stats);
+    }
+
     pub fn report(&self) {
         datapoint_info!(
             "shrink_ancient_stats",
@@ -722,23 +766,40 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "store_accounts_elapsed",
+                "flush_read_cache_us",
+                self.flush_read_cache_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "write_accounts_us",
                 self.shrink_stats
-                    .store_accounts_elapsed
+                    .write_accounts_us
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "update_index_elapsed",
+                "mark_zero_lamport_single_ref_accounts_us",
                 self.shrink_stats
-                    .update_index_elapsed
+                    .mark_zero_lamport_single_ref_accounts_us
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
-                "handle_reclaims_elapsed",
+                "update_index_us",
+                self.shrink_stats.update_index_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_accounts_stored",
                 self.shrink_stats
-                    .handle_reclaims_elapsed
+                    .num_accounts_stored
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "num_zero_lamport_single_ref_accounts_marked",
+                self.shrink_stats
+                    .num_zero_lamport_single_ref_accounts_marked
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -11,7 +11,7 @@ use {
         accounts_db::{
             AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
             ShrinkCollectAliveSeparatedByRefs,
-            stats::{ShrinkAncientStats, ShrinkStatsSub},
+            stats::{ShrinkAncientStats, SquashStatsSub},
         },
         active_stats::ActiveStatItem,
         storable_accounts::{StorableAccounts, StorableAccountsBySlot},
@@ -331,7 +331,7 @@ struct WriteAncientAccounts<'a> {
     /// 'ShrinkInProgress' instances created by starting a shrink operation
     shrinks_in_progress: HashMap<Slot, ShrinkInProgress<'a>>,
 
-    metrics: ShrinkStatsSub,
+    metrics: SquashStatsSub,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -367,7 +367,7 @@ impl AccountsDb {
 
         let _guard = self.active_stats.activate(ActiveStatItem::SquashAncient);
 
-        let mut stats_sub = ShrinkStatsSub::default();
+        let mut stats_sub = SquashStatsSub::default();
 
         let (_, total_us) = measure_us!(self.combine_ancient_slots_packed_internal(
             sorted_slots,
@@ -375,7 +375,7 @@ impl AccountsDb {
             &mut stats_sub
         ));
 
-        Self::update_shrink_stats(&self.shrink_ancient_stats.shrink_stats, stats_sub, false);
+        self.shrink_ancient_stats.accumulate_sub_stats(stats_sub);
         self.shrink_ancient_stats
             .total_us
             .fetch_add(total_us, Ordering::Relaxed);
@@ -418,7 +418,7 @@ impl AccountsDb {
         &self,
         sorted_slots: Vec<Slot>,
         mut tuning: PackedAncientStorageTuning,
-        metrics: &mut ShrinkStatsSub,
+        metrics: &mut SquashStatsSub,
     ) {
         self.shrink_ancient_stats
             .slot
@@ -563,15 +563,15 @@ impl AccountsDb {
             .expect("ancient shrink target slot must already have a storage");
         let (shrink_in_progress, create_and_insert_store_elapsed_us) =
             measure_us!(self.get_store_for_shrink(target_slot, old_store, bytes));
-        let (store_accounts_timing, rewrite_elapsed_us) = measure_us!(
+        let (store_accounts_stats, rewrite_elapsed_us) = measure_us!(
             self.store_accounts_for_squash(accounts_to_write, shrink_in_progress.new_storage())
         );
 
-        write_ancient_accounts.metrics.accumulate(&ShrinkStatsSub {
-            store_accounts_timing,
+        write_ancient_accounts.metrics.accumulate(&SquashStatsSub {
+            store_accounts_stats,
             rewrite_elapsed_us: Saturating(rewrite_elapsed_us),
             create_and_insert_store_elapsed_us: Saturating(create_and_insert_store_elapsed_us),
-            ..ShrinkStatsSub::default()
+            ..SquashStatsSub::default()
         });
 
         write_ancient_accounts
@@ -726,7 +726,7 @@ impl AccountsDb {
         &self,
         accounts_to_combine: AccountsToCombine<'_>,
         mut write_ancient_accounts: WriteAncientAccounts,
-        metrics: &mut ShrinkStatsSub,
+        metrics: &mut SquashStatsSub,
     ) {
         let mut dropped_roots = Vec::with_capacity(accounts_to_combine.accounts_to_combine.len());
         for shrink_collect in accounts_to_combine.accounts_to_combine {
@@ -1557,7 +1557,7 @@ mod tests {
                         &default_tuning(),
                         IncludeManyRefSlots::Include,
                     );
-                    let mut stats = ShrinkStatsSub::default();
+                    let mut stats = SquashStatsSub::default();
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
 
                     slots.clone().for_each(|slot| {
@@ -3422,7 +3422,7 @@ mod tests {
                 db.combine_ancient_slots_packed_internal(
                     (0..num_slots).map(|slot| (slot as Slot) + slot1).collect(),
                     tuning,
-                    &mut ShrinkStatsSub::default(),
+                    &mut SquashStatsSub::default(),
                 );
                 let storage = db.storage.get_slot_storage_entry(slot1);
                 if num_slots == 0 {
@@ -3500,7 +3500,7 @@ mod tests {
             ..default_tuning()
         };
 
-        let mut stats_sub = ShrinkStatsSub::default();
+        let mut stats_sub = SquashStatsSub::default();
         db.combine_ancient_slots_packed_internal(sorted_slots, tuning, &mut stats_sub);
     }
 


### PR DESCRIPTION
#### Problem

Similar to #13415, but for shrink and squash.

There are multiple sets of metrics for shrink and squash: top-level shrink, top-level squash, and a shared store_accounts_for_shrink() (which both shrink and squash increment). One, this is confusing. Two, there's overlap between the the top-level and the store_accounts_for_shrink() metrics. Three, it's not obvious/always possible to know how much of shrink or squash contributed to the store_accounts_for_shrink metrics.

For me, the main one is to have all the top-level stats under one metric.


#### Summary of Changes

Remove the store_accounts_for_shrink() metric, and instead move those metrics into top-level shrink and squash. Now contributions to store_accounts_for_shrink() and properly attributed to either shrink or squash.

This PR purposely leaves the reporting intervals the same. That can be handled in subsequent PRs as necessary. Similarly, this PR retains the fields in AccountsDb for shrink and squash stats. That helps keep the PR much smaller, as it already is quite large.

With the consolidation, some metrics ended up duplicated/added/removed. Here are the changes:

**shrink_stats**

Added (moved from store_accounts_for_shrink):

  - write_accounts_us
  - mark_zero_lamport_single_ref_accounts_us
  - update_index_us
  - num_accounts_stored
  - num_zero_lamport_single_ref_accounts_marked

Removed:

  - store_accounts_elapsed (duplicate of write_accounts_us)
  - update_index_elapsed (duplicate of update_index_us)
  - handle_reclaims_elapsed (shrink doesn't handle reclaims)
 

**shrink_ancient_stats / squash**

Added (moved from store_accounts_for_shrink):

  - flush_read_cache_us (only in squash)
  - write_accounts_us
  - mark_zero_lamport_single_ref_accounts_us
  - update_index_us
  - num_accounts_stored
  - num_zero_lamport_single_ref_accounts_marked

Removed:

  - store_accounts_elapsed (duplicate of write_accounts_us)
  - update_index_elapsed (duplicate of udpate_index_us)
  - handle_reclaims_elapsed (squash doesn't handle reclaims)


#### Testing

Ran on a dev box and compared against master.

<details><summary>Metrics Charts</summary>
<p>

3XU is master in blue (commit `14e3be74`, the base of this PR)
DoC is this PR in purple

First here's the num of accounts stored. This is an example of the metric moving from store_accounts_for_shrink to top-level shrink. So the chart shows master's store_accounts_for_shrink metrics and this PR's top-level shrink metric.

<img width="926" height="447" alt="shrink - num accounts" src="https://github.com/user-attachments/assets/737e36e9-7a43-4587-9383-21298092d3a8" />


Second is the time spent updating the index. This metric was duplicated in both. This chart shows the top-level shrink metric for both.

<img width="925" height="446" alt="shrink - update index" src="https://github.com/user-attachments/assets/2cce51d6-df1f-4e99-a616-b34db9a90662" />


These charts to me show the metrics are still the same before and after this PR.


</p>
</details> 