### PR TITLE
(WIP) Clear stale dead state on no-op block switch

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2428,6 +2428,9 @@ impl ReplayStage {
 
         if bank_forks.read().unwrap().block_id(block.slot) == Some(block.block_id) {
             // Nothing to switch
+            // The requested block is already installed, but stale dead state
+            // from a prior duplicate can still prevent replay from using it.
+            Self::clear_original_dead_slot(blockstore, progress, block.slot)?;
             *pending_switch = None;
             return Ok(());
         }
@@ -2437,6 +2440,7 @@ impl ReplayStage {
         let mut ancestor_slot = block.slot;
         let mut ancestor_block_id = block.block_id;
         let mut blocks_to_switch = vec![];
+        let mut original_dead_slots_to_clear = BTreeSet::new();
         loop {
             if ancestor_slot <= root {
                 // This is either (1) an outdated attempt to switch out the
@@ -2456,8 +2460,13 @@ impl ReplayStage {
                 return Ok(());
             };
 
-            if location != BlockLocation::Original {
-                // Need to switch this block
+            if location == BlockLocation::Original {
+                if blockstore.is_dead(ancestor_slot)
+                    || progress.is_dead(ancestor_slot).unwrap_or(false)
+                {
+                    original_dead_slots_to_clear.insert(ancestor_slot);
+                }
+            } else {
                 blocks_to_switch.push((ancestor_slot, location));
             }
 
@@ -2486,10 +2495,12 @@ impl ReplayStage {
             ancestor_slot = parent_slot;
         }
 
-        let slots_to_clear = bank_forks
-            .read()
-            .unwrap()
-            .slots_to_clear(blocks_to_switch.iter().map(|(slot, _)| *slot));
+        let slots_to_clear = bank_forks.read().unwrap().slots_to_clear(
+            blocks_to_switch
+                .iter()
+                .map(|(slot, _)| *slot)
+                .chain(original_dead_slots_to_clear.iter().copied()),
+        );
 
         info!("{my_pubkey}: Clearing banks for switching and descendants: {slots_to_clear:?}");
         Self::clear_banks(
@@ -2509,7 +2520,27 @@ impl ReplayStage {
             info!("{my_pubkey}: Switched {slot} from {location:?}");
         }
 
+        for slot in original_dead_slots_to_clear {
+            Self::clear_original_dead_slot(blockstore, progress, slot)?;
+        }
+
         *pending_switch = None;
+
+        Ok(())
+    }
+
+    fn clear_original_dead_slot(
+        blockstore: &Blockstore,
+        progress: &mut ProgressMap,
+        slot: Slot,
+    ) -> Result<(), BlockstoreError> {
+        if blockstore.is_dead(slot) {
+            blockstore.remove_dead_slot(slot)?;
+        }
+
+        if let Some(fork_progress) = progress.get_mut(&slot) {
+            fork_progress.dead_reason = None;
+        }
 
         Ok(())
     }

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -11,6 +11,7 @@ use {
         replay_stage::ReplayStage,
         vote_simulator::{self, VoteSimulator},
     },
+    agave_votor::event::SwitchBankEvent,
     agave_votor_messages::{
         certificate::{CertSignature, GenesisCert},
         consensus_message::Block,
@@ -6122,6 +6123,50 @@ fn test_tower_load() {
         ReplayStage::load_tower(&tower_storage, &node_pubkey, &vote_account, &bank_forks).unwrap();
     assert_eq!(tower.vote_state, expected_tower.vote_state);
     assert_eq!(tower.node_pubkey, expected_tower.node_pubkey);
+}
+
+#[test]
+fn test_process_switch_bank_events_clears_dead_slot_when_bank_already_matches() {
+    let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(123);
+    let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+    let root_bank = bank_forks.read().unwrap().root_bank();
+    let bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 1);
+    let slot = bank.slot();
+    let last_blockhash = bank.last_blockhash();
+    let block_id = Hash::new_unique();
+    bank.set_block_id(Some(block_id));
+    bank_forks.write().unwrap().insert(bank);
+
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    blockstore.set_dead_slot(slot).unwrap();
+
+    let mut fork_progress = ForkProgress::new(last_blockhash, None, None, 0, 0, None);
+    fork_progress.mark_dead(DeadSlotReason::Hard);
+    let mut progress = ProgressMap::default();
+    progress.insert(slot, fork_progress);
+
+    let latest_switch_request = LatestSwitchRequest::default();
+    latest_switch_request.try_advance(SwitchBankEvent::Switch {
+        block: Block { slot, block_id },
+    });
+    let mut pending_switch = None;
+    let mut async_verification_freelist = vec![];
+
+    ReplayStage::process_switch_bank_events(
+        &Pubkey::new_unique(),
+        &latest_switch_request,
+        &mut pending_switch,
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut async_verification_freelist,
+    )
+    .unwrap();
+
+    assert!(pending_switch.is_none());
+    assert!(!blockstore.is_dead(slot));
+    assert_eq!(progress.is_dead(slot), Some(false));
 }
 
 #[test]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2435,6 +2435,7 @@ impl Blockstore {
     /// 2. Purges the original column data while preserving alternate columns
     /// 3. Copies shreds from the alternate location to the original location
     /// 4. Verify that the switch was successful
+    /// 5. Clear any stale dead-slot marker
     ///
     /// Holds `insert_shreds_lock` for the entire operation.
     ///
@@ -2496,12 +2497,17 @@ impl Blockstore {
         metrics.copy_elapsed_us = copy_measure.as_us();
 
         // 4. Verify the switch was successful
-        debug_assert!(
-            self.meta(slot)?
-                .expect("Slot must have SlotMeta after switch")
-                .is_full(),
-            "Slot must be full after switch"
-        );
+        let switched_meta = self
+            .meta(slot)?
+            .expect("Slot must have SlotMeta after switch");
+        debug_assert!(switched_meta.is_full(), "Slot must be full after switch");
+
+        // 5. Clear any stale dead-slot marker
+        if switched_meta.is_full() {
+            // Dead markers are slot-scoped. Once the repaired block is installed
+            // as Original, the old marker would make replay reject it.
+            self.remove_dead_slot(slot)?;
+        }
         total_measure.stop();
         metrics.total_elapsed_us = total_measure.as_us();
 

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6719,6 +6719,71 @@ fn test_get_data_shreds_for_slot() {
     }
 }
 
+#[test]
+fn test_switch_block_from_alternate_clears_dead_slot() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let parent_slot = 990;
+    let slot = 1000;
+    let num_entries = 200;
+    let alternate_location = BlockLocation::Alternate {
+        block_id: Hash::new_unique(),
+    };
+
+    let (alternate_data_shreds, _coding_shreds, leader_schedule_cache) =
+        setup_erasure_shreds(slot, parent_slot, num_entries);
+    let shreds = alternate_data_shreds
+        .iter()
+        .map(|shred| (Cow::Borrowed(shred), true, alternate_location));
+    let insert_results = blockstore
+        .do_insert_shreds(
+            shreds,
+            Some(&leader_schedule_cache),
+            false,
+            None,
+            &mut BlockstoreInsertionMetrics::default(),
+        )
+        .unwrap();
+    assert!(insert_results.duplicate_shreds.is_empty());
+    assert!(blockstore.meta(slot).unwrap().is_none());
+    assert!(
+        blockstore
+            .meta_from_location(slot, alternate_location)
+            .unwrap()
+            .unwrap()
+            .is_full()
+    );
+
+    let expected_block_id = blockstore
+        .get_double_merkle_root(slot, alternate_location)
+        .unwrap()
+        .unwrap();
+
+    blockstore.set_dead_slot(slot).unwrap();
+    assert_matches!(
+        blockstore.get_slot_entries_with_shred_info(slot, 0, false),
+        Err(BlockstoreError::DeadSlot)
+    );
+
+    blockstore
+        .switch_block_from_alternate(slot, alternate_location)
+        .unwrap();
+
+    assert!(!blockstore.is_dead(slot));
+    assert_eq!(
+        blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .unwrap(),
+        Some(expected_block_id),
+    );
+
+    let (_entries, num_shreds, is_full) = blockstore
+        .get_slot_entries_with_shred_info(slot, 0, false)
+        .unwrap();
+    assert!(is_full);
+    assert_eq!(num_shreds, alternate_data_shreds.len() as u64);
+}
+
 #[test_matrix([true, false], [
     (990, 980, false, false), // update parent before block header -> not dead
     (980, 990, false, true),  // update parent after block header -> dead


### PR DESCRIPTION
#### Problem
During Alpenglow block ID repair, replay can receive a switch request for a block that is already present in `BankForks` / `Original`.

  Before this change, `process_switch_bank_events()` treated that case as a no-op and cleared the pending switch request immediately. However, the slot may still have stale dead state from an earlier duplicate/conflict path:

  - a `Blockstore` dead-slot marker
  - a `ProgressMap` dead reason

  That stale state can cause replay to continue rejecting the slot even though the repaired/finalized block is already available.

#### Summary of Changes
When the requested block already matches the bank fork block ID, clear stale dead state for that slot before clearing the pending switch request.

#### Testing
Added regression tests:
- `test_process_switch_bank_events_clears_dead_slot_when_bank_already_matches`
- `test_switch_block_from_alternate_clears_dead_slot`

#### WIP
- [1ef7920](https://github.com/anza-xyz/agave/pull/13639/commits/1ef79205f4a2ebf5afe740f0cb74c9f004ef355f) is believed to be the fix.
- [200a366](https://github.com/anza-xyz/agave/pull/13639/commits/200a3667272b81dc714e7d94be7ac52cbd45363f) may be unnecessary but I believe that this cleanup is sound. Invalidator testing TBD, and if correct should this commit land here or in a follow-up?
