### PR TITLE
fix: refresh delegated stakes in block test banks

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6825,6 +6825,10 @@ impl Bank {
         );
 
         bank.apply_activated_features();
+        bank.stakes_cache.refresh_delegated_stakes(
+            bank.new_warmup_cooldown_rate_epoch(),
+            bank.use_fixed_point_stake_math(),
+        );
 
         // If booting mid-distribution, recalculate reward partitions from the
         // EpochRewards sysvar (mirrors initialize_after_snapshot_restore).


### PR DESCRIPTION
#### Problem
`new_for_block_tests` applies activated features after constructing the bank, which can leave delegated stake caches stale for tests that depend on updated stake math.

#### Summary of Changes
Refresh delegated stakes in `new_for_block_tests` after feature activation so test banks reflect the active warmup/cooldown and fixed-point stake math settings.

#### Testing
Not run; change is scoped to test bank initialization.
