### PR TITLE
votor: adjust timer manager to account for out of order timeouts

### DIFF
--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -49,7 +49,7 @@ impl TimerManager {
                         }
                         Some(next_fire) => next_fire.duration_since(Instant::now()),
                     };
-                    thread::sleep(duration);
+                    thread::park_timeout(duration);
                 }
             })
         };
@@ -64,16 +64,21 @@ impl TimerManager {
         delta_first_fec_set: Duration,
         delta_block: Duration,
     ) -> bool {
-        self.timers.write().set_timeouts(
+        let timeout_inserted = self.timers.write().set_timeouts(
             slot,
             Instant::now(),
             standstill_slot,
             delta_first_fec_set,
             delta_block,
-        )
+        );
+        if timeout_inserted {
+            self.handle.thread().unpark();
+        }
+        timeout_inserted
     }
 
     pub(crate) fn join(self) {
+        self.handle.thread().unpark();
         self.handle.join().unwrap();
     }
 
@@ -86,8 +91,11 @@ impl TimerManager {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::event::VotorEvent, crossbeam_channel::bounded,
-        solana_clock::DEFAULT_MS_PER_SLOT, std::time::Duration,
+        super::*,
+        crate::event::VotorEvent,
+        crossbeam_channel::bounded,
+        solana_clock::DEFAULT_MS_PER_SLOT,
+        std::{assert_matches, time::Duration},
     };
 
     #[test]
@@ -135,6 +143,38 @@ mod tests {
             timeouts_received == 2,
             "Did not receive all expected timeouts"
         );
+        exit.store(true, Ordering::Relaxed);
+        timer_manager.join();
+    }
+
+    #[test]
+    fn test_new_earlier_timer_wakes_sleeping_worker() {
+        let (event_sender, event_receiver) = bounded(1024);
+        let exit = Arc::new(AtomicBool::new(false));
+        let timer_manager = TimerManager::new(
+            event_sender,
+            exit.clone(),
+            Arc::new(MigrationStatus::post_migration_status()),
+        );
+
+        let old_slot = 52;
+        let old_delta = Duration::from_secs(5);
+        assert!(timer_manager.set_timeouts(old_slot, None, old_delta, old_delta));
+        std::thread::sleep(Duration::from_millis(500));
+
+        let new_slot = 1_000;
+        assert!(timer_manager.set_timeouts(
+            new_slot,
+            None,
+            Duration::ZERO,
+            Duration::from_millis(1),
+        ));
+
+        let event = event_receiver
+            .recv_timeout(DELTA_TIMEOUT + Duration::from_millis(500))
+            .expect("new earlier timer should wake the sleeping timer worker");
+        assert_matches!(event, VotorEvent::TimeoutCrashedLeader(slot) if slot == new_slot);
+
         exit.store(true, Ordering::Relaxed);
         timer_manager.join();
     }


### PR DESCRIPTION
#### Problem
We assume that timer events come in order - e.g. later slots' timeouts should never fire before earlier ones.
This is almost always the case except after a long Standstill period where timeouts have been increased.

e.g. a long period of standstill could lead timeouts to be extended to 1 hour. Then we finalize a slot and timeouts are back to normal. The timeout event inserted after this new finalization will be stuck behind the 1 hour sleep.

#### Summary of Changes
Rather than sleeping the thread, park it so that it can be woken up and checked when new timeouts are added