### PR TITLE
bls-sigverifier: improves stats / metrics for banning

### DIFF
--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -118,6 +118,7 @@ fn verify_certs(
             Err(e) => {
                 match &e {
                     CertVerifyError::CertVerifyFailed(_) => {
+                        stats.banning_validator += 1;
                         if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
                             stats.already_banned += 1;
                         } else {

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -24,8 +24,9 @@ use {
         ThreadPool,
         iter::{Either, IntoParallelIterator, ParallelIterator},
     },
-    solana_bls_signatures::pubkey::{
-        PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature,
+    solana_bls_signatures::{
+        BlsError,
+        pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine, VerifySignature},
     },
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
@@ -62,17 +63,15 @@ pub(super) struct UnverifiedVotePayload {
 }
 
 impl UnverifiedVotePayload {
-    fn verify(self) -> Option<VerifiedVotePayload> {
+    fn verify(self) -> Result<VerifiedVotePayload, BlsError> {
         let payload =
             get_vote_payload_to_sign(self.vote_message.vote, self.vote_message.shred_version);
-        let is_verified = self
-            .sender_bls_pubkey
+        self.sender_bls_pubkey
             .verify_signature(&self.vote_message.signature, &payload)
-            .is_ok();
-        is_verified.then_some(VerifiedVotePayload {
-            vote_message: into_vote_msg(self.vote_message),
-            sender_vote_account_pubkey: self.sender_vote_account_pubkey,
-        })
+            .map(|()| VerifiedVotePayload {
+                vote_message: into_vote_msg(self.vote_message),
+                sender_vote_account_pubkey: self.sender_vote_account_pubkey,
+            })
     }
 }
 
@@ -218,13 +217,14 @@ fn verify_votes(
     // Fallback to individual verification
     let ((verified_votes, invalid_remote_pubkeys), time_us) =
         measure_us!(verify_individual_votes(unverified_votes, thread_pool));
-    for sender_identity_pubkey in invalid_remote_pubkeys {
+    for (sender_identity_pubkey, error) in invalid_remote_pubkeys {
+        stats.banning_validator += 1;
         if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
             stats.already_banned += 1;
         } else {
             info!(
                 "bls_vote_sigverify: banned sender={sender_identity_pubkey} due to failed \
-                 verification"
+                 verification {error:?}"
             );
         }
     }
@@ -242,15 +242,15 @@ fn verify_votes(
 fn verify_individual_votes(
     unverified_votes: Vec<UnverifiedVotePayload>,
     thread_pool: &ThreadPool,
-) -> (Vec<VerifiedVotePayload>, Vec<Pubkey>) {
+) -> (Vec<VerifiedVotePayload>, Vec<(Pubkey, BlsError)>) {
     thread_pool.install(|| {
         unverified_votes
             .into_par_iter()
             .partition_map(|unverified_vote| {
                 let sender_identity_pubkey = unverified_vote.sender_identity_pubkey;
                 match unverified_vote.verify() {
-                    Some(vote) => Either::Left(vote),
-                    None => Either::Right(sender_identity_pubkey),
+                    Ok(vote) => Either::Left(vote),
+                    Err(e) => Either::Right((sender_identity_pubkey, e)),
                 }
             })
     })

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -194,6 +194,8 @@ pub(super) struct SigVerifyCertStats {
     pub(super) unnecessary_certs_verified: Saturating<u64>,
     /// Number of times we are banning a validator that was already banned.
     pub(super) already_banned: Saturating<u64>,
+    /// Number of times we are banning a validator.
+    pub(super) banning_validator: Saturating<u64>,
 
     /// Number of times cert verification failed.
     pub(super) certificate_verification_failed: Saturating<u64>,
@@ -218,6 +220,7 @@ impl SigVerifyCertStats {
             sig_verified_certs,
             unnecessary_certs_verified,
             already_banned,
+            banning_validator,
             certificate_verification_failed,
             too_far_in_future,
             pool_outstanding_msgs,
@@ -229,6 +232,7 @@ impl SigVerifyCertStats {
         self.sig_verified_certs += sig_verified_certs;
         self.unnecessary_certs_verified += unnecessary_certs_verified;
         self.already_banned += already_banned;
+        self.banning_validator += banning_validator;
         self.certificate_verification_failed += certificate_verification_failed;
         self.too_far_in_future += too_far_in_future;
         self.pool_outstanding_msgs += pool_outstanding_msgs;
@@ -244,6 +248,7 @@ impl SigVerifyCertStats {
             sig_verified_certs,
             unnecessary_certs_verified,
             already_banned,
+            banning_validator,
             certificate_verification_failed,
             too_far_in_future,
             pool_outstanding_msgs,
@@ -262,6 +267,7 @@ impl SigVerifyCertStats {
                 i64
             ),
             ("already_banned", already_banned.0, i64),
+            ("banning_validator", banning_validator.0, i64),
             (
                 "certificate_verification_failed",
                 certificate_verification_failed.0,
@@ -298,6 +304,8 @@ pub(super) struct SigVerifyVoteStats {
     pub(super) too_far_in_future: Saturating<u64>,
     /// Number of times we are banning a validator that was already banned.
     pub(super) already_banned: Saturating<u64>,
+    /// Number of times we are banning a validator.
+    pub(super) banning_validator: Saturating<u64>,
 
     /// Number of votes sent successfully over the channel to metrics.
     pub(super) metrics_sent: Saturating<u64>,
@@ -334,6 +342,7 @@ impl SigVerifyVoteStats {
             sig_verified_votes,
             too_far_in_future,
             already_banned,
+            banning_validator,
             metrics_sent,
             metrics_channel_full,
             rewards_sent,
@@ -351,6 +360,7 @@ impl SigVerifyVoteStats {
         self.sig_verified_votes += sig_verified_votes;
         self.too_far_in_future += too_far_in_future;
         self.already_banned += already_banned;
+        self.banning_validator += banning_validator;
         self.metrics_sent += metrics_sent;
         self.metrics_channel_full += metrics_channel_full;
         self.rewards_sent += rewards_sent;
@@ -373,6 +383,7 @@ impl SigVerifyVoteStats {
             sig_verified_votes,
             too_far_in_future,
             already_banned,
+            banning_validator,
             metrics_sent,
             metrics_channel_full,
             rewards_sent,
@@ -392,6 +403,7 @@ impl SigVerifyVoteStats {
             ("sig_verified_votes", sig_verified_votes.0, i64),
             ("too_far_in_future", too_far_in_future.0, i64),
             ("already_banned", already_banned.0, i64),
+            ("banning_validator", banning_validator.0, i64),
             ("metrics_sent", metrics_sent.0, i64),
             ("metrics_channel_full", metrics_channel_full.0, i64),
             ("rewards_sent", rewards_sent.0, i64),


### PR DESCRIPTION
#### Problem

We want better visibility into when we are banning validators in the bls-sigverifier.  This will help detect potential bugs that cause validators to get banned either because the receiver has a bug or the sender is sending wrong data.

#### Summary of Changes

- Logs the bls error we saw when we are banning a validator when vote verification fails.
- adds stats for when we ban validators due to failed vote and cert verification.


#### Testing

Just CI