### PR TITLE
lattice-hash: batched BLAKE3 XOF + LtHash group-add kernel

### DIFF
--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -33,5 +33,9 @@ solana-lattice-hash = { path = ".", features = ["agave-unstable-api"] }
 name = "bench_lt_hash"
 harness = false
 
+[[bench]]
+name = "bench_batch"
+harness = false
+
 [lints]
 workspace = true

--- a/lattice-hash/benches/bench_batch.rs
+++ b/lattice-hash/benches/bench_batch.rs
@@ -1,0 +1,67 @@
+//! Compares the current one-at-a-time lattice-hash path against the batched
+//! BLAKE3 kernel, on a realistic stream of small (token/stake-sized) accounts.
+
+use {
+    criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main},
+    rand::prelude::*,
+    rand_chacha::ChaChaRng,
+    solana_lattice_hash::{batch, lt_hash::LtHash},
+};
+
+const NUM_ACCOUNTS: usize = 1024;
+const MSG_LEN: usize = 273; // 8 lamports + ~200B data + 1 + 32 owner + 32 pubkey
+
+fn make_messages(rng: &mut impl Rng) -> Vec<Vec<u8>> {
+    (0..NUM_ACCOUNTS)
+        .map(|_| {
+            let mut m = vec![0u8; MSG_LEN];
+            rng.fill_bytes(&mut m);
+            m
+        })
+        .collect()
+}
+
+/// Baseline: today's path — `LtHash::with` (a `blake3` XOF) then `mix_in`, one
+/// account at a time.
+fn baseline(messages: &[&[u8]], acc: &mut LtHash) {
+    for msg in messages {
+        let mut h = blake3::Hasher::new();
+        h.update(msg);
+        acc.mix_in(&LtHash::with(&h));
+    }
+}
+
+fn bench(c: &mut Criterion) {
+    let mut rng = ChaChaRng::seed_from_u64(7);
+    let msgs = make_messages(&mut rng);
+    let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+
+    let mut group = c.benchmark_group("accounts_lt_hash");
+    group.throughput(Throughput::Elements(NUM_ACCOUNTS as u64));
+
+    group.bench_function("baseline_one_at_a_time", |b| {
+        b.iter_batched_ref(
+            LtHash::identity,
+            |acc| baseline(&refs, acc),
+            BatchSize::SmallInput,
+        )
+    });
+
+    // Streaming `Accumulator`: the shape the accounts-hash hot loop uses —
+    // create once, `add_message` (copies the message into the owned buffer the
+    // kernel then reads in place) each account, `into_lt_hash`.
+    group.bench_function("batched_accumulator", |b| {
+        b.iter(|| {
+            let mut acc = batch::Accumulator::new();
+            for &msg in &refs {
+                acc.add_message(msg);
+            }
+            acc.into_lt_hash()
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -1,0 +1,488 @@
+//! Batched BLAKE3 XOF + LtHash group-add kernel.
+//!
+//! Background: agave's accounts lattice hash computes, for every account, a
+//! 2048-byte BLAKE3 XOF and folds it (16-bit wrapping group-add) into a running
+//! [`crate::lt_hash::LtHash`].  Done one account at a time (the `blake3` crate's
+//! `into_lt_hash_xof`), the single-chunk input compression of a small account wastes
+//! all but one SIMD lane, and every account round-trips a 2048-byte buffer
+//! through memory plus a scalar `mix_in` loop.
+//!
+//! Firedancer's `fd_blake3_lthash_batch{8,16}` instead hash N independent
+//! messages (one per SIMD lane, each <= 1 chunk), expand each to 2048 bytes, and
+//! fuse the group-add — all in registers.  This module ports that idea to Rust.
+//!
+//! Layout:
+//!  - `arch`: stable `core::arch` SIMD backends (AVX2 = 8 lanes, AVX512 = 16),
+//!  - here: runtime dispatch, the non-SIMD `blake3`-crate fallback, and the
+//!    public [`Accumulator`]/[`accumulate`] API.
+
+#[cfg(target_arch = "x86_64")]
+mod arch;
+
+use crate::lt_hash::LtHash;
+
+/// Max input bytes that map to a single BLAKE3 chunk — the batch path. Larger
+/// messages need the full Merkle tree and take the `blake3`-crate fallback.
+const CHUNK_LEN: usize = 1024;
+/// Bytes in one BLAKE3 compression block.
+const BLOCK_LEN: usize = 64;
+/// `u32` words in one chunk-sized lane buffer (`CHUNK_LEN / 4` = 256).
+const NUM_CHUNK_WORDS: usize = CHUNK_LEN / 4;
+/// Widest SIMD lane count (AVX512 width) = max messages staged per batch.
+const MAX_LANES: usize = 16;
+
+/// A batched [`LtHash::mix_in`]: group-adds the XOF of exactly `bufs.len()`
+/// messages into `acc`, reading each lane in place from `bufs[l]` (a `u32`
+/// buffer zero-padded to its block boundary) of real byte length `lens[l]`.
+/// Implemented by the SIMD backends in [`arch`]; the non-SIMD path hashes via the
+/// `blake3` crate directly (see [`Accumulator::flush`]).
+///
+/// # Safety
+/// Caller must ensure the backend's target feature is available and uphold the
+/// buffer contract documented on `arch`'s `compress_batch`.
+type BatchMixInFn = unsafe fn(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash);
+
+/// Streaming accumulator for the lattice hash of many messages.
+///
+/// Feed each message either whole with [`add_message`](Self::add_message), or in parts with
+/// [`add_part`](Self::add_part) + [`finish_message`](Self::finish_message); each is group-added
+/// (LtHash `mix_in`) into the running value. Small messages (`<= CHUNK_LEN`) are
+/// copied into owned, reusable staging and run through the widest SIMD mix-in
+/// function the CPU supports as soon as a full batch (`lanes` of them) accumulates; larger
+/// messages are hashed immediately via the single-hash `blake3` path (they need
+/// the full Merkle tree). Group-add is commutative, so this reordering does not
+/// change the result.
+///
+/// Messages are *copied* into the accumulator's owned buffers, so the caller's
+/// source buffer can be transient. Those buffers are the mix-in function's input.
+pub struct Accumulator {
+    /// The lattice hash being built; the mix-in functions group-add into its raw elements.
+    acc: LtHash,
+    /// One contiguous allocation for all `num_available_lanes` lane buffers; lane
+    /// `l` occupies the sub-buffer `batch_buffer[l*NUM_CHUNK_WORDS .. (l+1)*NUM_CHUNK_WORDS]`,
+    /// zero-padded past its message.
+    batch_buffer: Box<[u32]>,
+    /// Real byte length of each pending message.
+    /// `batch_lens.len()` is the pending count; capacity is fixed at `num_available_lanes`.
+    batch_lens: Vec<usize>,
+    /// Messages per full batch = SIMD lane count of the selected backend (1 when
+    /// there is no SIMD backend). A batch flushes once this many messages are staged.
+    num_available_lanes: usize,
+    /// The SIMD backend used for a full batch, or `None` when the CPU has none.
+    batch_mix_in_fn: Option<BatchMixInFn>,
+    /// Serial blake3-crate hasher: the fallback for a message that overflows one
+    /// chunk (`> CHUNK_LEN`) and for the non-SIMD / partial-tail path in `flush`.
+    serial_hasher: blake3::Hasher,
+    /// Bytes written into the in-progress message's lane buffer by `add_part` so
+    /// far, i.e. its length before `finish_message`. `0` when no message is in progress.
+    cur_len: usize,
+    /// Set when the in-progress message overflowed one chunk and is being
+    /// streamed into `serial_hasher` rather than staged for the SIMD batch;
+    /// carries that state across the message's remaining `add_part`s until `finish_message`.
+    cur_spilled: bool,
+}
+
+impl core::fmt::Debug for Accumulator {
+    // Omits the large lane `batch_buffer` scratch (and the opaque hasher / fn ptr).
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Accumulator")
+            .field("acc", &self.acc)
+            .field("num_available_lanes", &self.num_available_lanes)
+            .field("batch_lens", &self.batch_lens)
+            .field("cur_len", &self.cur_len)
+            .field("cur_spilled", &self.cur_spilled)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Accumulator {
+    pub fn new() -> Self {
+        /// Pick the widest lane count + mix-in function this CPU supports, falling
+        /// back to a single lane (the `blake3`-crate fallback) when there is no
+        /// SIMD backend.
+        fn select_mix_in_fn() -> (usize, Option<BatchMixInFn>) {
+            #[cfg(target_arch = "x86_64")]
+            {
+                if is_x86_feature_detected!("avx512f") {
+                    return (16, Some(arch::mix_in_avx512));
+                }
+                if is_x86_feature_detected!("avx2") {
+                    return (8, Some(arch::mix_in_avx2));
+                }
+            }
+            (1, None)
+        }
+        let (num_available_lanes, batch_mix_in_fn) = select_mix_in_fn();
+        // usize needs to be `<= 16 * 256`
+        let batch_words = num_available_lanes
+            .checked_mul(NUM_CHUNK_WORDS)
+            .expect("batch buffer word count fits usize");
+        Self {
+            acc: LtHash::identity(),
+            batch_buffer: vec![0u32; batch_words].into_boxed_slice(),
+            batch_lens: Vec::with_capacity(num_available_lanes),
+            num_available_lanes,
+            batch_mix_in_fn,
+            serial_hasher: blake3::Hasher::new(),
+            cur_len: 0,
+            cur_spilled: false,
+        }
+    }
+
+    /// Append `bytes` to the message currently being built; call [`finish_message`] to
+    /// finish it. Feeding a message in parts lets the caller avoid assembling a
+    /// contiguous buffer — the parts are written straight into the SIMD lane
+    /// buffer, or, once a message passes [`CHUNK_LEN`], streamed into the `blake3`
+    /// fallback.
+    ///
+    /// [`finish_message`]: Self::finish_message
+    pub fn add_part(&mut self, bytes: &[u8]) {
+        if self.cur_spilled {
+            self.serial_hasher.update(bytes);
+            return;
+        }
+        // `saturating_add` so a huge `bytes` can't wrap the bound check; then this
+        // message is simply routed to the fallback below.
+        let end = self.cur_len.saturating_add(bytes.len());
+        if end <= CHUNK_LEN {
+            // Fits one chunk: write straight into the current lane buffer.
+            let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
+            let lane_bytes: &mut [u8] = bytemuck::cast_slice_mut(
+                &mut self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)],
+            );
+            lane_bytes[self.cur_len..end].copy_from_slice(bytes);
+            self.cur_len = end;
+        } else {
+            // Overflows one chunk: hand the bytes buffered so far, plus `bytes`, to
+            // the serial blake3 hasher; `finish_message` folds in the result.
+            self.spill_current();
+            self.serial_hasher.update(bytes);
+        }
+    }
+
+    /// Finish the message built by [`add_part`], fold its lattice hash into the
+    /// running value, and start a fresh message.
+    ///
+    /// [`add_part`]: Self::add_part
+    pub fn finish_message(&mut self) {
+        if self.cur_spilled {
+            self.acc.mix_in(&LtHash::with(&self.serial_hasher));
+            self.cur_spilled = false;
+            self.cur_len = 0;
+            return;
+        }
+        // Zero-pad the message's last block, stage its length, and flush once a
+        // full batch has accumulated. `max(1)` keeps an empty message as a single
+        // zeroed root block (= blake3("")).
+        let valid = self.cur_len.max(1).next_multiple_of(BLOCK_LEN);
+        let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
+        let lane_bytes: &mut [u8] = bytemuck::cast_slice_mut(
+            &mut self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)],
+        );
+        lane_bytes[self.cur_len..valid].fill(0);
+        self.batch_lens.push(self.cur_len);
+        self.cur_len = 0;
+        if self.batch_lens.len() == self.num_available_lanes {
+            self.flush();
+        }
+    }
+
+    /// Group-add the lattice hash of one whole `msg` into the running value:
+    /// [`add_part`] then [`finish_message`].
+    ///
+    /// [`add_part`]: Self::add_part
+    /// [`finish_message`]: Self::finish_message
+    pub fn add_message(&mut self, msg: &[u8]) {
+        self.add_part(msg);
+        self.finish_message();
+    }
+
+    /// Group-add a precomputed `LtHash` (e.g. one produced elsewhere, or another
+    /// accumulator's [`into_lt_hash`]) into the running value, without hashing any
+    /// message.
+    ///
+    /// [`into_lt_hash`]: Self::into_lt_hash
+    pub fn mix_in(&mut self, hash: &LtHash) {
+        self.acc.mix_in(hash);
+    }
+
+    /// Move the bytes buffered for the current message into `serial_hasher` and
+    /// mark it spilled — its message exceeds one chunk, so it can't be staged for
+    /// the SIMD batch. Called by [`add_part`](Self::add_part) on overflow.
+    fn spill_current(&mut self) {
+        self.serial_hasher.reset();
+        let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
+        let lane_bytes: &[u8] =
+            bytemuck::cast_slice(&self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)]);
+        self.serial_hasher.update(&lane_bytes[..self.cur_len]);
+        self.cur_spilled = true;
+    }
+
+    /// Run the staged messages into `acc`, then reset the stage. A full batch on
+    /// a SIMD backend goes through the vector kernel; anything else — no SIMD
+    /// backend, or a partial tail that doesn't fill every lane — falls back to the
+    /// `blake3` crate.
+    fn flush(&mut self) {
+        let count = self.batch_lens.len();
+        if let Some(simd) = self
+            .batch_mix_in_fn
+            .filter(|_| count == self.num_available_lanes)
+        {
+            let mut bufs: [&[u32]; MAX_LANES] = [&[][..]; MAX_LANES];
+            for (b, lane_buf) in bufs
+                .iter_mut()
+                .zip(self.batch_buffer.chunks_exact(NUM_CHUNK_WORDS))
+            {
+                *b = lane_buf;
+            }
+            // SAFETY: a SIMD backend exists only when its target feature was
+            // detected, and `filter` guarantees a full batch
+            // (`count == num_available_lanes == L::N`).
+            unsafe { simd(&bufs[..count], self.batch_lens.as_slice(), &mut self.acc) };
+        } else {
+            for (lane_buf, &len) in self
+                .batch_buffer
+                .chunks_exact(NUM_CHUNK_WORDS)
+                .zip(&self.batch_lens)
+            {
+                let bytes: &[u8] = bytemuck::cast_slice(lane_buf);
+                // Reset before each message: the shared hasher may be dirty from a
+                // prior message, flush, or `> CHUNK_LEN` add.
+                self.serial_hasher.reset();
+                self.serial_hasher.update(&bytes[..len]);
+                self.acc.mix_in(&LtHash::with(&self.serial_hasher));
+            }
+        }
+        self.batch_lens.clear();
+    }
+
+    /// Flush any staged remainder and return the accumulated lattice hash.
+    pub fn into_lt_hash(mut self) -> LtHash {
+        debug_assert!(
+            self.cur_len == 0 && !self.cur_spilled,
+            "into_lt_hash() called with an unfinish_messageted message in progress",
+        );
+        if !self.batch_lens.is_empty() {
+            self.flush();
+        }
+        self.acc
+    }
+}
+
+/// Test helpers shared by this module's tests and the backend tests in `arch`.
+#[cfg(test)]
+pub(super) mod test_util {
+    // Bounded index/offset math in test fixtures; overflow checks add no value.
+    #![allow(clippy::arithmetic_side_effects)]
+    use {
+        super::*,
+        rand::{Rng, RngCore, SeedableRng},
+        rand_chacha::ChaChaRng,
+    };
+
+    /// A deterministic (seeded) RNG, so a failing randomized test reproduces.
+    pub fn seeded_rng(seed: u64) -> ChaChaRng {
+        ChaChaRng::seed_from_u64(seed)
+    }
+
+    /// `n` messages of uniformly random length in `0..=max_len` filled with
+    /// random bytes.
+    pub fn random_messages(rng: &mut ChaChaRng, n: usize, max_len: usize) -> Vec<Vec<u8>> {
+        (0..n)
+            .map(|_| {
+                let mut m = vec![0u8; rng.random_range(0..=max_len)];
+                rng.fill_bytes(&mut m);
+                m
+            })
+            .collect()
+    }
+
+    /// Independent oracle: the lattice hash of `messages` via the `blake3` crate
+    /// — `LtHash::with` + `mix_in` over the batch, the same blake3 reference the
+    /// mix-in functions are checked against. Reuses one `Hasher`, resetting
+    /// between messages.
+    pub fn expected_lthash(messages: &[&[u8]]) -> LtHash {
+        let mut acc = LtHash::identity();
+        let mut hasher = blake3::Hasher::new();
+        for msg in messages {
+            hasher.reset();
+            hasher.update(msg);
+            acc.mix_in(&LtHash::with(&hasher));
+        }
+        acc
+    }
+
+    /// `n` deterministic messages of assorted single-chunk lengths (exercising
+    /// partial/exact/multi-block and the single-block and full-chunk boundaries).
+    pub fn make_messages(n: usize) -> Vec<Vec<u8>> {
+        let lens = [
+            0usize, 1, 5, 63, 64, 65, 127, 200, 273, 512, 700, 960, 1000, 1023, 1024, 333,
+        ];
+        (0..n)
+            .map(|j| {
+                let len = lens[j % lens.len()];
+                (0..len)
+                    .map(|i| (i.wrapping_mul(31).wrapping_add(j * 7)) as u8)
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Bounded index/offset math in test fixtures; overflow checks add no value.
+    #![allow(clippy::arithmetic_side_effects)]
+    use {
+        super::{test_util::*, *},
+        rand::{Rng, seq::SliceRandom},
+    };
+
+    /// Mix the lattice hash of every message in `messages` into `acc`.
+    fn accumulate(messages: &[&[u8]], acc: &mut LtHash) {
+        let mut a = Accumulator::new();
+        for &m in messages {
+            a.add_message(m);
+        }
+        acc.mix_in(&a.into_lt_hash());
+    }
+
+    /// Both entry points — one-shot `accumulate` and one-by-one streaming `add_message`
+    /// (whatever batch size this CPU picks, its partial tail, and the
+    /// `> CHUNK_LEN` fallback) — must equal the independent `blake3`-crate oracle.
+    fn assert_matches_oracle(msgs: &[Vec<u8>], ctx: &str) {
+        let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+        let expected = expected_lthash(&refs);
+
+        let mut one_shot = LtHash::identity();
+        accumulate(&refs, &mut one_shot);
+        assert_eq!(one_shot, expected, "one-shot accumulate [{ctx}]");
+
+        let mut streamed = Accumulator::new();
+        for r in &refs {
+            streamed.add_message(r);
+        }
+        assert_eq!(streamed.into_lt_hash(), expected, "streamed add [{ctx}]");
+    }
+
+    #[test]
+    fn accumulate_matches_oracle() {
+        // 35 messages: not a multiple of 8 or 16, with oversized ones that
+        // exercise the multi-chunk blake3 fallback.
+        let mut msgs = make_messages(35);
+        msgs[3] = (0..5000u32).map(|i| i as u8).collect(); // > CHUNK_LEN
+        msgs[30] = (0..1500u32).map(|i| (i * 3) as u8).collect(); // > CHUNK_LEN
+        assert_matches_oracle(&msgs, "fixed 35 + oversized");
+    }
+
+    /// Counts bracketing both the 8- and 16-lane batch boundaries, plus several
+    /// full batches followed by a partial tail.
+    #[test]
+    fn batch_size_boundaries() {
+        for count in [0usize, 1, 7, 8, 9, 15, 16, 17, 31, 32, 33, 48, 100] {
+            assert_matches_oracle(&make_messages(count), &format!("count={count}"));
+        }
+    }
+
+    /// Empty / degenerate and boundary-length inputs.
+    #[test]
+    fn edge_cases() {
+        assert_eq!(Accumulator::new().into_lt_hash(), LtHash::identity()); // no messages
+        assert_matches_oracle(&[vec![]], "one empty"); // = blake3("")
+        assert_matches_oracle(&vec![vec![]; 40], "40 empty"); // spanning batches
+
+        // Every block boundary and both sides of the single-chunk limit (1024),
+        // including multi-chunk sizes that take the blake3 fallback.
+        let lens = [
+            0usize, 1, 63, 64, 65, 127, 128, 129, 1023, 1024, 1025, 2047, 2048, 4096,
+        ];
+        let msgs: Vec<Vec<u8>> = lens
+            .iter()
+            .map(|&l| (0..l).map(|i| i as u8).collect())
+            .collect();
+        assert_matches_oracle(&msgs, "boundary lengths");
+    }
+
+    /// Feeding each message in parts via `add_part` + `finish_message` must equal the
+    /// oracle — including a message that overflows one chunk partway through its
+    /// parts (exercising the mid-stream spill).
+    #[test]
+    fn streaming_in_parts_matches_oracle() {
+        let mut msgs = make_messages(20);
+        msgs.push((0..3000u32).map(|i| i as u8).collect()); // > CHUNK_LEN
+        let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+
+        let mut streamed = Accumulator::new();
+        for m in &refs {
+            // Split into three parts so a chunk boundary (and the spill) can fall
+            // mid-message rather than only at an `add_part` that starts one.
+            let a = m.len() / 3;
+            let b = m.len() * 2 / 3;
+            streamed.add_part(&m[..a]);
+            streamed.add_part(&m[a..b]);
+            streamed.add_part(&m[b..]);
+            streamed.finish_message();
+        }
+        assert_eq!(streamed.into_lt_hash(), expected_lthash(&refs));
+    }
+
+    /// `mix_in` of a precomputed hash composes with added messages.
+    #[test]
+    fn mix_in_precomputed_hash() {
+        let msgs = make_messages(10);
+        let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+        let (head, tail) = refs.split_at(5);
+
+        let mut acc = Accumulator::new();
+        acc.mix_in(&expected_lthash(head)); // precomputed elsewhere
+        for m in tail {
+            acc.add_message(m);
+        }
+        assert_eq!(acc.into_lt_hash(), expected_lthash(&refs));
+    }
+
+    /// Many random batches — varied counts and lengths straddling the chunk limit
+    /// so both the SIMD batch path and the blake3 fallback run — bit-exact vs the
+    /// oracle.
+    #[test]
+    fn randomized_matches_oracle() {
+        let seed = rand::random::<u64>();
+        let mut rng = seeded_rng(seed);
+        for iter in 0..128 {
+            let n = rng.random_range(0..=40);
+            let msgs = random_messages(&mut rng, n, 1200);
+            assert_matches_oracle(&msgs, &format!("seed={seed:#018x} iter={iter}"));
+        }
+    }
+
+    /// Group-add is commutative, so the result must not depend on the order
+    /// messages are added, nor on how they align to batch boundaries.
+    #[test]
+    fn order_independent() {
+        let seed = rand::random::<u64>();
+        let mut rng = seeded_rng(seed);
+        let msgs = random_messages(&mut rng, 50, 1500);
+        let mut refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+
+        let mut base = LtHash::identity();
+        accumulate(&refs, &mut base);
+        for _ in 0..20 {
+            refs.shuffle(&mut rng);
+            let mut acc = LtHash::identity();
+            accumulate(&refs, &mut acc);
+            assert_eq!(acc, base, "order independence (seed={seed:#018x})");
+        }
+    }
+
+    /// Cross-check the `Accumulator` against the canonical `hello` LtHash vector
+    /// that pins down `LtHash::with` in `lt_hash.rs`.
+    #[test]
+    fn known_vector() {
+        let hello_head: [u16; 8] = [
+            0x8fea, 0x3d16, 0x86b3, 0x9282, 0x445e, 0xc591, 0x8de5, 0xb34b,
+        ];
+        let mut a = Accumulator::new();
+        a.add_message(b"hello");
+        assert_eq!(&a.into_lt_hash().0[..8], &hello_head);
+    }
+}

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -340,16 +340,26 @@ impl Accumulator {
         self.staging.clear();
     }
 
-    /// Flush any staged remainder and return the accumulated lattice hash.
-    pub fn into_lt_hash(mut self) -> LtHash {
+    /// Flush any staged remainder and return the accumulated lattice hash,
+    /// resetting the running value to [`LtHash::identity`] so the accumulator can
+    /// be reused (its SIMD staging buffers are retained). Unlike
+    /// [`into_lt_hash`](Self::into_lt_hash), this does not consume `self`.
+    pub fn take_lt_hash(&mut self) -> LtHash {
         debug_assert!(
             self.staging.cur_len() == 0 && !self.cur_spilled,
-            "into_lt_hash() called with an unfinished message in progress",
+            "take_lt_hash() called with an unfinished message in progress",
         );
         if !self.staging.is_empty() {
             self.flush();
         }
-        self.acc
+        core::mem::replace(&mut self.acc, LtHash::identity())
+    }
+
+    /// Flush any staged remainder and return the accumulated lattice hash,
+    /// consuming the accumulator. See [`take_lt_hash`](Self::take_lt_hash) to drain
+    /// a reusable accumulator behind a `&mut` instead.
+    pub fn into_lt_hash(mut self) -> LtHash {
+        self.take_lt_hash()
     }
 }
 

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -176,8 +176,8 @@ type BatchMixInFn = unsafe fn(batch: Batch<'_>, acc: &mut LtHash);
 
 /// Streaming accumulator for the lattice hash of many messages.
 ///
-/// Feed each message either whole with [`add_message`](Self::add_message), or in parts with
-/// [`add_part`](Self::add_part) + [`finish_message`](Self::finish_message); each is group-added
+/// Feed each message either whole with [`add_message`](Self::add_message), or in
+/// parts with [`start_message`](Self::start_message); each is group-added
 /// (LtHash `mix_in`) into the running value. Small messages (`<= CHUNK_LEN`) are
 /// copied into owned, reusable staging and run through the widest SIMD mix-in
 /// function the CPU supports as soon as a full batch (`lanes` of them) accumulates; larger
@@ -202,7 +202,7 @@ pub struct Accumulator {
     serial_hasher: blake3::Hasher,
     /// Set when the in-progress message overflowed one chunk and is being
     /// streamed into `serial_hasher` rather than staged for the SIMD batch;
-    /// carries that state across the message's remaining `add_part`s until `finish_message`.
+    /// carries that state across the message's remaining parts until it is committed.
     cur_spilled: bool,
 }
 
@@ -246,52 +246,54 @@ impl Accumulator {
         }
     }
 
-    /// Append `bytes` to the message currently being built; call [`finish_message`] to
-    /// finish it. Feeding a message in parts lets the caller avoid assembling a
-    /// contiguous buffer — the parts are written straight into the SIMD lane
-    /// buffer, or, once a message passes [`CHUNK_LEN`], streamed into the `blake3`
-    /// fallback.
-    ///
-    /// [`finish_message`]: Self::finish_message
-    pub fn add_part(&mut self, bytes: &[u8]) {
+    /// Group-add the lattice hash of one whole `msg` into the running value. To
+    /// supply a message in pieces instead, use [`start_message`](Self::start_message).
+    pub fn add_message(&mut self, msg: &[u8]) {
+        self.stage_part(msg);
+        self.commit_message();
+    }
+
+    /// Begin a message assembled from parts, borrowing the accumulator until the
+    /// returned [`MessageBuilder`] is finished. Feed each piece with
+    /// [`add_part`](MessageBuilder::add_part) and commit with
+    /// [`finish`](MessageBuilder::finish); the exclusive borrow keeps any other
+    /// accumulator operation from interleaving mid-message.
+    pub fn start_message(&mut self) -> MessageBuilder<'_> {
+        MessageBuilder { acc: self }
+    }
+
+    /// Append `bytes` to the message currently being staged: written straight into
+    /// the SIMD lane buffer, or, once the message passes [`CHUNK_LEN`], streamed
+    /// into the `blake3` fallback (`commit_message` folds in the result).
+    fn stage_part(&mut self, bytes: &[u8]) {
         if self.cur_spilled {
             self.serial_hasher.update(bytes);
             return;
         }
-        // Stage into the current lane unless the message overflows one chunk; then
-        // hand the bytes buffered so far, plus `bytes`, to the serial blake3 hasher
-        // (`finish_message` folds in the result).
         if !self.staging.try_append(bytes) {
             self.spill_current();
             self.serial_hasher.update(bytes);
         }
     }
 
-    /// Finish the message built by [`add_part`], fold its lattice hash into the
-    /// running value, and start a fresh message.
-    ///
-    /// [`add_part`]: Self::add_part
-    pub fn finish_message(&mut self) {
+    /// Commit the staged message — group-add its lattice hash into the running
+    /// value and start a fresh message, flushing the SIMD batch once it fills.
+    fn commit_message(&mut self) {
         if self.cur_spilled {
             self.acc.mix_in(&LtHash::with(&self.serial_hasher));
             self.cur_spilled = false;
             return;
         }
-        // Commit the message (zero-pads its last compression block, stages the
-        // length) and flush once the batch is full.
         if self.staging.finish_current() {
             self.flush();
         }
     }
 
-    /// Group-add the lattice hash of one whole `msg` into the running value:
-    /// [`add_part`] then [`finish_message`].
-    ///
-    /// [`add_part`]: Self::add_part
-    /// [`finish_message`]: Self::finish_message
-    pub fn add_message(&mut self, msg: &[u8]) {
-        self.add_part(msg);
-        self.finish_message();
+    /// Abandon the in-progress message's staged bytes without folding it in, so the
+    /// next message starts clean — for an unfinished [`MessageBuilder`] on drop.
+    fn discard_message(&mut self) {
+        self.staging.discard_current();
+        self.cur_spilled = false;
     }
 
     /// Group-add a precomputed `LtHash` (e.g. one produced elsewhere, or another
@@ -305,7 +307,7 @@ impl Accumulator {
 
     /// Move the bytes buffered for the current message into `serial_hasher` and
     /// mark it spilled — its message exceeds one chunk, so it can't be staged for
-    /// the SIMD batch. Called by [`add_part`](Self::add_part) on overflow.
+    /// the SIMD batch. Called by [`stage_part`](Self::stage_part) on overflow.
     fn spill_current(&mut self) {
         self.serial_hasher.reset();
         self.serial_hasher.update(self.staging.staged_bytes());
@@ -360,6 +362,39 @@ impl Accumulator {
     /// a reusable accumulator behind a `&mut` instead.
     pub fn into_lt_hash(mut self) -> LtHash {
         self.take_lt_hash()
+    }
+}
+
+/// A message being assembled part-by-part, returned by
+/// [`Accumulator::start_message`]. Holds an exclusive borrow of the accumulator,
+/// so no other accumulator operation can run until this message is finished. Feed
+/// pieces with [`add_part`](Self::add_part), then [`finish`](Self::finish) to
+/// commit; dropping the builder without finishing discards the staged bytes.
+#[must_use = "a started message does nothing until `.finish()`; dropping it discards the message"]
+pub struct MessageBuilder<'a> {
+    acc: &'a mut Accumulator,
+}
+
+impl MessageBuilder<'_> {
+    /// Append `bytes` to the message being built.
+    pub fn add_part(&mut self, bytes: &[u8]) -> &mut Self {
+        self.acc.stage_part(bytes);
+        self
+    }
+
+    /// Commit the message: group-add its lattice hash into the accumulator's
+    /// running value.
+    pub fn finish(self) {
+        self.acc.commit_message();
+        // Committed — skip the discarding `Drop`.
+        core::mem::forget(self);
+    }
+}
+
+impl Drop for MessageBuilder<'_> {
+    fn drop(&mut self) {
+        // Unfinished: abandon the staged bytes so the next message starts clean.
+        self.acc.discard_message();
     }
 }
 
@@ -497,9 +532,9 @@ mod tests {
         assert_matches_oracle(&msgs, "boundary lengths");
     }
 
-    /// Feeding each message in parts via `add_part` + `finish_message` must equal the
-    /// oracle — including a message that overflows one chunk partway through its
-    /// parts (exercising the mid-stream spill).
+    /// Feeding each message in parts via [`Accumulator::start_message`] must equal
+    /// the oracle — including a message that overflows one chunk partway through
+    /// its parts (exercising the mid-stream spill).
     #[test]
     fn streaming_in_parts_matches_oracle() {
         let mut msgs = make_messages(20);
@@ -512,12 +547,35 @@ mod tests {
             // mid-message rather than only at an `add_part` that starts one.
             let a = m.len() / 3;
             let b = m.len() * 2 / 3;
-            streamed.add_part(&m[..a]);
-            streamed.add_part(&m[a..b]);
-            streamed.add_part(&m[b..]);
-            streamed.finish_message();
+            let mut msg = streamed.start_message();
+            msg.add_part(&m[..a]);
+            msg.add_part(&m[a..b]);
+            msg.add_part(&m[b..]);
+            msg.finish();
         }
         assert_eq!(streamed.into_lt_hash(), expected_lthash(&refs));
+    }
+
+    /// Dropping a builder without `finish` discards its staged bytes, for both the
+    /// staged (`<= CHUNK_LEN`) and spilled (`> CHUNK_LEN`) in-progress states.
+    #[test]
+    fn builder_drop_discards_unfinished() {
+        let msg = b"the message that is actually committed".as_slice();
+
+        let mut acc = Accumulator::new();
+        {
+            let mut abandoned = acc.start_message();
+            abandoned.add_part(b"staged but");
+            abandoned.add_part(b" never finished");
+        } // dropped without `finish` — nothing folded in
+        {
+            let mut spilled = acc.start_message();
+            spilled.add_part(&vec![7u8; CHUNK_LEN + 500]); // overflows → serial spill
+            spilled.add_part(b"more");
+        } // dropped mid-spill — must reset `cur_spilled` too
+        acc.add_message(msg);
+
+        assert_eq!(acc.into_lt_hash(), expected_lthash(&[msg]));
     }
 
     /// `mix_in` of a precomputed hash composes with added messages.

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -19,14 +19,15 @@
 #[cfg(target_arch = "x86_64")]
 mod arch;
 
-use crate::lt_hash::LtHash;
+use {
+    crate::lt_hash::LtHash,
+    blake3::{BLOCK_LEN, CHUNK_LEN},
+};
 
-/// Max input bytes that map to a single BLAKE3 chunk — the batch path. Larger
-/// messages need the full Merkle tree and take the `blake3`-crate fallback.
-const CHUNK_LEN: usize = 1024;
-/// Bytes in one BLAKE3 compression block.
-const BLOCK_LEN: usize = 64;
 /// `u32` words in one chunk-sized lane buffer (`CHUNK_LEN / 4` = 256).
+/// `CHUNK_LEN` (1024) is the max input that maps to a single BLAKE3 chunk — the
+/// batch path; larger messages need the full Merkle tree and take the
+/// `blake3`-crate fallback.
 const NUM_CHUNK_WORDS: usize = CHUNK_LEN / 4;
 /// Widest SIMD lane count (AVX512 width) = max messages staged per batch.
 const MAX_LANES: usize = 16;
@@ -171,9 +172,10 @@ impl Accumulator {
             self.cur_len = 0;
             return;
         }
-        // Zero-pad the message's last block, stage its length, and flush once a
-        // full batch has accumulated. `max(1)` keeps an empty message as a single
-        // zeroed root block (= blake3("")).
+        // Zero-pad the message's last block (`BLOCK_LEN` = 64, one BLAKE3
+        // compression block), stage its length, and flush once a full batch has
+        // accumulated. `max(1)` keeps an empty message as a single zeroed root
+        // block (= blake3("")).
         let valid = self.cur_len.max(1).next_multiple_of(BLOCK_LEN);
         let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
         let lane_bytes: &mut [u8] = bytemuck::cast_slice_mut(

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -2,10 +2,10 @@
 //!
 //! Background: agave's accounts lattice hash computes, for every account, a
 //! 2048-byte BLAKE3 XOF and folds it (16-bit wrapping group-add) into a running
-//! [`crate::lt_hash::LtHash`].  Done one account at a time (the `blake3` crate's
-//! `into_lt_hash_xof`), the single-chunk input compression of a small account wastes
-//! all but one SIMD lane, and every account round-trips a 2048-byte buffer
-//! through memory plus a scalar `mix_in` loop.
+//! [`crate::lt_hash::LtHash`].  Done one account at a time (via [`LtHash::with`],
+//! which finalizes blake3's XOF), the single-chunk input compression of a small
+//! account wastes all but one SIMD lane, and every account round-trips a
+//! 2048-byte buffer through memory plus a scalar `mix_in` loop.
 //!
 //! Firedancer's `fd_blake3_lthash_batch{8,16}` instead hash N independent
 //! messages (one per SIMD lane, each <= 1 chunk), expand each to 2048 bytes, and
@@ -14,7 +14,7 @@
 //! Layout:
 //!  - `arch`: stable `core::arch` SIMD backends (AVX2 = 8 lanes, AVX512 = 16),
 //!  - here: runtime dispatch, the non-SIMD `blake3`-crate fallback, and the
-//!    public [`Accumulator`]/[`accumulate`] API.
+//!    public [`Accumulator`] API.
 
 #[cfg(target_arch = "x86_64")]
 mod arch;

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -32,16 +32,147 @@ const NUM_CHUNK_WORDS: usize = CHUNK_LEN / 4;
 /// Widest SIMD lane count (AVX512 width) = max messages staged per batch.
 const MAX_LANES: usize = 16;
 
-/// A batched [`LtHash::mix_in`]: group-adds the XOF of exactly `bufs.len()`
-/// messages into `acc`, reading each lane in place from `bufs[l]` (a `u32`
-/// buffer zero-padded to its block boundary) of real byte length `lens[l]`.
+/// One lane's staging buffer: a whole BLAKE3 chunk of `u32` words, zero-padded
+/// past the message. Fixed size so a batch of them is contiguous, fixed-stride
+/// storage the SIMD kernel can read in place.
+type LaneBuf = [u32; NUM_CHUNK_WORDS];
+
+/// A read-only, matched view of one full-or-partial batch's staged lanes: for
+/// each `l < len()`, `lanes[l]` is a zero-padded chunk buffer holding a message
+/// of real byte length `lengths[l]` (`<= CHUNK_LEN`). `lanes.len() ==
+/// lengths.len()`. Produced by [`Staging::batch`], consumed by the mix-in
+/// functions and the `blake3` fallback in [`Accumulator::flush`].
+#[derive(Clone, Copy)]
+struct Batch<'a> {
+    lanes: &'a [LaneBuf],
+    lengths: &'a [usize],
+}
+
+impl Batch<'_> {
+    fn len(&self) -> usize {
+        self.lanes.len()
+    }
+}
+
+/// The staged lanes of one pending batch and their metadata, kept together so the
+/// invariants the SIMD kernel relies on live in one place: one fixed-size buffer
+/// per lane, each committed message zero-padded through its final compression
+/// block and no longer than `CHUNK_LEN`, and `count` completed lanes whose
+/// `lengths` line up exactly. `count == lanes.len()` means the batch is full.
+struct Staging {
+    /// `num_available_lanes` contiguous, fixed-stride lane buffers.
+    lanes: Box<[LaneBuf]>,
+    /// Real byte length of each committed lane; only `lengths[..count]` is valid.
+    lengths: [usize; MAX_LANES],
+    /// Number of committed messages staged so far (the in-progress one is lane `count`).
+    count: usize,
+    /// Bytes written into the in-progress lane (`lanes[count]`) so far — the
+    /// current message's length before `finish_current`. `0` between messages.
+    cur_len: usize,
+}
+
+impl Staging {
+    fn new(num_available_lanes: usize) -> Self {
+        Self {
+            lanes: vec![[0u32; NUM_CHUNK_WORDS]; num_available_lanes].into_boxed_slice(),
+            lengths: [0; MAX_LANES],
+            count: 0,
+            cur_len: 0,
+        }
+    }
+
+    /// The in-progress (not yet committed) lane's buffer, as bytes.
+    fn current_lane(&self) -> &[u8] {
+        bytemuck::cast_slice(self.lanes[self.count].as_slice())
+    }
+
+    /// The in-progress lane's buffer, as writable bytes.
+    fn current_lane_mut(&mut self) -> &mut [u8] {
+        bytemuck::cast_slice_mut(self.lanes[self.count].as_mut_slice())
+    }
+
+    /// Bytes staged for the in-progress message so far (`0` between messages).
+    fn cur_len(&self) -> usize {
+        self.cur_len
+    }
+
+    /// The in-progress message's staged bytes.
+    fn staged_bytes(&self) -> &[u8] {
+        &self.current_lane()[..self.cur_len]
+    }
+
+    /// Append `bytes` to the in-progress lane, advancing the cursor; returns
+    /// `false` (writing nothing) if they wouldn't fit one chunk, so the caller can
+    /// route the message to the `blake3` fallback instead.
+    fn try_append(&mut self, bytes: &[u8]) -> bool {
+        // `saturating_add` so a huge `bytes` can't wrap the bound check.
+        let end = self.cur_len.saturating_add(bytes.len());
+        if end > CHUNK_LEN {
+            return false;
+        }
+        let start = self.cur_len;
+        self.current_lane_mut()[start..end].copy_from_slice(bytes);
+        self.cur_len = end;
+        true
+    }
+
+    /// Abandon the in-progress message's staged bytes — it spilled to the `blake3`
+    /// fallback — leaving the lane free for the next message.
+    fn discard_current(&mut self) {
+        self.cur_len = 0;
+    }
+
+    /// Zero-pad the in-progress message's final compression block, commit it, and
+    /// report whether the batch is now full. `max(1)` keeps an empty message as a
+    /// single zeroed root block (= blake3("")).
+    fn finish_current(&mut self) -> bool {
+        let len = self.cur_len;
+        let valid = len.max(1).next_multiple_of(BLOCK_LEN);
+        self.current_lane_mut()[len..valid].fill(0);
+        self.lengths[self.count] = len;
+        self.count = self.count.wrapping_add(1);
+        self.cur_len = 0;
+        self.count == self.lanes.len()
+    }
+
+    /// A matched view of the `count` completed lanes and their lengths.
+    fn batch(&self) -> Batch<'_> {
+        Batch {
+            lanes: &self.lanes[..self.count],
+            lengths: &self.lengths[..self.count],
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    fn clear(&mut self) {
+        self.count = 0;
+    }
+}
+
+impl core::fmt::Debug for Staging {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Omit the large lane buffers; the committed lengths are the useful state.
+        let lengths = &self.lengths[..self.count];
+        f.debug_struct("Staging")
+            .field("count", &self.count)
+            .field("lengths", &lengths)
+            .field("cur_len", &self.cur_len)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A batched [`LtHash::mix_in`]: group-adds the XOF of every message in `batch`
+/// into `acc`, reading each lane in place from its zero-padded buffer.
 /// Implemented by the SIMD backends in [`arch`]; the non-SIMD path hashes via the
 /// `blake3` crate directly (see [`Accumulator::flush`]).
 ///
 /// # Safety
 /// Caller must ensure the backend's target feature is available and uphold the
 /// buffer contract documented on `arch`'s `compress_batch`.
-type BatchMixInFn = unsafe fn(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash);
+type BatchMixInFn = unsafe fn(batch: Batch<'_>, acc: &mut LtHash);
 
 /// Streaming accumulator for the lattice hash of many messages.
 ///
@@ -59,13 +190,8 @@ type BatchMixInFn = unsafe fn(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash)
 pub struct Accumulator {
     /// The lattice hash being built; the mix-in functions group-add into its raw elements.
     acc: LtHash,
-    /// One contiguous allocation for all `num_available_lanes` lane buffers; lane
-    /// `l` occupies the sub-buffer `batch_buffer[l*NUM_CHUNK_WORDS .. (l+1)*NUM_CHUNK_WORDS]`,
-    /// zero-padded past its message.
-    batch_buffer: Box<[u32]>,
-    /// Real byte length of each pending message.
-    /// `batch_lens.len()` is the pending count; capacity is fixed at `num_available_lanes`.
-    batch_lens: Vec<usize>,
+    /// The pending batch's staged lane buffers and their metadata.
+    staging: Staging,
     /// Messages per full batch = SIMD lane count of the selected backend (1 when
     /// there is no SIMD backend). A batch flushes once this many messages are staged.
     num_available_lanes: usize,
@@ -74,9 +200,6 @@ pub struct Accumulator {
     /// Serial blake3-crate hasher: the fallback for a message that overflows one
     /// chunk (`> CHUNK_LEN`) and for the non-SIMD / partial-tail path in `flush`.
     serial_hasher: blake3::Hasher,
-    /// Bytes written into the in-progress message's lane buffer by `add_part` so
-    /// far, i.e. its length before `finish_message`. `0` when no message is in progress.
-    cur_len: usize,
     /// Set when the in-progress message overflowed one chunk and is being
     /// streamed into `serial_hasher` rather than staged for the SIMD batch;
     /// carries that state across the message's remaining `add_part`s until `finish_message`.
@@ -84,13 +207,12 @@ pub struct Accumulator {
 }
 
 impl core::fmt::Debug for Accumulator {
-    // Omits the large lane `batch_buffer` scratch (and the opaque hasher / fn ptr).
+    // Omits the opaque hasher / fn ptr; `Staging`'s own `Debug` drops its buffers.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Accumulator")
             .field("acc", &self.acc)
             .field("num_available_lanes", &self.num_available_lanes)
-            .field("batch_lens", &self.batch_lens)
-            .field("cur_len", &self.cur_len)
+            .field("staging", &self.staging)
             .field("cur_spilled", &self.cur_spilled)
             .finish_non_exhaustive()
     }
@@ -114,18 +236,12 @@ impl Accumulator {
             (1, None)
         }
         let (num_available_lanes, batch_mix_in_fn) = select_mix_in_fn();
-        // usize needs to be `<= 16 * 256`
-        let batch_words = num_available_lanes
-            .checked_mul(NUM_CHUNK_WORDS)
-            .expect("batch buffer word count fits usize");
         Self {
             acc: LtHash::identity(),
-            batch_buffer: vec![0u32; batch_words].into_boxed_slice(),
-            batch_lens: Vec::with_capacity(num_available_lanes),
+            staging: Staging::new(num_available_lanes),
             num_available_lanes,
             batch_mix_in_fn,
             serial_hasher: blake3::Hasher::new(),
-            cur_len: 0,
             cur_spilled: false,
         }
     }
@@ -142,20 +258,10 @@ impl Accumulator {
             self.serial_hasher.update(bytes);
             return;
         }
-        // `saturating_add` so a huge `bytes` can't wrap the bound check; then this
-        // message is simply routed to the fallback below.
-        let end = self.cur_len.saturating_add(bytes.len());
-        if end <= CHUNK_LEN {
-            // Fits one chunk: write straight into the current lane buffer.
-            let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
-            let lane_bytes: &mut [u8] = bytemuck::cast_slice_mut(
-                &mut self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)],
-            );
-            lane_bytes[self.cur_len..end].copy_from_slice(bytes);
-            self.cur_len = end;
-        } else {
-            // Overflows one chunk: hand the bytes buffered so far, plus `bytes`, to
-            // the serial blake3 hasher; `finish_message` folds in the result.
+        // Stage into the current lane unless the message overflows one chunk; then
+        // hand the bytes buffered so far, plus `bytes`, to the serial blake3 hasher
+        // (`finish_message` folds in the result).
+        if !self.staging.try_append(bytes) {
             self.spill_current();
             self.serial_hasher.update(bytes);
         }
@@ -169,22 +275,11 @@ impl Accumulator {
         if self.cur_spilled {
             self.acc.mix_in(&LtHash::with(&self.serial_hasher));
             self.cur_spilled = false;
-            self.cur_len = 0;
             return;
         }
-        // Zero-pad the message's last block (`BLOCK_LEN` = 64, one BLAKE3
-        // compression block), stage its length, and flush once a full batch has
-        // accumulated. `max(1)` keeps an empty message as a single zeroed root
-        // block (= blake3("")).
-        let valid = self.cur_len.max(1).next_multiple_of(BLOCK_LEN);
-        let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
-        let lane_bytes: &mut [u8] = bytemuck::cast_slice_mut(
-            &mut self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)],
-        );
-        lane_bytes[self.cur_len..valid].fill(0);
-        self.batch_lens.push(self.cur_len);
-        self.cur_len = 0;
-        if self.batch_lens.len() == self.num_available_lanes {
+        // Commit the message (zero-pads its last compression block, stages the
+        // length) and flush once the batch is full.
+        if self.staging.finish_current() {
             self.flush();
         }
     }
@@ -213,10 +308,8 @@ impl Accumulator {
     /// the SIMD batch. Called by [`add_part`](Self::add_part) on overflow.
     fn spill_current(&mut self) {
         self.serial_hasher.reset();
-        let start = self.batch_lens.len().wrapping_mul(NUM_CHUNK_WORDS);
-        let lane_bytes: &[u8] =
-            bytemuck::cast_slice(&self.batch_buffer[start..start.wrapping_add(NUM_CHUNK_WORDS)]);
-        self.serial_hasher.update(&lane_bytes[..self.cur_len]);
+        self.serial_hasher.update(self.staging.staged_bytes());
+        self.staging.discard_current();
         self.cur_spilled = true;
     }
 
@@ -225,29 +318,18 @@ impl Accumulator {
     /// backend, or a partial tail that doesn't fill every lane — falls back to the
     /// `blake3` crate.
     fn flush(&mut self) {
-        let count = self.batch_lens.len();
+        let batch = self.staging.batch();
         if let Some(simd) = self
             .batch_mix_in_fn
-            .filter(|_| count == self.num_available_lanes)
+            .filter(|_| batch.len() == self.num_available_lanes)
         {
-            let mut bufs: [&[u32]; MAX_LANES] = [&[][..]; MAX_LANES];
-            for (b, lane_buf) in bufs
-                .iter_mut()
-                .zip(self.batch_buffer.chunks_exact(NUM_CHUNK_WORDS))
-            {
-                *b = lane_buf;
-            }
             // SAFETY: a SIMD backend exists only when its target feature was
             // detected, and `filter` guarantees a full batch
-            // (`count == num_available_lanes == L::N`).
-            unsafe { simd(&bufs[..count], self.batch_lens.as_slice(), &mut self.acc) };
+            // (`batch.len() == num_available_lanes == L::N`).
+            unsafe { simd(batch, &mut self.acc) };
         } else {
-            for (lane_buf, &len) in self
-                .batch_buffer
-                .chunks_exact(NUM_CHUNK_WORDS)
-                .zip(&self.batch_lens)
-            {
-                let bytes: &[u8] = bytemuck::cast_slice(lane_buf);
+            for (lane, &len) in batch.lanes.iter().zip(batch.lengths) {
+                let bytes: &[u8] = bytemuck::cast_slice(lane.as_slice());
                 // Reset before each message: the shared hasher may be dirty from a
                 // prior message, flush, or `> CHUNK_LEN` add.
                 self.serial_hasher.reset();
@@ -255,16 +337,16 @@ impl Accumulator {
                 self.acc.mix_in(&LtHash::with(&self.serial_hasher));
             }
         }
-        self.batch_lens.clear();
+        self.staging.clear();
     }
 
     /// Flush any staged remainder and return the accumulated lattice hash.
     pub fn into_lt_hash(mut self) -> LtHash {
         debug_assert!(
-            self.cur_len == 0 && !self.cur_spilled,
-            "into_lt_hash() called with an unfinish_messageted message in progress",
+            self.staging.cur_len() == 0 && !self.cur_spilled,
+            "into_lt_hash() called with an unfinished message in progress",
         );
-        if !self.batch_lens.is_empty() {
+        if !self.staging.is_empty() {
             self.flush();
         }
         self.acc

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -1,0 +1,686 @@
+//! Stable `core::arch` SIMD backends for the batched BLAKE3 lattice-hash kernel.
+//!
+//! Provenance: the overall structure is ported from firedancer's batched BLAKE3
+//! (`src/ballet/blake3`). The across-lanes input compression with per-lane length
+//! masking mirrors `fd_blake3_avx512_compress16` + `fd_blake3_fini_xof_compress`,
+//! and the 2048-byte XOF expansion mirrors `fd_blake3_fini_2048` (32 root-block
+//! compressions with an incrementing counter). Fusing all lanes' group-add into
+//! one `LtHash` is firedancer's `fd_blake3_lthash_batch{8,16}` idea (`fd_blake3.c`).
+//! The BLAKE3 compression itself (`compress_pre`, `g`, `round`, the message
+//! schedule) mirrors the upstream `blake3` crate's portable reference
+//! (`src/portable.rs`), and the per-lane vector ops behind [`Lanes`] mirror
+//! firedancer's `wu_`/`wwu_` SIMD wrappers (`src/util/simd`).
+//!
+//! Two pieces are ours, in neither source: the [`Lanes`] trait, which lets one
+//! generic kernel body serve both AVX2 and AVX512, and the in-register SWAR `u16`
+//! reduction ([`swar_add_u16`]) — firedancer's `fd_lthash_add` group-adds with a
+//! scalar element loop, not in vectors.
+//!
+//! The per-lane vector ops are abstracted behind the [`Lanes`] trait; the kernel
+//! body (input-compress phase, XOF phase, transpose-load, SWAR-u16 reduce) is
+//! written once, generic over `Lanes`.  Backends: AVX2 (`__m256i`, 8 lanes) and
+//! AVX512 (`__m512i`, 16 lanes).
+//!
+//! Each backend is checked against the `blake3` crate in this module's `tests`
+//! (whichever backends the test CPU supports).
+#![cfg(target_arch = "x86_64")]
+// A hash kernel: the arithmetic is intentional (wrapping hash adds) or bounded
+// index/offset math, not a place where overflow checks add value, as poh/xdp do.
+#![allow(clippy::arithmetic_side_effects)]
+
+use {
+    super::{BLOCK_LEN, MAX_LANES},
+    crate::lt_hash::LtHash,
+    core::arch::x86_64::*,
+};
+
+// BLAKE3 protocol constants used only by this SIMD kernel. Defined here (rather
+// than in the always-compiled parent) so they don't become dead code on targets
+// without an x86 backend.
+/// Bytes of XOF output per message: exactly one `LtHash` (1024 little-endian u16).
+const XOF_LEN: usize = size_of::<LtHash>();
+/// Compression blocks needed to fill one XOF output (`XOF_LEN / BLOCK_LEN` = 32).
+const NUM_XOF_BLOCKS: usize = XOF_LEN / BLOCK_LEN;
+/// `u32` words in one 64-byte BLAKE3 block / compression state (`BLOCK_LEN / 4` = 16).
+const NUM_BLOCK_WORDS: usize = BLOCK_LEN / size_of::<u32>();
+/// `u32` words in a BLAKE3 chaining value — the IV length and half the 16-word
+/// state (256 bits = 8).
+const NUM_CV_WORDS: usize = 8;
+
+// BLAKE3 domain-separation flags.
+const CHUNK_START: u32 = 1 << 0;
+const CHUNK_END: u32 = 1 << 1;
+const ROOT: u32 = 1 << 3;
+
+/// BLAKE3 initialization vector.
+const IV: [u32; NUM_CV_WORDS] = [
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+/// BLAKE3 7-round message word permutation schedule (standard, matches
+/// firedancer's `FD_BLAKE3_MSG_SCHEDULE` and the upstream reference).
+const MSG_SCHEDULE: [[usize; NUM_BLOCK_WORDS]; 7] = [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8],
+    [3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1],
+    [10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6],
+    [12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4],
+    [9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7],
+    [11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13],
+];
+
+/// A vector of `N` parallel `u32` lanes (one per message), abstracting the
+/// per-lane ops that firedancer spells out per backend in its `wu_` (AVX2) and
+/// `wwu_` (AVX512) SIMD wrappers.  All methods are `#[target_feature]`-free here
+/// and `#[inline(always)]`; they become legal + vectorized once monomorphized
+/// inside a `#[target_feature]` wrapper.
+///
+/// # Safety
+/// Implementors use SIMD intrinsics; every method must only be called from a
+/// context where this backend's target feature is enabled (the runtime-detected
+/// `run_*` wrappers guarantee this).
+#[allow(clippy::missing_safety_doc)]
+pub trait Lanes: Copy {
+    /// Number of lanes (8 for AVX2, 16 for AVX512).
+    const N: usize;
+    /// Per-lane "active" selector used to blend the chaining value.
+    type Mask: Copy;
+
+    /// Broadcast one `u32` into all `N` lanes (every lane gets `x`).
+    unsafe fn splat(x: u32) -> Self;
+    /// Load `N` contiguous `u32` from `p`.
+    unsafe fn load(p: *const u32) -> Self;
+    /// Store `N` contiguous `u32` to `p`.
+    unsafe fn store(self, p: *mut u32);
+    unsafe fn add(self, o: Self) -> Self;
+    unsafe fn xor(self, o: Self) -> Self;
+    unsafe fn and(self, o: Self) -> Self;
+    /// Rotate each lane right by `R` bits (`R` in {16,12,8,7}).
+    unsafe fn ror<const R: u32>(self) -> Self;
+    /// Build a mask from per-lane active flags (`active.len() == N`).
+    unsafe fn mask(active: &[bool]) -> Self::Mask;
+    /// Per lane: `if_active` where the mask is set, else `if_inactive`.
+    unsafe fn select(m: Self::Mask, if_active: Self, if_inactive: Self) -> Self;
+    /// In-place `N x N` element transpose of `io` (`io.len() == N`).
+    unsafe fn transpose(io: &mut [Self]);
+}
+
+/// Vectorized BLAKE3 quarter-round `g` and full `round`, identical in structure
+/// to the `blake3` crate's `g`/`round` (`src/portable.rs`) and firedancer's
+/// `round_fn{8,16}` — only the element type differs (a `Lanes` vector instead of
+/// a scalar `u32`).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+unsafe fn g<L: Lanes>(
+    v: &mut [L; NUM_BLOCK_WORDS],
+    a: usize,
+    b: usize,
+    c: usize,
+    d: usize,
+    mx: L,
+    my: L,
+) {
+    unsafe {
+        v[a] = v[a].add(v[b]).add(mx);
+        v[d] = v[d].xor(v[a]).ror::<16>();
+        v[c] = v[c].add(v[d]);
+        v[b] = v[b].xor(v[c]).ror::<12>();
+        v[a] = v[a].add(v[b]).add(my);
+        v[d] = v[d].xor(v[a]).ror::<8>();
+        v[c] = v[c].add(v[d]);
+        v[b] = v[b].xor(v[c]).ror::<7>();
+    }
+}
+
+#[inline(always)]
+unsafe fn round<L: Lanes>(v: &mut [L; NUM_BLOCK_WORDS], m: &[L; NUM_BLOCK_WORDS], r: usize) {
+    let s = &MSG_SCHEDULE[r];
+    unsafe {
+        g(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+        g(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+        g(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+        g(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+        g(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+        g(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+        g(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+        g(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
+    }
+}
+
+/// SWAR add of two lane-vectors as independent wrapping `u16` fields:
+/// `(a & 0x7fff7fff) + (b & 0x7fff7fff)) ^ ((a ^ b) & 0x80008000)` — sum the low
+/// 15 bits of each `u16` without carrying across the 16-bit boundary, then patch
+/// the top bit back in via xor. New code (our vectorized LtHash group-add);
+/// firedancer's `fd_lthash_add` (`fd_lthash.h`) instead loops over the 1024
+/// elements with scalar `u16` adds.
+#[inline(always)]
+unsafe fn swar_add_u16<L: Lanes>(a: L, b: L) -> L {
+    unsafe {
+        let lo = L::splat(0x7fff_7fff);
+        let hi = L::splat(0x8000_8000);
+        a.and(lo).add(b.and(lo)).xor(a.xor(b).and(hi))
+    }
+}
+
+/// Build the 16-word BLAKE3 state `[cv, IV[0..4], counter_lo, counter_hi,
+/// block_len, flags]` and run the 7 rounds, returning the post-round state `v`
+/// *before* the feed-forward. The vector analogue of the `blake3` crate's
+/// `compress_pre` (`src/portable.rs`); callers apply the feed-forward themselves
+/// — the low 8 words for a chaining value (blake3's `compress_in_place`) or all
+/// 16 for XOF output (blake3's `compress_xof`).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+unsafe fn compress_pre<L: Lanes>(
+    cv: &[L; NUM_CV_WORDS],
+    iv: &[L; NUM_CV_WORDS],
+    m: &[L; NUM_BLOCK_WORDS],
+    counter_lo: L,
+    counter_hi: L,
+    block_len: L,
+    flags: L,
+) -> [L; NUM_BLOCK_WORDS] {
+    let mut v: [L; NUM_BLOCK_WORDS] = [
+        cv[0], cv[1], cv[2], cv[3], cv[4], cv[5], cv[6], cv[7], iv[0], iv[1], iv[2], iv[3],
+        counter_lo, counter_hi, block_len, flags,
+    ];
+    unsafe {
+        for r in 0..7 {
+            round(&mut v, m, r);
+        }
+    }
+    v
+}
+
+/// Fused batch of `L::N` messages: hash each to a 2048-byte XOF and group-add
+/// (wrapping `u16`) all of them into `acc`. Reads each lane's message in place
+/// from a caller-owned, zero-padded buffer (no copy / staging here). The Rust
+/// analogue of firedancer's `fd_blake3_lthash_batch{8,16}`, generic over the
+/// lane width.
+///
+/// # Safety
+/// Must be called from a context where `L`'s target feature is enabled.
+/// `bufs.len()` and `lens.len()` must both equal `L::N`. Each `bufs[l]` must be
+/// zero-padded to its block boundary and hold at least `ceil(lens[l]/64)*16`
+/// `u32` words (i.e. `ceil(lens[l]/64)` full 64-byte blocks).
+#[inline(always)]
+unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
+    let n = L::N;
+    debug_assert_eq!(bufs.len(), n);
+    debug_assert_eq!(lens.len(), n);
+    let sub_blocks = NUM_BLOCK_WORDS / n; // AVX2: 2 tiles of 8 words; AVX512: 1 tile of 16
+
+    let zero = unsafe { L::splat(0) };
+    let iv: [L; NUM_CV_WORDS] = core::array::from_fn(|w| unsafe { L::splat(IV[w]) });
+    let mut h = iv;
+    let mut off = [0usize; MAX_LANES];
+
+    // Build a lane vector from up to `N` per-lane u32 values (rest zero).
+    let lanes = |vals: &[u32]| -> L {
+        let mut t = [0u32; MAX_LANES];
+        t[..vals.len()].copy_from_slice(vals);
+        unsafe { L::load(t.as_ptr()) }
+    };
+
+    // Load the current 64-byte block of every lane into SoA word vectors,
+    // reading directly from the caller's zero-padded buffers.
+    let load_m = |off: &[usize; MAX_LANES]| -> [L; NUM_BLOCK_WORDS] {
+        let mut m = [zero; NUM_BLOCK_WORDS];
+        for blk in 0..sub_blocks {
+            let mut rows = [zero; MAX_LANES];
+            for l in 0..n {
+                // `off[l]` is a byte offset; `bufs[l]` is `&[u32]`
+                let base = off[l] / size_of::<u32>() + blk * n;
+                rows[l] = unsafe { L::load(bufs[l].as_ptr().add(base)) };
+            }
+            unsafe { L::transpose(&mut rows[..n]) };
+            m[blk * n..blk * n + n].copy_from_slice(&rows[..n]);
+        }
+        m
+    };
+
+    // ---- Input compression phase (mirrors fd_blake3_fini_xof_compress) ----
+    // Compress every block but the root, chaining the CV forward. Per-lane flags
+    // + an active-lane mask handle messages of differing length within the batch,
+    // as in fd_blake3_avx512_compress16. Loop ends holding the root block (the
+    // last block of each lane), which the XOF phase compresses repeatedly.
+    let (root_m, root_sz, root_flags) = loop {
+        let mut block_flags = [0u32; MAX_LANES];
+        let mut block_sz = [0u32; MAX_LANES];
+        let mut active = [false; MAX_LANES];
+        for l in 0..n {
+            let is_last = lens[l] <= off[l] + BLOCK_LEN;
+            let is_first = off[l] == 0;
+            let mut f = if is_last { ROOT | CHUNK_END } else { 0 };
+            if is_first {
+                f |= CHUNK_START;
+            }
+            block_flags[l] = f;
+            block_sz[l] = (lens[l] - off[l]).min(BLOCK_LEN) as u32;
+            active[l] = !is_last;
+        }
+
+        let m = load_m(&off);
+        let block_sz_v = lanes(&block_sz[..n]);
+        let block_flags_v = lanes(&block_flags[..n]);
+
+        if !active[..n].iter().any(|&a| a) {
+            break (m, block_sz_v, block_flags_v);
+        }
+
+        // Compress this block (chunk counter is 0 for a single chunk), then fold
+        // into the CV of active lanes only and advance them. The feed-forward
+        // keeps just the low 8 words (the next chaining value) — the vector
+        // analogue of blake3's `compress_in_place`.
+        let v = unsafe { compress_pre(&h, &iv, &m, zero, zero, block_sz_v, block_flags_v) };
+        unsafe {
+            let mask = L::mask(&active[..n]);
+            for w in 0..NUM_CV_WORDS {
+                h[w] = L::select(mask, v[w].xor(v[w + NUM_CV_WORDS]), h[w]);
+            }
+        }
+        for l in 0..n {
+            if active[l] {
+                off[l] += BLOCK_LEN;
+            }
+        }
+    };
+
+    // ---- XOF expansion phase (mirrors fd_blake3_fini_2048) ----
+    // Re-compress the root block NUM_XOF_BLOCKS (32) times with an incrementing
+    // output-block counter; each pass yields one 64-byte output block, which we
+    // transpose back to per-lane rows and SWAR-u16-reduce into `acc`.
+    let mut out_words = [zero; NUM_BLOCK_WORDS];
+    let mut s_arr = [0u32; MAX_LANES];
+    for xof_block in 0..NUM_XOF_BLOCKS {
+        let counter = xof_block as u64;
+        // XOF feed-forward keeps all 16 words (blake3's `compress_xof`):
+        // out[w] = v[w]^v[w+8] for w<8, else h[w-8]^v[w].
+        let v = unsafe {
+            compress_pre(
+                &h,
+                &iv,
+                &root_m,
+                L::splat(counter as u32),
+                L::splat((counter >> 32) as u32),
+                root_sz,
+                root_flags,
+            )
+        };
+        unsafe {
+            for w in 0..NUM_CV_WORDS {
+                out_words[w] = v[w].xor(v[w + NUM_CV_WORDS]);
+                out_words[w + NUM_CV_WORDS] = h[w].xor(v[w + NUM_CV_WORDS]);
+            }
+        }
+
+        let base = xof_block * (BLOCK_LEN / 2); // u16 element index
+        for blk in 0..sub_blocks {
+            let mut cols = [zero; MAX_LANES];
+            cols[..n].copy_from_slice(&out_words[blk * n..blk * n + n]);
+            unsafe {
+                L::transpose(&mut cols[..n]); // cols[l] = lane l's words
+                let mut s = cols[0];
+                for &col in &cols[1..n] {
+                    s = swar_add_u16(s, col);
+                }
+                s.store(s_arr.as_mut_ptr());
+            }
+            for (j, packed) in s_arr[..n].iter().enumerate() {
+                let e = base + (blk * n + j) * 2;
+                acc.0[e] = acc.0[e].wrapping_add(*packed as u16);
+                acc.0[e + 1] = acc.0[e + 1].wrapping_add((*packed >> 16) as u16);
+            }
+        }
+    }
+}
+
+// ----------------------------- AVX2 backend -----------------------------
+
+impl Lanes for __m256i {
+    const N: usize = 8;
+    type Mask = __m256i;
+
+    #[inline(always)]
+    unsafe fn splat(x: u32) -> Self {
+        unsafe { _mm256_set1_epi32(x as i32) }
+    }
+    #[inline(always)]
+    unsafe fn load(p: *const u32) -> Self {
+        unsafe { _mm256_loadu_si256(p as *const __m256i) }
+    }
+    #[inline(always)]
+    unsafe fn store(self, p: *mut u32) {
+        unsafe { _mm256_storeu_si256(p as *mut __m256i, self) }
+    }
+    #[inline(always)]
+    unsafe fn add(self, o: Self) -> Self {
+        unsafe { _mm256_add_epi32(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn xor(self, o: Self) -> Self {
+        unsafe { _mm256_xor_si256(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn and(self, o: Self) -> Self {
+        unsafe { _mm256_and_si256(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn ror<const R: u32>(self) -> Self {
+        // AVX2 has no vector rotate; use shift|shift, as the blake3 crate's
+        // `rot16/12/8/7` (`src/rust_avx2.rs`) and firedancer's `wu_ror` do. The
+        // `match` on the const `R` resolves to one arm with literal shift immediates.
+        unsafe {
+            match R {
+                16 => _mm256_or_si256(_mm256_srli_epi32::<16>(self), _mm256_slli_epi32::<16>(self)),
+                12 => _mm256_or_si256(_mm256_srli_epi32::<12>(self), _mm256_slli_epi32::<20>(self)),
+                8 => _mm256_or_si256(_mm256_srli_epi32::<8>(self), _mm256_slli_epi32::<24>(self)),
+                7 => _mm256_or_si256(_mm256_srli_epi32::<7>(self), _mm256_slli_epi32::<25>(self)),
+                _ => unreachable!(),
+            }
+        }
+    }
+    #[inline(always)]
+    unsafe fn mask(active: &[bool]) -> Self::Mask {
+        // `active.len() == N == 8` per the trait contract, so fill all 8 lanes.
+        let t: [i32; 8] = core::array::from_fn(|i| if active[i] { -1 } else { 0 });
+        unsafe { _mm256_loadu_si256(t.as_ptr() as *const __m256i) }
+    }
+    #[inline(always)]
+    unsafe fn select(m: Self::Mask, if_active: Self, if_inactive: Self) -> Self {
+        unsafe { _mm256_blendv_epi8(if_inactive, if_active, m) }
+    }
+    #[inline(always)]
+    unsafe fn transpose(io: &mut [Self]) {
+        // Standard 8x8 u32 transpose: unpck32 -> unpck64 -> permute2x128.
+        // Mirrors the blake3 crate's `transpose_vecs` (`src/rust_avx2.rs`).
+        unsafe {
+            let (a, b, c, d, e, f, g, h) = (io[0], io[1], io[2], io[3], io[4], io[5], io[6], io[7]);
+            let t0 = _mm256_unpacklo_epi32(a, b);
+            let t1 = _mm256_unpackhi_epi32(a, b);
+            let t2 = _mm256_unpacklo_epi32(c, d);
+            let t3 = _mm256_unpackhi_epi32(c, d);
+            let t4 = _mm256_unpacklo_epi32(e, f);
+            let t5 = _mm256_unpackhi_epi32(e, f);
+            let t6 = _mm256_unpacklo_epi32(g, h);
+            let t7 = _mm256_unpackhi_epi32(g, h);
+            let u0 = _mm256_unpacklo_epi64(t0, t2);
+            let u1 = _mm256_unpackhi_epi64(t0, t2);
+            let u2 = _mm256_unpacklo_epi64(t1, t3);
+            let u3 = _mm256_unpackhi_epi64(t1, t3);
+            let u4 = _mm256_unpacklo_epi64(t4, t6);
+            let u5 = _mm256_unpackhi_epi64(t4, t6);
+            let u6 = _mm256_unpacklo_epi64(t5, t7);
+            let u7 = _mm256_unpackhi_epi64(t5, t7);
+            io[0] = _mm256_permute2x128_si256::<0x20>(u0, u4);
+            io[1] = _mm256_permute2x128_si256::<0x20>(u1, u5);
+            io[2] = _mm256_permute2x128_si256::<0x20>(u2, u6);
+            io[3] = _mm256_permute2x128_si256::<0x20>(u3, u7);
+            io[4] = _mm256_permute2x128_si256::<0x31>(u0, u4);
+            io[5] = _mm256_permute2x128_si256::<0x31>(u1, u5);
+            io[6] = _mm256_permute2x128_si256::<0x31>(u2, u6);
+            io[7] = _mm256_permute2x128_si256::<0x31>(u3, u7);
+        }
+    }
+}
+
+/// AVX2 (8-lane) batch.
+///
+/// # Safety
+/// AVX2 must be available, and `bufs`/`lens` must satisfy the contract on
+/// [`compress_batch`] (`len() == 8`, each buffer zero-padded to its blocks).
+#[target_feature(enable = "avx2")]
+pub unsafe fn mix_in_avx2(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
+    unsafe { compress_batch::<__m256i>(bufs, lens, acc) }
+}
+
+// ---------------------------- AVX512 backend ----------------------------
+
+impl Lanes for __m512i {
+    const N: usize = 16;
+    type Mask = __mmask16;
+
+    #[inline(always)]
+    unsafe fn splat(x: u32) -> Self {
+        unsafe { _mm512_set1_epi32(x as i32) }
+    }
+    #[inline(always)]
+    unsafe fn load(p: *const u32) -> Self {
+        unsafe { _mm512_loadu_si512(p as *const _) }
+    }
+    #[inline(always)]
+    unsafe fn store(self, p: *mut u32) {
+        unsafe { _mm512_storeu_si512(p as *mut _, self) }
+    }
+    #[inline(always)]
+    unsafe fn add(self, o: Self) -> Self {
+        unsafe { _mm512_add_epi32(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn xor(self, o: Self) -> Self {
+        unsafe { _mm512_xor_si512(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn and(self, o: Self) -> Self {
+        unsafe { _mm512_and_si512(self, o) }
+    }
+    #[inline(always)]
+    unsafe fn ror<const R: u32>(self) -> Self {
+        // Native rotate (vprold), as firedancer's `wwu_ror` (`fd_avx512_wwu.h`).
+        // `_mm512_ror_epi32` takes an i32 const, so match the const `R` to a
+        // literal arm.
+        unsafe {
+            match R {
+                16 => _mm512_ror_epi32::<16>(self),
+                12 => _mm512_ror_epi32::<12>(self),
+                8 => _mm512_ror_epi32::<8>(self),
+                7 => _mm512_ror_epi32::<7>(self),
+                _ => unreachable!(),
+            }
+        }
+    }
+    #[inline(always)]
+    unsafe fn mask(active: &[bool]) -> Self::Mask {
+        let mut m: u16 = 0;
+        for (i, &a) in active.iter().enumerate() {
+            m |= (a as u16) << i;
+        }
+        m
+    }
+    #[inline(always)]
+    unsafe fn select(m: Self::Mask, if_active: Self, if_inactive: Self) -> Self {
+        // mask_blend(k, a, b) -> b where k set, else a.
+        unsafe { _mm512_mask_blend_epi32(m, if_inactive, if_active) }
+    }
+    #[inline(always)]
+    unsafe fn transpose(io: &mut [Self]) {
+        // Transliteration of firedancer's `wwu_transpose_16x16`
+        // (`src/util/simd/fd_avx512_wwu.h`): two shuffle_i32x4 stages (4x4-block
+        // transpose) then two unpack_epi32 stages (inner 4x4 transpose).
+        // `io.len() == 16`.
+        unsafe {
+            let r = |i: usize| io[i];
+            // Outer 4x4 transpose of 4x4 blocks (stage A).
+            let t0 = _mm512_shuffle_i32x4::<0x88>(r(0), r(4));
+            let t1 = _mm512_shuffle_i32x4::<0x88>(r(1), r(5));
+            let t2 = _mm512_shuffle_i32x4::<0x88>(r(2), r(6));
+            let t3 = _mm512_shuffle_i32x4::<0x88>(r(3), r(7));
+            let t4 = _mm512_shuffle_i32x4::<0xdd>(r(0), r(4));
+            let t5 = _mm512_shuffle_i32x4::<0xdd>(r(1), r(5));
+            let t6 = _mm512_shuffle_i32x4::<0xdd>(r(2), r(6));
+            let t7 = _mm512_shuffle_i32x4::<0xdd>(r(3), r(7));
+            let t8 = _mm512_shuffle_i32x4::<0x88>(r(8), r(12));
+            let t9 = _mm512_shuffle_i32x4::<0x88>(r(9), r(13));
+            let ta = _mm512_shuffle_i32x4::<0x88>(r(10), r(14));
+            let tb = _mm512_shuffle_i32x4::<0x88>(r(11), r(15));
+            let tc = _mm512_shuffle_i32x4::<0xdd>(r(8), r(12));
+            let td = _mm512_shuffle_i32x4::<0xdd>(r(9), r(13));
+            let te = _mm512_shuffle_i32x4::<0xdd>(r(10), r(14));
+            let tf = _mm512_shuffle_i32x4::<0xdd>(r(11), r(15));
+            // Stage B.
+            let r0 = _mm512_shuffle_i32x4::<0x88>(t0, t8);
+            let r1 = _mm512_shuffle_i32x4::<0x88>(t1, t9);
+            let r2 = _mm512_shuffle_i32x4::<0x88>(t2, ta);
+            let r3 = _mm512_shuffle_i32x4::<0x88>(t3, tb);
+            let r4 = _mm512_shuffle_i32x4::<0x88>(t4, tc);
+            let r5 = _mm512_shuffle_i32x4::<0x88>(t5, td);
+            let r6 = _mm512_shuffle_i32x4::<0x88>(t6, te);
+            let r7 = _mm512_shuffle_i32x4::<0x88>(t7, tf);
+            let r8 = _mm512_shuffle_i32x4::<0xdd>(t0, t8);
+            let r9 = _mm512_shuffle_i32x4::<0xdd>(t1, t9);
+            let ra = _mm512_shuffle_i32x4::<0xdd>(t2, ta);
+            let rb = _mm512_shuffle_i32x4::<0xdd>(t3, tb);
+            let rc = _mm512_shuffle_i32x4::<0xdd>(t4, tc);
+            let rd = _mm512_shuffle_i32x4::<0xdd>(t5, td);
+            let re = _mm512_shuffle_i32x4::<0xdd>(t6, te);
+            let rf = _mm512_shuffle_i32x4::<0xdd>(t7, tf);
+            // Inner 4x4 transpose of 1x1 blocks (stage C).
+            let t0 = _mm512_unpacklo_epi32(r0, r2);
+            let t1 = _mm512_unpacklo_epi32(r1, r3);
+            let t2 = _mm512_unpackhi_epi32(r0, r2);
+            let t3 = _mm512_unpackhi_epi32(r1, r3);
+            let t4 = _mm512_unpacklo_epi32(r4, r6);
+            let t5 = _mm512_unpacklo_epi32(r5, r7);
+            let t6 = _mm512_unpackhi_epi32(r4, r6);
+            let t7 = _mm512_unpackhi_epi32(r5, r7);
+            let t8 = _mm512_unpacklo_epi32(r8, ra);
+            let t9 = _mm512_unpacklo_epi32(r9, rb);
+            let ta = _mm512_unpackhi_epi32(r8, ra);
+            let tb = _mm512_unpackhi_epi32(r9, rb);
+            let tc = _mm512_unpacklo_epi32(rc, re);
+            let td = _mm512_unpacklo_epi32(rd, rf);
+            let te = _mm512_unpackhi_epi32(rc, re);
+            let tf = _mm512_unpackhi_epi32(rd, rf);
+            // Stage D.
+            io[0] = _mm512_unpacklo_epi32(t0, t1);
+            io[1] = _mm512_unpackhi_epi32(t0, t1);
+            io[2] = _mm512_unpacklo_epi32(t2, t3);
+            io[3] = _mm512_unpackhi_epi32(t2, t3);
+            io[4] = _mm512_unpacklo_epi32(t4, t5);
+            io[5] = _mm512_unpackhi_epi32(t4, t5);
+            io[6] = _mm512_unpacklo_epi32(t6, t7);
+            io[7] = _mm512_unpackhi_epi32(t6, t7);
+            io[8] = _mm512_unpacklo_epi32(t8, t9);
+            io[9] = _mm512_unpackhi_epi32(t8, t9);
+            io[10] = _mm512_unpacklo_epi32(ta, tb);
+            io[11] = _mm512_unpackhi_epi32(ta, tb);
+            io[12] = _mm512_unpacklo_epi32(tc, td);
+            io[13] = _mm512_unpackhi_epi32(tc, td);
+            io[14] = _mm512_unpacklo_epi32(te, tf);
+            io[15] = _mm512_unpackhi_epi32(te, tf);
+        }
+    }
+}
+
+/// AVX512 (16-lane) batch.
+///
+/// # Safety
+/// AVX512F must be available, and `bufs`/`lens` must satisfy the contract on
+/// [`compress_batch`] (`len() == 16`, each buffer zero-padded to its blocks).
+#[target_feature(enable = "avx512f")]
+pub unsafe fn mix_in_avx512(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
+    unsafe { compress_batch::<__m512i>(bufs, lens, acc) }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            batch::{
+                BatchMixInFn, CHUNK_LEN, NUM_CHUNK_WORDS,
+                test_util::{expected_lthash, make_messages, random_messages, seeded_rng},
+            },
+            lt_hash::LtHash,
+        },
+    };
+
+    /// Zero-padded `u32` buffers + real lengths, as `Accumulator::add` builds them.
+    fn pad(msgs: &[&[u8]]) -> (Vec<Vec<u32>>, Vec<usize>) {
+        let bufs = msgs
+            .iter()
+            .map(|m| {
+                let mut buf = vec![0u32; NUM_CHUNK_WORDS];
+                let bytes: &mut [u8] = bytemuck::cast_slice_mut(&mut buf);
+                bytes[..m.len()].copy_from_slice(m);
+                buf
+            })
+            .collect();
+        let lens = msgs.iter().map(|m| m.len()).collect();
+        (bufs, lens)
+    }
+
+    /// Run `mix` over `msgs` (one lane each) and check it equals the oracle both
+    /// from `identity` and mixed on top of a non-identity accumulator — the kernel
+    /// must group-add onto whatever is already in `acc`, not overwrite it.
+    ///
+    /// # Safety
+    /// `mix`'s target feature must be available.
+    unsafe fn check(mix: BatchMixInFn, msgs: &[Vec<u8>], ctx: &str) {
+        let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
+        let (owned, lens) = pad(&refs);
+        let bufs: Vec<&[u32]> = owned.iter().map(|b| b.as_slice()).collect();
+        let oracle = expected_lthash(&refs);
+
+        let mut from_identity = LtHash::identity();
+        unsafe { mix(&bufs, &lens, &mut from_identity) };
+        assert_eq!(from_identity, oracle, "from identity [{ctx}]");
+
+        let base = expected_lthash(&[b"preset accumulator contents".as_slice()]);
+        let mut onto = base; // LtHash is `Copy` under cfg(test)
+        unsafe { mix(&bufs, &lens, &mut onto) };
+        let mut want = base;
+        want.mix_in(&oracle);
+        assert_eq!(onto, want, "onto non-identity [{ctx}]");
+    }
+
+    /// Exercise one backend: deterministic assorted lengths, the all-empty and
+    /// all-full-chunk extremes, and many random full batches — all bit-exact
+    /// against the oracle.
+    ///
+    /// # Safety
+    /// `mix`'s target feature must be available; `n` is its lane count.
+    unsafe fn exercise(mix: BatchMixInFn, n: usize) {
+        unsafe {
+            // Assorted single-chunk lengths (block boundaries, full chunk).
+            check(mix, &make_messages(n), "assorted lengths");
+
+            // Every lane empty (each is one zeroed root block = blake3("")).
+            check(mix, &vec![Vec::new(); n], "all empty");
+
+            // Every lane a full chunk (the maximum per-lane input).
+            let full: Vec<Vec<u8>> = (0..n)
+                .map(|j| (0..CHUNK_LEN).map(|i| (i + j) as u8).collect())
+                .collect();
+            check(mix, &full, "all full chunk");
+
+            // Many random full batches (lanes of differing length exercise the
+            // per-lane flags and active-lane masking).
+            let seed = rand::random::<u64>();
+            let mut rng = seeded_rng(seed);
+            for iter in 0..128 {
+                let msgs = random_messages(&mut rng, n, CHUNK_LEN);
+                check(mix, &msgs, &format!("seed={seed:#018x} iter={iter}"));
+            }
+        }
+    }
+
+    #[test]
+    fn avx2_matches_oracle() {
+        if !is_x86_feature_detected!("avx2") {
+            eprintln!("skipping: no AVX2");
+            return;
+        }
+        // SAFETY: AVX2 just confirmed available.
+        unsafe { exercise(mix_in_avx2, 8) };
+    }
+
+    #[test]
+    fn avx512_matches_oracle() {
+        if !is_x86_feature_detected!("avx512f") {
+            eprintln!("skipping: no AVX512F");
+            return;
+        }
+        // SAFETY: AVX512F just confirmed available.
+        unsafe { exercise(mix_in_avx512, 16) };
+    }
+}

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -219,14 +219,13 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
     let load_m = |off: &[usize; MAX_LANES]| -> [L; NUM_BLOCK_WORDS] {
         let mut m = [zero; NUM_BLOCK_WORDS];
         for blk in 0..sub_blocks {
-            let mut rows = [zero; MAX_LANES];
-            for l in 0..n {
+            let tile = &mut m[blk * n..blk * n + n];
+            for (l, row) in tile.iter_mut().enumerate() {
                 // `off[l]` is a byte offset; `bufs[l]` is `&[u32]`
                 let base = off[l] / size_of::<u32>() + blk * n;
-                rows[l] = unsafe { L::load(bufs[l].as_ptr().add(base)) };
+                *row = unsafe { L::load(bufs[l][base..].as_ptr()) };
             }
-            unsafe { L::transpose(&mut rows[..n]) };
-            m[blk * n..blk * n + n].copy_from_slice(&rows[..n]);
+            unsafe { L::transpose(tile) };
         }
         m
     };

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -284,7 +284,6 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
     // output-block counter; each pass yields one 64-byte output block, which we
     // transpose back to per-lane rows and SWAR-u16-reduce into `acc`.
     let mut out_words = [zero; NUM_BLOCK_WORDS];
-    let mut s_arr = [0u32; MAX_LANES];
     for xof_block in 0..NUM_XOF_BLOCKS {
         let counter = xof_block as u64;
         // XOF feed-forward keeps all 16 words (blake3's `compress_xof`):
@@ -318,12 +317,11 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
                 for &col in &tile[1..n] {
                     s = swar_add_u16(s, col);
                 }
-                s.store(s_arr.as_mut_ptr());
-            }
-            for (j, packed) in s_arr[..n].iter().enumerate() {
-                let e = base + (blk * n + j) * 2;
-                acc.0[e] = acc.0[e].wrapping_add(*packed as u16);
-                acc.0[e + 1] = acc.0[e + 1].wrapping_add((*packed >> 16) as u16);
+                // `s`'s `n` u32 words are `2n` contiguous `u16` accumulator
+                // elements: load that region, SWAR-add the batch's sum, store back.
+                let start = base + blk * n * 2;
+                let acc_words = acc.0[start..start + 2 * n].as_mut_ptr().cast::<u32>();
+                swar_add_u16(L::load(acc_words), s).store(acc_words);
             }
         }
     }

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -29,7 +29,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    super::{BLOCK_LEN, MAX_LANES},
+    super::{BLOCK_LEN, Batch, MAX_LANES},
     crate::lt_hash::LtHash,
     core::arch::x86_64::*,
 };
@@ -199,14 +199,13 @@ unsafe fn compress_pre<L: Lanes>(
 ///
 /// # Safety
 /// Must be called from a context where `L`'s target feature is enabled.
-/// `bufs.len()` and `lens.len()` must both equal `L::N`. Each `bufs[l]` must be
-/// zero-padded to its block boundary and hold at least `ceil(lens[l]/64)*16`
-/// `u32` words (i.e. `ceil(lens[l]/64)` full 64-byte blocks).
+/// `batch.len()` must equal `L::N`. Each `batch.lanes[l]` must be zero-padded to
+/// its block boundary and hold at least `ceil(batch.lengths[l]/64)*16` `u32`
+/// words (i.e. `ceil(batch.lengths[l]/64)` full 64-byte blocks).
 #[inline(always)]
-unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
+unsafe fn compress_batch<L: Lanes>(batch: Batch<'_>, acc: &mut LtHash) {
     let n = L::N;
-    debug_assert_eq!(bufs.len(), n);
-    debug_assert_eq!(lens.len(), n);
+    debug_assert_eq!(batch.len(), n);
     let sub_blocks = NUM_BLOCK_WORDS / n; // AVX2: 2 tiles of 8 words; AVX512: 1 tile of 16
 
     let zero = unsafe { L::splat(0) };
@@ -221,9 +220,9 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
         for blk in 0..sub_blocks {
             let tile = &mut m[blk * n..blk * n + n];
             for (l, row) in tile.iter_mut().enumerate() {
-                // `off[l]` is a byte offset; `bufs[l]` is `&[u32]`
+                // `off[l]` is a byte offset; `batch.lanes[l]` is `&[u32]`
                 let base = off[l] / size_of::<u32>() + blk * n;
-                *row = unsafe { L::load(bufs[l][base..].as_ptr()) };
+                *row = unsafe { L::load(batch.lanes[l][base..].as_ptr()) };
             }
             unsafe { L::transpose(tile) };
         }
@@ -240,14 +239,14 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
         let mut block_sz = [0u32; MAX_LANES];
         let mut active = [false; MAX_LANES];
         for l in 0..n {
-            let is_last = lens[l] <= off[l] + BLOCK_LEN;
+            let is_last = batch.lengths[l] <= off[l] + BLOCK_LEN;
             let is_first = off[l] == 0;
             let mut f = if is_last { ROOT | CHUNK_END } else { 0 };
             if is_first {
                 f |= CHUNK_START;
             }
             block_flags[l] = f;
-            block_sz[l] = (lens[l] - off[l]).min(BLOCK_LEN) as u32;
+            block_sz[l] = (batch.lengths[l] - off[l]).min(BLOCK_LEN) as u32;
             active[l] = !is_last;
         }
 
@@ -419,11 +418,11 @@ impl Lanes for __m256i {
 /// AVX2 (8-lane) batch.
 ///
 /// # Safety
-/// AVX2 must be available, and `bufs`/`lens` must satisfy the contract on
+/// AVX2 must be available, and `batch` must satisfy the contract on
 /// [`compress_batch`] (`len() == 8`, each buffer zero-padded to its blocks).
 #[target_feature(enable = "avx2")]
-pub unsafe fn mix_in_avx2(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
-    unsafe { compress_batch::<__m256i>(bufs, lens, acc) }
+pub unsafe fn mix_in_avx2(batch: Batch<'_>, acc: &mut LtHash) {
+    unsafe { compress_batch::<__m256i>(batch, acc) }
 }
 
 // ---------------------------- AVX512 backend ----------------------------
@@ -567,11 +566,11 @@ impl Lanes for __m512i {
 /// AVX512 (16-lane) batch.
 ///
 /// # Safety
-/// AVX512F must be available, and `bufs`/`lens` must satisfy the contract on
+/// AVX512F must be available, and `batch` must satisfy the contract on
 /// [`compress_batch`] (`len() == 16`, each buffer zero-padded to its blocks).
 #[target_feature(enable = "avx512f")]
-pub unsafe fn mix_in_avx512(bufs: &[&[u32]], lens: &[usize], acc: &mut LtHash) {
-    unsafe { compress_batch::<__m512i>(bufs, lens, acc) }
+pub unsafe fn mix_in_avx512(batch: Batch<'_>, acc: &mut LtHash) {
+    unsafe { compress_batch::<__m512i>(batch, acc) }
 }
 
 #[cfg(test)]
@@ -580,26 +579,26 @@ mod tests {
         super::*,
         crate::{
             batch::{
-                BatchMixInFn, CHUNK_LEN, NUM_CHUNK_WORDS,
+                Batch, BatchMixInFn, CHUNK_LEN, LaneBuf, NUM_CHUNK_WORDS,
                 test_util::{expected_lthash, make_messages, random_messages, seeded_rng},
             },
             lt_hash::LtHash,
         },
     };
 
-    /// Zero-padded `u32` buffers + real lengths, as `Accumulator::add` builds them.
-    fn pad(msgs: &[&[u8]]) -> (Vec<Vec<u32>>, Vec<usize>) {
-        let bufs = msgs
+    /// Zero-padded lane buffers + real lengths, as `Accumulator` stages them.
+    fn pad(msgs: &[&[u8]]) -> (Vec<LaneBuf>, Vec<usize>) {
+        let lanes = msgs
             .iter()
             .map(|m| {
-                let mut buf = vec![0u32; NUM_CHUNK_WORDS];
-                let bytes: &mut [u8] = bytemuck::cast_slice_mut(&mut buf);
+                let mut buf = [0u32; NUM_CHUNK_WORDS];
+                let bytes: &mut [u8] = bytemuck::cast_slice_mut(buf.as_mut_slice());
                 bytes[..m.len()].copy_from_slice(m);
                 buf
             })
             .collect();
-        let lens = msgs.iter().map(|m| m.len()).collect();
-        (bufs, lens)
+        let lengths = msgs.iter().map(|m| m.len()).collect();
+        (lanes, lengths)
     }
 
     /// Run `mix` over `msgs` (one lane each) and check it equals the oracle both
@@ -610,17 +609,20 @@ mod tests {
     /// `mix`'s target feature must be available.
     unsafe fn check(mix: BatchMixInFn, msgs: &[Vec<u8>], ctx: &str) {
         let refs: Vec<&[u8]> = msgs.iter().map(|m| m.as_slice()).collect();
-        let (owned, lens) = pad(&refs);
-        let bufs: Vec<&[u32]> = owned.iter().map(|b| b.as_slice()).collect();
+        let (lanes, lengths) = pad(&refs);
+        let batch = Batch {
+            lanes: &lanes,
+            lengths: &lengths,
+        };
         let oracle = expected_lthash(&refs);
 
         let mut from_identity = LtHash::identity();
-        unsafe { mix(&bufs, &lens, &mut from_identity) };
+        unsafe { mix(batch, &mut from_identity) };
         assert_eq!(from_identity, oracle, "from identity [{ctx}]");
 
         let base = expected_lthash(&[b"preset accumulator contents".as_slice()]);
         let mut onto = base; // LtHash is `Copy` under cfg(test)
-        unsafe { mix(&bufs, &lens, &mut onto) };
+        unsafe { mix(batch, &mut onto) };
         let mut want = base;
         want.mix_in(&oracle);
         assert_eq!(onto, want, "onto non-identity [{ctx}]");

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -309,12 +309,13 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
 
         let base = xof_block * (BLOCK_LEN / 2); // u16 element index
         for blk in 0..sub_blocks {
-            let mut cols = [zero; MAX_LANES];
-            cols[..n].copy_from_slice(&out_words[blk * n..blk * n + n]);
+            // Transpose this tile in place (`out_words` is rewritten next XOF
+            // iteration): `tile[l]` becomes lane `l`'s words.
+            let tile = &mut out_words[blk * n..blk * n + n];
             unsafe {
-                L::transpose(&mut cols[..n]); // cols[l] = lane l's words
-                let mut s = cols[0];
-                for &col in &cols[1..n] {
+                L::transpose(tile);
+                let mut s = tile[0];
+                for &col in &tile[1..n] {
                     s = swar_add_u16(s, col);
                 }
                 s.store(s_arr.as_mut_ptr());

--- a/lattice-hash/src/batch/arch.rs
+++ b/lattice-hash/src/batch/arch.rs
@@ -214,13 +214,6 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
     let mut h = iv;
     let mut off = [0usize; MAX_LANES];
 
-    // Build a lane vector from up to `N` per-lane u32 values (rest zero).
-    let lanes = |vals: &[u32]| -> L {
-        let mut t = [0u32; MAX_LANES];
-        t[..vals.len()].copy_from_slice(vals);
-        unsafe { L::load(t.as_ptr()) }
-    };
-
     // Load the current 64-byte block of every lane into SoA word vectors,
     // reading directly from the caller's zero-padded buffers.
     let load_m = |off: &[usize; MAX_LANES]| -> [L; NUM_BLOCK_WORDS] {
@@ -260,8 +253,10 @@ unsafe fn compress_batch<L: Lanes>(bufs: &[&[u32]], lens: &[usize], acc: &mut Lt
         }
 
         let m = load_m(&off);
-        let block_sz_v = lanes(&block_sz[..n]);
-        let block_flags_v = lanes(&block_flags[..n]);
+        // `block_sz`/`block_flags` are already `MAX_LANES`-wide with their first
+        // `n == L::N` entries set, and `load` reads exactly `L::N` lanes.
+        let block_sz_v = unsafe { L::load(block_sz.as_ptr()) };
+        let block_flags_v = unsafe { L::load(block_flags.as_ptr()) };
 
         if !active[..n].iter().any(|&a| a) {
             break (m, block_sz_v, block_flags_v);

--- a/lattice-hash/src/lib.rs
+++ b/lattice-hash/src/lib.rs
@@ -1,2 +1,3 @@
 #![cfg(feature = "agave-unstable-api")]
+pub mod batch;
 pub mod lt_hash;


### PR DESCRIPTION
#### Problem
Hashing many small slices in a sequence doesn't use hardware (SIMD lines) as much as it could.

#### Summary of Changes
Add a `batch` module that hashes many small accounts at once instead of one at a time. Following firedancer's `fd_blake3_lthash_batch{8,16}`, it hashes N independent (<= 1 chunk) messages across SIMD lanes, expands each to its 2048-byte BLAKE3 XOF, and fuses the 16-bit wrapping group-add into a running `LtHash` -- all in registers.
    
- `Accumulator`: 
  - feed each message whole with `add_message`, or in parts with `add_part` + `finish_message` (writing straight into the SIMD lane buffer, no caller buffer); 
  - `into_lt_hash` consumes it and returns the running `LtHash`.
  - Small messages are staged and flushed through the widest SIMD backend the CPU supports once a full batch accumulates; 
  - a message that overflows one chunk (`> CHUNK_LEN`) and the partial tail fall back to the `blake3` crate. Group-add is commutative, so the reordering does not change the result.
- `arch`: stable `core::arch` AVX2 (8-lane) and AVX512 (16-lane) backends behind a `Lanes` trait, so one generic kernel body serves both (native vprold on AVX512, shift-or on AVX2; in-register transpose; SWAR u16 reduction).
    
Provenance is documented inline: the batch structure and transposes are ported from firedancer, the BLAKE3 compression mirrors the `blake3` crate's portable reference, and the `Lanes` trait + SWAR u16 reduction are new.
    
#### Testing
* added unit tests
* benchmark on AVX512 devbox
```

accounts_lt_hash/baseline_one_at_a_time
                        time:   [521.50 µs 521.65 µs 521.79 µs]
                        thrpt:  [1.9625 Melem/s 1.9630 Melem/s 1.9636 Melem/s]

accounts_lt_hash/batched_accumulator
                        time:   [216.81 µs 216.94 µs 217.16 µs]
                        thrpt:  [4.7154 Melem/s 4.7201 Melem/s 4.7231 Melem/s]
```
* passed `ledger-tool verify` with integration (follow up PR: https://github.com/anza-xyz/agave/pull/13773) into generate index - timing change is `38.695s` (master) -> `34.198s` (this PR)