### PR TITLE
Update mergify config for v4.2 backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -109,23 +109,6 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v4.1
-  - name: backport warning comment
-    conditions:
-      - or:
-        - label=v4.0
-        - label=v4.1
-    actions:
-      comment:
-        message: >
-          Backports to release branches are to be avoided unless absolutely
-          necessary for fixing bugs, security issues, and perf regressions.
-          Changes intended for backport should be structured such that a
-          minimum effective diff can be committed separately from any
-          refactoring, plumbing, cleanup, etc that are not strictly
-          necessary to achieve the goal. Any of the latter should go only
-          into master and ride the normal stabilization schedule. Exceptions
-          include CI/metrics changes, CLI improvements and documentation
-          updates on a case by case basis.
   - name: v4.2 feature-gate backport
     conditions:
       - label=v4.2
@@ -150,13 +133,16 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v4.2
-  - name: v4.2 backport warning comment
+  - name: backport warning comment
     conditions:
-      - label=v4.2
+      - or:
+        - label=v4.0
+        - label=v4.1
+        - label=v4.2
     actions:
       comment:
         message: >
-          Backports to the alpha branch are to be avoided unless absolutely
+          Backports to release branches are to be avoided unless absolutely
           necessary for fixing bugs, security issues, and perf regressions.
           Changes intended for backport should be structured such that a
           minimum effective diff can be committed separately from any

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,7 @@
 # https://doc.mergify.io/
+shared:
+  backport_assignee: &BackportAssignee
+    - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@anza-xyz/community-pr-subscribers')) }}"
 pull_request_rules:
   - name: label changes from community
     conditions:
@@ -58,31 +61,6 @@ pull_request_rules:
           - automerge
       comment:
         message: automerge label removed due to a CI failure
-  - name: v3.1 feature-gate backport
-    conditions:
-      - label=v3.1
-      - label=feature-gate
-    actions:
-      backport:
-        assignees: &BackportAssignee
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@anza-xyz/community-pr-subscribers')) }}"
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        labels:
-          - feature-gate
-        branches:
-          - v3.1
-  - name: v3.1 non-feature-gate backport
-    conditions:
-      - label=v3.1
-      - label!=feature-gate
-    actions:
-      backport:
-        assignees: *BackportAssignee
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        branches:
-          - v3.1
   - name: v4.0 feature-gate backport
     conditions:
       - label=v4.0
@@ -134,13 +112,51 @@ pull_request_rules:
   - name: backport warning comment
     conditions:
       - or:
-        - label=v3.1
         - label=v4.0
         - label=v4.1
     actions:
       comment:
         message: >
           Backports to release branches are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule. Exceptions
+          include CI/metrics changes, CLI improvements and documentation
+          updates on a case by case basis.
+  - name: v4.2 feature-gate backport
+    conditions:
+      - label=v4.2
+      - label=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        labels:
+          - feature-gate
+        branches:
+          - v4.2
+  - name: v4.2 non-feature-gate backport
+    conditions:
+      - label=v4.2
+      - label!=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        branches:
+          - v4.2
+  - name: v4.2 backport warning comment
+    conditions:
+      - label=v4.2
+    actions:
+      comment:
+        message: >
+          Backports to the alpha branch are to be avoided unless absolutely
           necessary for fixing bugs, security issues, and perf regressions.
           Changes intended for backport should be structured such that a
           minimum effective diff can be committed separately from any


### PR DESCRIPTION
#### Problem

v4.2 release branch exists now and needs a backport label. v3.1 is no
longer maintained.

#### Summary of Changes

Add v4.2 backport rules (alpha candidate; v4.0 and v4.1 stay active) and
its alpha-branch warning. Drop the inactive v3.1 rules. Move the shared
backport assignee into a `shared` anchor.