### PR TITLE
Clear stale dead state on no-op block switch

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2453,6 +2453,7 @@ impl ReplayStage {
         let mut ancestor_slot = block.slot;
         let mut ancestor_block_id = block.block_id;
         let mut blocks_to_switch = vec![];
+        let mut original_dead_slots_to_clear = BTreeSet::new();
         loop {
             if ancestor_slot <= root {
                 // This is either (1) an outdated attempt to switch out the
@@ -2473,8 +2474,11 @@ impl ReplayStage {
                 return Ok(());
             };
 
-            if location != BlockLocation::Original {
-                // Need to switch this block
+            if location == BlockLocation::Original {
+                if blockstore.is_dead(ancestor_slot) {
+                    original_dead_slots_to_clear.insert(ancestor_slot);
+                }
+            } else {
                 blocks_to_switch.push((ancestor_slot, location));
             }
 
@@ -2500,10 +2504,12 @@ impl ReplayStage {
             ancestor_slot = parent_slot;
         }
 
-        let slots_to_clear = bank_forks
-            .read()
-            .unwrap()
-            .slots_to_clear(blocks_to_switch.iter().map(|(slot, _)| *slot));
+        let slots_to_clear = bank_forks.read().unwrap().slots_to_clear(
+            blocks_to_switch
+                .iter()
+                .map(|(slot, _)| *slot)
+                .chain(original_dead_slots_to_clear.iter().copied()),
+        );
 
         info!("{my_pubkey}: Clearing banks for switching and descendants: {slots_to_clear:?}");
         Self::clear_banks(
@@ -2521,6 +2527,10 @@ impl ReplayStage {
             blockstore.switch_block_from_alternate(slot, location)?;
             progress.increment_num_bank_switches(slot);
             info!("{my_pubkey}: Switched {slot} from {location:?}");
+        }
+
+        for slot in original_dead_slots_to_clear {
+            blockstore.remove_dead_slot(slot)?;
         }
 
         *pending_switch = None;


### PR DESCRIPTION

#### Problem
During Alpenglow block ID repair, replay can receive a switch request for a block that is already present in `BankForks` / `Original`.

Before this change, `process_switch_bank_events()` treated that case as a no-op and cleared the pending switch request immediately. However, the slot may still have stale dead state from an earlier duplicate/conflict path. That stale state can cause replay to continue rejecting the slot even though the repaired/finalized block is already available.

#### Summary of Changes
When the requested block already matches the bank fork block ID, clear stale dead state for that slot before clearing the pending switch request.

#### Testing
Tested invalidator cluster: forced one validator to be stuck at root 231/223 with FailedToLoadEntries(DeadSlot). After applying the fix, attacked validator advanced with the rest.