### PR TITLE
banking trace: disable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+* Banking trace is now disabled by default. To enable, provide `--enable-banking-trace <max bytes>`.
+#### Deprecations
+* `--disable-banking-trace` is now deprecated and a no-op (banking trace is disabled by
+  default). The flag is still accepted for backward compatibility.
 #### Changes
 
 ## 4.2.0

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -22,7 +22,7 @@ rm -rf config/run/init-completed config/ledger
 # Also the banking_tracer thread needs some extra time to flush due to
 # unsynchronized and buffered IO.
 validator_timeout="${SOLANA_VALIDATOR_EXIT_TIMEOUT:-120}"
-SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 200" \
+SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 200 --enable-banking-trace $((1024 * 1024 * 1024))" \
   SOLANA_VALIDATOR_EXIT_TIMEOUT="$validator_timeout" \
   timeout "$validator_timeout" ./scripts/run.sh &
 

--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -7,8 +7,8 @@ use {
             update_bank_forks_and_poh_recorder_for_new_tpu_bank,
         },
         banking_trace::{
-            BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT, BASENAME, BankingTracer, ChannelLabel, Channels,
-            TimedTracedEvent, TracedEvent, TracedSender, TracerThread,
+            BASENAME, BankingTracer, ChannelLabel, Channels, TimedTracedEvent, TracedEvent,
+            TracedSender,
         },
         validator::BlockProductionMethod,
     },
@@ -421,7 +421,6 @@ struct SimulatorLoop {
     blockstore: Arc<Blockstore>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
     retransmit_slots_sender: Sender<Slot>,
-    retracer: Arc<BankingTracer>,
 }
 
 impl SimulatorLoop {
@@ -489,10 +488,6 @@ impl SimulatorLoop {
                 }
                 let new_bank =
                     Bank::new_from_parent(bank.clone_without_scheduler(), new_leader, new_slot);
-                // make sure parent is frozen for finalized hashes via the above
-                // new()-ing of its child bank
-                self.retracer
-                    .hash_event(bank.slot(), &bank.last_blockhash(), &bank.hash());
                 if *bank.leader_id() == self.simulated_leader {
                     logger.log_frozen_bank_cost(&bank, bank_created.elapsed());
                 }
@@ -531,7 +526,6 @@ struct SimulatorThreads {
     poh_service: PohService,
     banking_stage: BankingStageHandle,
     broadcast_stage: BroadcastStage,
-    retracer_thread: TracerThread,
     exit: Arc<AtomicBool>,
 }
 
@@ -542,13 +536,10 @@ impl SimulatorThreads {
         self.exit.store(true, Ordering::Relaxed);
 
         // The order is important. Consuming sender_thread by joining will drop some channels. That
-        // triggers termination of banking_stage, in turn retracer thread will be terminated.
+        // triggers termination of banking_stage.
         sender_thread.join().unwrap();
         self.banking_stage.join().unwrap();
         self.poh_service.join().unwrap();
-        if let Some(retracer_thread) = self.retracer_thread {
-            retracer_thread.join().unwrap().unwrap();
-        }
 
         info!("Joining broadcast stage...");
         drop(retransmit_slots_sender);
@@ -767,27 +758,8 @@ impl BankingSimulator {
             record_receiver_sender,
         );
 
-        // Enable BankingTracer to approximate the real environment as close as possible because
-        // it's not expected to disable BankingTracer on production environments.
-        //
-        // It's not likely for it to affect the banking stage performance noticeably. So, make sure
-        // that assumption is held here. That said, it incurs additional channel sending,
-        // SystemTime::now() and buffered seq IO, and indirectly functions as a background dropper
-        // of `BankingPacketBatch`.
-        //
-        // Lastly, the actual retraced events can be used to evaluate simulation timing accuracy in
-        // the future.
-        let (retracer, retracer_thread) = BankingTracer::new(Some((
-            &blockstore.banking_retracer_path(),
-            exit.clone(),
-            BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
-        )))
-        .unwrap();
-        assert!(retracer.is_enabled());
-        info!("Enabled banking retracer (dir_byte_limit: {BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT})",);
-
         let num_workers = BankingStage::default_num_workers();
-        let banking_tracer_channels = retracer.create_channels();
+        let banking_tracer_channels = BankingTracer::new_disabled().create_channels();
         let Channels {
             non_vote_sender,
             non_vote_receiver,
@@ -908,14 +880,12 @@ impl BankingSimulator {
             blockstore,
             leader_schedule_cache,
             retransmit_slots_sender,
-            retracer,
         };
 
         let simulator_threads = SimulatorThreads {
             poh_service,
             banking_stage,
             broadcast_stage,
-            retracer_thread,
             exit,
         };
 

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -55,8 +55,6 @@ const TRACE_FILE_ROTATE_COUNT: u64 = 14; // target 2 weeks retention under norma
 const TRACE_FILE_WRITE_INTERVAL_MS: u64 = 100;
 const BUF_WRITER_CAPACITY: usize = 10 * 1024 * 1024;
 pub const TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD: u64 = 1024 * 1024 * 1024;
-// disable banking trace by default
-pub const BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT: DirByteLimit = 0;
 
 #[derive(Clone)]
 struct ActiveTracer {

--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -55,9 +55,8 @@ const TRACE_FILE_ROTATE_COUNT: u64 = 14; // target 2 weeks retention under norma
 const TRACE_FILE_WRITE_INTERVAL_MS: u64 = 100;
 const BUF_WRITER_CAPACITY: usize = 10 * 1024 * 1024;
 pub const TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD: u64 = 1024 * 1024 * 1024;
-pub const DISABLED_BAKING_TRACE_DIR: DirByteLimit = 0;
-pub const BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT: DirByteLimit =
-    TRACE_FILE_DEFAULT_ROTATE_BYTE_THRESHOLD * TRACE_FILE_ROTATE_COUNT;
+// disable banking trace by default
+pub const BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT: DirByteLimit = 0;
 
 #[derive(Clone)]
 struct ActiveTracer {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -554,10 +554,6 @@ pub fn banking_trace_path(path: &Path) -> PathBuf {
     path.join("banking_trace")
 }
 
-pub fn banking_retrace_path(path: &Path) -> PathBuf {
-    path.join("banking_retrace")
-}
-
 impl Blockstore {
     pub fn ledger_path(&self) -> &PathBuf {
         &self.ledger_path
@@ -565,10 +561,6 @@ impl Blockstore {
 
     pub fn banking_trace_path(&self) -> PathBuf {
         banking_trace_path(&self.ledger_path)
-    }
-
-    pub fn banking_retracer_path(&self) -> PathBuf {
-        banking_retrace_path(&self.ledger_path)
     }
 
     /// Opens a Ledger in directory, provides "infinite" window of shreds

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -22,7 +22,6 @@ use {
         },
     },
     solana_clock::Slot,
-    solana_core::banking_trace::BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT,
     solana_epoch_schedule::MINIMUM_SLOTS_PER_EPOCH,
     solana_faucet::faucet::{self, FAUCET_PORT},
     solana_hash::Hash,
@@ -364,7 +363,7 @@ impl DefaultArgs {
             tpu_max_fwd_unstaked_connections: 0.to_string(),
             tpu_max_streams_per_ms: DEFAULT_MAX_STREAMS_PER_MS.to_string(),
             num_quic_endpoints: DEFAULT_QUIC_ENDPOINTS.to_string(),
-            banking_trace_dir_byte_limit: BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT.to_string(),
+            banking_trace_dir_byte_limit: 0.to_string(),
             block_production_pacing_fill_time_millis: BankingStage::default_fill_time_millis()
                 .to_string(),
             thread_args: DefaultThreadArgs::default(),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -165,6 +165,14 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         replaced_by: "accounts-db-write-cache-limit",
     );
     add_arg!(
+        // deprecated in v4.3.0
+        Arg::with_name("disable_banking_trace")
+            .long("disable-banking-trace")
+            .conflicts_with("banking_trace_dir_byte_limit")
+            .takes_value(false)
+            .help("Disables the banking trace. No-op, banking trace is disabled by default."),
+    );
+    add_arg!(
         // deprecated in v4.0.0
         Arg::with_name("enable_accounts_disk_index")
             .long("enable-accounts-disk-index")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1124,24 +1124,12 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .value_name("BYTES")
             .validator(is_parsable::<DirByteLimit>)
             .takes_value(true)
-            // Firstly, zero limit value causes tracer to be disabled
-            // altogether, intuitively. On the other hand, this non-zero
-            // default doesn't enable banking tracer unless this flag is
-            // explicitly given, similar to --limit-ledger-size.
-            // see configure_banking_trace_dir_byte_limit() for this.
             .default_value(&default_args.banking_trace_dir_byte_limit)
             .help(
-                "Enables the banking trace explicitly, which is enabled by default and writes \
-                 trace files for simulate-leader-blocks, retaining up to the default or specified \
-                 total bytes in the ledger. This flag can be used to override its byte limit.",
+                "Enables the banking trace that writes trace files for simulate-leader-blocks, \
+                 retaining up to the specified total bytes in the ledger. Banking trace is \
+                 disabled by default.",
             ),
-    )
-    .arg(
-        Arg::with_name("disable_banking_trace")
-            .long("disable-banking-trace")
-            .conflicts_with("banking_trace_dir_byte_limit")
-            .takes_value(false)
-            .help("Disables the banking trace"),
     )
     .arg(
         Arg::with_name("no_delay_leader_block_for_pending_fork")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -33,7 +33,6 @@ use {
     solana_clock::{DEFAULT_SLOTS_PER_EPOCH, Slot},
     solana_core::{
         banking_stage::transaction_scheduler::scheduler_controller::SchedulerConfig,
-        banking_trace::DISABLED_BAKING_TRACE_DIR,
         consensus::tower_storage,
         repair::repair_handler::RepairHandlerType,
         resource_limits,
@@ -869,7 +868,11 @@ pub fn execute(
         },
         enable_block_production_forwarding: staked_nodes_overrides_path.is_some(),
         enable_scheduler_bindings: matches.is_present("enable_scheduler_bindings"),
-        banking_trace_dir_byte_limit: parse_banking_trace_dir_byte_limit(matches),
+        banking_trace_dir_byte_limit: value_t_or_exit!(
+            matches,
+            "banking_trace_dir_byte_limit",
+            u64
+        ),
         validator_exit: Arc::new(RwLock::new(Exit::default())),
         validator_exit_backpressure: [(
             SnapshotPackagerService::NAME.to_string(),
@@ -1189,19 +1192,6 @@ fn get_cluster_shred_version(entrypoints: &[SocketAddr], bind_address: IpAddr) -
         }
     }
     None
-}
-
-fn parse_banking_trace_dir_byte_limit(matches: &ArgMatches) -> u64 {
-    if matches.is_present("disable_banking_trace") {
-        // disable with an explicit flag; This effectively becomes `opt-out` by resetting to
-        // DISABLED_BAKING_TRACE_DIR, while allowing us to specify a default sensible limit in clap
-        // configuration for cli help.
-        DISABLED_BAKING_TRACE_DIR
-    } else {
-        // a default value in clap configuration (BANKING_TRACE_DIR_DEFAULT_BYTE_LIMIT) or
-        // explicit user-supplied override value
-        value_t_or_exit!(matches, "banking_trace_dir_byte_limit", u64)
-    }
 }
 
 fn new_snapshot_config(


### PR DESCRIPTION
#### Problem

- Banking trace has few uses outside of dev/debugging processes
- We run it by default consuming CPU and IOPS

#### Summary of Changes

- Disable by default
- Deprecate old CLI
- Add appropriate entry to the change log
- Remove retracing from banking simulation - its purpose was to emulate production interference of banking trace, which is now disabled = > does not interfere.

#### Testing

Running on mainnet validator, works as advertised.
