### PR TITLE
refactor: `VmSlice::set_len` is a safe function

### DIFF
--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -497,14 +497,9 @@ impl<'ix_data> TransactionContext<'ix_data> {
         data: Vec<u8>,
     ) -> Result<(), InstructionError> {
         self.transaction_frame.return_data_pubkey = program_id;
-        // SAFETY: `return_data_scratchpad` is backed by `self.return_data_bytes`
-        // and `return_data_bytes` is being reset to `data`
-        // in the next statement.
-        unsafe {
-            self.transaction_frame
-                .return_data_scratchpad
-                .set_len(data.len() as u64);
-        }
+        self.transaction_frame
+            .return_data_scratchpad
+            .set_len(data.len() as u64);
         self.return_data_bytes = data;
         Ok(())
     }

--- a/transaction-context/src/transaction_accounts.rs
+++ b/transaction-context/src/transaction_accounts.rs
@@ -100,10 +100,7 @@ impl TransactionAccountViewMut<'_> {
 
     pub(crate) fn resize(&mut self, new_len: usize, value: u8) {
         self.data_mut().resize(new_len, value);
-        // SAFETY: We are synchronizing the lengths.
-        unsafe {
-            self.abi_account.payload.set_len(new_len as u64);
-        }
+        self.abi_account.payload.set_len(new_len as u64);
     }
 
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
@@ -113,10 +110,7 @@ impl TransactionAccountViewMut<'_> {
             // If the buffer is shared, the cheapest thing to do is to clone the
             // incoming slice and replace the buffer.
             self.private_fields.payload = Arc::new(new_data.to_vec());
-            // SAFETY: We are synchronizing the lengths.
-            unsafe {
-                self.abi_account.payload.set_len(new_data.len() as u64);
-            }
+            self.abi_account.payload.set_len(new_data.len() as u64);
             return;
         };
 
@@ -152,12 +146,9 @@ impl TransactionAccountViewMut<'_> {
 
     pub(crate) fn extend_from_slice(&mut self, data: &[u8]) {
         self.data_mut().extend_from_slice(data);
-        // SAFETY: We are synchronizing the lengths.
-        unsafe {
-            self.abi_account
-                .payload
-                .set_len(self.private_fields.payload_len() as u64);
-        }
+        self.abi_account
+            .payload
+            .set_len(self.private_fields.payload_len() as u64);
     }
 
     pub(crate) fn reserve(&mut self, additional: usize) {
@@ -578,13 +569,10 @@ pub struct AccountRefMut<'a> {
 #[cfg(not(any(target_arch = "bpf", target_arch = "sbf")))]
 impl Drop for AccountRefMut<'_> {
     fn drop(&mut self) {
-        // SAFETY: We are synchronizing the lengths.
-        unsafe {
-            self.account
-                .abi_account
-                .payload
-                .set_len(self.account.private_fields.payload_len() as u64);
-        }
+        self.account
+            .abi_account
+            .payload
+            .set_len(self.account.private_fields.payload_len() as u64);
         self.borrow_counter.release_borrow_mut();
     }
 }

--- a/transaction-context/src/vm_slice.rs
+++ b/transaction-context/src/vm_slice.rs
@@ -1,18 +1,18 @@
-// The VmSlice class is used for cases when you need a slice that is stored in the BPF
-// interpreter's virtual address space. Because this source code can be compiled with
-// addresses of different bit depths, we cannot assume that the 64-bit BPF interpreter's
-// pointer sizes can be mapped to physical pointer sizes. In particular, if you need a
-// slice-of-slices in the virtual space, the inner slices will be different sizes in a
-// 32-bit app build than in the 64-bit virtual space. Therefore instead of a slice-of-slices,
-// you should implement a slice-of-VmSlices, which can then use VmSlice::translate() to
-// map to the physical address.
-// This class must consist only of 16 bytes: a u64 ptr and a u64 len, to match the 64-bit
-// implementation of a slice in Rust. The PhantomData entry takes up 0 bytes.
-
 use std::marker::PhantomData;
 
-/// VmSlice serves as a stable layout for slices shared between the guest and the host.
-/// It is also the layout for SolSignerSeedC and SolSignerSeedsC.
+/// A guest-side representation of a slice of memory.
+///
+/// `VmSlice` serves as a stable layout for memory shared between the guest and the host.
+/// It is also the layout for `SolSignerSeedC` and `SolSignerSeedsC`. `VmSlice` is used anytime you
+/// need a slice that is stored in the BPF interpreter's virtual address space. Because this source
+/// code can be compiled with addresses of different bit depths, we cannot assume that the 64-bit
+/// BPF interpreter's pointer sizes can be mapped to physical pointer sizes (`usize`, `*const u8`,
+/// etc.)
+///
+/// In particular, if you need a slice-of-slices in the virtual space, the inner slices will
+/// be different sizes in a 32-bit app build than in the 64-bit virtual space. Therefore instead of
+/// a slice-of-slices, you should implement a slice-of-VmSlices, which can then use
+/// [`VmSlice::translate`] to map to the physical address.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct VmSlice<T> {
@@ -47,11 +47,11 @@ impl<T> VmSlice<T> {
             .saturating_add(self.len().saturating_mul(size_of::<T>() as u64))
     }
 
-    /// # Safety
-    /// Set a new length for the mapped area.
-    /// This function is not safe to use if not coupled with the respective change in
-    /// the underlying vector.
-    pub unsafe fn set_len(&mut self, new_len: u64) {
+    pub fn set_len(&mut self, new_len: u64) {
         self.len = new_len;
     }
 }
+
+const _: () = assert!(size_of::<VmSlice<u8>>() == 16);
+const _: () = assert!(size_of::<VmSlice<u64>>() == 16);
+const _: () = assert!(size_of::<VmSlice<VmSlice<u8>>>() == 16);


### PR DESCRIPTION
`VmSlice` does not actually represent memory dereferenceable on the host, it primarily is a guest-side structure. Getting length wrong in this context will at worst be a logic error (i.e. guest may attempt to map addresses that aren't valid and will get an access violation event.) This can happen normally, however, and this is not a safety issue.

Another way to think about this is that the `unsafe` on `set_len` is easily circumvented. One can replace `vm_slice.set_len(42)` with an equivalent and safe `*vm_slice = VmSlice::new(vm_slice.ptr(), 42)`. If `set_len` was actually unsafe, so should be `VmSlice::new`. But neither are.

Finally, even *if* `VmSlice` was used as an equivalent of `*mut [T]` for host side purposes, constructing a `*mut [T]` or modifying its size are also safe operations in Rust. Only the dereference operation is unsafe there. For `VmSlice` such operation is made safe by checks that occur during memory translation logic which will ensure that the `VmSlice` does not point at memory outside the bounds of the backing host memory buffer.