### PR TITLE
runtime: enable strict_nonce_size_check for simulation

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3828,7 +3828,7 @@ impl Bank {
                 },
                 drop_on_failure: false,
                 all_or_nothing: false,
-                strict_nonce_size_check: false,
+                strict_nonce_size_check: true,
             },
         );
 


### PR DESCRIPTION
#### Problem
simulation represents the likely outcome of submitting a transaction to a leader, so we should use the same options as leader

#### Summary of Changes
change `strict_nonce_size_check` in `simulate_transaction_unchecked()` to be true
