### PR TITLE
feat(storage-proto): make protobuf-src an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -491,7 +491,7 @@ solana-stable-layout = "3.0.1"
 solana-stake-history = "1.0.0"
 solana-stake-interface = "4.3.1"
 solana-storage-bigtable = { path = "storage-bigtable", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
-solana-storage-proto = { path = "storage-proto", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
+solana-storage-proto = { path = "storage-proto", version = "=4.3.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
 solana-streamer = { path = "streamer", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-svm = { path = "svm", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-svm-callback = { path = "svm-callback", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -97,7 +97,7 @@ solana-signature = { workspace = true, features = ["wincode"] }
 solana-signer = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-storage-bigtable = { workspace = true }
-solana-storage-proto = { workspace = true }
+solana-storage-proto = { workspace = true, features = ["protobuf-src"] }
 solana-streamer = { workspace = true }
 solana-svm = { workspace = true, features = ["metrics"] }
 solana-svm-timings = { workspace = true }

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -55,7 +55,7 @@ solana-metrics = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-serde = { workspace = true }
 solana-signature = { workspace = true }
-solana-storage-proto = { workspace = true }
+solana-storage-proto = { workspace = true, features = ["protobuf-src"] }
 solana-time-utils = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -19,7 +19,9 @@ crate-type = ["lib"]
 name = "solana_storage_proto"
 
 [features]
+default = ["protobuf-src"]
 agave-unstable-api = []
+protobuf-src = ["dep:protobuf-src"]
 
 [dependencies]
 bs58 = { workspace = true }
@@ -45,7 +47,7 @@ tonic-prost-build = { workspace = true }
 # windows users should install the protobuf compiler manually and set the PROTOC
 # envar to point to the installed binary
 [target."cfg(not(windows))".build-dependencies]
-protobuf-src = { workspace = true }
+protobuf-src = { workspace = true, optional = true }
 
 [dev-dependencies]
 enum-iterator = { workspace = true }

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), std::io::Error> {
     const PROTOC_ENVAR: &str = "PROTOC";
     // Safety: env is checked and updated before any threads might exist
     if std::env::var(PROTOC_ENVAR).is_err() {
-        #[cfg(not(windows))]
+        #[cfg(all(not(windows), feature = "protobuf-src"))]
         unsafe {
             std::env::set_var(PROTOC_ENVAR, protobuf_src::protoc())
         }
@@ -24,6 +24,8 @@ fn main() -> Result<(), std::io::Error> {
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(false)
+        // proto3 optional fields need this on older system protoc (protobuf-src off)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(
             "TransactionErrorType",
             "#[cfg_attr(test, derive(enum_iterator::Sequence))]",


### PR DESCRIPTION
#### Problem

`protobuf-src` is a mandatory build dependency of `solana-storage-proto` on non-Windows targets, and it builds libprotobuf from source. So every build compiles it even if you already have a working `protoc`, with no way to skip it. Windows already avoids this: the dep is `cfg(not(windows))`-gated, and Windows users point `PROTOC` at their own binary.

#### Summary of Changes

Put `protobuf-src` behind a default feature so it stays on by default but can be turned off.

- `storage-proto`: add a default `protobuf-src` feature and make the build dep `optional`. `build.rs` only sets `PROTOC` from the vendored protoc when the feature is on. With it off, `PROTOC` is left to the environment and `tonic-prost-build` picks up the system `protoc`, same as Windows does today.
- Set `default-features = false` at the top-level `Cargo.toml`, and re-enable `protobuf-src` in the only two crates that use it, `solana-ledger` and `solana-storage-bigtable`. The default workspace build is unchanged.

Anything downstream that wants its own `protoc` can now depend on `solana-storage-proto` with `default-features = false`.

Picks up #9615, plus the `default-features = false` wiring asked for there. Feature name's the one settled on in that discussion.

#### Testing

- `cargo check -p solana-storage-proto` still builds with the vendored protoc.
- `cargo check -p solana-storage-proto --no-default-features --features agave-unstable-api` builds against the system `protoc`.
- CI's `cargo hack --each-feature` covers the feature-off build.


#### Follow-up idea (not part of this PR)

Separate from this change, there's a pure-Rust route worth flagging: `protox` compiles proto files with no external `protoc` at all (`tonic-prost-build` takes its `FileDescriptorSet` through `compile_fds`), which could eventually drop the C++ libprotobuf build outright rather than just gating it. It's a bigger call than this PR: it swaps the compiler that generates these wire types, so descriptor parity with `protoc` and reproducible builds would want checking, and the bigtable proto helper uses `protobuf-src` too. 

I couldn't find prior discussion of it here, so I may be missing some context. If it's of interest I'm happy to open a separate issue to weigh the tradeoffs rather than assume it. (atuinsh/atuin#2122 is one project that made the switch.)

Fixes #9614
