### PR TITLE
Fix `monitor` cmd when running without `--full-rpc-api`

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -98,6 +98,7 @@ pub struct AdminRpcContactInfo {
     pub tvu: SocketAddr,
     pub serve_repair_quic: SocketAddr,
     pub tpu: SocketAddr,
+    pub tpu_quic: SocketAddr,
     pub tpu_forwards: SocketAddr,
     pub tpu_vote: SocketAddr,
     pub rpc: SocketAddr,
@@ -141,6 +142,7 @@ impl From<ContactInfo> for AdminRpcContactInfo {
             tvu: unwrap_socket!(tvu, Protocol::UDP),
             serve_repair_quic: unwrap_socket!(serve_repair, Protocol::QUIC),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
+            tpu_quic: unwrap_socket!(tpu, Protocol::QUIC),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
             tpu_vote: unwrap_socket!(tpu_vote, Protocol::UDP),
             rpc: unwrap_socket!(rpc),
@@ -157,6 +159,7 @@ impl Display for AdminRpcContactInfo {
         writeln!(f, "Gossip: {}", self.gossip)?;
         writeln!(f, "TVU: {}", self.tvu)?;
         writeln!(f, "TPU: {}", self.tpu)?;
+        writeln!(f, "TPU QUIC: {}", self.tpu_quic)?;
         writeln!(f, "TPU Forwards: {}", self.tpu_forwards)?;
         writeln!(f, "TPU Votes: {}", self.tpu_vote)?;
         writeln!(f, "RPC: {}", self.rpc)?;

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -98,7 +98,7 @@ pub struct AdminRpcContactInfo {
     pub tvu: SocketAddr,
     pub serve_repair_quic: SocketAddr,
     pub tpu: SocketAddr,
-    pub tpu_quic: SocketAddr,
+    pub tpu_quic: Option<SocketAddr>,
     pub tpu_forwards: SocketAddr,
     pub tpu_vote: SocketAddr,
     pub rpc: SocketAddr,
@@ -142,7 +142,7 @@ impl From<ContactInfo> for AdminRpcContactInfo {
             tvu: unwrap_socket!(tvu, Protocol::UDP),
             serve_repair_quic: unwrap_socket!(serve_repair, Protocol::QUIC),
             tpu: unwrap_socket!(tpu, Protocol::UDP),
-            tpu_quic: unwrap_socket!(tpu, Protocol::QUIC),
+            tpu_quic: node.tpu(Protocol::QUIC),
             tpu_forwards: unwrap_socket!(tpu_forwards, Protocol::UDP),
             tpu_vote: unwrap_socket!(tpu_vote, Protocol::UDP),
             rpc: unwrap_socket!(rpc),
@@ -159,7 +159,9 @@ impl Display for AdminRpcContactInfo {
         writeln!(f, "Gossip: {}", self.gossip)?;
         writeln!(f, "TVU: {}", self.tvu)?;
         writeln!(f, "TPU: {}", self.tpu)?;
-        writeln!(f, "TPU QUIC: {}", self.tpu_quic)?;
+        if let Some(tpu_quic) = self.tpu_quic {
+            writeln!(f, "TPU QUIC: {tpu_quic}")?;
+        }
         writeln!(f, "TPU Forwards: {}", self.tpu_forwards)?;
         writeln!(f, "TPU Votes: {}", self.tpu_vote)?;
         writeln!(f, "RPC: {}", self.rpc)?;

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -316,32 +316,35 @@ async fn wait_for_validator_startup(
         }
 
         let admin_client = admin_client.take().unwrap();
-        match async move {
-            let Some(rpc_addr) = admin_client.rpc_addr().await? else {
-                return Ok(None);
-            };
-            let start_time = admin_client.start_time().await?;
-            let contact_info = Some(admin_client.contact_info().await?);
-            let vat_status = admin_client.vat_status().await.ok();
-            Ok::<_, jsonrpc_core_client::RpcError>(Some((
-                rpc_addr,
-                start_time,
-                contact_info,
-                vat_status,
-            )))
-        }
-        .await
-        {
+        match get_validator_startup_info(admin_client).await {
             Ok(None) => progress_bar.set_message("RPC service not available"),
-            Ok(Some((rpc_addr, start_time, contact_info, vat_status))) => {
-                return Some((rpc_addr, start_time, contact_info, vat_status));
-            }
+            Ok(Some(validator_startup_info)) => return Some(validator_startup_info),
             Err(err) => {
                 progress_bar.set_message(format!("Failed to get validator info: {err}"));
             }
         }
         thread::sleep(refresh_interval);
     }
+}
+
+async fn get_validator_startup_info(
+    admin_client: admin_rpc_service::gen_client::Client,
+) -> Result<
+    Option<(
+        SocketAddr,
+        SystemTime,
+        Option<admin_rpc_service::AdminRpcContactInfo>,
+        Option<admin_rpc_service::AdminRpcValidatorAdmissionTicketStatus>,
+    )>,
+    jsonrpc_core_client::RpcError,
+> {
+    let Some(rpc_addr) = admin_client.rpc_addr().await? else {
+        return Ok(None);
+    };
+    let start_time = admin_client.start_time().await?;
+    let contact_info = Some(admin_client.contact_info().await?);
+    let vat_status = admin_client.vat_status().await.ok();
+    Ok(Some((rpc_addr, start_time, contact_info, vat_status)))
 }
 
 fn get_validator_stats(

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -110,7 +110,7 @@ impl Dashboard {
             {
                 println_name_value("Shred Version:", &shred_version.to_string());
                 println_name_value("Gossip Address:", &gossip.to_string());
-                if tpu_quic.port() != 0 {
+                if let Some(tpu_quic) = tpu_quic {
                     println_name_value("TPU QUIC Address:", &tpu_quic.to_string());
                 }
                 if rpc.port() != 0 {
@@ -321,7 +321,7 @@ async fn wait_for_validator_startup(
                 return Ok(None);
             };
             let start_time = admin_client.start_time().await?;
-            let contact_info = admin_client.contact_info().await.ok();
+            let contact_info = Some(admin_client.contact_info().await?);
             let vat_status = admin_client.vat_status().await.ok();
             Ok::<_, jsonrpc_core_client::RpcError>(Some((
                 rpc_addr,
@@ -384,4 +384,72 @@ fn get_validator_stats(
         Sol(identity_balance),
         health,
     ))
+}
+
+#[cfg(all(test, not(target_family = "windows")))]
+mod tests {
+    use {
+        super::*,
+        jsonrpc_core::{Error, IoHandler},
+        jsonrpc_ipc_server::ServerBuilder,
+        solana_gossip::contact_info::ContactInfo,
+        solana_keypair::Keypair,
+        solana_signer::Signer,
+        std::sync::atomic::AtomicUsize,
+    };
+
+    #[test]
+    fn test_wait_for_validator_startup_retries_legacy_contact_info() {
+        let ledger_path = tempfile::tempdir().unwrap();
+        let rpc_addr = "127.0.0.1:8899".parse::<SocketAddr>().unwrap();
+        let start_time = SystemTime::now();
+        let keypair = Keypair::new();
+        let mut contact_info = serde_json::to_value(admin_rpc_service::AdminRpcContactInfo::from(
+            ContactInfo::new(keypair.pubkey(), 0, 0),
+        ))
+        .unwrap();
+        contact_info
+            .as_object_mut()
+            .unwrap()
+            .remove("tpu_quic")
+            .unwrap();
+        let contact_info_attempts = Arc::new(AtomicUsize::new(0));
+
+        let mut io = IoHandler::default();
+        io.add_sync_method("startProgress", |_| {
+            Ok(serde_json::to_value(ValidatorStartProgress::Running).unwrap())
+        });
+        io.add_sync_method("rpcAddress", move |_| {
+            Ok(serde_json::to_value(Some(rpc_addr)).unwrap())
+        });
+        io.add_sync_method("startTime", move |_| {
+            Ok(serde_json::to_value(start_time).unwrap())
+        });
+        let attempts = contact_info_attempts.clone();
+        io.add_sync_method("contactInfo", move |_| {
+            if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                Err(Error::invalid_params(
+                    "Retry once validator start up is complete",
+                ))
+            } else {
+                Ok(contact_info.clone())
+            }
+        });
+        let server = ServerBuilder::new(io)
+            .start(&ledger_path.path().join("admin.rpc").display().to_string())
+            .unwrap();
+        let exit = AtomicBool::new(false);
+        let (_, _, contact_info, _) = admin_rpc_service::runtime()
+            .block_on(wait_for_validator_startup(
+                ledger_path.path(),
+                &exit,
+                new_spinner_progress_bar(),
+                Duration::from_millis(1),
+            ))
+            .unwrap();
+
+        assert!(contact_info.unwrap().tpu_quic.is_none());
+        assert_eq!(contact_info_attempts.load(Ordering::Relaxed), 2);
+        server.close();
+    }
 }

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -10,7 +10,7 @@ use {
     solana_native_token::Sol,
     solana_pubkey::Pubkey,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_rpc_client_api::{client_error, request, response::RpcContactInfo},
+    solana_rpc_client_api::{client_error, request},
     solana_validator_exit::Exit,
     std::{
         net::SocketAddr,
@@ -71,7 +71,7 @@ impl Dashboard {
             let progress_bar = new_spinner_progress_bar();
             progress_bar.set_message("Connecting...");
 
-            let Some((rpc_addr, start_time, mut vat_status)) = runtime.block_on(
+            let Some((rpc_addr, start_time, contact_info, mut vat_status)) = runtime.block_on(
                 wait_for_validator_startup(&ledger_path, &exit, progress_bar, refresh_interval),
             ) else {
                 continue;
@@ -96,25 +96,28 @@ impl Dashboard {
                 println_name_value("Genesis Hash:", &genesis_hash.to_string());
             }
 
-            if let Some(contact_info) = get_contact_info(&rpc_client, &identity) {
-                println_name_value(
-                    "Version:",
-                    &contact_info.version.unwrap_or_else(|| "?".to_string()),
-                );
-                if let Some(shred_version) = contact_info.shred_version {
-                    println_name_value("Shred Version:", &shred_version.to_string());
+            if let Ok(version) = rpc_client.get_version() {
+                println_name_value("Version:", &version.to_string());
+            }
+            if let Some(admin_rpc_service::AdminRpcContactInfo {
+                gossip,
+                rpc,
+                rpc_pubsub,
+                shred_version,
+                tpu_quic,
+                ..
+            }) = contact_info
+            {
+                println_name_value("Shred Version:", &shred_version.to_string());
+                println_name_value("Gossip Address:", &gossip.to_string());
+                if tpu_quic.port() != 0 {
+                    println_name_value("TPU QUIC Address:", &tpu_quic.to_string());
                 }
-                if let Some(gossip) = contact_info.gossip {
-                    println_name_value("Gossip Address:", &gossip.to_string());
-                }
-                if let Some(tpu) = contact_info.tpu_quic {
-                    println_name_value("TPU QUIC Address:", &tpu.to_string());
-                }
-                if let Some(rpc) = contact_info.rpc {
+                if rpc.port() != 0 {
                     println_name_value("JSON RPC URL:", &format!("http://{rpc}"));
                 }
-                if let Some(pubsub) = contact_info.pubsub {
-                    println_name_value("WebSocket PubSub URL:", &format!("ws://{pubsub}"));
+                if rpc_pubsub.port() != 0 {
+                    println_name_value("WebSocket PubSub URL:", &format!("ws://{rpc_pubsub}"));
                 }
             }
 
@@ -276,6 +279,7 @@ async fn wait_for_validator_startup(
 ) -> Option<(
     SocketAddr,
     SystemTime,
+    Option<admin_rpc_service::AdminRpcContactInfo>,
     Option<admin_rpc_service::AdminRpcValidatorAdmissionTicketStatus>,
 )> {
     let mut admin_client = None;
@@ -285,62 +289,59 @@ async fn wait_for_validator_startup(
         }
 
         if admin_client.is_none() {
-            match admin_rpc_service::connect(ledger_path).await {
-                Ok(new_admin_client) => admin_client = Some(new_admin_client),
+            admin_client = Some(match admin_rpc_service::connect(ledger_path).await {
+                Ok(new_admin_client) => new_admin_client,
                 Err(err) => {
                     progress_bar.set_message(format!("Unable to connect to validator: {err}"));
                     thread::sleep(refresh_interval);
                     continue;
                 }
-            }
+            });
         }
 
-        match admin_client.as_ref().unwrap().start_progress().await {
-            Ok(start_progress) => {
-                if start_progress == ValidatorStartProgress::Running {
-                    let admin_client = admin_client.take().unwrap();
-
-                    let validator_info = async move {
-                        let rpc_addr = admin_client.rpc_addr().await?;
-                        let start_time = admin_client.start_time().await?;
-                        let vat_status = if rpc_addr.is_some() {
-                            admin_client.vat_status().await.ok()
-                        } else {
-                            None
-                        };
-                        Ok::<_, jsonrpc_core_client::RpcError>((rpc_addr, start_time, vat_status))
-                    }
-                    .await;
-                    match validator_info {
-                        Ok((None, _, _)) => progress_bar.set_message("RPC service not available"),
-                        Ok((Some(rpc_addr), start_time, vat_status)) => {
-                            return Some((rpc_addr, start_time, vat_status));
-                        }
-                        Err(err) => {
-                            progress_bar
-                                .set_message(format!("Failed to get validator info: {err}"));
-                        }
-                    }
-                } else {
-                    progress_bar.set_message(format!("Validator startup: {start_progress:?}..."));
-                }
-            }
+        let start_progress = match admin_client.as_ref().unwrap().start_progress().await {
+            Ok(start_progress) => start_progress,
             Err(err) => {
                 admin_client = None;
                 progress_bar.set_message(format!("Failed to get validator start progress: {err}"));
+                thread::sleep(refresh_interval);
+                continue;
+            }
+        };
+
+        if start_progress != ValidatorStartProgress::Running {
+            progress_bar.set_message(format!("Validator startup: {start_progress:?}..."));
+            thread::sleep(refresh_interval);
+            continue;
+        }
+
+        let admin_client = admin_client.take().unwrap();
+        match async move {
+            let Some(rpc_addr) = admin_client.rpc_addr().await? else {
+                return Ok(None);
+            };
+            let start_time = admin_client.start_time().await?;
+            let contact_info = admin_client.contact_info().await.ok();
+            let vat_status = admin_client.vat_status().await.ok();
+            Ok::<_, jsonrpc_core_client::RpcError>(Some((
+                rpc_addr,
+                start_time,
+                contact_info,
+                vat_status,
+            )))
+        }
+        .await
+        {
+            Ok(None) => progress_bar.set_message("RPC service not available"),
+            Ok(Some((rpc_addr, start_time, contact_info, vat_status))) => {
+                return Some((rpc_addr, start_time, contact_info, vat_status));
+            }
+            Err(err) => {
+                progress_bar.set_message(format!("Failed to get validator info: {err}"));
             }
         }
         thread::sleep(refresh_interval);
     }
-}
-
-fn get_contact_info(rpc_client: &RpcClient, identity: &Pubkey) -> Option<RpcContactInfo> {
-    rpc_client
-        .get_cluster_nodes()
-        .ok()
-        .unwrap_or_default()
-        .into_iter()
-        .find(|node| node.pubkey == identity.to_string())
 }
 
 fn get_validator_stats(


### PR DESCRIPTION
## Summary

Fix `agave-validator monitor` so the header still shows validator metadata when the validator is not running with `--full-rpc-api`. `getClusterNodes` is only available on the full RPC API. This change gets the running validator version from minimal RPC `getVersion`, and gets local contact info through admin RPC `contactInfo`.

Before
```
  user@host:~$ ~/jito-solana/docker-output/agave-validator -l /solana/ledger/ monitor
  Ledger location: /solana/ledger/
  Identity: 2X5yarNUWGyyiJDtRoPATvJYeNecvWG7zCkBrY2J1to1
  Genesis Hash: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
  ⠉ 63:52:37 | Processed Slot: 431450523 | Confirmed Slot: 431450523 | Finalized Slot^C
```

## Testing
Running `monitor` command on `v4.1.2` node

with commit [f5e0a5c](https://github.com/anza-xyz/agave/pull/13701/commits/f5e0a5c257c4585a6727d2e5a9b86d99c41ae3f6) 
```
user@host:~/jito-solana$ agave-validator -l /solana/ledger/ monitor
Ledger location: /solana/ledger/
Identity: 2X5yarNUWGyyiJDtRoPATvJYeNecvWG7zCkBrY2J1to1
Genesis Hash: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
Version: 4.1.2
Shred Version: 50093
Gossip Address: 109.109.165.42:8000
⠖ 102:35:37 | Processed Slot: 433835699 | Confirmed Slot: 433835699 | Finalized Slot: 433835667 | Full Snapshot Slot: 433832450 | Incremental Snapshot Slot: 433835650 | Transactions: 530514863722 | ◎164.391071354                                                                                                                                                                            VAT: failed to connect to admin RPC                                                                                                                                                                                                                                                                                                                                                           
```

without commit [f5e0a5c](https://github.com/anza-xyz/agave/pull/13701/commits/f5e0a5c257c4585a6727d2e5a9b86d99c41ae3f6)
```
user@host:~/jito-solana$ agave-validator -l /solana/ledger/ monitor
Ledger location: /solana/ledger/
Identity: 2X5yarNUWGyyiJDtRoPATvJYeNecvWG7zCkBrY2J1to1
Genesis Hash: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d
Version: 4.1.2
⠖ 102:41:08 | Processed Slot: 433836482 | Confirmed Slot: 433836482 | Finalized Slot: 433836450 | Full Snapshot Slot: 433832450 | Incremental Snapshot Slot: 433836350 | Transactions: 530515833922 | ◎164.387156354                                                                                                                                                                            VAT: failed to connect to admin RPC        
```                                                                                                                                                                                                                                                                                                                                                     