### PR TITLE
chore(deps): bump solana-transaction-error from 3.3.0 to 3.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes 0.14.100",
  "rand 0.8.6",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -11416,9 +11416,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
+checksum = "a949797bc1ac31836d0070e791083028a8c2e0d493fa4cf51c0bed7a04c65c22"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,7 +514,7 @@ solana-tpu-client = { path = "tpu-client", version = "=4.3.0-alpha.0", default-f
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction = "4.1.4"
 solana-transaction-context = { path = "transaction-context", version = "=4.3.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-error = "3.3.0"
+solana-transaction-error = "3.3.1"
 solana-transaction-status = { path = "transaction-status", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8850,9 +8850,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
+checksum = "a949797bc1ac31836d0070e791083028a8c2e0d493fa4cf51c0bed7a04c65c22"
 dependencies = [
  "serde",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9875,9 +9875,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-error"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757a648388ab1e7350a806ffceb31ce656dc5b5fe607b9f8209aa56f63040179"
+checksum = "a949797bc1ac31836d0070e791083028a8c2e0d493fa4cf51c0bed7a04c65c22"
 dependencies = [
  "serde",
  "serde_derive",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -270,7 +270,7 @@ static NANOSECOND_CLOCK_ACCOUNT: LazyLock<Pubkey> = LazyLock::new(|| {
 pub type BankStatusCache = StatusCache<Result<()>>;
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(digest = "HvpA8mUc4TZAcDF3BpcynmYWYBK3scJRTem2qadCiF5Z")
+    frozen_abi(digest = "23uAyYmzMrmPvPDKf6SvF1YoojYstmEPmdkfAQDnpwsq")
 )]
 pub type BankSlotDelta = SlotDelta<Result<()>>;
 

--- a/runtime/src/serde_snapshot/status_cache.rs
+++ b/runtime/src/serde_snapshot/status_cache.rs
@@ -19,8 +19,8 @@ use {
 #[cfg_attr(
     feature = "frozen-abi",
     frozen_abi(
-        api_digest = "DM9FgEZxfdt43ZgxNAtU2YoGV2P1NgiABgJJunURuV2p",
-        abi_digest = "GuQrL8fa1SCkbNyctatMnKgxvVQFs47oR5nwAcLKCzXq",
+        api_digest = "AardUUq1At4qq6oNNp9V2JZFsMR5k54RZmBmZkxUfk7m",
+        abi_digest = "AGXdE33medQcQ5Bzq7Mppz3cQ9TNPxBaaX2iUM68pnmC",
         abi_serializer = "wincode",
         test_roundtrip = "eq_and_wire"
     )
@@ -117,7 +117,7 @@ pub fn deserialize_status_cache(
 /// contain a string in the BorshIoError variant.
 #[cfg_attr(
     feature = "frozen-abi",
-    frozen_abi(api_digest = "H4jrGnmko28mgcxgsVyC49ihwiZmBJbSFAnYGHYtNpS"),
+    frozen_abi(api_digest = "5pMgydVNgsYbg64Trhjxbftsug5La7fRDmooyrsHd4wy"),
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
 )]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SchemaRead, SchemaWrite)]
@@ -161,7 +161,6 @@ enum SerdeTransactionError {
     UnbalancedTransaction,
     ProgramCacheHitMaxLimit,
     CommitCancelled,
-    InstructionsSysvarOverflow,
 }
 
 impl From<&TransactionError> for SerdeTransactionError {
@@ -230,7 +229,6 @@ impl From<&TransactionError> for SerdeTransactionError {
             TransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
             TransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
             TransactionError::CommitCancelled => Self::CommitCancelled,
-            TransactionError::InstructionsSysvarOverflow => Self::InstructionsSysvarOverflow,
         }
     }
 }
@@ -301,7 +299,6 @@ impl From<SerdeTransactionError> for TransactionError {
             SerdeTransactionError::UnbalancedTransaction => Self::UnbalancedTransaction,
             SerdeTransactionError::ProgramCacheHitMaxLimit => Self::ProgramCacheHitMaxLimit,
             SerdeTransactionError::CommitCancelled => Self::CommitCancelled,
-            SerdeTransactionError::InstructionsSysvarOverflow => Self::InstructionsSysvarOverflow,
         }
     }
 }

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -439,13 +439,11 @@ pub mod worker_message_types {
         pub const UNBALANCED_TRANSACTION: u8 = 100;
         /// Program cache hit max limit.
         pub const PROGRAM_CACHE_HIT_MAX_LIMIT: u8 = 101;
-        /// Instructions sysvar overflowed format.
-        pub const INSTRUCTIONS_SYSVAR_OVERFLOW: u8 = 102;
 
         // This error in agave is only internal, and to avoid updating the sdk
         // it is reused for mapping into `ALL_OR_NOTHING_BATCH_FAILURE`.
         // /// Commit cancelled internally.
-        // pub const COMMIT_CANCELLED: u8 = 103;
+        // pub const COMMIT_CANCELLED: u8 = 102;
     }
 
     /// Tag indicating [`CheckResponse`] inner message.

--- a/scheduling-utils/src/error.rs
+++ b/scheduling-utils/src/error.rs
@@ -87,9 +87,6 @@ pub fn transaction_error_to_not_included_reason(error: &TransactionError) -> u8 
         TransactionError::ProgramCacheHitMaxLimit => {
             not_included_reasons::PROGRAM_CACHE_HIT_MAX_LIMIT
         }
-        TransactionError::InstructionsSysvarOverflow => {
-            not_included_reasons::INSTRUCTIONS_SYSVAR_OVERFLOW
-        }
 
         // SPECIAL CASE - CommitCancelled is an internal error reused to avoid breaking sdk
         TransactionError::CommitCancelled => not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE,

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -126,7 +126,7 @@ fn key_to_slot(key: &str) -> Option<Slot> {
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample, PartialEq),
     frozen_abi(
-        abi_digest = "GcFQWu3jGSH6BXJhGdJXaBDPamhszdXFXfdfPqTmTkFe",
+        abi_digest = "AqgEWHGTni7ZV6JGTPkvewggW5YQutUEWv3bMUbN7o3f",
         test_roundtrip = "eq_and_wire"
     )
 )]
@@ -351,7 +351,7 @@ impl From<Reward> for StoredConfirmedBlockReward {
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "6WZ7LHbaEy2SSt8PvySFEnRNjFek3aMy18eM5p7Qj5Au",
+        abi_digest = "3RJqJCwpbxdqKp5PLDeoE3xkawxtJYBuZmVPEHYFB8bc",
         test_roundtrip = "eq_and_wire"
     )
 )]
@@ -402,7 +402,7 @@ impl From<TransactionInfo> for TransactionStatus {
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "86r1cp4pK2UX84rrPyYXL4NYZW1h7Hf7CAdeJq295AXp",
+        abi_digest = "3j7JBoVWnTHm2vMpZtJUCV2vjbaNdbAHtCrb42UUV3VX",
         test_roundtrip = "eq_and_wire"
     )
 )]

--- a/storage-proto/proto/transaction_by_addr.proto
+++ b/storage-proto/proto/transaction_by_addr.proto
@@ -64,7 +64,6 @@ enum TransactionErrorType {
     UNBALANCED_TRANSACTION = 36;
     PROGRAM_CACHE_HIT_MAX_LIMIT = 37;
     COMMIT_CANCELLED = 38;
-    INSTRUCTIONS_SYSVAR_OVERFLOW = 39;
 }
 
 message InstructionError {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -932,7 +932,6 @@ impl TryFrom<tx_by_addr::TransactionError> for TransactionError {
             36 => TransactionError::UnbalancedTransaction,
             37 => TransactionError::ProgramCacheHitMaxLimit,
             38 => TransactionError::CommitCancelled,
-            39 => TransactionError::InstructionsSysvarOverflow,
             _ => return Err("Invalid TransactionError"),
         })
     }
@@ -1056,9 +1055,6 @@ impl From<TransactionError> for tx_by_addr::TransactionError {
                 }
                 TransactionError::CommitCancelled => {
                     tx_by_addr::TransactionErrorType::CommitCancelled
-                }
-                TransactionError::InstructionsSysvarOverflow => {
-                    tx_by_addr::TransactionErrorType::InstructionsSysvarOverflow
                 }
             } as i32,
             instruction_error: match transaction_error {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -659,7 +659,7 @@ fn construct_instructions_account(message: &impl SVMMessage) -> Result<AccountSh
 
     Ok(AccountSharedData::from(Account {
         data: construct_instructions_data(&decompiled_instructions)
-            .map_err(|_err| TransactionError::InstructionsSysvarOverflow)?,
+            .map_err(|_err| TransactionError::MaxLoadedAccountsDataSizeExceeded)?,
         owner: sysvar::id(),
         ..Account::default()
     }))
@@ -2328,7 +2328,7 @@ mod tests {
         assert!(matches!(
             load_result,
             TransactionLoadResult::FeesOnly(FeesOnlyTransaction {
-                load_error: TransactionError::InstructionsSysvarOverflow,
+                load_error: TransactionError::MaxLoadedAccountsDataSizeExceeded,
                 ..
             }),
         ));


### PR DESCRIPTION
#### Problem
- Adding a new transaction error in 3.3.0 was breaking, but we do not want a breaking change at this time
- We plan to yank 3.3.0

#### Summary of Changes
- Bump solana-transaction-error from 3.3.0 to 3.3.1:
	- this removes `TransactionError::InstructionsSysvarOverflow`
- Change ix sysvar overflow error return to re-use: `TransactionError::MaxLoadedAccountsDataSizeExceeded` (closest variant we could find)
- Remove internal mappings of `InstructionsSysvarOverflow`
- Update abi/api digests that changed with removal of error variants

#### Testing
- CI

Fixes #
