### PR TITLE
accounts-db: Removes `from` param in create_store()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3100,7 +3100,7 @@ impl AccountsDb {
         old_store: Arc<AccountStorageEntry>,
         size: u64,
     ) -> ShrinkInProgress<'_> {
-        let shrunken_store = self.create_store(slot, size, "shrink");
+        let shrunken_store = self.create_store(slot, size);
         self.storage
             .shrinking_in_progress(slot, old_store, shrunken_store)
     }
@@ -4043,35 +4043,19 @@ impl AccountsDb {
         }
     }
 
-    fn create_store(&self, slot: Slot, size: u64, from: &str) -> Arc<AccountStorageEntry> {
+    fn create_store(&self, slot: Slot, size: u64) -> Arc<AccountStorageEntry> {
         self.stats
             .create_store_count
             .fetch_add(1, Ordering::Relaxed);
         let paths = &self.paths;
         let path_index = rng().random_range(0..paths.len());
-        let store = Arc::new(self.new_storage_entry(slot, Path::new(&paths[path_index]), size));
-
-        debug!(
-            "creating store: {} slot: {} len: {} size: {} from: {} path: {}",
-            store.id(),
-            slot,
-            store.accounts.len(),
-            store.accounts.capacity(),
-            from,
-            store.accounts.path().display(),
-        );
-
-        store
+        let store = self.new_storage_entry(slot, Path::new(&paths[path_index]), size);
+        Arc::new(store)
     }
 
     #[cfg(test)]
-    fn create_and_insert_store(
-        &self,
-        slot: Slot,
-        size: u64,
-        from: &str,
-    ) -> Arc<AccountStorageEntry> {
-        let store = self.create_store(slot, size, from);
+    fn create_and_insert_store(&self, slot: Slot, size: u64) -> Arc<AccountStorageEntry> {
+        let store = self.create_store(slot, size);
         self.storage.insert(store.clone());
         store
     }
@@ -4695,8 +4679,7 @@ impl AccountsDb {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
             // will be able to find the account in storage
-            let flushed_store =
-                self.create_store(slot, flush_stats.num_bytes_flushed.0, "flush_slot_cache");
+            let flushed_store = self.create_store(slot, flush_stats.num_bytes_flushed.0);
             self.storage.insert(Arc::clone(&flushed_store));
 
             let (store_accounts_for_flush_stats, store_accounts_for_flush_us) =

--- a/accounts-db/src/accounts_db/geyser_plugin_utils.rs
+++ b/accounts-db/src/accounts_db/geyser_plugin_utils.rs
@@ -108,20 +108,20 @@ mod tests {
         // to correct slots. Cache flush can skip writes if accounts have already been written to
         // a newer slot
         let slot0 = 0;
-        let storage0 = accounts_db.create_and_insert_store(slot0, /*size*/ 4_096, "");
+        let storage0 = accounts_db.create_and_insert_store(slot0, /*size*/ 4_096);
         storage0
             .accounts
             .write_accounts(&(slot0, [(&key1, &account)].as_slice()));
 
         let slot1 = 1;
-        let storage1 = accounts_db.create_and_insert_store(slot1, /*size*/ 4_096, "");
+        let storage1 = accounts_db.create_and_insert_store(slot1, /*size*/ 4_096);
         storage1
             .accounts
             .write_accounts(&(slot1, [(&key1, &account)].as_slice()));
 
         // Account with key2 is updated in a single slot, should get notified once
         let slot2 = 2;
-        let storage2 = accounts_db.create_and_insert_store(slot2, /*size*/ 4_096, "");
+        let storage2 = accounts_db.create_and_insert_store(slot2, /*size*/ 4_096);
         storage2
             .accounts
             .write_accounts(&(slot2, [(&key2, &account)].as_slice()));

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -177,7 +177,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
 
     let pubkey = Pubkey::from([1; 32]);
 
-    let append_vec = db.create_and_insert_store(slot0, 1000, "test");
+    let append_vec = db.create_and_insert_store(slot0, 1000);
 
     let mut account_small = AccountSharedData::default();
     account_small.set_data(vec![1]);
@@ -228,7 +228,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     let db = AccountsDb::new_single_for_tests();
     let slot0 = 0;
     let pubkey = Pubkey::from([1; 32]);
-    let append_vec = db.create_and_insert_store(slot0, 1000, "test");
+    let append_vec = db.create_and_insert_store(slot0, 1000);
     let account = AccountSharedData::default();
 
     let data = [(&pubkey, &account)];
@@ -594,7 +594,7 @@ fn test_flush_slots_with_reclaim_old_slots() {
         })
         .collect();
 
-    let storage = accounts.create_and_insert_store(new_slot, 4096, "test_flush_slots");
+    let storage = accounts.create_and_insert_store(new_slot, 4096);
 
     accounts.accounts_cache.add_root(new_slot);
 
@@ -2415,7 +2415,7 @@ fn test_storage_finder() {
     let data_len = 8190;
     let account = AccountSharedData::new(lamports, data_len, &solana_pubkey::new_rand());
     // pre-populate with a smaller empty store
-    db.create_and_insert_store(1, 8192, "test_storage_finder");
+    db.create_and_insert_store(1, 8192);
     db.store_for_tests((1, [(&key, &account)].as_slice()));
 }
 
@@ -5227,7 +5227,7 @@ define_accounts_db_test!(test_calculate_storage_count_and_alive_bytes, |accounts
 
     accounts.accounts_index.set_startup(Startup::Startup);
 
-    let storage = accounts.create_and_insert_store(slot0, 4_000, "flush_slot_cache");
+    let storage = accounts.create_and_insert_store(slot0, 4_000);
     storage
         .accounts
         .write_accounts(&(slot0, &[(&shared_key, &account)][..]));
@@ -5251,7 +5251,7 @@ define_accounts_db_test!(
     test_calculate_storage_count_and_alive_bytes_0_accounts,
     |accounts| {
         // empty store
-        let storage = accounts.create_and_insert_store(0, 1, "test");
+        let storage = accounts.create_and_insert_store(0, 1);
         let mut reader = append_vec::new_scan_accounts_reader();
         let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
         accounts.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
@@ -5283,7 +5283,7 @@ define_accounts_db_test!(
         let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
         let account_big = AccountSharedData::new(1, 1000, AccountSharedData::default().owner());
         let slot0 = 0;
-        let storage = accounts.create_and_insert_store(slot0, 4_000, "flush_slot_cache");
+        let storage = accounts.create_and_insert_store(slot0, 4_000);
         storage
             .accounts
             .write_accounts(&(slot0, &[(&keys[0], &account), (&keys[1], &account_big)][..]));
@@ -5329,7 +5329,7 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
         .collect();
 
     let slot0 = 0;
-    let storage = accounts.create_and_insert_store(slot0, 10_000, "");
+    let storage = accounts.create_and_insert_store(slot0, 10_000);
     let offsets = storage.accounts.write_accounts(&(slot0, &account_list[..]));
 
     let offsets = offsets.unwrap().offsets;
@@ -5853,7 +5853,7 @@ fn test_mark_dirty_dead_stores_no_shrink_in_progress() {
         let slot = 0;
         let db = AccountsDb::new_single_for_tests();
         let size = 1;
-        let existing_store = db.create_and_insert_store(slot, size, "test");
+        let existing_store = db.create_and_insert_store(slot, size);
         let old_id = existing_store.id();
         let dead_storages = db.mark_dirty_dead_stores(slot, add_dirty_stores, None, false);
         assert!(db.storage.get_slot_storage_entry(slot).is_none());
@@ -5878,7 +5878,7 @@ fn test_mark_dirty_dead_stores() {
     for add_dirty_stores in [false, true] {
         let db = AccountsDb::new_single_for_tests();
         let size = 1;
-        let old_store = db.create_and_insert_store(slot, size, "test");
+        let old_store = db.create_and_insert_store(slot, size);
         let old_id = old_store.id();
         let shrink_in_progress = db.get_store_for_shrink(slot, old_store, 100);
         let dead_storages =
@@ -6043,10 +6043,10 @@ define_accounts_db_test!(test_get_sorted_potential_ancient_slots, |db| {
     );
     let root1 = DEFAULT_MAX_ANCIENT_STORAGES as u64 + ancient_append_vec_offset as u64 + 1;
     db.add_root(root1);
-    db.create_and_insert_store(root1, 4096, "test");
+    db.create_and_insert_store(root1, 4096);
     let root2 = root1 + 1;
     db.add_root(root2);
-    db.create_and_insert_store(root2, 4096, "test");
+    db.create_and_insert_store(root2, 4096);
     let oldest_non_ancient_slot = db.get_oldest_non_ancient_slot(&epoch_schedule);
     assert!(
         db.get_sorted_potential_ancient_slots(oldest_non_ancient_slot)
@@ -6822,7 +6822,7 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
 #[test]
 fn test_batch_insert_zero_lamport_single_ref_account_offsets() {
     let accounts = AccountsDb::new_single_for_tests();
-    let storage = accounts.create_and_insert_store(1, 100, "test");
+    let storage = accounts.create_and_insert_store(1, 100);
 
     // Test inserting new offsets
     let offsets1 = vec![10, 20, 30];


### PR DESCRIPTION
#### Problem

The `from` parameter in `AccountsDb::create_store()` is only used for a debug log, which IMO isn't useful.

Additional context: When adding a new storage file format, which will have two files, what would be useful to put in this debug message? Both paths? Both file sizes? Would the AccountsFile API need to handle this just for a debug log?


#### Summary of Changes

Remove it.


#### Testing

Nothing additional.