### PR TITLE
introduces notar; finalize; fast-finalize certs

### DIFF
--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -132,7 +132,7 @@
 use {
     crate::entry::{Entry, MaxDataShredsLen},
     agave_votor_messages::{
-        certificate::{Certificate, GenesisCert},
+        certificate::{CertSignature, GenesisCert},
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
     },
     solana_bls_signatures::{
@@ -302,11 +302,11 @@ impl VotesAggregate {
     /// # Panics
     /// Panics if the signature cannot be converted to compressed format.
     /// This should never happen for valid certificates from the consensus pool.
-    pub fn from_certificate(cert: &Certificate) -> Self {
+    pub fn from_cert_signature(signature: CertSignature) -> Self {
         Self {
-            signature: BLSSignatureCompressed::try_from(&cert.signature)
+            signature: BLSSignatureCompressed::try_from(&signature.signature)
                 .expect("valid certificate signature should convert to compressed format"),
-            bitmap: cert.bitmap.clone(),
+            bitmap: signature.bitmap,
         }
     }
 

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -614,7 +614,7 @@ mod tests {
         },
         agave_feature_set::FeatureSet,
         agave_votor_messages::{
-            certificate::{Certificate, CertificateType},
+            certificate::{CertSignature, FastFinalizeCert},
             consensus_message::Block,
             reward_certificate::NUM_SLOTS_FOR_REWARD,
         },
@@ -676,18 +676,18 @@ mod tests {
             slot: bank.slot(),
             block_id: Hash::new_unique(),
         };
-        let cert_type = CertificateType::FinalizeFast(block);
         let max_rank = signing_ranks.iter().copied().max().unwrap_or(0);
         let mut bitvec = BitVec::<u8, Lsb0>::repeat(false, max_rank.saturating_add(1));
         for &rank in signing_ranks {
             bitvec.set(rank, true);
         }
         let bitmap = encode_base2(&bitvec).unwrap();
-
-        let cert = Certificate {
-            cert_type,
-            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
-            bitmap,
+        let cert = FastFinalizeCert {
+            block,
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap,
+            },
         };
         ValidatedBlockFinalizationCert::from_validated_fast(cert, bank)
     }

--- a/runtime/src/validated_block_finalization.rs
+++ b/runtime/src/validated_block_finalization.rs
@@ -7,7 +7,9 @@
 use {
     crate::bank::Bank,
     agave_votor_messages::{
-        certificate::{Certificate, CertificateType},
+        certificate::{
+            CertSignature, Certificate, CertificateType, FastFinalizeCert, FinalizeCert, NotarCert,
+        },
         consensus_message::Block,
         finalized_slot::FinalizedSlot,
         unverified_vote_message::UnverifiedCertificate,
@@ -54,12 +56,12 @@ enum ValidatedBlockFinalizationCertKind {
     /// Slow finalization: requires both a Finalize cert and a Notarize cert for the same slot
     Finalize {
         /// The finalize certificate
-        finalize_cert: Certificate,
+        finalize_cert: FinalizeCert,
         /// The notarize certificate
-        notarize_cert: Certificate,
+        notarize_cert: NotarCert,
     },
     /// Fast finalization: a single FastFinalize certificate
-    FastFinalize(Certificate),
+    FastFinalize(FastFinalizeCert),
 }
 
 /// A validated proof that a block has been finalized.
@@ -98,7 +100,7 @@ impl ValidatedBlockFinalizationCert {
             let notarize_cert_type = CertificateType::Notarize(block);
             let finalize_cert_type = CertificateType::Finalize(block.slot);
 
-            let notarize_cert = UnverifiedCertificate {
+            let unverified_notar_cert = UnverifiedCertificate {
                 cert_type: notarize_cert_type,
                 signature: notar_aggregate
                     .uncompress_signature()
@@ -106,7 +108,7 @@ impl ValidatedBlockFinalizationCert {
                 bitmap: notar_aggregate.into_bitmap(),
                 shred_version,
             };
-            let finalize_cert = UnverifiedCertificate {
+            let unverified_finalize_cert = UnverifiedCertificate {
                 cert_type: finalize_cert_type,
                 signature: block_final_cert
                     .final_aggregate
@@ -117,12 +119,23 @@ impl ValidatedBlockFinalizationCert {
             };
 
             // Verify both certificates
-            let notarize_cert = Self::verify_certificate(bank, notarize_cert)?;
-            let finalize_cert = Self::verify_certificate(bank, finalize_cert)?;
+            let notar_signature = Self::verify_certificate(bank, unverified_notar_cert)?;
+            let finalize_signature = Self::verify_certificate(bank, unverified_finalize_cert)?;
 
-            let finalize_signers = Self::extract_signers(bank, &finalize_cert)?;
-            let mut signers = Self::extract_signers(bank, &notarize_cert)?;
+            let finalize_signers =
+                Self::extract_signers(bank, finalize_cert_type, &finalize_signature.bitmap)?;
+            let mut signers =
+                Self::extract_signers(bank, notarize_cert_type, &notar_signature.bitmap)?;
             signers.extend(finalize_signers);
+
+            let notarize_cert = NotarCert {
+                block,
+                signature: notar_signature,
+            };
+            let finalize_cert = FinalizeCert {
+                slot: block.slot,
+                signature: finalize_signature,
+            };
 
             Ok(Self {
                 kind: ValidatedBlockFinalizationCertKind::Finalize {
@@ -147,9 +160,9 @@ impl ValidatedBlockFinalizationCert {
                 shred_version,
             };
 
-            let fast_finalize_cert = Self::verify_certificate(bank, fast_finalize_cert)?;
-
-            let signers = Self::extract_signers(bank, &fast_finalize_cert)?;
+            let signature = Self::verify_certificate(bank, fast_finalize_cert)?;
+            let signers = Self::extract_signers(bank, fast_finalize_cert_type, &signature.bitmap)?;
+            let fast_finalize_cert = FastFinalizeCert { block, signature };
             Ok(Self {
                 kind: ValidatedBlockFinalizationCertKind::FastFinalize(fast_finalize_cert),
                 signers,
@@ -166,21 +179,24 @@ impl ValidatedBlockFinalizationCert {
     /// The caller must ensure that the provided certificates have been properly validated.
     /// Using unvalidated certificates will compromise the type's safety guarantees.
     pub fn from_validated_slow(
-        finalize_cert: Certificate,
-        notarize_cert: Certificate,
+        finalize_cert: FinalizeCert,
+        notarize_cert: NotarCert,
         bank: &Bank,
     ) -> Self {
-        debug_assert!(finalize_cert.cert_type.is_slow_finalization());
-        debug_assert!(notarize_cert.cert_type.is_notarize());
-        debug_assert_eq!(
-            notarize_cert.cert_type.slot(),
-            finalize_cert.cert_type.slot()
-        );
+        debug_assert_eq!(notarize_cert.block.slot, finalize_cert.slot);
 
-        let finalize_signers = Self::extract_signers(bank, &finalize_cert)
-            .expect("Certificate should have been validated");
-        let mut signers = Self::extract_signers(bank, &notarize_cert)
-            .expect("Certificate should have been validated");
+        let finalize_signers = Self::extract_signers(
+            bank,
+            CertificateType::Finalize(finalize_cert.slot),
+            &finalize_cert.signature.bitmap,
+        )
+        .expect("Certificate should have been validated");
+        let mut signers = Self::extract_signers(
+            bank,
+            CertificateType::Notarize(notarize_cert.block),
+            &notarize_cert.signature.bitmap,
+        )
+        .expect("Certificate should have been validated");
         signers.extend(finalize_signers);
         Self {
             kind: ValidatedBlockFinalizationCertKind::Finalize {
@@ -199,11 +215,10 @@ impl ValidatedBlockFinalizationCert {
     /// # Safety
     /// The caller must ensure that the provided certificate has been properly validated.
     /// Using an unvalidated certificate will compromise the type's safety guarantees.
-    pub fn from_validated_fast(cert: Certificate, bank: &Bank) -> Self {
-        debug_assert!(cert.cert_type.is_fast_finalization());
-
-        let signers =
-            Self::extract_signers(bank, &cert).expect("Certificate should have been validated");
+    pub fn from_validated_fast(cert: FastFinalizeCert, bank: &Bank) -> Self {
+        let cert_type = CertificateType::FinalizeFast(cert.block);
+        let signers = Self::extract_signers(bank, cert_type, &cert.signature.bitmap)
+            .expect("Certificate should have been validated");
         Self {
             kind: ValidatedBlockFinalizationCertKind::FastFinalize(cert),
             signers,
@@ -217,14 +232,11 @@ impl ValidatedBlockFinalizationCert {
                 finalize_cert,
                 notarize_cert,
             } => {
-                debug_assert_eq!(
-                    finalize_cert.cert_type.slot(),
-                    notarize_cert.cert_type.slot()
-                );
-                FinalizedSlot::Slow(finalize_cert.cert_type.slot())
+                debug_assert_eq!(finalize_cert.slot, notarize_cert.block.slot);
+                FinalizedSlot::Slow(finalize_cert.slot)
             }
             ValidatedBlockFinalizationCertKind::FastFinalize(certificate) => {
-                FinalizedSlot::Fast(certificate.cert_type.slot())
+                FinalizedSlot::Fast(certificate.block.slot)
             }
         }
     }
@@ -232,14 +244,10 @@ impl ValidatedBlockFinalizationCert {
     /// Returns the block that is finalized (slot, block_id).
     pub fn block(&self) -> Block {
         match &self.kind {
-            ValidatedBlockFinalizationCertKind::Finalize { notarize_cert, .. } => notarize_cert
-                .cert_type
-                .to_block()
-                .expect("notarize certificate has block"),
-            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => cert
-                .cert_type
-                .to_block()
-                .expect("fast finalize certificate has block"),
+            ValidatedBlockFinalizationCertKind::Finalize { notarize_cert, .. } => {
+                notarize_cert.block
+            }
+            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => cert.block,
         }
     }
 
@@ -260,8 +268,27 @@ impl ValidatedBlockFinalizationCert {
             ValidatedBlockFinalizationCertKind::Finalize {
                 finalize_cert,
                 notarize_cert,
-            } => vec![finalize_cert.clone(), notarize_cert.clone()],
-            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => vec![cert.clone()],
+            } => {
+                let notar = Certificate {
+                    cert_type: CertificateType::Notarize(notarize_cert.block),
+                    signature: notarize_cert.signature.signature,
+                    bitmap: notarize_cert.signature.bitmap.clone(),
+                };
+                let finalize = Certificate {
+                    cert_type: CertificateType::Finalize(finalize_cert.slot),
+                    signature: finalize_cert.signature.signature,
+                    bitmap: finalize_cert.signature.bitmap.clone(),
+                };
+                vec![finalize, notar]
+            }
+            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => {
+                let cert = Certificate {
+                    cert_type: CertificateType::FinalizeFast(cert.block),
+                    signature: cert.signature.signature,
+                    bitmap: cert.signature.bitmap.clone(),
+                };
+                vec![cert]
+            }
         }
     }
 
@@ -280,8 +307,27 @@ impl ValidatedBlockFinalizationCert {
             ValidatedBlockFinalizationCertKind::Finalize {
                 finalize_cert,
                 notarize_cert,
-            } => (finalize_cert, Some(notarize_cert)),
-            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => (cert, None),
+            } => {
+                let notar = Certificate {
+                    cert_type: CertificateType::Notarize(notarize_cert.block),
+                    signature: notarize_cert.signature.signature,
+                    bitmap: notarize_cert.signature.bitmap,
+                };
+                let finalize = Certificate {
+                    cert_type: CertificateType::Finalize(finalize_cert.slot),
+                    signature: finalize_cert.signature.signature,
+                    bitmap: finalize_cert.signature.bitmap,
+                };
+                (finalize, Some(notar))
+            }
+            ValidatedBlockFinalizationCertKind::FastFinalize(cert) => {
+                let cert = Certificate {
+                    cert_type: CertificateType::FinalizeFast(cert.block),
+                    signature: cert.signature.signature,
+                    bitmap: cert.signature.bitmap,
+                };
+                (cert, None)
+            }
         };
         (signers, final_cert, notar_cert)
     }
@@ -293,65 +339,63 @@ impl ValidatedBlockFinalizationCert {
                 finalize_cert,
                 notarize_cert,
             } => {
-                let slot = finalize_cert.cert_type.slot();
-                let block_id = notarize_cert
-                    .cert_type
-                    .to_block()
-                    .expect("notarize certificates correspond to blocks")
-                    .block_id;
+                let slot = finalize_cert.slot;
+                let block_id = notarize_cert.block.block_id;
                 BlockFinalizationCert {
                     slot,
                     block_id,
-                    final_aggregate: VotesAggregate::from_certificate(finalize_cert),
-                    notar_aggregate: Some(VotesAggregate::from_certificate(notarize_cert)),
+                    final_aggregate: VotesAggregate::from_cert_signature(
+                        finalize_cert.signature.clone(),
+                    ),
+                    notar_aggregate: Some(VotesAggregate::from_cert_signature(
+                        notarize_cert.signature.clone(),
+                    )),
                 }
             }
             ValidatedBlockFinalizationCertKind::FastFinalize(cert) => {
-                let block = cert
-                    .cert_type
-                    .to_block()
-                    .expect("fast finalizations correspond to blocks");
+                let block = cert.block;
                 BlockFinalizationCert {
                     slot: block.slot,
                     block_id: block.block_id,
-                    final_aggregate: VotesAggregate::from_certificate(cert),
+                    final_aggregate: VotesAggregate::from_cert_signature(cert.signature.clone()),
                     notar_aggregate: None,
                 }
             }
         }
     }
 
-    /// Verifies the certificate, returning (stake present in certificate, total stake in validator set) on success.
+    /// Verifies the certificate and returns `CertSignature` on success.
     fn verify_certificate(
         bank: &Bank,
         cert: UnverifiedCertificate,
-    ) -> Result<Certificate, BlockFinalizationCertError> {
+    ) -> Result<CertSignature, BlockFinalizationCertError> {
         let cert_type = cert.cert_type;
         let cert = bank
             .verify_certificate(cert)
             .map_err(|_| BlockFinalizationCertError::CertificateVerificationFailed(cert_type))?;
-        Ok(cert)
+        debug_assert_eq!(cert.cert_type, cert_type);
+        Ok(CertSignature {
+            signature: cert.signature,
+            bitmap: cert.bitmap,
+        })
     }
 
     fn extract_signers(
         bank: &Bank,
-        cert: &Certificate,
+        cert_type: CertificateType,
+        bitmap: &[u8],
     ) -> Result<HashSet<Pubkey>, BlockFinalizationCertError> {
-        let Some(epoch_stakes) = bank.epoch_stakes_from_slot(cert.cert_type.slot()) else {
-            return Err(BlockFinalizationCertError::MissingEpochStakes(
-                cert.cert_type,
-            ));
+        let Some(epoch_stakes) = bank.epoch_stakes_from_slot(cert_type.slot()) else {
+            return Err(BlockFinalizationCertError::MissingEpochStakes(cert_type));
         };
         let rank_map = epoch_stakes.bls_pubkey_to_rank_map();
-        let decoded = decode(&cert.bitmap, rank_map.len());
+        let decoded = decode(bitmap, rank_map.len());
         let ranks = match decoded {
             Ok(Decoded::Base2(ranks)) => ranks,
             Ok(Decoded::Base3(_, _)) => {
-                return Err(BlockFinalizationCertError::Base3Finalization(
-                    cert.cert_type,
-                ));
+                return Err(BlockFinalizationCertError::Base3Finalization(cert_type));
             }
-            Err(err) => return Err(BlockFinalizationCertError::DecodeError(cert.cert_type, err)),
+            Err(err) => return Err(BlockFinalizationCertError::DecodeError(cert_type, err)),
         };
 
         Ok(ranks
@@ -403,15 +447,14 @@ mod tests {
         (bank, validator_keypairs)
     }
 
-    /// Build a certificate by manually aggregating BLS signatures and encoding bitmap.
+    /// Build a cert signature by manually aggregating BLS signatures and encoding bitmap.
     /// `signing_ranks` specifies which validator ranks are signing.
-    fn build_certificate_manual(
-        cert_type: CertificateType,
+    fn build_cert_signature(
         vote: Vote,
         shred_version: u16,
         signing_ranks: &[usize],
         validator_keypairs: &[ValidatorVoteKeypairs],
-    ) -> Certificate {
+    ) -> CertSignature {
         let serialized_vote = get_vote_payload_to_sign(vote, shred_version);
 
         // Aggregate signatures
@@ -429,8 +472,7 @@ mod tests {
         }
         let bitmap = encode_base2(&bitvec).expect("Failed to encode bitmap");
 
-        Certificate {
-            cert_type,
+        CertSignature {
             signature: signature.into(),
             bitmap,
         }
@@ -474,18 +516,18 @@ mod tests {
             let cert_type = CertificateType::FinalizeFast(block);
             let vote = Vote::new_notarization_vote(block);
             let signing_ranks: Vec<usize> = (0..6).collect();
-            let fast_finalize_cert = build_certificate_manual(
+            let fast_finalize_cert_sig =
+                build_cert_signature(vote, shred_version, &signing_ranks, &validator_keypairs);
+            let fast_finalize_cert = Certificate {
                 cert_type,
-                vote,
-                shred_version,
-                &signing_ranks,
-                &validator_keypairs,
-            );
+                signature: fast_finalize_cert_sig.signature,
+                bitmap: fast_finalize_cert_sig.bitmap.clone(),
+            };
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
                 block_id: block.block_id,
-                final_aggregate: VotesAggregate::from_certificate(&fast_finalize_cert),
+                final_aggregate: VotesAggregate::from_cert_signature(fast_finalize_cert_sig),
                 notar_aggregate: None,
             };
 
@@ -504,30 +546,38 @@ mod tests {
             let notarize_cert_type = CertificateType::Notarize(block);
             let notarize_vote = Vote::new_notarization_vote(block);
             let notarize_signing_ranks: Vec<usize> = (0..4).collect();
-            let notarize_cert = build_certificate_manual(
-                notarize_cert_type,
+            let notarize_cert_sig = build_cert_signature(
                 notarize_vote,
                 shred_version,
                 &notarize_signing_ranks,
                 &validator_keypairs,
             );
+            let notarize_cert = Certificate {
+                cert_type: notarize_cert_type,
+                signature: notarize_cert_sig.signature,
+                bitmap: notarize_cert_sig.bitmap.clone(),
+            };
 
             let finalize_cert_type = CertificateType::Finalize(block.slot);
             let finalize_vote = Vote::new_finalization_vote(block.slot);
             let finalize_signing_ranks: Vec<usize> = (0..4).collect();
-            let finalize_cert = build_certificate_manual(
-                finalize_cert_type,
+            let finalize_cert_sig = build_cert_signature(
                 finalize_vote,
                 shred_version,
                 &finalize_signing_ranks,
                 &validator_keypairs,
             );
+            let finalize_cert = Certificate {
+                cert_type: finalize_cert_type,
+                signature: finalize_cert_sig.signature,
+                bitmap: finalize_cert_sig.bitmap.clone(),
+            };
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
                 block_id: block.block_id,
-                final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
-                notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
+                final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
+                notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };
 
             let validated = ValidatedBlockFinalizationCert::try_from_footer(
@@ -554,27 +604,29 @@ mod tests {
             block_id: Hash::new_unique(),
         };
 
-        let notarize_cert_type = CertificateType::Notarize(block);
         let notarize_vote = Vote::new_notarization_vote(block);
         let notarize_signing_ranks = vec![0, 1, 3];
-        let notarize_cert = build_certificate_manual(
-            notarize_cert_type,
-            notarize_vote,
-            shred_version,
-            &notarize_signing_ranks,
-            &validator_keypairs,
-        );
+        let notarize_cert = NotarCert {
+            block,
+            signature: build_cert_signature(
+                notarize_vote,
+                shred_version,
+                &notarize_signing_ranks,
+                &validator_keypairs,
+            ),
+        };
 
-        let finalize_cert_type = CertificateType::Finalize(block.slot);
         let finalize_vote = Vote::new_finalization_vote(block.slot);
         let finalize_signing_ranks = vec![0, 1, 2];
-        let finalize_cert = build_certificate_manual(
-            finalize_cert_type,
-            finalize_vote,
-            shred_version,
-            &finalize_signing_ranks,
-            &validator_keypairs,
-        );
+        let finalize_cert = FinalizeCert {
+            slot: block.slot,
+            signature: build_cert_signature(
+                finalize_vote,
+                shred_version,
+                &finalize_signing_ranks,
+                &validator_keypairs,
+            ),
+        };
 
         let mut expected_signers = vote_pubkeys_for_ranks(&bank, &notarize_signing_ranks);
         expected_signers.extend(vote_pubkeys_for_ranks(&bank, &finalize_signing_ranks));
@@ -582,8 +634,10 @@ mod tests {
         let block_final_cert = BlockFinalizationCert {
             slot: block.slot,
             block_id: block.block_id,
-            final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
-            notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
+            final_aggregate: VotesAggregate::from_cert_signature(finalize_cert.signature.clone()),
+            notar_aggregate: Some(VotesAggregate::from_cert_signature(
+                notarize_cert.signature.clone(),
+            )),
         };
         let validated =
             ValidatedBlockFinalizationCert::try_from_footer(block_final_cert, &bank, shred_version)
@@ -619,21 +673,15 @@ mod tests {
         // Fast finalize with insufficient stake (requires 80% = 4400)
         // Top 5 validators = 1000+900+800+700+600 = 4000 (< 80%)
         {
-            let cert_type = CertificateType::FinalizeFast(block);
             let vote = Vote::new_notarization_vote(block);
             let signing_ranks: Vec<usize> = (0..5).collect();
-            let fast_finalize_cert = build_certificate_manual(
-                cert_type,
-                vote,
-                shred_version,
-                &signing_ranks,
-                &validator_keypairs,
-            );
+            let fast_finalize_cert_sig =
+                build_cert_signature(vote, shred_version, &signing_ranks, &validator_keypairs);
 
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
                 block_id: block.block_id,
-                final_aggregate: VotesAggregate::from_certificate(&fast_finalize_cert),
+                final_aggregate: VotesAggregate::from_cert_signature(fast_finalize_cert_sig),
                 notar_aggregate: None,
             };
 
@@ -655,11 +703,9 @@ mod tests {
         // Slow finalize with insufficient notarize stake (requires 60% = 3300)
         // Top 3 validators = 1000+900+800 = 2700 (< 60%)
         {
-            let notarize_cert_type = CertificateType::Notarize(block);
             let notarize_vote = Vote::new_notarization_vote(block);
             let notarize_signing_ranks: Vec<usize> = (0..3).collect();
-            let notarize_cert = build_certificate_manual(
-                notarize_cert_type,
+            let notarize_cert_sig = build_cert_signature(
                 notarize_vote,
                 shred_version,
                 &notarize_signing_ranks,
@@ -667,11 +713,9 @@ mod tests {
             );
 
             // Finalize cert has enough stake
-            let finalize_cert_type = CertificateType::Finalize(block.slot);
             let finalize_vote = Vote::new_finalization_vote(block.slot);
             let finalize_signing_ranks: Vec<usize> = (0..4).collect();
-            let finalize_cert = build_certificate_manual(
-                finalize_cert_type,
+            let finalize_cert_sig = build_cert_signature(
                 finalize_vote,
                 shred_version,
                 &finalize_signing_ranks,
@@ -681,8 +725,8 @@ mod tests {
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
                 block_id: block.block_id,
-                final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
-                notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
+                final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
+                notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };
 
             let err = ValidatedBlockFinalizationCert::try_from_footer(
@@ -704,11 +748,9 @@ mod tests {
         // Notarize has enough stake, but finalize doesn't
         {
             // Notarize cert has enough stake
-            let notarize_cert_type = CertificateType::Notarize(block);
             let notarize_vote = Vote::new_notarization_vote(block);
             let notarize_signing_ranks: Vec<usize> = (0..4).collect();
-            let notarize_cert = build_certificate_manual(
-                notarize_cert_type,
+            let notarize_cert_sig = build_cert_signature(
                 notarize_vote,
                 shred_version,
                 &notarize_signing_ranks,
@@ -717,11 +759,9 @@ mod tests {
 
             // Finalize cert has insufficient stake
             // Top 3 validators = 1000+900+800 = 2700 (< 60%)
-            let finalize_cert_type = CertificateType::Finalize(block.slot);
             let finalize_vote = Vote::new_finalization_vote(block.slot);
             let finalize_signing_ranks: Vec<usize> = (0..3).collect();
-            let finalize_cert = build_certificate_manual(
-                finalize_cert_type,
+            let finalize_cert_sig = build_cert_signature(
                 finalize_vote,
                 shred_version,
                 &finalize_signing_ranks,
@@ -731,8 +771,8 @@ mod tests {
             let block_final_cert = BlockFinalizationCert {
                 slot: block.slot,
                 block_id: block.block_id,
-                final_aggregate: VotesAggregate::from_certificate(&finalize_cert),
-                notar_aggregate: Some(VotesAggregate::from_certificate(&notarize_cert)),
+                final_aggregate: VotesAggregate::from_cert_signature(finalize_cert_sig),
+                notar_aggregate: Some(VotesAggregate::from_cert_signature(notarize_cert_sig)),
             };
 
             let err = ValidatedBlockFinalizationCert::try_from_footer(

--- a/votor-messages/src/certificate.rs
+++ b/votor-messages/src/certificate.rs
@@ -31,6 +31,33 @@ pub struct GenesisCert {
     pub signature: CertSignature,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A notarize cert
+pub struct NotarCert {
+    /// Block the cert is for.
+    pub block: Block,
+    /// the signature on the cert
+    pub signature: CertSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A slow finalized cert
+pub struct FinalizeCert {
+    /// Slot the cert is for.
+    pub slot: Slot,
+    /// the signature on the cert
+    pub signature: CertSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A fast finalized cert
+pub struct FastFinalizeCert {
+    /// Block the cert is for.
+    pub block: Block,
+    /// the signature on the cert
+    pub signature: CertSignature,
+}
+
 /// The actual certificate with the aggregate signature and bitmap for which validators are included in the aggregate.
 /// BLS vote message, we need rank to look up pubkey
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -15,7 +15,10 @@ use {
     },
     agave_bls_sigverify::generated_cert_types::GeneratedCertTypes,
     agave_votor_messages::{
-        certificate::{CertSignature, Certificate, CertificateType, GenesisCert},
+        certificate::{
+            CertSignature, Certificate, CertificateType, FastFinalizeCert, FinalizeCert,
+            GenesisCert, NotarCert,
+        },
         consensus_message::{Block, ConsensusMessage, VoteMessage},
         finalized_slot::FinalizedSlot,
         fraction::Fraction,
@@ -306,10 +309,17 @@ impl ConsensusPool {
                         .highest_finalized_slot()
                         .is_none_or(|s| s < FinalizedSlot::Slow(block.slot))
                     {
+                        let notarize_cert = NotarCert {
+                            block,
+                            signature: CertSignature {
+                                signature: cert.signature,
+                                bitmap: cert.bitmap.clone(),
+                            },
+                        };
                         self.highest_finalized_slot_cert =
                             Some(ValidatedBlockFinalizationCert::from_validated_slow(
-                                Arc::unwrap_or_clone(finalize_cert.clone()),
-                                Arc::unwrap_or_clone(cert),
+                                finalize_cert,
+                                notarize_cert,
                                 root_bank,
                             ));
                     }
@@ -317,16 +327,23 @@ impl ConsensusPool {
             }
             CertificateType::Finalize(slot) => {
                 if let Some(notarize_cert) = self.get_notarize_cert(slot) {
-                    let block = notarize_cert.cert_type.to_block().unwrap();
+                    let block = notarize_cert.block;
                     events.push(VotorEvent::Finalized(block, false));
                     if self
                         .highest_finalized_slot()
                         .is_none_or(|s| s < FinalizedSlot::Slow(slot))
                     {
+                        let finalize_cert = FinalizeCert {
+                            slot,
+                            signature: CertSignature {
+                                signature: cert.signature,
+                                bitmap: cert.bitmap.clone(),
+                            },
+                        };
                         self.highest_finalized_slot_cert =
                             Some(ValidatedBlockFinalizationCert::from_validated_slow(
-                                Arc::unwrap_or_clone(cert),
-                                Arc::unwrap_or_clone(notarize_cert),
+                                finalize_cert,
+                                notarize_cert,
                                 root_bank,
                             ));
                     }
@@ -340,9 +357,16 @@ impl ConsensusPool {
                     .highest_finalized_slot()
                     .is_none_or(|s| s < FinalizedSlot::Fast(block.slot))
                 {
+                    let fast_finalize_cert = FastFinalizeCert {
+                        block,
+                        signature: CertSignature {
+                            signature: cert.signature,
+                            bitmap: cert.bitmap.clone(),
+                        },
+                    };
                     self.highest_finalized_slot_cert =
                         Some(ValidatedBlockFinalizationCert::from_validated_fast(
-                            Arc::unwrap_or_clone(cert),
+                            fast_finalize_cert,
                             root_bank,
                         ));
                 }
@@ -486,19 +510,32 @@ impl ConsensusPool {
     }
 
     /// Get the Notarize certificate for a slot
-    fn get_notarize_cert(&self, slot: Slot) -> Option<Arc<Certificate>> {
+    fn get_notarize_cert(&self, slot: Slot) -> Option<NotarCert> {
         self.completed_certificates
             .iter()
             .find_map(|(cert_type, cert)| match cert_type {
-                CertificateType::Notarize(block) if slot == block.slot => Some(cert.clone()),
+                CertificateType::Notarize(block) if slot == block.slot => Some(NotarCert {
+                    block: *block,
+                    signature: CertSignature {
+                        signature: cert.signature,
+                        bitmap: cert.bitmap.clone(),
+                    },
+                }),
                 _ => None,
             })
     }
 
     /// Get the Finalize certificate for a slot
-    fn get_finalize_cert(&self, slot: Slot) -> Option<&Arc<Certificate>> {
+    fn get_finalize_cert(&self, slot: Slot) -> Option<FinalizeCert> {
         self.completed_certificates
             .get(&CertificateType::Finalize(slot))
+            .map(|c| FinalizeCert {
+                slot,
+                signature: CertSignature {
+                    signature: c.signature,
+                    bitmap: c.bitmap.clone(),
+                },
+            })
     }
 
     /// Get the highest finalized slot (slow or fast)


### PR DESCRIPTION
#### Problem

- A number of places in the code assume that the `Certificate` will contain a more specific type cert and are panicking if that is not the case.  Having more type safety here would be better.
- As discussed in https://github.com/anza-xyz/agave/issues/13560, in particular in https://github.com/anza-xyz/agave/issues/13560#issuecomment-4845332996, we want to revamp the `Certificate` type.
- Also see https://github.com/anza-xyz/agave/pull/13574

#### Summary of Changes

- Introduces `NotarCert`; `FinalizeCert`, and `FastFinalizeCert` types
- Uses them in various places where earlier we were using `Certificate`.

#### Testing

Just CI