### PR TITLE
Automatically close PRs against EoL version branches

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -151,6 +151,15 @@ pull_request_rules:
           into master and ride the normal stabilization schedule. Exceptions
           include CI/metrics changes, CLI improvements and documentation
           updates on a case by case basis.
+  - name: close PRs against EoL version branches
+    conditions:
+      - base ~= ^v[0-9]+\.[0-9]+$
+      - base != v4.0
+      - base != v4.1
+      - base != v4.2
+    actions:
+      close:
+        message: "`{{base}}` is end-of-life and no longer accepts changes."
   - name: Reminder to update RPC clients for changes in `rpc/`
     conditions:
       - or:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -127,7 +127,7 @@ Create a PR that makes the following updates to [CHANGELOG.md](https://github.co
 
 1. Update [CHANGELOG.md](https://github.com/anza-xyz/agave/blob/master/CHANGELOG.md) to remove the channel links on the new branch. Additionally, remove any wording about the new branch being unreleased.
 1. Update [CODEOWNERS](https://github.com/anza-xyz/agave/blob/master/.github/CODEOWNERS) to `* @anza-xyz/backport-reviewers` on the new branch.
-1. Update [mergify.yml](https://github.com/anza-xyz/agave/blob/master/.mergify.yml) to add backport actions for the new branch and remove actions for the obsolete branch.
+1. Update [mergify.yml](https://github.com/anza-xyz/agave/blob/master/.mergify.yml) to add backport actions for the new branch, remove actions for the obsolete branch and update the list of non EoL version branches.
 1. Adjust the [Github backport labels](https://github.com/anza-xyz/agave/labels) to add the new branch label and remove the label for the obsolete branch.
 1. Announce on Discord #development that the release branch exists so people know to use the new backport labels.
 


### PR DESCRIPTION
#### Problem

It is technically possible to open PRs against old branches like v3.1 that are EoL and don't accept any changes.

#### Summary of Changes

Just close such PRs automatically.