### PR TITLE
Removes rent_epoch from Geyser account types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Release channels have their own copy of this changelog:
 ### Validator
 #### Breaking
 #### Changes
+### Geyser
+#### Changes
+* Account update notifications use a new account info type, `ReplicaAccountInfoV4`.
 
 ## 4.2.0
 ### RPC

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6074,7 +6074,6 @@ impl AccountsDb {
                         lamports: account.lamports(),
                         owner: account.owner(),
                         executable: account.executable(),
-                        rent_epoch: account.rent_epoch(),
                         data: account.data(),
                     };
                     geyser_notifier.notify_account_restore_from_snapshot(

--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
     solana_account::{AccountSharedData, ReadableAccount},
-    solana_clock::{Epoch, Slot},
+    solana_clock::Slot,
     solana_pubkey::Pubkey,
     solana_transaction::sanitized::SanitizedTransaction,
     std::sync::Arc,
@@ -42,7 +42,6 @@ pub struct AccountForGeyser<'a> {
     pub lamports: u64,
     pub owner: &'a Pubkey,
     pub executable: bool,
-    pub rent_epoch: Epoch,
     pub data: &'a [u8],
 }
 
@@ -59,7 +58,8 @@ impl ReadableAccount for AccountForGeyser<'_> {
     fn executable(&self) -> bool {
         self.executable
     }
-    fn rent_epoch(&self) -> Epoch {
-        self.rent_epoch
+    fn rent_epoch(&self) -> u64 {
+        // AccountForGeyser does not contains a rent_epoch field
+        0
     }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -110,6 +110,37 @@ pub struct ReplicaAccountInfoV3<'a> {
     pub txn: Option<&'a SanitizedTransaction>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(C)]
+/// Information about an account being updated
+/// (extended with reference to transaction doing this update)
+pub struct ReplicaAccountInfoV4<'a> {
+    /// The Pubkey for the account
+    pub pubkey: &'a [u8],
+
+    /// The lamports for the account
+    pub lamports: u64,
+
+    /// The Pubkey of the owner program account
+    pub owner: &'a [u8],
+
+    /// This account's data contains a loaded program (and is now read-only)
+    pub executable: bool,
+
+    /// The data held in this account.
+    pub data: &'a [u8],
+
+    /// A global monotonically increasing atomic number, which can be used
+    /// to tell the order of the account update. For example, when an
+    /// account is updated in the same slot multiple times, the update
+    /// with higher write_version should supersede the one with lower
+    /// write_version.
+    pub write_version: u64,
+
+    /// Reference to transaction causing this account modification
+    pub txn: Option<&'a SanitizedTransaction>,
+}
+
 /// A wrapper to future-proof ReplicaAccountInfo handling.
 /// If there were a change to the structure of ReplicaAccountInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -119,6 +150,7 @@ pub enum ReplicaAccountInfoVersions<'a> {
     V0_0_1(&'a ReplicaAccountInfo<'a>),
     V0_0_2(&'a ReplicaAccountInfoV2<'a>),
     V0_0_3(&'a ReplicaAccountInfoV3<'a>),
+    V0_0_4(&'a ReplicaAccountInfoV4<'a>),
 }
 
 /// Information about a transaction

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaAccountInfoV3, ReplicaAccountInfoVersions,
+        ReplicaAccountInfoV4, ReplicaAccountInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -93,13 +93,12 @@ impl AccountsUpdateNotifierImpl {
         txn: &'a Option<&'a SanitizedTransaction>,
         pubkey: &'a Pubkey,
         write_version: u64,
-    ) -> ReplicaAccountInfoV3<'a> {
-        ReplicaAccountInfoV3 {
+    ) -> ReplicaAccountInfoV4<'a> {
+        ReplicaAccountInfoV4 {
             pubkey: pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
             executable: account.executable(),
-            rent_epoch: account.rent_epoch(),
             data: account.data(),
             write_version,
             txn: *txn,
@@ -109,13 +108,12 @@ impl AccountsUpdateNotifierImpl {
     fn accountinfo_from_account_for_geyser<'a>(
         &self,
         account: &'a AccountForGeyser<'_>,
-    ) -> ReplicaAccountInfoV3<'a> {
-        ReplicaAccountInfoV3 {
+    ) -> ReplicaAccountInfoV4<'a> {
+        ReplicaAccountInfoV4 {
             pubkey: account.pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
             executable: account.executable(),
-            rent_epoch: account.rent_epoch(),
             data: account.data(),
             write_version: 0, // can/will be populated afterwards
             txn: None,
@@ -124,7 +122,7 @@ impl AccountsUpdateNotifierImpl {
 
     fn notify_plugins_of_account_update(
         &self,
-        account: ReplicaAccountInfoV3,
+        account: ReplicaAccountInfoV4,
         slot: Slot,
         is_startup: bool,
     ) {
@@ -138,7 +136,7 @@ impl AccountsUpdateNotifierImpl {
                 continue;
             }
             match plugin.update_account(
-                ReplicaAccountInfoVersions::V0_0_3(&account),
+                ReplicaAccountInfoVersions::V0_0_4(&account),
                 slot,
                 is_startup,
             ) {


### PR DESCRIPTION
#### Problem

The concept of "rent" has been removed from the protocol. However, `rent_epoch` still lives on inside many account types unnecessarily. These should all be removed.

For this PR, remove them from Geyser.


#### Summary of Changes

* Remove the `rent_epoch` field from `AccountForGeyser`.
* Add a new `ReplicaAccountInfo` version, which does not include rent epoch.
* Use the new `ReplicaAccountInfo` for Geyser account update notifications.

> [!IMPORTANT]
> Adding an enum variant to `ReplicaAccountInfoVersions` in `geyser-plugin-interface/src/geyser_plugin_interface.rs` may require a major version bump for semver.
>
> As such, may need to either (1) wait for the monorepo to bump to v5.0, OR (2) move the geyser interface crate *out* of the monorepo.


#### Testing

Nothing additional.