### PR TITLE
Handle broken stdout pipes in solana CLI output

### DIFF
--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -1,5 +1,8 @@
 use {
-    crate::cli_output::CliSignatureVerificationStatus,
+    crate::{
+        cli_output::CliSignatureVerificationStatus,
+        stdout::{write_stdout_str, writeln_stdout},
+    },
     agave_reserved_account_keys::ReservedAccountKeys,
     base64::{Engine, prelude::BASE64_STANDARD},
     chrono::{DateTime, Local, SecondsFormat, TimeZone, Utc},
@@ -89,13 +92,13 @@ pub fn build_balance_message(lamports: u64, use_lamports_unit: bool, show_unit: 
 }
 
 // Pretty print a "name value"
-pub fn println_name_value(name: &str, value: &str) {
+pub fn println_name_value(name: &str, value: &str) -> io::Result<()> {
     let styled_value = if value.is_empty() {
         style("(not set)").italic()
     } else {
         style(value)
     };
-    println!("{} {}", style(name).bold(), styled_value);
+    writeln_stdout(format_args!("{} {}", style(name).bold(), styled_value))
 }
 
 pub fn writeln_name_value(f: &mut dyn fmt::Write, name: &str, value: &str) -> fmt::Result {
@@ -107,19 +110,19 @@ pub fn writeln_name_value(f: &mut dyn fmt::Write, name: &str, value: &str) -> fm
     writeln!(f, "{} {}", style(name).bold(), styled_value)
 }
 
-pub fn println_name_value_or(name: &str, value: &str, setting_type: SettingType) {
+pub fn println_name_value_or(name: &str, value: &str, setting_type: SettingType) -> io::Result<()> {
     let description = match setting_type {
         SettingType::Explicit => "",
         SettingType::Computed => "(computed)",
         SettingType::SystemDefault => "(default)",
     };
 
-    println!(
+    writeln_stdout(format_args!(
         "{} {} {}",
         style(name).bold(),
         style(value),
         style(description).italic(),
-    );
+    ))
 }
 
 pub fn format_labeled_address(pubkey: &str, address_labels: &HashMap<String, String>) -> String {
@@ -140,22 +143,28 @@ pub fn println_signers(
     signers: &[String],
     absent: &[String],
     bad_sig: &[String],
-) {
-    println!();
-    println!("Blockhash: {blockhash}");
+) -> io::Result<()> {
+    writeln_stdout(format_args!(""))?;
+    writeln_stdout(format_args!("Blockhash: {blockhash}"))?;
     if !signers.is_empty() {
-        println!("Signers (Pubkey=Signature):");
-        signers.iter().for_each(|signer| println!("  {signer}"))
+        writeln_stdout(format_args!("Signers (Pubkey=Signature):"))?;
+        for signer in signers {
+            writeln_stdout(format_args!("  {signer}"))?;
+        }
     }
     if !absent.is_empty() {
-        println!("Absent Signers (Pubkey):");
-        absent.iter().for_each(|pubkey| println!("  {pubkey}"))
+        writeln_stdout(format_args!("Absent Signers (Pubkey):"))?;
+        for pubkey in absent {
+            writeln_stdout(format_args!("  {pubkey}"))?;
+        }
     }
     if !bad_sig.is_empty() {
-        println!("Bad Signatures (Pubkey):");
-        bad_sig.iter().for_each(|pubkey| println!("  {pubkey}"))
+        writeln_stdout(format_args!("Bad Signatures (Pubkey):"))?;
+        for pubkey in bad_sig {
+            writeln_stdout(format_args!("  {pubkey}"))?;
+        }
     }
-    println!();
+    writeln_stdout(format_args!(""))
 }
 
 struct CliAccountMeta {
@@ -662,7 +671,7 @@ pub fn println_transaction(
     prefix: &str,
     sigverify_status: Option<&[CliSignatureVerificationStatus]>,
     block_time: Option<UnixTimestamp>,
-) {
+) -> io::Result<()> {
     let mut w = Vec::new();
     if write_transaction(
         &mut w,
@@ -676,8 +685,9 @@ pub fn println_transaction(
     .is_ok()
         && let Ok(s) = String::from_utf8(w)
     {
-        print!("{s}");
+        write_stdout_str(&s)?;
     }
+    Ok(())
 }
 
 pub fn writeln_transaction(

--- a/cli-output/src/lib.rs
+++ b/cli-output/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli_clientid;
 mod cli_output;
 pub mod cli_version;
 pub mod display;
+pub mod stdout;
 pub use cli_output::*;
 
 pub trait QuietDisplay: std::fmt::Display {

--- a/cli-output/src/stdout.rs
+++ b/cli-output/src/stdout.rs
@@ -1,0 +1,18 @@
+use std::{
+    fmt,
+    io::{self, Write},
+};
+
+pub fn write_stdout(args: fmt::Arguments<'_>) -> io::Result<()> {
+    io::stdout().lock().write_fmt(args)
+}
+
+pub fn write_stdout_str(s: &str) -> io::Result<()> {
+    io::stdout().lock().write_all(s.as_bytes())
+}
+
+pub fn writeln_stdout(args: fmt::Arguments<'_>) -> io::Result<()> {
+    let mut stdout = io::stdout().lock();
+    stdout.write_fmt(args)?;
+    stdout.write_all(b"\n")
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -830,16 +830,16 @@ pub type ProcessResult = Result<String, Box<dyn std::error::Error>>;
 
 pub async fn process_command(config: &CliConfig<'_>) -> ProcessResult {
     if config.verbose && config.output_format == OutputFormat::DisplayVerbose {
-        println_name_value("RPC URL:", &config.json_rpc_url);
-        println_name_value("Default Signer Path:", &config.keypair_path);
+        println_name_value("RPC URL:", &config.json_rpc_url)?;
+        println_name_value("Default Signer Path:", &config.keypair_path)?;
         if config.keypair_path.starts_with("usb://") {
             let pubkey = config
                 .pubkey()
                 .map(|pubkey| format!("{pubkey:?}"))
                 .unwrap_or_else(|_| "Unavailable".to_string());
-            println_name_value("Pubkey:", &pubkey);
+            println_name_value("Pubkey:", &pubkey)?;
         }
-        println_name_value("Commitment:", &config.commitment.commitment.to_string());
+        println_name_value("Commitment:", &config.commitment.commitment.to_string())?;
     }
 
     let rpc_client = if let Some(rpc_client) = config.rpc_client.as_ref() {

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -16,6 +16,7 @@ use {
             build_balance_message, format_labeled_address, new_spinner_progress_bar,
             writeln_name_value,
         },
+        stdout::writeln_stdout,
         *,
     },
     solana_clock::{self as clock, Clock, Epoch, Slot},
@@ -664,10 +665,10 @@ pub async fn process_catchup(
         match node_json_rpc_url.as_ref() {
             Some(node_json_rpc_url) if node_json_rpc_url != &gussed_default => {
                 // go to new line to leave this message on console
-                println!(
+                writeln_stdout(format_args!(
                     "Preferring explicitly given rpc ({node_json_rpc_url}) as us, although \
                      --our-localhost is given\n"
-                )
+                ))?;
             }
             _ => {
                 node_json_rpc_url = Some(gussed_default);
@@ -683,10 +684,10 @@ pub async fn process_catchup(
             (match node_pubkey {
                 Some(node_pubkey) if node_pubkey != guessed_default => {
                     // go to new line to leave this message on console
-                    println!(
+                    writeln_stdout(format_args!(
                         "Preferring explicitly given node pubkey ({node_pubkey}) as us, although \
                          --our-localhost is given\n"
-                    );
+                    ))?;
                     node_pubkey
                 }
                 _ => guessed_default,
@@ -769,7 +770,10 @@ pub async fn process_catchup(
                     *retry_count = retry_count.saturating_add(1);
                     if log {
                         // go to new line to leave this message on console
-                        println!("Retrying({}/{max_retry_count}): {e}\n", *retry_count);
+                        writeln_stdout(format_args!(
+                            "Retrying({}/{max_retry_count}): {e}\n",
+                            *retry_count
+                        ))?;
                     }
                     sleep(Duration::from_secs(1));
                 }
@@ -890,7 +894,7 @@ pub async fn process_catchup(
             },
         ));
         if log {
-            println!();
+            writeln_stdout(format_args!(""))?;
         }
 
         sleep(sleep_interval);
@@ -1466,7 +1470,7 @@ pub fn parse_logs(
 }
 
 pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> ProcessResult {
-    println!(
+    writeln_stdout(format_args!(
         "Streaming transaction logs{}. {:?} commitment",
         match filter {
             RpcTransactionLogsFilter::All => "".into(),
@@ -1475,7 +1479,7 @@ pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> Pr
                 format!(" mentioning {}", addresses.join(",")),
         },
         config.commitment.commitment
-    );
+    ))?;
 
     let (_client, receiver) = PubsubClient::logs_subscribe(
         &config.websocket_url,
@@ -1488,18 +1492,21 @@ pub fn process_logs(config: &CliConfig, filter: &RpcTransactionLogsFilter) -> Pr
     loop {
         match receiver.recv() {
             Ok(logs) => {
-                println!("Transaction executed in slot {}:", logs.context.slot);
-                println!("  Signature: {}", logs.value.signature);
-                println!(
+                writeln_stdout(format_args!(
+                    "Transaction executed in slot {}:",
+                    logs.context.slot
+                ))?;
+                writeln_stdout(format_args!("  Signature: {}", logs.value.signature))?;
+                writeln_stdout(format_args!(
                     "  Status: {}",
                     logs.value
                         .err
                         .map(|err| err.to_string())
                         .unwrap_or_else(|| "Ok".to_string())
-                );
-                println!("  Log Messages:");
+                ))?;
+                writeln_stdout(format_args!("  Log Messages:"))?;
                 for log in logs.value.logs {
-                    println!("    {log}");
+                    writeln_stdout(format_args!("    {log}"))?;
                 }
             }
             Err(err) => {

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -15,7 +15,9 @@ use {
         compute_budget::ComputeUnitLimit, fee_payer::*, hidden_unless_forced, input_parsers::*,
         input_validators::*, keypair::*,
     },
-    solana_cli_output::{QuietDisplay, VerboseDisplay, cli_version::CliVersion},
+    solana_cli_output::{
+        QuietDisplay, VerboseDisplay, cli_version::CliVersion, stdout::writeln_stdout,
+    },
     solana_clock::{Epoch, Slot},
     solana_cluster_type::ClusterType,
     solana_epoch_schedule::EpochSchedule,
@@ -1011,7 +1013,7 @@ async fn process_activate(
                         .into(),
                 );
             }
-            ForceActivation::Yes => println!("FEATURE ACTIVATION FORCED"),
+            ForceActivation::Yes => writeln_stdout(format_args!("FEATURE ACTIVATION FORCED"))?,
             ForceActivation::No => {
                 return Err("Feature activation is not allowed at this time".into());
             }
@@ -1042,11 +1044,11 @@ async fn process_activate(
     let mut transaction = Transaction::new_unsigned(message);
     transaction.try_sign(&config.signers, blockhash)?;
 
-    println!(
+    writeln_stdout(format_args!(
         "Activating {} ({})",
         FEATURE_NAMES.get(&feature_id).unwrap(),
         feature_id
-    );
+    ))?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &transaction,
@@ -1099,11 +1101,11 @@ async fn process_revoke(
     let mut transaction = Transaction::new_unsigned(message);
     transaction.try_sign(&config.signers, blockhash)?;
 
-    println!(
+    writeln_stdout(format_args!(
         "Revoking {} ({})",
         FEATURE_NAMES.get(&feature_id).unwrap(),
         feature_id
-    );
+    ))?;
     let result = rpc_client
         .send_and_confirm_transaction_with_spinner_and_config(
             &transaction,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -261,13 +261,7 @@ async fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> 
 
 fn write_stdout(result: &str) -> Result<(), io::Error> {
     let mut stdout = io::stdout().lock();
-    if let Err(err) = stdout.write_all(result.as_bytes()) {
-        if err.kind() == io::ErrorKind::BrokenPipe {
-            return Ok(());
-        }
-        return Err(err);
-    }
-    if let Err(err) = stdout.write_all(b"\n") {
+    if let Err(err) = writeln!(&mut stdout, "{result}") {
         if err.kind() == io::ErrorKind::BrokenPipe {
             return Ok(());
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,14 @@ use {
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
-    std::{collections::HashMap, error, path::PathBuf, rc::Rc, time::Duration},
+    std::{
+        collections::HashMap,
+        error,
+        io::{self, Write},
+        path::PathBuf,
+        rc::Rc,
+        time::Duration,
+    },
 };
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
@@ -247,7 +254,24 @@ async fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> 
         let (mut config, signers) = parse_args(matches, &mut wallet_manager)?;
         config.signers = signers.iter().map(|s| s.as_ref()).collect();
         let result = process_command(&config).await?;
-        println!("{result}");
+        write_stdout(&result)?;
     };
+    Ok(())
+}
+
+fn write_stdout(result: &str) -> Result<(), io::Error> {
+    let mut stdout = io::stdout().lock();
+    if let Err(err) = stdout.write_all(result.as_bytes()) {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    if let Err(err) = stdout.write_all(b"\n") {
+        if err.kind() == io::ErrorKind::BrokenPipe {
+            return Ok(());
+        }
+        return Err(err);
+    }
     Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,28 +14,22 @@ use {
     solana_cli_output::{
         OutputFormat,
         display::{println_name_value, println_name_value_or},
+        stdout::writeln_stdout,
     },
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
     solana_rpc_client_api::config::RpcSendTransactionConfig,
-    std::{
-        collections::HashMap,
-        error,
-        io::{self, Write},
-        path::PathBuf,
-        rc::Rc,
-        time::Duration,
-    },
+    std::{collections::HashMap, error, io, path::PathBuf, rc::Rc, time::Duration},
 };
 
 fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error>> {
     let parse_args = match matches.subcommand() {
         ("config", Some(matches)) => {
             let Some(config_file) = matches.value_of("config_file") else {
-                println!(
+                writeln_stdout(format_args!(
                     "{} Either provide the `--config` arg or ensure home directory exists to use \
                      the default config location",
                     style("No config file found.").bold()
-                );
+                ))?;
                 return Ok(false);
             };
             let mut config = Config::load(config_file).unwrap_or_default();
@@ -68,17 +62,21 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                             ),
                             _ => unreachable!(),
                         };
-                        println_name_value_or(&format!("{field_name}:"), &value, setting_type);
+                        println_name_value_or(&format!("{field_name}:"), &value, setting_type)?;
                     } else {
-                        println_name_value("Config File:", config_file);
-                        println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type);
-                        println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
-                        println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
+                        println_name_value("Config File:", config_file)?;
+                        println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type)?;
+                        println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type)?;
+                        println_name_value_or(
+                            "Keypair Path:",
+                            &keypair_path,
+                            keypair_setting_type,
+                        )?;
                         println_name_value_or(
                             "Commitment:",
                             &commitment.commitment.to_string(),
                             commitment_setting_type,
-                        );
+                        )?;
                     }
                 }
                 ("set", Some(subcommand_matches)) => {
@@ -114,26 +112,26 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
                     let (commitment_setting_type, commitment) =
                         ConfigInput::compute_commitment_config("", &config.commitment);
 
-                    println_name_value("Config File:", config_file);
-                    println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type);
-                    println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type);
-                    println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type);
+                    println_name_value("Config File:", config_file)?;
+                    println_name_value_or("RPC URL:", &json_rpc_url, url_setting_type)?;
+                    println_name_value_or("WebSocket URL:", &websocket_url, ws_setting_type)?;
+                    println_name_value_or("Keypair Path:", &keypair_path, keypair_setting_type)?;
                     println_name_value_or(
                         "Commitment:",
                         &commitment.commitment.to_string(),
                         commitment_setting_type,
-                    );
+                    )?;
                 }
                 ("import-address-labels", Some(subcommand_matches)) => {
                     let filename = value_t_or_exit!(subcommand_matches, "filename", PathBuf);
                     config.import_address_labels(&filename)?;
                     config.save(config_file)?;
-                    println!("Address labels imported from {filename:?}");
+                    writeln_stdout(format_args!("Address labels imported from {filename:?}"))?;
                 }
                 ("export-address-labels", Some(subcommand_matches)) => {
                     let filename = value_t_or_exit!(subcommand_matches, "filename", PathBuf);
                     config.export_address_labels(&filename)?;
-                    println!("Address labels exported to {filename:?}");
+                    writeln_stdout(format_args!("Address labels exported to {filename:?}"))?;
                 }
                 _ => unreachable!(),
             }
@@ -242,9 +240,11 @@ async fn main() -> Result<(), Box<dyn error::Error>> {
     )
     .get_matches();
 
-    do_main(&matches)
-        .await
-        .map_err(|err| DisplayError::new_as_boxed(err).into())
+    match do_main(&matches).await {
+        Ok(()) => Ok(()),
+        Err(err) if is_broken_pipe(err.as_ref()) => Ok(()),
+        Err(err) => Err(DisplayError::new_as_boxed(err).into()),
+    }
 }
 
 async fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> {
@@ -254,18 +254,26 @@ async fn do_main(matches: &ArgMatches<'_>) -> Result<(), Box<dyn error::Error>> 
         let (mut config, signers) = parse_args(matches, &mut wallet_manager)?;
         config.signers = signers.iter().map(|s| s.as_ref()).collect();
         let result = process_command(&config).await?;
-        write_stdout(&result)?;
+        writeln_stdout(format_args!("{result}"))?;
     };
     Ok(())
 }
 
-fn write_stdout(result: &str) -> Result<(), io::Error> {
-    let mut stdout = io::stdout().lock();
-    if let Err(err) = writeln!(&mut stdout, "{result}") {
-        if err.kind() == io::ErrorKind::BrokenPipe {
-            return Ok(());
-        }
-        return Err(err);
+fn is_broken_pipe(err: &(dyn error::Error + 'static)) -> bool {
+    if let Some(err) = err.downcast_ref::<io::Error>()
+        && err.kind() == io::ErrorKind::BrokenPipe
+    {
+        return true;
     }
-    Ok(())
+
+    let mut source = err.source();
+    while let Some(err) = source {
+        if let Some(err) = err.downcast_ref::<io::Error>()
+            && err.kind() == io::ErrorKind::BrokenPipe
+        {
+            return true;
+        }
+        source = err.source();
+    }
+    false
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -30,7 +30,7 @@ use {
     solana_cli_output::{
         self, CliBalance, CliEpochReward, CliStakeHistory, CliStakeHistoryEntry, CliStakeState,
         CliStakeType, OutputFormat, ReturnSignersConfig, display::BuildBalanceMessageConfig,
-        return_signers_with_config,
+        return_signers_with_config, stdout::writeln_stdout,
     },
     solana_clock::{Clock, Epoch, SECONDS_PER_DAY, UnixTimestamp},
     solana_commitment_config::CommitmentConfig,
@@ -2913,7 +2913,7 @@ pub async fn process_delegate_stake(
             if !force {
                 sanity_check_result?;
             } else {
-                println!("--force supplied, ignoring: {err}");
+                writeln_stdout(format_args!("--force supplied, ignoring: {err}"))?;
             }
         }
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -19,7 +19,7 @@ use {
         input_validators::{is_pubkey, is_url},
         keypair::DefaultSigner,
     },
-    solana_cli_output::{CliValidatorInfo, CliValidatorInfoVec},
+    solana_cli_output::{CliValidatorInfo, CliValidatorInfoVec, stdout::writeln_stdout},
     solana_config_interface::{
         instruction::{self as config_instruction},
         state::{ConfigKeys, get_config_data},
@@ -282,7 +282,9 @@ pub async fn process_publish_validator_info(
     // Validate keybase username
     if let Some(string) = validator_info.get("keybaseUsername") {
         if force_keybase {
-            println!("--force supplied, skipping Keybase verification");
+            writeln_stdout(format_args!(
+                "--force supplied, skipping Keybase verification"
+            ))?;
         } else {
             let result = verify_keybase(&config.signers[0].pubkey(), string);
             if result.is_err() {
@@ -349,7 +351,9 @@ pub async fn process_publish_validator_info(
 
     let signers = if balance == 0 {
         if info_pubkey != info_keypair.pubkey() {
-            println!("Account {info_pubkey:?} does not exist. Generating new keypair...");
+            writeln_stdout(format_args!(
+                "Account {info_pubkey:?} does not exist. Generating new keypair..."
+            ))?;
             info_pubkey = info_keypair.pubkey();
         }
         vec![config.signers[0], &info_keypair]
@@ -358,13 +362,21 @@ pub async fn process_publish_validator_info(
     };
 
     let compute_unit_limit = ComputeUnitLimit::Simulated;
+    if balance == 0 {
+        writeln_stdout(format_args!(
+            "Publishing info for Validator {:?}",
+            config.signers[0].pubkey()
+        ))?;
+    } else {
+        writeln_stdout(format_args!(
+            "Updating Validator {:?} info at: {:?}",
+            config.signers[0].pubkey(),
+            info_pubkey
+        ))?;
+    }
     let build_message = |lamports| {
         let keys = keys.clone();
         if balance == 0 {
-            println!(
-                "Publishing info for Validator {:?}",
-                config.signers[0].pubkey()
-            );
             let mut instructions =
                 config_instruction::create_account_with_max_config_space::<ValidatorInfo>(
                     &config.signers[0].pubkey(),
@@ -385,11 +397,6 @@ pub async fn process_publish_validator_info(
             )]);
             Message::new(&instructions, Some(&config.signers[0].pubkey()))
         } else {
-            println!(
-                "Updating Validator {:?} info at: {:?}",
-                config.signers[0].pubkey(),
-                info_pubkey
-            );
             let instructions = vec![config_instruction::store(
                 &info_pubkey,
                 false,
@@ -427,8 +434,10 @@ pub async fn process_publish_validator_info(
         )
         .await?;
 
-    println!("Success! Validator info published at: {info_pubkey:?}");
-    println!("{signature_str}");
+    writeln_stdout(format_args!(
+        "Success! Validator info published at: {info_pubkey:?}"
+    ))?;
+    writeln_stdout(format_args!("{signature_str}"))?;
     Ok("".to_string())
 }
 

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -27,6 +27,7 @@ use {
         CliTransaction, CliTransactionConfirmation, OutputFormat, ReturnSignersConfig,
         display::{BuildBalanceMessageConfig, build_balance_message},
         return_signers_with_config,
+        stdout::writeln_stdout,
     },
     solana_commitment_config::CommitmentConfig,
     solana_message::Message,
@@ -761,23 +762,25 @@ pub async fn process_airdrop(
     } else {
         config.pubkey()?
     };
-    println!(
+    writeln_stdout(format_args!(
         "Requesting airdrop of {}",
         build_balance_message(lamports, false, true),
-    );
+    ))?;
 
     let pre_balance = rpc_client.get_balance(&pubkey).await?;
 
     let result = request_and_confirm_airdrop(rpc_client, config, &pubkey, lamports).await;
     if let Ok(signature) = result {
         let signature_cli_message = log_instruction_custom_error::<SystemError>(result, config)?;
-        println!("{signature_cli_message}");
+        writeln_stdout(format_args!("{signature_cli_message}"))?;
 
         let current_balance = rpc_client.get_balance(&pubkey).await?;
 
         if current_balance < pre_balance.saturating_add(lamports) {
-            println!("Balance unchanged");
-            println!("Run `solana confirm -v {signature:?}` for more info");
+            writeln_stdout(format_args!("Balance unchanged"))?;
+            writeln_stdout(format_args!(
+                "Run `solana confirm -v {signature:?}` for more info"
+            ))?;
             Ok("".to_string())
         } else {
             Ok(build_balance_message(current_balance, false, true))

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -587,7 +587,7 @@ pub async fn transaction_history(
                                     "  ",
                                     None,
                                     None,
-                                );
+                                )?;
                             }
                         }
                         break;


### PR DESCRIPTION
#### Problem

When stdout is closed by a downstream consumer before solana finishes writing command output, we get panic. For example sometimes I get with `less`:

```
> solana -ut leader-schedule |less

thread 'main' (843381) panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

`println!("{result}")` panics on stdout write failures, including EPIPE. 

#### Summary of Changes

The CLI now writes the final formatted command output through `std::io::Write` and treats `io::ErrorKind::BrokenPipe` as a normal early-close condition.
Other stdout write errors are still returned as errors.

#### Testing

Try (instead of less) before/after:
```
./target/debug/solana -ut leader-schedule | head -n 1 >/dev/null
```
