### PR TITLE
Adds the `Votor` prefix to threads created in votor crate

### DIFF
--- a/votor/src/consensus_metrics.rs
+++ b/votor/src/consensus_metrics.rs
@@ -112,7 +112,7 @@ impl ConsensusMetrics {
         exit: Arc<AtomicBool>,
     ) -> JoinHandle<()> {
         Builder::new()
-            .name("solConsMetrics".into())
+            .name("solVotorMetrics".into())
             .spawn(move || {
                 let mut metrics = Self::new(epoch_schedule, receiver);
                 metrics.run(exit);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -97,7 +97,7 @@ pub(crate) struct ConsensusPoolService {
 impl ConsensusPoolService {
     pub(crate) fn new(ctx: ConsensusPoolContext) -> Self {
         let t_consensus_pool_service = Builder::new()
-            .name("solConPoolService".to_string())
+            .name("solVotorPoolSvc".to_string())
             .spawn(move || {
                 Self::main_loop(ctx);
                 info!("consensus pool service exited.");


### PR DESCRIPTION
#### Problem

I recently had my first experience running slowlana.  It will be good to add similar prefixes to the threads so they are easier to look up.


#### Summary of Changes

adds the `Votor` prefix to some threads created in the votor crate so that all threads created in the crate have the `solVotor` prefix.


#### Testing

Just CI
