### PR TITLE
fix(BlockComponent): LengthPrefixed canonical decoding

### DIFF
--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -143,8 +143,8 @@ use {
     solana_hash::Hash,
     std::mem::MaybeUninit,
     wincode::{
-        ReadResult, SchemaRead, SchemaWrite, WriteResult,
-        config::{Config, DefaultConfig},
+        ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
+        config::{Config, ConfigCore, DefaultConfig},
         containers::Vec as WincodeVec,
         error::write_length_encoding_overflow,
         io::{Reader, Writer},
@@ -165,10 +165,39 @@ pod_wrapper! {
 /// Wraps a value with a u16 length prefix for TLV-style serialization.
 ///
 /// The length prefix represents the serialized byte size of the inner value.
-#[derive(Debug, Clone, PartialEq, Eq, SchemaRead, SchemaWrite)]
+#[derive(Debug, Clone, PartialEq, Eq, SchemaWrite)]
 pub struct LengthPrefixed<T> {
     len: u16,
     inner: T,
+}
+
+unsafe impl<'de, T, C: ConfigCore> SchemaRead<'de, C> for LengthPrefixed<T>
+where
+    T: SchemaRead<'de, C, Dst = T> + SchemaWrite<C, Src = T>,
+{
+    type Dst = Self;
+
+    const TYPE_META: TypeMeta = TypeMeta::join_types([
+        <u16 as SchemaRead<'de, C>>::TYPE_META,
+        <T as SchemaRead<'de, C>>::TYPE_META,
+    ])
+    .keep_zero_copy(false);
+
+    fn read(mut reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let len = <u16 as SchemaRead<'de, C>>::get(reader.by_ref())?;
+        let inner = T::get(reader)?;
+        let inner_size = T::size_of(&inner)
+            .map_err(|_| wincode::ReadError::Custom("LengthPrefixed: inner size_of overflow"))?;
+
+        if inner_size != usize::from(len) {
+            return Err(wincode::ReadError::Custom(
+                "LengthPrefixed: inner serialized size does not match length prefix",
+            ));
+        }
+
+        dst.write(Self { len, inner });
+        Ok(())
+    }
 }
 
 impl<T> LengthPrefixed<T>
@@ -632,6 +661,47 @@ mod tests {
         let bytes = wincode::serialize(&comp).unwrap();
         let deser: BlockComponent = wincode::deserialize(&bytes).unwrap();
         assert_eq!(comp, deser);
+    }
+
+    #[test]
+    fn length_prefixed_rejects_inner_size_mismatch() {
+        let header = VersionedBlockHeader::V1(BlockHeaderV1 {
+            parent_slot: 12345,
+            parent_block_id: Hash::new_unique(),
+        });
+        let prefixed = LengthPrefixed::new(header);
+        let mut bytes = wincode::serialize(&prefixed).unwrap();
+        let wrong_len = prefixed.len + 1;
+        bytes[..std::mem::size_of::<u16>()].copy_from_slice(&wrong_len.to_le_bytes());
+
+        assert!(matches!(
+            wincode::deserialize::<LengthPrefixed<VersionedBlockHeader>>(&bytes),
+            Err(wincode::ReadError::Custom(
+                "LengthPrefixed: inner serialized size does not match length prefix"
+            ))
+        ));
+    }
+
+    #[test]
+    fn length_prefixed_rejects_oversized_deserialized_inner() {
+        let marker = GenesisCertBlockMarker {
+            slot: 999,
+            block_id: Hash::new_unique(),
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![0xAB; usize::from(u16::MAX) + 1],
+        };
+        let wire = LengthPrefixed {
+            len: 7,
+            inner: marker,
+        };
+        let bytes = wincode::serialize(&wire).unwrap();
+
+        assert!(matches!(
+            wincode::deserialize::<LengthPrefixed<GenesisCertBlockMarker>>(&bytes),
+            Err(wincode::ReadError::Custom(
+                "LengthPrefixed: inner serialized size does not match length prefix"
+            ))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

```rs
pub struct LengthPrefixed<T> {
    len: u16,
    inner: T,
}
```

Construction of `LengthPrefixed<T>` via `LengthPrefixed::new(T)` ensures canonical construction of `LengthPrefixed` by:
1. Computing the serialized length of `T`;
2. Rendering the length into the resulting `LengthPrefixed` struct alongside the `T`.

I.e., the canonical form of `LengthPrefixed` is invariant over `size_of(&t) == len`. Additionally, `size_of(&t)` cannot exceed `u16::MAX`, which is implicit by `len` being represented by `u16`.

`LengthPrefixed` _derives_ `SchemaRead`, which cannot enforce the canonicity invariant since it reads and places members structurally, without any validation (the derive is blind to logical invariants).

As such, one could theoretically craft a non-canonical payload, deserialize it, and have an in-memory `LengthPrefixed` that doesn't adhere to its invariant.

#### Summary of Changes

This adds a custom `SchemaRead` implementation that ensures `size_of(&t) == len`.