### PR TITLE
votor: pin StableAbi/wincode formats and gate vestigial serde

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -393,8 +393,6 @@ dependencies = [
  "lazy-lru",
  "log",
  "parking_lot 0.12.5",
- "serde",
- "serde_bytes",
  "solana-bls-signatures",
  "solana-client",
  "solana-clock",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -381,8 +381,6 @@ dependencies = [
  "lazy-lru",
  "log",
  "parking_lot 0.12.2",
- "serde",
- "serde_bytes",
  "solana-bls-signatures",
  "solana-client",
  "solana-clock",

--- a/votor-messages/src/wire.rs
+++ b/votor-messages/src/wire.rs
@@ -66,8 +66,11 @@ pod_wrapper! {
     unsafe struct PodBLSSignature(BLSSignature);
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
+)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireVoteSignature {
     #[cfg_attr(
         feature = "frozen-abi",
@@ -87,15 +90,21 @@ impl From<VoteMessage> for WireVoteSignature {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
+)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireBlockVoteMessage {
     pub(crate) block: Block,
     pub(crate) signature: WireVoteSignature,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
+)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireSlotVoteMessage {
     pub(crate) slot: Slot,
     pub(crate) signature: WireVoteSignature,
@@ -125,8 +134,11 @@ impl From<Certificate> for WireCertSignature {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite, Serialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
+)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaRead, SchemaWrite)]
 pub(crate) struct WireSlotCertMessage {
     pub(crate) slot: Slot,
     pub(crate) signature: WireCertSignature,
@@ -144,9 +156,9 @@ pub struct WireBlockCertMessage {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, StableAbi, StableAbiSample, AbiEnumVisitor)
+    derive(AbiExample, StableAbi, StableAbiSample, AbiEnumVisitor, Serialize)
 )]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead, Serialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead)]
 #[wincode(tag_encoding = "u8")]
 pub(crate) enum WireConsensusMessageKind {
     #[wincode(tag = 1)]
@@ -252,8 +264,11 @@ impl WireConsensusMessageKind {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, SchemaWrite, SchemaRead)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize)
+)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead)]
 /// First version of a wire consensus message
 pub struct WireConsensusMessageV1 {
     pub(crate) kind: WireConsensusMessageKind,
@@ -289,7 +304,7 @@ impl WireConsensusMessageV1 {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize),
     frozen_abi(
         digest = "Gf8GEMXaXezQnGsqwDdpZN3WtNkMZw5wfp3nwep9j55V",
         abi_digest = "AHPJsANgE3T8wfzkFZwao1PAWwd6LtS5GAhGrN9X4Xhy",
@@ -297,7 +312,7 @@ impl WireConsensusMessageV1 {
         test_roundtrip = "eq_and_wire",
     )
 )]
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, SchemaWrite, SchemaRead)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, SchemaWrite, SchemaRead)]
 #[wincode(tag_encoding = "u8")]
 /// versioned wire format of consensus message
 pub enum VersionedWireConsensusMessage {
@@ -335,7 +350,7 @@ impl VersionedWireConsensusMessage {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize),
     frozen_abi(
         digest = "AKMt6bqYRf1xh7tWg4eAgG7jNN1qtUvNVPb5XZn9vjtV",
         abi_digest = "2aBMTuPyDgGSYeYX1aBbXURgA4qqr92Eh9yiTeHX6qZq",
@@ -343,7 +358,7 @@ impl VersionedWireConsensusMessage {
         test_roundtrip = "eq_and_wire",
     )
 )]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, SchemaWrite, SchemaRead)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, SchemaWrite, SchemaRead)]
 #[wincode(tag_encoding = "u8")]
 /// Vote payload that must be signed
 pub enum VotePayloadToSign {

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -21,6 +21,8 @@ dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
 ]
 frozen-abi = [
+    "dep:serde",
+    "dep:serde_bytes",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-ledger/frozen-abi",
@@ -40,8 +42,8 @@ itertools = { workspace = true }
 lazy-lru = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }
-serde = { workspace = true }
-serde_bytes = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_bytes = { workspace = true, optional = true }
 solana-bls-signatures = { workspace = true, features = ["solana-signer-derive"] }
 solana-client = { workspace = true }
 solana-clock = { workspace = true }

--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -1,7 +1,8 @@
+#[cfg(feature = "frozen-abi")]
+use serde::{Deserialize, Serialize};
 use {
     super::vote_history::*,
     log::trace,
-    serde::{Deserialize, Serialize},
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     solana_signer::Signer,
@@ -15,8 +16,16 @@ use {
 
 pub type Result<T> = std::result::Result<T, VoteHistoryError>;
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize, Deserialize),
+    frozen_abi(
+        abi_digest = "4VVxd5brhUZgopYJ7zwAYC8J62zU2nUZSAV4kETb3m9q",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
+    )
+)]
+#[derive(Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub enum SavedVoteHistoryVersions {
     Current(SavedVoteHistory),
 }
@@ -64,16 +73,24 @@ impl From<SavedVoteHistory> for SavedVoteHistoryVersions {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "J6vB6FWFT8CFEvxndXWes461hroo8Q5L9Wq9cv4FEzaQ")
+    derive(AbiExample, StableAbi, StableAbiSample, Serialize, Deserialize),
+    frozen_abi(
+        digest = "J6vB6FWFT8CFEvxndXWes461hroo8Q5L9Wq9cv4FEzaQ",
+        abi_digest = "Mhh4tHGaVTfWbkJ78sY1dDbYZHtQjXiVFBtC3BfQH5C",
+        abi_serializer = ["bincode", "wincode"],
+    )
 )]
-#[derive(Default, Clone, Serialize, Deserialize, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
+#[derive(Default, Clone, Debug, PartialEq, Eq, SchemaWrite, SchemaRead)]
 pub struct SavedVoteHistory {
     signature: Signature,
-    #[serde(with = "serde_bytes")]
+    #[cfg_attr(feature = "frozen-abi", serde(with = "serde_bytes"))]
     data: Vec<u8>,
-    #[serde(skip)]
     #[wincode(skip)]
+    #[cfg_attr(
+        feature = "frozen-abi",
+        serde(skip),
+        stable_abi_sample(with = "Default::default()")
+    )]
     node_pubkey: Pubkey,
 }
 


### PR DESCRIPTION
#### Problem
These types are already serialized with wincode in production

#### Summary of Changes
Pins their ABI and remove serde from production where it is unused.

votor (`vote_history_storage.rs`):
- Derive `StableAbi/StableAbiSample` on `SavedVoteHistoryVersions` (top-level
  type written to disk) and `SavedVoteHistory`, and pin both the bincode and
  wincode formats via `abi_serializer = ["bincode", "wincode"]` against a
  single abi_digest (they are byte-identical). `SavedVoteHistoryVersions` also
  gets `test_roundtrip = "eq_and_wire"`; the wincode-skipped node_pubkey
  samples to Default so that roundtrip holds.
- serde Serialize/Deserialize are only needed for the bincode ABI check, so
  move them behind the frozen-abi feature and make serde/serde_bytes optional.

votor-messages (`wire.rs`):
- The wire types are wincode-only (u8 tag encoding, not bincode-compatible).
  Move their Serialize-only (vestigial) derives behind frozen-abi so they are
  absent from production builds while keeping the legacy AbiEnumVisitor/api
  digest working. `WireCertSignature, WireBlockCertMessage` and `Block` keep
  unconditional serde: they are serialized as JSON by the RPC
  `get_ag_genesis_cert` API.

#### Testing
frozen-abi tests in CI

Fixes #