### PR TITLE
svm: fix conformance instr harness loader lookup and account capture

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8431,6 +8431,7 @@ dependencies = [
  "solana-keypair",
  "solana-loader-v3-interface",
  "solana-message",
+ "solana-program-binaries",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rent",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -201,6 +201,7 @@ solana-instruction = { workspace = true }
 solana-keypair = "3.1.2"
 solana-loader-v3-interface = "7.0.0"
 solana-message = "4.1.0"
+solana-program-binaries = { path = "../../program-binaries", version = "=4.3.0-alpha.1", features = ["agave-unstable-api"] }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = "4.2.0"
 solana-rent = "4.1.0"

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -80,8 +80,8 @@ use {
     solana_svm::conformance::{
         instr::{context::InstrContext, harness::execute_instr},
         programs::{
-            add_program_to_program_cache, keyed_account_for_system_program,
-            new_program_cache_with_builtins,
+            add_program_to_program_cache, keyed_account_for_bpf_loader_program,
+            keyed_account_for_system_program, new_program_cache_with_builtins,
         },
     },
     std::{fs::File, io::Read, path::PathBuf},
@@ -119,6 +119,15 @@ fn default_program_cache_with_program(
         feature_set,
     );
     program_cache
+}
+
+fn upgradeable_program_accounts(program_id: &Pubkey, program_elf: &[u8]) -> Vec<(Pubkey, Account)> {
+    solana_program_binaries::bpf_loader_upgradeable_program_accounts(
+        program_id,
+        program_elf,
+        &Rent::default(),
+    )
+    .into()
 }
 
 #[cfg(feature = "sbf_rust")]
@@ -305,7 +314,8 @@ fn test_program_sbf_sanity() {
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
 
-        let accounts = vec![(pubkey1, Account::default()), (pubkey2, Account::default())];
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        accounts.extend([(pubkey1, Account::default()), (pubkey2, Account::default())]);
 
         let mut program_cache =
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -358,7 +368,16 @@ fn test_program_sbf_loader_deprecated() {
 
         let pubkey = Pubkey::new_unique();
         let accounts = vec![
-            (program_id, Account::new(0, 0, &bpf_loader_deprecated::id())),
+            (
+                program_id,
+                Account {
+                    lamports: 1,
+                    data: vec![],
+                    owner: bpf_loader_deprecated::id(),
+                    executable: true,
+                    rent_epoch: u64::MAX,
+                },
+            ),
             (pubkey, Account::default()),
         ];
 
@@ -466,6 +485,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
             },
         ),
         keyed_account_for_system_program(),
+        solana_svm::conformance::programs::keyed_account_for_bpf_loader_upgradeable_program(),
         (authority_pubkey, Account::default()),
     ];
 
@@ -534,13 +554,15 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new(pubkey, false),
             AccountMeta::new(pubkey, false),
         ];
+        let program_accounts = upgradeable_program_accounts(&program_id, &program_elf);
 
         let mut execute = |data: &[u8]| {
-            let accounts = vec![
+            let mut accounts = program_accounts.clone();
+            accounts.extend([
                 (payer_pubkey, Account::new(100, 0, &Pubkey::default())),
                 (payee_pubkey, Account::new(10, 1, &program_id)),
                 (pubkey, account.clone()),
-            ];
+            ]);
             let instruction = Instruction::new_with_bytes(program_id, data, account_metas.clone());
             let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
             execute_instr(&context, &mut program_cache, &sysvar_cache)
@@ -584,11 +606,12 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new_readonly(pubkey, true),
             AccountMeta::new_readonly(program_id, false),
         ];
-        let accounts = vec![
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        accounts.extend([
             (payer_pubkey, Account::new(100, 0, &Pubkey::default())),
             (payee_pubkey, Account::new(10, 1, &program_id)),
             (pubkey, Account::new(10, 1, &program_id)),
-        ];
+        ]);
         let instruction = Instruction::new_with_bytes(program_id, &[7], account_metas);
         let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
         let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
@@ -621,7 +644,8 @@ fn test_program_sbf_error_handling() {
 
         let pubkey1 = Pubkey::new_unique();
 
-        let accounts = vec![(pubkey1, Account::default())];
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        accounts.push((pubkey1, Account::default()));
 
         let mut program_cache =
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -706,7 +730,8 @@ fn test_return_data_and_log_data_syscall() {
         let feature_set = SVMFeatureSet::all_enabled();
 
         let pubkey = Pubkey::new_unique();
-        let accounts = vec![(pubkey, Account::default())];
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        accounts.push((pubkey, Account::default()));
 
         let mut program_cache =
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -1376,15 +1401,19 @@ fn test_program_sbf_program_id_spoofing() {
     let from_pubkey = Pubkey::new_unique();
     let to_pubkey = Pubkey::new_unique();
 
-    let accounts = vec![
-        keyed_account_for_system_program(),
-        (
-            malicious_system_pubkey,
-            Account::new(0, 0, &bpf_loader_upgradeable::id()),
-        ),
+    let mut accounts = vec![keyed_account_for_system_program()];
+    accounts.extend(upgradeable_program_accounts(
+        &malicious_swap_pubkey,
+        &spoof1_elf,
+    ));
+    accounts.extend(upgradeable_program_accounts(
+        &malicious_system_pubkey,
+        &spoof1_system_elf,
+    ));
+    accounts.extend([
         (from_pubkey, Account::new(10, 0, &system_program::id())),
         (to_pubkey, Account::new(0, 0, &system_program::id())),
-    ];
+    ]);
 
     let mut program_cache = new_program_cache_with_builtins(0);
     add_program_to_program_cache(
@@ -1439,16 +1468,11 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let accounts = vec![
-        (
-            caller_pubkey,
-            Account::new(0, 0, &bpf_loader_upgradeable::id()),
-        ),
-        (
-            caller2_pubkey,
-            Account::new(0, 0, &bpf_loader_upgradeable::id()),
-        ),
-    ];
+    let mut accounts = upgradeable_program_accounts(&caller_pubkey, &caller_access_elf);
+    accounts.extend(upgradeable_program_accounts(
+        &caller2_pubkey,
+        &caller_access_elf,
+    ));
 
     let mut program_cache = new_program_cache_with_builtins(0);
     add_program_to_program_cache(
@@ -1491,10 +1515,9 @@ fn test_program_sbf_ro_modify() {
     let feature_set = SVMFeatureSet::all_enabled();
 
     let test_pubkey = Pubkey::new_unique();
-    let accounts = vec![
-        keyed_account_for_system_program(),
-        (test_pubkey, Account::new(10, 0, &system_program::id())),
-    ];
+    let mut accounts = vec![keyed_account_for_system_program()];
+    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
+    accounts.push((test_pubkey, Account::new(10, 0, &system_program::id())));
 
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -1535,11 +1558,16 @@ fn test_program_sbf_call_depth() {
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
+    let program_accounts = upgradeable_program_accounts(&program_id, &program_elf);
 
     let mut execute = |depth: usize| {
         let instruction = Instruction::new_with_bincode(program_id, &depth, vec![]);
 
-        let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
+        let context = InstrContext::new_with_default_budget(
+            feature_set,
+            program_accounts.clone(),
+            instruction,
+        );
 
         execute_instr(&context, &mut program_cache, &sysvar_cache)
     };
@@ -1561,10 +1589,7 @@ fn test_program_sbf_compute_budget() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let accounts = vec![(
-        program_id,
-        Account::new(0, 0, &bpf_loader_upgradeable::id()),
-    )];
+    let accounts = upgradeable_program_accounts(&program_id, &program_elf);
 
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -1642,7 +1667,8 @@ fn assert_instruction_count() {
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
 
         let account_pubkey = Pubkey::new_unique();
-        let accounts = vec![(account_pubkey, Account::new(0, 0, &program_id))];
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        accounts.push((account_pubkey, Account::new(0, 0, &program_id)));
 
         let instruction_accounts = vec![AccountMeta {
             pubkey: account_pubkey,
@@ -1762,6 +1788,8 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
             account_metas.push(AccountMeta::new_readonly(pubkey, false));
         }
     }
+
+    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
 
     // The provided instruction data will be set to the return data.
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
@@ -2287,7 +2315,18 @@ fn test_program_sbf_disguised_as_sbf_loader() {
         let account_metas = vec![AccountMeta::new_readonly(program_id, false)];
         let instruction = Instruction::new_with_bytes(bpf_loader::id(), &[1], account_metas);
 
-        let context = InstrContext::new_with_default_budget(feature_set, vec![], instruction);
+        let context = InstrContext::new_with_default_budget(
+            feature_set,
+            vec![
+                keyed_account_for_bpf_loader_program(),
+                solana_program_binaries::bpf_loader_program_account(
+                    &program_id,
+                    &program_elf,
+                    &Rent::default(),
+                ),
+            ],
+            instruction,
+        );
 
         let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
         assert_eq!(effects.result, Some(InstructionError::UnsupportedProgramId));
@@ -2367,11 +2406,9 @@ fn test_program_sbf_c_dup() {
     ];
     let instruction = Instruction::new_with_bytes(program_id, &[4, 5, 6, 7], account_metas);
 
-    let context = InstrContext::new_with_default_budget(
-        feature_set,
-        vec![(account_address, account)],
-        instruction,
-    );
+    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    accounts.push((account_address, account));
+    let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
     let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
     assert!(effects.result.is_none());
@@ -2558,7 +2595,8 @@ fn test_program_sbf_ro_account_modify() {
     let sysvar_cache = default_sysvar_cache();
 
     let argument_pubkey = Pubkey::new_unique();
-    let accounts = vec![(argument_pubkey, Account::new(42, 100, &program_id))];
+    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    accounts.push((argument_pubkey, Account::new(42, 100, &program_id)));
 
     let account_metas = vec![
         AccountMeta::new_readonly(argument_pubkey, false),
@@ -4473,7 +4511,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
 
     let context = InstrContext {
         feature_set,
-        accounts: vec![],
+        accounts: upgradeable_program_accounts(&program_id, &program_elf),
         instruction,
         cu_avail: 10_000,
     };
@@ -5547,6 +5585,8 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
         let pubkey = accounts[i].0;
         account_metas.push(AccountMeta::new(pubkey, false));
     }
+
+    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
 
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
 

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -5,10 +5,11 @@ use {
     crate::conformance::{
         callback::DefaultCallback,
         setup::{
-            InvokeContextFields, compute_budget, prepare_invoke_context_fields,
+            InvokeContextFields, compute_budget, prepare_invoke_context_fields, program_loader_key,
             program_runtime_environments,
         },
     },
+    solana_account::AccountSharedData,
     solana_instruction::error::InstructionError,
     solana_program_runtime::{
         invoke_context::InvokeContext, loaded_programs::ProgramCacheForTxBatch,
@@ -17,7 +18,7 @@ use {
     solana_pubkey::Pubkey,
     solana_svm_callback::InvokeContextCallback,
     solana_svm_timings::ExecuteTimings,
-    std::rc::Rc,
+    std::{collections::HashMap, rc::Rc},
 };
 #[cfg(feature = "conformance")]
 use {
@@ -55,10 +56,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
     let mut compute_budget = compute_budget(&input.feature_set);
     compute_budget.compute_unit_limit = input.cu_avail; // Clamp budget for execution by cu_avail
 
-    let loader_key = program_cache
-        .find(&input.instruction.program_id)
-        .expect("program not loaded in cache")
-        .account_owner();
+    let loader_key = program_loader_key(&input.accounts, &input.instruction.program_id);
 
     let program_runtime_environments =
         program_runtime_environments(&input.feature_set, &compute_budget);
@@ -113,10 +111,31 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
         .map(|index| {
             *transaction_context
                 .get_key_of_account_at_index(index)
-                .clone()
                 .unwrap()
         })
-        .collect::<Vec<_>>();
+        .collect();
+
+    // Post-execution state of the accounts in the compiled message.
+    let mut executed: HashMap<Pubkey, AccountSharedData> = account_keys
+        .into_iter()
+        .zip(transaction_context.deconstruct_without_keys().unwrap())
+        .collect();
+
+    // Preserve input account order, overlaying executed state for accounts
+    // present in the compiled message.
+    let resulting_accounts = input
+        .accounts
+        .iter()
+        .map(|(pubkey, account)| {
+            (
+                *pubkey,
+                executed
+                    .remove(pubkey)
+                    .map(Into::into)
+                    .unwrap_or_else(|| account.clone()),
+            )
+        })
+        .collect();
 
     InstrEffects {
         custom_err: if let Err(InstructionError::Custom(code)) = result {
@@ -125,13 +144,7 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
             None
         },
         result: result.err(),
-        resulting_accounts: transaction_context
-            .deconstruct_without_keys()
-            .unwrap()
-            .into_iter()
-            .zip(account_keys)
-            .map(|(account, key)| (key, account.into()))
-            .collect(),
+        resulting_accounts,
         cu_avail,
         return_data,
         logs,
@@ -403,9 +416,16 @@ mod tests {
     #[test_case(solana_sdk_ids::bpf_loader_upgradeable::id(); "loader_v3")]
     fn test_bpf_noop_program_exec(loader_key: Pubkey) {
         let program_id = Pubkey::new_unique();
+        let program_account = Account {
+            lamports: 1,
+            data: vec![],
+            owner: loader_key,
+            executable: true,
+            rent_epoch: u64::MAX,
+        };
         let context = InstrContext::new_with_default_budget(
             SVMFeatureSet::default(),
-            vec![],
+            vec![(program_id, program_account)],
             Instruction::new_with_bytes(program_id, &[], vec![]),
         );
         let sysvar_cache = sysvar_cache_with_rent();

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -85,6 +85,14 @@ pub fn keyed_account_for_system_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&SVM_BUILTINS[0].program_id, SVM_BUILTINS[0].name)
 }
 
+pub fn keyed_account_for_bpf_loader_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&SVM_BUILTINS[2].program_id, SVM_BUILTINS[2].name)
+}
+
+pub fn keyed_account_for_bpf_loader_upgradeable_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&SVM_BUILTINS[3].program_id, SVM_BUILTINS[3].name)
+}
+
 pub fn keyed_account_for_compute_budget_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&SVM_BUILTINS[4].program_id, SVM_BUILTINS[4].name)
 }

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -91,7 +91,6 @@ pub(crate) fn compute_budget(feature_set: &SVMFeatureSet) -> ComputeBudget {
 /// The loader that owns the program account in `accounts`, used as the program
 /// account's owner when compiling the transaction. `None` if the program
 /// account isn't present.
-#[cfg(feature = "conformance")]
 pub(crate) fn program_loader_key(accounts: &[(Pubkey, Account)], program_id: &Pubkey) -> Pubkey {
     accounts
         .iter()


### PR DESCRIPTION
#### Problem
The instr conformance harness was deriving the program loader from the program cache, which does not reflect the loader/account ownership encoded in the input fixture. It also only reported accounts present in the compiled transaction context, so input accounts not referenced by the instruction could be omitted from the resulting effects.


#### Summary of Changes
Derive the loader key from the input program account instead of the program cache. Preserve all input accounts in the reported effects by overlaying executed account state onto the original input account list.

#### Testing
* `cargo test -p solana-svm conformance::instr::harness::tests`
* `cargo test -p solana-svm --features conformance conformance::instr::harness::tests::test_duplicate_accounts_panic_with_invariant_violation`

These are all test-only functions anyways.