### PR TITLE
Bump `solana-zk-sdk` to 7.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes 0.14.100",
  "rand 0.8.6",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -3474,6 +3474,15 @@ name = "histogram"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -7628,7 +7637,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-system-interface 3.2.0",
- "solana-zk-sdk 5.0.1",
+ "solana-zk-sdk 7.0.1",
  "tempfile",
  "thiserror 2.0.18",
  "uriparse",
@@ -11787,12 +11796,12 @@ version = "4.3.0-alpha.0"
 dependencies = [
  "bytemuck",
  "criterion",
- "curve25519-dalek 4.1.3",
  "solana-instruction",
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
- "solana-zk-sdk 5.0.1",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk 7.0.1",
 ]
 
 [[package]]
@@ -11811,7 +11820,8 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
- "solana-zk-sdk 5.0.1",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk 7.0.1",
 ]
 
 [[package]]
@@ -11853,33 +11863,32 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-sdk"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09670ff59f60e6ddc2209c2e4353992a9b9f01d4e244f3e9d67bd5146e33d388"
+checksum = "96cd8535d2f40d43a1d47af2849e1c86706a597a2ad84207441f51a50f09d8fd"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
  "bincode",
  "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "hkdf",
  "itertools 0.14.0",
  "merlin",
- "num-derive",
- "num-traits",
  "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "sha3",
  "solana-address 2.6.1",
  "solana-derivation-path",
- "solana-instruction",
- "solana-sdk-ids",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "subtle",
  "thiserror 2.0.18",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,6 @@ crossbeam-channel = "0.5.15"
 crossbeam-utils = "0.8.21"
 csv = "1.4.0"
 ctrlc = "3.5.2"
-curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 dashmap = "5.5.3"
 derive-where = "1.6.1"
 derive_more = { version = "2.1.1", features = ["full"] }
@@ -527,8 +526,9 @@ solana-vote = { path = "vote", version = "=4.3.0-alpha.0", features = ["agave-un
 solana-vote-interface = "6.0.2"
 solana-vote-program = { path = "programs/vote", version = "=4.3.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 solana-wincode-varint = "1.0.0"
+solana-zk-elgamal-proof-interface = "0.1.3"
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
-solana-zk-sdk = "5.0.1"
+solana-zk-sdk = "7.0.1"
 solana-zk-sdk-pod = "0.1.2"
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.3.0-alpha.0", features = ["agave-unstable-api"] }
 spl-associated-token-account-interface = "2.0.0"
@@ -579,17 +579,6 @@ zstd = "0.13.3"
 
 [profile.dev]
 debug = "line-tables-only"
-
-# curve25519-dalek uses the simd backend by default in v4 if possible,
-# which has very slow performance on some platforms with opt-level 0,
-# which is the default for dev and test builds.
-# This slowdown causes certain interactions in the solana-test-validator,
-# such as verifying ZK proofs in transactions, to take much more than 400ms,
-# creating problems in the testing environment.
-# To enable better performance in solana-test-validator during tests and dev builds,
-# we override the opt-level to 3 for the crate.
-[profile.dev.package.curve25519-dalek]
-opt-level = 3
 
 [profile.full-dev]
 inherits = "dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -580,6 +580,17 @@ zstd = "0.13.3"
 [profile.dev]
 debug = "line-tables-only"
 
+# curve25519-dalek uses the simd backend by default in v4 if possible,
+# which has very slow performance on some platforms with opt-level 0,
+# which is the default for dev and test builds.
+# This slowdown causes certain interactions in the solana-test-validator,
+# such as verifying ZK proofs in transactions, to take much more than 400ms,
+# creating problems in the testing environment.
+# To enable better performance in solana-test-validator during tests and dev builds,
+# we override the opt-level to 3 for the crate.
+[profile.dev.package.curve25519-dalek]
+opt-level = 3
+
 [profile.full-dev]
 inherits = "dev"
 debug = "full"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -2890,6 +2890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9170,38 +9179,38 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
+ "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09670ff59f60e6ddc2209c2e4353992a9b9f01d4e244f3e9d67bd5146e33d388"
+checksum = "96cd8535d2f40d43a1d47af2849e1c86706a597a2ad84207441f51a50f09d8fd"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
  "bincode",
  "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "hkdf",
  "itertools 0.14.0",
  "merlin",
- "num-derive",
- "num-traits",
  "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "sha3",
  "solana-address 2.6.1",
  "solana-derivation-path",
- "solana-instruction",
- "solana-sdk-ids",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "subtle",
  "thiserror 2.0.18",
  "zeroize",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -2829,6 +2829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10195,38 +10204,38 @@ dependencies = [
  "solana-program-runtime",
  "solana-sdk-ids",
  "solana-svm-log-collector",
+ "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk",
 ]
 
 [[package]]
 name = "solana-zk-sdk"
-version = "5.0.1"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09670ff59f60e6ddc2209c2e4353992a9b9f01d4e244f3e9d67bd5146e33d388"
+checksum = "96cd8535d2f40d43a1d47af2849e1c86706a597a2ad84207441f51a50f09d8fd"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.22.1",
  "bincode",
  "bytemuck",
- "bytemuck_derive",
  "curve25519-dalek 4.1.3",
+ "hkdf",
  "itertools 0.14.0",
  "merlin",
- "num-derive",
- "num-traits",
  "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2 0.10.9",
  "sha3",
  "solana-address 2.6.1",
  "solana-derivation-path",
- "solana-instruction",
- "solana-sdk-ids",
  "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
+ "solana-zk-elgamal-proof-interface",
+ "solana-zk-sdk-pod",
  "subtle",
  "thiserror 2.0.18",
  "zeroize",

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -23,6 +23,7 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+solana-zk-elgamal-proof-interface = { workspace = true }
 solana-zk-sdk = { workspace = true }
 
 [lints]

--- a/programs/zk-elgamal-proof-tests/tests/process_transaction.rs
+++ b/programs/zk-elgamal-proof-tests/tests/process_transaction.rs
@@ -9,13 +9,16 @@ use {
     solana_system_interface::instruction as system_instruction,
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
+    solana_zk_elgamal_proof_interface::{
+        self, instruction::*, proof_data::*, state::ProofContextState,
+    },
     solana_zk_sdk::{
         encryption::{
             elgamal::{ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey},
             grouped_elgamal::GroupedElGamal,
             pedersen::{Pedersen, PedersenOpening},
         },
-        zk_elgamal_proof_program::{self, instruction::*, proof_data::*, state::ProofContextState},
+        zk_elgamal_proof_program::*,
     },
     std::mem::size_of,
 };
@@ -41,7 +44,7 @@ async fn test_zero_balance() {
 
     let zero_ciphertext = elgamal_keypair.pubkey().encrypt(0_u64);
     let success_proof_data =
-        ZeroCiphertextProofData::new(&elgamal_keypair, &zero_ciphertext).unwrap();
+        build_zero_ciphertext_proof_data(&elgamal_keypair, &zero_ciphertext).unwrap();
 
     let mut fail_proof_context = success_proof_data.context;
     fail_proof_context.pubkey = ElGamalPubkey::default().into();
@@ -94,7 +97,7 @@ async fn test_ciphertext_ciphertext_equality() {
         .pubkey()
         .encrypt_with(amount, &destination_opening);
 
-    let success_proof_data = CiphertextCiphertextEqualityProofData::new(
+    let success_proof_data = build_ciphertext_ciphertext_equality_proof_data(
         &source_keypair,
         destination_keypair.pubkey(),
         &source_ciphertext,
@@ -145,13 +148,13 @@ async fn test_ciphertext_ciphertext_equality() {
 async fn test_pubkey_validity() {
     let elgamal_keypair = ElGamalKeypair::new_rand();
 
-    let success_proof_data = PubkeyValidityProofData::new(&elgamal_keypair).unwrap();
+    let success_proof_data = build_pubkey_validity_proof_data(&elgamal_keypair).unwrap();
 
     let incorrect_pubkey = elgamal_keypair.pubkey();
     let incorrect_secret = ElGamalSecretKey::new_rand();
     let incorrect_keypair = ElGamalKeypair::new_for_tests(*incorrect_pubkey, incorrect_secret);
 
-    let fail_proof_data = PubkeyValidityProofData::new(&incorrect_keypair).unwrap();
+    let fail_proof_data = build_pubkey_validity_proof_data(&incorrect_keypair).unwrap();
 
     test_verify_proof_without_context(
         ProofInstruction::VerifyPubkeyValidity,
@@ -192,7 +195,7 @@ async fn test_batched_range_proof_u64() {
     let (commitment_1, opening_1) = Pedersen::new(amount_1);
     let (commitment_2, opening_2) = Pedersen::new(amount_2);
 
-    let success_proof_data = BatchedRangeProofU64Data::new(
+    let success_proof_data = build_batched_range_proof_u64_data(
         vec![&commitment_1, &commitment_2],
         vec![amount_1, amount_2],
         vec![32, 32],
@@ -201,7 +204,7 @@ async fn test_batched_range_proof_u64() {
     .unwrap();
 
     let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = BatchedRangeProofU64Data::new(
+    let fail_proof_data = build_batched_range_proof_u64_data(
         vec![&commitment_1, &commitment_2],
         vec![amount_1, amount_2],
         vec![32, 32],
@@ -248,7 +251,7 @@ async fn test_batched_range_proof_u128() {
     let (commitment_1, opening_1) = Pedersen::new(amount_1);
     let (commitment_2, opening_2) = Pedersen::new(amount_2);
 
-    let success_proof_data = BatchedRangeProofU128Data::new(
+    let success_proof_data = build_batched_range_proof_u128_data(
         vec![&commitment_1, &commitment_2],
         vec![amount_1, amount_2],
         vec![64, 64],
@@ -257,7 +260,7 @@ async fn test_batched_range_proof_u128() {
     .unwrap();
 
     let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = BatchedRangeProofU128Data::new(
+    let fail_proof_data = build_batched_range_proof_u128_data(
         vec![&commitment_1, &commitment_2],
         vec![amount_1, amount_2],
         vec![64, 64],
@@ -308,7 +311,7 @@ async fn test_batched_range_proof_u256() {
     let (commitment_3, opening_3) = Pedersen::new(amount_3);
     let (commitment_4, opening_4) = Pedersen::new(amount_4);
 
-    let success_proof_data = BatchedRangeProofU256Data::new(
+    let success_proof_data = build_batched_range_proof_u256_data(
         vec![&commitment_1, &commitment_2, &commitment_3, &commitment_4],
         vec![amount_1, amount_2, amount_3, amount_4],
         vec![64, 64, 64, 64],
@@ -317,7 +320,7 @@ async fn test_batched_range_proof_u256() {
     .unwrap();
 
     let incorrect_opening = PedersenOpening::new_rand();
-    let fail_proof_data = BatchedRangeProofU256Data::new(
+    let fail_proof_data = build_batched_range_proof_u256_data(
         vec![&commitment_1, &commitment_2, &commitment_3, &commitment_4],
         vec![amount_1, amount_2, amount_3, amount_4],
         vec![64, 64, 64, 64],
@@ -363,7 +366,7 @@ async fn test_ciphertext_commitment_equality() {
     let ciphertext = keypair.pubkey().encrypt(amount);
     let (commitment, opening) = Pedersen::new(amount);
 
-    let success_proof_data = CiphertextCommitmentEqualityProofData::new(
+    let success_proof_data = build_ciphertext_commitment_equality_proof_data(
         &keypair,
         &ciphertext,
         &commitment,
@@ -423,7 +426,7 @@ async fn test_grouped_ciphertext_2_handles_validity() {
     let grouped_ciphertext =
         GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount, &opening);
 
-    let success_proof_data = GroupedCiphertext2HandlesValidityProofData::new(
+    let success_proof_data = build_grouped_ciphertext_2_handles_validity_proof_data(
         destination_pubkey,
         auditor_pubkey,
         &grouped_ciphertext,
@@ -489,7 +492,7 @@ async fn test_batched_grouped_ciphertext_2_handles_validity() {
     let grouped_ciphertext_hi =
         GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount_hi, &opening_hi);
 
-    let success_proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
+    let success_proof_data = build_batched_grouped_ciphertext_2_handles_validity_proof_data(
         destination_pubkey,
         auditor_pubkey,
         &grouped_ciphertext_lo,
@@ -558,7 +561,7 @@ async fn test_grouped_ciphertext_3_handles_validity() {
         &opening,
     );
 
-    let success_proof_data = GroupedCiphertext3HandlesValidityProofData::new(
+    let success_proof_data = build_grouped_ciphertext_3_handles_validity_proof_data(
         source_pubkey,
         destination_pubkey,
         auditor_pubkey,
@@ -626,7 +629,7 @@ async fn test_batched_grouped_ciphertext_3_handles_validity() {
         &opening_hi,
     );
 
-    let success_proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
+    let success_proof_data = build_batched_grouped_ciphertext_3_handles_validity_proof_data(
         source_pubkey,
         destination_pubkey,
         auditor_pubkey,
@@ -822,7 +825,7 @@ async fn test_verify_proof_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), fail_proof_data),
     ];
@@ -849,7 +852,7 @@ async fn test_verify_proof_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             (space.checked_sub(1).unwrap()) as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
     ];
@@ -876,7 +879,7 @@ async fn test_verify_proof_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space).checked_sub(1).unwrap(),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
     ];
@@ -908,7 +911,7 @@ async fn test_verify_proof_with_context<T, U>(
                 &context_state_account.pubkey(),
                 rent.minimum_balance(space),
                 space as u64,
-                &zk_elgamal_proof_program::id(),
+                &solana_zk_elgamal_proof_interface::id(),
             ),
             wrong_instruction_type
                 .encode_verify_proof(Some(context_state_info), success_proof_data),
@@ -937,7 +940,7 @@ async fn test_verify_proof_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
     ];
@@ -981,7 +984,7 @@ async fn test_verify_proof_with_context<T, U>(
             &context_state_account_and_authority.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
     ];
@@ -1047,7 +1050,7 @@ async fn test_verify_proof_from_account_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof_from_account(
             Some(context_state_info),
@@ -1078,7 +1081,7 @@ async fn test_verify_proof_from_account_with_context<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof_from_account(
             Some(context_state_info),
@@ -1129,7 +1132,7 @@ async fn test_verify_proof_from_account_with_context<T, U>(
             &context_state_account_and_authority.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof_from_account(
             Some(context_state_info),
@@ -1180,7 +1183,7 @@ async fn test_close_context_state<T, U>(
             &context_state_account.pubkey(),
             rent.minimum_balance(space),
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
     ];
@@ -1240,7 +1243,7 @@ async fn test_close_context_state<T, U>(
             &context_state_account.pubkey(),
             0_u64, // do not deposit rent
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
         close_context_state(
@@ -1266,7 +1269,7 @@ async fn test_close_context_state<T, U>(
             &context_state_account.pubkey(),
             0_u64,
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
         close_context_state(
@@ -1292,7 +1295,7 @@ async fn test_close_context_state<T, U>(
             &context_state_account.pubkey(),
             0_u64,
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
         close_context_state(
@@ -1332,7 +1335,7 @@ async fn test_close_context_state<T, U>(
             &context_state_account_and_authority.pubkey(),
             0_u64,
             space as u64,
-            &zk_elgamal_proof_program::id(),
+            &solana_zk_elgamal_proof_interface::id(),
         ),
         instruction_type.encode_verify_proof(Some(context_state_info), success_proof_data),
         close_context_state(context_state_info, &context_state_account.pubkey()),

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -22,11 +22,11 @@ solana-instruction = { workspace = true, features = ["std"] }
 solana-program-runtime = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-svm-log-collector = { workspace = true }
+solana-zk-elgamal-proof-interface = { workspace = true }
 solana-zk-sdk = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-curve25519-dalek = { workspace = true }
 
 [[bench]]
 name = "verify_proofs"

--- a/programs/zk-elgamal-proof/benches/verify_proofs.rs
+++ b/programs/zk-elgamal-proof/benches/verify_proofs.rs
@@ -1,28 +1,19 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     criterion::{Criterion, criterion_group, criterion_main},
-    curve25519_dalek::scalar::Scalar,
     solana_zk_sdk::{
         encryption::{
             elgamal::ElGamalKeypair,
             grouped_elgamal::GroupedElGamal,
             pedersen::{Pedersen, PedersenOpening},
         },
-        zk_elgamal_proof_program::proof_data::{
-            BatchedGroupedCiphertext2HandlesValidityProofData,
-            BatchedGroupedCiphertext3HandlesValidityProofData, BatchedRangeProofU64Data,
-            BatchedRangeProofU128Data, BatchedRangeProofU256Data,
-            CiphertextCiphertextEqualityProofData, CiphertextCommitmentEqualityProofData,
-            GroupedCiphertext2HandlesValidityProofData, GroupedCiphertext3HandlesValidityProofData,
-            PercentageWithCapProofData, PubkeyValidityProofData, ZeroCiphertextProofData,
-            ZkProofData,
-        },
+        zk_elgamal_proof_program::*,
     },
 };
 
 fn bench_pubkey_validity(c: &mut Criterion) {
     let keypair = ElGamalKeypair::new_rand();
-    let proof_data = PubkeyValidityProofData::new(&keypair).unwrap();
+    let proof_data = build_pubkey_validity_proof_data(&keypair).unwrap();
 
     c.bench_function("pubkey_validity", |b| {
         b.iter(|| {
@@ -34,7 +25,7 @@ fn bench_pubkey_validity(c: &mut Criterion) {
 fn bench_zero_ciphertext(c: &mut Criterion) {
     let keypair = ElGamalKeypair::new_rand();
     let ciphertext = keypair.pubkey().encrypt(0_u64);
-    let proof_data = ZeroCiphertextProofData::new(&keypair, &ciphertext).unwrap();
+    let proof_data = build_zero_ciphertext_proof_data(&keypair, &ciphertext).unwrap();
 
     c.bench_function("zero_ciphertext", |b| {
         b.iter(|| {
@@ -55,7 +46,7 @@ fn bench_grouped_ciphertext_2_handles_validity(c: &mut Criterion) {
     let grouped_ciphertext =
         GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount, &opening);
 
-    let proof_data = GroupedCiphertext2HandlesValidityProofData::new(
+    let proof_data = build_grouped_ciphertext_2_handles_validity_proof_data(
         destination_pubkey,
         auditor_pubkey,
         &grouped_ciphertext,
@@ -89,7 +80,7 @@ fn bench_grouped_ciphertext_3_handles_validity(c: &mut Criterion) {
         &opening,
     );
 
-    let proof_data = GroupedCiphertext3HandlesValidityProofData::new(
+    let proof_data = build_grouped_ciphertext_3_handles_validity_proof_data(
         source_pubkey,
         destination_pubkey,
         auditor_pubkey,
@@ -112,7 +103,7 @@ fn bench_ciphertext_commitment_equality(c: &mut Criterion) {
     let ciphertext = keypair.pubkey().encrypt(amount);
     let (commitment, opening) = Pedersen::new(amount);
 
-    let proof_data = CiphertextCommitmentEqualityProofData::new(
+    let proof_data = build_ciphertext_commitment_equality_proof_data(
         &keypair,
         &ciphertext,
         &commitment,
@@ -140,7 +131,7 @@ fn bench_ciphertext_ciphertext_equality(c: &mut Criterion) {
         .pubkey()
         .encrypt_with(amount, &destination_opening);
 
-    let proof_data = CiphertextCiphertextEqualityProofData::new(
+    let proof_data = build_ciphertext_ciphertext_equality_proof_data(
         &source_keypair,
         destination_keypair.pubkey(),
         &source_ciphertext,
@@ -176,7 +167,7 @@ fn bench_batched_grouped_ciphertext_2_handles_validity(c: &mut Criterion) {
     let grouped_ciphertext_hi =
         GroupedElGamal::encrypt_with([destination_pubkey, auditor_pubkey], amount_hi, &opening_hi);
 
-    let proof_data = BatchedGroupedCiphertext2HandlesValidityProofData::new(
+    let proof_data = build_batched_grouped_ciphertext_2_handles_validity_proof_data(
         destination_pubkey,
         auditor_pubkey,
         &grouped_ciphertext_lo,
@@ -223,7 +214,7 @@ fn bench_batched_grouped_ciphertext_3_handles_validity(c: &mut Criterion) {
         &opening_hi,
     );
 
-    let proof_data = BatchedGroupedCiphertext3HandlesValidityProofData::new(
+    let proof_data = build_batched_grouped_ciphertext_3_handles_validity_proof_data(
         source_pubkey,
         destination_pubkey,
         auditor_pubkey,
@@ -255,14 +246,13 @@ fn bench_percentage_with_cap(c: &mut Criterion) {
     let (transfer_commitment, transfer_opening) = Pedersen::new(transfer_amount);
     let (fee_commitment, fee_opening) = Pedersen::new(fee_amount);
 
-    let scalar_rate = Scalar::from(fee_rate);
-    let delta_commitment =
-        &fee_commitment * Scalar::from(10_000_u64) - &transfer_commitment * &scalar_rate;
-    let delta_opening = &fee_opening * &Scalar::from(10_000_u64) - &transfer_opening * &scalar_rate;
+    let fee_rate_u64 = fee_rate as u64;
+    let delta_commitment = &fee_commitment * 10_000_u64 - &transfer_commitment * fee_rate_u64;
+    let delta_opening = &fee_opening * 10_000_u64 - &transfer_opening * fee_rate_u64;
 
     let (claimed_commitment, claimed_opening) = Pedersen::new(delta_fee);
 
-    let proof_data = PercentageWithCapProofData::new(
+    let proof_data = build_percentage_with_cap_proof_data(
         &fee_commitment,
         &fee_opening,
         fee_amount,
@@ -301,7 +291,7 @@ fn bench_batched_range_proof_u64(c: &mut Criterion) {
     let (commitment_7, opening_7) = Pedersen::new(amount_7);
     let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
-    let proof_data = BatchedRangeProofU64Data::new(
+    let proof_data = build_batched_range_proof_u64_data(
         vec![
             &commitment_1,
             &commitment_2,
@@ -349,7 +339,7 @@ fn bench_batched_range_proof_u128(c: &mut Criterion) {
     let (commitment_7, opening_7) = Pedersen::new(amount_7);
     let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
-    let proof_data = BatchedRangeProofU128Data::new(
+    let proof_data = build_batched_range_proof_u128_data(
         vec![
             &commitment_1,
             &commitment_2,
@@ -397,7 +387,7 @@ fn bench_batched_range_proof_u256(c: &mut Criterion) {
     let (commitment_7, opening_7) = Pedersen::new(amount_7);
     let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
-    let proof_data = BatchedRangeProofU256Data::new(
+    let proof_data = build_batched_range_proof_u256_data(
         vec![
             &commitment_1,
             &commitment_2,

--- a/programs/zk-elgamal-proof/src/lib.rs
+++ b/programs/zk-elgamal-proof/src/lib.rs
@@ -7,12 +7,13 @@ use {
     solana_program_runtime::{declare_process_instruction, invoke_context::InvokeContext},
     solana_sdk_ids::system_program,
     solana_svm_log_collector::ic_msg,
-    solana_zk_sdk::zk_elgamal_proof_program::{
+    solana_zk_elgamal_proof_interface::{
         id,
         instruction::ProofInstruction,
         proof_data::*,
         state::{ProofContextState, ProofContextStateMeta},
     },
+    solana_zk_sdk::zk_elgamal_proof_program::VerifyZkProof,
     std::result::Result,
 };
 
@@ -34,7 +35,7 @@ const INSTRUCTION_DATA_LENGTH_WITH_PROOF_ACCOUNT: usize = 5;
 
 fn process_verify_proof<T, U>(invoke_context: &mut InvokeContext) -> Result<(), InstructionError>
 where
-    T: Pod + ZkProofData<U>,
+    T: Pod + ZkProofData<U> + VerifyZkProof,
     U: Pod,
 {
     let transaction_context = &invoke_context.transaction_context;


### PR DESCRIPTION
#### Summary of Changes

The `solana-zk-sdk` v7.0.1 was published.

One can check the release notes for [v6.0](https://github.com/solana-program/zk-elgamal-proof/releases#release-zk-sdk@v6.0.0) and [v7.0](https://github.com/solana-program/zk-elgamal-proof/releases#release-zk-sdk@v7.0.0), but the following is the summary:

v6: The major change in this version was refactoring of the crates:
- The `pod` types were split out from the `solana-zk-sdk` into a separate crate `solana-zk-sdk-pod`.
- The program related components were split out into a separate `solana-zk-elgamal-proof-interface` crate.
Regarding the agave repo, this refactor should not really impact the zk-elgamal-proof-program verification other than the updated API from https://github.com/solana-program/zk-elgamal-proof/pull/289. The verification function from the `ZkProofData` was split into a separate `VerifyZkProof` trait and the proof generation functions became standalone functions.

v7: No changes that will impact proof verification in agave. The changes only impact key ElGamal key derivation on the client side.