### PR TITLE
accounts-db: convert shrink to create tombstones for zero lamport entries

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -203,6 +203,13 @@ impl AccountStorageEntry {
         self.tombstone_offsets.read().unwrap()
     }
 
+    /// True if every alive account in this storage is a tombstone. Such a storage holds no live
+    /// index entries (tombstones were removed from the index when created), so it is fully dead.
+    pub(crate) fn has_only_tombstones(&self) -> bool {
+        let num_tombstones = self.tombstone_offsets.read().unwrap().len();
+        num_tombstones > 0 && self.count() == num_tombstones
+    }
+
     /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
     pub(crate) fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
         let zero_lamport_dead_bytes = self

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -43,6 +43,13 @@ pub struct AccountStorageEntry {
     /// shrink more likely to visit this storage.
     zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
 
+    /// offsets to zero-lamport accounts that have been removed from the accounts index entirely
+    /// (a tombstone — carried forward to this storage by shrink). The index has no slot_list entry
+    /// pointing at them; their bytes are retained only so an incremental snapshot taken after the
+    /// latest full snapshot still observes the zero-lamport account and propagates the deletion.
+    /// Shrink uses this list to recognize tombstone entries without needing to scan the index.
+    tombstone_offsets: RwLock<IntSet<Offset>>,
+
     /// Obsolete Accounts. These are accounts that are still present in the storage
     /// but should be ignored during rebuild. They have been removed
     /// from the accounts index, so they will not be picked up by scan.
@@ -73,6 +80,7 @@ impl AccountStorageEntry {
             num_alive_accounts: AtomicUsize::new(0),
             num_alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
+            tombstone_offsets: RwLock::default(),
             obsolete_accounts: RwLock::default(),
         }
     }
@@ -88,6 +96,7 @@ impl AccountStorageEntry {
             zero_lamport_single_ref_offsets: RwLock::new(
                 self.zero_lamport_single_ref_offsets.read().unwrap().clone(),
             ),
+            tombstone_offsets: RwLock::new(self.tombstone_offsets.read().unwrap().clone()),
             obsolete_accounts: RwLock::new(self.obsolete_accounts.read().unwrap().clone()),
         })
     }
@@ -105,6 +114,7 @@ impl AccountStorageEntry {
             num_alive_accounts: AtomicUsize::new(0),
             num_alive_bytes: AtomicUsize::new(0),
             zero_lamport_single_ref_offsets: RwLock::default(),
+            tombstone_offsets: RwLock::default(),
             obsolete_accounts: RwLock::new(obsolete_accounts),
         }
     }
@@ -172,9 +182,25 @@ impl AccountStorageEntry {
         count
     }
 
-    /// Return the number of zero_lamport_single_ref accounts in the storage.
+    /// Number of dead zero-lamport accounts in the storage, counting both in-index single-ref
+    /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
+    /// (`tombstone_offsets`). Used for shrink-productivity accounting.
     pub(crate) fn num_zero_lamport_single_ref_accounts(&self) -> usize {
         self.zero_lamport_single_ref_offsets.read().unwrap().len()
+            + self.tombstone_offsets.read().unwrap().len()
+    }
+
+    /// Batch-insert tombstone offsets.
+    pub(crate) fn batch_insert_tombstone_offsets(&self, offsets: &[Offset]) {
+        let mut tombstone_offsets = self.tombstone_offsets.write().unwrap();
+        for offset in offsets {
+            tombstone_offsets.insert(*offset);
+        }
+    }
+
+    /// Locks the tombstone offset set with a read lock and returns it with the guard.
+    pub(crate) fn tombstone_offsets_read_lock(&self) -> RwLockReadGuard<'_, IntSet<Offset>> {
+        self.tombstone_offsets.read().unwrap()
     }
 
     /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -259,6 +259,10 @@ pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
     pub(crate) pubkeys_to_unref: Vec<&'a Pubkey>,
     pub(crate) zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
     pub(crate) alive_accounts: T,
+    /// Zero-lamport accounts written to the new storage as tombstones rather than live accounts.
+    pub(crate) tombstones_to_carry_forward: Vec<AccountFromStorage>,
+    /// total size in storage of all accounts in `tombstones_to_carry_forward`
+    pub(crate) tombstones_total_bytes: usize,
     /// total size in storage of all alive accounts
     pub(crate) alive_total_bytes: usize,
     pub(crate) total_starting_accounts: usize,
@@ -274,6 +278,8 @@ struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     pubkeys_to_unref: Vec<&'a Pubkey>,
     /// pubkeys that are the last remaining zero lamport instance of an account
     zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
+    /// accounts that are zero lamport but not indexed
+    zero_lamport_tombstones: Vec<AccountFromStorage>,
     /// true if all alive accounts are zero lamport accounts
     all_are_zero_lamports: bool,
 }
@@ -2432,6 +2438,7 @@ impl AccountsDb {
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
         let mut pubkeys_to_unref = Vec::with_capacity(count);
         let mut zero_lamport_single_ref_pubkeys = Vec::with_capacity(count);
+        let mut zero_lamport_tombstones = Vec::new();
 
         let mut alive = 0;
         let mut dead = 0;
@@ -2444,17 +2451,16 @@ impl AccountsDb {
             |pubkey, slots_refs| {
                 let stored_account = &accounts[index];
                 let mut do_populate_accounts_for_shrink = |ref_count, slot_list| {
-                    if stored_account.is_zero_lamport()
-                        && ref_count == 1
-                        && can_purge_zero_lamport_single_ref
-                    {
-                        // only do this if our slot is prior to the latest full snapshot
-                        // we found a zero lamport account that is the only instance of this account. We can delete it completely.
+                    if stored_account.is_zero_lamport() && ref_count == 1 {
+                        // The lone instance of a zero-lamport account. A load of a zero-lamport
+                        // account already reports "not found", so dropping its index entry is safe.
                         zero_lamport_single_ref_pubkeys.push(pubkey);
-                        self.add_uncleaned_pubkeys_after_shrink(
-                            slot_to_shrink,
-                            [*pubkey].into_iter(),
-                        );
+                        if !can_purge_zero_lamport_single_ref {
+                            // Newer than the latest full snapshot: keep the bytes in storage as a
+                            // tombstone so an incremental snapshot can still propagate the deletion,
+                            // rather than dropping it.
+                            zero_lamport_tombstones.push(*stored_account);
+                        }
                     } else {
                         all_are_zero_lamports &= stored_account.is_zero_lamport();
                         alive_accounts.add(ref_count, stored_account, slot_list);
@@ -2509,6 +2515,7 @@ impl AccountsDb {
             alive_accounts,
             pubkeys_to_unref,
             zero_lamport_single_ref_pubkeys,
+            zero_lamport_tombstones,
             all_are_zero_lamports,
         }
     }
@@ -2592,6 +2599,27 @@ impl AccountsDb {
         // Filter all the accounts that are marked obsolete
         let total_starting_accounts = stored_accounts.len();
         stored_accounts.retain(|account| !obsolete_offsets.contains(&account.index_info.offset()));
+        let num_obsolete_filtered = total_starting_accounts - stored_accounts.len();
+
+        // Filter and collect tombstones
+        let can_purge_zero_lamport_single_ref =
+            self.can_purge_zero_lamport_single_ref_after_shrink(slot);
+        let mut tombstones_to_carry_forward: Vec<AccountFromStorage> = Vec::new();
+        let tombstone_offsets = store.tombstone_offsets_read_lock();
+        if !tombstone_offsets.is_empty() {
+            stored_accounts.retain(|account| {
+                if tombstone_offsets.contains(&account.index_info.offset()) {
+                    // If we can't purge zero lamport accounts, they need to be rewritten after shrink
+                    if !can_purge_zero_lamport_single_ref {
+                        tombstones_to_carry_forward.push(*account);
+                    }
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+        drop(tombstone_offsets);
 
         let len = stored_accounts.len();
         let shrink_collect = Mutex::new(ShrinkCollect {
@@ -2600,6 +2628,8 @@ impl AccountsDb {
             pubkeys_to_unref: Vec::with_capacity(len),
             zero_lamport_single_ref_pubkeys: Vec::new(),
             alive_accounts: T::with_capacity(len, slot),
+            tombstones_to_carry_forward,
+            tombstones_total_bytes: 0, // will be updated after the tombstone list is populated
             total_starting_accounts,
             all_are_zero_lamports: true,
             alive_total_bytes: 0, // will be updated after `alive_accounts` is populated
@@ -2610,7 +2640,7 @@ impl AccountsDb {
             .fetch_add(len as u64, Ordering::Relaxed);
         stats
             .obsolete_accounts_filtered
-            .fetch_add((total_starting_accounts - len) as u64, Ordering::Relaxed);
+            .fetch_add(num_obsolete_filtered as u64, Ordering::Relaxed);
         self.thread_pool_background.install(|| {
             stored_accounts
                 .par_chunks(SHRINK_COLLECT_CHUNK_SIZE)
@@ -2620,6 +2650,7 @@ impl AccountsDb {
                         mut pubkeys_to_unref,
                         all_are_zero_lamports,
                         mut zero_lamport_single_ref_pubkeys,
+                        mut zero_lamport_tombstones,
                     } = self.load_accounts_index_for_shrink(stored_accounts, stats, slot);
 
                     // collect
@@ -2631,6 +2662,9 @@ impl AccountsDb {
                     shrink_collect
                         .zero_lamport_single_ref_pubkeys
                         .append(&mut zero_lamport_single_ref_pubkeys);
+                    shrink_collect
+                        .tombstones_to_carry_forward
+                        .append(&mut zero_lamport_tombstones);
                     if !all_are_zero_lamports {
                         shrink_collect.all_are_zero_lamports = false;
                     }
@@ -2642,17 +2676,28 @@ impl AccountsDb {
         let mut shrink_collect = shrink_collect.into_inner().unwrap();
         let alive_total_bytes = shrink_collect.alive_accounts.alive_bytes();
         shrink_collect.alive_total_bytes = alive_total_bytes;
+        shrink_collect.tombstones_total_bytes = shrink_collect
+            .tombstones_to_carry_forward
+            .iter()
+            .map(|account| account.stored_size())
+            .sum();
 
         stats
             .index_read_elapsed
             .fetch_add(index_read_elapsed.as_us(), Ordering::Relaxed);
 
+        // Tombstones carried forward are rewritten into the new storage, not reclaimed, so exclude
+        // them from the "removed" totals (which measure what shrink actually freed).
         stats.accounts_removed.fetch_add(
-            total_starting_accounts - shrink_collect.alive_accounts.len(),
+            total_starting_accounts
+                - shrink_collect.alive_accounts.len()
+                - shrink_collect.tombstones_to_carry_forward.len(),
             Ordering::Relaxed,
         );
         stats.bytes_removed.fetch_add(
-            capacity.saturating_sub(alive_total_bytes as u64),
+            capacity
+                .saturating_sub(alive_total_bytes as u64)
+                .saturating_sub(shrink_collect.tombstones_total_bytes as u64),
             Ordering::Relaxed,
         );
         stats
@@ -2872,14 +2917,15 @@ impl AccountsDb {
             &self.shrink_stats,
         );
 
+        let total_rewrite_bytes =
+            shrink_collect.alive_total_bytes + shrink_collect.tombstones_total_bytes;
+
         // This shouldn't happen if alive_bytes is accurate.
         // However, it is possible that the remaining alive bytes could be 0. In that case, the whole slot should be marked dead by clean.
-        if Self::should_not_shrink(
-            shrink_collect.alive_total_bytes as u64,
-            shrink_collect.capacity,
-        ) || shrink_collect.alive_total_bytes == 0
+        if Self::should_not_shrink(total_rewrite_bytes as u64, shrink_collect.capacity)
+            || total_rewrite_bytes == 0
         {
-            if shrink_collect.alive_total_bytes == 0 {
+            if total_rewrite_bytes == 0 {
                 // clean needs to take care of this dead slot
                 self.dirty_stores.insert(slot, store.clone());
             }
@@ -2916,7 +2962,7 @@ impl AccountsDb {
         let (shrink_in_progress, time_us) = measure_us!(self.get_store_for_shrink(
             slot,
             Arc::clone(&store),
-            shrink_collect.alive_total_bytes as u64
+            total_rewrite_bytes as u64
         ));
         stats_sub.create_and_insert_store_elapsed_us = Saturating(time_us);
 
@@ -2930,6 +2976,17 @@ impl AccountsDb {
             shrink_in_progress.new_storage(),
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
+
+        let tombstone_refs: Vec<&AccountFromStorage> =
+            shrink_collect.tombstones_to_carry_forward.iter().collect();
+        let tombstone_accounts = [(slot, &tombstone_refs[..])];
+        let storable_tombstones = StorableAccountsBySlot::new(slot, &tombstone_accounts, self);
+        let (num_tombstones_carried_forward, tombstone_carry_forward_us) = measure_us!(
+            self.store_tombstones(shrink_in_progress.new_storage(), storable_tombstones)
+        );
+        stats_sub.tombstone_carry_forward_us = Saturating(tombstone_carry_forward_us);
+        stats_sub.num_tombstones_carried_forward =
+            Saturating(num_tombstones_carried_forward as u64);
 
         rewrite_elapsed.stop();
         stats_sub.rewrite_elapsed_us = Saturating(rewrite_elapsed.as_us());
@@ -5388,10 +5445,15 @@ impl AccountsDb {
                             .obsolete_accounts_read_lock()
                             .filter_obsolete_accounts(None)
                             .collect();
+                        // Tombstones have already been removed from the index, so they must not be
+                        // unref'd here (a revived pubkey could otherwise be wrongly unref'd).
+                        let tombstone_offsets = store.tombstone_offsets_read_lock();
                         store
                             .accounts
                             .scan_accounts_without_data(|offset, account| {
-                                if !obsolete_accounts.contains(&(offset, account.data_len)) {
+                                if !obsolete_accounts.contains(&(offset, account.data_len))
+                                    && !tombstone_offsets.contains(&offset)
+                                {
                                     pubkeys.push((slot, *account.pubkey));
                                 }
                             })
@@ -5540,11 +5602,6 @@ impl AccountsDb {
         let infos = self.write_accounts_to_storage(slot, storage, &accounts);
         let write_accounts_us = write_accounts_time.end_as_us();
 
-        let mark_zero_lamport_single_ref_time = Measure::start("mark_zero_lamport_single_ref");
-        let num_zero_lamport_single_ref_accounts_marked =
-            self.mark_zero_lamport_single_ref_accounts_for_shrink(&infos, &accounts, storage);
-        let mark_zero_lamport_single_ref_us = mark_zero_lamport_single_ref_time.end_as_us();
-
         let update_index_time = Measure::start("update_index");
         self.update_index_for_shrink(
             &infos,
@@ -5556,11 +5613,27 @@ impl AccountsDb {
 
         StoreAccountsForShrinkStats {
             write_accounts_us,
-            mark_zero_lamport_single_ref_accounts_us: mark_zero_lamport_single_ref_us,
             update_index_us,
             num_accounts_stored: num_accounts_stored as u64,
-            num_zero_lamport_single_ref_accounts_marked,
         }
+    }
+
+    /// Write tombstones into new_storage and store the new offsets on its tombstone_offsets
+    /// Note: They are not added to the index
+    fn store_tombstones<'a>(
+        &self,
+        new_storage: &AccountStorageEntry,
+        tombstones: impl StorableAccounts<'a>,
+    ) -> usize {
+        if tombstones.is_empty() {
+            return 0;
+        }
+        let tombstone_infos =
+            self.write_accounts_to_storage(tombstones.target_slot(), new_storage, &tombstones);
+        let tombstone_offsets: Vec<Offset> =
+            tombstone_infos.iter().map(|info| info.offset()).collect();
+        new_storage.batch_insert_tombstone_offsets(&tombstone_offsets);
+        tombstone_offsets.len()
     }
 
     /// Stores accounts in the storage and updates the index.
@@ -5791,38 +5864,6 @@ impl AccountsDb {
             }
         }
 
-        num_marked
-    }
-
-    /// Marks zero lamport single reference accounts in the storage during store_accounts_for_shrink
-    ///
-    /// Returns the number of accounts marked.
-    fn mark_zero_lamport_single_ref_accounts_for_shrink<'a>(
-        &self,
-        account_infos: &[AccountInfo],
-        accounts: &impl StorableAccounts<'a>,
-        storage: &AccountStorageEntry,
-    ) -> u64 {
-        debug_assert_eq!(account_infos.len(), accounts.len());
-        let mut num_marked = 0;
-        for (i, account_info) in account_infos.iter().enumerate() {
-            if account_info.is_zero_lamport() {
-                let pubkey = accounts.pubkey(i);
-                let is_single_ref = self.accounts_index.get_and_then(pubkey, |entry| {
-                    let is_single_ref = entry.is_some_and(|entry| {
-                        entry.ref_count() == 1 && entry.slot_list_lock_read_len() == 1
-                    });
-                    (false, is_single_ref)
-                });
-                if is_single_ref {
-                    debug_assert_eq!(account_info.store_id(), storage.id());
-                    if storage.insert_zero_lamport_single_ref_account_offset(account_info.offset())
-                    {
-                        num_marked += 1;
-                    }
-                }
-            }
-        }
         num_marked
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1527,6 +1527,30 @@ impl AccountsDb {
                 false
             }
         });
+
+        // A storage holding only tombstones has no live index entries, so the reclaim path (which
+        // marks a slot dead only once its index entries are removed) never cleans it. Purge it
+        // directly — but only once it is no longer newer than the latest full snapshot, since until
+        // then its tombstones must be retained for an incremental snapshot to propagate the deletion
+        // (see `filter_zero_lamport_clean_for_incremental_snapshots`).
+        dirty_stores.retain(|(slot, _dirty_store)| {
+            if self.can_purge_zero_lamport_single_ref_after_shrink(*slot)
+                && self
+                    .storage
+                    .get_slot_storage_entry(*slot)
+                    .is_some_and(|store| store.has_only_tombstones())
+            {
+                self.purge_dead_slots_from_storage(
+                    iter::once(slot),
+                    &self.clean_accounts_stats.purge_stats,
+                );
+                // Purged; drop it from the candidate scan below.
+                false
+            } else {
+                true
+            }
+        });
+
         let dirty_stores_len = dirty_stores.len();
         let num_bins = self.accounts_index.bins();
         let candidates: Box<_> =

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -279,7 +279,7 @@ struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     /// pubkeys that are the last remaining zero lamport instance of an account
     zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
     /// accounts that are zero lamport but not indexed
-    zero_lamport_tombstones: Vec<AccountFromStorage>,
+    tombstones: Vec<AccountFromStorage>,
     /// true if all alive accounts are zero lamport accounts
     all_are_zero_lamports: bool,
 }
@@ -2438,7 +2438,7 @@ impl AccountsDb {
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
         let mut pubkeys_to_unref = Vec::with_capacity(count);
         let mut zero_lamport_single_ref_pubkeys = Vec::with_capacity(count);
-        let mut zero_lamport_tombstones = Vec::new();
+        let mut tombstones = Vec::new();
 
         let mut alive = 0;
         let mut dead = 0;
@@ -2459,7 +2459,7 @@ impl AccountsDb {
                             // Newer than the latest full snapshot: keep the bytes in storage as a
                             // tombstone so an incremental snapshot can still propagate the deletion,
                             // rather than dropping it.
-                            zero_lamport_tombstones.push(*stored_account);
+                            tombstones.push(*stored_account);
                         }
                     } else {
                         all_are_zero_lamports &= stored_account.is_zero_lamport();
@@ -2515,7 +2515,7 @@ impl AccountsDb {
             alive_accounts,
             pubkeys_to_unref,
             zero_lamport_single_ref_pubkeys,
-            zero_lamport_tombstones,
+            tombstones,
             all_are_zero_lamports,
         }
     }
@@ -2604,7 +2604,7 @@ impl AccountsDb {
         // Filter and collect tombstones
         let can_purge_zero_lamport_single_ref =
             self.can_purge_zero_lamport_single_ref_after_shrink(slot);
-        let mut tombstones_to_carry_forward: Vec<AccountFromStorage> = Vec::new();
+        let mut tombstones_to_carry_forward = Vec::new();
         let tombstone_offsets = store.tombstone_offsets_read_lock();
         if !tombstone_offsets.is_empty() {
             stored_accounts.retain(|account| {
@@ -2650,7 +2650,7 @@ impl AccountsDb {
                         mut pubkeys_to_unref,
                         all_are_zero_lamports,
                         mut zero_lamport_single_ref_pubkeys,
-                        mut zero_lamport_tombstones,
+                        mut tombstones,
                     } = self.load_accounts_index_for_shrink(stored_accounts, stats, slot);
 
                     // collect
@@ -2664,7 +2664,7 @@ impl AccountsDb {
                         .append(&mut zero_lamport_single_ref_pubkeys);
                     shrink_collect
                         .tombstones_to_carry_forward
-                        .append(&mut zero_lamport_tombstones);
+                        .append(&mut tombstones);
                     if !all_are_zero_lamports {
                         shrink_collect.all_are_zero_lamports = false;
                     }
@@ -2700,9 +2700,6 @@ impl AccountsDb {
                 .saturating_sub(shrink_collect.tombstones_total_bytes as u64),
             Ordering::Relaxed,
         );
-        stats
-            .bytes_written
-            .fetch_add(alive_total_bytes as u64, Ordering::Relaxed);
 
         shrink_collect
     }
@@ -2977,8 +2974,7 @@ impl AccountsDb {
             UpdateIndexThreadSelection::PoolWithThreshold,
         );
 
-        let tombstone_refs: Vec<&AccountFromStorage> =
-            shrink_collect.tombstones_to_carry_forward.iter().collect();
+        let tombstone_refs: Vec<_> = shrink_collect.tombstones_to_carry_forward.iter().collect();
         let tombstone_accounts = [(slot, &tombstone_refs[..])];
         let storable_tombstones = StorableAccountsBySlot::new(slot, &tombstone_accounts, self);
         let (num_tombstones_carried_forward, tombstone_carry_forward_us) = measure_us!(
@@ -2987,6 +2983,12 @@ impl AccountsDb {
         stats_sub.tombstone_carry_forward_us = Saturating(tombstone_carry_forward_us);
         stats_sub.num_tombstones_carried_forward =
             Saturating(num_tombstones_carried_forward as u64);
+
+        // Count the bytes actually written to the new storage
+        self.shrink_stats.bytes_written.fetch_add(
+            shrink_in_progress.new_storage().written_bytes(),
+            Ordering::Relaxed,
+        );
 
         rewrite_elapsed.stop();
         stats_sub.rewrite_elapsed_us = Saturating(rewrite_elapsed.as_us());
@@ -5620,6 +5622,7 @@ impl AccountsDb {
 
     /// Write tombstones into new_storage and store the new offsets on its tombstone_offsets
     /// Note: They are not added to the index
+    /// Returns the number of tombstones stored
     fn store_tombstones<'a>(
         &self,
         new_storage: &AccountStorageEntry,
@@ -5630,8 +5633,7 @@ impl AccountsDb {
         }
         let tombstone_infos =
             self.write_accounts_to_storage(tombstones.target_slot(), new_storage, &tombstones);
-        let tombstone_offsets: Vec<Offset> =
-            tombstone_infos.iter().map(|info| info.offset()).collect();
+        let tombstone_offsets: Vec<_> = tombstone_infos.iter().map(|info| info.offset()).collect();
         new_storage.batch_insert_tombstone_offsets(&tombstone_offsets);
         tombstone_offsets.len()
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1707,18 +1707,23 @@ impl AccountsDb {
             || Box::new(append_vec::new_scan_accounts_reader()),
             |reader, storage| {
                 let slot = storage.slot();
-                // Obsolete accounts are skipped during index generation, so they do not
-                // contribute to the index refcount. Skip them here too, otherwise we would count
-                // a physical copy the index never tracked and report a spurious mismatch.
+                // Obsolete accounts and tombstones are not tracked by the accounts index — obsolete
+                // accounts are skipped during index generation, and tombstones were removed from the
+                // index when shrink created them — so neither contributes to the index refcount.
+                // Skip them here too, otherwise we would count a physical copy the index never
+                // tracked and report a spurious mismatch.
                 let obsolete_accounts: IntSet<_> = storage
                     .obsolete_accounts_read_lock()
                     .filter_obsolete_accounts(None)
                     .map(|(offset, _)| offset)
                     .collect();
+                let tombstone_offsets = storage.tombstone_offsets_read_lock();
                 storage
                     .accounts
                     .scan_accounts(reader.as_mut(), |offset, account| {
-                        if obsolete_accounts.contains(&offset) {
+                        if obsolete_accounts.contains(&offset)
+                            || tombstone_offsets.contains(&offset)
+                        {
                             return;
                         }
                         let pk = account.pubkey();

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -104,21 +104,15 @@ impl StoreAccountsUnfrozenStats {
 #[derive(Debug, Default)]
 pub struct StoreAccountsForShrinkStats {
     pub write_accounts_us: u64,
-    pub mark_zero_lamport_single_ref_accounts_us: u64,
     pub update_index_us: u64,
     pub num_accounts_stored: u64,
-    pub num_zero_lamport_single_ref_accounts_marked: u64,
 }
 
 impl StoreAccountsForShrinkStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.write_accounts_us += other.write_accounts_us;
-        self.mark_zero_lamport_single_ref_accounts_us +=
-            other.mark_zero_lamport_single_ref_accounts_us;
         self.update_index_us += other.update_index_us;
         self.num_accounts_stored += other.num_accounts_stored;
-        self.num_zero_lamport_single_ref_accounts_marked +=
-            other.num_zero_lamport_single_ref_accounts_marked;
     }
 }
 
@@ -344,6 +338,8 @@ pub struct ShrinkStatsSub {
     pub store_accounts_stats: StoreAccountsForShrinkStats,
     pub rewrite_elapsed_us: Saturating<u64>,
     pub create_and_insert_store_elapsed_us: Saturating<u64>,
+    pub tombstone_carry_forward_us: Saturating<u64>,
+    pub num_tombstones_carried_forward: Saturating<u64>,
 }
 
 #[derive(Debug, Default)]
@@ -380,6 +376,9 @@ pub struct ShrinkStats {
     pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
     pub remove_old_stores_shrink_us: AtomicU64,
     pub rewrite_elapsed: AtomicU64,
+    pub tombstone_carry_forward_us: AtomicU64,
+    /// number of zero-lamport accounts carried forward to the new storage as tombstones
+    pub num_tombstones_carried_forward: AtomicU64,
     pub unpackable_slots_count: AtomicU64,
     pub newest_alive_packed_count: AtomicU64,
     pub drop_storage_entries_elapsed: AtomicU64,
@@ -415,6 +414,12 @@ impl ShrinkStats {
         );
         self.rewrite_elapsed
             .fetch_add(stats_sub.rewrite_elapsed_us.0, Ordering::Relaxed);
+        self.tombstone_carry_forward_us
+            .fetch_add(stats_sub.tombstone_carry_forward_us.0, Ordering::Relaxed);
+        self.num_tombstones_carried_forward.fetch_add(
+            stats_sub.num_tombstones_carried_forward.0,
+            Ordering::Relaxed,
+        );
         self.accumulate_store_accounts_for_shrink_stats(stats_sub.store_accounts_stats);
     }
 
@@ -424,18 +429,10 @@ impl ShrinkStats {
     ) {
         self.write_accounts_us
             .fetch_add(store_accounts_stats.write_accounts_us, Ordering::Relaxed);
-        self.mark_zero_lamport_single_ref_accounts_us.fetch_add(
-            store_accounts_stats.mark_zero_lamport_single_ref_accounts_us,
-            Ordering::Relaxed,
-        );
         self.update_index_us
             .fetch_add(store_accounts_stats.update_index_us, Ordering::Relaxed);
         self.num_accounts_stored
             .fetch_add(store_accounts_stats.num_accounts_stored, Ordering::Relaxed);
-        self.num_zero_lamport_single_ref_accounts_marked.fetch_add(
-            store_accounts_stats.num_zero_lamport_single_ref_accounts_marked,
-            Ordering::Relaxed,
-        );
     }
 
     pub fn report(&self) {
@@ -525,6 +522,17 @@ impl ShrinkStats {
                 (
                     "rewrite_elapsed",
                     self.rewrite_elapsed.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "tombstone_carry_forward_us",
+                    self.tombstone_carry_forward_us.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_tombstones_carried_forward",
+                    self.num_tombstones_carried_forward
+                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1356,9 +1356,10 @@ fn test_shrink_zero_lamport_single_ref_account() {
     }
 }
 
-/// Ensure that `shrink` marks zero lamport single ref accounts in the new storage.
+/// Ensure that `shrink` converts a not-yet-purgeable zero lamport single ref account into a
+/// tombstone in the new storage
 #[test]
-fn test_shrink_marks_zero_lamport_single_ref_account_in_new_storage() {
+fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
     let accounts_db = AccountsDb::new_single_for_tests();
     let slot0 = 0;
     let slot1 = slot0 + 1;
@@ -1398,7 +1399,7 @@ fn test_shrink_marks_zero_lamport_single_ref_account_in_new_storage() {
         true,
         Some(&accounts_db.accounts_index),
     );
-    // store a zero lamport single ref account; it *should* be marked ZLSR
+    // store a zero lamport single ref account; shrink *should* convert it to a tombstone
     append_single_account_with_default_hash(
         &storage1,
         &zero_lamport_single_ref_pubkey,
@@ -1455,33 +1456,130 @@ fn test_shrink_marks_zero_lamport_single_ref_account_in_new_storage() {
     accounts_db.shrink_slot_forced(slot1);
 
     let new_storage1 = accounts_db.get_and_assert_single_storage(slot1);
-    let new_zero_lamport_single_ref_info = accounts_db
-        .accounts_index
-        .get_with_and_then(
-            &zero_lamport_single_ref_pubkey,
-            &ancestors,
-            false,
-            |(_slot, account_info)| account_info,
-        )
-        .unwrap();
 
     // ensure ids are different, to indicate shrink ran
     assert_ne!(new_storage1.id(), storage1.id());
-    // ensure there are three accounts in the storage now, removing the two obsolete ones
+    // ensure there are three accounts in the storage now, removing the two obsolete ones: the
+    // alive account, the zero-lamport multi-ref account, and the zero-lamport single-ref account
+    // carried forward as a tombstone
     assert_eq!(new_storage1.count(), 3);
-    // ensure the zlsr account info has the correct id for the new shrunk storage
-    assert_eq!(
-        new_zero_lamport_single_ref_info.store_id(),
-        new_storage1.id(),
+
+    // the zero lamport single ref account is dropped from the index now that it is a tombstone
+    assert!(
+        accounts_db
+            .accounts_index
+            .get_with_and_then(
+                &zero_lamport_single_ref_pubkey,
+                &ancestors,
+                false,
+                |(_slot, _account_info)| (),
+            )
+            .is_none()
     );
-    // ensure the new shrunk storage does have a marked zlsr account
+
+    // it is recorded on the new storage's tombstone list, not the zero-lamport-single-ref list
+    assert_eq!(new_storage1.tombstone_offsets_read_lock().len(), 1);
+    assert!(
+        new_storage1
+            .zero_lamport_single_ref_offsets()
+            .read()
+            .unwrap()
+            .is_empty()
+    );
+    // the combined single-ref + tombstone count still reflects the one removable account
     assert_eq!(new_storage1.num_zero_lamport_single_ref_accounts(), 1);
-    let new_storage_zlsr_offsets = new_storage1
-        .zero_lamport_single_ref_offsets()
-        .read()
+}
+
+/// `shrink_collect` must recognize tombstone offsets already recorded on a storage (carried
+/// forward by a prior shrink) and route them into `tombstones_to_carry_forward`: rewritten while
+/// the slot is newer than the latest full snapshot, and dropped once the snapshot advances past it.
+#[test]
+fn test_shrink_collect_carries_forward_existing_tombstones() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot = 2;
+    // Latest full snapshot older than `slot`: tombstones are not yet purgeable.
+    accounts_db.set_latest_full_snapshot_slot(slot - 1);
+
+    let alive_pubkey = Pubkey::new_unique();
+    let tombstone_pubkey = Pubkey::new_unique();
+    let alive_account = AccountSharedData::new(1, 0, &Pubkey::default());
+    let zero_lamport_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+    let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+    let storage = Arc::new(AccountStorageEntry::new(
+        &paths[0],
+        slot,
+        100,
+        DEFAULT_FILE_SIZE,
+        AccountsFileProvider::AppendVec,
+    ));
+    // An ordinary alive account, present in the index.
+    append_single_account_with_default_hash(
+        &storage,
+        &alive_pubkey,
+        &alive_account,
+        true,
+        Some(&accounts_db.accounts_index),
+    );
+    // A zero-lamport account physically in the storage but NOT in the index: i.e. a tombstone
+    // carried forward by a prior shrink of an even-older storage.
+    append_single_account_with_default_hash(
+        &storage,
+        &tombstone_pubkey,
+        &zero_lamport_account,
+        true,
+        None,
+    );
+    insert_store(&accounts_db, Arc::clone(&storage));
+    accounts_db.add_root(slot);
+
+    // Record the tombstone account's offset on the storage's tombstone list, as a prior shrink
+    // would have.
+    let mut tombstone_offset = None;
+    storage
+        .accounts
+        .scan_accounts_without_data(|offset, account| {
+            if account.pubkey == &tombstone_pubkey {
+                tombstone_offset = Some(offset);
+            }
+        })
         .unwrap();
-    // ensure the storage's zlsr offset list contains the zlsr account info's
-    assert!(new_storage_zlsr_offsets.contains(&new_zero_lamport_single_ref_info.offset()));
+    storage.batch_insert_tombstone_offsets(&[tombstone_offset.unwrap()]);
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 1);
+
+    // Newer than the latest full snapshot: the tombstone must be carried forward, not dropped and
+    // not mis-routed into the alive set.
+    let mut unique_accounts =
+        accounts_db.get_unique_accounts_from_storage_for_shrink(&storage, &ShrinkStats::default());
+    let shrink_collect = accounts_db.shrink_collect::<AliveAccounts<'_>>(
+        &storage,
+        &mut unique_accounts,
+        &ShrinkStats::default(),
+    );
+    assert_eq!(shrink_collect.tombstones_to_carry_forward.len(), 1);
+    assert!(shrink_collect.tombstones_total_bytes > 0);
+    assert_eq!(
+        shrink_collect
+            .alive_accounts
+            .accounts
+            .iter()
+            .map(|account| *account.pubkey())
+            .collect::<Vec<_>>(),
+        vec![alive_pubkey],
+    );
+
+    // Once the full snapshot advances to `slot`, the tombstone is purgeable and must be dropped
+    // rather than carried forward.
+    accounts_db.set_latest_full_snapshot_slot(slot);
+    let mut unique_accounts =
+        accounts_db.get_unique_accounts_from_storage_for_shrink(&storage, &ShrinkStats::default());
+    let shrink_collect = accounts_db.shrink_collect::<AliveAccounts<'_>>(
+        &storage,
+        &mut unique_accounts,
+        &ShrinkStats::default(),
+    );
+    assert!(shrink_collect.tombstones_to_carry_forward.is_empty());
+    assert_eq!(shrink_collect.tombstones_total_bytes, 0);
 }
 
 /// unit test for `alive_bytes_after_shrink()`
@@ -6023,15 +6121,44 @@ fn test_shrink_collect_simple() {
                                     vec![]
                                 };
 
+                            // a zero-lamport single-ref account is removed from the index by shrink
+                            // and carried forward as a tombstone, so it is not rewritten as alive
+                            let is_zero_lamport = |pubkey: &Pubkey| {
+                                if Some(pubkey) == pubkey_opposite_zero_lamports {
+                                    lamports == 1
+                                } else {
+                                    lamports == 0
+                                }
+                            };
                             let expected_alive_accounts = if alive {
                                 pubkeys[..normal_account_count]
                                     .iter()
                                     .filter(|p| Some(p) != pubkey_opposite_alive.as_ref())
+                                    .filter(|p| !is_zero_lamport(p))
                                     .sorted()
                                     .cloned()
                                     .collect::<Vec<_>>()
                             } else {
-                                expect_single_opposite_alive_account.clone()
+                                expect_single_opposite_alive_account
+                                    .iter()
+                                    .filter(|p| !is_zero_lamport(p))
+                                    .cloned()
+                                    .collect::<Vec<_>>()
+                            };
+                            let expected_tombstones = if alive {
+                                pubkeys[..normal_account_count]
+                                    .iter()
+                                    .filter(|p| Some(p) != pubkey_opposite_alive.as_ref())
+                                    .filter(|p| is_zero_lamport(p))
+                                    .sorted()
+                                    .cloned()
+                                    .collect::<Vec<_>>()
+                            } else {
+                                expect_single_opposite_alive_account
+                                    .iter()
+                                    .filter(|p| is_zero_lamport(p))
+                                    .cloned()
+                                    .collect::<Vec<_>>()
                             };
 
                             let expected_unrefed = if alive {
@@ -6056,6 +6183,27 @@ fn test_shrink_collect_simple() {
                                     .collect::<Vec<_>>(),
                                 expected_alive_accounts
                             );
+                            // zero-lamport single-refs are dropped from the index and carried
+                            // forward as tombstones (slot5 is newer than the latest full snapshot)
+                            assert_eq!(
+                                shrink_collect
+                                    .zero_lamport_single_ref_pubkeys
+                                    .iter()
+                                    .sorted()
+                                    .cloned()
+                                    .cloned()
+                                    .collect::<Vec<_>>(),
+                                expected_tombstones
+                            );
+                            assert_eq!(
+                                shrink_collect
+                                    .tombstones_to_carry_forward
+                                    .iter()
+                                    .map(|account| *account.pubkey())
+                                    .sorted()
+                                    .collect::<Vec<_>>(),
+                                expected_tombstones
+                            );
                             assert_eq!(
                                 shrink_collect
                                     .pubkeys_to_unref
@@ -6068,25 +6216,15 @@ fn test_shrink_collect_simple() {
                             );
 
                             let alive_total_one_account = 136 + space;
-                            if alive {
-                                let mut expected_alive_total_bytes =
-                                    alive_total_one_account * normal_account_count;
-                                if append_opposite_zero_lamport_account {
-                                    // zero lamport accounts store size=0 data
-                                    expected_alive_total_bytes -= space;
-                                }
-                                assert_eq!(
-                                    shrink_collect.alive_total_bytes,
-                                    expected_alive_total_bytes
-                                );
-                            } else if append_opposite_alive_account {
-                                assert_eq!(
-                                    shrink_collect.alive_total_bytes,
-                                    alive_total_one_account
-                                );
-                            } else {
-                                assert_eq!(shrink_collect.alive_total_bytes, 0);
-                            }
+                            assert_eq!(
+                                shrink_collect.alive_total_bytes,
+                                expected_alive_accounts.len() * alive_total_one_account
+                            );
+                            // tombstones (zero-lamport accounts) always store 0 bytes of data
+                            assert_eq!(
+                                shrink_collect.tombstones_total_bytes,
+                                expected_tombstones.len() * 136
+                            );
                             // expected_capacity is determined by what size append vec gets created when the write cache is flushed to an append vec.
                             let mut expected_capacity =
                                 (account_count * AppendVec::calculate_stored_size(space)) as u64;
@@ -6097,16 +6235,9 @@ fn test_shrink_collect_simple() {
 
                             assert_eq!(shrink_collect.capacity, expected_capacity);
                             assert_eq!(shrink_collect.total_starting_accounts, account_count);
-                            let mut expected_all_are_zero_lamports = lamports == 0;
-                            if !append_opposite_alive_account {
-                                expected_all_are_zero_lamports |= !alive;
-                            }
-                            if append_opposite_zero_lamport_account && lamports == 0 && alive {
-                                expected_all_are_zero_lamports = !expected_all_are_zero_lamports;
-                            }
                             assert_eq!(
                                 shrink_collect.all_are_zero_lamports,
-                                expected_all_are_zero_lamports
+                                expected_alive_accounts.is_empty()
                             );
                         }
                     }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -315,7 +315,7 @@ fn sample_storage_with_entries_id_fill_percentage(
 ) -> Arc<AccountStorageEntry> {
     let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
     let file_size = account_data_size.unwrap_or(123) * 100 / fill_percentage;
-    let size_aligned: usize = AppendVec::calculate_stored_size(file_size as usize);
+    let size_aligned = AppendVec::calculate_stored_size(file_size as usize);
     let mut data = AccountStorageEntry::new(
         &paths[0],
         slot,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1582,6 +1582,94 @@ fn test_shrink_collect_carries_forward_existing_tombstones() {
     assert_eq!(shrink_collect.tombstones_total_bytes, 0);
 }
 
+/// Verify that a storage containing only tombstones is retained by clean if the latest full
+/// snapshot is older than the slot, and reclaimed if the latest full snapshot is newer.
+#[test]
+fn test_fully_tombstoned_storage_reclaim() {
+    let accounts_db = AccountsDb::new_single_for_tests();
+    let slot = 1;
+    let zero_lamport_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+    // Latest full snapshot older than `slot`: tombstones are not yet purgeable.
+    accounts_db.set_latest_full_snapshot_slot(slot);
+
+    let slot = slot + 1;
+    let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+    let storage = Arc::new(AccountStorageEntry::new(
+        &paths[0],
+        slot,
+        100,
+        DEFAULT_FILE_SIZE,
+        AccountsFileProvider::AppendVec,
+    ));
+
+    // Every account is a zero-lamport account physically present but NOT in the index: i.e. the
+    // storage is 100% tombstones carried forward by a prior shrink.
+    let num_tombstones = 3;
+    for _ in 0..num_tombstones {
+        append_single_account_with_default_hash(
+            &storage,
+            &Pubkey::new_unique(),
+            &zero_lamport_account,
+            true,
+            None,
+        );
+    }
+    insert_store(&accounts_db, Arc::clone(&storage));
+    accounts_db.add_root(slot);
+
+    // Record every account's offset on the storage's tombstone list, as a prior shrink would have.
+    let mut tombstone_offsets = Vec::new();
+    storage
+        .accounts
+        .scan_accounts_without_data(|offset, _account| {
+            tombstone_offsets.push(offset);
+        })
+        .unwrap();
+    storage.batch_insert_tombstone_offsets(&tombstone_offsets);
+
+    // The storage reads as entirely tombstones / fully removable.
+    assert!(storage.has_only_tombstones());
+
+    let epoch_schedule = EpochSchedule::default();
+
+    // Shrink routes the fully-dead slot to clean; clean retains the storage because the latest full
+    // snapshot is older than the slot, so the slot is not yet eligible for shrink.
+    accounts_db.shrink_slot_forced(slot);
+    accounts_db.clean_accounts(Some(slot), false);
+    assert!(accounts_db.storage.get_slot_storage_entry(slot).is_some());
+    // Verify that the slot is not queued for shrink at this time
+    assert!(
+        !accounts_db
+            .shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .contains(&slot)
+    );
+
+    // Advance the latest full snapshot past the slot so its tombstones become purgeable. Clean then
+    // queues the slot for shrink.
+    accounts_db.set_latest_full_snapshot_slot(slot + 1);
+    accounts_db.clean_accounts(Some(slot + 1), false);
+    // Verify that it gets queued for shrink
+    assert!(
+        accounts_db
+            .shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .contains(&slot)
+    );
+
+    // Shrink finds nothing to rewrite, routes the fully-dead slot to clean via `dirty_stores`, and
+    // drains it from the shrink candidates. The storage survives until clean reclaims it.
+    accounts_db.shrink_candidate_slots(&epoch_schedule);
+    assert!(accounts_db.storage.get_slot_storage_entry(slot).is_some());
+
+    // Clean reclaims the dirty, fully-tombstoned storage.
+    accounts_db.clean_accounts(Some(slot + 1), false);
+    assert!(accounts_db.storage.get_slot_storage_entry(slot).is_none());
+}
+
 /// unit test for `alive_bytes_after_shrink()`
 ///
 /// Check all the permutations of latest full snapshot slot w.r.t. if/how

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6303,7 +6303,7 @@ fn test_shrink_collect_simple() {
                                 expected_unrefed
                             );
 
-                            let alive_total_one_account = 136 + space;
+                            let alive_total_one_account = AppendVec::calculate_stored_size(space);
                             assert_eq!(
                                 shrink_collect.alive_total_bytes,
                                 expected_alive_accounts.len() * alive_total_one_account
@@ -6311,7 +6311,7 @@ fn test_shrink_collect_simple() {
                             // tombstones (zero-lamport accounts) always store 0 bytes of data
                             assert_eq!(
                                 shrink_collect.tombstones_total_bytes,
-                                expected_tombstones.len() * 136
+                                expected_tombstones.len() * AppendVec::calculate_stored_size(0)
                             );
                             // expected_capacity is determined by what size append vec gets created when the write cache is flushed to an append vec.
                             let mut expected_capacity =

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -732,6 +732,15 @@ impl AccountsDb {
         for shrink_collect in accounts_to_combine.accounts_to_combine {
             let slot = shrink_collect.slot;
 
+            // Ancient squash only runs on slots far older than the latest full snapshot, where
+            // tombstones are purgeable and `shrink_collect` drops them rather than carrying them
+            // forward. The squash write path has no tombstone handling, so a non-empty list here
+            // would be silently lost; assert the invariant at the point that loss would occur.
+            debug_assert!(
+                shrink_collect.tombstones_to_carry_forward.is_empty(),
+                "ancient squash reached a carry-forward tombstone at slot {slot}",
+            );
+
             let shrink_in_progress = write_ancient_accounts.shrinks_in_progress.remove(&slot);
 
             let mut reopen = false;
@@ -3790,6 +3799,8 @@ mod tests {
                     many_refs_this_is_newest_alive: AliveAccounts::default(),
                     many_refs_old_alive: AliveAccounts::default(),
                 },
+                tombstones_to_carry_forward: Vec::new(),
+                tombstones_total_bytes: 0,
                 alive_total_bytes: 0,
                 total_starting_accounts: 0,
                 all_are_zero_lamports: false,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -567,6 +567,15 @@ impl AccountsDb {
             self.store_accounts_for_squash(accounts_to_write, shrink_in_progress.new_storage())
         );
 
+        // Count the bytes actually written into the packed storage
+        self.shrink_ancient_stats
+            .shrink_stats
+            .bytes_written
+            .fetch_add(
+                shrink_in_progress.new_storage().written_bytes(),
+                Ordering::Relaxed,
+            );
+
         write_ancient_accounts.metrics.accumulate(&SquashStatsSub {
             store_accounts_stats,
             rewrite_elapsed_us: Saturating(rewrite_elapsed_us),

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1447,6 +1447,175 @@ mod tests {
         }
     }
 
+    /// Test that the full zero-lamport tombstone path works end to end across snapshots.
+    /// Here's the scenario:
+    ///
+    /// slot 1:
+    ///     - fund Account1 (from Account2) to bring it to life
+    ///     - take a full snapshot, capturing Account1 with a non-zero balance
+    /// slot 2:
+    ///     - drain Account1 back to zero lamports (send to Account2)
+    ///     - root and flush so slot 2's storage (holding the zero-lamport Account1) is written
+    /// slot 3:
+    ///     - update Account2 again so its slot-2 version dies, giving slot 2 dead bytes
+    ///     - root, flush, and clean so the slot-1 (funded) version of Account1 is removed, leaving
+    ///       the zero-lamport account at slot 2 as the lone reference
+    ///     - shrink slot 2 into a tombstone: Account1 is removed from the index, its bytes retained
+    ///     - take an incremental snapshot, which must carry the tombstone
+    ///     - ensure deserializing from full + incremental is equal to this bank
+    ///     - ensure Account1 hasn't come back from the dead
+    ///
+    /// The full snapshot is older than slot 2, so shrink must NOT purge the zero-lamport account; it
+    /// has to retain the bytes as a tombstone. The incremental snapshot then carries that tombstone
+    /// so that rebuilding from full + incremental overrides the still-funded full-snapshot version
+    /// and the account ends up deleted. If the tombstone were dropped during shrink, the rebuild
+    /// would resurrect Account1 from the full snapshot and the checks below would fail.
+    #[test]
+    fn test_incremental_snapshots_handle_zero_lamport_tombstones() {
+        let key1 = Keypair::new();
+        let key2 = Keypair::new();
+
+        let (_tmp_dir, accounts_dir) = create_tmp_accounts_dir_for_tests();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let full_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let incremental_snapshot_archives_dir = tempfile::TempDir::new().unwrap();
+        let snapshot_config = snapshot_config_for_tests(
+            &bank_snapshots_dir,
+            &full_snapshot_archives_dir,
+            &incremental_snapshot_archives_dir,
+        );
+
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            1_000_000 * LAMPORTS_PER_SOL,
+        );
+        // test expects 0 transaction fee
+        genesis_config.fee_rate_governor = solana_fee_calculator::FeeRateGovernor::new(0, 0);
+
+        let lamports_to_transfer = 123_456 * LAMPORTS_PER_SOL;
+        let (bank0, bank_forks) =
+            Bank::new_with_paths_for_tests(&genesis_config, None, vec![accounts_dir.clone()], None)
+                .wrap_with_bank_forks_for_tests();
+        let leader = *bank0.leader();
+        bank0
+            .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank0.fill_bank_with_ticks_for_tests();
+
+        let full_snapshot_slot = 1;
+        let bank1 = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank0,
+            leader,
+            full_snapshot_slot,
+        );
+        bank1
+            .transfer(lamports_to_transfer, &key2, &key1.pubkey())
+            .unwrap();
+        bank1.fill_bank_with_ticks_for_tests();
+        bank1.set_block_id(Some(Hash::default()));
+        let full_snapshot_archive_info =
+            bank_to_full_snapshot_archive(&snapshot_config, &bank1).unwrap();
+
+        let zeroed_slot = full_snapshot_slot + 1;
+        let bank2 =
+            Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank1, leader, zeroed_slot);
+        bank2
+            .transfer(lamports_to_transfer, &key1, &key2.pubkey())
+            .unwrap();
+        assert_eq!(
+            bank2.get_balance(&key1.pubkey()),
+            0,
+            "Ensure Account1's balance is zero"
+        );
+        bank2.fill_bank_with_ticks_for_tests();
+        bank2.set_block_id(Some(Hash::default()));
+        // root and flush so slot 2's storage holding the zero-lamport Account1 is written
+        bank2.squash();
+        bank2.force_flush_accounts_cache();
+
+        let slot = zeroed_slot + 1;
+        let bank3 = Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank2, leader, slot);
+        bank3
+            .transfer(lamports_to_transfer, &mint_keypair, &key2.pubkey())
+            .unwrap();
+        bank3.fill_bank_with_ticks_for_tests();
+        bank3.set_block_id(Some(Hash::default()));
+
+        // flush and clean so slot 1's funded Account1 is removed, leaving the zero-lamport account
+        // at slot 2 as the lone reference
+        bank3.squash();
+        bank3.force_flush_accounts_cache();
+        bank3.clean_accounts();
+
+        let accounts_db = &bank3.rc.accounts.accounts_db;
+        // full snapshot is older than slot 2, so shrink keeps the tombstone instead of purging
+        accounts_db.set_latest_full_snapshot_slot(full_snapshot_slot);
+        assert_eq!(
+            accounts_db
+                .accounts_index
+                .ref_count_from_storage(&key1.pubkey()),
+            1,
+            "Ensure Account1 is a zero-lamport single-ref in the index before shrink"
+        );
+
+        // shrink converts the zero-lamport single-ref into a tombstone
+        accounts_db.shrink_all_slots(false, None);
+        assert_eq!(
+            accounts_db
+                .accounts_index
+                .ref_count_from_storage(&key1.pubkey()),
+            0,
+            "Ensure shrink removed the tombstoned account from the index"
+        );
+        assert!(
+            !accounts_db
+                .get_storages(zeroed_slot..zeroed_slot + 1)
+                .0
+                .is_empty(),
+            "Ensure the zeroed slot's storage is retained so the tombstone survives for the \
+             incremental snapshot"
+        );
+
+        let incremental_snapshot_archive_info =
+            bank_to_incremental_snapshot_archive(&snapshot_config, &bank3, full_snapshot_slot)
+                .unwrap();
+
+        let deserialized_bank = bank_from_snapshot_archives(
+            slice::from_ref(&accounts_dir),
+            &full_snapshot_archive_info,
+            Some(&incremental_snapshot_archive_info),
+            &snapshot_config,
+            &genesis_config,
+            &RuntimeConfig::default(),
+            None,
+            None, // leader_for_tests
+            None,
+            false,
+            false,
+            false,
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            deserialized_bank, *bank3,
+            "Ensure rebuilding from full + incremental (with the tombstone) matches the live bank"
+        );
+        assert!(
+            deserialized_bank
+                .get_account_modified_slot(&key1.pubkey())
+                .is_none(),
+            "Ensure Account1 has not been brought back from the dead"
+        );
+    }
+
     /// Test that cleaning works well in the edge cases of zero-lamport accounts and snapshots.
     /// Here's the scenario:
     ///

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1447,7 +1447,7 @@ mod tests {
         }
     }
 
-    /// Test that the full zero-lamport tombstone path works end to end across snapshots.
+    /// Test that the full tombstone path works end to end across snapshots.
     /// Here's the scenario:
     ///
     /// slot 1:
@@ -1471,7 +1471,7 @@ mod tests {
     /// and the account ends up deleted. If the tombstone were dropped during shrink, the rebuild
     /// would resurrect Account1 from the full snapshot and the checks below would fail.
     #[test]
-    fn test_incremental_snapshots_handle_zero_lamport_tombstones() {
+    fn test_incremental_snapshots_handle_tombstones() {
         let key1 = Keypair::new();
         let key2 = Keypair::new();
 


### PR DESCRIPTION
#### Problem
Zero lamport entries use memory in the accounts index.

#### Summary of Changes
Introduce the concept of a Tombstone: A tombstone is written to an account storage entry, but not stored in the index. It is persisted across shrink and clean until the next full snapshot.

Implemented Tombstone creation during shrink. Eventually this will be done in flush/index generation/clean as well. 

#### Testing
Ran a validator with this change. 
Metrics:
The most important one! You can see the number of accounts in the index is no longer a jig saw, even if they are only added on shrink.
<img width="1678" height="543" alt="image" src="https://github.com/user-attachments/assets/3a14405a-52ea-4116-aa29-a76dd3ed8f99" />

Actual Tombstone addition is pretty fast. There are spikes every 100 slots, I would guess related to flush
<img width="1678" height="462" alt="image" src="https://github.com/user-attachments/assets/57dc28a6-8704-4d20-a5d7-8df2fb9c4923" />


Snapshot Testing
Tombstones means a Validator running the Tombstone change
Master means  No Tombstone Change
| Source     | Destination | Method   |
| ---------- | ----------- | -------- |
| Tombstones | Tombstones  | Fastboot |
| Tombstones | Master      | Fastboot |
| Tombstones | Tombstones  | Archives |
| Tombstones | Master      | Archives |

Not surprising as Tombstones are just persisted as zero lamport accounts. They give revived into zero lamport accounts after snapshot recovery at this time. 

Fixes #
