### PR TITLE
bcp: disallow entry batches after footer and enforce alpentick

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1757,7 +1757,7 @@ pub fn confirm_slot(
                 // since it won't have the required block markers.
                 if slot != 0 {
                     processor
-                        .on_entry_batch(migration_status, slot)
+                        .on_entry_batch(migration_status, slot, &entries, is_final)
                         .inspect_err(|err| {
                             warn!(
                                 "BlockComponentProcessor::on_entry_batch() for slot {slot} failed \
@@ -1804,10 +1804,12 @@ pub fn confirm_slot(
                             migration_status,
                         )
                         .inspect_err(|err| {
-                            warn!(
-                                "BlockComponentProcessor::on_marker() for slot {slot} failed with \
-                                 {err}"
-                            );
+                            if !matches!(err, BlockComponentProcessorError::AbandonedBank(_)) {
+                                warn!(
+                                    "BlockComponentProcessor::on_marker() for slot {slot} failed \
+                                     with {err}"
+                                );
+                            }
                         })?;
                 }
                 progress.num_shreds += num_shreds as u64;
@@ -6037,8 +6039,9 @@ pub mod tests {
         }
     }
 
-    fn confirm_slot_with_block_markers_common()
-    -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
+    fn confirm_slot_with_block_markers_common(
+        footer_before_alpentick: bool,
+    ) -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(100 * LAMPORTS_PER_SOL);
@@ -6092,39 +6095,73 @@ pub mod tests {
             .collect();
         next_shred_index = header_shreds.last().unwrap().index() + 1;
 
-        let entries = create_ticks(ticks_per_slot, 0, genesis_config.hash());
-        let entry_shreds: Vec<Shred> = shredder
-            .make_merkle_shreds_from_entries(
-                &keypair,
-                &entries,
-                false,
-                Hash::default(),
-                next_shred_index,
-                0,
-                &reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
-            )
-            .filter(Shred::is_data)
-            .collect();
-        next_shred_index = entry_shreds.last().unwrap().index() + 1;
-
-        let footer_shreds: Vec<Shred> = shredder
-            .make_merkle_shreds_from_component(
-                &keypair,
-                &footer_component,
-                true, // last in slot
-                Hash::default(),
-                next_shred_index,
-                0,
-                &reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
-            )
-            .filter(Shred::is_data)
-            .collect();
-
         let mut all_shreds = header_shreds;
-        all_shreds.extend(entry_shreds);
-        all_shreds.extend(footer_shreds);
+        let entries = vec![next_entry(&genesis_config.hash(), 1, vec![])];
+        if footer_before_alpentick {
+            let footer_shreds: Vec<Shred> = shredder
+                .make_merkle_shreds_from_component(
+                    &keypair,
+                    &footer_component,
+                    false,
+                    Hash::default(),
+                    next_shred_index,
+                    0,
+                    &reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
+                )
+                .filter(Shred::is_data)
+                .collect();
+            next_shred_index = footer_shreds.last().unwrap().index() + 1;
+
+            let entry_shreds: Vec<Shred> = shredder
+                .make_merkle_shreds_from_entries(
+                    &keypair,
+                    &entries,
+                    true, // last in slot
+                    Hash::default(),
+                    next_shred_index,
+                    0,
+                    &reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
+                )
+                .filter(Shred::is_data)
+                .collect();
+
+            all_shreds.extend(footer_shreds);
+            all_shreds.extend(entry_shreds);
+        } else {
+            let entry_shreds: Vec<Shred> = shredder
+                .make_merkle_shreds_from_entries(
+                    &keypair,
+                    &entries,
+                    false,
+                    Hash::default(),
+                    next_shred_index,
+                    0,
+                    &reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
+                )
+                .filter(Shred::is_data)
+                .collect();
+            next_shred_index = entry_shreds.last().unwrap().index() + 1;
+
+            let footer_shreds: Vec<Shred> = shredder
+                .make_merkle_shreds_from_component(
+                    &keypair,
+                    &footer_component,
+                    true, // last in slot
+                    Hash::default(),
+                    next_shred_index,
+                    0,
+                    &reed_solomon_cache,
+                    &mut ProcessShredsStats::default(),
+                )
+                .filter(Shred::is_data)
+                .collect();
+
+            all_shreds.extend(entry_shreds);
+            all_shreds.extend(footer_shreds);
+        }
         blockstore.insert_shreds(all_shreds, true).unwrap();
 
         let replay_tx_thread_pool = create_thread_pool(1);
@@ -6140,7 +6177,7 @@ pub mod tests {
     #[test]
     fn test_confirm_slot_block_with_markers_fails_without_alpenglow() {
         let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
-            confirm_slot_with_block_markers_common();
+            confirm_slot_with_block_markers_common(true);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
@@ -6175,7 +6212,7 @@ pub mod tests {
     #[test]
     fn test_confirm_slot_block_with_markers_succeeds_with_alpenglow() {
         let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
-            confirm_slot_with_block_markers_common();
+            confirm_slot_with_block_markers_common(true);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
@@ -6206,6 +6243,42 @@ pub mod tests {
             &MigrationStatus::post_migration_status(),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_confirm_slot_rejects_alpentick_before_footer() {
+        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+            confirm_slot_with_block_markers_common(false);
+
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+        let mut bank1 = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
+        bank1.activate_feature(&agave_feature_set::alpenglow::id());
+        let bank1 = bank_forks.write().unwrap().insert(bank1);
+
+        let result = confirm_slot(
+            &blockstore,
+            &bank1,
+            compute_shred_version(&genesis_config.hash(), None),
+            &replay_tx_thread_pool,
+            &mut ConfirmationTiming::default(),
+            &mut ConfirmationProgress::new(bank0.last_blockhash()),
+            true,
+            None,
+            None,
+            None,
+            None,
+            false,
+            None,
+            None,
+            &MigrationStatus::post_migration_status(),
+        );
+        assert_matches!(
+            result,
+            Err(BlockstoreProcessorError::BlockComponentProcessor(
+                BlockComponentProcessorError::InvalidAlpentickPosition
+            ))
+        );
     }
 
     #[test]

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -19,9 +19,12 @@ use {
     crossbeam_channel::Sender,
     log::*,
     solana_clock::Slot,
-    solana_entry::block_component::{
-        BlockFooterV1, BlockMarkerV1, GenesisCertBlockMarker, VersionedBlockFooter,
-        VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
+    solana_entry::{
+        block_component::{
+            BlockFooterV1, BlockMarkerV1, GenesisCertBlockMarker, VersionedBlockFooter,
+            VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
+        },
+        entry::Entry,
     },
     solana_hash::Hash,
     solana_pubkey::Pubkey,
@@ -59,6 +62,10 @@ pub enum BlockComponentProcessorError {
     MissingGenesisCertificateMarker,
     #[error("Missing parent marker (neither a header nor an update parent was present)")]
     MissingParentMarker,
+    #[error("Entry batch detected after block footer")]
+    EntryBatchAfterBlockFooter,
+    #[error("Alpentick must be the final block component and appear after block footer")]
+    InvalidAlpentickPosition,
     #[error("Multiple block footers detected")]
     MultipleBlockFooters,
     #[error("Multiple block headers detected")]
@@ -94,6 +101,8 @@ impl BlockComponentProcessorError {
     pub fn is_update_parent_recoverable_replay_error(&self) -> bool {
         match self {
             BlockComponentProcessorError::MissingParentMarker
+            | BlockComponentProcessorError::EntryBatchAfterBlockFooter
+            | BlockComponentProcessorError::InvalidAlpentickPosition
             | BlockComponentProcessorError::MultipleBlockFooters
             | BlockComponentProcessorError::MultipleBlockHeaders
             | BlockComponentProcessorError::HeaderParentSlotMismatch { .. }
@@ -118,13 +127,186 @@ impl BlockComponentProcessorError {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// The parent marker that established the current entry section.
+enum EntryParentMarker {
+    BlockHeader,
+    UpdateParent,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+/// The stage within the block we are currently in
+///
+/// All blocks MUST follow this exact shape
+///
+/// Header
+/// Optional Genesis marker - this is the only valid position for a genesis marker
+/// 0 or more Entries
+/// Optional UpdateParent
+/// 0 or more Entries
+/// Footer
+/// Alpentick
+///
+/// Block component processing can start either from the header
+/// or from the UpdateParent.
+enum BlockComponentStage {
+    #[default]
+    /// Beginning of the block, can only accept a parent marker
+    PreParentMarker,
+    /// Immediately after the header, can accept genesis marker, entries or footer
+    AcceptingGenesisOrEntries,
+    /// During the entries section, can accept entries or the footer
+    /// If the parent marker was a block header, can also accept an UpdateParent marker
+    AcceptingEntriesOrFooter { parent_marker: EntryParentMarker },
+    /// After the footer, can only accept the alpentick
+    AcceptingAlpentick,
+    /// After the alpentick, nothing more is accepted
+    Done,
+}
+
+impl BlockComponentStage {
+    /// If current stage is `PreParentMarker`, transition to `AcceptingGenesisOrEntries`
+    fn on_header(&mut self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => {
+                *self = Self::AcceptingGenesisOrEntries;
+                Ok(())
+            }
+            Self::AcceptingGenesisOrEntries
+            | Self::AcceptingEntriesOrFooter {
+                parent_marker: EntryParentMarker::BlockHeader,
+            }
+            | Self::AcceptingAlpentick
+            | Self::Done => Err(BlockComponentProcessorError::MultipleBlockHeaders),
+            Self::AcceptingEntriesOrFooter {
+                parent_marker: EntryParentMarker::UpdateParent,
+            } => Err(BlockComponentProcessorError::SpuriousUpdateParent),
+        }
+    }
+
+    /// If current stage is `AcceptingGenesisOrEntries`, transition to `AcceptingEntriesOrFooter`
+    fn on_genesis_certificate(&mut self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => Err(BlockComponentProcessorError::MissingParentMarker),
+            Self::AcceptingGenesisOrEntries => {
+                *self = Self::AcceptingEntriesOrFooter {
+                    parent_marker: EntryParentMarker::BlockHeader,
+                };
+                Ok(())
+            }
+            Self::AcceptingEntriesOrFooter { .. } | Self::AcceptingAlpentick | Self::Done => {
+                Err(BlockComponentProcessorError::GenesisCertificateOutOfOrder)
+            }
+        }
+    }
+
+    /// If current stage is `AcceptingGenesisOrEntries` or `AcceptingEntriesOrFooter`, transition to
+    /// `AcceptingEntriesOrFooter`
+    fn on_entry_batch(&mut self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => Err(BlockComponentProcessorError::MissingParentMarker),
+            Self::AcceptingGenesisOrEntries => {
+                *self = Self::AcceptingEntriesOrFooter {
+                    parent_marker: EntryParentMarker::BlockHeader,
+                };
+                Ok(())
+            }
+            Self::AcceptingEntriesOrFooter { .. } => Ok(()),
+            Self::AcceptingAlpentick | Self::Done => {
+                Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
+            }
+        }
+    }
+
+    /// If current stage is `AcceptingGenesisOrEntries` or `AcceptingEntriesOrFooter`, return `AbandonedBank`
+    /// If current stage is `PreParentMarker` and `allow_initial_update_parent` is specified,
+    /// transition to `AcceptingEntriesOrFooter` with `EntryParentMarker::UpdateParent`
+    fn on_update_parent(
+        &mut self,
+        update_parent: &VersionedUpdateParent,
+        allow_initial_update_parent: bool,
+    ) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => {
+                if !allow_initial_update_parent {
+                    return Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent);
+                }
+                *self = Self::AcceptingEntriesOrFooter {
+                    parent_marker: EntryParentMarker::UpdateParent,
+                };
+                Ok(())
+            }
+            Self::AcceptingGenesisOrEntries
+            | Self::AcceptingEntriesOrFooter {
+                parent_marker: EntryParentMarker::BlockHeader,
+            } => {
+                // Only an error in the sense that replay execution of this block
+                // prefix is now over. Replay execution can continue after resetting
+                // bank.
+                Err(BlockComponentProcessorError::AbandonedBank(
+                    update_parent.clone(),
+                ))
+            }
+            Self::AcceptingEntriesOrFooter {
+                parent_marker: EntryParentMarker::UpdateParent,
+            } => Err(BlockComponentProcessorError::MultipleUpdateParents),
+            Self::AcceptingAlpentick | BlockComponentStage::Done => {
+                Err(BlockComponentProcessorError::SpuriousUpdateParent)
+            }
+        }
+    }
+
+    /// If the current stage is `AcceptingGenesisOrEntries`, `AcceptingEntriesOrFooter`
+    /// transition to `AcceptingAlpentick`
+    fn on_footer(&mut self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => Err(BlockComponentProcessorError::MissingParentMarker),
+            Self::AcceptingGenesisOrEntries | Self::AcceptingEntriesOrFooter { .. } => {
+                *self = Self::AcceptingAlpentick;
+                Ok(())
+            }
+            Self::AcceptingAlpentick | Self::Done => {
+                Err(BlockComponentProcessorError::MultipleBlockFooters)
+            }
+        }
+    }
+
+    /// If stage is `AcceptingAlpentick`, transition to `Done`
+    fn on_alpentick(&mut self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::PreParentMarker => Err(BlockComponentProcessorError::MissingParentMarker),
+            Self::AcceptingGenesisOrEntries => {
+                Err(BlockComponentProcessorError::InvalidAlpentickPosition)
+            }
+            Self::AcceptingEntriesOrFooter { .. } => {
+                Err(BlockComponentProcessorError::InvalidAlpentickPosition)
+            }
+            Self::AcceptingAlpentick => {
+                *self = Self::Done;
+                Ok(())
+            }
+            Self::Done => Err(BlockComponentProcessorError::InvalidAlpentickPosition),
+        }
+    }
+
+    /// Return `Ok(())` only if the stage is `Done`
+    fn on_final(&self) -> Result<(), BlockComponentProcessorError> {
+        match self {
+            Self::Done => Ok(()),
+            Self::AcceptingAlpentick => Err(BlockComponentProcessorError::InvalidAlpentickPosition),
+            Self::PreParentMarker
+            | Self::AcceptingGenesisOrEntries
+            | Self::AcceptingEntriesOrFooter { .. } => {
+                Err(BlockComponentProcessorError::MissingBlockFooter)
+            }
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct BlockComponentProcessor {
-    has_header: bool,
-    has_footer: bool,
-    has_entry_batch: bool,
+    stage: BlockComponentStage,
     has_genesis_certificate_marker: bool,
-    update_parent: Option<VersionedUpdateParent>,
 }
 
 impl BlockComponentProcessor {
@@ -134,27 +316,18 @@ impl BlockComponentProcessor {
         slot: Slot,
         parent_slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
+        // Only require block markers (header/footer) for slots where they should be present
+        if !migration_status.should_allow_block_markers(slot) {
+            return Ok(());
+        }
+
         if Self::requires_genesis_certificate_marker(migration_status, parent_slot)
             && !self.has_genesis_certificate_marker
         {
             return Err(BlockComponentProcessorError::MissingGenesisCertificateMarker);
         }
 
-        // Only require block markers (header/footer) for slots where they should be present
-        if !migration_status.should_allow_block_markers(slot) {
-            return Ok(());
-        }
-
-        // Post-migration: both header and footer are required
-        if !self.has_footer {
-            return Err(BlockComponentProcessorError::MissingBlockFooter);
-        }
-
-        if !self.has_header && self.update_parent.is_none() {
-            return Err(BlockComponentProcessorError::MissingParentMarker);
-        }
-
-        Ok(())
+        self.stage.on_final()
     }
 
     /// Check if `parent_slot` is the alpenglow genesis block for use in enforcing
@@ -175,25 +348,31 @@ impl BlockComponentProcessor {
 
     /// Process an entry batch.
     ///
-    /// Validates that a parent marker (header or update parent) has been
-    /// processed before any entry batches.
+    /// Validates that a parent marker (header or update parent) has been processed
+    /// before any entry batches. The terminal Alpenglow tick is the only entry
+    /// batch allowed after the block footer.
     pub fn on_entry_batch(
         &mut self,
         migration_status: &MigrationStatus,
         slot: Slot,
+        entries: &[Entry],
+        is_final_component: bool,
     ) -> Result<(), BlockComponentProcessorError> {
         if !migration_status.should_allow_block_markers(slot) {
-            self.has_entry_batch = true;
             return Ok(());
         }
 
-        // We must have either a header or an update parent prior to processing entry batches.
-        if !self.has_header && self.update_parent.is_none() {
-            return Err(BlockComponentProcessorError::MissingParentMarker);
-        }
+        // The alpentick must be the final block component.
+        // It is fine for other ticks to be present in the block, they will be rejected
+        // for `TooManyTicks` in `verify_ticks()`
+        let is_alpentick = is_final_component
+            && matches!(entries, [entry] if entry.is_tick() && entry.num_hashes == 1);
 
-        self.has_entry_batch = true;
-        Ok(())
+        if is_alpentick {
+            self.stage.on_alpentick()
+        } else {
+            self.stage.on_entry_batch()
+        }
     }
 
     /// Process a block marker:
@@ -268,42 +447,34 @@ impl BlockComponentProcessor {
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
-        self.validate_genesis_cert_block_marker_position()?;
-        self.process_genesis_cert_block_marker(
+        self.stage.on_genesis_certificate()?;
+        self.process_unvalidated_genesis_cert_block_marker(
             bank,
             genesis_block_marker,
             migration_status,
             Some(shred_version),
-        )
+        )?;
+        Ok(())
     }
 
-    /// Processes a locally produced genesis certificate marker without
-    /// re-verifying the certificate signature.
+    /// Processes a locally produced genesis certificate marker without verification
     pub fn on_genesis_cert_block_marker_leader(
         &mut self,
         bank: Arc<Bank>,
         genesis_block_marker: GenesisCertBlockMarker,
         migration_status: &MigrationStatus,
     ) -> Result<(), BlockComponentProcessorError> {
-        self.process_genesis_cert_block_marker(bank, genesis_block_marker, migration_status, None)
-    }
-
-    fn validate_genesis_cert_block_marker_position(
-        &self,
-    ) -> Result<(), BlockComponentProcessorError> {
-        if !self.has_header {
-            return Err(BlockComponentProcessorError::MissingParentMarker);
-        }
-
-        if self.has_entry_batch || self.has_footer || self.update_parent.is_some() {
-            return Err(BlockComponentProcessorError::GenesisCertificateOutOfOrder);
-        }
-
+        self.process_unvalidated_genesis_cert_block_marker(
+            bank,
+            genesis_block_marker,
+            migration_status,
+            None,
+        )?;
         Ok(())
     }
 
     /// Performs verification if `shred_version` is specified
-    fn process_genesis_cert_block_marker(
+    fn process_unvalidated_genesis_cert_block_marker(
         &mut self,
         bank: Arc<Bank>,
         genesis_block_marker: GenesisCertBlockMarker,
@@ -400,13 +571,7 @@ impl BlockComponentProcessor {
         footer: VersionedBlockFooter,
         finalization_cert_sender: Option<&Sender<ConsensusMessage>>,
     ) -> Result<(), BlockComponentProcessorError> {
-        if !self.has_header && self.update_parent.is_none() {
-            return Err(BlockComponentProcessorError::MissingParentMarker);
-        }
-
-        if self.has_footer {
-            return Err(BlockComponentProcessorError::MultipleBlockFooters);
-        }
+        self.stage.on_footer()?;
 
         let VersionedBlockFooter::V1(footer) = footer;
 
@@ -476,7 +641,6 @@ impl BlockComponentProcessor {
                 .inspect_err(|_| info!("ConsensusMessage sender disconnected"));
         }
 
-        self.has_footer = true;
         Ok(())
     }
 
@@ -485,13 +649,7 @@ impl BlockComponentProcessor {
         header: &VersionedBlockHeader,
         bank_parent_slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
-        if self.has_header {
-            return Err(BlockComponentProcessorError::MultipleBlockHeaders);
-        }
-
-        if self.update_parent.is_some() {
-            return Err(BlockComponentProcessorError::SpuriousUpdateParent);
-        }
+        self.stage.on_header()?;
 
         let VersionedBlockHeader::V1(header) = header;
         if header.parent_slot != bank_parent_slot {
@@ -500,8 +658,6 @@ impl BlockComponentProcessor {
                 bank_parent_slot,
             });
         }
-
-        self.has_header = true;
         Ok(())
     }
 
@@ -511,30 +667,12 @@ impl BlockComponentProcessor {
         update_parent: &VersionedUpdateParent,
         allow_initial_update_parent: bool,
     ) -> Result<(), BlockComponentProcessorError> {
-        if self.update_parent.is_some() {
-            return Err(BlockComponentProcessorError::MultipleUpdateParents);
-        }
-
         if leader_slot_index(slot) != 0 {
             return Err(BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(slot));
         }
 
-        if !self.has_header && !allow_initial_update_parent {
-            return Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent);
-        }
-
-        self.update_parent = Some(update_parent.clone());
-
-        if self.has_header {
-            // Only an error in the sense that replay execution of this block
-            // prefix is now over. Replay execution can continue after resetting
-            // bank.
-            Err(BlockComponentProcessorError::AbandonedBank(
-                update_parent.clone(),
-            ))
-        } else {
-            Ok(())
-        }
+        self.stage
+            .on_update_parent(update_parent, allow_initial_update_parent)
     }
 
     fn enforce_nanosecond_clock_bounds(
@@ -640,11 +778,17 @@ mod tests {
         rand::Rng,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::DEFAULT_MS_PER_SLOT,
-        solana_entry::block_component::{
-            BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
+        solana_entry::{
+            block_component::{
+                BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
+            },
+            entry::Entry,
         },
         solana_hash::Hash,
-        std::sync::{Arc, RwLock},
+        std::{
+            assert_matches,
+            sync::{Arc, RwLock},
+        },
     };
 
     const DEFAULT_NS_PER_SLOT: u64 = DEFAULT_MS_PER_SLOT * 1_000_000;
@@ -705,13 +849,38 @@ mod tests {
         migration_status
     }
 
+    fn processor_after_header() -> BlockComponentProcessor {
+        BlockComponentProcessor {
+            stage: BlockComponentStage::AcceptingGenesisOrEntries,
+            ..BlockComponentProcessor::default()
+        }
+    }
+
+    fn processor_after_footer() -> BlockComponentProcessor {
+        BlockComponentProcessor {
+            stage: BlockComponentStage::AcceptingAlpentick,
+            ..BlockComponentProcessor::default()
+        }
+    }
+
+    fn processor_done() -> BlockComponentProcessor {
+        BlockComponentProcessor {
+            stage: BlockComponentStage::Done,
+            ..BlockComponentProcessor::default()
+        }
+    }
+
+    fn alpentick(num_hashes: u64) -> [Entry; 1] {
+        [Entry::new(&Hash::default(), num_hashes, vec![])]
+    }
+
     #[test]
     fn test_missing_header_error_on_entry_batch() {
         let migration_status = MigrationStatus::post_migration_status();
         let mut processor = BlockComponentProcessor::default();
 
         // Try to process entry batch without header - should fail
-        let result = processor.on_entry_batch(&migration_status, 1);
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
         assert!(matches!(
             result,
             Err(BlockComponentProcessorError::MissingParentMarker)
@@ -768,7 +937,7 @@ mod tests {
             )
             .unwrap();
         processor
-            .on_entry_batch(&migration_status, bank.slot())
+            .on_entry_batch(&migration_status, bank.slot(), &[], false)
             .unwrap();
 
         let marker =
@@ -832,10 +1001,7 @@ mod tests {
     #[test]
     fn test_missing_footer_error_on_slot_full() {
         let migration_status = MigrationStatus::post_migration_status();
-        let processor = BlockComponentProcessor {
-            has_header: true,
-            ..BlockComponentProcessor::default()
-        };
+        let processor = processor_after_header();
 
         // Try to mark slot as full without footer - should fail
         let result = processor.on_final(&migration_status, 1, 0);
@@ -848,11 +1014,7 @@ mod tests {
     #[test]
     fn test_first_alpenglow_block_requires_genesis_certificate_marker() {
         let migration_status = post_migration_status_with_genesis_slot(1);
-        let processor = BlockComponentProcessor {
-            has_header: true,
-            has_footer: true,
-            ..BlockComponentProcessor::default()
-        };
+        let processor = processor_after_footer();
 
         let result = processor.on_final(&migration_status, 2, 1);
         assert!(matches!(
@@ -875,26 +1037,19 @@ mod tests {
             bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             bitmap: vec![],
         };
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            has_footer: true,
-            ..BlockComponentProcessor::default()
-        };
+        let mut processor = processor_after_header();
 
         processor
             .on_genesis_cert_block_marker_leader(bank, genesis_marker, &migration_status)
             .unwrap();
+        processor.stage = BlockComponentStage::Done;
         assert!(processor.on_final(&migration_status, 2, 1).is_ok());
     }
 
     #[test]
     fn test_first_alpenglow_block_genesis_slot_zero_skips_genesis_certificate_marker_check() {
         let migration_status = MigrationStatus::post_migration_status();
-        let processor = BlockComponentProcessor {
-            has_header: true,
-            has_footer: true,
-            ..BlockComponentProcessor::default()
-        };
+        let processor = processor_done();
 
         assert!(processor.on_final(&migration_status, 1, 0).is_ok());
     }
@@ -920,10 +1075,7 @@ mod tests {
 
     #[test]
     fn test_multiple_footers_error() {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
@@ -965,10 +1117,7 @@ mod tests {
 
     #[test]
     fn test_on_footer_sets_timestamp() {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
@@ -992,7 +1141,7 @@ mod tests {
             .on_footer(bank.clone(), parent, shred_version, footer, None)
             .unwrap();
 
-        assert!(processor.has_footer);
+        assert_eq!(processor.stage, BlockComponentStage::AcceptingAlpentick);
 
         // Verify clock sysvar was updated with correct timestamp (nanos converted to seconds)
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
@@ -1007,7 +1156,10 @@ mod tests {
         });
 
         processor.on_header(&header, 0).unwrap();
-        assert!(processor.has_header);
+        assert_eq!(
+            processor.stage,
+            BlockComponentStage::AcceptingGenesisOrEntries
+        );
     }
 
     #[test]
@@ -1051,7 +1203,10 @@ mod tests {
                 &migration_status,
             )
             .unwrap();
-        assert!(processor.has_header);
+        assert_eq!(
+            processor.stage,
+            BlockComponentStage::AcceptingGenesisOrEntries
+        );
     }
 
     #[test]
@@ -1087,10 +1242,7 @@ mod tests {
     #[test]
     fn test_on_marker_processes_footer() {
         let migration_status = MigrationStatus::post_migration_status();
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
 
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
@@ -1121,7 +1273,7 @@ mod tests {
                 &migration_status,
             )
             .unwrap();
-        assert!(processor.has_footer);
+        assert_eq!(processor.stage, BlockComponentStage::AcceptingAlpentick);
 
         // Verify clock sysvar was updated
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
@@ -1148,7 +1300,9 @@ mod tests {
         processor.on_header(&header, bank.parent_slot()).unwrap();
 
         // Process some entry batches (not full yet)
-        assert!(processor.on_entry_batch(&migration_status, 1).is_ok());
+        processor
+            .on_entry_batch(&migration_status, 1, &[], false)
+            .unwrap();
 
         // Process footer with valid timestamp
         let footer = VersionedBlockFooter::V1(BlockFooterV1 {
@@ -1166,9 +1320,46 @@ mod tests {
         // Verify clock sysvar was updated
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
 
-        // Entry batch after footer should still succeed
-        let result = processor.on_entry_batch(&migration_status, 1);
-        assert!(result.is_ok());
+        // Entry batch after footer should fail because the footer is terminal.
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        assert_matches!(
+            result,
+            Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
+        );
+    }
+
+    #[test]
+    fn test_alpentick_position_validation() {
+        let migration_status = MigrationStatus::post_migration_status();
+        let mut processor = processor_after_footer();
+        let good_alpentick = alpentick(1);
+
+        processor
+            .on_entry_batch(&migration_status, 1, &good_alpentick, true)
+            .unwrap();
+        assert_matches!(
+            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true),
+            Err(BlockComponentProcessorError::InvalidAlpentickPosition)
+        );
+
+        let mut processor = BlockComponentProcessor::default();
+        assert_matches!(
+            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true),
+            Err(BlockComponentProcessorError::MissingParentMarker)
+        );
+
+        let mut processor = processor_after_footer();
+        let bad_alpentick = alpentick(2);
+        assert_matches!(
+            processor.on_entry_batch(&migration_status, 1, &bad_alpentick, true),
+            Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
+        );
+
+        let migration_status = MigrationStatus::default();
+        let mut processor = BlockComponentProcessor::default();
+        processor
+            .on_entry_batch(&migration_status, 1, &good_alpentick, true)
+            .unwrap();
     }
 
     #[test]
@@ -1263,11 +1454,11 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
 
         // Processing entry batches pre-migration (without markers) should succeed
-        let result = processor.on_entry_batch(&migration_status, 1);
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
         assert!(result.is_ok());
 
         // Even with slot full
-        let result = processor.on_entry_batch(&migration_status, 1);
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
         assert!(result.is_ok());
     }
 
@@ -1297,7 +1488,9 @@ mod tests {
             .unwrap();
 
         // Process entry batches
-        assert!(processor.on_entry_batch(&migration_status, 1).is_ok());
+        processor
+            .on_entry_batch(&migration_status, 1, &[], false)
+            .unwrap();
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -1328,9 +1521,12 @@ mod tests {
         // Verify clock sysvar was updated
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
 
-        // Entry batch after footer should still succeed
-        let result = processor.on_entry_batch(&migration_status, 1);
-        assert!(result.is_ok());
+        // Entry batch after footer should fail because the footer is terminal.
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        assert_matches!(
+            result,
+            Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
+        );
     }
 
     #[test]
@@ -1362,13 +1558,10 @@ mod tests {
     #[test]
     fn test_marker_with_footer_at_slot_full() {
         let migration_status = MigrationStatus::post_migration_status();
-        let mut processor = BlockComponentProcessor::default();
+        let mut processor = processor_after_header();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 1);
         let shred_version = rand::rng().random();
-
-        // Process header first
-        processor.has_header = true;
 
         // Calculate valid timestamp based on parent's time
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
@@ -1397,7 +1590,7 @@ mod tests {
                 &migration_status,
             )
             .unwrap();
-        assert!(processor.has_footer);
+        assert_eq!(processor.stage, BlockComponentStage::AcceptingAlpentick);
 
         // Verify clock sysvar was updated
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
@@ -1406,22 +1599,16 @@ mod tests {
     #[test]
     fn test_entry_batch_with_header_not_full_succeeds() {
         let migration_status = MigrationStatus::post_migration_status();
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
 
         // Process entry batch with header but not full - should succeed even without footer
-        let result = processor.on_entry_batch(&migration_status, 1);
+        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_footer_sets_epoch_start_timestamp_on_epoch_change() {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
         // Create genesis bank
@@ -1486,10 +1673,7 @@ mod tests {
         timestamp_fn: impl FnOnce(i64, i64, i64) -> i64,
         should_pass: bool,
     ) {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
@@ -1569,10 +1753,7 @@ mod tests {
 
     #[test]
     fn test_clock_bounds_without_parent_nanosecond_clock_rejects_out_of_bounds() {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
@@ -1606,10 +1787,7 @@ mod tests {
 
     #[test]
     fn test_clock_bounds_rejects_timestamp_above_i64() {
-        let mut processor = BlockComponentProcessor {
-            has_header: true,
-            ..Default::default()
-        };
+        let mut processor = processor_after_header();
         let shred_version = rand::rng().random();
 
         let (parent, bank_forks) = create_test_bank_alpenglow();
@@ -1702,7 +1880,7 @@ mod tests {
             processor.on_update_parent(4, &update_parent, false),
             Err(BlockComponentProcessorError::UnexpectedInitialUpdateParent)
         ));
-        assert!(processor.update_parent.is_none());
+        assert_eq!(processor.stage, BlockComponentStage::PreParentMarker);
     }
 
     #[test]
@@ -1717,7 +1895,7 @@ mod tests {
             processor.on_update_parent(5, &update_parent, true),
             Err(BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(5))
         ));
-        assert!(processor.update_parent.is_none());
+        assert_eq!(processor.stage, BlockComponentStage::PreParentMarker);
     }
 
     #[test]
@@ -1729,7 +1907,12 @@ mod tests {
         });
 
         processor.on_update_parent(4, &update_parent, true).unwrap();
-        assert!(processor.update_parent.is_some());
+        assert_eq!(
+            processor.stage,
+            BlockComponentStage::AcceptingEntriesOrFooter {
+                parent_marker: EntryParentMarker::UpdateParent,
+            }
+        );
     }
 
     #[test]
@@ -1757,6 +1940,20 @@ mod tests {
     }
 
     #[test]
+    fn test_update_parent_after_footer_error() {
+        let mut processor = processor_after_footer();
+        let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
+            new_parent_slot: 0,
+            new_parent_block_id: Hash::default(),
+        });
+
+        assert_matches!(
+            processor.on_update_parent(4, &update_parent, false),
+            Err(BlockComponentProcessorError::SpuriousUpdateParent)
+        );
+    }
+
+    #[test]
     fn test_multiple_update_parents_error() {
         let mut processor = BlockComponentProcessor::default();
         let update_parent = VersionedUpdateParent::V1(UpdateParentV1 {
@@ -1768,10 +1965,10 @@ mod tests {
         processor.on_update_parent(4, &update_parent, true).unwrap();
 
         // Second should fail
-        assert!(matches!(
+        assert_matches!(
             processor.on_update_parent(4, &update_parent, true),
             Err(BlockComponentProcessorError::MultipleUpdateParents)
-        ));
+        );
     }
 
     #[test]
@@ -1805,11 +2002,12 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
         let (parent, bank_forks) = create_test_bank();
         let bank = create_child_bank(&bank_forks, &parent, 4);
+        let slot = bank.slot();
         let shred_version = rand::rng().random();
 
         processor
             .on_update_parent(
-                bank.slot(),
+                slot,
                 &VersionedUpdateParent::V1(UpdateParentV1 {
                     new_parent_slot: 0,
                     new_parent_block_id: Hash::default(),
@@ -1818,7 +2016,9 @@ mod tests {
             )
             .unwrap();
 
-        assert!(processor.on_entry_batch(&migration_status, 1).is_ok());
+        processor
+            .on_entry_batch(&migration_status, slot, &[], false)
+            .unwrap();
 
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);
         let footer = VersionedBlockFooter::V1(BlockFooterV1 {
@@ -1833,6 +2033,11 @@ mod tests {
             .on_footer(bank, parent, shred_version, footer, None)
             .unwrap();
 
-        assert!(processor.on_final(&migration_status, 1, 0).is_ok());
+        let good_alpentick = alpentick(1);
+        processor
+            .on_entry_batch(&migration_status, slot, &good_alpentick, true)
+            .unwrap();
+
+        processor.on_final(&migration_status, slot, 0).unwrap();
     }
 }


### PR DESCRIPTION
#### Problem
We currently allow txs to be specified after the footer.
Although this doesn't break anything this could be really confusing for users as the footer will change the clock timestamp

We also allow the Alpentick to happen before the footer.
This can cause divergent behavior depending on blockstore deserialization.

#### Summary of Changes
Clean up BCP to be a state machine and verify this exact ordering:

```
/// Header
/// Optional Genesis marker
/// 0 or more Entries
/// Optional UpdateParent
/// 0 or more Entries
/// Footer
/// Alpentick
```

Processing is allowed to start from either the `Header` or the `UpdateParent`

#### Testing
Just unit tests

Fixes #13575 
