### PR TITLE
accounts-db: Uses set_len() when creating a new AppendVec

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -37,7 +37,7 @@ use {
         self,
         convert::TryFrom,
         fs::{File, OpenOptions, remove_file},
-        io::{self, Seek, SeekFrom, Write},
+        io,
         mem::{self, MaybeUninit},
         path::{Path, PathBuf},
         ptr, slice,
@@ -213,7 +213,7 @@ impl AppendVec {
 
         let _ignored = remove_file(&file);
 
-        let mut data = OpenOptions::new()
+        let data = OpenOptions::new()
             .read(true)
             .write(true)
             .create_new(true)
@@ -228,13 +228,10 @@ impl AppendVec {
             })
             .unwrap();
 
-        // Theoretical performance optimization: write a zero to the end of
-        // the file so that we won't have to resize it later, which may be
-        // expensive.
-        data.seek(SeekFrom::Start((size - 1) as u64)).unwrap();
-        data.write_all(&[0]).unwrap();
-        data.rewind().unwrap();
-        data.flush().unwrap();
+        // Theoretical performance optimization: set the logical/inode size
+        // so that we don't have to resize it later, which may be expensive.
+        let size = u64::try_from(size).unwrap();
+        data.set_len(size).unwrap();
 
         APPEND_VEC_STATS.files_open.fetch_add(1, Ordering::Relaxed);
 
@@ -245,7 +242,7 @@ impl AppendVec {
             // reads. See UNSAFE usage in `append_ptr`
             read_write_state: ReadWriteState::new(true),
             current_len: AtomicUsize::new(initial_len),
-            file_size: size as u64,
+            file_size: size,
             remove_file_on_drop: AtomicBool::new(true),
             is_dirty: AtomicBool::new(false),
         }
@@ -1087,7 +1084,11 @@ mod tests {
         rand_chacha::ChaChaRng,
         solana_account::{AccountSharedData, WritableAccount, accounts_equal},
         solana_clock::Slot,
-        std::{mem::ManuallyDrop, time::Instant},
+        std::{
+            io::{Seek as _, SeekFrom, Write as _},
+            mem::ManuallyDrop,
+            time::Instant,
+        },
         test_case::test_case,
     };
 


### PR DESCRIPTION
#### Problem

AppendVec::new() has a theoretical performance optimization of writing a 0 at the end of the file to avoid resizing later. Writing a 0 doesn't allocate disk space though. It *does* update the inode/EOF/logical size, which may be useful. As a side effect, it also allocates a block for the lone 0, which may never be used.


#### Summary of Changes

Instead of the *seek + write a 0 + rewind + flush* song and dance, just use `File::set_len()`. This sets the inode/logical size, which IMO more clearly expresses intent.


#### Testing

Nothing additional.