### PR TITLE
runtime: shorten blockhash queue lock hold

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -17,7 +17,7 @@ use {
             Bank, LoadAndExecuteTransactionsOutput, ProcessedTransactionCounts,
             entry_bytes_budget::EntryBytesReserveError,
         },
-        transaction_batch::TransactionBatch,
+        transaction_batch::{TARGET_NUM_TRANSACTIONS_PER_BATCH, TransactionBatch},
     },
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_svm::{
@@ -32,9 +32,6 @@ use {
     solana_vote::vote_parser,
     std::num::Saturating,
 };
-
-/// Consumer will create chunks of transactions from buffer with up to this size.
-pub const TARGET_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
 
 pub(crate) const ENTRY_OVERHEAD_BYTES: u64 = 48;
 

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -10,7 +10,7 @@ use {
         transaction_state_container::StateContainer,
     },
     crate::banking_stage::{
-        consumer::{ENTRY_OVERHEAD_BYTES, TARGET_NUM_TRANSACTIONS_PER_BATCH},
+        consumer::ENTRY_OVERHEAD_BYTES,
         scheduler_messages::{ConsumeWork, FinishedConsumeWork},
     },
     agave_scheduling_utils::thread_aware_account_locks::{
@@ -19,6 +19,7 @@ use {
     crossbeam_channel::{Receiver, Sender},
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_ledger::shred::get_data_shred_bytes_per_batch_typical,
+    solana_runtime::transaction_batch::TARGET_NUM_TRANSACTIONS_PER_BATCH,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::num::Saturating,
 };

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -534,7 +534,7 @@ mod tests {
         super::*,
         crate::banking_stage::{
             TransactionViewReceiveAndBuffer,
-            consumer::{RetryableIndex, TARGET_NUM_TRANSACTIONS_PER_BATCH},
+            consumer::RetryableIndex,
             scheduler_messages::{ConsumeWork, FinishedConsumeWork, TransactionBatchId},
             tests::create_slow_genesis_config,
             transaction_scheduler::greedy_scheduler::{GreedyScheduler, GreedySchedulerConfig},
@@ -554,7 +554,9 @@ mod tests {
         solana_nonce::{self as nonce, state::DurableNonce},
         solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
         solana_pubkey::Pubkey,
-        solana_runtime::{bank::Bank, bank_forks::BankForks},
+        solana_runtime::{
+            bank::Bank, bank_forks::BankForks, transaction_batch::TARGET_NUM_TRANSACTIONS_PER_BATCH,
+        },
         solana_runtime_transaction::transaction_meta::TransactionMeta,
         solana_sdk_ids::system_program,
         solana_signer::Signer,

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -87,10 +87,13 @@ impl Bank {
             return Err(TransactionError::UnsupportedVersion);
         }
 
-        let hash_queue = self.blockhash_queue.read().unwrap();
-        let next_durable_nonce = hash_queue.next_durable_nonce();
-        let age_is_ok = hash_queue.is_hash_valid_for_age(tx.recent_blockhash(), max_age);
-        drop(hash_queue);
+        let (next_durable_nonce, age_is_ok) = {
+            let hash_queue = self.blockhash_queue.read().unwrap();
+            (
+                hash_queue.next_durable_nonce(),
+                hash_queue.is_hash_valid_for_age(tx.recent_blockhash(), max_age),
+            )
+        };
 
         self.check_transaction_age(
             tx,
@@ -157,14 +160,16 @@ impl Bank {
         strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Vec<TransactionCheckResult> {
-        let hash_queue = self.blockhash_queue.read().unwrap();
-        let next_durable_nonce = hash_queue.next_durable_nonce();
-        // Snapshot age checks so fee derivation and nonce loads below run unlocked.
-        let ages_ok: SmallVec<[bool; TARGET_NUM_TRANSACTIONS_PER_BATCH]> = sanitized_txs
-            .iter()
-            .map(|tx| hash_queue.is_hash_valid_for_age(tx.borrow().recent_blockhash(), max_age))
-            .collect();
-        drop(hash_queue);
+        let (next_durable_nonce, ages_ok) = {
+            let hash_queue = self.blockhash_queue.read().unwrap();
+            let next_durable_nonce = hash_queue.next_durable_nonce();
+            // Snapshot age checks so fee derivation and nonce loads below run unlocked.
+            let ages_ok: SmallVec<[bool; TARGET_NUM_TRANSACTIONS_PER_BATCH]> = sanitized_txs
+                .iter()
+                .map(|tx| hash_queue.is_hash_valid_for_age(tx.borrow().recent_blockhash(), max_age))
+                .collect();
+            (next_durable_nonce, ages_ok)
+        };
 
         let feature_set: &FeatureSet = &self.feature_set;
         let feature_snapshot = feature_set.snapshot();

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -1,8 +1,9 @@
 use {
     super::{Bank, BankStatusCache},
+    crate::transaction_batch::TARGET_NUM_TRANSACTIONS_PER_BATCH,
     agave_feature_set::FeatureSet,
+    smallvec::SmallVec,
     solana_account::ReadableAccount,
-    solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_fee::calculate_fee_details,
@@ -88,12 +89,13 @@ impl Bank {
 
         let hash_queue = self.blockhash_queue.read().unwrap();
         let next_durable_nonce = hash_queue.next_durable_nonce();
+        let age_is_ok = hash_queue.is_hash_valid_for_age(tx.recent_blockhash(), max_age);
+        drop(hash_queue);
 
         self.check_transaction_age(
             tx,
-            max_age,
+            age_is_ok,
             &next_durable_nonce,
-            &hash_queue,
             error_counters,
             true, // strict_nonce_size_check
             true, // strict_nonce_authority_check
@@ -157,6 +159,12 @@ impl Bank {
     ) -> Vec<TransactionCheckResult> {
         let hash_queue = self.blockhash_queue.read().unwrap();
         let next_durable_nonce = hash_queue.next_durable_nonce();
+        // Snapshot age checks so fee derivation and nonce loads below run unlocked.
+        let ages_ok: SmallVec<[bool; TARGET_NUM_TRANSACTIONS_PER_BATCH]> = sanitized_txs
+            .iter()
+            .map(|tx| hash_queue.is_hash_valid_for_age(tx.borrow().recent_blockhash(), max_age))
+            .collect();
+        drop(hash_queue);
 
         let feature_set: &FeatureSet = &self.feature_set;
         let feature_snapshot = feature_set.snapshot();
@@ -167,7 +175,8 @@ impl Bank {
         sanitized_txs
             .iter()
             .zip(lock_results)
-            .map(|(tx, lock_res)| match lock_res {
+            .zip(ages_ok)
+            .map(|((tx, lock_res), age_is_ok)| match lock_res {
                 Ok(()) => {
                     let compute_budget_and_limits = tx
                         .borrow()
@@ -208,9 +217,8 @@ impl Bank {
 
                     let nonce_address = self.check_transaction_age(
                         tx.borrow(),
-                        max_age,
+                        age_is_ok,
                         &next_durable_nonce,
-                        &hash_queue,
                         error_counters,
                         strict_nonce_size_check,
                         false,
@@ -229,18 +237,13 @@ impl Bank {
     fn check_transaction_age(
         &self,
         tx: &impl SVMMessage,
-        max_age: usize,
+        age_is_ok: bool,
         next_durable_nonce: &DurableNonce,
-        hash_queue: &BlockhashQueue,
         error_counters: &mut TransactionErrorMetrics,
         strict_nonce_size_check: bool,
         strict_nonce_authority_check: bool,
     ) -> TransactionResult<Option<Pubkey>> {
-        let recent_blockhash = tx.recent_blockhash();
-        if hash_queue
-            .get_hash_info_if_valid(recent_blockhash, max_age)
-            .is_some()
-        {
+        if age_is_ok {
             Ok(None)
         } else if let Some((nonce_address, _)) = self.check_nonce_transaction_validity(
             tx,

--- a/runtime/src/transaction_batch.rs
+++ b/runtime/src/transaction_batch.rs
@@ -3,6 +3,9 @@ use {
     solana_transaction_error::TransactionResult as Result,
 };
 
+/// Target number of transactions in a batch produced by the banking stage.
+pub const TARGET_NUM_TRANSACTIONS_PER_BATCH: usize = 64;
+
 pub enum OwnedOrBorrowed<'a, T> {
     Owned(Vec<T>),
     Borrowed(&'a [T]),


### PR DESCRIPTION
## Summary

Snapshot transaction age checks while holding the blockhash queue read lock, then release it before fee calculation and nonce account loading.

Use the banking-stage batch target as the `SmallVec` inline capacity.

Split PRs: #14195, #14196, #14197.

## Testing

`cargo check -p solana-core -p solana-runtime --lib`
