### PR TITLE
Upgrades Rust to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.96.1"


### PR DESCRIPTION
Rust 1.96.1 was released. It fixes a miscompilation.

https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/