### PR TITLE
core: filter duplicate nonce account transactions

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -3,8 +3,7 @@ use {
         transaction_priority_id::TransactionPriorityId,
         transaction_state::TransactionState,
         transaction_state_container::{
-            EXTRA_CAPACITY, SharedBytes, StateContainer, TransactionViewState,
-            TransactionViewStateContainer,
+            SharedBytes, StateContainer, TransactionViewState, TransactionViewStateContainer,
         },
     },
     crate::{
@@ -19,7 +18,6 @@ use {
         transaction_data::TransactionData, transaction_version::TransactionVersion,
         transaction_view::SanitizedTransactionView,
     },
-    arrayvec::ArrayVec,
     core::time::Duration,
     crossbeam_channel::{RecvTimeoutError, TryRecvError},
     solana_accounts_db::account_locks::validate_account_locks,
@@ -46,6 +44,7 @@ use {
 pub(crate) struct DisconnectedError;
 
 /// Stats/metrics returned by `receive_and_buffer_packets`.
+#[derive(Debug, Default)]
 pub(crate) struct ReceivingStats {
     pub num_received: usize,
     /// Count of packets that passed sigverify but were dropped
@@ -61,14 +60,57 @@ pub(crate) struct ReceivingStats {
     pub num_dropped_on_fee_payer: usize,
     pub num_dropped_on_filter_key: usize,
     pub num_dropped_on_capacity: usize,
+    pub num_dropped_on_nonce_dedup: usize,
 
     pub num_buffered: usize,
+    pub num_evicted_on_nonce_dedup: usize,
 
     pub receive_time_us: u64,
     pub buffer_time_us: u64,
 }
 
+trait RecordReceiveError {
+    fn record_err(&self, receiving_stats: &mut ReceivingStats);
+}
+
+impl RecordReceiveError for PacketHandlingError {
+    fn record_err(&self, receiving_stats: &mut ReceivingStats) {
+        match self {
+            PacketHandlingError::Sanitization | PacketHandlingError::ALTResolution => {
+                receiving_stats.num_dropped_on_parsing_and_sanitization += 1;
+            }
+            PacketHandlingError::LockValidation => {
+                receiving_stats.num_dropped_on_lock_validation += 1;
+            }
+            PacketHandlingError::ComputeBudget => {
+                receiving_stats.num_dropped_on_compute_budget += 1;
+            }
+            PacketHandlingError::FilterKey => {
+                receiving_stats.num_dropped_on_filter_key += 1;
+            }
+        }
+    }
+}
+
+impl RecordReceiveError for TransactionError {
+    fn record_err(&self, receiving_stats: &mut ReceivingStats) {
+        match self {
+            TransactionError::BlockhashNotFound => {
+                receiving_stats.num_dropped_on_age += 1;
+            }
+            TransactionError::AlreadyProcessed => {
+                receiving_stats.num_dropped_on_already_processed += 1;
+            }
+            _ => {}
+        }
+    }
+}
+
 impl ReceivingStats {
+    fn record_err<E: RecordReceiveError>(&mut self, err: &E) {
+        err.record_err(self);
+    }
+
     fn accumulate(&mut self, other: ReceivingStats) {
         self.num_received += other.num_received;
         self.num_dropped_without_parsing += other.num_dropped_without_parsing;
@@ -81,7 +123,9 @@ impl ReceivingStats {
         self.num_dropped_on_fee_payer += other.num_dropped_on_fee_payer;
         self.num_dropped_on_filter_key += other.num_dropped_on_filter_key;
         self.num_dropped_on_capacity += other.num_dropped_on_capacity;
+        self.num_dropped_on_nonce_dedup += other.num_dropped_on_nonce_dedup;
         self.num_buffered += other.num_buffered;
+        self.num_evicted_on_nonce_dedup += other.num_evicted_on_nonce_dedup;
 
         self.receive_time_us += other.receive_time_us;
         self.buffer_time_us += other.buffer_time_us;
@@ -128,21 +172,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
         let start = Instant::now();
 
         let mut received_message = false;
-        let mut stats = ReceivingStats {
-            num_received: 0,
-            num_dropped_without_parsing: 0,
-            num_dropped_on_parsing_and_sanitization: 0,
-            num_dropped_on_lock_validation: 0,
-            num_dropped_on_compute_budget: 0,
-            num_dropped_on_age: 0,
-            num_dropped_on_already_processed: 0,
-            num_dropped_on_fee_payer: 0,
-            num_dropped_on_filter_key: 0,
-            num_dropped_on_capacity: 0,
-            num_buffered: 0,
-            receive_time_us: 0,
-            buffer_time_us: 0,
-        };
+        let mut stats = ReceivingStats::default();
 
         // If not leader/unknown, do a blocking-receive initially. This lets
         // the thread sleep until a message is received, or until the timeout.
@@ -207,21 +237,7 @@ impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
             }
         }
 
-        Ok(ReceivingStats {
-            num_received: stats.num_received,
-            num_dropped_without_parsing: stats.num_dropped_without_parsing,
-            num_dropped_on_parsing_and_sanitization: stats.num_dropped_on_parsing_and_sanitization,
-            num_dropped_on_lock_validation: stats.num_dropped_on_lock_validation,
-            num_dropped_on_compute_budget: stats.num_dropped_on_compute_budget,
-            num_dropped_on_age: stats.num_dropped_on_age,
-            num_dropped_on_already_processed: stats.num_dropped_on_already_processed,
-            num_dropped_on_fee_payer: stats.num_dropped_on_fee_payer,
-            num_dropped_on_filter_key: stats.num_dropped_on_filter_key,
-            num_dropped_on_capacity: stats.num_dropped_on_capacity,
-            num_buffered: stats.num_buffered,
-            receive_time_us: stats.receive_time_us,
-            buffer_time_us: stats.buffer_time_us,
-        })
+        Ok(stats)
     }
 }
 
@@ -250,98 +266,17 @@ impl TransactionViewReceiveAndBuffer {
         let sanitize_config = sanitize_config();
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
 
-        // Create temporary batches of transactions to be age-checked.
-        let mut transaction_priority_ids = ArrayVec::<_, EXTRA_CAPACITY>::new();
-        let lock_results: [_; EXTRA_CAPACITY] = core::array::from_fn(|_| Ok(()));
         let mut error_counters = TransactionErrorMetrics::default();
-        let mut num_dropped_on_age = 0;
-        let mut num_dropped_on_already_processed = 0;
-        let mut num_dropped_on_fee_payer = 0;
-        let mut num_dropped_on_filter_key = 0;
-        let mut num_dropped_on_capacity = 0;
-        let mut num_buffered = 0;
-
-        let mut check_and_push_to_queue = |container: &mut TransactionViewStateContainer,
-                                           transaction_priority_ids: &mut ArrayVec<
-            TransactionPriorityId,
-            EXTRA_CAPACITY,
-        >| {
-            // Temporary scope so that transaction references are immediately
-            // dropped and transactions not passing
-            let mut check_results = {
-                let mut transactions = ArrayVec::<_, EXTRA_CAPACITY>::new();
-                transactions.extend(transaction_priority_ids.iter().map(|priority_id| {
-                    container
-                        .get_transaction(priority_id.id)
-                        .expect("transaction must exist")
-                }));
-                working_bank.check_transactions_without_status_cache::<RuntimeTransaction<_>>(
-                    &transactions,
-                    &lock_results[..transactions.len()],
-                    working_bank.max_processing_age(),
-                    true,
-                    &mut error_counters,
-                )
-            };
-
-            // Remove errored transactions
-            for (result, priority_id) in check_results
-                .iter_mut()
-                .zip(transaction_priority_ids.iter())
-            {
-                if let Err(err) = result {
-                    match err {
-                        TransactionError::BlockhashNotFound => {
-                            num_dropped_on_age += 1;
-                        }
-                        TransactionError::AlreadyProcessed => {
-                            num_dropped_on_already_processed += 1;
-                        }
-                        _ => {}
-                    }
-                    container.remove_by_id(priority_id.id);
-                    continue;
-                }
-                let transaction = container
-                    .get_transaction(priority_id.id)
-                    .expect("transaction must exist");
-                if let Err(err) = Consumer::check_fee_payer_unlocked(
-                    working_bank,
-                    transaction,
-                    &mut error_counters,
-                ) {
-                    *result = Err(err);
-                    num_dropped_on_fee_payer += 1;
-                    container.remove_by_id(priority_id.id);
-                    continue;
-                }
-
-                num_buffered += 1;
-            }
-            // Push non-errored transaction into queue.
-            num_dropped_on_capacity += container.push_ids_into_queue(
-                check_results
-                    .into_iter()
-                    .zip(transaction_priority_ids.drain(..))
-                    .filter(|(r, _)| r.is_ok())
-                    .map(|(_, id)| id),
-            );
-        };
-
-        let mut num_received = 0;
-        let mut num_dropped_without_parsing = 0;
-        let mut num_dropped_on_parsing_and_sanitization = 0;
-        let mut num_dropped_on_lock_validation = 0;
-        let mut num_dropped_on_compute_budget = 0;
+        let mut receiving_stats = ReceivingStats::default();
 
         for packet in packet_batch_message.iter() {
             let Some(packet_data) = packet.data(..) else {
                 continue;
             };
 
-            num_received += 1;
+            receiving_stats.num_received += 1;
             if !should_parse {
-                num_dropped_without_parsing += 1;
+                receiving_stats.num_dropped_without_parsing += 1;
                 continue;
             }
 
@@ -356,59 +291,104 @@ impl TransactionViewReceiveAndBuffer {
                         &sanitize_config,
                         &self.filter_keys,
                     ) {
+                        // Parent giving us state means successful parse, ALTs resolved, no obvious static issues.
                         Ok(state) => Ok(state),
-                        Err(
-                            PacketHandlingError::Sanitization | PacketHandlingError::ALTResolution,
-                        ) => {
-                            num_dropped_on_parsing_and_sanitization += 1;
-                            Err(())
-                        }
-                        Err(PacketHandlingError::LockValidation) => {
-                            num_dropped_on_lock_validation += 1;
-                            Err(())
-                        }
-                        Err(PacketHandlingError::ComputeBudget) => {
-                            num_dropped_on_compute_budget += 1;
-                            Err(())
-                        }
-                        Err(PacketHandlingError::FilterKey) => {
-                            num_dropped_on_filter_key += 1;
+
+                        // Parsing or some other static checks failed.
+                        Err(ref err) => {
+                            receiving_stats.record_err(err);
                             Err(())
                         }
                     }
                 })
             {
-                let priority = container
+                let (priority, raw_nonce_address) = container
                     .get_mut_transaction_state(transaction_id)
-                    .expect("transaction must exist")
-                    .priority();
-                transaction_priority_ids.push(TransactionPriorityId::new(priority, transaction_id));
+                    .map(|state| {
+                        (
+                            state.priority(),
+                            state.transaction().get_durable_nonce().cloned(),
+                        )
+                    })
+                    .expect("transaction must exist");
+                let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
-                // If at capacity, run checks and remove invalid transactions.
-                if transaction_priority_ids.len() == EXTRA_CAPACITY {
-                    check_and_push_to_queue(container, &mut transaction_priority_ids);
+                // When we first receive a transaction, we drop it if a) it looks nonce-like, and
+                // b) there is a higher-priority nonce transaction using the same nonce in the queue,
+                // or any in-flight nonce transaction using the same nonce. This means we discard
+                // blockhash transactions structured like nonce transactions; this is acceptable because
+                // they would fail after the earlier nonce transaction is processed, and it allows us to
+                // prefilter without loading from accounts-db.
+                if let Some(nonce_address) = raw_nonce_address
+                    && let Some(existing_nonce_priority_id) =
+                        container.get_nonce_transaction_priority_id(&nonce_address)
+                {
+                    // There is a queued transaction with higher priority, or any in-flight transaction,
+                    // using this nonce account. Drop the new transaction.
+                    if existing_nonce_priority_id.priority >= priority
+                        || !container.is_queued(existing_nonce_priority_id)
+                    {
+                        receiving_stats.num_dropped_on_nonce_dedup += 1;
+                        container.remove_by_id(transaction_id);
+                        continue;
+                    }
                 }
+
+                let transaction = container
+                    .get_transaction(transaction_id)
+                    .expect("transaction must exist");
+
+                // Check blockhash transaction age is ok, or nonce transaction has a valid nonce.
+                // This nonce, not the nonce we got from the raw transaction bytes, will be used for eviction.
+                let verified_nonce_address = match working_bank
+                    .check_transaction_without_status_cache(
+                        transaction,
+                        working_bank.max_processing_age(),
+                        &mut error_counters,
+                    ) {
+                    Ok(opt) => opt,
+                    Err(ref err) => {
+                        receiving_stats.record_err(err);
+                        container.remove_by_id(transaction_id);
+                        continue;
+                    }
+                };
+
+                // Check the transaction's fee-payer validates.
+                if let Err(_err) = Consumer::check_fee_payer_unlocked(
+                    working_bank,
+                    transaction,
+                    &mut error_counters,
+                ) {
+                    receiving_stats.num_dropped_on_fee_payer += 1;
+                    container.remove_by_id(transaction_id);
+                    continue;
+                };
+
+                // Now we know we have a verified, higher-priority nonce transaction than any which
+                // may exist in the priority queue. If there is one, evict it. Regardless, record this
+                // transaction's nonce as in use, if it is a nonce transaction.
+                if let Some(nonce_address) = verified_nonce_address {
+                    if let Some(existing_nonce_priority_id) =
+                        container.get_nonce_transaction_priority_id(&nonce_address)
+                    {
+                        receiving_stats.num_evicted_on_nonce_dedup += 1;
+                        container.remove_by_id(existing_nonce_priority_id.id);
+                    }
+                    container.set_nonce_transaction_priority_id(&nonce_address, priority_id);
+                }
+
+                // Transaction is already fully validated and can be inserted into priority queue.
+                receiving_stats.num_dropped_on_capacity +=
+                    container.push_ids_into_queue(std::iter::once(priority_id));
+
+                receiving_stats.num_buffered += 1;
             }
         }
 
-        // Any remaining packets undergo status/age checks
-        check_and_push_to_queue(container, &mut transaction_priority_ids);
-
-        ReceivingStats {
-            num_received,
-            num_dropped_without_parsing,
-            num_dropped_on_parsing_and_sanitization,
-            num_dropped_on_lock_validation,
-            num_dropped_on_compute_budget,
-            num_dropped_on_age,
-            num_dropped_on_already_processed,
-            num_dropped_on_fee_payer,
-            num_dropped_on_filter_key,
-            num_dropped_on_capacity,
-            num_buffered,
-            receive_time_us: 0, // receive is outside this function
-            buffer_time_us: start.elapsed().as_micros() as u64,
-        }
+        // `receive_time_us` is set outside this function
+        receiving_stats.buffer_time_us = start.elapsed().as_micros() as u64;
+        receiving_stats
     }
 
     fn try_handle_packet(
@@ -445,7 +425,7 @@ impl TransactionViewReceiveAndBuffer {
         let (priority, cost) =
             calculate_priority_and_cost(working_bank, &view, &transaction_configuration);
 
-        Ok(TransactionState::new(view, max_age, priority, cost))
+        Ok(TransactionState::new(view, max_age, priority, cost, None))
     }
 }
 
@@ -548,32 +528,47 @@ mod tests {
         super::*,
         crate::banking_stage::tests::create_slow_genesis_config,
         agave_banking_stage_ingress_types::{
-            to_banking_packet_batch, to_single_banking_packet_batch,
+            BankingPacketBatch, to_banking_packet_batch, to_single_banking_packet_batch,
         },
-        crossbeam_channel::{Receiver, bounded},
+        crossbeam_channel::{Receiver, Sender, bounded},
+        solana_account::AccountSharedData,
+        solana_compute_budget_interface::ComputeBudgetInstruction,
+        solana_fee_calculator::FeeRateGovernor,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::{
-            AccountMeta, AddressLookupTableAccount, Instruction, VersionedMessage, v0,
+            AccountMeta, AddressLookupTableAccount, Instruction, Message, VersionedMessage, v0,
         },
+        solana_nonce::{self as nonce, state::DurableNonce},
         solana_packet::{Meta, PACKET_DATA_SIZE},
         solana_perf::packet::{Packet, PacketBatch, RecycledPacketBatch},
         solana_pubkey::Pubkey,
         solana_runtime::bank_forks::BankForks,
+        solana_sdk_ids::system_program,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_system_transaction::transfer,
-        solana_transaction::versioned::VersionedTransaction,
+        solana_transaction::{Transaction, versioned::VersionedTransaction},
         std::sync::{Arc, RwLock},
+        test_case::test_case,
     };
 
     fn test_bank_forks() -> (Arc<RwLock<BankForks>>, Keypair) {
+        _test_bank_forks(0)
+    }
+
+    fn test_bank_forks_with_fee() -> (Arc<RwLock<BankForks>>, Keypair) {
+        _test_bank_forks(5_000)
+    }
+
+    fn _test_bank_forks(fee: u64) -> (Arc<RwLock<BankForks>>, Keypair) {
         let GenesisConfigInfo {
-            genesis_config,
+            mut genesis_config,
             mint_keypair,
             ..
         } = create_slow_genesis_config(u64::MAX);
+        genesis_config.fee_rate_governor = FeeRateGovernor::new(fee, 0);
 
         let (_bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         (bank_forks, mint_keypair)
@@ -615,13 +610,22 @@ mod tests {
     // verify container state makes sense:
     // 1. Number of transactions matches expectation
     // 2. All transactions IDs in priority queue exist in the map
+    // 3. Nonce transactions have a matching nonces-in-use entry.
+    #[track_caller]
     fn verify_container<Tx: TransactionWithMeta>(
         container: &mut impl StateContainer<Tx>,
         expected_length: usize,
     ) {
         let mut actual_length: usize = 0;
         while let Some(id) = container.pop() {
-            let Some(_) = container.get_transaction(id.id) else {
+            if let Some(state) = container.get_mut_transaction_state(id.id) {
+                if let Some(nonce) = state.nonce_address().cloned() {
+                    assert_eq!(
+                        id,
+                        *container.get_nonce_transaction_priority_id(&nonce).unwrap()
+                    );
+                }
+            } else {
                 panic!(
                     "transaction in queue position {} with id {} must exist.",
                     actual_length, id.id
@@ -631,6 +635,19 @@ mod tests {
         }
 
         assert_eq!(actual_length, expected_length);
+    }
+
+    fn send_transactions(sender: &Sender<BankingPacketBatch>, transactions: &[Transaction]) {
+        sender.send(to_banking_packet_batch(transactions)).unwrap();
+    }
+
+    fn receive(
+        receive_and_buffer: &mut TransactionViewReceiveAndBuffer,
+        container: &mut TransactionViewStateContainer,
+    ) -> ReceivingStats {
+        receive_and_buffer
+            .receive_and_buffer_packets(container, &BufferedPacketsDecision::Hold)
+            .unwrap()
     }
 
     #[test]
@@ -697,7 +714,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -716,7 +735,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
         verify_container(&mut container, 0);
     }
 
@@ -752,7 +773,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -768,7 +791,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
     }
@@ -796,7 +821,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -812,7 +839,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
     }
@@ -839,7 +868,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -855,7 +886,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
     }
@@ -887,7 +920,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -903,7 +938,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 1);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
     }
@@ -950,7 +987,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -966,7 +1005,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
     }
@@ -998,7 +1039,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -1014,7 +1057,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 1);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 1);
     }
@@ -1172,7 +1217,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -1188,7 +1235,9 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert!(num_dropped_on_capacity > 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, num_transactions);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, TEST_CONTAINER_CAPACITY);
     }
@@ -1252,7 +1301,9 @@ mod tests {
             num_dropped_on_fee_payer,
             num_dropped_on_filter_key: _,
             num_dropped_on_capacity,
+            num_dropped_on_nonce_dedup,
             num_buffered,
+            num_evicted_on_nonce_dedup,
             receive_time_us: _,
             buffer_time_us: _,
         } = receive_and_buffer
@@ -1268,8 +1319,518 @@ mod tests {
         assert_eq!(num_dropped_on_already_processed, 0);
         assert_eq!(num_dropped_on_fee_payer, 0);
         assert_eq!(num_dropped_on_capacity, 0);
+        assert_eq!(num_dropped_on_nonce_dedup, 0);
         assert_eq!(num_buffered, 0);
+        assert_eq!(num_evicted_on_nonce_dedup, 0);
 
         verify_container(&mut container, 0);
+    }
+
+    const LOW_FEE: u64 = 1;
+    const HIGH_FEE: u64 = 1_000_000;
+
+    // sets up a nonce account in the bank for a true nonce transaction, or returns a recent
+    // blockhash for a pseudo-nonce transaction
+    fn create_nonce_identity(
+        bank_forks: &RwLock<BankForks>,
+        nonce_authority: &Pubkey,
+        true_nonce: bool,
+    ) -> (Pubkey, Hash) {
+        let nonce_pubkey = Pubkey::new_unique();
+        if true_nonce {
+            let bank = bank_forks.read().unwrap().root_bank();
+            let nonce_data = nonce::state::Data::new(
+                *nonce_authority,
+                DurableNonce::from_blockhash(&Hash::new_unique()),
+                5_000,
+            );
+            let nonce_account = AccountSharedData::new_data(
+                bank.get_minimum_balance_for_rent_exemption(nonce::state::State::size()),
+                &nonce::versions::Versions::new(nonce::state::State::Initialized(
+                    nonce_data.clone(),
+                )),
+                &system_program::id(),
+            )
+            .unwrap();
+            bank.store_account(&nonce_pubkey, &nonce_account);
+            (nonce_pubkey, nonce_data.blockhash())
+        } else {
+            let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
+            (nonce_pubkey, blockhash)
+        }
+    }
+
+    // build a nonce transaction
+    fn create_nonce_transaction(
+        fee_payer: &Keypair,
+        nonce_pubkey: &Pubkey,
+        compute_unit_price: u64,
+        lifetime: Hash,
+    ) -> Transaction {
+        let ixs = [
+            system_instruction::advance_nonce_account(nonce_pubkey, &fee_payer.pubkey()),
+            ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
+            system_instruction::transfer(&fee_payer.pubkey(), &Pubkey::new_unique(), 1),
+        ];
+        let message = Message::new(&ixs, Some(&fee_payer.pubkey()));
+        Transaction::new(&[fee_payer], message, lifetime)
+    }
+
+    // adding nonce transactions works normally. different nonces dont conflict
+    #[test]
+    fn test_receive_and_buffer_nonce_tracked() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey1, lifetime1) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey2, lifetime2) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        send_transactions(
+            &sender,
+            &[
+                create_nonce_transaction(&mint_keypair, &nonce_pubkey1, LOW_FEE, lifetime1),
+                create_nonce_transaction(&mint_keypair, &nonce_pubkey2, HIGH_FEE, lifetime2),
+            ],
+        );
+
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_buffered, 2);
+        assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+
+        let nonce_entry1 = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey1)
+            .unwrap();
+        let nonce_entry2 = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey2)
+            .unwrap();
+
+        assert!(container.is_queued(&nonce_entry1));
+        assert!(container.is_queued(&nonce_entry2));
+
+        container.remove_by_id(nonce_entry1.id);
+        assert!(!container.is_queued(&nonce_entry1));
+        assert!(container.is_queued(&nonce_entry2));
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey1)
+                .is_none()
+        );
+
+        container.remove_by_id(nonce_entry2.id);
+        assert!(!container.is_queued(&nonce_entry1));
+        assert!(!container.is_queued(&nonce_entry2));
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey2)
+                .is_none()
+        );
+
+        verify_container(&mut container, 0);
+    }
+
+    // a higher priority incoming nonce transaction evicts the existing
+    // a lower or equal priority incoming nonce transaction is dropped
+    #[test_case((HIGH_FEE, LOW_FEE); "hilo_drop")]
+    #[test_case((HIGH_FEE, HIGH_FEE); "hihi_drop")]
+    #[test_case((LOW_FEE, HIGH_FEE); "lohi_evict")]
+    fn test_receive_and_buffer_nonce_dedup_drop_evict(fees: (u64, u64)) {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        let (old_fee, new_fee) = fees;
+        let new_has_priority = new_fee > old_fee;
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                old_fee,
+                lifetime,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+        let prior_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                new_fee,
+                lifetime,
+            )],
+        );
+
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        let current_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+
+        if new_has_priority {
+            assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+            assert_eq!(stats.num_evicted_on_nonce_dedup, 1);
+            assert_eq!(stats.num_buffered, 1);
+
+            assert_ne!(prior_nonce_entry, current_nonce_entry);
+            assert!(current_nonce_entry.priority > prior_nonce_entry.priority);
+            assert!(
+                container
+                    .get_mut_transaction_state(prior_nonce_entry.id)
+                    .is_none()
+            );
+        } else {
+            assert_eq!(stats.num_dropped_on_nonce_dedup, 1);
+            assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+            assert_eq!(stats.num_buffered, 0);
+            assert_eq!(prior_nonce_entry, current_nonce_entry);
+        }
+
+        assert!(container.is_queued(&current_nonce_entry));
+
+        verify_container(&mut container, 1);
+    }
+
+    // a scheduled or held nonce transaction is never evicted regardless of priority
+    #[test_case(false; "held")]
+    #[test_case(true; "scheduled")]
+    fn test_receive_and_buffer_nonce_dedup_preserves_in_flight(is_scheduled: bool) {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                LOW_FEE,
+                lifetime,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+
+        let queue_entry = container.pop().unwrap();
+        if is_scheduled {
+            container
+                .get_mut_transaction_state(queue_entry.id)
+                .unwrap()
+                .take_transaction_for_scheduling();
+        } else {
+            container.hold_transaction(queue_entry);
+        }
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                HIGH_FEE,
+                lifetime,
+            )],
+        );
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_dropped_on_nonce_dedup, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        assert_eq!(stats.num_buffered, 0);
+
+        let nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+        assert_eq!(queue_entry, nonce_entry);
+        assert!(
+            container
+                .get_mut_transaction_state(nonce_entry.id)
+                .is_some()
+        );
+    }
+
+    // a higher priority nonce transaction that fails validation does not harm the existing one
+    #[test]
+    fn test_receive_and_buffer_nonce_dedup_validation_failure() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                LOW_FEE,
+                lifetime,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+        let prior_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+
+        // bad blockhash
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                HIGH_FEE,
+                Hash::new_unique(),
+            )],
+        );
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_dropped_on_age, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+        assert_eq!(stats.num_buffered, 0);
+
+        // bad feepayer
+        let bad_payer = Keypair::new();
+        let message = Message::new(
+            &[
+                system_instruction::advance_nonce_account(&nonce_pubkey, &mint_keypair.pubkey()),
+                ComputeBudgetInstruction::set_compute_unit_price(HIGH_FEE),
+                system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 1),
+            ],
+            Some(&bad_payer.pubkey()),
+        );
+        let transaction = Transaction::new(&[&bad_payer, &mint_keypair], message, lifetime);
+
+        send_transactions(&sender, &[transaction]);
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_dropped_on_fee_payer, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+        assert_eq!(stats.num_buffered, 0);
+
+        let current_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+        assert_eq!(prior_nonce_entry, current_nonce_entry);
+        assert!(container.is_queued(&current_nonce_entry));
+
+        verify_container(&mut container, 1);
+    }
+
+    // when a nonce transaction is bumped for capacity, its nonce map entry is cleared
+    #[test]
+    fn test_receive_and_buffer_nonce_capacity_eviction() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, _container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let mut container = TransactionViewStateContainer::with_capacity(1);
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                0,
+                lifetime,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+
+        let nonce_entry = container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .cloned()
+            .unwrap();
+
+        let transaction = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank_forks.read().unwrap().root_bank().last_blockhash(),
+        );
+
+        send_transactions(&sender, &[transaction]);
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_buffered, 1);
+        assert_eq!(stats.num_dropped_on_capacity, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_none()
+        );
+        assert!(!container.is_queued(&nonce_entry));
+
+        verify_container(&mut container, 1);
+    }
+
+    // nonce-like blockhash transactions are queued but not tracked
+    #[test]
+    fn test_receive_and_buffer_pseudo_nonce_untracked() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                HIGH_FEE,
+                blockhash,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_none()
+        );
+
+        // a real nonce for the same account is still admitted and tracked
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                LOW_FEE,
+                lifetime,
+            )],
+        );
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_buffered, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_some()
+        );
+
+        verify_container(&mut container, 2);
+    }
+
+    // nonce transactions are dropped on invalid authority
+    #[test]
+    fn test_receive_and_buffer_nonce_invalid_authority() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &Keypair::new(),
+                &nonce_pubkey,
+                HIGH_FEE,
+                lifetime,
+            )],
+        );
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_dropped_on_age, 1);
+        assert_eq!(stats.num_buffered, 0);
+        assert!(
+            container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_none()
+        );
+
+        verify_container(&mut container, 0);
+    }
+
+    // pseudo-nonce blockhash transactions never evict real nonce transactions
+    #[test_case(LOW_FEE, HIGH_FEE; "lohi_coexist")]
+    #[test_case(HIGH_FEE, LOW_FEE; "hilo_drop")]
+    fn test_receive_and_buffer_pseudo_nonce_never_evicts(real_fee: u64, pseudo_fee: u64) {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+        let (nonce_pubkey, lifetime) =
+            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
+        let pseudo_has_priority = pseudo_fee > real_fee;
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                real_fee,
+                lifetime,
+            )],
+        );
+        assert_eq!(
+            receive(&mut receive_and_buffer, &mut container).num_buffered,
+            1
+        );
+        let nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+
+        send_transactions(
+            &sender,
+            &[create_nonce_transaction(
+                &mint_keypair,
+                &nonce_pubkey,
+                pseudo_fee,
+                blockhash,
+            )],
+        );
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        let expected_len = if pseudo_has_priority {
+            assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+            assert_eq!(stats.num_buffered, 1);
+            2
+        } else {
+            assert_eq!(stats.num_dropped_on_nonce_dedup, 1);
+            assert_eq!(stats.num_buffered, 0);
+            1
+        };
+
+        // the real nonce transaction still holds the nonce and is queued
+        assert_eq!(
+            *container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .unwrap(),
+            nonce_entry
+        );
+        assert!(container.is_queued(&nonce_entry));
+
+        verify_container(&mut container, expected_len);
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -69,46 +69,34 @@ pub(crate) struct ReceivingStats {
     pub buffer_time_us: u64,
 }
 
-trait RecordReceiveError {
-    fn record_err(&self, receiving_stats: &mut ReceivingStats);
-}
-
-impl RecordReceiveError for PacketHandlingError {
-    fn record_err(&self, receiving_stats: &mut ReceivingStats) {
-        match self {
+impl ReceivingStats {
+    fn add_packet_handling_error(&mut self, err: &PacketHandlingError) {
+        match err {
             PacketHandlingError::Sanitization | PacketHandlingError::ALTResolution => {
-                receiving_stats.num_dropped_on_parsing_and_sanitization += 1;
+                self.num_dropped_on_parsing_and_sanitization += 1;
             }
             PacketHandlingError::LockValidation => {
-                receiving_stats.num_dropped_on_lock_validation += 1;
+                self.num_dropped_on_lock_validation += 1;
             }
             PacketHandlingError::ComputeBudget => {
-                receiving_stats.num_dropped_on_compute_budget += 1;
+                self.num_dropped_on_compute_budget += 1;
             }
             PacketHandlingError::FilterKey => {
-                receiving_stats.num_dropped_on_filter_key += 1;
+                self.num_dropped_on_filter_key += 1;
             }
         }
     }
-}
 
-impl RecordReceiveError for TransactionError {
-    fn record_err(&self, receiving_stats: &mut ReceivingStats) {
-        match self {
+    fn add_transaction_error(&mut self, err: &TransactionError) {
+        match err {
             TransactionError::BlockhashNotFound => {
-                receiving_stats.num_dropped_on_age += 1;
+                self.num_dropped_on_age += 1;
             }
             TransactionError::AlreadyProcessed => {
-                receiving_stats.num_dropped_on_already_processed += 1;
+                self.num_dropped_on_already_processed += 1;
             }
             _ => {}
         }
-    }
-}
-
-impl ReceivingStats {
-    fn record_err<E: RecordReceiveError>(&mut self, err: &E) {
-        err.record_err(self);
     }
 
     fn accumulate(&mut self, other: ReceivingStats) {
@@ -296,7 +284,7 @@ impl TransactionViewReceiveAndBuffer {
 
                         // Parsing or some other static checks failed.
                         Err(ref err) => {
-                            receiving_stats.record_err(err);
+                            receiving_stats.add_packet_handling_error(err);
                             Err(())
                         }
                     }
@@ -351,7 +339,7 @@ impl TransactionViewReceiveAndBuffer {
 
                     // Invalid
                     Err(ref err) => {
-                        receiving_stats.record_err(err);
+                        receiving_stats.add_transaction_error(err);
                         container.remove_by_id(transaction_id);
                         continue;
                     }

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -313,25 +313,22 @@ impl TransactionViewReceiveAndBuffer {
                     .expect("transaction must exist");
                 let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
-                // When we first receive a transaction, we drop it if a) it looks nonce-like, and
-                // b) there is a higher-priority nonce transaction using the same nonce in the queue,
+                // When we first receive a transaction, we drop it if a) it looks nonce-like, AND
+                // b) there is a higher-priority nonce transaction using the same nonce in the queue
                 // or any in-flight nonce transaction using the same nonce. This means we discard
                 // blockhash transactions structured like nonce transactions; this is acceptable because
                 // they would fail after the earlier nonce transaction is processed, and it allows us to
                 // prefilter without loading from accounts-db.
-                if let Some(nonce_address) = raw_nonce_address
-                    && let Some(existing_nonce_priority_id) =
-                        container.get_nonce_transaction_priority_id(&nonce_address)
-                {
-                    // There is a queued transaction with higher priority, or any in-flight transaction,
-                    // using this nonce account. Drop the new transaction.
-                    if existing_nonce_priority_id.priority >= priority
-                        || !container.is_queued(existing_nonce_priority_id)
-                    {
-                        receiving_stats.num_dropped_on_nonce_dedup += 1;
-                        container.remove_by_id(transaction_id);
-                        continue;
-                    }
+                let drop_incoming_nonce_tx = raw_nonce_address
+                    .and_then(|address| container.get_nonce_transaction_priority_id(&address))
+                    .is_some_and(|existing| {
+                        existing.priority >= priority || !container.is_queued(existing)
+                    });
+
+                if drop_incoming_nonce_tx {
+                    receiving_stats.num_dropped_on_nonce_dedup += 1;
+                    container.remove_by_id(transaction_id);
+                    continue;
                 }
 
                 let transaction = container
@@ -339,14 +336,20 @@ impl TransactionViewReceiveAndBuffer {
                     .expect("transaction must exist");
 
                 // Check blockhash transaction age is ok, or nonce transaction has a valid nonce.
-                // This nonce, not the nonce we got from the raw transaction bytes, will be used for eviction.
-                let verified_nonce_address = match working_bank
+                // Only a fully validated nonce address can be used for priority queue eviction.
+                let validated_nonce_address = match working_bank
                     .check_transaction_without_status_cache(
                         transaction,
                         working_bank.max_processing_age(),
                         &mut error_counters,
                     ) {
-                    Ok(opt) => opt,
+                    // Valid nonce transaction
+                    Ok(Some(nonce_address)) => Some(nonce_address),
+
+                    // Valid blockhash transaction
+                    Ok(None) => None,
+
+                    // Invalid
                     Err(ref err) => {
                         receiving_stats.record_err(err);
                         container.remove_by_id(transaction_id);
@@ -365,10 +368,10 @@ impl TransactionViewReceiveAndBuffer {
                     continue;
                 };
 
-                // Now we know we have a verified, higher-priority nonce transaction than any which
-                // may exist in the priority queue. If there is one, evict it. Regardless, record this
-                // transaction's nonce as in use, if it is a nonce transaction.
-                if let Some(nonce_address) = verified_nonce_address {
+                // Now, if this is a nonce transaction, we know it is validated and higher-priority than any
+                // which may exist in the priority queue. If one is queued, evict it. Regardless, record the
+                // incoming nonce transaction's nonce as in-use.
+                if let Some(nonce_address) = validated_nonce_address {
                     if let Some(existing_nonce_priority_id) =
                         container.get_nonce_transaction_priority_id(&nonce_address)
                     {
@@ -425,7 +428,7 @@ impl TransactionViewReceiveAndBuffer {
         let (priority, cost) =
             calculate_priority_and_cost(working_bank, &view, &transaction_configuration);
 
-        Ok(TransactionState::new(view, max_age, priority, cost, None))
+        Ok(TransactionState::new(view, max_age, priority, cost))
     }
 }
 
@@ -1329,38 +1332,30 @@ mod tests {
     const LOW_FEE: u64 = 1;
     const HIGH_FEE: u64 = 1_000_000;
 
-    // sets up a nonce account in the bank for a true nonce transaction, or returns a recent
-    // blockhash for a pseudo-nonce transaction
+    // sets up a nonce account in the bank for a true nonce transaction
     fn create_nonce_identity(
         bank_forks: &RwLock<BankForks>,
         nonce_authority: &Pubkey,
-        true_nonce: bool,
     ) -> (Pubkey, Hash) {
         let nonce_pubkey = Pubkey::new_unique();
-        if true_nonce {
-            let bank = bank_forks.read().unwrap().root_bank();
-            let nonce_data = nonce::state::Data::new(
-                *nonce_authority,
-                DurableNonce::from_blockhash(&Hash::new_unique()),
-                5_000,
-            );
-            let nonce_account = AccountSharedData::new_data(
-                bank.get_minimum_balance_for_rent_exemption(nonce::state::State::size()),
-                &nonce::versions::Versions::new(nonce::state::State::Initialized(
-                    nonce_data.clone(),
-                )),
-                &system_program::id(),
-            )
-            .unwrap();
-            bank.store_account(&nonce_pubkey, &nonce_account);
-            (nonce_pubkey, nonce_data.blockhash())
-        } else {
-            let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
-            (nonce_pubkey, blockhash)
-        }
+        let bank = bank_forks.read().unwrap().root_bank();
+        let nonce_data = nonce::state::Data::new(
+            *nonce_authority,
+            DurableNonce::from_blockhash(&Hash::new_unique()),
+            5_000,
+        );
+        let nonce_account = AccountSharedData::new_data(
+            bank.get_minimum_balance_for_rent_exemption(nonce::state::State::size()),
+            &nonce::versions::Versions::new(nonce::state::State::Initialized(nonce_data.clone())),
+            &system_program::id(),
+        )
+        .unwrap();
+        bank.store_account(&nonce_pubkey, &nonce_account);
+        (nonce_pubkey, nonce_data.blockhash())
     }
 
-    // build a nonce transaction
+    // build a nonce-like transaction, which may be nonce- or blockhash-based, depending
+    // on the value of `lifetime`
     fn create_nonce_transaction(
         fee_payer: &Keypair,
         nonce_pubkey: &Pubkey,
@@ -1376,23 +1371,22 @@ mod tests {
         Transaction::new(&[fee_payer], message, lifetime)
     }
 
-    // adding nonce transactions works normally. different nonces dont conflict
+    // adding nonce transactions works normally. different nonces dont conflict,
+    // removing a nonce transaction removes its nonces-in-use entry
     #[test]
     fn test_receive_and_buffer_nonce_tracked() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey1, lifetime1) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
-        let (nonce_pubkey2, lifetime2) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey1, durable1) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
+        let (nonce_pubkey2, durable2) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
 
         send_transactions(
             &sender,
             &[
-                create_nonce_transaction(&mint_keypair, &nonce_pubkey1, LOW_FEE, lifetime1),
-                create_nonce_transaction(&mint_keypair, &nonce_pubkey2, HIGH_FEE, lifetime2),
+                create_nonce_transaction(&mint_keypair, &nonce_pubkey1, LOW_FEE, durable1),
+                create_nonce_transaction(&mint_keypair, &nonce_pubkey2, HIGH_FEE, durable2),
             ],
         );
 
@@ -1432,20 +1426,17 @@ mod tests {
         verify_container(&mut container, 0);
     }
 
-    // a higher priority incoming nonce transaction evicts the existing
+    // a higher priority incoming nonce transaction evicts the existing transaction,
     // a lower or equal priority incoming nonce transaction is dropped
-    #[test_case((HIGH_FEE, LOW_FEE); "hilo_drop")]
-    #[test_case((HIGH_FEE, HIGH_FEE); "hihi_drop")]
-    #[test_case((LOW_FEE, HIGH_FEE); "lohi_evict")]
-    fn test_receive_and_buffer_nonce_dedup_drop_evict(fees: (u64, u64)) {
+    #[test_case(HIGH_FEE, LOW_FEE; "hilo_drop")]
+    #[test_case(HIGH_FEE, HIGH_FEE; "hihi_drop")]
+    #[test_case(LOW_FEE, HIGH_FEE; "lohi_evict")]
+    fn test_receive_and_buffer_nonce_dedup_drop_evict(old_fee: u64, new_fee: u64) {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
-
-        let (old_fee, new_fee) = fees;
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
         let new_has_priority = new_fee > old_fee;
 
         send_transactions(
@@ -1454,7 +1445,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 old_fee,
-                lifetime,
+                durable,
             )],
         );
         assert_eq!(
@@ -1471,7 +1462,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 new_fee,
-                lifetime,
+                durable,
             )],
         );
 
@@ -1512,8 +1503,7 @@ mod tests {
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
 
         send_transactions(
             &sender,
@@ -1521,7 +1511,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 LOW_FEE,
-                lifetime,
+                durable,
             )],
         );
         assert_eq!(
@@ -1545,7 +1535,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 HIGH_FEE,
-                lifetime,
+                durable,
             )],
         );
         let stats = receive(&mut receive_and_buffer, &mut container);
@@ -1564,15 +1554,15 @@ mod tests {
         );
     }
 
-    // a higher priority nonce transaction that fails validation does not harm the existing one
+    // a higher priority nonce transaction that fails validation does not evict the existing one,
+    // and does not affect its nonces-in-use entry
     #[test]
     fn test_receive_and_buffer_nonce_dedup_validation_failure() {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
 
         send_transactions(
             &sender,
@@ -1580,7 +1570,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 LOW_FEE,
-                lifetime,
+                durable,
             )],
         );
         assert_eq!(
@@ -1607,6 +1597,36 @@ mod tests {
         assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
         assert_eq!(stats.num_buffered, 0);
 
+        let current_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+        assert_eq!(prior_nonce_entry, current_nonce_entry);
+        assert!(container.is_queued(&current_nonce_entry));
+
+        // bad authority
+        let bad_authority = Keypair::new();
+        let message = Message::new(
+            &[
+                system_instruction::advance_nonce_account(&nonce_pubkey, &bad_authority.pubkey()),
+                ComputeBudgetInstruction::set_compute_unit_price(HIGH_FEE),
+                system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 1),
+            ],
+            Some(&mint_keypair.pubkey()),
+        );
+        let transaction = Transaction::new(&[&mint_keypair, &bad_authority], message, durable);
+        send_transactions(&sender, &[transaction]);
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_dropped_on_age, 1);
+        assert_eq!(stats.num_evicted_on_nonce_dedup, 0);
+        assert_eq!(stats.num_dropped_on_nonce_dedup, 0);
+        assert_eq!(stats.num_buffered, 0);
+
+        let current_nonce_entry = *container
+            .get_nonce_transaction_priority_id(&nonce_pubkey)
+            .unwrap();
+        assert_eq!(prior_nonce_entry, current_nonce_entry);
+        assert!(container.is_queued(&current_nonce_entry));
+
         // bad feepayer
         let bad_payer = Keypair::new();
         let message = Message::new(
@@ -1617,8 +1637,7 @@ mod tests {
             ],
             Some(&bad_payer.pubkey()),
         );
-        let transaction = Transaction::new(&[&bad_payer, &mint_keypair], message, lifetime);
-
+        let transaction = Transaction::new(&[&bad_payer, &mint_keypair], message, durable);
         send_transactions(&sender, &[transaction]);
         let stats = receive(&mut receive_and_buffer, &mut container);
         assert_eq!(stats.num_dropped_on_fee_payer, 1);
@@ -1643,8 +1662,7 @@ mod tests {
         let (mut receive_and_buffer, _container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
         let mut container = TransactionViewStateContainer::with_capacity(1);
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
 
         send_transactions(
             &sender,
@@ -1652,7 +1670,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 0,
-                lifetime,
+                durable,
             )],
         );
         assert_eq!(
@@ -1665,6 +1683,7 @@ mod tests {
             .cloned()
             .unwrap();
 
+        // the previous txn is 0 priority, so this evicts it, even with 0 priority
         let transaction = transfer(
             &mint_keypair,
             &Pubkey::new_unique(),
@@ -1695,8 +1714,7 @@ mod tests {
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
         let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
 
         send_transactions(
@@ -1725,7 +1743,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 LOW_FEE,
-                lifetime,
+                durable,
             )],
         );
         let stats = receive(&mut receive_and_buffer, &mut container);
@@ -1740,47 +1758,16 @@ mod tests {
         verify_container(&mut container, 2);
     }
 
-    // nonce transactions are dropped on invalid authority
-    #[test]
-    fn test_receive_and_buffer_nonce_invalid_authority() {
-        let (sender, receiver) = bounded(1024);
-        let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
-        let (mut receive_and_buffer, mut container) =
-            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
-
-        send_transactions(
-            &sender,
-            &[create_nonce_transaction(
-                &Keypair::new(),
-                &nonce_pubkey,
-                HIGH_FEE,
-                lifetime,
-            )],
-        );
-        let stats = receive(&mut receive_and_buffer, &mut container);
-        assert_eq!(stats.num_dropped_on_age, 1);
-        assert_eq!(stats.num_buffered, 0);
-        assert!(
-            container
-                .get_nonce_transaction_priority_id(&nonce_pubkey)
-                .is_none()
-        );
-
-        verify_container(&mut container, 0);
-    }
-
-    // pseudo-nonce blockhash transactions never evict real nonce transactions
+    // nonce-like blockhash transactions never evict real nonce transactions
     #[test_case(LOW_FEE, HIGH_FEE; "lohi_coexist")]
     #[test_case(HIGH_FEE, LOW_FEE; "hilo_drop")]
+    #[test_case(HIGH_FEE, HIGH_FEE; "hihi_drop")]
     fn test_receive_and_buffer_pseudo_nonce_never_evicts(real_fee: u64, pseudo_fee: u64) {
         let (sender, receiver) = bounded(1024);
         let (bank_forks, mint_keypair) = test_bank_forks_with_fee();
         let (mut receive_and_buffer, mut container) =
             setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
-        let (nonce_pubkey, lifetime) =
-            create_nonce_identity(&bank_forks, &mint_keypair.pubkey(), true);
+        let (nonce_pubkey, durable) = create_nonce_identity(&bank_forks, &mint_keypair.pubkey());
         let blockhash = bank_forks.read().unwrap().root_bank().last_blockhash();
         let pseudo_has_priority = pseudo_fee > real_fee;
 
@@ -1790,7 +1777,7 @@ mod tests {
                 &mint_keypair,
                 &nonce_pubkey,
                 real_fee,
-                lifetime,
+                durable,
             )],
         );
         assert_eq!(

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -468,7 +468,9 @@ where
                 num_dropped_on_fee_payer,
                 num_dropped_on_filter_key,
                 num_dropped_on_capacity,
+                num_dropped_on_nonce_dedup,
                 num_buffered,
+                num_evicted_on_nonce_dedup,
                 receive_time_us: _,
                 buffer_time_us: _,
             } = &receiving_stats;
@@ -485,7 +487,9 @@ where
             count_metrics.num_dropped_on_receive_fee_payer += *num_dropped_on_fee_payer;
             count_metrics.num_dropped_on_filter_key += *num_dropped_on_filter_key;
             count_metrics.num_dropped_on_capacity += *num_dropped_on_capacity;
+            count_metrics.num_dropped_on_nonce_dedup += *num_dropped_on_nonce_dedup;
             count_metrics.num_buffered += *num_buffered;
+            count_metrics.num_evicted_on_nonce_dedup += *num_evicted_on_nonce_dedup;
         });
 
         self.timing_metrics.update(|timing_metrics| {
@@ -540,16 +544,19 @@ mod tests {
         },
         crossbeam_channel::{Receiver, Sender, bounded},
         itertools::Itertools,
+        solana_account::AccountSharedData,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_fee_calculator::FeeRateGovernor,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::GenesisConfigInfo,
         solana_message::Message,
+        solana_nonce::{self as nonce, state::DurableNonce},
         solana_poh::poh_recorder::{LeaderState, SharedLeaderState},
         solana_pubkey::Pubkey,
         solana_runtime::{bank::Bank, bank_forks::BankForks},
         solana_runtime_transaction::transaction_meta::TransactionMeta,
+        solana_sdk_ids::system_program,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::Transaction,
@@ -665,6 +672,108 @@ mod tests {
         let prioritization = ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
         let message = Message::new(&[transfer, prioritization], Some(&from_keypair.pubkey()));
         Transaction::new(&vec![from_keypair], message, recent_blockhash)
+    }
+
+    fn create_nonce_account_and_transaction(
+        bank: &Bank,
+        mint_keypair: &Keypair,
+    ) -> (Transaction, Pubkey) {
+        let nonce_pubkey = Pubkey::new_unique();
+        let nonce_data = nonce::state::Data::new(
+            mint_keypair.pubkey(),
+            DurableNonce::from_blockhash(&Hash::new_unique()),
+            5000,
+        );
+        let nonce_account = AccountSharedData::new_data(
+            bank.get_minimum_balance_for_rent_exemption(nonce::state::State::size()),
+            &nonce::versions::Versions::new(nonce::state::State::Initialized(nonce_data.clone())),
+            &system_program::id(),
+        )
+        .unwrap();
+        bank.store_account(&nonce_pubkey, &nonce_account);
+
+        let ixs = [
+            system_instruction::advance_nonce_account(&nonce_pubkey, &mint_keypair.pubkey()),
+            system_instruction::transfer(&mint_keypair.pubkey(), &Pubkey::new_unique(), 1),
+        ];
+        let message = Message::new(&ixs, Some(&mint_keypair.pubkey()));
+        let transaction = Transaction::new(&[mint_keypair], message, nonce_data.blockhash());
+        (transaction, nonce_pubkey)
+    }
+
+    // `clear_container()` removes nonce map entries with nonce transactions
+    #[test]
+    fn test_clear_container_clears_nonce_entry() {
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
+        let TestFrame {
+            bank,
+            mint_keypair,
+            banking_packet_sender,
+            ..
+        } = &mut test_frame;
+
+        let (transaction, nonce_pubkey) = create_nonce_account_and_transaction(bank, mint_keypair);
+        banking_packet_sender
+            .send(to_banking_packet_batch(&[transaction]))
+            .unwrap();
+        scheduler_controller
+            .receive_and_buffer_packets(&BufferedPacketsDecision::Hold)
+            .unwrap();
+
+        assert!(
+            scheduler_controller
+                .container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_some()
+        );
+
+        scheduler_controller.clear_container();
+
+        assert!(
+            scheduler_controller
+                .container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_none()
+        );
+    }
+
+    // `incremental_recheck()` removes nonce map entries with nonce transactions
+    #[test]
+    fn test_incremental_recheck_clears_nonce_entry() {
+        let (mut test_frame, mut scheduler_controller) =
+            create_test_frame(1, test_create_transaction_view_receive_and_buffer);
+        let TestFrame {
+            bank,
+            mint_keypair,
+            banking_packet_sender,
+            ..
+        } = &mut test_frame;
+
+        let (transaction, nonce_pubkey) = create_nonce_account_and_transaction(bank, mint_keypair);
+        banking_packet_sender
+            .send(to_banking_packet_batch(std::slice::from_ref(&transaction)))
+            .unwrap();
+        scheduler_controller
+            .receive_and_buffer_packets(&BufferedPacketsDecision::Hold)
+            .unwrap();
+
+        assert!(
+            scheduler_controller
+                .container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_some()
+        );
+
+        bank.process_transaction(&transaction).unwrap();
+        scheduler_controller.incremental_recheck();
+
+        assert!(
+            scheduler_controller
+                .container
+                .get_nonce_transaction_priority_id(&nonce_pubkey)
+                .is_none()
+        );
     }
 
     // Helper function to let test receive and then schedule packets.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -85,6 +85,8 @@ pub struct SchedulerCountMetricsInner {
     pub num_dropped_on_clean: Saturating<usize>,
     /// Number of transactions that were dropped due to exceeded capacity.
     pub num_dropped_on_capacity: Saturating<usize>,
+    pub num_dropped_on_nonce_dedup: Saturating<usize>,
+    pub num_evicted_on_nonce_dedup: Saturating<usize>,
     /// Min prioritization fees in the transaction container
     pub min_prioritization_fees: u64,
     /// Max prioritization fees in the transaction container
@@ -140,6 +142,8 @@ impl SchedulerCountMetricsInner {
             num_dropped_on_clear: Saturating(num_dropped_on_clear),
             num_dropped_on_clean: Saturating(num_dropped_on_clean),
             num_dropped_on_capacity: Saturating(num_dropped_on_capacity),
+            num_dropped_on_nonce_dedup: Saturating(num_dropped_on_nonce_dedup),
+            num_evicted_on_nonce_dedup: Saturating(num_evicted_on_nonce_dedup),
             min_prioritization_fees: _min_prioritization_fees,
             max_prioritization_fees: _max_prioritization_fees,
         } = self;
@@ -187,6 +191,8 @@ impl SchedulerCountMetricsInner {
                 i64
             ),
             ("num_dropped_on_capacity", num_dropped_on_capacity, i64),
+            ("num_dropped_on_nonce_dedup", num_dropped_on_nonce_dedup, i64),
+            ("num_evicted_on_nonce_dedup", num_evicted_on_nonce_dedup, i64),
             ("min_priority", self.get_min_priority(), i64),
             ("max_priority", self.get_max_priority(), i64),
         );
@@ -226,6 +232,8 @@ impl SchedulerCountMetricsInner {
         self.num_dropped_on_clear = Saturating(0);
         self.num_dropped_on_clean = Saturating(0);
         self.num_dropped_on_capacity = Saturating(0);
+        self.num_dropped_on_nonce_dedup = Saturating(0);
+        self.num_evicted_on_nonce_dedup = Saturating(0);
         self.min_prioritization_fees = u64::MAX;
         self.max_prioritization_fees = 0;
     }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -20,25 +20,19 @@ pub(crate) struct TransactionState<Tx> {
     priority: u64,
     /// Estimated cost of the transaction.
     cost: u64,
-    /// Nonce address, if this is a nonce transaction.
+    /// Nonce address, if this is a validated nonce transaction.
     nonce_address: Option<Pubkey>,
 }
 
 impl<Tx> TransactionState<Tx> {
     /// Creates a new `TransactionState` in the `Unprocessed` state.
-    pub(crate) fn new(
-        transaction: Tx,
-        max_age: MaxAge,
-        priority: u64,
-        cost: u64,
-        nonce_address: Option<Pubkey>,
-    ) -> Self {
+    pub(crate) fn new(transaction: Tx, max_age: MaxAge, priority: u64, cost: u64) -> Self {
         Self {
             transaction: Some(transaction),
             max_age,
             priority,
             cost,
-            nonce_address,
+            nonce_address: None,
         }
     }
 
@@ -94,6 +88,8 @@ impl<Tx> TransactionState<Tx> {
             .expect("transaction is not pending")
     }
 
+    /// Set the nonce address, used in `set_nonce_transaction_priority_id()` after
+    /// the nonce transaction is fully validated.
     pub(crate) fn set_nonce_address(&mut self, nonce_address: Option<Pubkey>) {
         self.nonce_address = nonce_address;
     }
@@ -130,7 +126,6 @@ mod tests {
             MaxAge::MAX,
             compute_unit_price,
             TEST_TRANSACTION_COST,
-            None,
         )
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,4 +1,4 @@
-use crate::banking_stage::scheduler_messages::MaxAge;
+use {crate::banking_stage::scheduler_messages::MaxAge, solana_pubkey::Pubkey};
 
 /// TransactionState is used to track the state of a transaction in the transaction scheduler
 /// and banking stage as a whole.
@@ -20,16 +20,25 @@ pub(crate) struct TransactionState<Tx> {
     priority: u64,
     /// Estimated cost of the transaction.
     cost: u64,
+    /// Nonce address, if this is a nonce transaction.
+    nonce_address: Option<Pubkey>,
 }
 
 impl<Tx> TransactionState<Tx> {
     /// Creates a new `TransactionState` in the `Unprocessed` state.
-    pub(crate) fn new(transaction: Tx, max_age: MaxAge, priority: u64, cost: u64) -> Self {
+    pub(crate) fn new(
+        transaction: Tx,
+        max_age: MaxAge,
+        priority: u64,
+        cost: u64,
+        nonce_address: Option<Pubkey>,
+    ) -> Self {
         Self {
             transaction: Some(transaction),
             max_age,
             priority,
             cost,
+            nonce_address,
         }
     }
 
@@ -43,6 +52,11 @@ impl<Tx> TransactionState<Tx> {
     /// Return the cost of the transaction.
     pub(crate) fn cost(&self) -> u64 {
         self.cost
+    }
+
+    /// Return the nonce address of the transaction, if one exists.
+    pub(crate) fn nonce_address(&self) -> Option<&Pubkey> {
+        self.nonce_address.as_ref()
     }
 
     /// Intended to be called when a transaction is scheduled. This method
@@ -79,6 +93,10 @@ impl<Tx> TransactionState<Tx> {
             .as_ref()
             .expect("transaction is not pending")
     }
+
+    pub(crate) fn set_nonce_address(&mut self, nonce_address: Option<Pubkey>) {
+        self.nonce_address = nonce_address;
+    }
 }
 
 #[cfg(test)]
@@ -112,6 +130,7 @@ mod tests {
             MaxAge::MAX,
             compute_unit_price,
             TEST_TRANSACTION_COST,
+            None,
         )
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -4,10 +4,16 @@ use {
     agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
     slab::{Slab, VacantEntry},
     solana_packet::PACKET_DATA_SIZE,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
     },
-    std::{collections::BTreeSet, iter::Rev, ops::Bound, sync::Arc},
+    std::{
+        collections::{BTreeSet, HashMap, hash_map::Entry},
+        iter::Rev,
+        ops::Bound,
+        sync::Arc,
+    },
 };
 
 /// This structure will hold `TransactionState` for the entirety of a
@@ -40,6 +46,7 @@ pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
     priority_queue: BTreeSet<TransactionPriorityId>,
     id_to_transaction_state: Slab<TransactionState<Tx>>,
     held_transactions: Vec<TransactionPriorityId>,
+    nonces_in_use: HashMap<Pubkey, TransactionPriorityId, PubkeyHasherBuilder>,
 }
 
 pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
@@ -112,6 +119,19 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
         &self,
         cursor: Option<&TransactionPriorityId>,
     ) -> Rev<std::collections::btree_set::Range<'_, TransactionPriorityId>>;
+
+    fn is_queued(&self, id: &TransactionPriorityId) -> bool;
+
+    fn get_nonce_transaction_priority_id(
+        &self,
+        nonce_address: &Pubkey,
+    ) -> Option<&TransactionPriorityId>;
+
+    fn set_nonce_transaction_priority_id(
+        &mut self,
+        nonce_address: &Pubkey,
+        priority_id: TransactionPriorityId,
+    );
 }
 
 // Extra capacity is added because some additional space is needed when
@@ -125,6 +145,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
             priority_queue: BTreeSet::new(),
             id_to_transaction_state: Slab::with_capacity(capacity + EXTRA_CAPACITY),
             held_transactions: Vec::with_capacity(capacity),
+            nonces_in_use: HashMap::with_hasher(PubkeyHasherBuilder::default()),
         }
     }
 
@@ -176,7 +197,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
 
         for _ in 0..num_dropped {
             let priority_id = self.priority_queue.pop_first().expect("queue is not empty");
-            self.id_to_transaction_state.remove(priority_id.id);
+            self.remove_state(priority_id.id);
         }
 
         num_dropped
@@ -187,11 +208,10 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
     }
 
     fn remove_by_id(&mut self, id: TransactionId) {
-        let state = self.id_to_transaction_state.remove(id);
+        let priority_id = self.remove_state(id);
         // Remove from queue if present. May not be present if the transaction was already popped
         // (in-flight/scheduling).
-        self.priority_queue
-            .remove(&TransactionPriorityId::new(state.priority(), id));
+        self.priority_queue.remove(&priority_id);
     }
 
     fn flush_held_transactions(&mut self) {
@@ -219,6 +239,28 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
                 .rev(),
         }
     }
+
+    fn is_queued(&self, id: &TransactionPriorityId) -> bool {
+        self.priority_queue.contains(id)
+    }
+
+    fn get_nonce_transaction_priority_id(
+        &self,
+        nonce_address: &Pubkey,
+    ) -> Option<&TransactionPriorityId> {
+        self.nonces_in_use.get(nonce_address)
+    }
+
+    fn set_nonce_transaction_priority_id(
+        &mut self,
+        nonce_address: &Pubkey,
+        priority_id: TransactionPriorityId,
+    ) {
+        self.nonces_in_use.insert(*nonce_address, priority_id);
+        if let Some(state) = self.id_to_transaction_state.get_mut(priority_id.id) {
+            state.set_nonce_address(Some(*nonce_address))
+        }
+    }
 }
 
 impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
@@ -235,7 +277,13 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         let priority_id = {
             let entry = self.get_vacant_map_entry();
             let transaction_id = entry.key();
-            entry.insert(TransactionState::new(transaction, max_age, priority, cost));
+            entry.insert(TransactionState::new(
+                transaction,
+                max_age,
+                priority,
+                cost,
+                None,
+            ));
             TransactionPriorityId::new(priority, transaction_id)
         };
 
@@ -245,6 +293,20 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
     fn get_vacant_map_entry(&mut self) -> VacantEntry<'_, TransactionState<Tx>> {
         assert!(self.id_to_transaction_state.len() < self.id_to_transaction_state.capacity());
         self.id_to_transaction_state.vacant_entry()
+    }
+
+    fn remove_state(&mut self, id: TransactionId) -> TransactionPriorityId {
+        let state = self.id_to_transaction_state.remove(id);
+        let priority_id = TransactionPriorityId::new(state.priority(), id);
+
+        if let Some(nonce_address) = state.nonce_address()
+            && let Entry::Occupied(entry) = self.nonces_in_use.entry(*nonce_address)
+            && *entry.get() == priority_id
+        {
+            entry.remove();
+        }
+
+        priority_id
     }
 }
 
@@ -383,6 +445,29 @@ impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
     ) -> Rev<std::collections::btree_set::Range<'_, TransactionPriorityId>> {
         self.inner.recheck_iter(cursor)
     }
+
+    #[inline]
+    fn is_queued(&self, id: &TransactionPriorityId) -> bool {
+        self.inner.is_queued(id)
+    }
+
+    #[inline]
+    fn get_nonce_transaction_priority_id(
+        &self,
+        nonce_address: &Pubkey,
+    ) -> Option<&TransactionPriorityId> {
+        self.inner.get_nonce_transaction_priority_id(nonce_address)
+    }
+
+    #[inline]
+    fn set_nonce_transaction_priority_id(
+        &mut self,
+        nonce_address: &Pubkey,
+        priority_id: TransactionPriorityId,
+    ) {
+        self.inner
+            .set_nonce_transaction_priority_id(nonce_address, priority_id);
+    }
 }
 
 #[cfg(test)]
@@ -501,7 +586,13 @@ mod tests {
             )
             .unwrap();
 
-            Ok(TransactionState::new(view, MaxAge::MAX, priority, cost))
+            Ok(TransactionState::new(
+                view,
+                MaxAge::MAX,
+                priority,
+                cost,
+                None,
+            ))
         };
 
         // Push 2 transactions into the queue so buffer is full.

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -600,7 +600,6 @@ mod tests {
         }
 
         // Push 5 additional packets in. 5 should be dropped.
-        let mut priority_ids = Vec::with_capacity(5);
         for priority in [10, 11, 12, 1, 2] {
             let (transaction, _max_age, priority, cost) = test_transaction(priority);
             let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
@@ -610,9 +609,11 @@ mod tests {
                 })
                 .unwrap();
             let priority_id = TransactionPriorityId::new(priority, id);
-            priority_ids.push(priority_id);
+            assert_eq!(
+                container.push_ids_into_queue(std::iter::once(priority_id)),
+                1,
+            );
         }
-        assert_eq!(container.push_ids_into_queue(priority_ids.into_iter()), 5);
         assert_eq!(container.pop().unwrap().priority, 12);
         assert_eq!(container.pop().unwrap().priority, 11);
         assert!(container.pop().is_none());

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -259,6 +259,8 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
         self.nonces_in_use.insert(*nonce_address, priority_id);
         if let Some(state) = self.id_to_transaction_state.get_mut(priority_id.id) {
             state.set_nonce_address(Some(*nonce_address))
+        } else {
+            debug_assert!(false, "transaction must exist");
         }
     }
 }
@@ -277,13 +279,7 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         let priority_id = {
             let entry = self.get_vacant_map_entry();
             let transaction_id = entry.key();
-            entry.insert(TransactionState::new(
-                transaction,
-                max_age,
-                priority,
-                cost,
-                None,
-            ));
+            entry.insert(TransactionState::new(transaction, max_age, priority, cost));
             TransactionPriorityId::new(priority, transaction_id)
         };
 
@@ -586,13 +582,7 @@ mod tests {
             )
             .unwrap();
 
-            Ok(TransactionState::new(
-                view,
-                MaxAge::MAX,
-                priority,
-                cost,
-                None,
-            ))
+            Ok(TransactionState::new(view, MaxAge::MAX, priority, cost))
         };
 
         // Push 2 transactions into the queue so buffer is full.

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -95,8 +95,6 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     /// Pushes transaction ids into the priority queue. If the queue if full,
     /// the lowest priority transactions will be dropped (removed from the
     /// queue and map) **after** all ids have been pushed.
-    /// To avoid allocating, the caller should not push more than
-    /// [`EXTRA_CAPACITY`] ids in a call.
     /// Returns the number of dropped transactions.
     fn push_ids_into_queue(
         &mut self,
@@ -134,9 +132,9 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
     );
 }
 
-// Extra capacity is added because some additional space is needed when
-// pushing a new transaction into the container to avoid reallocation.
-pub(crate) const EXTRA_CAPACITY: usize = 64;
+// Extra capacity is added to avoid reallocation because each new transaction
+// is added to the slab before anything can be evicted from a full queue.
+pub(crate) const EXTRA_CAPACITY: usize = 1;
 
 impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<Tx> {
     fn with_capacity(capacity: usize) -> Self {

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -6,7 +6,10 @@ use {
     solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_fee::calculate_fee_details,
-    solana_nonce::state::{Data as NonceData, DurableNonce, State as NonceState},
+    solana_nonce::{
+        NONCED_TX_MARKER_IX_INDEX,
+        state::{Data as NonceData, DurableNonce, State as NonceState},
+    },
     solana_nonce_account as nonce_account,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
     solana_pubkey::Pubkey,
@@ -66,24 +69,35 @@ impl Bank {
         .0
     }
 
-    /// Checks a batch of sanitized transactions against the bank for age and
-    /// compute-budget limits, without checking the status cache.
-    pub fn check_transactions_without_status_cache<Tx: TransactionWithMeta>(
+    /// Checks a sanitized transaction against the bank for age,
+    /// without checking the status cache. This is a leader-only
+    /// function and must not be used in replay without a feature gate.
+    pub fn check_transaction_without_status_cache(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: &[TransactionResult<()>],
+        tx: &impl SVMMessage,
         max_age: usize,
-        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
-    ) -> Vec<TransactionCheckResult> {
-        let lock_results = self.filter_v1_transactions(sanitized_txs, lock_results);
+    ) -> TransactionResult<Option<Pubkey>> {
+        let feature_set: &FeatureSet = &self.feature_set;
+        let feature_snapshot = feature_set.snapshot();
+        let enable_tx_v1 = feature_snapshot.enable_tx_v1;
 
-        self.check_age_and_compute_budget_limits(
-            sanitized_txs,
-            lock_results,
+        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
+            return Err(TransactionError::UnsupportedVersion);
+        }
+
+        let hash_queue = self.blockhash_queue.read().unwrap();
+        let last_blockhash = hash_queue.last_hash();
+        let next_durable_nonce = DurableNonce::from_blockhash(&last_blockhash);
+
+        self.check_transaction_age(
+            tx,
             max_age,
-            strict_nonce_size_check,
+            &next_durable_nonce,
+            &hash_queue,
             error_counters,
+            true, // strict_nonce_size_check
+            true, // strict_nonce_authority_check
         )
     }
 
@@ -193,15 +207,21 @@ impl Bank {
                         .inspect_err(|_err| {
                             error_counters.invalid_compute_budget += 1;
                         })?;
-                    self.check_transaction_age(
+
+                    let nonce_address = self.check_transaction_age(
                         tx.borrow(),
                         max_age,
                         &next_durable_nonce,
                         &hash_queue,
                         error_counters,
-                        compute_budget_and_limits,
                         strict_nonce_size_check,
-                    )
+                        false,
+                    )?;
+
+                    Ok(CheckedTransactionDetails::new(
+                        nonce_address,
+                        compute_budget_and_limits,
+                    ))
                 }
                 Err(e) => Err(e),
             })
@@ -215,22 +235,22 @@ impl Bank {
         next_durable_nonce: &DurableNonce,
         hash_queue: &BlockhashQueue,
         error_counters: &mut TransactionErrorMetrics,
-        compute_budget: SVMTransactionExecutionAndFeeBudgetLimits,
         strict_nonce_size_check: bool,
-    ) -> TransactionCheckResult {
+        strict_nonce_authority_check: bool,
+    ) -> TransactionResult<Option<Pubkey>> {
         let recent_blockhash = tx.recent_blockhash();
         if hash_queue
             .get_hash_info_if_valid(recent_blockhash, max_age)
             .is_some()
         {
-            Ok(CheckedTransactionDetails::new(None, compute_budget))
-        } else if let Some((nonce_address, _)) =
-            self.check_nonce_transaction_validity(tx, next_durable_nonce, strict_nonce_size_check)
-        {
-            Ok(CheckedTransactionDetails::new(
-                Some(nonce_address),
-                compute_budget,
-            ))
+            Ok(None)
+        } else if let Some((nonce_address, _)) = self.check_nonce_transaction_validity(
+            tx,
+            next_durable_nonce,
+            strict_nonce_size_check,
+            strict_nonce_authority_check,
+        ) {
+            Ok(Some(nonce_address))
         } else {
             error_counters.blockhash_not_found += 1;
             Err(TransactionError::BlockhashNotFound)
@@ -242,6 +262,7 @@ impl Bank {
         message: &impl SVMMessage,
         next_durable_nonce: &DurableNonce,
         strict_nonce_size_check: bool,
+        strict_nonce_authority_check: bool,
     ) -> Option<(Pubkey, u64)> {
         let nonce_is_advanceable = message.recent_blockhash() != next_durable_nonce.as_hash();
         if !nonce_is_advanceable {
@@ -250,6 +271,15 @@ impl Bank {
 
         let (nonce_address, nonce_data) =
             self.load_message_nonce_data(message, strict_nonce_size_check)?;
+
+        if strict_nonce_authority_check
+            && !message
+                .get_ix_signers(NONCED_TX_MARKER_IX_INDEX as usize)
+                .any(|signer| signer == &nonce_data.authority)
+        {
+            return None;
+        }
+
         let previous_lamports_per_signature = nonce_data.get_lamports_per_signature();
 
         Some((nonce_address, previous_lamports_per_signature))
@@ -352,7 +382,10 @@ mod tests {
             instruction::{self as system_instruction, SystemInstruction},
             program as system_program,
         },
-        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
+        solana_transaction::{
+            sanitized::{MessageHash, SanitizedTransaction},
+            versioned::VersionedTransaction,
+        },
         std::collections::HashSet,
     };
 
@@ -387,7 +420,12 @@ mod tests {
         bank.store_account(&nonce_pubkey, &nonce_account);
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false),
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                false,
+                false
+            ),
             Some((nonce_pubkey, STALE_LAMPORTS_PER_SIGNATURE)),
         );
     }
@@ -409,8 +447,13 @@ mod tests {
             &nonce_hash,
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
-                .is_none()
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                false,
+                false
+            )
+            .is_none()
         );
     }
 
@@ -442,8 +485,13 @@ mod tests {
         bank.store_account(&nonce_pubkey, &resized_nonce_account);
 
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), true)
-                .is_none()
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                true,
+                false
+            )
+            .is_none()
         );
     }
 
@@ -469,6 +517,7 @@ mod tests {
                 &new_sanitized_message(message),
                 &bank.next_durable_nonce(),
                 false,
+                false,
             )
             .is_none()
         );
@@ -493,8 +542,13 @@ mod tests {
             &nonce_hash,
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
-                .is_none()
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                false,
+                false
+            )
+            .is_none()
         );
     }
 
@@ -514,8 +568,13 @@ mod tests {
             &Hash::default(),
         ));
         assert!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false)
-                .is_none()
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                false,
+                false
+            )
+            .is_none()
         );
     }
 
@@ -572,7 +631,12 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(&message, &bank.next_durable_nonce(), false),
+            bank.check_nonce_transaction_validity(
+                &message,
+                &bank.next_durable_nonce(),
+                false,
+                false
+            ),
             None,
         );
     }
@@ -584,7 +648,7 @@ mod tests {
     fn make_test_tx_with_blockhash(
         version: TransactionVersion,
         recent_blockhash: Hash,
-    ) -> impl TransactionWithMeta {
+    ) -> RuntimeTransaction<SanitizedTransaction> {
         let payer = Keypair::new();
         let recipient = Pubkey::new_unique();
         let ix = system_instruction::transfer(&payer.pubkey(), &recipient, 1);
@@ -624,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_transactions_without_status_cache_allows_already_processed() {
+    fn test_check_transaction_without_status_cache_allows_already_processed() {
         let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
         let bank = Bank::new_for_tests(&genesis_config);
         let tx = make_test_tx_with_blockhash(TransactionVersion::LEGACY, bank.last_blockhash());
@@ -636,11 +700,10 @@ mod tests {
             Ok(()),
         );
 
-        let txs = [tx];
         let lock_results = [Ok(())];
         let mut error_counters = TransactionErrorMetrics::default();
         let check_results = bank.check_transactions(
-            &txs,
+            std::slice::from_ref(&tx),
             &lock_results,
             bank.max_processing_age(),
             true,
@@ -652,14 +715,12 @@ mod tests {
         ));
 
         let mut error_counters = TransactionErrorMetrics::default();
-        let check_results = bank.check_transactions_without_status_cache(
-            &txs,
-            &lock_results,
+        let check_result = bank.check_transaction_without_status_cache(
+            &tx,
             bank.max_processing_age(),
-            true,
             &mut error_counters,
         );
-        assert!(matches!(check_results.as_slice(), [Ok(_)]));
+        assert_eq!(check_result, Ok(None));
     }
 
     #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4620,6 +4620,7 @@ fn test_check_ro_durable_nonce_fails() {
             &new_sanitized_message(tx.message().clone()),
             &bank.next_durable_nonce(),
             false,
+            false,
         ),
         None
     );


### PR DESCRIPTION
#### Problem
nonce transactions are ~3% of landed transactions but ~60% of received transactions. a major reason is that invalid nonce transactions must be dropped without paying fees, so it is viable to submit many distinct versions of functionally the same nonce transaction, paying very high priority, knowing only one will ultimately be charged

each transaction is scheduled and takes up space in the priority queue, crowding legitimate transactions out of priority, imposing validation costs (up to four accounts-db trips, three wincode passes, and one bincode pass, though the last will be fixed by https://github.com/anza-xyz/agave/pull/13709), and producing sparse batches with transactions that are not dropped until runtime or svm

#### Summary of Changes
introduce a mechanism in the central scheduler to track which nonce accounts will be used by received transactions. this allows us to drop new transactions using the same nonce if lower/equal priority, or evict the existing transaction if not in flight and the new is higher priority. importantly, we can drop incoming nonce transactions before doing _any_ validation that depends on account state

we also eliminate pre-check batching in `handle_packet_batch_message()` since we no longer have to take a lock on `StatusCache`

i would have liked to put all validation logic inside the `try_insert_map_only_with_data()` callback, so that we can drop invalid transactions before inserting them into the slab, but the mut borrow on the container makes this quite difficult. nevertheless this version is much better than master and i dont think a refactor is worth attempting in this pr

#### Testing
`test_receive_and_buffer_nonce_*` tests confirm all expected behavior, `test_clear_container_clears_nonce_entry()` and `test_incremental_recheck_clears_nonce_entry()` guard against refactors of these functions that might poison the nonce tracker