### PR TITLE
Loads accounts in parallel for lt hash updates of stake accounts

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2657,7 +2657,7 @@ impl Bank {
         );
         accounts_to_store.push((incinerator::id(), incinerator_account));
 
-        self.store_accounts((self.slot, accounts_to_store.as_slice()));
+        self.store_accounts((self.slot, accounts_to_store.as_slice()), None);
         info!(
             "Transferred total VAT of {total_vat} lamports to incinerator from staked vote \
              accounts"
@@ -4336,7 +4336,7 @@ impl Bank {
 
             let to_store = (self.slot(), accounts_to_store.as_slice());
             self.update_bank_hash_stats(&to_store);
-            self.enqueue_accounts_lt_hash_updates(&to_store);
+            self.enqueue_on_chain_accounts_lt_hash_updates(&to_store);
             // See https://github.com/solana-labs/solana/pull/31455 for discussion
             // on *not* updating the index within a threadpool.
             self.rc
@@ -4701,10 +4701,19 @@ impl Bank {
     /// fn store the single `account` with `pubkey`.
     /// Uses `store_accounts`, which works on a vector of accounts.
     pub fn store_account(&self, pubkey: &Pubkey, account: &AccountSharedData) {
-        self.store_accounts((self.slot(), &[(pubkey, account)][..]))
+        self.store_accounts((self.slot(), &[(pubkey, account)][..]), None)
     }
 
-    pub fn store_accounts<'a>(&self, accounts: impl StorableAccounts<'a>) {
+    // Store `accounts`.
+    //
+    // - Callers must ensure there are no duplicates in `accounts`.
+    // - `thread_pool_for_loading_accounts` is used for accounts lt hashing,
+    //   to load the previous version of accounts in parallel.
+    pub fn store_accounts<'a>(
+        &self,
+        accounts: impl StorableAccounts<'a>,
+        thread_pool_for_loading_accounts: Option<&ThreadPool>,
+    ) {
         assert!(!self.freeze_started());
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
@@ -4720,7 +4729,7 @@ impl Bank {
                 )
             })
         });
-        self.store_accounts_without_stakes_cache(accounts);
+        self.store_accounts_without_stakes_cache(accounts, thread_pool_for_loading_accounts);
         m.stop();
         self.rc
             .accounts
@@ -4731,13 +4740,25 @@ impl Bank {
     }
 
     fn store_account_without_stakes_cache(&self, pubkey: &Pubkey, account: &AccountSharedData) {
-        self.store_accounts_without_stakes_cache((self.slot(), &[(pubkey, account)][..]))
+        self.store_accounts_without_stakes_cache((self.slot(), &[(pubkey, account)][..]), None)
     }
 
-    fn store_accounts_without_stakes_cache<'a>(&self, accounts: impl StorableAccounts<'a>) {
+    // Store `accounts`, without updating the stakes cache.
+    //
+    // - Callers must ensure there are no duplicates in `accounts`.
+    // - `thread_pool_for_loading_accounts` is used for accounts lt hashing,
+    //   to load the previous version of accounts in parallel.
+    fn store_accounts_without_stakes_cache<'a>(
+        &self,
+        accounts: impl StorableAccounts<'a>,
+        thread_pool_for_loading_accounts: Option<&ThreadPool>,
+    ) {
         assert!(!self.freeze_started());
         self.update_bank_hash_stats(&accounts);
-        self.enqueue_accounts_lt_hash_updates(&accounts);
+        self.enqueue_off_chain_accounts_lt_hash_updates(
+            &accounts,
+            thread_pool_for_loading_accounts,
+        );
         self.rc
             .accounts
             .store_accounts_par(accounts, None, &self.ancestors);

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1,7 +1,10 @@
 use {
     super::Bank,
     crossbeam_utils::CachePadded,
-    rayon::{ThreadPool, ThreadPoolBuilder},
+    rayon::{
+        ThreadPool, ThreadPoolBuilder,
+        iter::{IntoParallelIterator, ParallelIterator},
+    },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{accounts_db::AccountsDb, storable_accounts::StorableAccounts},
     solana_lattice_hash::lt_hash::LtHash,
@@ -25,7 +28,17 @@ const MAX_BYTES_SEEN_ACCOUNTS_FREELIST: usize = 10_000_000;
 
 impl Bank {
     /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher thread pool.
-    pub fn enqueue_accounts_lt_hash_updates<'a>(&self, accounts: &impl StorableAccounts<'a>) {
+    ///
+    /// This fn is meant to be called by on-chain events, e.g. transaction processing.
+    /// This fn deduplicates from `accounts`, keeping only the latest version of each account.
+    /// It also loads the previous version of each account inline, because we assume the previous
+    /// version of each account is still in the accounts write cache, and thus fast to load.
+    ///
+    /// For non-transaction processing callers, consider `enqueue_off_chain_accounts_lt_hash_updates()`.
+    pub fn enqueue_on_chain_accounts_lt_hash_updates<'a>(
+        &self,
+        accounts: &impl StorableAccounts<'a>,
+    ) {
         if accounts.is_empty() {
             return;
         }
@@ -67,6 +80,93 @@ impl Bank {
 
         // reclaim the seen accounts hashset
         seen_accounts_freelist.try_push(seen_accounts);
+    }
+
+    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher thread pool.
+    ///
+    /// This fn is meant to be called by off-chain events, meaning we know/control `accounts`.
+    /// Contrasting with `enqueue_on_chain_accounts_lt_hash_updates()`, this fn:
+    /// - Does not deduplicate accounts, requiring the caller to ensure there are no duplicates.
+    /// - Does not assume loading the previous version of accounts is fast,
+    ///   e.g. when storing stake accounts as part of partitioned epoch rewards.
+    ///
+    /// If Some, `thread_pool_for_hashing_accounts` will be used
+    /// to load the previous version of accounts in parallel.
+    pub fn enqueue_off_chain_accounts_lt_hash_updates<'a>(
+        &self,
+        accounts: &impl StorableAccounts<'a>,
+        thread_pool_for_loading_accounts: Option<&ThreadPool>,
+    ) {
+        if cfg!(debug_assertions) {
+            // if debug assertions are on, we will check for duplicates
+            use ahash::HashSetExt as _;
+            let mut seen_accounts = ahash::HashSet::with_capacity(accounts.len());
+            let mut duplicate_pubkeys = ahash::HashSet::with_capacity(0); // assume no duplicates
+            for index in 0..accounts.len() {
+                let pubkey = accounts.pubkey(index);
+                if !seen_accounts.insert(pubkey) {
+                    // we've already seen this account, so add it to the duplicates list
+                    duplicate_pubkeys.insert(pubkey);
+                }
+            }
+            if !duplicate_pubkeys.is_empty() {
+                let mut duplicate_accounts = ahash::HashMap::<_, Vec<_>>::default();
+                for duplicate_pubkey in duplicate_pubkeys {
+                    for index in 0..accounts.len() {
+                        let pubkey = accounts.pubkey(index);
+                        if pubkey == duplicate_pubkey {
+                            duplicate_accounts
+                                .entry(pubkey)
+                                .or_default()
+                                .push(accounts.account(index, |account| account.take_account()));
+                        }
+                    }
+                }
+                panic!("duplicate accounts were enqueued for hashing: {duplicate_accounts:?}");
+            }
+        }
+
+        let async_progress = &self.accounts_lt_hash_async_progress;
+        let thread_pool_for_hashing_accounts = accounts_hasher_thread_pool();
+
+        // A closure that does the loading and enqueueing, so code is shared
+        // whether using the thread_pool_for_loading_accounts or not.
+        let load_then_enqueue = |index| {
+            let address = accounts.pubkey(index);
+            let prev_account = self
+                .rc
+                .accounts
+                .load_with_fixed_root_do_not_populate_read_cache(&self.ancestors, address)
+                .map(|(account, _slot)| account);
+            let curr_account = accounts.account(index, |account| {
+                (account.lamports() != 0).then(|| account.take_account())
+            });
+            if prev_account.is_none() && curr_account.is_none() {
+                // the account was ephemeral; skip it
+            } else {
+                // the account was modified; enqueue this update
+                async_progress.spawn(
+                    thread_pool_for_hashing_accounts,
+                    AccountsLtHashUpdate {
+                        address: *address,
+                        prev_account,
+                        curr_account,
+                    },
+                );
+            }
+        };
+
+        if let Some(thread_pool_for_loading_accounts) = thread_pool_for_loading_accounts {
+            // The previous version of accounts must be loaded before subsequent account
+            // modifications occur, so ThreadPool::spawn() canot be used here.
+            thread_pool_for_loading_accounts.install(|| {
+                (0..accounts.len())
+                    .into_par_iter()
+                    .for_each(load_then_enqueue);
+            });
+        } else {
+            (0..accounts.len()).for_each(load_then_enqueue);
+        }
     }
 
     /// Updates the accounts lt hash.
@@ -863,6 +963,35 @@ mod tests {
         .unwrap();
 
         assert_eq!(roundtrip_bank, *bank);
+    }
+
+    /// Ensure enqueue_off_chain_accounts_lt_hash_updates() catches duplicates in debug mode.
+    #[should_panic(expected = "duplicate accounts were enqueued for hashing")]
+    #[test_case(Features::None; "no features")]
+    #[test_case(Features::All; "all features")]
+    fn test_enqueue_off_chain_accounts_lt_hash_updates_catches_duplicates(features: Features) {
+        use rand::seq::SliceRandom as _;
+        let (genesis_config, _) = genesis_config_with(features);
+        let bank = Bank::new_for_tests(&genesis_config);
+
+        let pubkey1 = pubkey::new_rand();
+        let pubkey2 = pubkey::new_rand();
+        let pubkey3 = pubkey::new_rand();
+
+        let mut accounts = [
+            // one version of pubkey1
+            (&pubkey1, &AccountSharedData::new(11, 0, &Pubkey::default())),
+            // two versions of pubkey2
+            (&pubkey2, &AccountSharedData::new(21, 0, &Pubkey::default())),
+            (&pubkey2, &AccountSharedData::new(22, 0, &Pubkey::default())),
+            // three versions of pubkey3
+            (&pubkey3, &AccountSharedData::new(31, 0, &Pubkey::default())),
+            (&pubkey3, &AccountSharedData::new(32, 0, &Pubkey::default())),
+            (&pubkey3, &AccountSharedData::new(33, 0, &Pubkey::default())),
+        ];
+        accounts.shuffle(&mut rand::rng());
+
+        bank.store_accounts((bank.slot(), accounts.as_slice()), None);
     }
 
     /// Ensure freelist respects max size.

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -387,7 +387,7 @@ impl Bank {
                 slot: self.slot(),
                 reward_commission_accounts,
             };
-            self.store_accounts(storable);
+            self.store_accounts(storable, None);
         });
 
         metrics

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -387,7 +387,12 @@ impl Bank {
             }
         }
         drop(stakes_cache);
-        self.store_accounts((self.slot(), &updated_stake_rewards[..]));
+        self.store_accounts(
+            (self.slot(), &updated_stake_rewards[..]),
+            // Reuse the rewards calculation thread pool to parallelize
+            // loading the previous versions of the stake accounts.
+            Some(crate::bank::rewards_calculation_thread_pool()),
+        );
         DistributionResults {
             stake_reward_lamports_minted,
             stake_reward_lamports_burned,

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -478,7 +478,7 @@ pub(super) fn calc_vote_rewards_update_vote_states(
         )?,
     };
 
-    bank.store_accounts((bank.slot(), updated_accounts.as_slice()));
+    bank.store_accounts((bank.slot(), updated_accounts.as_slice()), None);
     Ok(())
 }
 

--- a/runtime/src/block_component_processor/vote_reward/migration_test.rs
+++ b/runtime/src/block_component_processor/vote_reward/migration_test.rs
@@ -212,7 +212,7 @@ mod tests {
                     vote_state.serialize().unwrap()
                 })
                 .collect::<Vec<_>>();
-            bank.store_accounts((bank.slot(), updated_accounts.as_slice()));
+            bank.store_accounts((bank.slot(), updated_accounts.as_slice()), None);
             let slot = bank.slot() + 10;
             new_bank_from_parent(bank, slot)
         }
@@ -236,7 +236,7 @@ mod tests {
                     vote_state.serialize().unwrap()
                 })
                 .collect::<Vec<_>>();
-            bank.store_accounts((bank.slot(), updated_accounts.as_slice()));
+            bank.store_accounts((bank.slot(), updated_accounts.as_slice()), None);
             let slot = bank.slot() + 10;
             new_bank_from_parent(bank, slot)
         }


### PR DESCRIPTION
#### Problem

When storing stake accounts as part of partitioned epoch rewards, we have to update the accounts lt hash. To update the lt hash, the old version of the account is needed too. Since the stake accounts are not in either the read/write accounts caches, loading the old version of the account must read from disk.

This is slow.

Prior to https://github.com/anza-xyz/agave/pull/12474, this was done during Bank::freeze() in a thread pool, so at least the loading was done in parallel. But now we are doing it without a thread pool, serially one account at a time.

This is slower.


#### Summary of Changes

When storing stake accounts as part of partitioned epoch rewards, use a thread pool for loading the old version of the accounts.


#### Testing

I ran two nodes, one with this PR and one on master. 

In master, we spend 225+ milliseconds in solReplayStage during `distribute_partitioned_epoch_rewards()` waiting for file io from loading old versions of stake accounts.

In this PR we spend ~10 milliseconds, because we are now farming the account loading out to a thread pool.


##### Flamegraph

Here's a flamegraph covering `distribute_partitioned_epoch_rewards()` on the same slot. Master spends almost all its time on file io. Whereas this PR spends significantly less. Now checking and updating the stakes cache is the long pole.

master:

<img width="2377" height="1761" alt="Screenshot 2026-07-08 at 7 35 41 AM" src="https://github.com/user-attachments/assets/e4d1d577-ae50-412f-9430-66ef66146f41" />

pr:

<img width="2377" height="1761" alt="Screenshot 2026-07-08 at 7 36 14 AM" src="https://github.com/user-attachments/assets/32a952b0-f301-4c1a-b611-c7b134a3a6a3" />


##### Stack Chart

And here's the stack chart over the same time. Total time spent making the new bank shrinks from 275 milliseconds to 66 milliseconds. 

master:

The long blank in the middle is all file io.

<img width="2377" height="1761" alt="Screenshot 2026-07-08 at 7 52 34 AM" src="https://github.com/user-attachments/assets/835ad37c-536f-48c7-bf75-d8911d1f1d7a" />


pr:

The blank in the middle is much shorter, as the thread pool is now doing the file io.

<img width="2377" height="1761" alt="Screenshot 2026-07-08 at 7 52 43 AM" src="https://github.com/user-attachments/assets/d543e314-c55c-44df-8ff7-8f7f0671bb04" />