### PR TITLE
svm, conformance(instr): panic on duplicate account loads

### DIFF
--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -166,8 +166,7 @@ pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
             environments.get_env_for_deployment(),
             &instr_context.accounts,
             slot,
-        )
-        .unwrap();
+        );
 
         cache
     };
@@ -312,6 +311,31 @@ mod tests {
         sysvar_cache
     }
 
+    #[cfg(feature = "conformance")]
+    fn proto_account(pubkey: Pubkey, account: Account) -> protosol::protos::AcctState {
+        protosol::protos::AcctState {
+            address: pubkey.to_bytes().to_vec(),
+            owner: account.owner.to_bytes().to_vec(),
+            lamports: account.lamports,
+            data: account.data,
+            executable: account.executable,
+        }
+    }
+
+    #[cfg(feature = "conformance")]
+    fn proto_sysvar_account<T: serde::Serialize>(
+        pubkey: Pubkey,
+        sysvar: &T,
+    ) -> protosol::protos::AcctState {
+        protosol::protos::AcctState {
+            address: pubkey.to_bytes().to_vec(),
+            owner: solana_sdk_ids::sysvar::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(sysvar).unwrap(),
+            executable: false,
+        }
+    }
+
     fn build_system_transfer_context(from: &Pubkey, to: &Pubkey, amount: u64) -> InstrContext {
         let feature_set = SVMFeatureSet::default();
         let accounts = vec![
@@ -406,5 +430,48 @@ mod tests {
         let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
         assert_eq!(effects.result, None);
         assert_eq!(effects.custom_err, None);
+    }
+
+    #[cfg(feature = "conformance")]
+    #[test]
+    #[should_panic(expected = "invariant violation: duplicate account load")]
+    fn test_duplicate_accounts_panic_with_invariant_violation() {
+        let from = Pubkey::new_unique();
+        let to = Pubkey::new_unique();
+        let duplicate = Pubkey::new_unique();
+        let instruction = solana_system_interface::instruction::transfer(&from, &to, 1);
+
+        execute_instr_proto(ProtoInstrContext {
+            program_id: solana_sdk_ids::system_program::id().to_bytes().to_vec(),
+            accounts: vec![
+                proto_account(from, system_account_with_lamports(FROM_BASE_LAMPORTS)),
+                proto_account(to, system_account_with_lamports(TO_BASE_LAMPORTS)),
+                proto_account(duplicate, system_account_with_lamports(1)),
+                proto_account(duplicate, system_account_with_lamports(1)),
+                proto_account(
+                    keyed_account_for_system_program().0,
+                    keyed_account_for_system_program().1,
+                ),
+                proto_sysvar_account(
+                    solana_sdk_ids::sysvar::clock::id(),
+                    &solana_clock::Clock::default(),
+                ),
+            ],
+            instr_accounts: vec![
+                protosol::protos::InstrAcct {
+                    index: 0,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                protosol::protos::InstrAcct {
+                    index: 1,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ],
+            data: instruction.data,
+            cu_avail: SYSTEM_TRANSFER_CUS,
+            features: None,
+        });
     }
 }

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -6,7 +6,6 @@ use {
     crate::program_loader::load_program_with_pubkey,
     solana_account::{Account, AccountSharedData},
     solana_compute_budget::compute_budget::ComputeBudget,
-    solana_instruction::error::InstructionError,
     solana_program_runtime::{
         invoke_context::BuiltinFunctionRegisterer,
         loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
@@ -146,13 +145,14 @@ pub fn fill_program_cache_from_accounts(
     program_runtime_environment: &ProgramRuntimeEnvironment,
     accounts: &[(Pubkey, Account)],
     slot: u64,
-) -> Result<(), InstructionError> {
+) {
     let mut newly_loaded_programs = HashSet::<Pubkey>::new();
 
     for acc in accounts {
-        if !newly_loaded_programs.insert(acc.0) {
-            return Err(InstructionError::UnsupportedProgramId);
-        }
+        assert!(
+            newly_loaded_programs.insert(acc.0),
+            "invariant violation: duplicate account load",
+        );
 
         if program_cache.find(&acc.0).is_none() {
             if !solana_sdk_ids::bpf_loader_deprecated::check_id(&acc.1.owner)
@@ -172,8 +172,6 @@ pub fn fill_program_cache_from_accounts(
             }
         }
     }
-
-    Ok(())
 }
 
 struct FillFromAccountsCallback<'a>(&'a [(Pubkey, Account)]);

--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -77,8 +77,7 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
             deployment_environment,
             &instr_context.accounts,
             slot,
-        )
-        .expect("failed to fill program cache from accounts");
+        );
         cache
     } else {
         ProgramCacheForTxBatch::default()


### PR DESCRIPTION
#### Problem
Failures in `fill_program_cache_from_accounts` may be potentially covered up by future callers instead of immediately surfacing an invariant violation that the caller must handle.

#### Summary of Changes
Make `fill_program_cache_from_accounts` infallible by panicking on duplicate account loads.

#### Testing


Fixes #
