### PR TITLE
Removes AccountsFile::remaining_bytes()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5833,9 +5833,9 @@ impl AccountsDb {
             .unwrap_or_else(|| {
                 panic!(
                     "failed to write accounts to storage: slot! {slot}, id: {store_id}, capacity: \
-                     {} bytes, remaining: {} bytes, num accounts: {num_accounts}",
+                     {} bytes, len: {} bytes, num accounts: {num_accounts}",
                     storage.accounts.capacity(),
-                    storage.accounts.remaining_bytes(),
+                    storage.accounts.len(),
                 )
             });
 
@@ -5843,9 +5843,9 @@ impl AccountsDb {
             stored_accounts_info.offsets.len(),
             num_accounts,
             "failed to write all accounts to storage! {slot}, id: {store_id}, capacity: {} bytes, \
-             remaining: {} bytes, num accounts written: {}, num accounts total: {num_accounts}",
+             len: {} bytes, num accounts written: {}, num accounts total: {num_accounts}",
             storage.accounts.capacity(),
-            storage.accounts.remaining_bytes(),
+            storage.accounts.len(),
             stored_accounts_info.offsets.len(),
         );
 

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -100,12 +100,6 @@ impl AccountsFile {
         Ok(())
     }
 
-    pub fn remaining_bytes(&self) -> u64 {
-        match self {
-            Self::AppendVec(av) => av.remaining_bytes(),
-        }
-    }
-
     /// Returns the number of bytes, *not accounts*, used in the AccountsFile
     pub fn len(&self) -> usize {
         match self {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -308,12 +308,6 @@ impl AppendVec {
         Some(new)
     }
 
-    /// how many more bytes can be stored in this append vec
-    pub fn remaining_bytes(&self) -> u64 {
-        self.capacity()
-            .saturating_sub(u64_align!(self.len()) as u64)
-    }
-
     /// Returns the number of bytes, *not items*, used in the AppendVec
     pub fn len(&self) -> usize {
         self.current_len.load(Ordering::Acquire)
@@ -1216,46 +1210,6 @@ mod tests {
         );
         assert_eq!(av.get_account_test(index).unwrap(), account);
         truncate_and_test(av, index);
-    }
-
-    #[test]
-    fn test_remaining_bytes() {
-        let path = get_append_vec_path("test_append");
-        let sz = 1024 * 1024;
-        let sz64 = sz as u64;
-        let av = AppendVec::new(&path.path, sz);
-        assert_eq!(av.capacity(), sz64);
-        assert_eq!(av.remaining_bytes(), sz64);
-
-        // append first account, an u64 aligned account (136 bytes)
-        let mut av_len = 0;
-        let account = create_test_account(0);
-        av.append_account_test(&account).unwrap();
-        av_len += STORE_META_OVERHEAD;
-        assert_eq!(av.capacity(), sz64);
-        assert_eq!(av.remaining_bytes(), sz64 - (STORE_META_OVERHEAD as u64));
-        assert_eq!(av.len(), av_len);
-
-        // append second account, a *not* u64 aligned account (137 bytes)
-        let account = create_test_account(1);
-        let account_storage_len = STORE_META_OVERHEAD + 1;
-        av_len += account_storage_len;
-        av.append_account_test(&account).unwrap();
-        assert_eq!(av.capacity(), sz64);
-        assert_eq!(av.len(), av_len);
-        let alignment_bytes = u64_align!(av_len) - av_len; // bytes used for alignment (7 bytes)
-        assert_eq!(alignment_bytes, 7);
-        assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
-
-        // append third account, a *not* u64 aligned account (137 bytes)
-        let account = create_test_account(1);
-        av.append_account_test(&account).unwrap();
-        let account_storage_len = STORE_META_OVERHEAD + 1;
-        av_len += alignment_bytes; // bytes used for alignment at the end of previous account
-        av_len += account_storage_len;
-        assert_eq!(av.capacity(), sz64);
-        assert_eq!(av.len(), av_len);
-        assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`AccountsFile::remaining_bytes()` is unused.

More context: We're working on adding new account storage file formats, and simplifying the existing AccountsFile API is beneficial. The concept of "remaining bytes" won't really make sense in the new format. And also we don't use remaining_bytes() anywhere today since we always write all accounts in one shot.


#### Summary of Changes

Remove the fn from both AccountsFile and AppendVec.


#### Testing

Nothing additional.