### PR TITLE
fs: skip unreadable dirs when probing direct-io support

### DIFF
--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -175,8 +175,16 @@ pub fn validate_account_paths_for_direct_io(
         let mut unsupported_paths = vec![];
         for path in paths.into_iter() {
             let path = path.as_ref();
-            if agave_fs::metadata::check_direct_io_capability(path)? == DirectIoSupport::Unsupported
-            {
+            let support = agave_fs::metadata::check_direct_io_capability(path).map_err(|err| {
+                io::Error::new(
+                    err.kind(),
+                    format!(
+                        "failed to validate direct-io support for account path `{}`: {err}",
+                        path.display()
+                    ),
+                )
+            })?;
+            if support == DirectIoSupport::Unsupported {
                 unsupported_paths.push(path.display().to_string());
             }
         }

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -134,37 +134,22 @@ fn check_direct_io_via_open_probe(file: &Path) -> DirectIoSupport {
 }
 
 /// Returns a path to any regular file at or under `path`, recursively traversing
-/// directories and returning as soon as one file is found. Returns `Ok(None)` if
-/// no file exists under `path`.
+/// directories and returning as soon as one is found. Directories beneath `path` that
+/// cannot be read are skipped. Returns `Ok(None)` if `path` is readable but holds no
+/// file, or an error if `path` itself cannot be read.
 #[cfg(target_os = "linux")]
 fn find_any_file_under_path(path: &Path) -> io::Result<Option<PathBuf>> {
     if path.is_file() {
         return Ok(Some(path.to_path_buf()));
     }
-    if path.is_dir() {
-        let entries = match fs::read_dir(path) {
-            Ok(entries) => entries,
-            // An unreadable directory has no probe file to open, and unreadable files are already
-            // tolerated by check_direct_io_via_open_probe; skip it instead of aborting startup.
-            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
-                log::warn!(
-                    "skipping unreadable directory while probing direct-io support: `{}`: {err}",
-                    path.display()
-                );
-                return Ok(None);
-            }
-            Err(err) => {
-                return Err(io::Error::new(
-                    err.kind(),
-                    format!("failed to read directory `{}`: {err}", path.display()),
-                ));
-            }
-        };
-        for entry in entries {
-            let entry = entry?;
-            if let Some(path) = find_any_file_under_path(&entry.path())? {
-                return Ok(Some(path));
-            }
+    if !path.is_dir() {
+        return Ok(None);
+    }
+    for entry in fs::read_dir(path)? {
+        // Only failing to read the path we were handed is fatal. A directory beneath it that
+        // we cannot read can't hold a probe file, so skip it instead of aborting startup.
+        if let Some(found) = find_any_file_under_path(&entry?.path()).ok().flatten() {
+            return Ok(Some(found));
         }
     }
     Ok(None)
@@ -210,15 +195,54 @@ mod tests {
             return;
         }
         let dir = TempDir::new().unwrap();
+        let file = make_temp_file(&dir, "snapshot.bin", b"data");
         let unreadable = dir.path().join("lost+found");
         std::fs::create_dir(&unreadable).unwrap();
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
 
+        // The readable file is found regardless of readdir order; the unreadable sibling is skipped.
         let found = find_any_file_under_path(dir.path());
 
         // Restore perms so TempDir cleanup can recurse, then assert.
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(found.unwrap(), Some(file));
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_readable_dir_only_unreadable_subdir() {
+        use std::os::unix::fs::PermissionsExt;
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let unreadable = dir.path().join("lost+found");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // The dir itself is readable but holds no file, so the caller falls back to the temp
+        // probe rather than aborting; the unreadable subdir doesn't turn this into an error.
+        let found = find_any_file_under_path(dir.path());
+
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
         assert_eq!(found.unwrap(), None);
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_errors_when_path_unreadable() {
+        use std::os::unix::fs::PermissionsExt;
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let parent = TempDir::new().unwrap();
+        let dir = parent.path().join("accounts");
+        std::fs::create_dir(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // Failing to read the path we were handed is fatal, so the caller can report it.
+        let result = find_any_file_under_path(&dir);
+
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -30,7 +30,7 @@ pub enum DirectIoSupport {
 #[cfg(target_os = "linux")]
 pub fn check_direct_io_capability(path: impl AsRef<Path>) -> io::Result<DirectIoSupport> {
     let path = path.as_ref();
-    if let Some(file) = find_any_file_under_path(path)? {
+    if let Some(file) = find_any_file_under_path(path) {
         check_direct_io_for_file(&file)
     } else {
         if !path.is_dir() {
@@ -134,25 +134,32 @@ fn check_direct_io_via_open_probe(file: &Path) -> DirectIoSupport {
 }
 
 /// Returns a path to any regular file at or under `path`, recursively traversing
-/// directories and returning as soon as one is found. Directories beneath `path` that
-/// cannot be read are skipped. Returns `Ok(None)` if `path` is readable but holds no
-/// file, or an error if `path` itself cannot be read.
+/// directories and returning as soon as one is found. A directory that cannot be read
+/// is logged and skipped. Returns `None` if no file is found under `path`.
 #[cfg(target_os = "linux")]
-fn find_any_file_under_path(path: &Path) -> io::Result<Option<PathBuf>> {
+fn find_any_file_under_path(path: &Path) -> Option<PathBuf> {
     if path.is_file() {
-        return Ok(Some(path.to_path_buf()));
+        return Some(path.to_path_buf());
     }
     if !path.is_dir() {
-        return Ok(None);
+        return None;
     }
-    for entry in fs::read_dir(path)? {
-        // Only failing to read the path we were handed is fatal. A directory beneath it that
-        // we cannot read can't hold a probe file, so skip it instead of aborting startup.
-        if let Some(found) = find_any_file_under_path(&entry?.path()).ok().flatten() {
-            return Ok(Some(found));
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(err) => {
+            log::warn!(
+                "skipping `{}` while probing direct-io support: {err}",
+                path.display()
+            );
+            return None;
+        }
+    };
+    for entry in entries.flatten() {
+        if let Some(found) = find_any_file_under_path(&entry.path()) {
+            return Some(found);
         }
     }
-    Ok(None)
+    None
 }
 
 #[cfg(all(test, target_os = "linux"))]
@@ -169,14 +176,14 @@ mod tests {
     fn test_find_any_file_under_path_file() {
         let dir = TempDir::new().unwrap();
         let file = make_temp_file(&dir, "f.bin", b"hello");
-        assert_eq!(find_any_file_under_path(&file).unwrap(), Some(file));
+        assert_eq!(find_any_file_under_path(&file), Some(file));
     }
 
     #[test]
     fn test_find_any_file_under_path_dir() {
         let dir = TempDir::new().unwrap();
         make_temp_file(&dir, "a.bin", b"data");
-        let candidate = find_any_file_under_path(dir.path()).unwrap();
+        let candidate = find_any_file_under_path(dir.path());
         assert!(candidate.is_some());
         assert!(candidate.unwrap().is_file());
     }
@@ -184,7 +191,7 @@ mod tests {
     #[test]
     fn test_find_any_file_under_path_empty_dir() {
         let dir = TempDir::new().unwrap();
-        assert_eq!(find_any_file_under_path(dir.path()).unwrap(), None);
+        assert_eq!(find_any_file_under_path(dir.path()), None);
     }
 
     #[test]
@@ -205,7 +212,7 @@ mod tests {
 
         // Restore perms so TempDir cleanup can recurse, then assert.
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(found.unwrap(), Some(file));
+        assert_eq!(found, Some(file));
     }
 
     #[test]
@@ -224,11 +231,11 @@ mod tests {
         let found = find_any_file_under_path(dir.path());
 
         std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(found.unwrap(), None);
+        assert_eq!(found, None);
     }
 
     #[test]
-    fn test_find_any_file_under_path_errors_when_path_unreadable() {
+    fn test_find_any_file_under_path_unreadable_path_returns_none() {
         use std::os::unix::fs::PermissionsExt;
         if unsafe { libc::geteuid() } == 0 {
             return;
@@ -238,11 +245,11 @@ mod tests {
         std::fs::create_dir(&dir).unwrap();
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
 
-        // Failing to read the path we were handed is fatal, so the caller can report it.
-        let result = find_any_file_under_path(&dir);
+        // An unreadable path is logged and skipped, so the caller falls back to the temp probe.
+        let found = find_any_file_under_path(&dir);
 
         std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(found, None);
     }
 
     #[test]

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -172,6 +172,31 @@ mod tests {
         path
     }
 
+    enum UnreadableDirTest<R> {
+        SkippedAsRoot,
+        Ran(R),
+    }
+
+    // Create an unreadable directory at `path`, run `f`, then restore permissions so the
+    // TempDir can clean up. read_dir on a mode-0000 dir only fails for non-root, so skip as root.
+    fn with_unreadable_dir<R>(
+        path: &std::path::Path,
+        f: impl FnOnce() -> R,
+    ) -> UnreadableDirTest<R> {
+        use std::os::unix::fs::PermissionsExt;
+
+        if unsafe { libc::geteuid() } == 0 {
+            return UnreadableDirTest::SkippedAsRoot;
+        }
+
+        std::fs::create_dir(path).unwrap();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = f();
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        UnreadableDirTest::Ran(result)
+    }
+
     #[test]
     fn test_find_any_file_under_path_file() {
         let dir = TempDir::new().unwrap();
@@ -196,60 +221,43 @@ mod tests {
 
     #[test]
     fn test_find_any_file_under_path_skips_unreadable_subdir() {
-        use std::os::unix::fs::PermissionsExt;
-        // read_dir on a mode-0000 dir only fails for non-root; root bypasses the permission bits.
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
         let dir = TempDir::new().unwrap();
         let file = make_temp_file(&dir, "snapshot.bin", b"data");
         let unreadable = dir.path().join("lost+found");
-        std::fs::create_dir(&unreadable).unwrap();
-        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         // The readable file is found regardless of readdir order; the unreadable sibling is skipped.
-        let found = find_any_file_under_path(dir.path());
-
-        // Restore perms so TempDir cleanup can recurse, then assert.
-        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(found, Some(file));
+        if let UnreadableDirTest::Ran(found) =
+            with_unreadable_dir(&unreadable, || find_any_file_under_path(dir.path()))
+        {
+            assert_eq!(found, Some(file));
+        }
     }
 
     #[test]
     fn test_find_any_file_under_path_readable_dir_only_unreadable_subdir() {
-        use std::os::unix::fs::PermissionsExt;
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
         let dir = TempDir::new().unwrap();
         let unreadable = dir.path().join("lost+found");
-        std::fs::create_dir(&unreadable).unwrap();
-        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         // The dir itself is readable but holds no file, so the caller falls back to the temp
         // probe rather than aborting; the unreadable subdir doesn't turn this into an error.
-        let found = find_any_file_under_path(dir.path());
-
-        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(found, None);
+        if let UnreadableDirTest::Ran(found) =
+            with_unreadable_dir(&unreadable, || find_any_file_under_path(dir.path()))
+        {
+            assert_eq!(found, None);
+        }
     }
 
     #[test]
     fn test_find_any_file_under_path_unreadable_path_returns_none() {
-        use std::os::unix::fs::PermissionsExt;
-        if unsafe { libc::geteuid() } == 0 {
-            return;
-        }
         let parent = TempDir::new().unwrap();
         let dir = parent.path().join("accounts");
-        std::fs::create_dir(&dir).unwrap();
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
 
         // An unreadable path is logged and skipped, so the caller falls back to the temp probe.
-        let found = find_any_file_under_path(&dir);
-
-        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
-        assert_eq!(found, None);
+        if let UnreadableDirTest::Ran(found) =
+            with_unreadable_dir(&dir, || find_any_file_under_path(&dir))
+        {
+            assert_eq!(found, None);
+        }
     }
 
     #[test]

--- a/fs/src/metadata.rs
+++ b/fs/src/metadata.rs
@@ -142,7 +142,25 @@ fn find_any_file_under_path(path: &Path) -> io::Result<Option<PathBuf>> {
         return Ok(Some(path.to_path_buf()));
     }
     if path.is_dir() {
-        for entry in fs::read_dir(path)? {
+        let entries = match fs::read_dir(path) {
+            Ok(entries) => entries,
+            // An unreadable directory has no probe file to open, and unreadable files are already
+            // tolerated by check_direct_io_via_open_probe; skip it instead of aborting startup.
+            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
+                log::warn!(
+                    "skipping unreadable directory while probing direct-io support: `{}`: {err}",
+                    path.display()
+                );
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(io::Error::new(
+                    err.kind(),
+                    format!("failed to read directory `{}`: {err}", path.display()),
+                ));
+            }
+        };
+        for entry in entries {
             let entry = entry?;
             if let Some(path) = find_any_file_under_path(&entry.path())? {
                 return Ok(Some(path));
@@ -182,6 +200,25 @@ mod tests {
     fn test_find_any_file_under_path_empty_dir() {
         let dir = TempDir::new().unwrap();
         assert_eq!(find_any_file_under_path(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn test_find_any_file_under_path_skips_unreadable_subdir() {
+        use std::os::unix::fs::PermissionsExt;
+        // read_dir on a mode-0000 dir only fails for non-root; root bypasses the permission bits.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let dir = TempDir::new().unwrap();
+        let unreadable = dir.path().join("lost+found");
+        std::fs::create_dir(&unreadable).unwrap();
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let found = find_any_file_under_path(dir.path());
+
+        // Restore perms so TempDir cleanup can recurse, then assert.
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(found.unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

A validator can abort at startup with a bare OS error and no clue which path caused it:

```
INFO  solana_core::validator] Validating and cleaning accounts paths...
ERROR agave_validator] Failed to start validator: Permission denied (os error 13)
```

The direct-io check from #10957 walks the account and snapshot paths for a file to probe with `O_DIRECT`. `find_any_file_under_path` recurses with a bare `?` on `read_dir`, so one unreadable subdirectory takes down startup. The usual cause is a path at a disk mount point: every ext4/xfs root has a `lost+found` owned by root with mode 0700, and the walk descends into it and gets `EACCES`.

This is easy to hit in production. `use_direct_io` is on by default, and the walk stops at the first file it finds, so whether a host reaches `lost+found` before a real file comes down to directory order. Two machines with the same config can behave differently, and an upgrade can turn a working setup into a crash loop. Reported by @McSim85 on a 4.1.0 mainnet validator.

#### Summary of Changes

- On `read_dir` returning `PermissionDenied`, skip that subdirectory and log a warning instead of aborting. An unreadable directory has no probe file we could open, and an unreadable file is already skipped in `check_direct_io_via_open_probe`, so directories now behave the same way.
- Other `read_dir` errors carry the directory that failed, and the validation carries the account path it was checking, so a real failure is no longer a bare os error.

The probe result stays the same. When no readable file is found under a path, the existing branch probes a temporary file instead, so a skipped subtree still lands on the same answer.

#### Testing

- New `test_find_any_file_under_path_skips_unreadable_subdir`: a readable file beside a mode-0000 `lost+found`, checking the search returns the file. It returns early under `geteuid() == 0`, where root ignores the mode bits.
- Reproduced the abort and confirmed the fix clears it.
- `cargo fmt`, `clippy`, and `check` clean on the touched crates.

Fixes #13661
