### PR TITLE
geyser: Include bank_id in transaction notifications

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -499,11 +499,13 @@ impl Accounts {
     pub fn store_accounts_seq<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
+        bank_id: BankId,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         ancestors: &Ancestors,
     ) {
         self._store_accounts(
             accounts,
+            bank_id,
             transactions,
             UpdateIndexThreadSelection::Inline,
             ancestors,
@@ -517,11 +519,13 @@ impl Accounts {
     pub fn store_accounts_par<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
+        bank_id: BankId,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         ancestors: &Ancestors,
     ) {
         self._store_accounts(
             accounts,
+            bank_id,
             transactions,
             UpdateIndexThreadSelection::PoolWithThreshold,
             ancestors,
@@ -536,6 +540,7 @@ impl Accounts {
     fn _store_accounts<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
+        bank_id: BankId,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         update_index_thread_selection: UpdateIndexThreadSelection,
         ancestors: &Ancestors,
@@ -552,6 +557,7 @@ impl Accounts {
                 accounts.account_for_geyser(index, |pubkey, account_shared_data| {
                     accounts_db.notify_account_at_accounts_update(
                         slot,
+                        bank_id,
                         account_shared_data,
                         &transaction,
                         pubkey,

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -1,12 +1,16 @@
 use {
-    crate::accounts_db::AccountsDb, solana_account::AccountSharedData, solana_clock::Slot,
-    solana_pubkey::Pubkey, solana_transaction::sanitized::SanitizedTransaction,
+    crate::accounts_db::AccountsDb,
+    solana_account::AccountSharedData,
+    solana_clock::{BankId, Slot},
+    solana_pubkey::Pubkey,
+    solana_transaction::sanitized::SanitizedTransaction,
 };
 
 impl AccountsDb {
     pub fn notify_account_at_accounts_update(
         &self,
         slot: Slot,
+        bank_id: BankId,
         account: &AccountSharedData,
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
@@ -15,6 +19,7 @@ impl AccountsDb {
         if let Some(accounts_update_notifier) = &self.accounts_update_notifier {
             accounts_update_notifier.notify_account_update(
                 slot,
+                bank_id,
                 account,
                 txn,
                 pubkey,
@@ -65,6 +70,7 @@ mod tests {
         fn notify_account_update(
             &self,
             slot: Slot,
+            _bank_id: BankId,
             account: &AccountSharedData,
             _txn: &Option<&SanitizedTransaction>,
             pubkey: &Pubkey,
@@ -179,26 +185,48 @@ mod tests {
         let account1 =
             AccountSharedData::new(account1_lamports1, 1, AccountSharedData::default().owner());
         let slot0 = 0;
+        let bank_id0 = 100;
         let mut ancestors = Ancestors::from(vec![slot0]);
-        accounts.store_accounts_seq((slot0, &[(&key1, &account1)][..]), None, &ancestors);
+        accounts.store_accounts_seq(
+            (slot0, &[(&key1, &account1)][..]),
+            bank_id0,
+            None,
+            &ancestors,
+        );
 
         let key2 = solana_pubkey::new_rand();
         let account2_lamports: u64 = 200;
         let account2 =
             AccountSharedData::new(account2_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_accounts_seq((slot0, &[(&key2, &account2)][..]), None, &ancestors);
+        accounts.store_accounts_seq(
+            (slot0, &[(&key2, &account2)][..]),
+            bank_id0,
+            None,
+            &ancestors,
+        );
 
         let account1_lamports2 = 2;
         let slot1 = 1;
+        let bank_id1 = 101;
         ancestors.insert(slot1);
         let account1 = AccountSharedData::new(account1_lamports2, 1, account1.owner());
-        accounts.store_accounts_seq((slot1, &[(&key1, &account1)][..]), None, &ancestors);
+        accounts.store_accounts_seq(
+            (slot1, &[(&key1, &account1)][..]),
+            bank_id1,
+            None,
+            &ancestors,
+        );
 
         let key3 = solana_pubkey::new_rand();
         let account3_lamports: u64 = 300;
         let account3 =
             AccountSharedData::new(account3_lamports, 1, AccountSharedData::default().owner());
-        accounts.store_accounts_seq((slot1, &[(&key3, &account3)][..]), None, &ancestors);
+        accounts.store_accounts_seq(
+            (slot1, &[(&key3, &account3)][..]),
+            bank_id1,
+            None,
+            &ancestors,
+        );
 
         assert_eq!(notifier.accounts_notified.get(&key1).unwrap().len(), 2);
         assert_eq!(
@@ -252,11 +280,13 @@ mod tests {
         let slot_close = slot_open + 1;
         accounts.store_accounts_seq(
             (slot_open, [(&address, &account_open)].as_slice()),
+            106,
             None,
             &Ancestors::from(vec![slot_open]),
         );
         accounts.store_accounts_seq(
             (slot_close, [(&address, &account_close)].as_slice()),
+            107,
             None,
             &Ancestors::from(vec![slot_open, slot_close]),
         );

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_clock::{Epoch, Slot},
+    solana_clock::{BankId, Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_transaction::sanitized::SanitizedTransaction,
     std::sync::Arc,
@@ -14,6 +14,7 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
     fn notify_account_update(
         &self,
         slot: Slot,
+        bank_id: BankId,
         account: &AccountSharedData,
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -178,6 +178,7 @@ impl Committer {
 
             transaction_status_sender.send_transaction_status_batch(
                 bank.slot(),
+                bank.bank_id(),
                 txs,
                 commit_results,
                 balances,

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -768,7 +768,7 @@ impl ClusterInfoVoteListener {
                 sender
                     .sender
                     .send((
-                        BankNotification::OptimisticallyConfirmed(last_vote_slot),
+                        BankNotification::OptimisticallyConfirmed(last_vote_slot, last_vote_hash),
                         dependency_work,
                     ))
                     .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4183,6 +4183,7 @@ impl ReplayStage {
                         bank.parent_slot(),
                         &parent_blockhash.to_string(),
                         bank.slot(),
+                        bank.bank_id(),
                         &bank.last_blockhash().to_string(),
                         &bank.get_rewards_and_num_partitions(),
                         Some(bank.clock().unix_timestamp),
@@ -5367,13 +5368,16 @@ impl ReplayStage {
         if let Some(rpc_subscriptions) = rpc_subscriptions {
             rpc_subscriptions.notify_slot(slot, parent.slot(), root_slot);
         }
+        let parent_slot = parent.slot();
+        let bank = Bank::new_from_parent_with_options(parent, leader, slot, new_bank_options);
         if let Some(slot_status_notifier) = slot_status_notifier {
-            slot_status_notifier
-                .read()
-                .unwrap()
-                .notify_created_bank(slot, parent.slot());
+            slot_status_notifier.read().unwrap().notify_created_bank(
+                slot,
+                parent_slot,
+                bank.bank_id(),
+            );
         }
-        Bank::new_from_parent_with_options(parent, leader, slot, new_bank_options)
+        bank
     }
 
     fn log_heaviest_fork_failures(

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -906,17 +906,17 @@ impl SlotStatusNotifierForTest {
 }
 
 impl SlotStatusNotifierInterface for SlotStatusNotifierForTest {
-    fn notify_slot_confirmed(&self, _slot: Slot, _parent: Option<Slot>) {}
+    fn notify_slot_confirmed(&self, _slot: Slot, _parent: Option<Slot>, _bank_id: BankId) {}
 
-    fn notify_slot_processed(&self, _slot: Slot, _parent: Option<Slot>) {}
+    fn notify_slot_processed(&self, _slot: Slot, _parent: Option<Slot>, _bank_id: BankId) {}
 
-    fn notify_slot_rooted(&self, _slot: Slot, _parent: Option<Slot>) {}
+    fn notify_slot_rooted(&self, _slot: Slot, _parent: Option<Slot>, _bank_id: BankId) {}
 
     fn notify_first_shred_received(&self, _slot: Slot) {}
 
     fn notify_completed(&self, _slot: Slot) {}
 
-    fn notify_created_bank(&self, _slot: Slot, _parent: Slot) {}
+    fn notify_created_bank(&self, _slot: Slot, _parent: Slot, _bank_id: BankId) {}
 
     fn notify_slot_dead(&self, slot: Slot, _parent: Slot, _error: String) {
         self.dead_slots.lock().unwrap().insert(slot);

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,5 +1,6 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    solana_clock::BankId,
     solana_entry::{entry::EntrySummary, entry_or_marker::EntryOrMarker},
     solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
     solana_poh::poh_recorder::WorkingBankEntryOrMarker,
@@ -28,6 +29,7 @@ impl TpuEntryNotifier {
             .name("solTpuEntry".to_string())
             .spawn(move || {
                 let mut current_slot = 0;
+                let mut current_bank_id = BankId::default();
                 let mut current_index = 0;
                 let mut current_transaction_index = 0;
                 loop {
@@ -41,6 +43,7 @@ impl TpuEntryNotifier {
                         &entry_notification_sender,
                         &broadcast_entry_sender,
                         &mut current_slot,
+                        &mut current_bank_id,
                         &mut current_index,
                         &mut current_transaction_index,
                     ) {
@@ -58,16 +61,19 @@ impl TpuEntryNotifier {
         entry_notification_sender: &EntryNotifierSender,
         broadcast_entry_sender: &Sender<WorkingBankEntryOrMarker>,
         current_slot: &mut u64,
+        current_bank_id: &mut BankId,
         current_index: &mut usize,
         current_transaction_index: &mut usize,
     ) -> Result<(), RecvTimeoutError> {
         let (bank, (entry_or_marker, tick_height)) =
             entry_receiver.recv_timeout(Duration::from_secs(1))?;
         let slot = bank.slot();
-        if slot != *current_slot {
+        let bank_id = bank.bank_id();
+        if slot != *current_slot || bank_id != *current_bank_id {
             *current_index = 0;
             *current_transaction_index = 0;
             *current_slot = slot;
+            *current_bank_id = bank_id;
         };
         let index = *current_index;
 
@@ -79,6 +85,7 @@ impl TpuEntryNotifier {
             };
             if let Err(err) = entry_notification_sender.send(EntryNotification {
                 slot,
+                bank_id,
                 index,
                 entry: entry_summary,
                 starting_transaction_index: *current_transaction_index,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -3,7 +3,7 @@
 //! In addition, the dynamic library must export a "C" function _create_plugin which
 //! creates the implementation of the plugin.
 use {
-    solana_clock::{Slot, UnixTimestamp},
+    solana_clock::{BankId, Slot, UnixTimestamp},
     solana_hash::Hash,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
@@ -110,15 +110,59 @@ pub struct ReplicaAccountInfoV3<'a> {
     pub txn: Option<&'a SanitizedTransaction>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Information about an account being updated
+/// (extended with reference to transaction doing this update and bank id)
+pub struct ReplicaAccountInfoV4<'a> {
+    /// The Pubkey for the account
+    pub pubkey: &'a [u8],
+
+    /// The lamports for the account
+    pub lamports: u64,
+
+    /// The Pubkey of the owner program account
+    pub owner: &'a [u8],
+
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    /// The epoch at which this account will next owe rent
+    pub rent_epoch: u64,
+
+    /// The data held in this account.
+    pub data: &'a [u8],
+
+    /// A global monotonically increasing atomic number, which can be used
+    /// to tell the order of the account update. For example, when an
+    /// account is updated in the same slot multiple times, the update
+    /// with higher write_version should supersede the one with lower
+    /// write_version.
+    pub write_version: u64,
+
+    /// Reference to transaction causing this account modification
+    pub txn: Option<&'a SanitizedTransaction>,
+
+    /// The id of the bank that processed the account update.
+    ///
+    /// This is `None` for account updates restored from a snapshot because they
+    /// are not associated with a live bank.
+    pub bank_id: Option<BankId>,
+}
+
 /// A wrapper to future-proof ReplicaAccountInfo handling.
 /// If there were a change to the structure of ReplicaAccountInfo,
 /// there would be new enum entry for the newer version, forcing
 /// plugin implementations to handle the change.
 #[repr(u32)]
 pub enum ReplicaAccountInfoVersions<'a> {
+    #[deprecated]
     V0_0_1(&'a ReplicaAccountInfo<'a>),
+    #[deprecated]
     V0_0_2(&'a ReplicaAccountInfoV2<'a>),
+    #[deprecated]
     V0_0_3(&'a ReplicaAccountInfoV3<'a>),
+    V0_0_4(&'a ReplicaAccountInfoV4<'a>),
 }
 
 /// Information about a transaction
@@ -181,15 +225,45 @@ pub struct ReplicaTransactionInfoV3<'a> {
     pub index: usize,
 }
 
+/// Information about a transaction, including index in block and bank id
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaTransactionInfoV4<'a> {
+    /// The transaction signature, used for identifying the transaction.
+    pub signature: &'a Signature,
+
+    /// The transaction message hash, used for identifying the transaction.
+    pub message_hash: &'a Hash,
+
+    /// Indicates if the transaction is a simple vote transaction.
+    pub is_vote: bool,
+
+    /// The versioned transaction.
+    pub transaction: &'a VersionedTransaction,
+
+    /// Metadata of the transaction status.
+    pub transaction_status_meta: &'a TransactionStatusMeta,
+
+    /// The transaction's index in the block
+    pub index: usize,
+
+    /// The id of the bank that processed the transaction.
+    pub bank_id: BankId,
+}
+
 /// A wrapper to future-proof ReplicaTransactionInfo handling.
 /// If there were a change to the structure of ReplicaTransactionInfo,
 /// there would be new enum entry for the newer version, forcing
 /// plugin implementations to handle the change.
 #[repr(u32)]
 pub enum ReplicaTransactionInfoVersions<'a> {
+    #[deprecated]
     V0_0_1(&'a ReplicaTransactionInfo<'a>),
+    #[deprecated]
     V0_0_2(&'a ReplicaTransactionInfoV2<'a>),
+    #[deprecated]
     V0_0_3(&'a ReplicaTransactionInfoV3<'a>),
+    V0_0_4(&'a ReplicaTransactionInfoV4<'a>),
 }
 
 /// Information about a transaction after deshredding (when entries are formed from shreds).
@@ -287,13 +361,36 @@ pub struct ReplicaEntryInfoV2<'a> {
     pub starting_transaction_index: usize,
 }
 
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaEntryInfoV3<'a> {
+    /// The slot number of the block containing this Entry
+    pub slot: Slot,
+    /// The id of the bank that executed this Entry.
+    pub bank_id: BankId,
+    /// The Entry's index in the block
+    pub index: usize,
+    /// The number of hashes since the previous Entry
+    pub num_hashes: u64,
+    /// The Entry's SHA-256 hash, generated from the previous Entry's hash with
+    /// `solana_entry::entry::next_hash()`
+    pub hash: &'a [u8],
+    /// The number of executed transactions in the Entry
+    pub executed_transaction_count: u64,
+    /// The index-in-block of the first executed transaction in this Entry
+    pub starting_transaction_index: usize,
+}
+
 /// A wrapper to future-proof ReplicaEntryInfo handling. To make a change to the structure of
 /// ReplicaEntryInfo, add an new enum variant wrapping a newer version, which will force plugin
 /// implementations to handle the change.
 #[repr(u32)]
 pub enum ReplicaEntryInfoVersions<'a> {
+    #[deprecated]
     V0_0_1(&'a ReplicaEntryInfo<'a>),
+    #[deprecated]
     V0_0_2(&'a ReplicaEntryInfoV2<'a>),
+    V0_0_3(&'a ReplicaEntryInfoV3<'a>),
 }
 
 #[derive(Clone, Debug)]
@@ -350,12 +447,33 @@ pub struct ReplicaBlockInfoV4<'a> {
     pub entry_count: u64,
 }
 
+/// Extending ReplicaBlockInfoV4 by sending bank id.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockInfoV5<'a> {
+    pub parent_slot: Slot,
+    pub parent_blockhash: &'a str,
+    pub slot: Slot,
+    pub bank_id: BankId,
+    pub blockhash: &'a str,
+    pub rewards: &'a RewardsAndNumPartitions,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub entry_count: u64,
+}
+
 #[repr(u32)]
 pub enum ReplicaBlockInfoVersions<'a> {
+    #[deprecated]
     V0_0_1(&'a ReplicaBlockInfo<'a>),
+    #[deprecated]
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
+    #[deprecated]
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
+    #[deprecated]
     V0_0_4(&'a ReplicaBlockInfoV4<'a>),
+    V0_0_5(&'a ReplicaBlockInfoV5<'a>),
 }
 
 /// A snapshot of a validator's gossip contact info at a point in time.
@@ -599,7 +717,8 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
-    /// Called when a slot status is updated
+    /// Called when a slot status is updated.
+    #[deprecated]
     #[allow(unused_variables)]
     fn update_slot_status(
         &self,
@@ -608,6 +727,28 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         status: &SlotStatus,
     ) -> Result<()> {
         Ok(())
+    }
+
+    /// Called when a slot status is updated.
+    ///
+    /// `bank_id` identifies the concrete bank instance associated with the
+    /// status update. It is `Some` for bank-scoped statuses, where the slot
+    /// status is tied to a particular `Bank`: `CreatedBank`, `Processed`,
+    /// `Confirmed`, and `Rooted`.
+    ///
+    /// It is `None` for shred- or slot-level statuses that are not associated
+    /// with a specific bank instance: `FirstShredReceived`, `Completed`, and
+    /// `Dead`.
+    #[allow(deprecated)]
+    #[allow(unused_variables)]
+    fn update_slot_status_v2(
+        &self,
+        slot: Slot,
+        parent: Option<u64>,
+        status: &SlotStatus,
+        bank_id: Option<BankId>,
+    ) -> Result<()> {
+        self.update_slot_status(slot, parent, status)
     }
 
     /// Called when a transaction is processed in a slot.

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaAccountInfoV3, ReplicaAccountInfoVersions,
+        ReplicaAccountInfoV4, ReplicaAccountInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -10,7 +10,7 @@ use {
     solana_accounts_db::accounts_update_notifier_interface::{
         AccountForGeyser, AccountsUpdateNotifierInterface,
     },
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     solana_pubkey::Pubkey,
     solana_transaction::sanitized::SanitizedTransaction,
     std::sync::Arc,
@@ -29,13 +29,19 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
     fn notify_account_update(
         &self,
         slot: Slot,
+        bank_id: BankId,
         account: &AccountSharedData,
         txn: &Option<&SanitizedTransaction>,
         pubkey: &Pubkey,
         write_version: u64,
     ) {
-        let account_info =
-            self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version);
+        let account_info = self.accountinfo_from_shared_account_data(
+            Some(bank_id),
+            account,
+            txn,
+            pubkey,
+            write_version,
+        );
         self.notify_plugins_of_account_update(account_info, slot, false);
     }
 
@@ -89,12 +95,13 @@ impl AccountsUpdateNotifierImpl {
 
     fn accountinfo_from_shared_account_data<'a>(
         &self,
+        bank_id: Option<BankId>,
         account: &'a AccountSharedData,
         txn: &'a Option<&'a SanitizedTransaction>,
         pubkey: &'a Pubkey,
         write_version: u64,
-    ) -> ReplicaAccountInfoV3<'a> {
-        ReplicaAccountInfoV3 {
+    ) -> ReplicaAccountInfoV4<'a> {
+        ReplicaAccountInfoV4 {
             pubkey: pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -103,14 +110,15 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version,
             txn: *txn,
+            bank_id,
         }
     }
 
     fn accountinfo_from_account_for_geyser<'a>(
         &self,
         account: &'a AccountForGeyser<'_>,
-    ) -> ReplicaAccountInfoV3<'a> {
-        ReplicaAccountInfoV3 {
+    ) -> ReplicaAccountInfoV4<'a> {
+        ReplicaAccountInfoV4 {
             pubkey: account.pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -119,12 +127,13 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version: 0, // can/will be populated afterwards
             txn: None,
+            bank_id: None,
         }
     }
 
     fn notify_plugins_of_account_update(
         &self,
-        account: ReplicaAccountInfoV3,
+        account: ReplicaAccountInfoV4,
         slot: Slot,
         is_startup: bool,
     ) {
@@ -138,7 +147,7 @@ impl AccountsUpdateNotifierImpl {
                 continue;
             }
             match plugin.update_account(
-                ReplicaAccountInfoVersions::V0_0_3(&account),
+                ReplicaAccountInfoVersions::V0_0_4(&account),
                 slot,
                 is_startup,
             ) {
@@ -176,7 +185,7 @@ mod tests {
         libloading::Library,
         solana_accounts_db::accounts_update_notifier_interface::AccountsUpdateNotifierInterface,
         std::sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
     };
@@ -186,6 +195,7 @@ mod tests {
         name: &'static str,
         account_updates_enabled: bool,
         account_update_count: Arc<AtomicUsize>,
+        account_update_bank_ids: Arc<Mutex<Vec<Option<BankId>>>>,
     }
 
     impl GeyserPlugin for TestAccountPlugin {
@@ -195,10 +205,17 @@ mod tests {
 
         fn update_account(
             &self,
-            _account: ReplicaAccountInfoVersions,
+            account: ReplicaAccountInfoVersions,
             _slot: Slot,
             _is_startup: bool,
         ) -> agave_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
+            let ReplicaAccountInfoVersions::V0_0_4(account) = account else {
+                panic!("expected V0_0_4 account info");
+            };
+            self.account_update_bank_ids
+                .lock()
+                .unwrap()
+                .push(account.bank_id);
             self.account_update_count.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
@@ -225,27 +242,65 @@ mod tests {
     fn test_notify_account_update_skips_plugins_with_account_notifications_disabled() {
         let enabled_count = Arc::new(AtomicUsize::new(0));
         let disabled_count = Arc::new(AtomicUsize::new(0));
+        let enabled_bank_ids = Arc::new(Mutex::new(Vec::new()));
+        let disabled_bank_ids = Arc::new(Mutex::new(Vec::new()));
         let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
             plugins: vec![
                 loaded_test_plugin(TestAccountPlugin {
                     name: "enabled",
                     account_updates_enabled: true,
                     account_update_count: enabled_count.clone(),
+                    account_update_bank_ids: enabled_bank_ids.clone(),
                 }),
                 loaded_test_plugin(TestAccountPlugin {
                     name: "disabled",
                     account_updates_enabled: false,
                     account_update_count: disabled_count.clone(),
+                    account_update_bank_ids: disabled_bank_ids.clone(),
                 }),
             ],
         })));
         let notifier = AccountsUpdateNotifierImpl::new(plugin_manager, false);
         let account = AccountSharedData::new(1, 0, &Pubkey::new_unique());
         let pubkey = Pubkey::new_unique();
+        let bank_id = 9;
 
-        notifier.notify_account_update(42, &account, &None, &pubkey, 7);
+        notifier.notify_account_update(42, bank_id, &account, &None, &pubkey, 7);
 
         assert_eq!(enabled_count.load(Ordering::Relaxed), 1);
         assert_eq!(disabled_count.load(Ordering::Relaxed), 0);
+        assert_eq!(*enabled_bank_ids.lock().unwrap(), vec![Some(bank_id)]);
+        assert!(disabled_bank_ids.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_notify_account_restore_from_snapshot_has_no_bank_id() {
+        let account_update_count = Arc::new(AtomicUsize::new(0));
+        let account_update_bank_ids = Arc::new(Mutex::new(Vec::new()));
+        let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
+            plugins: vec![loaded_test_plugin(TestAccountPlugin {
+                name: "enabled",
+                account_updates_enabled: true,
+                account_update_count: account_update_count.clone(),
+                account_update_bank_ids: account_update_bank_ids.clone(),
+            })],
+        })));
+        let notifier = AccountsUpdateNotifierImpl::new(plugin_manager, true);
+        let pubkey = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let data = [1, 2, 3];
+        let account = AccountForGeyser {
+            pubkey: &pubkey,
+            lamports: 1,
+            owner: &owner,
+            executable: false,
+            rent_epoch: 0,
+            data: &data,
+        };
+
+        notifier.notify_account_restore_from_snapshot(42, 7, &account);
+
+        assert_eq!(account_update_count.load(Ordering::Relaxed), 1);
+        assert_eq!(*account_update_bank_ids.lock().unwrap(), vec![None]);
     }
 }

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,11 +4,11 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV5, ReplicaBlockInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
-    solana_clock::UnixTimestamp,
+    solana_clock::{BankId, UnixTimestamp},
     solana_runtime::bank::KeyedRewardsAndNumPartitions,
     solana_transaction_status::{Reward, RewardsAndNumPartitions},
     std::sync::Arc,
@@ -25,6 +25,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         parent_slot: u64,
         parent_blockhash: &str,
         slot: u64,
+        bank_id: BankId,
         blockhash: &str,
         rewards: &KeyedRewardsAndNumPartitions,
         block_time: Option<UnixTimestamp>,
@@ -43,6 +44,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             parent_slot,
             parent_blockhash,
             slot,
+            bank_id,
             blockhash,
             &rewards,
             block_time,
@@ -52,7 +54,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         );
 
         for plugin in plugin_manager.plugins.iter() {
-            let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
+            let block_info = ReplicaBlockInfoVersions::V0_0_5(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {
                     error!(
@@ -104,21 +106,24 @@ impl BlockMetadataNotifierImpl {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_replica_block_info<'a>(
         parent_slot: u64,
         parent_blockhash: &'a str,
         slot: u64,
+        bank_id: BankId,
         blockhash: &'a str,
         rewards: &'a RewardsAndNumPartitions,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-    ) -> ReplicaBlockInfoV4<'a> {
-        ReplicaBlockInfoV4 {
+    ) -> ReplicaBlockInfoV5<'a> {
+        ReplicaBlockInfoV5 {
             parent_slot,
             parent_blockhash,
             slot,
+            bank_id,
             blockhash,
             rewards,
             block_time,
@@ -130,5 +135,87 @@ impl BlockMetadataNotifierImpl {
 
     pub fn new(plugin_manager: Arc<ArcSwap<GeyserPluginManager>>) -> Self {
         Self { plugin_manager }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::geyser_plugin_manager::{GeyserPluginManager, LoadedGeyserPlugin},
+        agave_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin, Result},
+        arc_swap::ArcSwap,
+        libloading::Library,
+        std::sync::{Arc, Mutex},
+    };
+
+    type BlockMetadataUpdate = (u64, BankId, u64, u64);
+
+    #[derive(Debug)]
+    struct TestBlockMetadataPlugin {
+        updates: Arc<Mutex<Vec<BlockMetadataUpdate>>>,
+    }
+
+    impl GeyserPlugin for TestBlockMetadataPlugin {
+        fn name(&self) -> &'static str {
+            "test-block-metadata-plugin"
+        }
+
+        fn notify_block_metadata(&self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
+            let ReplicaBlockInfoVersions::V0_0_5(blockinfo) = blockinfo else {
+                panic!("expected V0_0_5 block info");
+            };
+            self.updates.lock().unwrap().push((
+                blockinfo.slot,
+                blockinfo.bank_id,
+                blockinfo.executed_transaction_count,
+                blockinfo.entry_count,
+            ));
+            Ok(())
+        }
+    }
+
+    fn loaded_test_plugin(plugin: TestBlockMetadataPlugin) -> Arc<LoadedGeyserPlugin> {
+        #[cfg(unix)]
+        let library = libloading::os::unix::Library::this();
+        #[cfg(windows)]
+        let library = libloading::os::windows::Library::this().unwrap();
+
+        Arc::new(LoadedGeyserPlugin::new(
+            Library::from(library),
+            Box::new(plugin),
+            None,
+        ))
+    }
+
+    #[test]
+    fn test_notify_block_metadata_includes_bank_id() {
+        let updates = Arc::new(Mutex::new(Vec::new()));
+        let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
+            plugins: vec![loaded_test_plugin(TestBlockMetadataPlugin {
+                updates: updates.clone(),
+            })],
+        })));
+        let notifier = BlockMetadataNotifierImpl::new(plugin_manager);
+        let rewards = KeyedRewardsAndNumPartitions {
+            keyed_rewards: Vec::new(),
+            num_partitions: None,
+        };
+
+        notifier.notify_block_metadata(
+            41,
+            "parent-blockhash",
+            42,
+            9,
+            "blockhash",
+            &rewards,
+            Some(123),
+            Some(10),
+            7,
+            3,
+            false,
+        );
+
+        assert_eq!(*updates.lock().unwrap(), vec![(42, 9, 7, 3)]);
     }
 }

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,5 +1,7 @@
 use {
-    solana_clock::UnixTimestamp, solana_runtime::bank::KeyedRewardsAndNumPartitions, std::sync::Arc,
+    solana_clock::{BankId, UnixTimestamp},
+    solana_runtime::bank::KeyedRewardsAndNumPartitions,
+    std::sync::Arc,
 };
 
 /// Interface for notifying block metadata changes
@@ -11,6 +13,7 @@ pub trait BlockMetadataNotifier {
         parent_slot: u64,
         parent_blockhash: &str,
         slot: u64,
+        bank_id: BankId,
         blockhash: &str,
         rewards: &KeyedRewardsAndNumPartitions,
         block_time: Option<UnixTimestamp>,

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -2,11 +2,11 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaEntryInfoV2, ReplicaEntryInfoVersions,
+        ReplicaEntryInfoV3, ReplicaEntryInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     solana_entry::entry::EntrySummary,
     solana_ledger::entry_notifier_interface::EntryNotifier,
     std::sync::Arc,
@@ -20,6 +20,7 @@ impl EntryNotifier for EntryNotifierImpl {
     fn notify_entry<'a>(
         &'a self,
         slot: Slot,
+        bank_id: BankId,
         index: usize,
         entry: &'a EntrySummary,
         starting_transaction_index: usize,
@@ -30,13 +31,13 @@ impl EntryNotifier for EntryNotifierImpl {
         }
 
         let entry_info =
-            Self::build_replica_entry_info(slot, index, entry, starting_transaction_index);
+            Self::build_replica_entry_info(slot, bank_id, index, entry, starting_transaction_index);
 
         for plugin in plugin_manager.plugins.iter() {
             if !plugin.entry_notifications_enabled() {
                 continue;
             }
-            match plugin.notify_entry(ReplicaEntryInfoVersions::V0_0_2(&entry_info)) {
+            match plugin.notify_entry(ReplicaEntryInfoVersions::V0_0_3(&entry_info)) {
                 Err(err) => {
                     error!(
                         "Failed to notify entry, error: ({}) to plugin {}",
@@ -59,17 +60,105 @@ impl EntryNotifierImpl {
 
     fn build_replica_entry_info(
         slot: Slot,
+        bank_id: BankId,
         index: usize,
         entry: &'_ EntrySummary,
         starting_transaction_index: usize,
-    ) -> ReplicaEntryInfoV2<'_> {
-        ReplicaEntryInfoV2 {
+    ) -> ReplicaEntryInfoV3<'_> {
+        ReplicaEntryInfoV3 {
             slot,
+            bank_id,
             index,
             num_hashes: entry.num_hashes,
             hash: entry.hash.as_ref(),
             executed_transaction_count: entry.num_transactions,
             starting_transaction_index,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::geyser_plugin_manager::{GeyserPluginManager, LoadedGeyserPlugin},
+        agave_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin, Result},
+        arc_swap::ArcSwap,
+        libloading::Library,
+        solana_hash::Hash,
+        std::sync::{Arc, Mutex},
+    };
+
+    type EntryUpdate = (Slot, BankId, usize, usize);
+
+    #[derive(Debug)]
+    struct TestEntryPlugin {
+        entry_notifications_enabled: bool,
+        updates: Arc<Mutex<Vec<EntryUpdate>>>,
+    }
+
+    impl GeyserPlugin for TestEntryPlugin {
+        fn name(&self) -> &'static str {
+            "test-entry-plugin"
+        }
+
+        fn notify_entry(&self, entry: ReplicaEntryInfoVersions) -> Result<()> {
+            let ReplicaEntryInfoVersions::V0_0_3(entry) = entry else {
+                panic!("expected V0_0_3 entry info");
+            };
+            self.updates.lock().unwrap().push((
+                entry.slot,
+                entry.bank_id,
+                entry.index,
+                entry.starting_transaction_index,
+            ));
+            Ok(())
+        }
+
+        fn entry_notifications_enabled(&self) -> bool {
+            self.entry_notifications_enabled
+        }
+    }
+
+    fn loaded_test_plugin(plugin: TestEntryPlugin) -> Arc<LoadedGeyserPlugin> {
+        #[cfg(unix)]
+        let library = libloading::os::unix::Library::this();
+        #[cfg(windows)]
+        let library = libloading::os::windows::Library::this().unwrap();
+
+        Arc::new(LoadedGeyserPlugin::new(
+            Library::from(library),
+            Box::new(plugin),
+            None,
+        ))
+    }
+
+    #[test]
+    fn test_notify_entry_includes_bank_id() {
+        let enabled_updates = Arc::new(Mutex::new(Vec::new()));
+        let disabled_updates = Arc::new(Mutex::new(Vec::new()));
+        let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
+            plugins: vec![
+                loaded_test_plugin(TestEntryPlugin {
+                    entry_notifications_enabled: true,
+                    updates: enabled_updates.clone(),
+                }),
+                loaded_test_plugin(TestEntryPlugin {
+                    entry_notifications_enabled: false,
+                    updates: disabled_updates.clone(),
+                }),
+            ],
+        })));
+        let notifier = EntryNotifierImpl::new(plugin_manager);
+        let entry = EntrySummary {
+            num_hashes: 1,
+            hash: Hash::new_unique(),
+            num_transactions: 2,
+        };
+
+        notifier.notify_entry(42, 9, 3, &entry, 7);
+
+        assert_eq!(*enabled_updates.lock().unwrap(), vec![(42, 9, 3, 7)]);
+        assert!(disabled_updates.lock().unwrap().is_empty());
     }
 }

--- a/geyser-plugin-manager/src/slot_status_notifier.rs
+++ b/geyser-plugin-manager/src/slot_status_notifier.rs
@@ -1,7 +1,10 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
-    agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus, arc_swap::ArcSwap, log::*,
-    solana_clock::Slot, solana_rpc::slot_status_notifier::SlotStatusNotifierInterface,
+    agave_geyser_plugin_interface::geyser_plugin_interface::SlotStatus,
+    arc_swap::ArcSwap,
+    log::*,
+    solana_clock::{BankId, Slot},
+    solana_rpc::slot_status_notifier::SlotStatusNotifierInterface,
     std::sync::Arc,
 };
 
@@ -10,32 +13,32 @@ pub struct SlotStatusNotifierImpl {
 }
 
 impl SlotStatusNotifierInterface for SlotStatusNotifierImpl {
-    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Confirmed);
+    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId) {
+        self.notify_slot_status(slot, parent, SlotStatus::Confirmed, Some(bank_id));
     }
 
-    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Processed);
+    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId) {
+        self.notify_slot_status(slot, parent, SlotStatus::Processed, Some(bank_id));
     }
 
-    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>) {
-        self.notify_slot_status(slot, parent, SlotStatus::Rooted);
+    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId) {
+        self.notify_slot_status(slot, parent, SlotStatus::Rooted, Some(bank_id));
     }
 
     fn notify_first_shred_received(&self, slot: Slot) {
-        self.notify_slot_status(slot, None, SlotStatus::FirstShredReceived);
+        self.notify_slot_status(slot, None, SlotStatus::FirstShredReceived, None);
     }
 
     fn notify_completed(&self, slot: Slot) {
-        self.notify_slot_status(slot, None, SlotStatus::Completed);
+        self.notify_slot_status(slot, None, SlotStatus::Completed, None);
     }
 
-    fn notify_created_bank(&self, slot: Slot, parent: Slot) {
-        self.notify_slot_status(slot, Some(parent), SlotStatus::CreatedBank);
+    fn notify_created_bank(&self, slot: Slot, parent: Slot, bank_id: BankId) {
+        self.notify_slot_status(slot, Some(parent), SlotStatus::CreatedBank, Some(bank_id));
     }
 
     fn notify_slot_dead(&self, slot: Slot, parent: Slot, error: String) {
-        self.notify_slot_status(slot, Some(parent), SlotStatus::Dead(error));
+        self.notify_slot_status(slot, Some(parent), SlotStatus::Dead(error), None);
     }
 }
 
@@ -44,14 +47,20 @@ impl SlotStatusNotifierImpl {
         Self { plugin_manager }
     }
 
-    pub fn notify_slot_status(&self, slot: Slot, parent: Option<Slot>, slot_status: SlotStatus) {
+    pub fn notify_slot_status(
+        &self,
+        slot: Slot,
+        parent: Option<Slot>,
+        slot_status: SlotStatus,
+        bank_id: Option<BankId>,
+    ) {
         let plugin_manager = self.plugin_manager.load();
         if plugin_manager.plugins.is_empty() {
             return;
         }
 
         for plugin in plugin_manager.plugins.iter() {
-            match plugin.update_slot_status(slot, parent, &slot_status) {
+            match plugin.update_slot_status_v2(slot, parent, &slot_status, bank_id) {
                 Err(err) => {
                     error!(
                         "Failed to update slot status at slot {}, error: {} to plugin {}",
@@ -69,5 +78,81 @@ impl SlotStatusNotifierImpl {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::geyser_plugin_manager::{GeyserPluginManager, LoadedGeyserPlugin},
+        agave_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin, Result},
+        arc_swap::ArcSwap,
+        libloading::Library,
+        std::sync::{Arc, Mutex},
+    };
+
+    type SlotStatusUpdate = (Slot, Option<Slot>, SlotStatus, Option<BankId>);
+
+    #[derive(Debug)]
+    struct TestSlotStatusPlugin {
+        updates: Arc<Mutex<Vec<SlotStatusUpdate>>>,
+    }
+
+    impl GeyserPlugin for TestSlotStatusPlugin {
+        fn name(&self) -> &'static str {
+            "test-slot-status-plugin"
+        }
+
+        fn update_slot_status_v2(
+            &self,
+            slot: Slot,
+            parent: Option<u64>,
+            status: &SlotStatus,
+            bank_id: Option<BankId>,
+        ) -> Result<()> {
+            self.updates
+                .lock()
+                .unwrap()
+                .push((slot, parent, status.clone(), bank_id));
+            Ok(())
+        }
+    }
+
+    fn loaded_test_plugin(plugin: TestSlotStatusPlugin) -> Arc<LoadedGeyserPlugin> {
+        #[cfg(unix)]
+        let library = libloading::os::unix::Library::this();
+        #[cfg(windows)]
+        let library = libloading::os::windows::Library::this().unwrap();
+
+        Arc::new(LoadedGeyserPlugin::new(
+            Library::from(library),
+            Box::new(plugin),
+            None,
+        ))
+    }
+
+    fn create_notifier(updates: Arc<Mutex<Vec<SlotStatusUpdate>>>) -> SlotStatusNotifierImpl {
+        let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
+            plugins: vec![loaded_test_plugin(TestSlotStatusPlugin { updates })],
+        })));
+        SlotStatusNotifierImpl::new(plugin_manager)
+    }
+
+    #[test]
+    fn test_notify_slot_status_bank_id() {
+        let updates = Arc::new(Mutex::new(Vec::new()));
+        let notifier = create_notifier(updates.clone());
+
+        notifier.notify_created_bank(42, 41, 9);
+        notifier.notify_slot_processed(42, Some(41), 9);
+
+        assert_eq!(
+            *updates.lock().unwrap(),
+            vec![
+                (42, Some(41), SlotStatus::CreatedBank, Some(9)),
+                (42, Some(41), SlotStatus::Processed, Some(9)),
+            ]
+        );
     }
 }

--- a/geyser-plugin-manager/src/slot_status_observer.rs
+++ b/geyser-plugin-manager/src/slot_status_observer.rs
@@ -55,23 +55,25 @@ impl SlotStatusObserver {
                 while !exit.load(Ordering::Relaxed) {
                     if let Ok(slot) = bank_notification_receiver.recv() {
                         match slot {
-                            SlotNotification::OptimisticallyConfirmed(slot) => {
+                            SlotNotification::OptimisticallyConfirmed(slot, bank_id) => {
                                 slot_status_notifier
                                     .read()
                                     .unwrap()
-                                    .notify_slot_confirmed(slot, None);
+                                    .notify_slot_confirmed(slot, None, bank_id);
                             }
-                            SlotNotification::Frozen((slot, parent)) => {
-                                slot_status_notifier
-                                    .read()
-                                    .unwrap()
-                                    .notify_slot_processed(slot, Some(parent));
+                            SlotNotification::Frozen((slot, parent, bank_id)) => {
+                                slot_status_notifier.read().unwrap().notify_slot_processed(
+                                    slot,
+                                    Some(parent),
+                                    bank_id,
+                                );
                             }
-                            SlotNotification::Root((slot, parent)) => {
-                                slot_status_notifier
-                                    .read()
-                                    .unwrap()
-                                    .notify_slot_rooted(slot, Some(parent));
+                            SlotNotification::Root((slot, parent, bank_id)) => {
+                                slot_status_notifier.read().unwrap().notify_slot_rooted(
+                                    slot,
+                                    Some(parent),
+                                    bank_id,
+                                );
                             }
                         }
                     }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,11 +2,11 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
+        ReplicaTransactionInfoV4, ReplicaTransactionInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     solana_hash::Hash,
     solana_rpc::transaction_notifier_interface::TransactionNotifier,
     solana_signature::Signature,
@@ -27,6 +27,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
     fn notify_transaction(
         &self,
         slot: Slot,
+        bank_id: BankId,
         index: usize,
         signature: &Signature,
         message_hash: &Hash,
@@ -35,6 +36,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
         transaction: &VersionedTransaction,
     ) {
         let transaction_log_info = Self::build_replica_transaction_info(
+            bank_id,
             index,
             signature,
             message_hash,
@@ -54,7 +56,7 @@ impl TransactionNotifier for TransactionNotifierImpl {
                 continue;
             }
             match plugin.notify_transaction(
-                ReplicaTransactionInfoVersions::V0_0_3(&transaction_log_info),
+                ReplicaTransactionInfoVersions::V0_0_4(&transaction_log_info),
                 slot,
             ) {
                 Err(err) => {
@@ -81,14 +83,16 @@ impl TransactionNotifierImpl {
     }
 
     fn build_replica_transaction_info<'a>(
+        bank_id: BankId,
         index: usize,
         signature: &'a Signature,
         message_hash: &'a Hash,
         is_vote: bool,
         transaction_status_meta: &'a TransactionStatusMeta,
         transaction: &'a VersionedTransaction,
-    ) -> ReplicaTransactionInfoV3<'a> {
-        ReplicaTransactionInfoV3 {
+    ) -> ReplicaTransactionInfoV4<'a> {
+        ReplicaTransactionInfoV4 {
+            bank_id,
             index,
             message_hash,
             signature,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1602,6 +1602,7 @@ fn confirm_slot_entries(
     };
 
     let slot = bank.slot();
+    let bank_id = bank.bank_id();
     let (entries, num_shreds, slot_full) = slot_entries_load_result;
     let num_entries = entries.len();
     let mut entry_tx_starting_indexes = Vec::with_capacity(num_entries);
@@ -1614,6 +1615,7 @@ fn confirm_slot_entries(
                 let entry_index = progress.num_entries.saturating_add(i);
                 if let Err(err) = entry_notification_sender.send(EntryNotification {
                     slot,
+                    bank_id,
                     index: entry_index,
                     entry: entry.into(),
                     starting_transaction_index: entry_tx_starting_index,

--- a/ledger/src/entry_notifier_interface.rs
+++ b/ledger/src/entry_notifier_interface.rs
@@ -1,9 +1,14 @@
-use {solana_clock::Slot, solana_entry::entry::EntrySummary, std::sync::Arc};
+use {
+    solana_clock::{BankId, Slot},
+    solana_entry::entry::EntrySummary,
+    std::sync::Arc,
+};
 
 pub trait EntryNotifier {
     fn notify_entry(
         &self,
         slot: Slot,
+        bank_id: BankId,
         index: usize,
         entry: &EntrySummary,
         starting_transaction_index: usize,

--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -1,7 +1,7 @@
 use {
     crate::entry_notifier_interface::EntryNotifierArc,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     solana_entry::entry::EntrySummary,
     std::{
         sync::{
@@ -15,6 +15,7 @@ use {
 
 pub struct EntryNotification {
     pub slot: Slot,
+    pub bank_id: BankId,
     pub index: usize,
     pub entry: EntrySummary,
     pub starting_transaction_index: usize,
@@ -59,11 +60,12 @@ impl EntryNotifierService {
     ) -> Result<(), RecvTimeoutError> {
         let EntryNotification {
             slot,
+            bank_id,
             index,
             entry,
             starting_transaction_index,
         } = entry_notification_receiver.recv_timeout(Duration::from_secs(1))?;
-        entry_notifier.notify_entry(slot, index, &entry, starting_transaction_index);
+        entry_notifier.notify_entry(slot, bank_id, index, &entry, starting_transaction_index);
         Ok(())
     }
 

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -11,7 +11,8 @@
 use {
     crate::rpc_subscriptions::RpcSubscriptions,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
+    solana_hash::Hash,
     solana_rpc_client_api::response::{SlotTransactionStats, SlotUpdate},
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, dependency_tracker::DependencyTracker,
@@ -43,31 +44,33 @@ impl OptimisticallyConfirmedBank {
 
 #[derive(Clone)]
 pub enum BankNotification {
-    OptimisticallyConfirmed(Slot),
+    OptimisticallyConfirmed(Slot, Hash),
     Frozen(Arc<Bank>),
     NewRootBank(Arc<Bank>),
-    /// The newly rooted slot chain including the parent slot of the oldest bank in the rooted chain.
-    NewRootedChain(Vec<Slot>),
+    /// The newly rooted slot chain with bank ids and the parent slot of the oldest bank in the rooted chain.
+    NewRootedChain(Vec<(Slot, BankId)>, Slot),
 }
 
 #[derive(Clone, Debug)]
 pub enum SlotNotification {
-    OptimisticallyConfirmed(Slot),
-    /// The (Slot, Parent Slot) pair for the slot frozen
-    Frozen((Slot, Slot)),
-    /// The (Slot, Parent Slot) pair for the root slot
-    Root((Slot, Slot)),
+    OptimisticallyConfirmed(Slot, BankId),
+    /// The (Slot, Parent Slot, Bank Id) tuple for the slot frozen
+    Frozen((Slot, Slot, BankId)),
+    /// The (Slot, Parent Slot, Bank Id) tuple for the root slot
+    Root((Slot, Slot, BankId)),
 }
 
 impl std::fmt::Debug for BankNotification {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            BankNotification::OptimisticallyConfirmed(slot) => {
-                write!(f, "OptimisticallyConfirmed({slot:?})")
+            BankNotification::OptimisticallyConfirmed(slot, hash) => {
+                write!(f, "OptimisticallyConfirmed({slot:?}, {hash:?})")
             }
             BankNotification::Frozen(bank) => write!(f, "Frozen({})", bank.slot()),
             BankNotification::NewRootBank(bank) => write!(f, "Root({})", bank.slot()),
-            BankNotification::NewRootedChain(chain) => write!(f, "RootedChain({chain:?})"),
+            BankNotification::NewRootedChain(chain, parent) => {
+                write!(f, "RootedChain({chain:?}, parent: {parent})")
+            }
         }
     }
 }
@@ -89,6 +92,7 @@ pub struct BankNotificationSenderConfig {
 
 pub type SlotNotificationReceiver = Receiver<SlotNotification>;
 pub type SlotNotificationSender = Sender<SlotNotification>;
+type PendingOptimisticallyConfirmedBanks = HashSet<(Slot, Hash)>;
 
 pub struct OptimisticallyConfirmedBankTracker {
     thread_hdl: JoinHandle<()>,
@@ -144,7 +148,7 @@ impl OptimisticallyConfirmedBankTracker {
         bank_forks: &RwLock<BankForks>,
         optimistically_confirmed_bank: &RwLock<OptimisticallyConfirmedBank>,
         subscriptions: &RpcSubscriptions,
-        pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+        pending_optimistically_confirmed_banks: &mut PendingOptimisticallyConfirmedBanks,
         last_notified_confirmed_slot: &mut Slot,
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
@@ -189,8 +193,9 @@ impl OptimisticallyConfirmedBankTracker {
         subscriptions: &RpcSubscriptions,
         bank_forks: &RwLock<BankForks>,
         bank: &Bank,
+        pending_confirmation: Option<(Slot, Hash)>,
         last_notified_confirmed_slot: &mut Slot,
-        pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+        pending_optimistically_confirmed_banks: &mut PendingOptimisticallyConfirmedBanks,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
         prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     ) {
@@ -204,7 +209,7 @@ impl OptimisticallyConfirmedBankTracker {
                 *last_notified_confirmed_slot = bank.slot();
                 Self::notify_slot_status(
                     slot_notification_subscribers,
-                    SlotNotification::OptimisticallyConfirmed(bank.slot()),
+                    SlotNotification::OptimisticallyConfirmed(bank.slot(), bank.bank_id()),
                 );
 
                 // finalize block's minimum prioritization fee cache for this bank
@@ -212,9 +217,12 @@ impl OptimisticallyConfirmedBankTracker {
                     prioritization_fee_cache.finalize_priority_fee(bank.slot(), bank.bank_id());
                 }
             }
-        } else if bank.slot() > bank_forks.read().unwrap().root() {
-            pending_optimistically_confirmed_banks.insert(bank.slot());
-            debug!("notify_or_defer defer notifying for slot {:?}", bank.slot());
+        } else if let Some((slot, hash)) = pending_confirmation
+            && bank.slot() == slot
+            && bank.slot() > bank_forks.read().unwrap().root()
+        {
+            pending_optimistically_confirmed_banks.insert((slot, hash));
+            debug!("notify_or_defer defer notifying for slot {slot:?}");
         }
     }
 
@@ -223,8 +231,9 @@ impl OptimisticallyConfirmedBankTracker {
         bank_forks: &RwLock<BankForks>,
         bank: Arc<Bank>,
         slot_threshold: Slot,
+        pending_confirmation: Option<(Slot, Hash)>,
         last_notified_confirmed_slot: &mut Slot,
-        pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+        pending_optimistically_confirmed_banks: &mut PendingOptimisticallyConfirmedBanks,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
         prioritization_fee_cache: Option<&PrioritizationFeeCache>,
     ) {
@@ -238,6 +247,7 @@ impl OptimisticallyConfirmedBankTracker {
                     subscriptions,
                     bank_forks,
                     confirmed_bank,
+                    pending_confirmation,
                     last_notified_confirmed_slot,
                     pending_optimistically_confirmed_banks,
                     slot_notification_subscribers,
@@ -248,27 +258,27 @@ impl OptimisticallyConfirmedBankTracker {
     }
 
     fn notify_new_root_slots(
-        roots: &mut [Slot],
+        roots: &mut [(Slot, BankId)],
+        oldest_parent: Slot,
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
     ) {
         if slot_notification_subscribers.is_none() {
             return;
         }
-        roots.sort_unstable();
-        // The chain are sorted already and must contain at least the parent of a newly rooted slot as the first element
-        assert!(roots.len() >= 2);
-        for i in 1..roots.len() {
-            let root = roots[i];
-            if root > *newest_root_slot {
-                let parent = roots[i - 1];
+        roots.sort_unstable_by_key(|(root, _bank_id)| *root);
+        assert!(!roots.is_empty());
+        let mut parent = oldest_parent;
+        for (root, bank_id) in roots.iter() {
+            if *root > *newest_root_slot {
                 debug!("Doing SlotNotification::Root for root {root}, parent: {parent}");
                 Self::notify_slot_status(
                     slot_notification_subscribers,
-                    SlotNotification::Root((root, parent)),
+                    SlotNotification::Root((*root, parent, *bank_id)),
                 );
-                *newest_root_slot = root;
+                *newest_root_slot = *root;
             }
+            parent = *root;
         }
     }
 
@@ -278,7 +288,7 @@ impl OptimisticallyConfirmedBankTracker {
         bank_forks: &RwLock<BankForks>,
         optimistically_confirmed_bank: &RwLock<OptimisticallyConfirmedBank>,
         subscriptions: &RpcSubscriptions,
-        pending_optimistically_confirmed_banks: &mut HashSet<Slot>,
+        pending_optimistically_confirmed_banks: &mut PendingOptimisticallyConfirmedBanks,
         last_notified_confirmed_slot: &mut Slot,
         highest_confirmed_slot: &mut Slot,
         newest_root_slot: &mut Slot,
@@ -294,34 +304,63 @@ impl OptimisticallyConfirmedBankTracker {
             tracker.wait_for_dependency(dependency_work);
         }
         match notification {
-            BankNotification::OptimisticallyConfirmed(slot) => {
+            BankNotification::OptimisticallyConfirmed(slot, hash) => {
                 let bank = bank_forks.read().unwrap().get(slot);
                 if let Some(bank) = bank {
-                    let mut w_optimistically_confirmed_bank =
-                        optimistically_confirmed_bank.write().unwrap();
+                    if !bank.is_frozen() {
+                        if slot > *highest_confirmed_slot {
+                            Self::notify_or_defer_confirmed_banks(
+                                subscriptions,
+                                bank_forks,
+                                bank,
+                                *highest_confirmed_slot,
+                                Some((slot, hash)),
+                                last_notified_confirmed_slot,
+                                pending_optimistically_confirmed_banks,
+                                slot_notification_subscribers,
+                                prioritization_fee_cache,
+                            );
+                            *highest_confirmed_slot = slot;
+                        } else if slot > bank_forks.read().unwrap().root() {
+                            pending_optimistically_confirmed_banks.insert((slot, hash));
+                            debug!("defer notifying optimistic confirmation for slot {slot}");
+                        }
+                    } else if bank.hash() != hash {
+                        if slot > bank_forks.read().unwrap().root() {
+                            pending_optimistically_confirmed_banks.insert((slot, hash));
+                            debug!(
+                                "defer notifying optimistic confirmation for slot {slot}: local \
+                                 bank hash {} does not match optimistic confirmation hash {hash}",
+                                bank.hash()
+                            );
+                        }
+                    } else {
+                        let mut w_optimistically_confirmed_bank =
+                            optimistically_confirmed_bank.write().unwrap();
 
-                    if bank.slot() > w_optimistically_confirmed_bank.bank.slot() && bank.is_frozen()
-                    {
-                        w_optimistically_confirmed_bank.bank = bank.clone();
+                        if bank.slot() > w_optimistically_confirmed_bank.bank.slot() {
+                            w_optimistically_confirmed_bank.bank = bank.clone();
+                        }
+
+                        if slot > *highest_confirmed_slot {
+                            Self::notify_or_defer_confirmed_banks(
+                                subscriptions,
+                                bank_forks,
+                                bank,
+                                *highest_confirmed_slot,
+                                None,
+                                last_notified_confirmed_slot,
+                                pending_optimistically_confirmed_banks,
+                                slot_notification_subscribers,
+                                prioritization_fee_cache,
+                            );
+
+                            *highest_confirmed_slot = slot;
+                        }
+                        drop(w_optimistically_confirmed_bank);
                     }
-
-                    if slot > *highest_confirmed_slot {
-                        Self::notify_or_defer_confirmed_banks(
-                            subscriptions,
-                            bank_forks,
-                            bank,
-                            *highest_confirmed_slot,
-                            last_notified_confirmed_slot,
-                            pending_optimistically_confirmed_banks,
-                            slot_notification_subscribers,
-                            prioritization_fee_cache,
-                        );
-
-                        *highest_confirmed_slot = slot;
-                    }
-                    drop(w_optimistically_confirmed_bank);
                 } else if slot > bank_forks.read().unwrap().root() {
-                    pending_optimistically_confirmed_banks.insert(slot);
+                    pending_optimistically_confirmed_banks.insert((slot, hash));
                 } else {
                     inc_new_counter_info!("dropped-already-rooted-optimistic-bank-notification", 1);
                 }
@@ -354,11 +393,11 @@ impl OptimisticallyConfirmedBankTracker {
 
                     Self::notify_slot_status(
                         slot_notification_subscribers,
-                        SlotNotification::Frozen((bank.slot(), bank.parent_slot())),
+                        SlotNotification::Frozen((bank.slot(), bank.parent_slot(), bank.bank_id())),
                     );
                 }
 
-                if pending_optimistically_confirmed_banks.remove(&bank.slot()) {
+                if pending_optimistically_confirmed_banks.remove(&(bank.slot(), bank.hash())) {
                     debug!(
                         "Calling notify_gossip_subscribers to send deferred notification \
                          {frozen_slot:?}"
@@ -369,11 +408,15 @@ impl OptimisticallyConfirmedBankTracker {
                         bank_forks,
                         bank.clone(),
                         *last_notified_confirmed_slot,
+                        None,
                         last_notified_confirmed_slot,
                         pending_optimistically_confirmed_banks,
                         slot_notification_subscribers,
                         prioritization_fee_cache,
                     );
+                    if frozen_slot > *highest_confirmed_slot {
+                        *highest_confirmed_slot = frozen_slot;
+                    }
 
                     let mut w_optimistically_confirmed_bank =
                         optimistically_confirmed_bank.write().unwrap();
@@ -392,11 +435,12 @@ impl OptimisticallyConfirmedBankTracker {
                 }
                 drop(w_optimistically_confirmed_bank);
 
-                pending_optimistically_confirmed_banks.retain(|&s| s > root_slot);
+                pending_optimistically_confirmed_banks.retain(|&(slot, _hash)| slot > root_slot);
             }
-            BankNotification::NewRootedChain(mut roots) => {
+            BankNotification::NewRootedChain(mut roots, oldest_parent) => {
                 Self::notify_new_root_slots(
                     &mut roots,
+                    oldest_parent,
                     newest_root_slot,
                     slot_notification_subscribers,
                 );
@@ -433,6 +477,22 @@ mod tests {
         notifications
     }
 
+    fn root_slot_notifications(root_bank: &Arc<Bank>) -> (Vec<(Slot, BankId)>, Slot) {
+        let mut rooted_banks = root_bank.parents();
+        let oldest_parent = rooted_banks
+            .last()
+            .map(|last| last.parent_slot())
+            .unwrap_or_else(|| root_bank.parent_slot());
+        rooted_banks.push(root_bank.clone());
+        (
+            rooted_banks
+                .iter()
+                .map(|bank| (bank.slot(), bank.bank_id()))
+                .collect(),
+            oldest_parent,
+        )
+    }
+
     #[test]
     fn test_process_notification() {
         let exit = Arc::new(AtomicBool::new(false));
@@ -448,6 +508,10 @@ mod tests {
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
         let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
+        let bank1_hash = bank_forks.read().unwrap().get(1).unwrap().hash();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
+        let bank2_hash = bank2.hash();
+        let bank3_pending_hash = Hash::new_unique();
 
         let optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>> =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -461,7 +525,7 @@ mod tests {
             block_commitment_cache,
             optimistically_confirmed_bank.clone(),
         ));
-        let mut pending_optimistically_confirmed_banks: HashSet<u64> = HashSet::new();
+        let mut pending_optimistically_confirmed_banks = PendingOptimisticallyConfirmedBanks::new();
 
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 0);
 
@@ -471,7 +535,7 @@ mod tests {
         let mut last_notified_confirmed_slot: Slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(2),
+                BankNotification::OptimisticallyConfirmed(2, bank2_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -491,7 +555,7 @@ mod tests {
         // Test max optimistically confirmed bank remains in the cache
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(1),
+                BankNotification::OptimisticallyConfirmed(1, bank1_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -511,7 +575,7 @@ mod tests {
         // Test bank will only be cached when frozen
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(3),
+                BankNotification::OptimisticallyConfirmed(3, bank3_pending_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -527,12 +591,14 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 2);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
-        assert!(pending_optimistically_confirmed_banks.contains(&3));
+        assert!(pending_optimistically_confirmed_banks.contains(&(3, bank3_pending_hash)));
         assert_eq!(highest_confirmed_slot, 3);
 
         // Test bank will only be cached when frozen
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
         bank3.freeze();
+        assert!(pending_optimistically_confirmed_banks.remove(&(3, bank3_pending_hash)));
+        pending_optimistically_confirmed_banks.insert((3, bank3.hash()));
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
@@ -558,9 +624,10 @@ mod tests {
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
         let bank4 = Bank::new_from_parent(bank3, SlotLeader::default(), 4);
         bank_forks.write().unwrap().insert(bank4);
+        let bank4_hash = Hash::new_unique();
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(4),
+                BankNotification::OptimisticallyConfirmed(4, bank4_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -576,7 +643,7 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 3);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
-        assert!(pending_optimistically_confirmed_banks.contains(&4));
+        assert!(pending_optimistically_confirmed_banks.contains(&(4, bank4_hash)));
         assert_eq!(highest_confirmed_slot, 4);
 
         let bank4 = bank_forks.read().unwrap().get(4).unwrap();
@@ -589,7 +656,7 @@ mod tests {
         bank_notification_senders.push(sender);
 
         let subscribers = Some(Arc::new(RwLock::new(bank_notification_senders)));
-        let parent_roots = bank5.ancestors.keys();
+        let (parent_roots, oldest_parent) = root_slot_notifications(&bank5);
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
@@ -609,14 +676,14 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
-        assert!(!pending_optimistically_confirmed_banks.contains(&4));
+        assert!(!pending_optimistically_confirmed_banks.contains(&(4, bank4_hash)));
         assert_eq!(highest_confirmed_slot, 4);
         // The newest_root_slot is updated via NewRootedChain only
         assert_eq!(newest_root_slot, 0);
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::NewRootedChain(parent_roots),
+                BankNotification::NewRootedChain(parent_roots, oldest_parent),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -645,9 +712,10 @@ mod tests {
         let bank7 = Bank::new_from_parent(bank5, SlotLeader::default(), 7);
         bank_forks.write().unwrap().insert(bank7);
         bank_forks.write().unwrap().set_root(7, None, None);
+        let bank6_hash = Hash::new_unique();
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(6),
+                BankNotification::OptimisticallyConfirmed(6, bank6_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -663,12 +731,12 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 5);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
-        assert!(!pending_optimistically_confirmed_banks.contains(&6));
+        assert!(!pending_optimistically_confirmed_banks.contains(&(6, bank6_hash)));
         assert_eq!(highest_confirmed_slot, 4);
         assert_eq!(newest_root_slot, 5);
 
         let bank7 = bank_forks.read().unwrap().get(7).unwrap();
-        let parent_roots = bank7.ancestors.keys();
+        let (parent_roots, oldest_parent) = root_slot_notifications(&bank7);
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
@@ -688,13 +756,13 @@ mod tests {
         );
         assert_eq!(optimistically_confirmed_bank.read().unwrap().bank.slot(), 7);
         assert_eq!(pending_optimistically_confirmed_banks.len(), 0);
-        assert!(!pending_optimistically_confirmed_banks.contains(&6));
+        assert!(!pending_optimistically_confirmed_banks.contains(&(6, bank6_hash)));
         assert_eq!(highest_confirmed_slot, 4);
         assert_eq!(newest_root_slot, 5);
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::NewRootedChain(parent_roots),
+                BankNotification::NewRootedChain(parent_roots, oldest_parent),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -733,8 +801,10 @@ mod tests {
             let bank0 = bank_forks.read().unwrap().get(0).unwrap();
             let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
             bank_forks.write().unwrap().insert(bank1);
+            let bank1_pending_hash = Hash::new_unique();
 
-            let mut pending_optimistically_confirmed_banks: HashSet<u64> = HashSet::new();
+            let mut pending_optimistically_confirmed_banks =
+                PendingOptimisticallyConfirmedBanks::new();
             let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
 
             let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
@@ -758,7 +828,7 @@ mod tests {
             // confirmed without fronzen received
             OptimisticallyConfirmedBankTracker::process_notification(
                 (
-                    BankNotification::OptimisticallyConfirmed(1),
+                    BankNotification::OptimisticallyConfirmed(1, bank1_pending_hash),
                     Some(work_id_1), /* dependency work id */
                 ),
                 &bank_forks,
@@ -777,9 +847,12 @@ mod tests {
             // highest_confirmed_slot is updated even when we have not received the frozen event
             assert_eq!(highest_confirmed_slot, 1);
             assert_eq!(pending_optimistically_confirmed_banks.len(), 1);
+            assert!(pending_optimistically_confirmed_banks.contains(&(1, bank1_pending_hash)));
 
             let bank1 = bank_forks.read().unwrap().get(1).unwrap();
             bank1.freeze();
+            assert!(pending_optimistically_confirmed_banks.remove(&(1, bank1_pending_hash)));
+            pending_optimistically_confirmed_banks.insert((1, bank1.hash()));
 
             OptimisticallyConfirmedBankTracker::process_notification(
                 (

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8999,6 +8999,10 @@ pub mod tests {
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
         let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
+        let bank3_pending_hash = Hash::new_unique();
+        let bank1_hash = bank_forks.read().unwrap().get(1).unwrap().hash();
+        let bank2 = bank_forks.read().unwrap().get(2).unwrap();
+        let bank2_hash = bank2.hash();
 
         let prioritization_fee_cache_inner = None;
         let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
@@ -9057,7 +9061,7 @@ pub mod tests {
 
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(2),
+                BankNotification::OptimisticallyConfirmed(2, bank2_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -9081,7 +9085,7 @@ pub mod tests {
         // Test rollback does not appear to happen, even if slots are notified out of order
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(1),
+                BankNotification::OptimisticallyConfirmed(1, bank1_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -9105,7 +9109,7 @@ pub mod tests {
         // Test bank will only be cached when frozen
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(3),
+                BankNotification::OptimisticallyConfirmed(3, bank3_pending_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -9128,6 +9132,9 @@ pub mod tests {
 
         // Test freezing an optimistically confirmed bank will update cache
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
+        bank3.freeze();
+        assert!(pending_optimistically_confirmed_banks.remove(&(3, bank3_pending_hash)));
+        pending_optimistically_confirmed_banks.insert((3, bank3.hash()));
         OptimisticallyConfirmedBankTracker::process_notification(
             (
                 BankNotification::Frozen(bank3),

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1217,6 +1217,7 @@ pub(crate) mod tests {
         },
         serial_test::serial,
         solana_commitment_config::CommitmentConfig,
+        solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::get_tmp_ledger_path_auto_delete,
         solana_message::Message,
@@ -1937,6 +1938,7 @@ pub(crate) mod tests {
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
 
         bank3.process_transaction(&tx).unwrap();
+        let bank3_pending_hash = Hash::new_unique();
 
         // now add programSubscribe at the "confirmed" commitment level
         let exit = Arc::new(AtomicBool::new(false));
@@ -1989,7 +1991,7 @@ pub(crate) mod tests {
         // to see transaction for alice and bob to be notified in order.
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(3),
+                BankNotification::OptimisticallyConfirmed(3, bank3_pending_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -2044,6 +2046,8 @@ pub(crate) mod tests {
         );
 
         bank3.freeze();
+        assert!(pending_optimistically_confirmed_banks.remove(&(3, bank3_pending_hash)));
+        pending_optimistically_confirmed_banks.insert((3, bank3.hash()));
         OptimisticallyConfirmedBankTracker::process_notification(
             (
                 BankNotification::Frozen(bank3),
@@ -2171,7 +2175,7 @@ pub(crate) mod tests {
         // expect to see any RPC notifications.
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(3),
+                BankNotification::OptimisticallyConfirmed(3, Hash::new_unique()),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -2242,6 +2246,22 @@ pub(crate) mod tests {
 
         bank2.process_transaction(&tx).unwrap();
 
+        // Prepare bank3 and its final hash, but do not insert it into BankForks until after
+        // the optimistic confirmation notification.
+        let joe = Keypair::new();
+        let tx = system_transaction::create_account(
+            &mint_keypair,
+            &joe,
+            blockhash,
+            3,
+            16,
+            &stake::program::id(),
+        );
+        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
+        bank3.process_transaction(&tx).unwrap();
+        bank3.freeze();
+        let bank3_hash = bank3.hash();
+
         // now add programSubscribe at the "confirmed" commitment level
         let exit = Arc::new(AtomicBool::new(false));
         let optimistically_confirmed_bank =
@@ -2293,7 +2313,7 @@ pub(crate) mod tests {
         // frozen. The notifications should be in the increasing order of the slot.
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(3),
+                BankNotification::OptimisticallyConfirmed(3, bank3_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -2333,23 +2353,8 @@ pub(crate) mod tests {
             })
         };
 
-        let bank3 = Bank::new_from_parent(bank2, SlotLeader::default(), 3);
         bank_forks.write().unwrap().insert(bank3);
-
-        // add account for joe and process the transaction at bank3
-        let joe = Keypair::new();
-        let tx = system_transaction::create_account(
-            &mint_keypair,
-            &joe,
-            blockhash,
-            3,
-            16,
-            &stake::program::id(),
-        );
         let bank3 = bank_forks.read().unwrap().get(3).unwrap();
-
-        bank3.process_transaction(&tx).unwrap();
-        bank3.freeze();
         OptimisticallyConfirmedBankTracker::process_notification(
             (
                 BankNotification::Frozen(bank3),
@@ -2782,6 +2787,7 @@ pub(crate) mod tests {
         let bank1 = bank_forks.write().unwrap().get(1).unwrap();
         bank1.process_transaction(&tx).unwrap();
         bank1.freeze();
+        let bank1_hash = bank1.hash();
 
         // Add the same transaction to the unfrozen 2nd bank
         bank_forks
@@ -2791,6 +2797,7 @@ pub(crate) mod tests {
             .unwrap()
             .process_transaction(&tx)
             .unwrap();
+        let bank2_pending_hash = Hash::new_unique();
 
         // First, notify the unfrozen bank first to queue pending notification
         let mut highest_confirmed_slot: Slot = 0;
@@ -2800,7 +2807,10 @@ pub(crate) mod tests {
         let prioritization_fee_cache = prioritization_fee_cache_inner.as_deref();
 
         OptimisticallyConfirmedBankTracker::process_notification(
-            (BankNotification::OptimisticallyConfirmed(2), None),
+            (
+                BankNotification::OptimisticallyConfirmed(2, bank2_pending_hash),
+                None,
+            ),
             &bank_forks,
             &optimistically_confirmed_bank,
             &subscriptions,
@@ -2817,7 +2827,7 @@ pub(crate) mod tests {
         highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             (
-                BankNotification::OptimisticallyConfirmed(1),
+                BankNotification::OptimisticallyConfirmed(1, bank1_hash),
                 None, /* no dependency work */
             ),
             &bank_forks,
@@ -2873,6 +2883,8 @@ pub(crate) mod tests {
 
         let bank2 = bank_forks.read().unwrap().get(2).unwrap();
         bank2.freeze();
+        assert!(pending_optimistically_confirmed_banks.remove(&(2, bank2_pending_hash)));
+        pending_optimistically_confirmed_banks.insert((2, bank2.hash()));
         highest_confirmed_slot = 0;
         OptimisticallyConfirmedBankTracker::process_notification(
             (

--- a/rpc/src/slot_status_notifier.rs
+++ b/rpc/src/slot_status_notifier.rs
@@ -1,17 +1,17 @@
 use {
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     std::sync::{Arc, RwLock},
 };
 
 pub trait SlotStatusNotifierInterface {
     /// Notified when a slot is optimistically confirmed
-    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_confirmed(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId);
 
     /// Notified when a slot is marked frozen.
-    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_processed(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId);
 
     /// Notified when a slot is rooted.
-    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>);
+    fn notify_slot_rooted(&self, slot: Slot, parent: Option<Slot>, bank_id: BankId);
 
     /// Notified when the first shred is received for a slot.
     fn notify_first_shred_received(&self, slot: Slot);
@@ -20,7 +20,7 @@ pub trait SlotStatusNotifierInterface {
     fn notify_completed(&self, slot: Slot);
 
     /// Notified when the slot has bank created.
-    fn notify_created_bank(&self, slot: Slot, parent: Slot);
+    fn notify_created_bank(&self, slot: Slot, parent: Slot, bank_id: BankId);
 
     /// Notified when the slot is marked "Dead"
     fn notify_slot_dead(&self, slot: Slot, parent: Slot, error: String);

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -1,13 +1,17 @@
 use {
-    solana_clock::Slot, solana_hash::Hash, solana_signature::Signature,
+    solana_clock::{BankId, Slot},
+    solana_hash::Hash,
+    solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
-    solana_transaction_status::TransactionStatusMeta, std::sync::Arc,
+    solana_transaction_status::TransactionStatusMeta,
+    std::sync::Arc,
 };
 
 pub trait TransactionNotifier {
     fn notify_transaction(
         &self,
         slot: Slot,
+        bank_id: BankId,
         transaction_slot_index: usize,
         signature: &Signature,
         message_hash: &Hash,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -130,6 +130,7 @@ impl TransactionStatusService {
             TransactionStatusMessage::Batch((
                 TransactionStatusBatch {
                     slot,
+                    bank_id,
                     transactions,
                     commit_results,
                     balances,
@@ -210,6 +211,7 @@ impl TransactionStatusService {
                         let transaction = transaction.to_versioned_transaction();
                         transaction_notifier.notify_transaction(
                             slot,
+                            bank_id,
                             transaction_index,
                             signature,
                             message_hash,
@@ -353,7 +355,7 @@ pub(crate) mod tests {
         solana_account_decoder::{
             parse_account_data::SplTokenAdditionalDataV2, parse_token::token_amount_to_ui_amount_v3,
         },
-        solana_clock::Slot,
+        solana_clock::{BankId, Slot},
         solana_fee_structure::FeeDetails,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -382,6 +384,7 @@ pub(crate) mod tests {
     #[derive(Eq, Hash, PartialEq)]
     struct TestNotifierKey {
         slot: Slot,
+        bank_id: BankId,
         transaction_index: usize,
         message_hash: Hash,
     }
@@ -407,6 +410,7 @@ pub(crate) mod tests {
         fn notify_transaction(
             &self,
             slot: Slot,
+            bank_id: BankId,
             transaction_index: usize,
             _signature: &Signature,
             message_hash: &Hash,
@@ -417,6 +421,7 @@ pub(crate) mod tests {
             self.notifications.insert(
                 TestNotifierKey {
                     slot,
+                    bank_id,
                     transaction_index,
                     message_hash: *message_hash,
                 },
@@ -514,10 +519,12 @@ pub(crate) mod tests {
         };
 
         let slot = bank.slot();
+        let bank_id = bank.bank_id();
         let message_hash = *transaction.message_hash();
         let transaction_index: usize = bank.transaction_count().try_into().unwrap();
         let transaction_status_batch = TransactionStatusBatch {
             slot,
+            bank_id,
             transactions: vec![transaction],
             commit_results: vec![commit_result],
             balances,
@@ -551,6 +558,7 @@ pub(crate) mod tests {
         assert_eq!(test_notifier.notifications.len(), 1);
         let key = TestNotifierKey {
             slot,
+            bank_id,
             transaction_index,
             message_hash,
         };
@@ -621,11 +629,13 @@ pub(crate) mod tests {
         };
 
         let slot = bank.slot();
+        let bank_id = bank.bank_id();
         let transaction_index1: usize = bank.transaction_count().try_into().unwrap();
         let transaction_index2: usize = transaction_index1 + 1;
 
         let transaction_status_batch = TransactionStatusBatch {
             slot,
+            bank_id,
             transactions: vec![transaction1, transaction2],
             commit_results: vec![commit_result.clone(), commit_result],
             balances: balances.clone(),
@@ -660,11 +670,13 @@ pub(crate) mod tests {
 
         let key1 = TestNotifierKey {
             slot,
+            bank_id,
             transaction_index: transaction_index1,
             message_hash: *expected_transaction1.message_hash(),
         };
         let key2 = TestNotifierKey {
             slot,
+            bank_id,
             transaction_index: transaction_index2,
             message_hash: *expected_transaction2.message_hash(),
         };

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4339,9 +4339,12 @@ impl Bank {
             self.enqueue_accounts_lt_hash_updates(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
-            self.rc
-                .accounts
-                .store_accounts_seq(to_store, transactions.as_deref(), &self.ancestors);
+            self.rc.accounts.store_accounts_seq(
+                to_store,
+                self.bank_id(),
+                transactions.as_deref(),
+                &self.ancestors,
+            );
         });
 
         // Cached vote and stake accounts are synchronized with accounts-db
@@ -4729,7 +4732,7 @@ impl Bank {
         self.enqueue_accounts_lt_hash_updates(&accounts);
         self.rc
             .accounts
-            .store_accounts_par(accounts, None, &self.ancestors);
+            .store_accounts_par(accounts, self.bank_id(), None, &self.ancestors);
     }
 
     pub fn force_flush_accounts_cache(&self) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12465,7 +12465,7 @@ fn test_new_for_txn_tests_system_transfer() {
 
     let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
     let ancestors = Ancestors::from(vec![parent_slot]);
-    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, &ancestors);
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), 0, None, &ancestors);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);
@@ -12644,7 +12644,7 @@ fn test_new_for_block_tests_with_vote_account() {
 
     let refs: Vec<_> = owned_accounts.iter().map(|(k, v)| (k, v)).collect();
     let ancestors = Ancestors::from(vec![parent_slot]);
-    accounts.store_accounts_seq((parent_slot, refs.as_slice()), None, &ancestors);
+    accounts.store_accounts_seq((parent_slot, refs.as_slice()), 0, None, &ancestors);
     accounts.accounts_db.add_root(parent_slot);
 
     let bank_rc = BankRc::new(accounts);

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -215,7 +215,12 @@ mod serde_snapshot_tests {
 
         for (i, pubkey) in pubkeys.iter().enumerate() {
             let account = AccountSharedData::new(i as u64 + 1, 0, &Pubkey::default());
-            accounts.store_accounts_seq((slot, [(pubkey, &account)].as_slice()), None, &ancestors);
+            accounts.store_accounts_seq(
+                (slot, [(pubkey, &account)].as_slice()),
+                0,
+                None,
+                &ancestors,
+            );
         }
         check_accounts_local(&accounts, &pubkeys, 100);
         accounts.accounts_db.add_root_and_flush_write_cache(slot);

--- a/runtime/src/transaction_execution.rs
+++ b/runtime/src/transaction_execution.rs
@@ -9,7 +9,7 @@ use {
         vote_sender_types::{ReplayVoteSendType, ReplayVoteSender},
     },
     log::{trace, warn},
-    solana_clock::Slot,
+    solana_clock::{BankId, Slot},
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
     solana_measure::measure::Measure,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -33,6 +33,7 @@ type WorkSequence = u64;
 #[derive(Debug)]
 pub struct TransactionStatusBatch {
     pub slot: Slot,
+    pub bank_id: BankId,
     pub transactions: Vec<SanitizedTransaction>,
     pub commit_results: Vec<TransactionCommitResult>,
     pub balances: TransactionBalancesSet,
@@ -140,6 +141,7 @@ pub fn execute_batch<'a>(
 
         transaction_status_sender.send_transaction_status_batch(
             bank.slot(),
+            bank.bank_id(),
             transactions,
             commit_results,
             balances,
@@ -236,6 +238,7 @@ impl TransactionStatusSender {
     pub fn send_transaction_status_batch(
         &self,
         slot: Slot,
+        bank_id: BankId,
         transactions: Vec<SanitizedTransaction>,
         commit_results: Vec<TransactionCommitResult>,
         balances: TransactionBalancesSet,
@@ -251,6 +254,7 @@ impl TransactionStatusSender {
         if let Err(e) = self.sender.send(TransactionStatusMessage::Batch((
             TransactionStatusBatch {
                 slot,
+                bank_id,
                 transactions,
                 commit_results,
                 balances,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -83,7 +83,7 @@ pub(crate) fn set_root(
             .map(|s| s.get_current_declared_work());
         // TODO: propagate error
         let _ = config.sender.send((
-            BankNotification::OptimisticallyConfirmed(new_root),
+            BankNotification::OptimisticallyConfirmed(new_root, hash),
             dependency_work,
         ));
     }
@@ -126,14 +126,15 @@ pub fn check_and_handle_new_root<CB>(
     let oldest_parent = rooted_banks.last().map(|last| last.parent_slot());
     rooted_banks.push(root_bank.clone());
     let rooted_slots: Vec<_> = rooted_banks.iter().map(|bank| bank.slot()).collect();
-    // The following differs from rooted_slots by including the parent slot of the oldest parent bank.
-    let rooted_slots_with_parents = bank_notification_sender
+    let rooted_slot_notifications = bank_notification_sender
         .as_ref()
         .is_some_and(|sender| sender.should_send_parents)
         .then(|| {
-            let mut new_chain = rooted_slots.clone();
-            new_chain.push(oldest_parent.unwrap_or(parent_slot));
-            new_chain
+            let new_chain = rooted_banks
+                .iter()
+                .map(|bank| (bank.slot(), bank.bank_id()))
+                .collect();
+            (new_chain, oldest_parent.unwrap_or(parent_slot))
         });
 
     // Call leader schedule_cache.set_root() before blockstore.set_root() because
@@ -166,14 +167,17 @@ pub fn check_and_handle_new_root<CB>(
             .send((BankNotification::NewRootBank(root_bank), dependency_work))
             .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
 
-        if let Some(new_chain) = rooted_slots_with_parents {
+        if let Some((new_chain, oldest_parent)) = rooted_slot_notifications {
             let dependency_work = sender
                 .dependency_tracker
                 .as_ref()
                 .map(|s| s.get_current_declared_work());
             sender
                 .sender
-                .send((BankNotification::NewRootedChain(new_chain), dependency_work))
+                .send((
+                    BankNotification::NewRootedChain(new_chain, oldest_parent),
+                    dependency_work,
+                ))
                 .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
         }
     }


### PR DESCRIPTION
#### Problem
With Alpenglow FLH, a validator can process more than one bank for the same slot. Geyser transaction notifications are currently scoped only by slot and transaction index, which makes it ambiguous for plugins to tell which bank a transaction belongs to. Because Geyser notifications are delivered asynchronously, plugins cannot rely on notification ordering to separate old-bank data from the replacement bank.

#### Summary of Changes
This PR adds `BankId` to Geyser bank-scoped notifications.

#### Testing
- Tested with `solana-test-validator` and dummy geyser plugin