### PR TITLE
vote: enforce vote state view item alignment on production builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11751,7 +11751,6 @@ dependencies = [
  "solana-transaction",
  "solana-vote",
  "solana-vote-interface",
- "static_assertions",
  "thiserror 2.0.18",
  "wincode",
 ]

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -79,7 +79,6 @@ solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode", "dev-context-only-utils"] }
 solana-vote = { path = ".", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
-static_assertions = { workspace = true }
 
 [[bench]]
 name = "vote_account"

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -9,13 +9,6 @@ use {
 pub(super) trait ListFrame {
     type Item;
 
-    // SAFETY: Each implementor MUST enforce that `Self::Item` is alignment 1 to
-    // ensure that after casting it won't have alignment issues, any heap
-    // allocated fields, or any assumptions about endianness.
-    #[cfg(test)]
-    #[allow(dead_code)]
-    const ASSERT_ITEM_ALIGNMENT: ();
-
     fn len(&self) -> usize;
     fn item_size(&self) -> usize {
         core::mem::size_of::<Self::Item>()
@@ -23,10 +16,12 @@ pub(super) trait ListFrame {
 
     /// This function is safe under the following conditions:
     /// SAFETY:
-    /// - `Self::Item` is alignment 1
+    /// - `Self::Item` is alignment 1 (enforced at compile time below) and has
+    ///   no heap allocated fields or assumptions about endianness
     /// - The passed `item_data` slice is large enough for the type `Self::Item`
     /// - `Self::Item` is valid for any sequence of bytes
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
+        const { assert!(core::mem::align_of::<Self::Item>() == 1) };
         unsafe { &*(item_data.as_ptr() as *const Self::Item) }
     }
 
@@ -46,11 +41,6 @@ pub(super) enum VotesFrame {
 
 impl ListFrame for VotesFrame {
     type Item = LockoutItem;
-
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
-    };
 
     fn len(&self) -> usize {
         match self {
@@ -112,11 +102,6 @@ impl LockoutListFrame {
 
 impl ListFrame for LockoutListFrame {
     type Item = LockoutItem;
-
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
-    };
 
     fn len(&self) -> usize {
         self.len as usize
@@ -209,11 +194,6 @@ pub(super) struct LandedVoteItem {
 impl ListFrame for LandedVotesListFrame {
     type Item = LockoutItem;
 
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<LockoutItem>() == 1);
-    };
-
     fn len(&self) -> usize {
         self.len as usize
     }
@@ -223,6 +203,7 @@ impl ListFrame for LandedVotesListFrame {
     }
 
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
+        const { assert!(core::mem::align_of::<LockoutItem>() == 1) };
         unsafe { &*(item_data[1..].as_ptr() as *const LockoutItem) }
     }
 }
@@ -253,11 +234,6 @@ pub(super) struct AuthorizedVoterItem {
 
 impl ListFrame for AuthorizedVotersListFrame {
     type Item = AuthorizedVoterItem;
-
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<AuthorizedVoterItem>() == 1);
-    };
 
     fn len(&self) -> usize {
         self.len as usize
@@ -303,11 +279,6 @@ impl EpochCreditsListFrame {
 
 impl ListFrame for EpochCreditsListFrame {
     type Item = EpochCreditsItem;
-
-    #[cfg(test)]
-    const ASSERT_ITEM_ALIGNMENT: () = {
-        static_assertions::const_assert!(core::mem::align_of::<EpochCreditsItem>() == 1);
-    };
 
     fn len(&self) -> usize {
         self.len as usize

--- a/vote/src/vote_state_view/field_frames.rs
+++ b/vote/src/vote_state_view/field_frames.rs
@@ -204,6 +204,7 @@ impl ListFrame for LandedVotesListFrame {
 
     unsafe fn read_item<'a>(&self, item_data: &'a [u8]) -> &'a Self::Item {
         const { assert!(core::mem::align_of::<LockoutItem>() == 1) };
+        const { assert!(core::mem::align_of::<LandedVoteItem>() == 1) };
         unsafe { &*(item_data[1..].as_ptr() as *const LockoutItem) }
     }
 }


### PR DESCRIPTION
#### Problem

The `ListFrame` SAFETY invariant that every `Item` type has alignment 1 is only asserted under `#[cfg(test)]`, and `static_assertions` is a dev-dependency, so the check cannot exist in release builds. The associated const carrying it is also `#[allow(dead_code)]` and never referenced. The production read path `read_item` casts `&[u8]` to `&Self::Item` with no enforcement.

All current item types have alignment 1, so this is hardening rather than a live bug. But `AuthorizedVoterItem` embeds `Pubkey`, which is defined in a foreign crate, and an upstream alignment change would silently turn that cast into misaligned references in production builds.

#### Summary of Changes

Implements Option 1 from #13554: an inline `const { assert!(align_of::<...>() == 1) }` immediately before each raw cast, in the default `read_item` and in the `LandedVotesListFrame` override that casts directly to `LockoutItem`. These evaluate in every build profile. The now redundant `ASSERT_ITEM_ALIGNMENT` consts and the `static_assertions` dev-dependency are removed (this file was its only use in the crate).

#### Testing

- `cargo build --release -p solana-vote --features agave-unstable-api` passes.
- Temporarily adding a `u64` field to each of `LockoutItem`, `AuthorizedVoterItem` and `EpochCreditsItem` fails that same release build at the new asserts (reverted), confirming the check is active outside tests.
- `cargo test -p solana-vote` passes except `vote_parser::test_parse_vote_transaction`, which fails identically on master when the crate is tested standalone (unrelated).

Fixes #13554
