### PR TITLE
Resolve stale data race by holding read lock during write

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -667,7 +667,7 @@ fn test_flush_defers_write_through_until_all_cached_slots_drop() {
     let baseline_writes = immediate_disk_writes();
 
     // Flush slot 0. Pubkey is still cached at slots 1 and 2, so remove_slot does
-    // not return it and try_write_through is never called, so no immediate disk
+    // not return it and write_through is never called, so no immediate disk
     // write must fire.
     db.add_root_and_flush_write_cache(0);
     assert_eq!(immediate_disk_writes(), baseline_writes);
@@ -677,7 +677,7 @@ fn test_flush_defers_write_through_until_all_cached_slots_drop() {
     assert_eq!(immediate_disk_writes(), baseline_writes);
 
     // Flush slot 2. The pubkey is no longer in any cached slot, so the cache-drop
-    // loop in flush_slot_cache calls try_write_through. ReclaimOldSlots has
+    // loop in flush_slot_cache calls write_through. ReclaimOldSlots has
     // collapsed the slot list to a single storage entry with ref_count == 1, so
     // write-through fires and bumps the counter by exactly one.
     db.add_root_and_flush_write_cache(2);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -745,7 +745,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             return;
         }
         for pubkey in pubkeys {
-            self.get_bin(&pubkey).try_write_through(&pubkey);
+            self.get_bin(&pubkey).write_through(&pubkey);
         }
     }
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -407,7 +407,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         pubkey: &Pubkey,
         user_fn: impl FnOnce(SlotListWriteGuard<T>, &AccountMapEntry<T>) -> RT,
     ) -> Option<RT> {
-        let mut write_through_args: Option<(Slot, T)> = None;
+        let mut should_write_through = false;
         let result = self.get_internal_inner(pubkey, |entry| {
             (
                 true,
@@ -416,17 +416,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     // always mark dirty unconditionally, even if user_fn made no changes
                     entry.mark_dirty();
                     if self.should_write_through && entry.ref_count() == 1 {
-                        let slot_list = entry.slot_list_read_lock();
-                        if slot_list.len() == 1 {
-                            write_through_args = Some(slot_list[0]);
-                        }
+                        should_write_through = entry.slot_list_read_lock().len() == 1;
                     }
                     result
                 }),
             )
         });
-        if let Some((slot, account_info)) = write_through_args {
-            self.write_through(pubkey, slot, account_info);
+        if should_write_through {
+            self.write_through(pubkey);
         }
         result
     }
@@ -452,54 +449,33 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         grow_us
     }
 
-    /// Write `(slot, account_info)` to the disk index, then under the slot list read lock
-    /// verify the in-mem entry still matches; if so, clear the dirty flag so the entry
-    /// is eligible for eviction without waiting for the background flush.
+    /// Under the slot list read lock, check the entry is dirty, single-slot, and single-ref;
+    /// if so write it to the disk index and clear the dirty flag so the entry is eligible for
+    /// eviction without waiting for the background flush.
     ///
-    /// We hold the slot list read lock during the equality check to prevent concurrent
-    /// modifications from invalidating our check between the disk write and the dirty-clear.
+    /// We hold the slot list read lock across the check and disk write so a concurrent
+    /// modification cannot invalidate the check between the disk write and the dirty-clear.
     /// Any concurrent upsert that modifies the slot list must hold the write lock, so it
     /// cannot proceed until we release. If it ran before us the check will fail and we leave
     /// the entry dirty for the next write to clean up; if it runs after, it will re-dirty
     /// the now-clean entry and call write_through itself.
-    fn write_through(&self, pubkey: &Pubkey, slot: Slot, account_info: T) {
+    pub(crate) fn write_through(&self, pubkey: &Pubkey) {
         let disk = self.bucket.as_ref().unwrap();
-        let disk_entry = [(slot, account_info.into())];
-        let grow_us = Self::write_to_disk(disk, pubkey, &disk_entry);
-        Self::update_stat(&self.stats().flush_entries_updated_on_disk_immediate, 1);
-        Self::update_stat(&self.stats().flush_grow_us, grow_us);
         self.get_only_in_mem(pubkey, false, |entry| {
-            if let Some(entry) = entry {
-                let slot_list = entry.slot_list_read_lock();
-                if slot_list.len() == 1
-                    && slot_list[0] == (slot, account_info)
-                    && entry.ref_count() == 1
-                {
-                    entry.clear_dirty();
-                }
+            let Some(entry) = entry else {
+                return;
+            };
+            let slot_list = entry.slot_list_read_lock();
+            if !entry.dirty() || slot_list.len() != 1 || entry.ref_count() != 1 {
+                return;
             }
+            let (slot, account_info) = slot_list[0];
+            let disk_entry = [(slot, account_info.into())];
+            let grow_us = Self::write_to_disk(disk, pubkey, &disk_entry);
+            Self::update_stat(&self.stats().flush_entries_updated_on_disk_immediate, 1);
+            Self::update_stat(&self.stats().flush_grow_us, grow_us);
+            entry.clear_dirty();
         });
-    }
-
-    /// If the in-mem entry for pubkey is `slot_list.len() == 1` with `ref_count == 1` and
-    /// currently dirty, write it through to disk
-    pub fn try_write_through(&self, pubkey: &Pubkey) {
-        let to_write = self.get_only_in_mem(pubkey, false, |entry| {
-            entry.and_then(|entry| {
-                if !entry.dirty() {
-                    return None;
-                }
-
-                let slot_list = entry.slot_list_read_lock();
-                match (entry.ref_count(), &slot_list[..]) {
-                    (1, [info]) => Some(*info),
-                    _ => None,
-                }
-            })
-        });
-        if let Some((slot, info)) = to_write {
-            self.write_through(pubkey, slot, info);
-        }
     }
 
     /// Clean the slot list by removing all slot_list items older than the max_slot.
@@ -597,8 +573,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 self.should_write_through && slot_list_length == 1 && entry.ref_count() == 1;
         });
         if should_write_through {
-            let (slot, account_info) = new_item;
-            self.write_through(pubkey, slot, account_info);
+            self.write_through(pubkey);
         }
     }
 
@@ -2993,9 +2968,9 @@ mod tests {
         );
     }
 
-    /// `upsert` then `try_write_through` clears the dirty flag.
+    /// `upsert` then `write_through` clears the dirty flag.
     #[test]
-    fn test_try_write_through_clears_dirty() {
+    fn test_write_through_clears_dirty() {
         let index = new_should_write_through_for_test(None);
         let pubkey = solana_pubkey::new_rand();
         let slot = 1;
@@ -3011,7 +2986,7 @@ mod tests {
             &mut ReclaimsSlotList::new(),
             UpsertReclaim::IgnoreReclaims,
         );
-        index.try_write_through(&pubkey);
+        index.write_through(&pubkey);
 
         index.get_only_in_mem(&pubkey, false, |entry| {
             let entry = entry.expect("entry should be in memory");
@@ -3025,12 +3000,12 @@ mod tests {
         assert_eq!(ref_count, 1);
     }
 
-    /// `try_write_through` must leave a multi-ref entry alone: if the pubkey still has more
+    /// `write_through` must leave a multi-ref entry alone: if the pubkey still has more
     /// than one slot-list entry (ref_count > 1), persisting just one of them to disk would let a
     /// later eviction drop the fresher in-mem entry in favor of an incomplete disk entry. The
     /// entry must stay dirty and nothing must be written to disk.
     #[test]
-    fn test_try_write_through_skips_multi_ref_entry() {
+    fn test_write_through_skips_multi_ref_entry() {
         let index = new_should_write_through_for_test(None);
         let pubkey = solana_pubkey::new_rand();
         let info = 10;
@@ -3065,7 +3040,7 @@ mod tests {
             .flush_entries_updated_on_disk_immediate
             .load(Ordering::Relaxed);
 
-        index.try_write_through(&pubkey);
+        index.write_through(&pubkey);
 
         index.get_only_in_mem(&pubkey, false, |entry| {
             let entry = entry.expect("entry should still be in memory");
@@ -3105,7 +3080,7 @@ mod tests {
                 &mut ReclaimsSlotList::new(),
                 UpsertReclaim::IgnoreReclaims,
             );
-            index.try_write_through(pubkey);
+            index.write_through(pubkey);
         }
         assert_eq!(index.map_internal.read().unwrap().len(), 3);
 


### PR DESCRIPTION
#### Problem
Resolves a potential stale data race in write_through by holding the read_lock when performing the write through. 

#### Summary of Changes
- Remove try_write_through as it is now just extra cost
- Hold the read lock during the write through

#### Testing
- Tested race condition. Base testing could not reproduce the issue on unmodified code. 
- Reproduced by injecting targeted waits
- With the new code, the race injection point doesn't exist, so the test is not useful. Injecting delays in similar areas did not reproduce the issue. 

Ran over the weekend: No crazy spikes on max load/store on RoryP

<img width="1678" height="515" alt="image" src="https://github.com/user-attachments/assets/50aa1420-6c23-417a-8e7c-2fe97487bf8e" />


Fixes #
