### PR TITLE
system-monitor-service: de-noise "os-config" metrics submission

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -651,7 +651,7 @@ impl SystemMonitorService {
                     }
                 }
             });
-        solana_metrics::submit(datapoint, log::Level::Warn);
+        solana_metrics::submit(datapoint, log::Level::Info);
         ret
     }
 

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -13,6 +13,7 @@ use {
     },
 };
 use {
+    solana_metrics::datapoint::DataPoint,
     solana_time_utils::AtomicInterval,
     std::{
         collections::HashMap,
@@ -623,12 +624,13 @@ impl SystemMonitorService {
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn linux_report_network_limits(
+        mut datapoint: DataPoint,
         current_limits: &[(&'static str, &'static InterestingLimit, i64)],
     ) -> bool {
-        current_limits
+        let ret = current_limits
             .iter()
             .all(|(key, interesting_limit, current_value)| {
-                datapoint_warn!("os-config", (key, *current_value, i64));
+                datapoint.add_field_i64(key, *current_value);
                 match interesting_limit {
                     InterestingLimit::Recommend(recommended_value)
                         if current_value < recommended_value =>
@@ -648,7 +650,9 @@ impl SystemMonitorService {
                         true
                     }
                 }
-            })
+            });
+        solana_metrics::submit(datapoint, log::Level::Warn);
+        ret
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -659,9 +663,10 @@ impl SystemMonitorService {
 
     #[cfg(target_os = "linux")]
     pub fn check_os_network_limits() -> bool {
-        datapoint_info!("os-config", ("platform", platform_id(), String));
+        let mut datapoint = DataPoint::new("os-config");
+        datapoint.add_field_str("platform", platform_id().as_str());
         let current_limits = Self::linux_get_current_network_limits();
-        Self::linux_report_network_limits(&current_limits)
+        Self::linux_report_network_limits(datapoint, &current_limits)
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
#### Problem
system monitor service commits many crimes. the worst being submitting the "os-config" metric fields as seven (7) individual datapoints. it also pollutes `warn` logs with `info` priority data.

#### Summary of Changes
this is a lighter touch version of #13122 

* build the "os-config" datapoint by hand, instead of using the metrics "convenience" macros
* switch "os-config" datapoint to info-level

#### Testing
yolo

closes #13122 