### PR TITLE
consensus_pool: use block id based pool for genesis votes

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1313,7 +1313,7 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    solana_pubkey::declare_id!("a2penGLz8Vm2QHYB3JPefBiU4BY3Z6JkW2k3Scw5GWP");
+    solana_pubkey::declare_id!("a1p3RiCfMmzm5jgCva97UUNwUiVLq5EJhtusRWHDBsp");
 }
 
 pub mod disable_zk_elgamal_proof_program {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5278,9 +5278,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "5PG7F5xaWbdVbGqMK4swGStgw6Dc3CRBwg3aYcDmY9q"
+                    "7JJ15D1ce8yW5NceFtK3YN4JMeRV9epZRbpNjiw4Y2BW"
                 } else {
-                    "BKPZ9wePLfR5995UW3zc487emH7KXh7fAMTG1unYBYbC"
+                    "GFDc9UWSp6E6sbjgk9EhZLBrX3bUyC8bkh9YmLUxsH23"
                 },
             );
         }
@@ -5289,9 +5289,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "6P7mQgYgfCKXJT4giFVG9AUTG1k2oqbEz9oaJkQFzaFZ"
+                    "AxoMcCKN43V2JPtAc3ivoCFTfS2wmjB7xpZkn7u9KbLQ"
                 } else {
-                    "9X9n98FSzPHCrEns4We6giA6QnsQEeYXqbxxULT5tHL1"
+                    "79wpAVbcHWEJGLWtW4rDNjwdHnuRKbJheEstvsx9g3Xf"
                 },
             );
             break;

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -147,6 +147,9 @@ impl ConsensusPool {
             VoteType::Notarize => VotePool::DuplicateBlockVotePool(DuplicateBlockVotePool::new(
                 MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
             )),
+            VoteType::Genesis => VotePool::DuplicateBlockVotePool(DuplicateBlockVotePool::new(
+                MAX_ENTRIES_PER_PUBKEY_FOR_OTHER_TYPES,
+            )),
             _ => VotePool::SimpleVotePool(SimpleVotePool::default()),
         }
     }


### PR DESCRIPTION
#### Problem
We are using the slot based vote pool for genesis votes meaning we aggregate multiple block ids together and create the certificate by using the last one.

#### Summary of Changes
Use the block id based pool instead