### PR TITLE
shred: expose get_data under DCOU

### DIFF
--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -1,6 +1,8 @@
 // Helper methods to extract pieces of the shred from the payload without
 // deserializing the entire payload.
 #![deny(clippy::indexing_slicing)]
+#[cfg(feature = "dev-context-only-utils")]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         blockstore_meta::ErasureConfig,
@@ -156,6 +158,7 @@ fn get_data_size(shred: &[u8]) -> Result<u16, Error> {
 }
 
 #[inline]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) fn get_data(shred: &[u8]) -> Result<&[u8], Error> {
     match get_shred_variant(shred)? {
         ShredVariant::MerkleCode { .. } => Err(Error::InvalidShredType),


### PR DESCRIPTION
#### Problem
`layout::get_data` is private and is required by testing harnesses.

#### Summary of Changes
Expose `layout::get_data` under `dev-context-only-utils`.

#### Testing


Fixes #
