### PR TITLE
chore(dep): bump crossbeam-epoch to 0.9.20

### DIFF
--- a/ci/xtask/Cargo.lock
+++ b/ci/xtask/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1778,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -1714,15 +1714,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
- "cfg-if 1.0.4",
  "crossbeam-utils",
- "lazy_static",
- "memoffset 0.6.4",
- "scopeguard",
 ]
 
 [[package]]
@@ -3876,15 +3872,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4034,7 +4021,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -7687,7 +7674,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778f08fb0eaf52c9a3bef2978247f7fab0ccfddc44cfddb936d5ad9f98ede886"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",


### PR DESCRIPTION
#### Problem

a rust advisory for updating `crossbeam-epoch` to >= 0.9.20
(https://rustsec.org/advisories/RUSTSEC-2026-0204)

<img width="1001" height="264" alt="Screenshot 2026-07-07 at 10 08 07" src="https://github.com/user-attachments/assets/030cdeca-7d3b-46a9-945f-0bc2e644b181" />

<img width="1177" height="284" alt="Screenshot 2026-07-07 at 11 27 20" src="https://github.com/user-attachments/assets/1b0093ac-4ac7-4113-8e49-c16e2dedad40" />


we have multiple versions of `crossbeam-epoch` in our repository:

1. `ci/xtask/Cargo.lock` and `dev-bins/Cargo.lock` use `crossbeam-epoch@0.9.18`


2. `programs/sbf/Cargo.lock` uses `crossbeam-epoch@0.9.5`

3. `./Cargo.lock` uses a custom patch (`source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"`)

#### Summary of Changes

1. bump `ci/xtask/Cargo.lock` and `dev-bins/Cargo.lock` to 0.9.20
2. `programs/sbf/Cargo.lock` have the dep because of deps in `[dev-dependencies]`. since it's test-only, I think we should be good to just bump it to 0.9.20.
3. `./Cargo.lock` wasn't included in this audit report, but we should review the create afterward 🫠 