### PR TITLE
Removes `skip` parameter from write_accounts() fns

### DIFF
--- a/accounts-db/benches/bench_accounts_file.rs
+++ b/accounts-db/benches/bench_accounts_file.rs
@@ -58,7 +58,7 @@ fn bench_write_accounts_file(c: &mut Criterion) {
                     AppendVec::new(path, true, file_size)
                 },
                 |append_vec| {
-                    let res = append_vec.append_accounts(&storable_accounts, 0).unwrap();
+                    let res = append_vec.append_accounts(&storable_accounts).unwrap();
                     let accounts_written_count = res.offsets.len();
                     assert_eq!(accounts_written_count, accounts_count);
                 },
@@ -97,7 +97,7 @@ fn bench_scan_pubkeys(c: &mut Criterion) {
             .sum();
         let append_vec = AppendVec::new(append_vec_path, true, file_size);
         let stored_accounts_info = append_vec
-            .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
+            .append_accounts(&(Slot::MAX, storable_accounts.as_slice()))
             .unwrap();
         assert_eq!(stored_accounts_info.offsets.len(), accounts_count);
         append_vec.flush().unwrap();
@@ -148,7 +148,7 @@ fn bench_get_account_shared_data(c: &mut Criterion) {
             .sum();
         let append_vec = AppendVec::new(append_vec_path, true, file_size);
         let stored_accounts_info = append_vec
-            .append_accounts(&(Slot::MAX, storable_accounts.as_slice()), 0)
+            .append_accounts(&(Slot::MAX, storable_accounts.as_slice()))
             .unwrap();
         assert_eq!(stored_accounts_info.offsets.len(), 1);
         append_vec.flush().unwrap();

--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -213,7 +213,7 @@ mod tests {
             (&Pubkey::new_unique(), &account2),
         ];
 
-        storage.accounts.write_accounts(&(slot, &accounts[..]), 0);
+        storage.accounts.write_accounts(&(slot, &accounts[..]));
 
         let files = open_storage_files(iter::once(&storage), false)
             .collect::<io::Result<Vec<_>>>()
@@ -260,7 +260,7 @@ mod tests {
 
         let offsets = storage
             .accounts
-            .write_accounts(&(slot, &accounts_to_append[..]), 0);
+            .write_accounts(&(slot, &accounts_to_append[..]));
 
         // Generate a seed from entropy and log the original seed
         let seed: u64 = rand::random();
@@ -367,7 +367,7 @@ mod tests {
 
         let offsets = storage
             .accounts
-            .write_accounts(&(slot, &accounts_to_append[..]), 0);
+            .write_accounts(&(slot, &accounts_to_append[..]));
 
         // Generate a seed from entropy and log the original seed
         let seed: u64 = rand::random();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5725,7 +5725,7 @@ impl AccountsDb {
         let store_id = storage.id();
         let stored_accounts_info = storage
             .accounts
-            .write_accounts(accounts_and_meta_to_store, 0)
+            .write_accounts(accounts_and_meta_to_store)
             .unwrap_or_else(|| {
                 panic!(
                     "failed to write accounts to storage: slot! {slot}, id: {store_id}, capacity: \

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -111,20 +111,20 @@ mod tests {
         let storage0 = accounts_db.create_and_insert_store(slot0, /*size*/ 4_096, "");
         storage0
             .accounts
-            .write_accounts(&(slot0, [(&key1, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot0, [(&key1, &account)].as_slice()));
 
         let slot1 = 1;
         let storage1 = accounts_db.create_and_insert_store(slot1, /*size*/ 4_096, "");
         storage1
             .accounts
-            .write_accounts(&(slot1, [(&key1, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot1, [(&key1, &account)].as_slice()));
 
         // Account with key2 is updated in a single slot, should get notified once
         let slot2 = 2;
         let storage2 = accounts_db.create_and_insert_store(slot2, /*size*/ 4_096, "");
         storage2
             .accounts
-            .write_accounts(&(slot2, [(&key2, &account)].as_slice()), /*skip*/ 0);
+            .write_accounts(&(slot2, [(&key2, &account)].as_slice()));
 
         // Do the notification
         let notifier = GeyserTestPlugin::default();

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -198,7 +198,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     let storable_accounts = (slot0, &data[..]);
 
     // construct append vec with account to generate an index from
-    append_vec.accounts.write_accounts(&storable_accounts, 0);
+    append_vec.accounts.write_accounts(&storable_accounts);
 
     assert!(!db.accounts_index.contains(&pubkey));
     let storage = db.get_storage_for_slot(slot0).unwrap();
@@ -233,7 +233,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
 
     let data = [(&pubkey, &account)];
     let storable_accounts = (slot0, &data[..]);
-    append_vec.accounts.write_accounts(&storable_accounts, 0);
+    append_vec.accounts.write_accounts(&storable_accounts);
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
     let slot_list_len = db.accounts_index.get_and_then(&pubkey, |entry| {
@@ -265,10 +265,7 @@ pub(crate) fn append_single_account_with_default_hash(
     let accounts = [(pubkey, account)];
     let slice = &accounts[..];
     let storable_accounts = (slot, slice);
-    let stored_accounts_info = storage
-        .accounts
-        .write_accounts(&storable_accounts, 0)
-        .unwrap();
+    let stored_accounts_info = storage.accounts.write_accounts(&storable_accounts).unwrap();
     if mark_alive {
         // updates 'alive_bytes' on the storage
         storage.add_account(stored_accounts_info.size);
@@ -5051,7 +5048,7 @@ define_accounts_db_test!(test_calculate_storage_count_and_alive_bytes, |accounts
     let storage = accounts.create_and_insert_store(slot0, 4_000, "flush_slot_cache");
     storage
         .accounts
-        .write_accounts(&(slot0, &[(&shared_key, &account)][..]), 0);
+        .write_accounts(&(slot0, &[(&shared_key, &account)][..]));
 
     let storage = accounts.storage.get_slot_storage_entry(slot0).unwrap();
     let mut reader = append_vec::new_scan_accounts_reader();
@@ -5105,10 +5102,9 @@ define_accounts_db_test!(
         let account_big = AccountSharedData::new(1, 1000, AccountSharedData::default().owner());
         let slot0 = 0;
         let storage = accounts.create_and_insert_store(slot0, 4_000, "flush_slot_cache");
-        storage.accounts.write_accounts(
-            &(slot0, &[(&keys[0], &account), (&keys[1], &account_big)][..]),
-            0,
-        );
+        storage
+            .accounts
+            .write_accounts(&(slot0, &[(&keys[0], &account), (&keys[1], &account_big)][..]));
 
         let mut reader = append_vec::new_scan_accounts_reader();
         let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
@@ -5152,9 +5148,7 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
 
     let slot0 = 0;
     let storage = accounts.create_and_insert_store(slot0, 10_000, "");
-    let offsets = storage
-        .accounts
-        .write_accounts(&(slot0, &account_list[..]), 0);
+    let offsets = storage.accounts.write_accounts(&(slot0, &account_list[..]));
 
     let offsets = offsets.unwrap().offsets;
     let data_lens = storage.accounts.get_account_data_lens(&offsets);

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -247,10 +247,9 @@ impl AccountsFile {
     pub fn write_accounts<'a>(
         &self,
         accounts: &impl StorableAccounts<'a>,
-        skip: usize,
     ) -> Option<StoredAccountsInfo> {
         match self {
-            Self::AppendVec(av) => av.append_accounts(accounts, skip),
+            Self::AppendVec(av) => av.append_accounts(accounts),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -984,18 +984,17 @@ impl AppendVec {
     pub fn append_accounts<'a>(
         &self,
         accounts: &impl StorableAccounts<'a>,
-        skip: usize,
     ) -> Option<StoredAccountsInfo> {
         let _lock = self.read_write_state.append_guard();
         let mut offset = self.len();
         let len = accounts.len();
-        // Here we have `len - skip` number of accounts.  The +1 extra capacity
+        // Here we have `len` number of accounts.  The +1 extra capacity
         // is for storing the aligned offset of the last-plus-one entry,
         // which is used to compute the size of the last stored account.
-        let offsets_len = len - skip + 1;
+        let offsets_len = len + 1;
         let mut offsets = Vec::with_capacity(offsets_len);
         let mut stop = false;
-        for i in skip..len {
+        for i in 0..len {
             if stop {
                 break;
             }
@@ -1107,7 +1106,7 @@ mod tests {
             let slice = &accounts[..];
             let storable_accounts = (slot_ignored, slice);
 
-            self.append_accounts(&storable_accounts, 0)
+            self.append_accounts(&storable_accounts)
                 .map(|res| res.offsets[0])
         }
     }
@@ -1343,7 +1342,7 @@ mod tests {
         let av = ManuallyDrop::new(AppendVec::new(&path.path, true, file_size));
         let slot = 42;
         let stored_accounts_info = av
-            .append_accounts(&(slot, test_accounts.as_slice()), 0)
+            .append_accounts(&(slot, test_accounts.as_slice()))
             .unwrap();
         av.flush().unwrap();
         (av, stored_accounts_info, test_accounts, path)
@@ -1823,7 +1822,7 @@ mod tests {
             let slot = 77; // the specific slot does not matter
             let storable_accounts: Vec<_> = std::iter::zip(&pubkeys, &accounts).collect();
             let stored_accounts_info = append_vec
-                .append_accounts(&(slot, storable_accounts.as_slice()), 0)
+                .append_accounts(&(slot, storable_accounts.as_slice()))
                 .unwrap();
             append_vec.flush().unwrap();
             stored_accounts_info.offsets
@@ -1874,7 +1873,7 @@ mod tests {
             let slot = 42; // the specific slot does not matter
             let storable_accounts: Vec<_> = std::iter::zip(&pubkeys, &accounts).collect();
             let stored_accounts_info = append_vec
-                .append_accounts(&(slot, storable_accounts.as_slice()), 0)
+                .append_accounts(&(slot, storable_accounts.as_slice()))
                 .unwrap();
             append_vec.flush().unwrap();
             stored_accounts_info.offsets

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -633,9 +633,8 @@ mod tests {
 
                     let storage = setup_sample_storage(&db, source_slot);
                     // store the accounts so they can be looked up later in `db`
-                    if let Some(offsets) = storage
-                        .accounts
-                        .write_accounts(&(source_slot, &three[..]), 0)
+                    if let Some(offsets) =
+                        storage.accounts.write_accounts(&(source_slot, &three[..]))
                     {
                         three_accounts_from_storage_byval
                             .iter_mut()
@@ -764,7 +763,7 @@ mod tests {
                                     let storage = setup_sample_storage(&db, slot);
                                     if let Some(offsets) = storage
                                         .accounts
-                                        .write_accounts(&(slot, &raw2_refs[range.clone()]), 0)
+                                        .write_accounts(&(slot, &raw2_refs[range.clone()]))
                                     {
                                         result.iter_mut().zip(offsets.offsets.iter()).for_each(
                                             |(account, offset)| {


### PR DESCRIPTION
#### Problem

The `skip` parameter on `write_accounts()` is always 0.

More context: I listed some in https://github.com/anza-xyz/agave/pull/13685. For this PR, the relevant part is that we always write all the accounts all at once, and never just some of the accounts. So no reason to support that in the api.


#### Summary of Changes

Remove it.


#### Testing

Nothing extra.