### PR TITLE
Handle dead keys secondary

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1336,6 +1336,60 @@ impl AccountsDb {
         }
     }
 
+    /// Purges each key in `removed_keys` from the enabled secondary indexes, unless the key is
+    /// still alive in the write cache. `removed_keys` must be keys that are not present in the
+    /// primary index
+    ///
+    /// The cache check is all-or-nothing per key: a key kept because it is cache-live retains all
+    /// of its secondary entries, including stale ones from its dead rooted versions (e.g. an old
+    /// mint after the account is re-created with a new one). Scans tolerate stale entries by
+    /// post-filtering against account data, and they are removed the next time the key dies while
+    /// not cache-resident.
+    ///
+    /// Cache writes populate the secondary indexes but not the primary index, so a key that is gone
+    /// from the primary index can still be alive in the write cache and must keep its secondary
+    /// entries. This is tricky due to the races that need to be considered:
+    /// 1) Removed from the cache then re-added to the cache by replay
+    /// - This is protected by re-checking the cache in the closure passed to purge. Since purge
+    ///   holds the secondary index's reverse-index lock when it re-checks cache presence, and a
+    ///   cache store writes the cache before inserting into the secondary index under that same
+    ///   lock, either the re-check sees the cache write and the entry is not removed, or the
+    ///   removal wins and the store's later insert re-adds it.
+    /// 2) Removed from the cache, and also simultaneously removed from storage by clean
+    /// - Since both the cache removal and the index removal are done before the removal from the
+    ///   secondary index, the worst case is a double removal (both paths remove the same secondary
+    ///   index entry). This is safe since the secondary index removal is idempotent.
+    /// 3) Removed from the storage, but still present in the cache
+    /// - This is protected by checking the cache presence in the closure. If the pubkey is still
+    ///   present in the cache, the secondary index entry is not removed.
+    ///
+    /// We do not need to consider removed from cache -> added to storage. Adding to storage
+    /// requires a cache entry to be present first, so a fresh store of the key would have to be
+    /// rooted and flushed inside this window — impossible because rooting is driven by the same
+    /// ReplayStage thread that purges unrooted slots, and clean runs serially with flush on the
+    /// ABS thread.
+    fn purge_secondary_indexes_for_dead_keys(
+        &self,
+        removed_keys: &PubkeysRemovedFromAccountsIndex,
+    ) {
+        if self.account_indexes.is_empty() {
+            return;
+        }
+        for key in removed_keys {
+            // Purging secondary entries for a key that is still alive in the primary index
+            // would leave a live account invisible to secondary-index scans
+            debug_assert!(
+                !self.accounts_index.contains(key),
+                "key removed from the primary index must not be present: {key}"
+            );
+            self.accounts_index.purge_secondary_indexes_by_inner_key_if(
+                key,
+                &self.account_indexes,
+                || !self.accounts_cache.contains_pubkey(key),
+            );
+        }
+    }
+
     #[must_use]
     pub fn purge_keys_exact<C>(
         &self,
@@ -1362,10 +1416,11 @@ impl AccountsDb {
                 }
             });
 
-        let (pubkeys_removed_from_accounts_index, handle_dead_keys_us) = measure_us!(
-            self.accounts_index
-                .handle_dead_keys(&dead_keys, &self.account_indexes)
-        );
+        let (pubkeys_removed_from_accounts_index, handle_dead_keys_us) = measure_us!({
+            let removed_keys = self.accounts_index.handle_dead_keys(&dead_keys);
+            self.purge_secondary_indexes_for_dead_keys(&removed_keys);
+            removed_keys
+        });
 
         self.stats
             .purge_exact_count
@@ -4129,21 +4184,10 @@ impl AccountsDb {
                     .accounts_cache
                     .remove_slot(*remove_slot)
                     .expect("slot cache entry must still be present");
-                // Cache writes populate the secondary indexes but not the primary index, so a
-                // cache-only accounts dropped here would otherwise leak its secondary entry.
-                // `handle_dead_keys` removes those secondary entries; its return value (the
-                // pubkeys not present in the primary index) is unused because this path does
-                // no reclaim handling.
-                //
-                // Narrow race: If a write re-adds the same pubkey between `remove_slot` and
-                // `handle_dead_keys`, the new secondary entry will be dropped. Only
-                // secondary-index scans observe it (no consensus impact), and it self-heals: the
-                // entry is re-added when that slot flushes, or stays correctly removed if the slot
-                // is later purged.
+                // Potentially purge the secondary entries for any key that has now left the cache
                 if !self.account_indexes.is_empty() {
-                    let _ = self
-                        .accounts_index
-                        .handle_dead_keys(&pubkeys_removed, &self.account_indexes);
+                    let removed_keys = self.accounts_index.handle_dead_keys(&pubkeys_removed);
+                    self.purge_secondary_indexes_for_dead_keys(&removed_keys);
                 }
                 self.accounts_index.write_through_pubkeys(pubkeys_removed);
             }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2025,8 +2025,8 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     assert_eq!(found_accounts, vec![pubkey2]);
 }
 
-// Verify that purge_keys exact does not remove pubkeys from the secondary index if the pubkey
-// is still present in the secondary index
+// Verify that purge_keys_exact does not remove pubkeys from the secondary index if the pubkey
+// is still present in the write cache
 #[test]
 fn test_clean_retains_secondary_index_for_still_cached_key() {
     let accounts = AccountsDb {
@@ -2048,13 +2048,13 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
     let mut account_data_with_mint = vec![0; spl_generic_token::token::Account::get_packed_len()];
     account_data_with_mint[..PUBKEY_BYTES].clone_from_slice(&(mint_key.to_bytes()));
     account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
-    let mut token_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
-    token_account.set_owner(spl_generic_token::token::id());
+    let mut token_account = AccountSharedData::new(1, 0, &spl_generic_token::token::id());
     token_account.set_data(account_data_with_mint);
 
-    let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+    let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
-    // Slot 1: a rooted zero-lamport tombstone. Flush with `All` so it is not reclaimed
+    // Slot 1: a rooted zero-lamport tombstone. Flush with `PubkeysToFlush::All` so it is not
+    // reclaimed
     accounts.store_for_tests((index_slot, [(&pubkey, &zero_account)].as_slice()));
     accounts.add_root(index_slot);
     accounts.flush_accounts_cache_slot_for_tests(index_slot);
@@ -2068,8 +2068,8 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
         Some(1),
     );
 
-    // Clean empties the primary slot list (the newest rooted version is zero lamport) and routes
-    // the pubkey through the secondary purge.
+    // Clean removes the entry from the accounts index (as the newest rooted version is zero
+    // lamport)
     accounts.clean_accounts_for_tests();
 
     // The pubkey is still live in the write cache, so its secondary index entry must survive.

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2025,6 +2025,77 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
     assert_eq!(found_accounts, vec![pubkey2]);
 }
 
+// Verify that purge_keys exact does not remove pubkeys from the secondary index if the pubkey
+// is still present in the secondary index
+#[test]
+fn test_clean_retains_secondary_index_for_still_cached_key() {
+    let accounts = AccountsDb {
+        account_indexes: spl_token_mint_index_enabled(),
+        ..AccountsDb::new_with_config(
+            Vec::new(),
+            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+            None,
+            Arc::default(),
+        )
+    };
+    let pubkey = solana_pubkey::new_rand();
+    let index_slot = 1;
+    let cache_slot = 2;
+
+    // Set up a token account to be added to the secondary index.
+    const SPL_TOKEN_INITIALIZED_OFFSET: usize = 108;
+    let mint_key = Pubkey::new_unique();
+    let mut account_data_with_mint = vec![0; spl_generic_token::token::Account::get_packed_len()];
+    account_data_with_mint[..PUBKEY_BYTES].clone_from_slice(&(mint_key.to_bytes()));
+    account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
+    let mut token_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
+    token_account.set_owner(spl_generic_token::token::id());
+    token_account.set_data(account_data_with_mint);
+
+    let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
+
+    // Slot 1: a rooted zero-lamport tombstone. Flush with `All` so it is not reclaimed
+    accounts.store_for_tests((index_slot, [(&pubkey, &zero_account)].as_slice()));
+    accounts.add_root(index_slot);
+    accounts.flush_accounts_cache_slot_for_tests(index_slot);
+
+    // Slot 2: the account is written to the write cache,
+    accounts.store_for_tests((cache_slot, [(&pubkey, &token_account)].as_slice()));
+    assert_eq!(
+        accounts
+            .accounts_index
+            .get_index_key_size(&AccountIndex::SplTokenMint, &mint_key),
+        Some(1),
+    );
+
+    // Clean empties the primary slot list (the newest rooted version is zero lamport) and routes
+    // the pubkey through the secondary purge.
+    accounts.clean_accounts_for_tests();
+
+    // The pubkey is still live in the write cache, so its secondary index entry must survive.
+    assert!(accounts.accounts_cache.contains_pubkey(&pubkey));
+    assert_eq!(
+        accounts
+            .accounts_index
+            .get_index_key_size(&AccountIndex::SplTokenMint, &mint_key),
+        Some(1),
+        "clean purged the secondary index entry for a live cached account",
+    );
+
+    accounts.purge_slots_from_cache(iter::once(&cache_slot), &PurgeStats::default());
+
+    // The pubkey has been removed from both the index and the write cache. Ensure it is
+    // removed from the secondary index as well.
+    assert!(!accounts.accounts_cache.contains_pubkey(&pubkey));
+    assert_eq!(
+        accounts
+            .accounts_index
+            .get_index_key_size(&AccountIndex::SplTokenMint, &mint_key),
+        None,
+        "Entry should be removed from the secondary index, but it is not",
+    );
+}
+
 #[test]
 fn test_clean_max_slot_zero_lamport_account() {
     let accounts = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -335,9 +335,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Remove keys from the account index if the key's slot list is empty.
-    /// Returns the keys that were removed from the index. These keys should not be accessed again in the current code path.
+    /// Returns the keys that were removed from the index. These keys should not be accessed again
+    /// in the current code path.
+    ///
     /// When secondary indexes are enabled, callers must pass the returned keys to
-    /// `AccountsDb::purge_secondary_indexes_for_dead_keys`, otherwise their secondary entries leak.
+    /// `AccountsDb::purge_secondary_indexes_for_dead_keys`, otherwise their secondary index
+    /// entries leak.
     #[must_use]
     pub fn handle_dead_keys(&self, dead_keys: &[Pubkey]) -> HashSet<Pubkey> {
         let mut pubkeys_removed_from_accounts_index = HashSet::default();

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -314,7 +314,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Is `pubkey` in the index?
-    #[cfg(feature = "dev-context-only-utils")]
     pub(crate) fn contains(&self, pubkey: &Pubkey) -> bool {
         self.get_and_then(pubkey, |entry| (false, entry.is_some()))
     }
@@ -337,22 +336,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     /// Remove keys from the account index if the key's slot list is empty.
     /// Returns the keys that were removed from the index. These keys should not be accessed again in the current code path.
+    /// When secondary indexes are enabled, callers must pass the returned keys to
+    /// `AccountsDb::purge_secondary_indexes_for_dead_keys`, otherwise their secondary entries leak.
     #[must_use]
-    pub fn handle_dead_keys(
-        &self,
-        dead_keys: &[Pubkey],
-        account_indexes: &AccountSecondaryIndexes,
-    ) -> HashSet<Pubkey> {
+    pub fn handle_dead_keys(&self, dead_keys: &[Pubkey]) -> HashSet<Pubkey> {
         let mut pubkeys_removed_from_accounts_index = HashSet::default();
         if !dead_keys.is_empty() {
             for key in dead_keys.iter() {
                 let w_index = self.get_bin(key);
                 if w_index.remove_if_slot_list_empty(*key) {
                     pubkeys_removed_from_accounts_index.insert(*key);
-                    // Note it's only safe to remove all the entries for this key
-                    // because we have the lock for this key's entry in the AccountsIndex,
-                    // so no other thread is also updating the index
-                    self.purge_secondary_indexes_by_inner_key(key, account_indexes);
                 }
             }
         }
@@ -920,21 +913,26 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         })
     }
 
-    fn purge_secondary_indexes_by_inner_key(
+    /// Purges `inner_key` from each enabled secondary index
+    pub(crate) fn purge_secondary_indexes_by_inner_key_if(
         &self,
         inner_key: &Pubkey,
         account_indexes: &AccountSecondaryIndexes,
+        should_remove: impl Fn() -> bool,
     ) {
         if account_indexes.contains(&AccountIndex::ProgramId) {
-            self.program_id_index.remove_by_inner_key(inner_key);
+            self.program_id_index
+                .remove_by_inner_key_if(inner_key, &should_remove);
         }
 
         if account_indexes.contains(&AccountIndex::SplTokenOwner) {
-            self.spl_token_owner_index.remove_by_inner_key(inner_key);
+            self.spl_token_owner_index
+                .remove_by_inner_key_if(inner_key, &should_remove);
         }
 
         if account_indexes.contains(&AccountIndex::SplTokenMint) {
-            self.spl_token_mint_index.remove_by_inner_key(inner_key);
+            self.spl_token_mint_index
+                .remove_by_inner_key_if(inner_key, &should_remove);
         }
     }
 
@@ -2016,7 +2014,10 @@ mod tests {
             &mut ReclaimsSlotList::new(),
         );
 
-        let _ = index.handle_dead_keys(&[account_key], secondary_indexes);
+        let pubkeys = index.handle_dead_keys(&[account_key]);
+        for pubkey in pubkeys {
+            index.purge_secondary_indexes_by_inner_key_if(&pubkey, secondary_indexes, || true);
+        }
         assert!(secondary_index.index.is_empty());
         assert!(secondary_index.reverse_index.is_empty());
     }
@@ -2350,7 +2351,10 @@ mod tests {
         index.slot_list_mut(&account_key, |mut slot_list| slot_list.clear());
 
         // Everything should be deleted
-        let _ = index.handle_dead_keys(&[account_key], &secondary_indexes);
+        let pubkeys = index.handle_dead_keys(&[account_key]);
+        for pubkey in pubkeys {
+            index.purge_secondary_indexes_by_inner_key_if(&pubkey, &secondary_indexes, || true);
+        }
         assert!(secondary_index.index.is_empty());
         assert!(secondary_index.reverse_index.is_empty());
     }
@@ -2498,7 +2502,10 @@ mod tests {
         // pubkey as dead and finally remove all the secondary indexes
         let mut reclaims = ReclaimsSlotList::new();
         index.purge_exact(&account_key, later_slot, &mut reclaims);
-        let _ = index.handle_dead_keys(&[account_key], secondary_indexes);
+        let pubkeys = index.handle_dead_keys(&[account_key]);
+        for pubkey in pubkeys {
+            index.purge_secondary_indexes_by_inner_key_if(&pubkey, secondary_indexes, || true);
+        }
         assert!(secondary_index.index.is_empty());
         assert!(secondary_index.reverse_index.is_empty());
     }
@@ -2654,7 +2661,7 @@ mod tests {
         let index = AccountsIndex::<bool, bool>::default_for_tests();
 
         assert_eq!(
-            index.handle_dead_keys(&[key], &AccountSecondaryIndexes::default()),
+            index.handle_dead_keys(&[key]),
             vec![key].into_iter().collect::<HashSet<_>>()
         );
     }

--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -217,7 +217,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
     /// correct decision if writers update the state that `should_remove` reads before calling
     /// `insert()`; otherwise the check can pass against stale state and remove a mapping that a
     /// concurrent writer expects to survive.
-    pub fn remove_by_inner_key_if(&self, inner_key: &Pubkey, should_remove: impl FnOnce() -> bool) {
+    pub fn remove_by_inner_key_if(&self, inner_key: &Pubkey, should_remove: impl Fn() -> bool) {
         // Note: Always lock the reverse-index first, so we synchronize with insert().
         let DashMapEntry::Occupied(reverse_index_entry) = self.reverse_index.entry(*inner_key)
         else {

--- a/accounts-db/src/accounts_index/secondary.rs
+++ b/accounts-db/src/accounts_index/secondary.rs
@@ -172,7 +172,7 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
 
     /// Removes `inner_key` from `outer_key`'s map.
     ///
-    /// Must only be called by remove_by_inner_key(), or equiv, that is
+    /// Must only be called by remove_by_inner_key_if(), or equiv, that is
     /// holding a lock on self.reverse_index.
     fn remove_index_entries(&self, outer_key: &Pubkey, inner_key: &Pubkey) -> bool {
         let Some(inner_keys) = self.index.get_mut(outer_key) else {
@@ -209,14 +209,27 @@ impl<SecondaryIndexEntryType: SecondaryIndexEntry + Default + Sync + Send>
         was_removed
     }
 
-    /// Removes `inner_key` from the secondary index.
-    pub fn remove_by_inner_key(&self, inner_key: &Pubkey) {
+    /// Removes `inner_key` from the secondary index, if the closure `should_remove` returns true.
+    ///
+    /// `should_remove` is evaluated while holding `inner_key`'s reverse-index entry lock. Because
+    /// `insert()` acquires that same lock before adding a mapping, holding it across the check
+    /// serializes this removal against a concurrent `insert(_, inner_key)`. This only yields a
+    /// correct decision if writers update the state that `should_remove` reads before calling
+    /// `insert()`; otherwise the check can pass against stale state and remove a mapping that a
+    /// concurrent writer expects to survive.
+    pub fn remove_by_inner_key_if(&self, inner_key: &Pubkey, should_remove: impl FnOnce() -> bool) {
         // Note: Always lock the reverse-index first, so we synchronize with insert().
         let DashMapEntry::Occupied(reverse_index_entry) = self.reverse_index.entry(*inner_key)
         else {
             // if inner_key doesn't exist in the reverse-index, nothing to do here
             return;
         };
+
+        // Re-check under the reverse-index entry lock. If the caller no longer wants the key
+        // removed (e.g. it was concurrently re-added), leave its mapping in place.
+        if !should_remove() {
+            return;
+        }
 
         // First go through the reverse-index and remove inner_key from all forward-indexes.
         let num_removed = reverse_index_entry
@@ -286,7 +299,7 @@ mod tests {
             .reverse_index
             .insert(inner_key, RwLock::new(vec![outer_key]));
 
-        secondary_index.remove_by_inner_key(&inner_key);
+        secondary_index.remove_by_inner_key_if(&inner_key, || true);
     }
 
     // Ensures remove_by_inner() enforces invariant that inner_key must
@@ -310,7 +323,31 @@ mod tests {
             .unwrap()
             .remove_inner_key(&inner_key);
 
-        secondary_index.remove_by_inner_key(&inner_key);
+        secondary_index.remove_by_inner_key_if(&inner_key, || true);
+    }
+
+    // remove_by_inner_key_if() only removes when the closure returns true, and the decision
+    // is made against the state observed at removal time.
+    #[test]
+    fn test_remove_by_inner_key_if() {
+        let secondary_index =
+            SecondaryIndex::<RwLockSecondaryIndexEntry>::new("test_secondary_index");
+        let outer_key = Pubkey::new_unique();
+        let inner_key = Pubkey::new_unique();
+        secondary_index.insert(&outer_key, &inner_key);
+
+        // should_remove == false: the mapping is retained.
+        secondary_index.remove_by_inner_key_if(&inner_key, || false);
+        assert!(secondary_index.reverse_index.contains_key(&inner_key));
+        assert!(secondary_index.index.contains_key(&outer_key));
+
+        // should_remove == true: the mapping is dropped.
+        secondary_index.remove_by_inner_key_if(&inner_key, || true);
+        assert!(!secondary_index.reverse_index.contains_key(&inner_key));
+        assert!(!secondary_index.index.contains_key(&outer_key));
+
+        // Absent inner_key: closure is not consulted and nothing panics.
+        secondary_index.remove_by_inner_key_if(&inner_key, || panic!("should not be called"));
     }
 
     /// Ensures concurrent calls to insert() and remove_by_inner() don't race/panic.
@@ -348,7 +385,7 @@ mod tests {
                 while !go.load(Ordering::Relaxed) {}
                 for _ in 0..ITERATIONS {
                     for inner_key in &inner_keys {
-                        secondary_index.remove_by_inner_key(inner_key);
+                        secondary_index.remove_by_inner_key_if(inner_key, || true);
                     }
                 }
             }));
@@ -362,7 +399,7 @@ mod tests {
         // After all the concurrent insert/removals, try removing everything
         // and ensure final state is consistent.
         for inner_key in &inner_keys {
-            secondary_index.remove_by_inner_key(inner_key);
+            secondary_index.remove_by_inner_key_if(inner_key, || true);
             assert!(secondary_index.reverse_index.get(inner_key).is_none());
         }
         for outer_key in &outer_keys {


### PR DESCRIPTION
#### Problem
There are currently two races with secondary key removal, added when accounts were removed from the index.
1. When a pubkey is purged from a dead slot in the cache, it can race with upsert and leave the key not present in the secondary cache until it is rooted.
2. When a zero lamport account is removed from the primary index, it will always be removed from the secondary index, even if it is present in the cache.

#### Summary of Changes
- When removing keys from the index (either the cache index or the accounts index), ensure that keys are not present in the cached index while holding the secondary index lock 


#### Testing
- Added testing for primary index removal issue. 
- Could not create a test that exercised the other race condition without high levels of instrumentation due to tight race. Tested locally with instrumentation

#### Notes
- Will likely backport 
Fixes #
