### PR TITLE
fix(bootstrap): download snapshot from lowest-ping RPC peer first

### DIFF
--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -625,7 +625,7 @@ pub fn rpc_bootstrap(
         );
         // `vetted_rpc_nodes` is sorted by ping ascending, so take the first
         // entry. `pop()` would take the highest-ping peer.
-        let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.swap_remove(0);
+        let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.remove(0);
         get_rpc_nodes_time += get_rpc_nodes_start.elapsed();
 
         let snapshot_download_start = Instant::now();

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -623,7 +623,9 @@ pub fn rpc_bootstrap(
             &mut blacklisted_rpc_nodes,
             &bootstrap_config,
         );
-        let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.pop().unwrap();
+        // `vetted_rpc_nodes` is sorted by ping ascending, so take the first
+        // entry. `pop()` would take the highest-ping peer.
+        let (rpc_contact_info, snapshot_hash, rpc_client) = vetted_rpc_nodes.swap_remove(0);
         get_rpc_nodes_time += get_rpc_nodes_start.elapsed();
 
         let snapshot_download_start = Instant::now();


### PR DESCRIPTION
**Problem:**

solana-labs/solana#31285 attempted to make rpc_node snapshot downloading faster by sorting known peers by ping. However, the PR sorted the peers by _ascending_ ping, while `vec::pop()` removes the _last_ element. This means that if known_validators is set, we iterate through the slowest peers first. 

code remains unchanged 3 years later:
https://github.com/anza-xyz/agave/blob/master/validator/src/bootstrap.rs#L541 
https://github.com/anza-xyz/agave/blob/master/validator/src/bootstrap.rs#L626


**Solution:**

Select index `0` instead:


References:
* https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by_key
* https://doc.rust-lang.org/std/vec/struct.Vec.html#method.pop
