### PR TITLE
enh(xdp): arbitrarly configure XDP queue ids

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -198,6 +198,20 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         replaced_by: "xdp-cpu-cores",
     );
     add_arg!(
+        // deprecated in v4.3.0
+        Arg::with_name("experimental_retransmit_xdp_queue_ids")
+            .long("experimental-retransmit-xdp-queue-ids")
+            .takes_value(true)
+            .value_name("QUEUE_LIST")
+            .conflicts_with("xdp_queue_ids")
+            .conflicts_with("no_xdp")
+            .validator(|value| {
+                validate_cpu_ranges(value, "--experimental-retransmit-xdp-queue-ids")
+            })
+            .help("NIC hardware TX queue ids to bind for XDP. Use --xdp-queue-ids instead"),
+        replaced_by: "xdp-queue-ids",
+    );
+    add_arg!(
         // deprecated in v4.1.0
         Arg::with_name("experimental_retransmit_xdp_interface")
             .long("experimental-retransmit-xdp-interface")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1243,6 +1243,22 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("xdp_queue_ids")
+            .long("xdp-queue-ids")
+            .takes_value(true)
+            .value_name("QUEUE_LIST")
+            .conflicts_with("no_xdp")
+            .conflicts_with("experimental_retransmit_xdp_cpu_cores")
+            .requires("xdp_cpu_cores")
+            .validator(|value| validate_cpu_ranges(value, "--xdp-queue-ids"))
+            .help(
+                "NIC hardware TX queue ids to bind, one per entry in --xdp-cpu-cores and in the \
+                 same order (e.g. \"2-4,17\"). Must contain the same number of ids as \
+                 --xdp-cpu-cores has cores. Requires --xdp-cpu-cores to be set explicitly. \
+                 Defaults to sequential queue ids starting at 0",
+            ),
+    )
+    .arg(
         Arg::with_name("xdp_zero_copy")
             .long("xdp-zero-copy")
             .takes_value(false)

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1450,19 +1450,48 @@ fn build_xdp_config(
             }
         }
     };
-    Ok(cpus.map(|cpus| {
-        info!("XDP enabled on CPU cores: {cpus:?}");
+    let xdp_queue_ids = matches
+        .value_of("xdp_queue_ids")
+        .or_else(|| matches.value_of("experimental_retransmit_xdp_queue_ids"))
+        .map(|queue_ids_str| {
+            parse_cpu_ranges(queue_ids_str)
+                .expect("clap validator already accepted this queue id list")
+        });
+
+    let Some(cpus) = cpus else {
+        return Ok(None);
+    };
+    info!("XDP enabled on CPU cores: {cpus:?}");
+    let queues = match xdp_queue_ids {
+        Some(queue_ids) => {
+            if queue_ids.len() != cpus.len() {
+                return Err(format!(
+                    "--xdp-queue-ids specifies {} queue id(s) but --xdp-cpu-cores specifies {} \
+                     core(s); as many queue ids as cpu cores shall be specified",
+                    queue_ids.len(),
+                    cpus.len()
+                ));
+            }
+            queue_ids
+                .into_iter()
+                .zip(cpus)
+                .map(|(queue, cpu)| QueueCpuBinding {
+                    queue: queue as u32,
+                    cpu,
+                })
+                .collect()
+        }
         // Map the CPU list onto hardware queues sequentially (queue i -> cpus[i]).
-        let queues = cpus
+        None => cpus
             .into_iter()
             .enumerate()
             .map(|(queue, cpu)| QueueCpuBinding {
                 queue: queue as u32,
                 cpu,
             })
-            .collect();
-        XdpConfig::new(xdp_interface, queues, xdp_zero_copy)
-    }))
+            .collect(),
+    };
+    Ok(Some(XdpConfig::new(xdp_interface, queues, xdp_zero_copy)))
 }
 
 #[cfg(all(target_os = "linux", test))]
@@ -1528,6 +1557,94 @@ mod xdp_tests {
         assert!(
             result.unwrap_err().contains("PoH core"),
             "XDP core overlapping PoH core must produce an error"
+        );
+    }
+
+    #[test]
+    fn test_default_queue_ids_are_sequential_by_cpu_position() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator", "--xdp-cpu-cores", "3-5"]);
+        let config = build_xdp_config(&matches, &Operation::Run, &single_ip_bind())
+            .unwrap()
+            .expect("XDP must be enabled");
+        assert_eq!(
+            config.queues,
+            vec![
+                QueueCpuBinding { queue: 0, cpu: 3 },
+                QueueCpuBinding { queue: 1, cpu: 4 },
+                QueueCpuBinding { queue: 2, cpu: 5 },
+            ],
+            "without --xdp-queue-ids, queue ids must default to the CPU's position in the list"
+        );
+    }
+
+    #[test]
+    fn test_explicit_queue_ids_are_bound_to_matching_cpus() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec![
+            "agave-validator",
+            "--xdp-cpu-cores",
+            "3-5",
+            "--xdp-queue-ids",
+            "2,7,19",
+        ]);
+        let config = build_xdp_config(&matches, &Operation::Run, &single_ip_bind())
+            .unwrap()
+            .expect("XDP must be enabled");
+        assert_eq!(
+            config.queues,
+            vec![
+                QueueCpuBinding { queue: 2, cpu: 3 },
+                QueueCpuBinding { queue: 7, cpu: 4 },
+                QueueCpuBinding { queue: 19, cpu: 5 },
+            ],
+            "--xdp-queue-ids must bind queue ids to CPUs in the order both lists are given"
+        );
+    }
+
+    #[test]
+    fn test_explicit_queue_ids_support_range_syntax() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec![
+            "agave-validator",
+            "--xdp-cpu-cores",
+            "3-6",
+            "--xdp-queue-ids",
+            "2-4,17",
+        ]);
+        let config = build_xdp_config(&matches, &Operation::Run, &single_ip_bind())
+            .unwrap()
+            .expect("XDP must be enabled");
+        assert_eq!(
+            config.queues,
+            vec![
+                QueueCpuBinding { queue: 2, cpu: 3 },
+                QueueCpuBinding { queue: 3, cpu: 4 },
+                QueueCpuBinding { queue: 4, cpu: 5 },
+                QueueCpuBinding { queue: 17, cpu: 6 },
+            ],
+            "--xdp-queue-ids must accept the same range syntax as --xdp-cpu-cores"
+        );
+    }
+
+    #[test]
+    fn test_queue_ids_count_mismatch_is_error() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec![
+            "agave-validator",
+            "--xdp-cpu-cores",
+            "3-5",
+            "--xdp-queue-ids",
+            "2,7",
+        ]);
+        let result = build_xdp_config(&matches, &Operation::Run, &single_ip_bind());
+        assert!(
+            result.unwrap_err().contains("--xdp-queue-ids"),
+            "a queue id count that doesn't match the CPU core count must produce an error"
         );
     }
 }


### PR DESCRIPTION
#### Problem

Make available configuration of XDP queue ids to be used, behavior currently allowed by `xdp/src/transmitter.rs` but not available to the user because of the default behavior of xdp-cpu-core using enumerate to populate the queue ids. Use the same syntax as xdp-cpu-core to provide the queue ids so a mix of range and id can be provided if needed.

#### Summary of Changes

Add a new flag (as well as the deprecated version of the flag) to configure xdp queue ids to be used by each cpu core. No change are needed within the xdp package as this behavior was already permitted, yet not available through the argument definition.

#### Testing

Added arguments validation test to ensure the amount of queue ids specified matches at all time the amount of cpu core provided.

No specific github issues are pointing to this behaviour