### PR TITLE
syscalls: move translate_mut closer to the write

### DIFF
--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -947,11 +947,16 @@ declare_builtin_function!(
 
         let check_aligned = invoke_context.get_check_aligned();
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let secp256k1_recover_result: (&mut [MaybeUninit<u8>]) = map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
-        );
+
+        {
+            // Just a check that this maps correctly for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _result: (&mut [MaybeUninit<u8>]) =
+                    map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
+            );
+        }
         let hash = translate_slice::<u8>(
             memory_mapping,
             hash_addr,
@@ -977,7 +982,6 @@ declare_builtin_function!(
         let Ok(signature) = libsecp256k1::Signature::parse_standard_slice(signature) else {
             return Ok(Secp256k1RecoverError::InvalidSignature.into());
         };
-
         let public_key = match libsecp256k1::recover(&message, &signature, &recovery_id) {
             Ok(key) => key.serialize(),
             Err(_) => {
@@ -985,7 +989,13 @@ declare_builtin_function!(
             }
         };
 
-        secp256k1_recover_result.write_copy_of_slice(&public_key[1..65]);
+        translate_mut!(
+            memory_mapping,
+            check_aligned,
+            let result: (&mut [MaybeUninit<u8>]) =
+                map(result_addr, SECP256K1_PUBLIC_KEY_LENGTH as u64)?;
+        );
+        result.write_copy_of_slice(&public_key[1..65]);
         Ok(SUCCESS)
     }
 );
@@ -2226,11 +2236,14 @@ declare_builtin_function!(
 
         let check_aligned = invoke_context.get_check_aligned();
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let call_result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
-        );
+        {
+            // Just a check that this maps correctly for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+            );
+        }
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
@@ -2292,7 +2305,12 @@ declare_builtin_function!(
 
         match result_point {
             Ok(point) => {
-                call_result.write_copy_of_slice(&point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&point);
                 Ok(SUCCESS)
             }
             Err(_) => {
@@ -2358,11 +2376,15 @@ declare_builtin_function!(
         let check_aligned = invoke_context.get_check_aligned();
         let poseidon_enforce_padding = invoke_context.get_feature_set().poseidon_enforce_padding;
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let hash_result: (&mut [MaybeUninit<u8>]) = map(result_addr, poseidon::HASH_BYTES as u64)?;
-        );
+        {
+            // Just a check that this will map later for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _result: (&mut [MaybeUninit<u8>]) =
+                    map(result_addr, poseidon::HASH_BYTES as u64)?;
+            );
+        }
         let inputs =
             translate_slice::<VmSlice<u8>>(memory_mapping, vals_addr, vals_len, check_aligned)?;
         let inputs = inputs
@@ -2378,7 +2400,14 @@ declare_builtin_function!(
         let Ok(hash) = result else {
             return Ok(1);
         };
-        hash_result.write_copy_of_slice(&hash.to_bytes());
+        drop(inputs);
+
+        translate_mut!(
+            memory_mapping,
+            check_aligned,
+            let result: (&mut [MaybeUninit<u8>]) = map(result_addr, poseidon::HASH_BYTES as u64)?;
+        );
+        result.write_copy_of_slice(&hash.to_bytes());
 
         Ok(SUCCESS)
     }
@@ -2468,11 +2497,14 @@ declare_builtin_function!(
 
         let check_aligned = invoke_context.get_check_aligned();
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let call_result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
-        );
+        {
+            // Just a check that this will map later for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+            );
+        }
         let input = translate_slice::<u8>(
             memory_mapping,
             input_addr,
@@ -2485,49 +2517,89 @@ declare_builtin_function!(
                 let Ok(result_point) = alt_bn128_g1_compress_be(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G1_COMPRESS_LE => {
                 let Ok(result_point) = alt_bn128_g1_compress_le(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G1_DECOMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g1_decompress_be(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G1_DECOMPRESS_LE => {
                 let Ok(result_point) = alt_bn128_g1_decompress_le(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G2_COMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g2_compress_be(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G2_COMPRESS_LE => {
                 let Ok(result_point) = alt_bn128_g2_compress_le(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G2_DECOMPRESS_BE => {
                 let Ok(result_point) = alt_bn128_g2_decompress_be(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             ALT_BN128_G2_DECOMPRESS_LE => {
                 let Ok(result_point) = alt_bn128_g2_decompress_le(input) else {
                     return Ok(1);
                 };
-                call_result.write_copy_of_slice(&result_point);
+                translate_mut!(
+                    memory_mapping,
+                    check_aligned,
+                    let result: (&mut [MaybeUninit<u8>]) = map(result_addr, output as u64)?;
+                );
+                result.write_copy_of_slice(&result_point);
             }
             _ => return Err(SyscallError::InvalidAttribute.into()),
         }
@@ -2567,11 +2639,15 @@ declare_builtin_function!(
         let check_aligned = invoke_context.get_check_aligned();
         let mem_op_base_cost = compute_cost.mem_op_base_cost;
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let hash_result: (&mut [MaybeUninit<u8>]) = map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
-        );
+        {
+            // Just a check that this maps correctly for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _result: (&mut [MaybeUninit<u8>]) =
+                    map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
+            );
+        }
         let mut hasher = H::create_hasher();
         if vals_len > 0 {
             let vals = translate_slice::<VmSlice<u8>>(
@@ -2594,7 +2670,13 @@ declare_builtin_function!(
                 hasher.hash(bytes);
             }
         }
-        hash_result.write_copy_of_slice(hasher.result().as_ref());
+        translate_mut!(
+            memory_mapping,
+            check_aligned,
+            let result: (&mut [MaybeUninit<u8>]) =
+                map(result_addr, std::mem::size_of::<H::Output>() as u64)?;
+        );
+        result.write_copy_of_slice(hasher.result().as_ref());
         Ok(0)
     }
 );

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -217,11 +217,14 @@ declare_builtin_function!(
 
         let memory_mapping = invoke_context.memory_contexts.memory_mapping_mut()?;
         // Abort: "Not all bytes in VM memory range `[var_addr, var_addr + length)` are writable."
-        translate_mut!(
-            memory_mapping,
-            check_aligned,
-            let var: (&mut [MaybeUninit<u8>]) = map(var_addr, length)?;
-        );
+        {
+            // Just a check that this maps correctly for error compatibility with old code.
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let _var: (&mut [MaybeUninit<u8>]) = map(var_addr, length)?;
+            );
+        }
 
         // Abort: "Not all bytes in VM memory range `[sysvar_id, sysvar_id + 32)` are readable."
         let sysvar_id = translate_type::<Pubkey>(memory_mapping, sysvar_id_addr, check_aligned)?;
@@ -245,6 +248,11 @@ declare_builtin_function!(
 
         // "`1` if `offset + length` is greater than the length of the sysvar data."
         if let Some(sysvar_slice) = sysvar_buf.get(offset as usize..offset_length as usize) {
+            translate_mut!(
+                memory_mapping,
+                check_aligned,
+                let var: (&mut [MaybeUninit<u8>]) = map(var_addr, length)?;
+            );
             var.write_copy_of_slice(sysvar_slice);
         } else {
             return Ok(OFFSET_LENGTH_EXCEEDS_SYSVAR);


### PR DESCRIPTION
#### Problem

In some syscalls' implementations we've been potentially invoking a technically-unsound-but-in-practice-harmless aliasing of mutable result slice for a pretty long time now.

#### Summary of Changes

This change addresses the issue by keeping the original `translate_mut` call to verify that the provided output buffer can be mapped. This ensures that the mapping error, if any, would be emitted in the same place as today. This mapped buffer is then immediately discarded before the read-only inputs are mapped in turn.

The result buffer is mapped again right before the result is written out (which happens to be straightforward for all the affected syscalls), which combined with non-lexical lifetimes satisfies the uniqueness condition of these slices.

#### Testing

Code builds, tests should pass.