### PR TITLE
blockstore: Remove unused error variant

### DIFF
--- a/ledger/src/blockstore/error.rs
+++ b/ledger/src/blockstore/error.rs
@@ -67,8 +67,6 @@ pub enum BlockstoreError {
     LegacyShred(Slot, u64),
     #[error("unable to read merkle root slot {0}, index {1}")]
     MissingMerkleRoot(Slot, u64),
-    #[error("block contains an empty entry batch for slot {0}")]
-    EmptyEntryBatch(Slot),
     #[error("unable to purge slots in range [{from_slot}, {to_slot}] {purge_type:?}: {inner:?}")]
     PurgeFailed {
         from_slot: Slot,


### PR DESCRIPTION
#### Problem
The only caller that raised EmptyEntryBatch variant was updated with BlockAborted in 870b198

#### Summary of Changes
Remove unused variant

#### Testing
Compilation is sufficient