### PR TITLE
ff cleanup: SIMD-0340

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -114,8 +114,6 @@ impl WindowServiceMetrics {
 pub fn check_duplicate_shred(
     blockstore: &Blockstore,
     shred: PossibleDuplicateShred,
-    validate_chained_block_id: bool,
-    validate_chained_block_id_2: bool,
     no_verify_chained_merkle_root: bool,
 ) -> Result<Option<(Shred, shred::Payload)>> {
     let shred_slot = shred.slot();
@@ -123,28 +121,13 @@ pub fn check_duplicate_shred(
         PossibleDuplicateShred::LastIndexConflict(shred, conflict)
         | PossibleDuplicateShred::ErasureConflict(shred, conflict)
         | PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
-        PossibleDuplicateShred::ChainedMerkleRootConflict(_slot) => {
-            if no_verify_chained_merkle_root {
-                // If we're in the full alpenglow epoch, we stop validating the chained merkle root.
-                // In Alpenglow we only use the double merkle root
-                return Ok(None);
-            }
-            if validate_chained_block_id || validate_chained_block_id_2 {
-                // Although chained merkle roots are not necessary for agave duplicate resolution protocols,
-                // We still need to mark the block as dead for other client teams.
-                blockstore.set_dead_slot(shred_slot)?;
-            }
-            return Ok(None);
-        }
         PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(_slot) => {
             if no_verify_chained_merkle_root {
                 // If we're in the full alpenglow epoch, we stop validating the chained merkle root.
                 // In Alpenglow we only use the double merkle root
                 return Ok(None);
             }
-            if validate_chained_block_id_2 {
-                blockstore.set_dead_slot(shred_slot)?;
-            }
+            blockstore.set_dead_slot(shred_slot)?;
             return Ok(None);
         }
         PossibleDuplicateShred::Exists(shred) => {
@@ -188,29 +171,14 @@ fn run_check_duplicate(
             root_bank = bank_forks.read().unwrap().root_bank();
         }
         let shred_slot = shred.slot();
-        let validate_chained_block_id = shred::filter::check_feature_activation_from_bank(
-            &feature_set::validate_chained_block_id::id(),
-            shred_slot,
-            &root_bank,
-        );
-        let validate_chained_block_id_2 = shred::filter::check_feature_activation_from_bank(
-            &feature_set::validate_chained_block_id_2::id(),
-            shred_slot,
-            &root_bank,
-        );
         let no_verify_chained_merkle_root = shred::filter::check_feature_activation_from_bank(
             &feature_set::alpenglow::id(),
             shred_slot,
             &root_bank,
         );
 
-        let Some((shred1, shred2)) = check_duplicate_shred(
-            blockstore,
-            shred,
-            validate_chained_block_id,
-            validate_chained_block_id_2,
-            no_verify_chained_merkle_root,
-        )?
+        let Some((shred1, shred2)) =
+            check_duplicate_shred(blockstore, shred, no_verify_chained_merkle_root)?
         else {
             return Ok(());
         };
@@ -655,8 +623,6 @@ mod test {
             &blockstore,
             PossibleDuplicateShred::Exists(duplicate_shred.clone()),
             true,
-            true,
-            false,
         )
         .unwrap()
         .unwrap();

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -78,7 +78,6 @@ pub struct FeatureSnapshot {
     pub limit_instruction_accounts: bool,
     pub block_revenue_sharing: bool,
     pub vote_account_initialize_v2: bool,
-    pub validate_chained_block_id: bool,
     pub validator_admission_ticket: bool,
     pub direct_account_pointers_in_program_input: bool,
     pub upgrade_bpf_stake_program_to_v5: bool,
@@ -87,7 +86,6 @@ pub struct FeatureSnapshot {
     pub relax_post_exec_min_balance_check: bool,
     pub enable_tx_v1: bool,
     pub define_ltds_fee_only_semantics: bool,
-    pub validate_chained_block_id_2: bool,
     pub upgrade_bpf_stake_program_to_v5_1: bool,
 }
 
@@ -189,7 +187,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             limit_instruction_accounts: is_active(&limit_instruction_accounts::ID),
             block_revenue_sharing: is_active(&block_revenue_sharing::ID),
             vote_account_initialize_v2: is_active(&vote_account_initialize_v2::ID),
-            validate_chained_block_id: is_active(&validate_chained_block_id::ID),
             validator_admission_ticket: is_active(&validator_admission_ticket::ID),
             direct_account_pointers_in_program_input: is_active(
                 &direct_account_pointers_in_program_input::ID,
@@ -202,7 +199,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             relax_post_exec_min_balance_check: is_active(&relax_post_exec_min_balance_check::ID),
             enable_tx_v1: is_active(&enable_tx_v1::ID),
             define_ltds_fee_only_semantics: is_active(&define_ltds_fee_only_semantics::ID),
-            validate_chained_block_id_2: is_active(&validate_chained_block_id_2::ID),
             upgrade_bpf_stake_program_to_v5_1: is_active(&upgrade_bpf_stake_program_to_v5_1::ID),
         }
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -79,7 +79,7 @@ use {
         fs::{self, File},
         io::Error as IoError,
         num::NonZeroUsize,
-        ops::{Bound, Range},
+        ops::Range,
         path::{Path, PathBuf},
         rc::Rc,
         sync::{
@@ -196,11 +196,8 @@ pub enum PossibleDuplicateShred {
         Shred,          // original
         shred::Payload, // conflict
     ),
-    // Merkle root chaining conflict with previous fec set
-    // As part of SIMD-0340
-    ChainedMerkleRootConflict(Slot),
-    // Secondary chained merkle root conflict with previous fec set
-    // As part of SIMD-0340
+    // Chained merkle root conflict with previous fec set
+    // A part of SIMD-0340
     FixedFECChainedMerkleRootConflict(Slot),
 }
 
@@ -211,8 +208,7 @@ impl PossibleDuplicateShred {
             Self::LastIndexConflict(shred, _) => shred.slot(),
             Self::ErasureConflict(shred, _) => shred.slot(),
             Self::MerkleRootConflict(shred, _) => shred.slot(),
-            Self::ChainedMerkleRootConflict(slot)
-            | Self::FixedFECChainedMerkleRootConflict(slot) => *slot,
+            Self::FixedFECChainedMerkleRootConflict(slot) => *slot,
         }
     }
 }
@@ -916,71 +912,6 @@ impl Blockstore {
             prev_merkle_root_meta.first_received_shred_index(),
             prev_merkle_root_meta.first_received_shred_type(),
         ))
-    }
-
-    /// Attempts to find the previous consecutive erasure set for `erasure_set`.
-    ///
-    /// Checks the map `erasure_metas`, if not present scans blockstore. Returns None
-    /// if the previous consecutive erasure set is not present in either.
-    fn previous_erasure_set<'a>(
-        &'a self,
-        erasure_set: ErasureSetId,
-        erasure_metas: &'a BTreeMap<ErasureSetId, WorkingEntry<ErasureMeta>>,
-    ) -> Result<Option<(ErasureSetId, Cow<'a, ErasureMeta>)>> {
-        let (slot, fec_set_index) = erasure_set.store_key();
-
-        // Check the previous entry from the in memory map to see if it is the consecutive
-        // set to `erasure set`
-        let candidate_erasure_entry = erasure_metas
-            .range((
-                Bound::Included(ErasureSetId::new(slot, 0)),
-                Bound::Excluded(erasure_set),
-            ))
-            .next_back();
-        let candidate_erasure_set_and_meta = candidate_erasure_entry
-            .filter(|(_, candidate_erasure_meta)| {
-                candidate_erasure_meta.as_ref().next_fec_set_index() == Some(fec_set_index)
-            })
-            .map(|(erasure_set, erasure_meta)| {
-                (*erasure_set, Cow::Borrowed(erasure_meta.as_ref()))
-            });
-        if candidate_erasure_set_and_meta.is_some() {
-            return Ok(candidate_erasure_set_and_meta);
-        }
-
-        // Consecutive set was not found in memory, scan blockstore for a potential candidate
-        let Some(((_, candidate_fec_set_index), candidate_erasure_meta)) = self
-            .erasure_meta_cf
-            .iter(IteratorMode::From(
-                (slot, u64::from(fec_set_index)),
-                IteratorDirection::Reverse,
-            ))?
-            // `find` here, to skip the first element in case the erasure meta for fec_set_index is already present
-            .find(|((_, candidate_fec_set_index), _)| {
-                *candidate_fec_set_index != u64::from(fec_set_index)
-            })
-            // Do not consider sets from the previous slot
-            .filter(|((candidate_slot, _), _)| *candidate_slot == slot)
-        else {
-            // No potential candidates
-            return Ok(None);
-        };
-        let candidate_fec_set_index = u32::try_from(candidate_fec_set_index)
-            .expect("fec_set_index from a previously inserted shred should fit in u32");
-        let candidate_erasure_set = ErasureSetId::new(slot, candidate_fec_set_index);
-        let candidate_erasure_meta = cf::ErasureMeta::deserialize(candidate_erasure_meta.as_ref())?;
-
-        // Check if this is actually the consecutive erasure set
-        let Some(next_fec_set_index) = candidate_erasure_meta.next_fec_set_index() else {
-            return Err(BlockstoreError::InvalidErasureConfig);
-        };
-        if next_fec_set_index == fec_set_index {
-            return Ok(Some((
-                candidate_erasure_set,
-                Cow::Owned(candidate_erasure_meta),
-            )));
-        }
-        Ok(None)
     }
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
@@ -1765,45 +1696,6 @@ impl Blockstore {
         &self,
         shred_insertion_tracker: &mut ShredInsertionTracker,
     ) {
-        for (erasure_set, working_erasure_meta) in shred_insertion_tracker.erasure_metas.iter() {
-            if !working_erasure_meta.should_write() {
-                // Not a new erasure meta
-                continue;
-            }
-            let (slot, _) = erasure_set.store_key();
-
-            // First coding shred from this erasure batch, check the forward merkle root chaining
-            // Note: This check is not performed on Alternate columns, as we cannot repair coding shreds
-            // and all shreds are trusted as they are verified via a separate merkle proof on repair ingest
-            let erasure_meta = working_erasure_meta.as_ref();
-            let shred_id = ShredId::new(
-                slot,
-                erasure_meta
-                    .first_received_coding_shred_index()
-                    .expect("First received coding index must fit in u32"),
-                ShredType::Code,
-            );
-            let shred = shred_insertion_tracker
-                .just_inserted_shreds
-                .get(&(BlockLocation::Original, shred_id))
-                .expect("Erasure meta was just created, initial shred must exist");
-
-            // Forward check for SIMD-0340
-            if let Some(next_fec_set_index) = erasure_meta.next_fec_set_index() {
-                let next_erasure_set = ErasureSetId::new(slot, next_fec_set_index);
-                if !self.check_forward_chained_merkle_root_consistency(
-                    shred,
-                    next_erasure_set,
-                    &shred_insertion_tracker.just_inserted_shreds,
-                    &shred_insertion_tracker.merkle_root_metas,
-                ) {
-                    shred_insertion_tracker
-                        .duplicate_shreds
-                        .push(PossibleDuplicateShred::ChainedMerkleRootConflict(slot));
-                }
-            }
-        }
-
         for ((location, erasure_set), working_merkle_root_meta) in
             shred_insertion_tracker.merkle_root_metas.iter()
         {
@@ -1813,7 +1705,6 @@ impl Blockstore {
             }
             let (slot, _) = erasure_set.store_key();
 
-            // First shred from this erasure batch, check the backwards merkle root chaining
             // Note: this check is not performed on Alternate columns as they are already validated
             // via a separate merkle proof on repair ingest
             if !matches!(location, BlockLocation::Original) {
@@ -1831,31 +1722,7 @@ impl Blockstore {
                 .get(&(*location, shred_id))
                 .expect("Merkle root meta was just created, initial shred must exist");
 
-            // Backward check for SIMD-0340
-            if let Some((_prev_erasure_set, prev_erasure_meta)) = self
-                .previous_erasure_set(*erasure_set, &shred_insertion_tracker.erasure_metas)
-                .expect("Expect database operations to succeed")
-            {
-                let prev_shred_id = ShredId::new(
-                    slot,
-                    prev_erasure_meta
-                        .first_received_coding_shred_index()
-                        .expect("First received coding index must fit in u32"),
-                    ShredType::Code,
-                );
-                if !self.check_backwards_chained_merkle_root_consistency(
-                    shred,
-                    prev_shred_id,
-                    &shred_insertion_tracker.just_inserted_shreds,
-                ) {
-                    shred_insertion_tracker
-                        .duplicate_shreds
-                        .push(PossibleDuplicateShred::ChainedMerkleRootConflict(slot));
-                    continue;
-                }
-            }
-
-            // Encompassing forward check for SIMD-0340
+            // Forward check for SIMD-0340
             if let Some(next_erasure_set) = erasure_set.next_fec_set()
                 && !self.check_forward_chained_merkle_root_consistency(
                     shred,
@@ -1870,7 +1737,7 @@ impl Blockstore {
                 continue;
             }
 
-            // Encompassing backward check for SIMD-0340
+            // Backwards check for SIMD-0340
             if let Some(prev_shred_id) = self
                 .previous_fec_set_shred_id(erasure_set, &shred_insertion_tracker.merkle_root_metas)
                 && !self.check_backwards_chained_merkle_root_consistency(

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -5685,148 +5685,6 @@ fn test_get_slot_entries_dead_slot_race() {
 }
 
 #[test]
-fn test_previous_erasure_set() {
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-    let mut erasure_metas = BTreeMap::new();
-
-    let parent_slot = 0;
-    let prev_slot = 1;
-    let slot = 2;
-    let (data_shreds_0, coding_shreds_0) =
-        setup_erasure_shreds_with_index(slot, parent_slot, 10, 0);
-    let erasure_set_0 = ErasureSetId::new(slot, 0);
-    let erasure_meta_0 = ErasureMeta::from_coding_shred(coding_shreds_0.first().unwrap()).unwrap();
-
-    let prev_fec_set_index = data_shreds_0.len() as u32;
-    let (data_shreds_prev, coding_shreds_prev) =
-        setup_erasure_shreds_with_index(slot, parent_slot, 10, prev_fec_set_index);
-    let erasure_set_prev = ErasureSetId::new(slot, prev_fec_set_index);
-    let erasure_meta_prev =
-        ErasureMeta::from_coding_shred(coding_shreds_prev.first().unwrap()).unwrap();
-
-    let (_, coding_shreds_prev_slot) =
-        setup_erasure_shreds_with_index(prev_slot, parent_slot, 10, prev_fec_set_index);
-    let erasure_set_prev_slot = ErasureSetId::new(prev_slot, prev_fec_set_index);
-    let erasure_meta_prev_slot =
-        ErasureMeta::from_coding_shred(coding_shreds_prev_slot.first().unwrap()).unwrap();
-
-    let fec_set_index = data_shreds_prev.len() as u32 + prev_fec_set_index;
-    let erasure_set = ErasureSetId::new(slot, fec_set_index);
-
-    // Blockstore is empty
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap(),
-        None
-    );
-
-    // Erasure metas does not contain the previous fec set, but only the one before that
-    erasure_metas.insert(erasure_set_0, WorkingEntry::Dirty(erasure_meta_0));
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap(),
-        None
-    );
-
-    // Both Erasure metas and blockstore, contain only contain the previous previous fec set
-    erasure_metas.insert(erasure_set_0, WorkingEntry::Clean(erasure_meta_0));
-    blockstore
-        .put_erasure_meta(erasure_set_0, &erasure_meta_0)
-        .unwrap();
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap(),
-        None
-    );
-
-    // Erasure meta contains the previous FEC set, blockstore only contains the older
-    erasure_metas.insert(erasure_set_prev, WorkingEntry::Dirty(erasure_meta_prev));
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap()
-            .map(|(erasure_set, erasure_meta)| (erasure_set, erasure_meta.into_owned())),
-        Some((erasure_set_prev, erasure_meta_prev))
-    );
-
-    // Erasure meta only contains the older, blockstore has the previous fec set
-    erasure_metas.remove(&erasure_set_prev);
-    blockstore
-        .put_erasure_meta(erasure_set_prev, &erasure_meta_prev)
-        .unwrap();
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap()
-            .map(|(erasure_set, erasure_meta)| (erasure_set, erasure_meta.into_owned())),
-        Some((erasure_set_prev, erasure_meta_prev))
-    );
-
-    // Both contain the previous fec set
-    erasure_metas.insert(erasure_set_prev, WorkingEntry::Clean(erasure_meta_prev));
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap()
-            .map(|(erasure_set, erasure_meta)| (erasure_set, erasure_meta.into_owned())),
-        Some((erasure_set_prev, erasure_meta_prev))
-    );
-
-    // Works even if the previous fec set has index 0
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set_prev, &erasure_metas)
-            .unwrap()
-            .map(|(erasure_set, erasure_meta)| (erasure_set, erasure_meta.into_owned())),
-        Some((erasure_set_0, erasure_meta_0))
-    );
-    erasure_metas.remove(&erasure_set_0);
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set_prev, &erasure_metas)
-            .unwrap()
-            .map(|(erasure_set, erasure_meta)| (erasure_set, erasure_meta.into_owned())),
-        Some((erasure_set_0, erasure_meta_0))
-    );
-
-    // Does not cross slot boundary
-    let ledger_path = get_tmp_ledger_path_auto_delete!();
-    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-    erasure_metas.clear();
-    erasure_metas.insert(
-        erasure_set_prev_slot,
-        WorkingEntry::Dirty(erasure_meta_prev_slot),
-    );
-    assert_eq!(
-        erasure_meta_prev_slot.next_fec_set_index().unwrap(),
-        fec_set_index
-    );
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap(),
-        None,
-    );
-    erasure_metas.insert(
-        erasure_set_prev_slot,
-        WorkingEntry::Clean(erasure_meta_prev_slot),
-    );
-    blockstore
-        .put_erasure_meta(erasure_set_prev_slot, &erasure_meta_prev_slot)
-        .unwrap();
-    assert_eq!(
-        blockstore
-            .previous_erasure_set(erasure_set, &erasure_metas)
-            .unwrap(),
-        None,
-    );
-}
-
-#[test]
 fn test_chained_merkle_root_consistency_backwards() {
     // Insert a coding shred then consistent data and coding shreds from the next FEC set
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -6024,7 +5882,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_code() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(coding_shred.slot())
+        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(coding_shred.slot())
     );
 
     // Should not check again, even though this shred conflicts as well
@@ -6072,7 +5930,7 @@ fn test_chained_merkle_root_inconsistency_backwards_insert_data() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(data_shred.slot())
+        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(data_shred.slot())
     );
     // Should not check again, even though this shred conflicts as well
     assert!(
@@ -6117,16 +5975,10 @@ fn test_chained_merkle_root_inconsistency_forwards() {
     // Insert previous FEC set
     let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
 
-    assert_eq!(duplicate_shreds.len(), 2);
-    assert!(
-        duplicate_shreds.contains(&PossibleDuplicateShred::ChainedMerkleRootConflict(
-            coding_shred.slot(),
-        ))
-    );
-    assert!(
-        duplicate_shreds.contains(&PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(
-            coding_shred.slot(),
-        ))
+    assert_eq!(duplicate_shreds.len(), 1);
+    assert_eq!(
+        duplicate_shreds[0],
+        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(coding_shred.slot(),)
     );
 }
 
@@ -6231,18 +6083,14 @@ fn test_chained_merkle_root_inconsistency_both() {
     assert_eq!(duplicate_shreds.len(), 1);
     assert_eq!(
         duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(data_shred.slot())
+        PossibleDuplicateShred::FixedFECChainedMerkleRootConflict(data_shred.slot())
     );
 
     // Insert coding shred
     let duplicate_shreds = blockstore.insert_shred_return_duplicate(coding_shred.clone());
 
-    // Now the forwards check will be performed
-    assert_eq!(duplicate_shreds.len(), 1);
-    assert_eq!(
-        duplicate_shreds[0],
-        PossibleDuplicateShred::ChainedMerkleRootConflict(coding_shred.slot())
-    );
+    // Since we already have reported the duplicate, no additional are reported
+    assert!(duplicate_shreds.is_empty());
 }
 
 #[test]

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -773,11 +773,6 @@ impl ErasureMeta {
         u32::try_from(self.first_received_coding_index).ok()
     }
 
-    pub(crate) fn next_fec_set_index(&self) -> Option<u32> {
-        let num_data = u32::try_from(self.config.num_data).ok()?;
-        self.fec_set_index.checked_add(num_data)
-    }
-
     // Returns true if some data shreds are missing, but there are enough data
     // and coding shreds to recover the erasure batch.
     // TODO: In order to retransmit all shreds from the erasure batch, we need

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -95,7 +95,7 @@ fn first_err(results: &[Result<()>]) -> Result<()> {
 
 /// Result of checking a child slot's chained block ID against its parent.
 pub enum ChainedBlockIdCheck {
-    /// Feature not active; no validation performed.
+    /// Alpenglow is active; no validation performed.
     Inactive,
     /// Chained block ID matches (or parent has no block ID to compare).
     Pass,
@@ -2373,24 +2373,13 @@ fn supermajority_root_from_vote_accounts(
 }
 
 /// Validates the chained block ID for a child slot against its parent.
-///
-/// Returns:
-/// - `Inactive`: feature not active, or alpenglow is active, no validation performed
-/// - `Pass`: chained block ID matches parent's block ID (or parent has no
-///   block ID yet)
-/// - `Mismatch`: definitive mismatch between child's chained merkle root
-///   and parent's block ID
-/// - `Unavailable`: data shred 0 not received yet, cannot validate
 pub fn check_chained_block_id(
     blockstore: &Blockstore,
     bank: &Bank,
     migration_status: &MigrationStatus,
 ) -> ChainedBlockIdCheck {
     let slot = bank.slot();
-    let feature_snapshot = bank.feature_set.snapshot();
-    if !(feature_snapshot.validate_chained_block_id || feature_snapshot.validate_chained_block_id_2)
-        || migration_status.should_use_double_merkle_block_id(slot)
-    {
+    if migration_status.should_use_double_merkle_block_id(slot) {
         return ChainedBlockIdCheck::Inactive;
     }
 
@@ -5851,27 +5840,6 @@ pub mod tests {
         assert!(matches!(
             check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
             ChainedBlockIdCheck::Mismatch
-        ));
-
-        // Case 3a: With only the replacement feature active, replay should
-        // still run the existing inter-slot SIMD-0340 check.
-        insert_shreds_with_chained_merkle_root(14, 0, Hash::new_unique());
-        let mut child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 14);
-        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id::id());
-        child_bank.activate_feature(&agave_feature_set::validate_chained_block_id_2::id());
-        assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
-            ChainedBlockIdCheck::Mismatch
-        ));
-
-        // Case 3b: With both feature gates inactive, replay should not run the
-        // chained block ID check.
-        let mut child_bank = Bank::new_from_parent(parent_bank.clone(), SlotLeader::default(), 14);
-        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id::id());
-        child_bank.deactivate_feature(&agave_feature_set::validate_chained_block_id_2::id());
-        assert!(matches!(
-            check_chained_block_id(&blockstore, &child_bank, &MigrationStatus::default()),
-            ChainedBlockIdCheck::Inactive
         ));
 
         // Case 4: UpdateParent metadata does not bypass Tower validation.


### PR DESCRIPTION
#### Problem
The 2 feature flags have been activated on all clusters:
```
vcmrbYbiMVKaq1snKP6eCacNDcr6qZvpCNUjmk6gxvZ  | active since epoch 992  | 428544000       | SIMD-0340: Validate chained block ID
vcmrw431aNM8ngQ46derkZXipoTGQdbHkEygBDh12dA  | active since epoch 992  | 428544000       | SIMD-340: Encompassing check for validate chained block ID
```


#### Summary of Changes
Remove the feature gating. Additionally remove the logic associated with the first feature flag `vcmrbYbiMVKaq1snKP6eCacNDcr6qZvpCNUjmk6gxvZ` as it is not necessary in the presence of the encompassing check 