### PR TITLE
Introduces `GenesisCert` type

### DIFF
--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -12,7 +12,7 @@ use {
         vote_simulator::{self, VoteSimulator},
     },
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{CertSignature, GenesisCert},
         consensus_message::Block,
     },
     blockstore_processor::{
@@ -135,10 +135,12 @@ fn post_migration_status_for_tests() -> MigrationStatus {
         slot: 0,
         block_id: Hash::default(),
     };
-    let genesis_certificate = Arc::new(Certificate {
-        cert_type: CertificateType::Genesis(genesis_block),
-        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-        bitmap: vec![],
+    let genesis_certificate = Arc::new(GenesisCert {
+        block: genesis_block,
+        signature: CertSignature {
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        },
     });
     migration_status.set_genesis_block(genesis_block);
     migration_status.set_genesis_certificate(genesis_certificate);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2066,7 +2066,7 @@ pub fn should_require_vote_history_file(
         // New vote account
         return false;
     };
-    let genesis_slot = genesis_certificate.cert_type.slot();
+    let genesis_slot = genesis_certificate.block.slot;
 
     // We've voted past the alpenglow genesis
     last_voted_slot > genesis_slot
@@ -3150,6 +3150,7 @@ pub fn is_snapshot_config_valid(snapshot_config: &SnapshotConfig) -> bool {
 mod tests {
     use {
         super::*,
+        agave_votor_messages::certificate::{CertSignature, GenesisCert},
         crossbeam_channel::{RecvTimeoutError, bounded},
         solana_entry::entry,
         solana_genesis_config::create_genesis_config,
@@ -3168,10 +3169,7 @@ mod tests {
     #[test]
     fn test_should_require_vote_history_file() {
         use {
-            agave_votor_messages::{
-                certificate::{Certificate, CertificateType},
-                consensus_message::Block,
-            },
+            agave_votor_messages::consensus_message::Block,
             solana_account::{AccountSharedData, state_traits::StateMut},
             solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         };
@@ -3229,14 +3227,17 @@ mod tests {
             &identity,
         ));
 
-        bank.set_alpenglow_genesis_certificate(&Certificate {
-            cert_type: CertificateType::Genesis(Block {
+        let cert = GenesisCert {
+            block: Block {
                 slot: 40,
                 block_id: Hash::new_unique(),
-            }),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
-        });
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
+        };
+        bank.set_alpenglow_genesis_certificate(&cert);
         assert!(!should_require_vote_history_file(
             &bank,
             &vote_account_pubkey,

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -132,7 +132,7 @@
 use {
     crate::entry::{Entry, MaxDataShredsLen},
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{Certificate, GenesisCert},
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
     },
     solana_bls_signatures::{
@@ -243,25 +243,22 @@ impl GenesisCertBlockMarker {
     pub const MAX_BITMAP_SIZE: usize = 512;
 }
 
-impl TryFrom<Certificate> for GenesisCertBlockMarker {
+impl TryFrom<GenesisCert> for GenesisCertBlockMarker {
     type Error = String;
 
-    fn try_from(cert: Certificate) -> Result<Self, Self::Error> {
-        let CertificateType::Genesis(block) = cert.cert_type else {
-            return Err("expected genesis certificate".into());
-        };
-        if cert.bitmap.len() > Self::MAX_BITMAP_SIZE {
+    fn try_from(cert: GenesisCert) -> Result<Self, Self::Error> {
+        if cert.signature.bitmap.len() > Self::MAX_BITMAP_SIZE {
             return Err(format!(
                 "bitmap size {} exceeds max {}",
-                cert.bitmap.len(),
+                cert.signature.bitmap.len(),
                 Self::MAX_BITMAP_SIZE
             ));
         }
         Ok(Self {
-            slot: block.slot,
-            block_id: block.block_id,
-            bls_signature: cert.signature,
-            bitmap: cert.bitmap,
+            slot: cert.block.slot,
+            block_id: cert.block.block_id,
+            bls_signature: cert.signature.signature,
+            bitmap: cert.signature.bitmap,
         })
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2904,7 +2904,7 @@ pub mod tests {
             shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
         agave_votor_messages::{
-            certificate::{Certificate, CertificateType},
+            certificate::{CertSignature, GenesisCert},
             consensus_message::Block,
         },
         assert_matches::assert_matches,
@@ -2960,11 +2960,13 @@ pub mod tests {
     };
 
     /// Generate a dummy alpenglow genesis certificate
-    fn genesis_certificate(genesis_block: Block) -> Arc<Certificate> {
-        Arc::new(Certificate {
-            cert_type: CertificateType::Genesis(genesis_block),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+    fn genesis_certificate(block: Block) -> Arc<GenesisCert> {
+        Arc::new(GenesisCert {
+            block,
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         })
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -925,10 +925,10 @@ impl JsonRpcRequestProcessor {
         let bank = self.bank(Some(CommitmentConfig::finalized()));
         bank.get_alpenglow_genesis_certificate()
             .map(|c| WireBlockCertMessage {
-                block: c.cert_type.to_block().unwrap(),
+                block: c.block,
                 signature: WireCertSignature {
-                    signature: c.signature,
-                    bitmap: c.bitmap,
+                    signature: c.signature.signature,
+                    bitmap: c.signature.bitmap,
                 },
             })
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -82,7 +82,7 @@ use {
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::snapshot_hash::SnapshotHash,
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{CertSignature, Certificate, GenesisCert},
         migration::GENESIS_CERTIFICATE_ACCOUNT,
         unverified_vote_message::UnverifiedCertificate,
         wire::{WireBlockCertMessage, WireCertSignature},
@@ -3345,7 +3345,7 @@ impl Bank {
     /// - If `get_alpenglow_genesis_certificate` is called before the marker is processed by replay
     ///   this account will be empty.
     /// - If `get_alpenglow_genesis_certificate` is called after the marker is processed, we return the certificate
-    pub fn get_alpenglow_genesis_certificate(&self) -> Option<Certificate> {
+    pub fn get_alpenglow_genesis_certificate(&self) -> Option<GenesisCert> {
         let acct = self.get_account(&GENESIS_CERTIFICATE_ACCOUNT)?;
         (!acct.data().is_empty()).then(|| {
             // The address is known in advance, so the account could already exist if it was prefunded.
@@ -3353,10 +3353,12 @@ impl Bank {
             // so this deserialize is safe if the account is non-empty
             let cert: WireBlockCertMessage = wincode::deserialize(acct.data())
                 .expect("Programmer error deserializing genesis certificate");
-            Certificate {
-                cert_type: CertificateType::Genesis(cert.block),
-                signature: cert.signature.signature,
-                bitmap: cert.signature.bitmap,
+            GenesisCert {
+                block: cert.block,
+                signature: CertSignature {
+                    signature: cert.signature.signature,
+                    bitmap: cert.signature.bitmap,
+                },
             }
         })
     }
@@ -3370,14 +3372,12 @@ impl Bank {
     }
 
     /// For use in the first Alpenglow block, set the genesis certificate.
-    pub fn set_alpenglow_genesis_certificate(&self, cert: &Certificate) {
-        debug_assert!(cert.cert_type.is_genesis());
-        let block = cert.cert_type.to_block().unwrap();
+    pub fn set_alpenglow_genesis_certificate(&self, cert: &GenesisCert) {
         let cert = WireBlockCertMessage {
-            block,
+            block: cert.block,
             signature: WireCertSignature {
-                signature: cert.signature,
-                bitmap: cert.bitmap.clone(),
+                signature: cert.signature.signature,
+                bitmap: cert.signature.bitmap.clone(),
             },
         };
         let data = wincode::serialize(&cert).unwrap();
@@ -6616,12 +6616,7 @@ impl Bank {
 
     pub(crate) fn get_alpenglow_migration_slot(&self) -> Option<Slot> {
         let genesis_cert = self.get_alpenglow_genesis_certificate()?;
-        debug_assert!(
-            genesis_cert.cert_type.is_genesis(),
-            "cert_type={:?}",
-            genesis_cert.cert_type
-        );
-        Some(genesis_cert.cert_type.slot())
+        Some(genesis_cert.block.slot)
     }
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -778,7 +778,7 @@ mod tests {
         },
         agave_feature_set::FeatureSet,
         agave_votor_messages::{
-            certificate::{Certificate, CertificateType},
+            certificate::{CertSignature, GenesisCert},
             consensus_message::Block,
             migration::{GENESIS_CERTIFICATE_ACCOUNT, MIGRATION_SLOT_OFFSET},
             wire::{WireBlockCertMessage, WireCertSignature},
@@ -978,7 +978,7 @@ mod tests {
     fn make_root_bank_for_migration_status_test(
         root_slot: Slot,
         ff_activation_slot: Option<Slot>,
-        genesis_cert: Option<Certificate>,
+        genesis_cert: Option<GenesisCert>,
     ) -> Bank {
         let GenesisConfigInfo {
             mut genesis_config, ..
@@ -987,10 +987,10 @@ mod tests {
 
         if let Some(genesis_cert) = genesis_cert {
             let cert = WireBlockCertMessage {
-                block: genesis_cert.cert_type.to_block().unwrap(),
+                block: genesis_cert.block,
                 signature: WireCertSignature {
-                    signature: genesis_cert.signature,
-                    bitmap: genesis_cert.bitmap,
+                    signature: genesis_cert.signature.signature,
+                    bitmap: genesis_cert.signature.bitmap,
                 },
             };
             let cert_data = wincode::serialize(&cert).unwrap();
@@ -1028,13 +1028,15 @@ mod tests {
     #[test]
     fn test_initialize_migration_status() {
         let ff_activation_slot = 5;
-        let genesis_cert = Certificate {
-            cert_type: CertificateType::Genesis(Block {
+        let genesis_cert = GenesisCert {
+            block: Block {
                 slot: 1,
                 block_id: Hash::default(),
-            }),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         };
 
         let root_bank = make_root_bank_for_migration_status_test(0, None, None);
@@ -1055,8 +1057,8 @@ mod tests {
             Some(genesis_cert.clone()),
         );
         assert_eq!(
-            root_bank.get_alpenglow_genesis_certificate(),
-            Some(genesis_cert.clone())
+            root_bank.get_alpenglow_genesis_certificate().unwrap(),
+            genesis_cert.clone()
         );
         let migration_status = BankForks::initialize_migration_status(&root_bank);
         assert!(migration_status.is_alpenglow_enabled());
@@ -1111,13 +1113,15 @@ mod tests {
 
         // Migration can still succeed
         let mut bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 10);
-        let genesis_cert = Certificate {
-            cert_type: CertificateType::Genesis(Block {
+        let genesis_cert = GenesisCert {
+            block: Block {
                 slot: 1,
                 block_id: Hash::new_unique(),
-            }),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         };
         bank.activate_feature(&agave_feature_set::alpenglow::id());
         bank.set_alpenglow_genesis_certificate(&genesis_cert);

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -11,7 +11,7 @@ use {
         validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
     },
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{CertSignature, CertificateType, GenesisCert},
         consensus_message::{Block, ConsensusMessage},
         migration::MigrationStatus,
         unverified_vote_message::UnverifiedCertificate,
@@ -328,26 +328,20 @@ impl BlockComponentProcessor {
             return Err(BlockComponentProcessorError::GenesisCertificateAlreadyPopulated);
         }
 
-        let genesis_cert_type = CertificateType::Genesis(Block {
-            slot: genesis_block_marker.slot,
-            block_id: genesis_block_marker.block_id,
-        });
-        let genesis_cert = match shred_version {
-            Some(shred_version) => {
-                let unverified_genesis_cert = UnverifiedCertificate {
-                    cert_type: genesis_cert_type,
-                    signature: genesis_block_marker.bls_signature,
-                    bitmap: genesis_block_marker.bitmap,
-                    shred_version,
-                };
-                Self::verify_genesis_certificate(&bank, unverified_genesis_cert)?
-            }
-            None => Certificate {
-                cert_type: genesis_cert_type,
+        let genesis_cert = GenesisCert {
+            block: Block {
+                slot: genesis_block_marker.slot,
+                block_id: genesis_block_marker.block_id,
+            },
+            signature: CertSignature {
                 signature: genesis_block_marker.bls_signature,
                 bitmap: genesis_block_marker.bitmap,
             },
         };
+        if let Some(shred_version) = shred_version {
+            Self::verify_genesis_certificate(&bank, &genesis_cert, shred_version)?;
+        }
+
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
         bank.set_hashes_per_tick(None);
         self.has_genesis_certificate_marker = true;
@@ -368,12 +362,7 @@ impl BlockComponentProcessor {
             migration_status.my_pubkey(),
             bank.slot()
         );
-        migration_status.set_genesis_block(
-            genesis_cert
-                .cert_type
-                .to_block()
-                .expect("Genesis cert must correspond to a block"),
-        );
+        migration_status.set_genesis_block(genesis_cert.block);
         migration_status.set_genesis_certificate(Arc::new(genesis_cert));
         assert!(migration_status.is_ready_to_enable());
 
@@ -382,12 +371,17 @@ impl BlockComponentProcessor {
 
     fn verify_genesis_certificate(
         bank: &Bank,
-        cert: UnverifiedCertificate,
-    ) -> Result<Certificate, BlockComponentProcessorError> {
-        debug_assert!(cert.cert_type.is_genesis());
-
-        let cert_slot = cert.cert_type.slot();
-        let cert = bank.verify_certificate(cert).map_err(|_| {
+        cert: &GenesisCert,
+        shred_version: u16,
+    ) -> Result<(), BlockComponentProcessorError> {
+        let cert_slot = cert.block.slot;
+        let unverified_cert = UnverifiedCertificate {
+            cert_type: CertificateType::Genesis(cert.block),
+            signature: cert.signature.signature,
+            bitmap: cert.signature.bitmap.clone(),
+            shred_version,
+        };
+        bank.verify_certificate(unverified_cert).map_err(|_| {
             warn!(
                 "Failed to verify genesis certificate for slot {cert_slot} in bank slot {}",
                 bank.slot()
@@ -395,7 +389,7 @@ impl BlockComponentProcessor {
             BlockComponentProcessorError::GenesisCertificateFailedVerification
         })?;
 
-        Ok(cert)
+        Ok(())
     }
 
     fn on_footer(
@@ -698,11 +692,14 @@ mod tests {
             block_id: Hash::default(),
         };
         migration_status.set_genesis_block(genesis_block);
-        migration_status.set_genesis_certificate(Arc::new(Certificate {
-            cert_type: CertificateType::Genesis(genesis_block),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
-        }));
+        let cert = Arc::new(GenesisCert {
+            block: genesis_block,
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
+        });
+        migration_status.set_genesis_certificate(cert);
         migration_status.enable_alpenglow_during_startup();
 
         migration_status

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -17,7 +17,7 @@ mod tests {
         },
         agave_feature_set::FeatureSet,
         agave_votor_messages::{
-            certificate::{Certificate, CertificateType},
+            certificate::{CertSignature, GenesisCert},
             consensus_message::Block,
         },
         solana_account::{Account, ReadableAccount, from_account},
@@ -282,7 +282,7 @@ mod tests {
             let first_slot_in_reward_epoch = payout_bank
                 .epoch_schedule
                 .get_first_slot_in_epoch(reward_bank.epoch());
-            let num_tower_slots = genesis_cert.cert_type.slot() - first_slot_in_reward_epoch + 1;
+            let num_tower_slots = genesis_cert.block.slot - first_slot_in_reward_epoch + 1;
             let total_slots = reward_bank.epoch_schedule.slots_per_epoch;
 
             let rent_exempt_reserve = reward_bank
@@ -437,13 +437,15 @@ mod tests {
 
         let bank_with_tower_rewards = state.add_tower_rewards(bank_at_migration0);
 
-        let genesis_cert = Certificate {
-            cert_type: CertificateType::Genesis(Block {
+        let genesis_cert = GenesisCert {
+            block: Block {
                 slot: bank_with_tower_rewards.slot(),
                 block_id: Hash::default(),
-            }),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         };
         bank_with_tower_rewards.set_alpenglow_genesis_certificate(&genesis_cert);
         let bank_with_genesis_cert_slot = bank_with_tower_rewards.slot() + 10_000;

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -12,6 +12,25 @@ use {
     solana_clock::Slot,
 };
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A cert signature
+pub struct CertSignature {
+    /// The aggregate signature.
+    pub signature: BLSSignature,
+    /// A rank bitmap for validators' signatures included in the aggregate.
+    /// See solana-signer-store for encoding format.
+    pub bitmap: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Genesis cert
+pub struct GenesisCert {
+    /// Block the cert is for.
+    pub block: Block,
+    /// the signature on the cert
+    pub signature: CertSignature,
+}
+
 /// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
 /// BLS vote message, we need rank to look up pubkey
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -42,12 +42,14 @@
 //! - When in `AlpenglowEnabled` various TowerBFT threads stop processsing alpenglow slots while still processing
 //!   TowerBFT slots pre alpenglow genesis in order to help other cluster participants catchup.
 //! - When in `FullAlpenglowEpoch` we completely shutdown these TowerBFT threads (AncestorHashesService and ClusterSlotsService)
+#[cfg(feature = "dev-context-only-utils")]
 use {
-    crate::{
-        certificate::{Certificate, CertificateType},
-        consensus_message::Block,
-        fraction::Fraction,
-    },
+    crate::certificate::CertSignature,
+    solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
+    solana_hash::Hash,
+};
+use {
+    crate::{certificate::GenesisCert, consensus_message::Block, fraction::Fraction},
     log::*,
     solana_address::Address,
     solana_clock::{Epoch, Slot},
@@ -60,11 +62,6 @@ use {
         },
         time::Duration,
     },
-};
-#[cfg(feature = "dev-context-only-utils")]
-use {
-    solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
-    solana_hash::Hash,
 };
 
 /// The slot offset post feature flag activation to begin the migration.
@@ -116,7 +113,7 @@ enum MigrationPhase {
         /// The block we've identified as the genesis block
         genesis_block: Option<Block>,
         /// The genesis certificate we've received
-        genesis_cert: Option<Arc<Certificate>>,
+        genesis_cert: Option<Arc<GenesisCert>>,
     },
 
     /// The alpenglow genesis vote has succeeded, and we have frozen the genesis bank. We are ready to
@@ -125,14 +122,14 @@ enum MigrationPhase {
     /// `AlpenglowEnabled` when it is safe to do so.
     ReadyToEnable {
         /// The genesis certificate produced by the cluster
-        genesis_cert: Arc<Certificate>,
+        genesis_cert: Arc<GenesisCert>,
     },
 
     /// Alpenglow has been enabled, TowerBFT blocks > the alpenglow genesis have been purged,
     /// and all further blocks are alpenglow.
     AlpenglowEnabled {
         /// The genesis certificate produced by the cluster
-        genesis_cert: Arc<Certificate>,
+        genesis_cert: Arc<GenesisCert>,
     },
 
     /// We have completed the mixed migration epoch and now all epochs only contain alpenglow blocks
@@ -141,7 +138,7 @@ enum MigrationPhase {
         #[allow(dead_code)]
         full_alpenglow_epoch: Epoch,
         /// The genesis certificate produced by the cluster
-        genesis_cert: Arc<Certificate>,
+        genesis_cert: Arc<GenesisCert>,
     },
 }
 
@@ -182,9 +179,7 @@ impl MigrationPhase {
             MigrationPhase::PreFeatureActivation
             | MigrationPhase::Migration { .. }
             | MigrationPhase::ReadyToEnable { .. } => false,
-            MigrationPhase::AlpenglowEnabled { genesis_cert } => {
-                slot > genesis_cert.cert_type.slot()
-            }
+            MigrationPhase::AlpenglowEnabled { genesis_cert } => slot > genesis_cert.block.slot,
             MigrationPhase::FullAlpenglowEpoch { .. } => true,
         }
     }
@@ -254,9 +249,7 @@ impl MigrationPhase {
             MigrationPhase::PreFeatureActivation
             | MigrationPhase::Migration { .. }
             | MigrationPhase::ReadyToEnable { .. } => true,
-            MigrationPhase::AlpenglowEnabled { genesis_cert } => {
-                slot <= genesis_cert.cert_type.slot()
-            }
+            MigrationPhase::AlpenglowEnabled { genesis_cert } => slot <= genesis_cert.block.slot,
             MigrationPhase::FullAlpenglowEpoch { .. } => false,
         }
     }
@@ -344,13 +337,15 @@ impl MigrationStatus {
     /// Creates a post migration status for use in tests
     #[cfg(feature = "dev-context-only-utils")]
     pub fn post_migration_status() -> Self {
-        let genesis_certificate = Certificate {
-            cert_type: CertificateType::Genesis(Block {
+        let genesis_certificate = GenesisCert {
+            block: Block {
                 slot: 0,
                 block_id: Hash::default(),
-            }),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         };
         Self::new(MigrationPhase::AlpenglowEnabled {
             genesis_cert: Arc::new(genesis_certificate),
@@ -360,25 +355,27 @@ impl MigrationStatus {
     /// Enable alpenglow for testing code
     #[cfg(feature = "dev-context-only-utils")]
     pub fn enable_alpenglow_for_tests(&self) {
-        let genesis_block = Block {
+        let block = Block {
             slot: 0,
             block_id: Hash::new_unique(),
         };
         self.record_feature_activation(0);
-        self.set_genesis_block(genesis_block);
-        self.set_genesis_certificate(Arc::new(Certificate {
-            cert_type: CertificateType::Genesis(genesis_block),
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap: vec![],
+        self.set_genesis_block(block);
+        self.set_genesis_certificate(Arc::new(GenesisCert {
+            block,
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
         }));
-        assert_eq!(self.enable_alpenglow_during_startup(), genesis_block.slot);
+        assert_eq!(self.enable_alpenglow_during_startup(), block.slot);
     }
 
     /// Initialize migration status based on feature flag activation and genesis certificate
     pub fn initialize(
         root_epoch: Epoch,
         ff_activation_slot: Option<Slot>,
-        genesis_cert: Option<Certificate>,
+        genesis_cert: Option<GenesisCert>,
         epoch_schedule: &EpochSchedule,
     ) -> Self {
         let phase = match (genesis_cert, ff_activation_slot) {
@@ -548,16 +545,15 @@ impl MigrationStatus {
         let Some(genesis_cert) = genesis_cert else {
             return;
         };
-        let CertificateType::Genesis(block) = genesis_cert.cert_type else {
-            unreachable!("Programmer error invalid genesis certificate");
-        };
-        if genesis_block.as_ref().map(|b| *b != block).unwrap_or(true) {
+
+        if discovered_genesis_block != genesis_cert.block {
             panic!(
                 "{}: We wish to cast a genesis vote on {discovered_genesis_block:?}, however we \
-                 have received a genesis certificate for ({block:?}). This means there is \
-                 significant malicious activity causing two distinct forks to reach the \
+                 have received a genesis certificate for ({:?}). This means there is significant \
+                 malicious activity causing two distinct forks to reach the \
                  {GENESIS_VOTE_THRESHOLD}. We cannot recover without operator intervention.",
-                self.my_pubkey()
+                self.my_pubkey(),
+                genesis_cert.block
             );
         }
 
@@ -571,7 +567,7 @@ impl MigrationStatus {
     /// This should only be called with certificates that have passed signature verification
     ///
     /// Transitions to `ReadyToEnable` if we have already received a genesis block and it matches.
-    pub fn set_genesis_certificate(&self, cert: Arc<Certificate>) {
+    pub fn set_genesis_certificate(&self, cert: Arc<GenesisCert>) {
         let mut phase = self.phase.write().unwrap();
         if phase.is_pre_feature_activation() {
             unreachable!(
@@ -590,27 +586,28 @@ impl MigrationStatus {
             return;
         };
 
-        let CertificateType::Genesis(block) = cert.cert_type else {
-            unreachable!("Programmer error adding invalid genesis certificate");
-        };
-
         assert!(
-            block.slot < *migration_slot,
+            cert.block.slot < *migration_slot,
             "Attempting to set a genesis certificate past the migration start"
         );
-        info!("{} Setting genesis cert for ({block:?})", self.my_pubkey());
+        info!(
+            "{} Setting genesis cert for ({:?})",
+            self.my_pubkey(),
+            cert.block
+        );
         *genesis_cert = Some(cert.clone());
 
         let Some(genesis_block) = genesis_block else {
             return;
         };
-        if *genesis_block != block {
+        if *genesis_block != cert.block {
             panic!(
                 "{}: We cast a genesis vote on {genesis_block:?}, however we have received a \
-                 genesis certificate for ({block:?}). This means there is significant malicious \
+                 genesis certificate for ({:?}). This means there is significant malicious \
                  activity causing two distinct forks to reach the {GENESIS_VOTE_THRESHOLD}. We \
                  cannot recover without operator intervention.",
-                self.my_pubkey()
+                self.my_pubkey(),
+                cert.block
             );
         }
 
@@ -676,7 +673,7 @@ impl MigrationStatus {
             );
         };
 
-        let genesis_slot = genesis_cert.cert_type.slot();
+        let genesis_slot = genesis_cert.block.slot;
         if self.poh_service_started.load(Ordering::Acquire) {
             // If `PohService` is started, use the full enable pathway
             // We do not respect the exit flag during startup replay
@@ -724,15 +721,11 @@ impl MigrationStatus {
 
     /// The alpenglow genesis block. This should only be used when we are in `ReadyToEnable` or further
     pub fn genesis_block(&self) -> Option<Block> {
-        self.genesis_certificate().map(|cert| {
-            cert.cert_type
-                .to_block()
-                .expect("Must be a genesis certificate")
-        })
+        self.genesis_certificate().map(|cert| cert.block)
     }
 
     /// The alpenglow genesis certificate. Only relevant when we are in `ReadyToEnable` or further
-    pub fn genesis_certificate(&self) -> Option<Arc<Certificate>> {
+    pub fn genesis_certificate(&self) -> Option<Arc<GenesisCert>> {
         let phase = self.phase.read().unwrap();
         match &*phase {
             MigrationPhase::PreFeatureActivation | MigrationPhase::Migration { .. } => None,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -15,7 +15,7 @@ use {
     },
     agave_bls_sigverify::generated_cert_types::GeneratedCertTypes,
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{CertSignature, Certificate, CertificateType, GenesisCert},
         consensus_message::{Block, ConsensusMessage, VoteMessage},
         finalized_slot::FinalizedSlot,
         fraction::Fraction,
@@ -348,7 +348,14 @@ impl ConsensusPool {
                 }
             }
             CertificateType::Genesis(block) => {
-                self.migration_status.set_genesis_certificate(cert);
+                let genesis_cert = Arc::new(GenesisCert {
+                    block,
+                    signature: CertSignature {
+                        signature: cert.signature,
+                        bitmap: cert.bitmap.clone(),
+                    },
+                });
+                self.migration_status.set_genesis_certificate(genesis_cert);
                 // The genesis block is automatically certified
                 self.parent_ready_tracker
                     .add_new_notar_fallback_or_stronger(block, events);


### PR DESCRIPTION
#### Problem

- A number of places in the code assume that the `Certificate` will contain a genesis cert and are panicking if that is not the case.  Having more type safety here would be better.
- As discussed in https://github.com/anza-xyz/agave/issues/13560, in particular in https://github.com/anza-xyz/agave/issues/13560#issuecomment-4845332996, we want to revamp the `Certificate` type.


#### Summary of Changes

- Introduces `GenesisCert`
- Uses it in various places where earlier we were using `Certificate`.


#### Testing

Just CI