### PR TITLE
blockstore: add pub qualifier to verify_ticks function

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1063,6 +1063,7 @@ pub fn process_blockstore_from_root(
 }
 
 /// Verify that a segment of entries has the correct number of ticks and hashes
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn verify_ticks(
     bank: &Bank,
     entries: &[Entry],


### PR DESCRIPTION
#### Problem
`verify_ticks` is needed for shred fuzzing but is a private method.

#### Summary of Changes
Expose `verify_ticks` as public under `dev-context-only-utils`.

#### Testing


Fixes #
