### PR TITLE
ci: clear channel pins to advance to v4.2

### DIFF
--- a/ci/channel-overrides
+++ b/ci/channel-overrides
@@ -1,5 +1,5 @@
 # Channel override file consumed by ci/channel-info.sh.
 # Single source of truth: edit on master only, no backports.
 # Empty = auto-detect.
-PINNED_BETA_CHANNEL=v4.1
-PINNED_STABLE_CHANNEL=v4.0
+PINNED_BETA_CHANNEL=
+PINNED_STABLE_CHANNEL=


### PR DESCRIPTION
#### Problem

v4.2 promoted to beta as v4.1 adoption >90% on mainnet

#### Summary of Changes

drop pins so channel-info.sh auto-detects beta=v4.2/stable=v4.1

#### Testing

Fixes #
