### PR TITLE
VotePacketReceiver: remove intermediate allocation

### DIFF
--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -2,7 +2,7 @@ use {
     super::{
         consumer::LeaderProcessedTransactionCounts,
         leader_slot_timing_metrics::{LeaderExecuteAndCommitTimings, LeaderSlotTimingMetrics},
-        vote_storage::VoteBatchInsertionMetrics,
+        vote_storage::VoteInsertionMetrics,
     },
     crate::banking_stage::vote_packet_receiver::PacketReceiverStats,
     solana_clock::Slot,
@@ -617,19 +617,17 @@ impl LeaderSlotMetricsTracker {
         }
     }
 
-    pub(crate) fn accumulate_vote_batch_insertion_metrics(
+    pub(crate) fn accumulate_vote_insertion_metrics(
         &mut self,
-        vote_batch_insertion_metrics: &VoteBatchInsertionMetrics,
+        vote_insertion_metrics: &VoteInsertionMetrics,
     ) {
         self.increment_exceeded_buffer_limit_dropped_packets_count(
-            vote_batch_insertion_metrics.total_dropped_packets() as u64,
+            vote_insertion_metrics.total_dropped_packets() as u64,
         );
         self.increment_dropped_gossip_vote_count(
-            vote_batch_insertion_metrics.dropped_gossip_packets() as u64,
+            vote_insertion_metrics.dropped_gossip_packets() as u64
         );
-        self.increment_dropped_tpu_vote_count(
-            vote_batch_insertion_metrics.dropped_tpu_packets() as u64
-        );
+        self.increment_dropped_tpu_vote_count(vote_insertion_metrics.dropped_tpu_packets() as u64);
     }
 
     pub(crate) fn accumulate_transaction_errors(

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -4,9 +4,10 @@ use {
         leader_slot_metrics::LeaderSlotMetricsTracker, vote_storage::VoteStorage,
     },
     crate::banking_stage::transaction_scheduler::transaction_state_container::SharedBytes,
-    agave_banking_stage_ingress_types::BankingPacketReceiver,
+    agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     agave_transaction_view::{
-        result::TransactionViewError, transaction_view::SanitizedTransactionView,
+        result::TransactionViewError, sanitize::SanitizeConfig,
+        transaction_view::SanitizedTransactionView,
     },
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
@@ -47,24 +48,22 @@ impl VotePacketReceiver {
         let (result, recv_time_us) = measure_us!({
             let recv_timeout = Self::get_receive_timeout(vote_storage);
             let mut recv_and_buffer_measure = Measure::start("recv_and_buffer");
-            self.receive_until(recv_timeout, vote_storage.max_receive_size())
-                // Consumes results if Ok, otherwise we keep the Err
-                .map(|(deserialized_packets, packet_stats)| {
-                    self.buffer_packets(
-                        deserialized_packets,
-                        packet_stats,
-                        vote_storage,
-                        vote_source,
-                        banking_stage_stats,
-                        slot_metrics_tracker,
-                    );
-                    recv_and_buffer_measure.stop();
+            self.receive_until_and_buffer(
+                recv_timeout,
+                vote_storage.max_receive_size(),
+                vote_storage,
+                vote_source,
+                banking_stage_stats,
+                slot_metrics_tracker,
+            )
+            .map(|()| {
+                recv_and_buffer_measure.stop();
 
-                    // Only incremented if packets are received
-                    banking_stage_stats
-                        .receive_and_buffer_packets_elapsed
-                        .fetch_add(recv_and_buffer_measure.as_us(), Ordering::Relaxed);
-                })
+                // Only incremented if packets are received
+                banking_stage_stats
+                    .receive_and_buffer_packets_elapsed
+                    .fetch_add(recv_and_buffer_measure.as_us(), Ordering::Relaxed);
+            })
         });
 
         slot_metrics_tracker.increment_receive_and_buffer_packets_us(recv_time_us);
@@ -72,90 +71,161 @@ impl VotePacketReceiver {
         result
     }
 
-    // Copied from packet_deserializer.rs.
-    fn receive_until(
+    fn receive_until_and_buffer(
         &self,
         recv_timeout: Duration,
         packet_count_upperbound: usize,
-    ) -> Result<
-        (
-            Vec<SanitizedTransactionView<SharedBytes>>,
-            PacketReceiverStats,
-        ),
-        RecvTimeoutError,
-    > {
+        vote_storage: &mut VoteStorage,
+        vote_source: VoteSource,
+        banking_stage_stats: &mut BankingStageStats,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
+    ) -> Result<(), RecvTimeoutError> {
         let start = Instant::now();
+        let sanitize_config = sanitize_config(true);
+        let mut stats = ReceiveAndBufferStats::default();
 
         let packet_batches = self.banking_packet_receiver.recv_timeout(recv_timeout)?;
-        let mut num_packets_received = packet_batches
-            .iter()
-            .map(|batch| batch.len())
-            .sum::<usize>();
-        let mut messages = vec![packet_batches];
+        self.buffer_packet_batches(
+            &packet_batches,
+            &sanitize_config,
+            vote_storage,
+            vote_source,
+            slot_metrics_tracker,
+            &mut stats,
+        );
 
         while let Ok(packet_batches) = self.banking_packet_receiver.try_recv() {
-            num_packets_received += packet_batches
-                .iter()
-                .map(|batch| batch.len())
-                .sum::<usize>();
-            messages.push(packet_batches);
+            self.buffer_packet_batches(
+                &packet_batches,
+                &sanitize_config,
+                vote_storage,
+                vote_source,
+                slot_metrics_tracker,
+                &mut stats,
+            );
 
-            if start.elapsed() >= recv_timeout || num_packets_received >= packet_count_upperbound {
+            if start.elapsed() >= recv_timeout
+                || stats.num_packets_received >= packet_count_upperbound
+            {
                 break;
             }
         }
 
-        // Parse & collect transaction views.
-        let mut packet_stats = PacketReceiverStats::default();
-        let mut errors = Saturating::<usize>(0);
-        let parsed_packets: Vec<_> = messages
+        self.update_receive_stats(
+            stats,
+            vote_storage,
+            vote_source,
+            banking_stage_stats,
+            slot_metrics_tracker,
+        );
+
+        Ok(())
+    }
+
+    fn buffer_packet_batches(
+        &self,
+        packet_batches: &BankingPacketBatch,
+        sanitize_config: &SanitizeConfig,
+        vote_storage: &mut VoteStorage,
+        vote_source: VoteSource,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
+        stats: &mut ReceiveAndBufferStats,
+    ) {
+        stats.num_packets_received += packet_batches
             .iter()
-            .flat_map(|batches| batches.iter())
-            .flat_map(|batch| batch.iter())
-            .filter_map(|pkt| {
+            .map(|batch| batch.len())
+            .sum::<usize>();
+
+        for packet_batch in packet_batches.iter() {
+            for packet in packet_batch.iter() {
+                let Some(packet_data) = packet.data(..) else {
+                    continue;
+                };
+
                 match SanitizedTransactionView::try_new_sanitized(
-                    Arc::new(pkt.data(..)?.to_vec()),
-                    // Vote instructions are created in the validator code, and they are not
-                    // referencing more than 255 accounts, so it is safe to enforce the
-                    // instruction accounts limit unconditionally.
-                    &sanitize_config(true),
+                    Arc::new(packet_data.to_vec()),
+                    sanitize_config,
                 ) {
-                    Ok(pkt) => {
-                        if self.should_filter_packet(&pkt) {
-                            packet_stats.filtered_account_key_count += 1;
-                            None
-                        } else {
-                            Some(pkt)
+                    Ok(packet) => {
+                        if self.should_filter_packet(&packet) {
+                            stats.packet_stats.filtered_account_key_count += 1;
+                            continue;
                         }
+
+                        stats.num_buffered_packets += 1;
+                        let vote_batch_insertion_metrics =
+                            vote_storage.insert_batch(vote_source, std::iter::once(packet));
+                        slot_metrics_tracker
+                            .accumulate_vote_batch_insertion_metrics(&vote_batch_insertion_metrics);
+                        stats.dropped_packets_count +=
+                            vote_batch_insertion_metrics.total_dropped_packets();
                     }
                     Err(err) => {
-                        errors += 1;
+                        stats.errors += 1;
                         match err {
                             TransactionViewError::AddressLookupMismatch => {}
                             TransactionViewError::ParseError
                             | TransactionViewError::SanitizeError => {
-                                packet_stats.failed_sanitization_count += 1
+                                stats.packet_stats.failed_sanitization_count += 1
                             }
                         }
-
-                        None
                     }
                 }
-            })
-            .collect();
-        let Saturating(errors) = errors;
-        let filtered_account_key_count = packet_stats.filtered_account_key_count.0 as usize;
+            }
+        }
+    }
+
+    fn update_receive_stats(
+        &self,
+        mut stats: ReceiveAndBufferStats,
+        vote_storage: &VoteStorage,
+        vote_source: VoteSource,
+        banking_stage_stats: &mut BankingStageStats,
+        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
+    ) {
+        let filtered_account_key_count = stats.packet_stats.filtered_account_key_count.0 as usize;
+        let Saturating(errors) = stats.errors;
         let passed_sigverify_count = errors
-            .saturating_add(parsed_packets.len())
+            .saturating_add(stats.num_buffered_packets)
             .saturating_add(filtered_account_key_count);
-        packet_stats.passed_sigverify_count += passed_sigverify_count as u64;
-        let failed_sigverify_count = num_packets_received
-            .saturating_sub(parsed_packets.len())
+        stats.packet_stats.passed_sigverify_count += passed_sigverify_count as u64;
+        let failed_sigverify_count = stats
+            .num_packets_received
+            .saturating_sub(stats.num_buffered_packets)
             .saturating_sub(errors)
             .saturating_sub(filtered_account_key_count);
-        packet_stats.failed_sigverify_count += failed_sigverify_count as u64;
+        stats.packet_stats.failed_sigverify_count += failed_sigverify_count as u64;
 
-        Ok((parsed_packets, packet_stats))
+        let vote_source_counts = match vote_source {
+            VoteSource::Gossip => &banking_stage_stats.gossip_counts,
+            VoteSource::Tpu => &banking_stage_stats.tpu_counts,
+        };
+
+        vote_source_counts
+            .receive_and_buffer_packets_count
+            .fetch_add(stats.num_buffered_packets, Ordering::Relaxed);
+        {
+            let Saturating(dropped_packets_count) = stats.dropped_packets_count;
+            vote_source_counts.dropped_packets_count.fetch_add(
+                dropped_packets_count.saturating_add(filtered_account_key_count),
+                Ordering::Relaxed,
+            );
+        }
+        vote_source_counts
+            .newly_buffered_packets_count
+            .fetch_add(stats.num_buffered_packets, Ordering::Relaxed);
+        banking_stage_stats
+            .current_buffered_packets_count
+            .swap(vote_storage.len(), Ordering::Relaxed);
+
+        if stats.num_buffered_packets != 0 {
+            let _ = banking_stage_stats
+                .batch_packet_indexes_len
+                .increment(stats.num_buffered_packets as u64);
+            slot_metrics_tracker
+                .increment_newly_buffered_packets_count(stats.num_buffered_packets as u64);
+        }
+        slot_metrics_tracker.increment_received_packet_counts(stats.packet_stats);
     }
 
     fn should_filter_packet(&self, packet: &SanitizedTransactionView<SharedBytes>) -> bool {
@@ -179,81 +249,15 @@ impl VotePacketReceiver {
             Duration::from_millis(100)
         }
     }
+}
 
-    fn buffer_packets(
-        &self,
-        deserialized_packets: Vec<SanitizedTransactionView<SharedBytes>>,
-        packet_stats: PacketReceiverStats,
-        vote_storage: &mut VoteStorage,
-        vote_source: VoteSource,
-        banking_stage_stats: &mut BankingStageStats,
-        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
-    ) {
-        let packet_count = deserialized_packets.len();
-
-        let filtered_account_key_count = packet_stats.filtered_account_key_count.0 as usize;
-        slot_metrics_tracker.increment_received_packet_counts(packet_stats);
-
-        let mut dropped_packets_count = Saturating(0);
-        let mut newly_buffered_packets_count = 0;
-        Self::push_unprocessed(
-            vote_storage,
-            vote_source,
-            deserialized_packets,
-            &mut dropped_packets_count,
-            &mut newly_buffered_packets_count,
-            banking_stage_stats,
-            slot_metrics_tracker,
-        );
-
-        let vote_source_counts = match vote_source {
-            VoteSource::Gossip => &banking_stage_stats.gossip_counts,
-            VoteSource::Tpu => &banking_stage_stats.tpu_counts,
-        };
-
-        vote_source_counts
-            .receive_and_buffer_packets_count
-            .fetch_add(packet_count, Ordering::Relaxed);
-        {
-            let Saturating(dropped_packets_count) = dropped_packets_count;
-            vote_source_counts.dropped_packets_count.fetch_add(
-                dropped_packets_count.saturating_add(filtered_account_key_count),
-                Ordering::Relaxed,
-            );
-        }
-        vote_source_counts
-            .newly_buffered_packets_count
-            .fetch_add(newly_buffered_packets_count, Ordering::Relaxed);
-        banking_stage_stats
-            .current_buffered_packets_count
-            .swap(vote_storage.len(), Ordering::Relaxed);
-    }
-
-    fn push_unprocessed(
-        vote_storage: &mut VoteStorage,
-        vote_source: VoteSource,
-        deserialized_packets: Vec<SanitizedTransactionView<SharedBytes>>,
-        dropped_packets_count: &mut Saturating<usize>,
-        newly_buffered_packets_count: &mut usize,
-        banking_stage_stats: &mut BankingStageStats,
-        slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
-    ) {
-        if !deserialized_packets.is_empty() {
-            let _ = banking_stage_stats
-                .batch_packet_indexes_len
-                .increment(deserialized_packets.len() as u64);
-
-            *newly_buffered_packets_count += deserialized_packets.len();
-            slot_metrics_tracker
-                .increment_newly_buffered_packets_count(deserialized_packets.len() as u64);
-
-            let vote_batch_insertion_metrics =
-                vote_storage.insert_batch(vote_source, deserialized_packets.into_iter());
-            slot_metrics_tracker
-                .accumulate_vote_batch_insertion_metrics(&vote_batch_insertion_metrics);
-            *dropped_packets_count += vote_batch_insertion_metrics.total_dropped_packets();
-        }
-    }
+#[derive(Default)]
+struct ReceiveAndBufferStats {
+    packet_stats: PacketReceiverStats,
+    num_packets_received: usize,
+    num_buffered_packets: usize,
+    dropped_packets_count: Saturating<usize>,
+    errors: Saturating<usize>,
 }
 
 #[derive(Default, Debug, PartialEq)]

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -246,7 +246,7 @@ impl VotePacketReceiver {
             Duration::from_millis(0)
         } else {
             // Default wait time
-            Duration::from_millis(100)
+            Duration::from_millis(10)
         }
     }
 }

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -153,12 +153,12 @@ impl VotePacketReceiver {
                         }
 
                         stats.num_buffered_packets += 1;
-                        let vote_batch_insertion_metrics =
-                            vote_storage.insert_batch(vote_source, std::iter::once(packet));
+                        let vote_insertion_metrics =
+                            vote_storage.insert_packet(vote_source, packet);
                         slot_metrics_tracker
-                            .accumulate_vote_batch_insertion_metrics(&vote_batch_insertion_metrics);
+                            .accumulate_vote_insertion_metrics(&vote_insertion_metrics);
                         stats.dropped_packets_count +=
-                            vote_batch_insertion_metrics.total_dropped_packets();
+                            vote_insertion_metrics.total_dropped_packets();
                     }
                     Err(err) => {
                         stats.errors += 1;

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -20,12 +20,12 @@ use {
 const MAX_NUM_VOTES_RECEIVE: usize = 1_000;
 
 #[derive(Default, Debug)]
-pub(crate) struct VoteBatchInsertionMetrics {
+pub(crate) struct VoteInsertionMetrics {
     pub(crate) num_dropped_gossip: usize,
     pub(crate) num_dropped_tpu: usize,
 }
 
-impl VoteBatchInsertionMetrics {
+impl VoteInsertionMetrics {
     pub fn total_dropped_packets(&self) -> usize {
         self.num_dropped_gossip + self.num_dropped_tpu
     }
@@ -105,23 +105,18 @@ impl VoteStorage {
         MAX_NUM_VOTES_RECEIVE
     }
 
-    pub(crate) fn insert_batch(
+    pub(crate) fn insert_packet(
         &mut self,
         vote_source: VoteSource,
-        votes: impl Iterator<Item = SanitizedTransactionView<SharedBytes>>,
-    ) -> VoteBatchInsertionMetrics {
-        let should_deprecate_legacy_vote_ixs = self.deprecate_legacy_vote_ixs;
-        self.insert_batch_with_replenish(
-            votes.filter_map(|vote| {
-                LatestValidatorVote::new_from_view(
-                    vote,
-                    vote_source,
-                    should_deprecate_legacy_vote_ixs,
-                )
-                .ok()
-            }),
-            false,
-        )
+        packet: SanitizedTransactionView<SharedBytes>,
+    ) -> VoteInsertionMetrics {
+        let Ok(vote) =
+            LatestValidatorVote::new_from_view(packet, vote_source, self.deprecate_legacy_vote_ixs)
+        else {
+            return VoteInsertionMetrics::default();
+        };
+
+        self.insert_vote(vote, false)
     }
 
     // Re-insert re-tryable packets.
@@ -130,17 +125,16 @@ impl VoteStorage {
         packets: impl Iterator<Item = SanitizedTransactionView<SharedBytes>>,
     ) {
         let should_deprecate_legacy_vote_ixs = self.deprecate_legacy_vote_ixs;
-        self.insert_batch_with_replenish(
-            packets.filter_map(|packet| {
-                LatestValidatorVote::new_from_view(
-                    packet,
-                    VoteSource::Tpu, // incorrect, but this bug has been here w/o issue for a long time.
-                    should_deprecate_legacy_vote_ixs,
-                )
-                .ok()
-            }),
-            true,
-        );
+        for vote in packets.filter_map(|packet| {
+            LatestValidatorVote::new_from_view(
+                packet,
+                VoteSource::Tpu, // incorrect, but this bug has been here w/o issue for a long time.
+                should_deprecate_legacy_vote_ixs,
+            )
+            .ok()
+        }) {
+            self.insert_vote(vote, true);
+        }
     }
 
     pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<SanitizedTransactionView<SharedBytes>> {
@@ -235,42 +229,40 @@ impl VoteStorage {
         );
     }
 
-    fn insert_batch_with_replenish(
+    fn insert_vote(
         &mut self,
-        votes: impl Iterator<Item = LatestValidatorVote>,
+        vote: LatestValidatorVote,
         should_replenish_taken_votes: bool,
-    ) -> VoteBatchInsertionMetrics {
-        let mut num_dropped_gossip = 0;
-        let mut num_dropped_tpu = 0;
-
-        for vote in votes {
-            if self
-                .cached_epoch_stakes
-                .vote_account_stake(&vote.vote_pubkey())
-                == 0
-            {
-                continue;
-            }
-
-            if self
-                .cached_epoch_authorized_voters
-                .get(&vote.vote_pubkey())
-                .is_none_or(|authorized| authorized != &vote.authorized_voter_pubkey())
-            {
-                continue;
-            }
-
-            if let Some(vote) = self.update_latest_vote(vote, should_replenish_taken_votes) {
-                match vote.source() {
-                    VoteSource::Gossip => num_dropped_gossip += 1,
-                    VoteSource::Tpu => num_dropped_tpu += 1,
-                }
-            }
+    ) -> VoteInsertionMetrics {
+        if self
+            .cached_epoch_stakes
+            .vote_account_stake(&vote.vote_pubkey())
+            == 0
+        {
+            return VoteInsertionMetrics::default();
         }
 
-        VoteBatchInsertionMetrics {
-            num_dropped_gossip,
-            num_dropped_tpu,
+        if self
+            .cached_epoch_authorized_voters
+            .get(&vote.vote_pubkey())
+            .is_none_or(|authorized| authorized != &vote.authorized_voter_pubkey())
+        {
+            return VoteInsertionMetrics::default();
+        }
+
+        if let Some(vote) = self.update_latest_vote(vote, should_replenish_taken_votes) {
+            match vote.source() {
+                VoteSource::Gossip => VoteInsertionMetrics {
+                    num_dropped_gossip: 1,
+                    num_dropped_tpu: 0,
+                },
+                VoteSource::Tpu => VoteInsertionMetrics {
+                    num_dropped_gossip: 0,
+                    num_dropped_tpu: 1,
+                },
+            }
+        } else {
+            VoteInsertionMetrics::default()
         }
     }
 
@@ -527,6 +519,16 @@ pub(crate) mod tests {
         .unwrap()
     }
 
+    fn insert_packets(
+        vote_storage: &mut VoteStorage,
+        vote_source: VoteSource,
+        packets: impl IntoIterator<Item = SanitizedTransactionView<SharedBytes>>,
+    ) {
+        for packet in packets {
+            vote_storage.insert_packet(vote_source, packet);
+        }
+    }
+
     #[test]
     fn test_reinsert_packets() {
         let keypair = ValidatorVoteKeypairs::new_rand();
@@ -537,7 +539,7 @@ pub(crate) mod tests {
 
         let vote = packet_from_slots(vec![(0, 1)], &keypair, None);
         let mut vote_storage = VoteStorage::new(&bank);
-        vote_storage.insert_batch(VoteSource::Tpu, std::iter::once(to_sanitized_view(vote)));
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(vote));
         assert_eq!(1, vote_storage.len());
 
         // Drain all packets, then re-insert.
@@ -795,7 +797,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_insert_batch_authorized_voter() {
+    fn test_insert_packet_authorized_voter() {
         // Test that votes are only accepted when signed by the correct authorized voter.
         let keypair = ValidatorVoteKeypairs::new_rand();
         let unauthorized_keypair = solana_keypair::Keypair::new();
@@ -813,10 +815,7 @@ pub(crate) mod tests {
             &keypair.vote_keypair,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(correct_vote)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(correct_vote));
         assert_eq!(1, vote_storage.len());
         assert_eq!(
             Some(0),
@@ -830,10 +829,7 @@ pub(crate) mod tests {
             &unauthorized_keypair,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(unauthorized_vote)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(unauthorized_vote));
         // Should still be 1 (unauthorized vote was filtered)
         assert_eq!(1, vote_storage.len());
         // Slot should still be 0 (the authorized vote), not 1 (the unauthorized one)
@@ -849,10 +845,7 @@ pub(crate) mod tests {
             &keypair.vote_keypair,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(correct_vote_2)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(correct_vote_2));
         assert_eq!(1, vote_storage.len());
         assert_eq!(
             Some(2),
@@ -920,10 +913,7 @@ pub(crate) mod tests {
             &epoch1_authorized_voter_keypair,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(epoch1_vote)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(epoch1_vote));
         assert_eq!(
             1,
             vote_storage.len(),
@@ -938,10 +928,7 @@ pub(crate) mod tests {
             &epoch2_authorized_voter_keypair, // This won't match epoch 1's authorized voter
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(wrong_epoch_vote)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(wrong_epoch_vote));
         // Should still be 1 - the vote with wrong authorized voter was rejected
         assert_eq!(
             1,
@@ -951,7 +938,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_insert_batch_unstaked() {
+    fn test_insert_packet_unstaked() {
         let keypair_a = ValidatorVoteKeypairs::new_rand();
         let keypair_b = ValidatorVoteKeypairs::new_rand();
         let keypair_c = ValidatorVoteKeypairs::new_rand();
@@ -975,8 +962,8 @@ pub(crate) mod tests {
         let bank_0 = Bank::new_for_tests(&GenesisConfig::default());
         let mut vote_storage = VoteStorage::new(&bank_0);
 
-        // Insert batch should filter out all votes as they are unstaked
-        vote_storage.insert_batch(VoteSource::Tpu, votes().into_iter());
+        // Insert should filter out all votes as they are unstaked
+        insert_packets(&mut vote_storage, VoteSource::Tpu, votes());
         assert!(vote_storage.is_empty());
 
         // Bank in same epoch should not update stakes
@@ -991,7 +978,7 @@ pub(crate) mod tests {
         );
         assert_eq!(bank.epoch(), 0);
         vote_storage.cache_epoch_boundary_info(&bank);
-        vote_storage.insert_batch(VoteSource::Tpu, votes().into_iter());
+        insert_packets(&mut vote_storage, VoteSource::Tpu, votes());
         assert!(vote_storage.is_empty());
 
         // Bank in next epoch should update stakes
@@ -1002,7 +989,7 @@ pub(crate) mod tests {
         let bank = Bank::new_from_parent(bank_0, SlotLeader::new_unique(), MINIMUM_SLOTS_PER_EPOCH);
         assert_eq!(bank.epoch(), 1);
         vote_storage.cache_epoch_boundary_info(&bank);
-        vote_storage.insert_batch(VoteSource::Gossip, votes().into_iter());
+        insert_packets(&mut vote_storage, VoteSource::Gossip, votes());
         assert_eq!(vote_storage.len(), 1);
         assert_eq!(
             vote_storage.get_latest_vote_slot(keypair_b.vote_keypair.pubkey()),
@@ -1025,7 +1012,7 @@ pub(crate) mod tests {
         assert_eq!(bank.epoch(), 2);
         vote_storage.cache_epoch_boundary_info(&bank);
         assert_eq!(vote_storage.len(), 0);
-        vote_storage.insert_batch(VoteSource::Tpu, votes().into_iter());
+        insert_packets(&mut vote_storage, VoteSource::Tpu, votes());
         assert_eq!(vote_storage.len(), 1);
         assert_eq!(
             vote_storage.get_latest_vote_slot(keypair_c.vote_keypair.pubkey()),
@@ -1090,9 +1077,10 @@ pub(crate) mod tests {
             &keypair_b.vote_keypair,
             None,
         );
-        vote_storage.insert_batch(
+        insert_packets(
+            &mut vote_storage,
             VoteSource::Tpu,
-            vec![to_sanitized_view(vote_a), to_sanitized_view(vote_b)].into_iter(),
+            vec![to_sanitized_view(vote_a), to_sanitized_view(vote_b)],
         );
 
         assert_eq!(2, vote_storage.len());
@@ -1102,7 +1090,7 @@ pub(crate) mod tests {
         // Move to the next epoch where A has rotated its authorized voter but remains staked
         // B remains unchanged.
         //
-        // Use warp_from_parent for the same reason as test_insert_batch_unstaked:
+        // Use warp_from_parent for the same reason as test_insert_packet_unstaked:
         // it populates epoch_stakes(bank.epoch()) with the key cache_epoch_boundary_info expects
         let (bank_0, _bank_forks) =
             Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
@@ -1148,10 +1136,7 @@ pub(crate) mod tests {
             &keypair_a.vote_keypair,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(stale_vote_a)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(stale_vote_a));
         assert_eq!(1, vote_storage.len());
         assert_eq!(None, vote_storage.get_latest_vote_slot(vote_pubkey_a));
 
@@ -1162,10 +1147,7 @@ pub(crate) mod tests {
             &new_authorized_voter_a,
             None,
         );
-        vote_storage.insert_batch(
-            VoteSource::Tpu,
-            std::iter::once(to_sanitized_view(fresh_vote_a)),
-        );
+        vote_storage.insert_packet(VoteSource::Tpu, to_sanitized_view(fresh_vote_a));
         assert_eq!(2, vote_storage.len());
         assert_eq!(Some(4), vote_storage.get_latest_vote_slot(vote_pubkey_a));
     }

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -17,7 +17,7 @@ use {
 };
 
 /// Maximum number of votes a single receive call will accept
-const MAX_NUM_VOTES_RECEIVE: usize = 10_000;
+const MAX_NUM_VOTES_RECEIVE: usize = 1_000;
 
 #[derive(Default, Debug)]
 pub(crate) struct VoteBatchInsertionMetrics {


### PR DESCRIPTION
#### Problem
- We allocate a vec to collect packet batches...then iterate over packets in those batches
- We can just iterate the packets as we recv and not collect anything

#### Summary of Changes
- Parse and insert votes in the recieve loop
- Change recv params to match scheduler more closely

#### Testing

Fixes #
