### PR TITLE
repair: fix race when responding to block id requests during bank switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9126,6 +9126,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "num_enum",
+ "parking_lot 0.12.3",
  "proptest",
  "prost 0.14.4",
  "qualifier_attr",

--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -35,7 +35,7 @@ use {
     solana_gossip::ping_pong::{Ping, Pong},
     solana_keypair::signable::Signable,
     solana_ledger::{
-        blockstore::{Blockstore, BlockstoreError, CompletedSlotsReceiver},
+        blockstore::{Blockstore, BlockstoreError, CompletedSlotsReceiver, SlotMeta},
         blockstore_meta::BlockLocation,
         shred::DATA_SHREDS_PER_FEC_BLOCK,
     },
@@ -157,7 +157,7 @@ enum PendingRepairDecision {
 /// Action to perform as a result of a repair event
 enum RepairAction {
     StartRepair { block: Block },
-    QueueParent { slot: Slot, location: BlockLocation },
+    QueueParent { slot_meta: SlotMeta },
 }
 
 struct RepairState {
@@ -457,7 +457,7 @@ impl BlockIdRepairService {
 
         // Generate repair requests for repair actions
         for action in repair_actions {
-            Self::process_repair_decision(&my_pubkey, action, context.blockstore.as_ref(), state)?;
+            Self::process_repair_decision(&my_pubkey, action, state)?;
         }
 
         // Retry requests that have timed out
@@ -731,12 +731,12 @@ impl BlockIdRepairService {
                     return Ok(PendingRepairDecision::Drop);
                 }
 
-                // Check if we already have the block, if so queue fetching the parent
-                // Note: when a block becomes full in blockstore -> we atomically calculate the DMR and populate location
-                if let Some(location) = blockstore.get_block_location(block.slot, block.block_id)? {
+                // Check if we already have the full block, if so queue fetching the parent.
+                if let Some((slot_meta, _location)) =
+                    blockstore.get_slot_meta_for_block_id(block.slot, block.block_id)?
+                {
                     return Ok(PendingRepairDecision::Act(RepairAction::QueueParent {
-                        slot: block.slot,
-                        location,
+                        slot_meta,
                     }));
                 }
 
@@ -783,10 +783,15 @@ impl BlockIdRepairService {
                              fetching parent",
                             block.slot
                         );
-                        Ok(PendingRepairDecision::Act(RepairAction::QueueParent {
-                            slot: block.slot,
-                            location: BlockLocation::Original,
-                        }))
+                        if let Some((slot_meta, _location)) =
+                            blockstore.get_slot_meta_for_block_id(block.slot, block.block_id)?
+                        {
+                            Ok(PendingRepairDecision::Act(RepairAction::QueueParent {
+                                slot_meta,
+                            }))
+                        } else {
+                            Ok(PendingRepairDecision::KeepPending)
+                        }
                     }
                 }
             }
@@ -797,7 +802,6 @@ impl BlockIdRepairService {
     fn process_repair_decision(
         my_pubkey: &Pubkey,
         action: RepairAction,
-        blockstore: &Blockstore,
         state: &mut RepairState,
     ) -> Result<(), BlockstoreError> {
         match action {
@@ -839,29 +843,18 @@ impl BlockIdRepairService {
                 state.requested_blocks.insert(block);
                 Ok(())
             }
-            RepairAction::QueueParent { slot, location } => {
-                Self::queue_fetch_parent_block(blockstore, slot, location, state)
+            RepairAction::QueueParent { slot_meta } => {
+                Self::queue_fetch_parent_block(slot_meta, state)
             }
         }
     }
 
     /// Helper to fetch the parent block for a slot we already have
     fn queue_fetch_parent_block(
-        blockstore: &Blockstore,
-        slot: Slot,
-        location: BlockLocation,
+        meta: SlotMeta,
         state: &mut RepairState,
     ) -> Result<(), BlockstoreError> {
-        debug_assert!(
-            blockstore
-                .meta_from_location(slot, location)
-                .unwrap()
-                .unwrap()
-                .is_full()
-        );
-        let meta = blockstore
-            .meta_from_location(slot, location)?
-            .expect("SlotMeta must be populated for full slots");
+        debug_assert!(meta.is_full());
 
         state.push_pending_repair_event(RepairEvent::FetchBlock {
             block: Block {
@@ -912,14 +905,9 @@ impl BlockIdRepairService {
             return false;
         };
 
-        let location = BlockLocation::Alternate {
-            block_id: *block_id,
-        };
         blockstore
-            .get_index_from_location(*slot, location)
+            .has_alternate_data_shred(*slot, u64::from(*index), *block_id)
             .ok()
-            .flatten()
-            .map(|idx| idx.data().contains(*index as u64))
             .unwrap_or(false)
     }
 
@@ -1173,7 +1161,7 @@ mod tests {
             }
             PendingRepairDecision::Drop => Ok(()),
             PendingRepairDecision::Act(action) => {
-                BlockIdRepairService::process_repair_decision(&my_pubkey, action, blockstore, state)
+                BlockIdRepairService::process_repair_decision(&my_pubkey, action, state)
             }
         }
     }
@@ -1937,13 +1925,7 @@ mod tests {
             .collect();
 
         for action in actions {
-            BlockIdRepairService::process_repair_decision(
-                &my_pubkey,
-                action,
-                &blockstore,
-                &mut state,
-            )
-            .unwrap();
+            BlockIdRepairService::process_repair_decision(&my_pubkey, action, &mut state).unwrap();
         }
 
         assert_eq!(

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -18,7 +18,7 @@ use {
         ancestor_iterator::{AncestorIterator, AncestorIteratorWithHash},
         blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{DATA_SHREDS_PER_FEC_BLOCK, ErasureSetId, Nonce},
+        shred::{DATA_SHREDS_PER_FEC_BLOCK, Nonce},
     },
     solana_perf::packet::{Packet, PacketBatch, PacketBatchRecycler, RecycledPacketBatch},
     solana_poh::poh_recorder::SharedLeaderState,
@@ -89,13 +89,9 @@ pub trait RepairHandler {
         block_id: Hash,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
-        let location = self
-            .blockstore()
-            .get_block_location(slot, block_id)
-            .ok()??;
         let shred = self
             .blockstore()
-            .get_data_shred_from_location(slot, shred_index, location)
+            .get_data_shred_for_block_id(slot, shred_index, block_id)
             .ok()??;
         let packet = repair_response_packet_from_bytes(shred, from_addr, nonce)?;
         Some(
@@ -170,14 +166,9 @@ pub trait RepairHandler {
         block_id: Hash,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
-        let (double_merkle_meta, location) = self
+        let (double_merkle_meta, slot_meta) = self
             .blockstore()
-            .get_double_merkle_meta_maybe_populate_proofs_for_block_id(slot, block_id)
-            .ok()??;
-
-        let slot_meta = self
-            .blockstore()
-            .meta_from_location(slot, location)
+            .get_parent_repair_metadata(slot, block_id)
             .ok()??;
 
         let parent_slot = slot_meta.parent_slot?;
@@ -207,16 +198,12 @@ pub trait RepairHandler {
         fec_set_index: u32,
         nonce: Nonce,
     ) -> Option<PacketBatch> {
-        let (double_merkle_meta, location) = self
+        let (double_merkle_meta, merkle_root_meta) = self
             .blockstore()
-            .get_double_merkle_meta_maybe_populate_proofs_for_block_id(slot, block_id)
+            .get_fec_set_root_repair_metadata(slot, block_id, fec_set_index)
             .ok()??;
 
-        let fec_set_root = self
-            .blockstore()
-            .merkle_root_meta_from_location(ErasureSetId::new(slot, fec_set_index), location)
-            .ok()??
-            .merkle_root()?;
+        let fec_set_root = merkle_root_meta.merkle_root()?;
         let proof_index = fec_set_index.checked_div(DATA_SHREDS_PER_FEC_BLOCK as u32)?;
         let fec_set_proof = double_merkle_meta.get_fec_set_proof(proof_index)?.to_vec();
 

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2450,7 +2450,8 @@ impl ReplayStage {
                 return Ok(());
             }
 
-            let Some(location) = blockstore.get_block_location(ancestor_slot, ancestor_block_id)?
+            let Some((slot_meta, location)) =
+                blockstore.get_slot_meta_for_block_id(ancestor_slot, ancestor_block_id)?
             else {
                 trace!(
                     "{my_pubkey}: Waiting for repair, deferring switch to block {ancestor_slot} \
@@ -2465,9 +2466,6 @@ impl ReplayStage {
                 blocks_to_switch.push((ancestor_slot, location));
             }
 
-            let slot_meta = blockstore
-                .meta_from_location(ancestor_slot, location)?
-                .expect("Full slots must contain SlotMeta");
             let parent_slot = slot_meta
                 .parent_slot
                 .expect("Full slots must have a parent");

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7164,6 +7164,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "num_enum",
+ "parking_lot 0.12.5",
  "prost",
  "qualifier_attr",
  "rand 0.9.4",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -51,6 +51,7 @@ lru = { workspace = true }
 mockall = { workspace = true }
 num_cpus = { workspace = true }
 num_enum = { workspace = true }
+parking_lot = { workspace = true }
 prost = { workspace = true }
 qualifier_attr = { workspace = true }
 rand = { workspace = true }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -33,6 +33,7 @@ use {
     itertools::Itertools,
     log::*,
     lru::LruCache,
+    parking_lot::{FairMutex, FairMutexGuard},
     rand::Rng,
     rayon::iter::{IntoParallelIterator, ParallelIterator},
     rocksdb::LiveFile,
@@ -273,6 +274,20 @@ pub struct BlockstoreSignals {
     pub update_parent_receiver: UpdateParentReceiver,
 }
 
+struct SwitchBlockLock(FairMutex<()>);
+
+struct SwitchBlockGuard<'a> {
+    _guard: FairMutexGuard<'a, ()>,
+}
+
+impl SwitchBlockLock {
+    fn lock(&self) -> SwitchBlockGuard<'_> {
+        SwitchBlockGuard {
+            _guard: self.0.lock(),
+        }
+    }
+}
+
 // ledger window
 pub struct Blockstore {
     ledger_path: PathBuf,
@@ -312,6 +327,7 @@ pub struct Blockstore {
 
     max_root: AtomicU64,
     insert_shreds_lock: Mutex<()>,
+    switch_block_lock: SwitchBlockLock,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
     update_parent_signals: Mutex<Vec<UpdateParentSender>>,
@@ -654,6 +670,7 @@ impl Blockstore {
                 UPDATE_PARENT_SHRED_PARENT_CACHE_CAPACITY,
             )),
             insert_shreds_lock: Mutex::<()>::default(),
+            switch_block_lock: SwitchBlockLock(FairMutex::new(())),
             max_root,
             lowest_cleanup_slot: RwLock::<Slot>::default(),
             manual_purge_request_sender: Mutex::default(),
@@ -761,7 +778,7 @@ impl Blockstore {
 
     /// Checks all available block versions, if we have a *complete* block for
     /// `block_id`, returns the location where it is stored
-    pub fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
+    fn get_block_location(&self, slot: Slot, block_id: Hash) -> Result<Option<BlockLocation>> {
         for location in [
             BlockLocation::Original,
             BlockLocation::Alternate { block_id },
@@ -771,6 +788,23 @@ impl Blockstore {
             }
         }
         Ok(None)
+    }
+
+    /// Returns the SlotMeta for a complete block identified by `block_id`, along with
+    /// its current location.
+    pub fn get_slot_meta_for_block_id(
+        &self,
+        slot: Slot,
+        block_id: Hash,
+    ) -> Result<Option<(SlotMeta, BlockLocation)>> {
+        let _lock = self.switch_block_lock.lock();
+        let Some(location) = self.get_block_location(slot, block_id)? else {
+            return Ok(None);
+        };
+        let Some(slot_meta) = self.meta_from_location(slot, location)? else {
+            return Ok(None);
+        };
+        Ok(Some((slot_meta, location)))
     }
 
     /// Returns the SlotMeta of the specified slot.
@@ -788,11 +822,7 @@ impl Blockstore {
     }
 
     /// Returns the SlotMeta of the specified slot from the specified location
-    pub fn meta_from_location(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<SlotMeta>> {
+    fn meta_from_location(&self, slot: Slot, location: BlockLocation) -> Result<Option<SlotMeta>> {
         match location {
             BlockLocation::Original => self.meta_cf.get(slot),
             BlockLocation::Alternate { block_id } => self.alt_meta_cf.get((slot, block_id)),
@@ -910,7 +940,7 @@ impl Blockstore {
         self.merkle_root_meta_cf.get(erasure_set.store_key())
     }
 
-    pub fn merkle_root_meta_from_location(
+    fn merkle_root_meta_from_location(
         &self,
         erasure_set: ErasureSetId,
         location: BlockLocation,
@@ -948,13 +978,61 @@ impl Blockstore {
         }
     }
 
-    /// Gets the double merkle meta for the given block denoted by block id
-    /// If the meta is present but the proofs have not yet been populated - generate and store them
-    /// returning the updated double merkle meta along with the location
-    pub fn get_double_merkle_meta_maybe_populate_proofs_for_block_id(
+    /// For serving parent fec-set-count block id repair responses.
+    ///
+    /// Returns relevant metadata for the complete block identified by `block_id`.
+    ///
+    /// If the repair proofs are missing, these are also populated.
+    pub fn get_parent_repair_metadata(
         &self,
         slot: Slot,
         block_id: Hash,
+    ) -> Result<Option<(DoubleMerkleMeta, SlotMeta)>> {
+        let lock = self.switch_block_lock.lock();
+        let Some((double_merkle_meta, location)) =
+            self.get_double_merkle_meta_with_proofs_locked(slot, block_id, &lock)?
+        else {
+            return Ok(None);
+        };
+        let Some(slot_meta) = self.meta_from_location(slot, location)? else {
+            return Ok(None);
+        };
+        Ok(Some((double_merkle_meta, slot_meta)))
+    }
+
+    /// For serving fec-set-root block id repair responses.
+    ///
+    /// Returns relevant metadata for the complete block identified by `block_id`.
+    ///
+    /// If the repair proofs are missing, these are also populated.
+    pub fn get_fec_set_root_repair_metadata(
+        &self,
+        slot: Slot,
+        block_id: Hash,
+        fec_set_index: u32,
+    ) -> Result<Option<(DoubleMerkleMeta, MerkleRootMeta)>> {
+        let lock = self.switch_block_lock.lock();
+        let Some((double_merkle_meta, location)) =
+            self.get_double_merkle_meta_with_proofs_locked(slot, block_id, &lock)?
+        else {
+            return Ok(None);
+        };
+        let erasure_set = ErasureSetId::new(slot, fec_set_index);
+        let Some(merkle_root_meta) = self.merkle_root_meta_from_location(erasure_set, location)?
+        else {
+            return Ok(None);
+        };
+        Ok(Some((double_merkle_meta, merkle_root_meta)))
+    }
+
+    /// Gets the double merkle meta for a complete block identified by `block_id`.
+    /// If the meta is present but the proofs have not yet been populated, generate
+    /// and store them and return the updated double merkle meta.
+    fn get_double_merkle_meta_with_proofs_locked(
+        &self,
+        slot: Slot,
+        block_id: Hash,
+        _switch_block_lock: &SwitchBlockGuard<'_>,
     ) -> Result<Option<(DoubleMerkleMeta, BlockLocation)>> {
         // Find which column this block resides in (if any)
         let Some(location) = self.get_block_location(slot, block_id)? else {
@@ -962,24 +1040,7 @@ impl Blockstore {
         };
 
         // Block was full above, get_block_location returned Some, but may have
-        // been purged by BlockstoreCleanupService in between, or swapped out.
-        if let Some(dmm) = self.get_double_merkle_meta_maybe_populate_proofs(slot, location)?
-            && dmm.double_merkle_root == block_id
-        {
-            Ok(Some((dmm, location)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Gets the double merkle meta for the given block.
-    /// If the meta is present but the proofs have not yet been populated - generate and store them
-    /// and return the updated double merkle meta
-    pub fn get_double_merkle_meta_maybe_populate_proofs(
-        &self,
-        slot: Slot,
-        location: BlockLocation,
-    ) -> Result<Option<DoubleMerkleMeta>> {
+        // been purged by BlockstoreCleanupService in between
         let Some(mut double_merkle_meta) = self.double_merkle_meta_cf.get((slot, location))? else {
             return Ok(None);
         };
@@ -990,7 +1051,11 @@ impl Blockstore {
                 .put((slot, location), &double_merkle_meta)?;
         }
 
-        Ok(Some(double_merkle_meta))
+        if double_merkle_meta.double_merkle_root == block_id {
+            Ok(Some((double_merkle_meta, location)))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Gets the double merkle root for the block in the given location.
@@ -1794,7 +1859,7 @@ impl Blockstore {
 
         let double_merkle_root = *merkle_tree.root();
         // We don't build the proofs here as they are only needed to serve repair requests.
-        // These will be built later when calling `get_double_merkle_meta_maybe_populate_proofs`
+        // These will be built later when serving block-id repair requests.
         let proofs = Vec::new();
 
         // Create and add DoubleMerkleMeta to write batch
@@ -2295,7 +2360,7 @@ impl Blockstore {
     /// 3. Copies shreds from the alternate location to the original location
     /// 4. Verify that the switch was successful
     ///
-    /// Holds `insert_shreds_lock` for the entire operation.
+    /// Holds `switch_block_lock` and `insert_shreds_lock` for the entire operation.
     ///
     /// Assumes that the block at `location` is full.
     pub fn switch_block_from_alternate(
@@ -2312,8 +2377,9 @@ impl Blockstore {
 
         let mut total_measure = Measure::start("switch_block_from_alternate_total");
 
-        let (lock, lock_time_us) = measure_us!(self.insert_shreds_lock.lock().unwrap());
-        metrics.lock_elapsed_us = lock_time_us;
+        let (_switch_block_lock, switch_lock_time_us) = measure_us!(self.switch_block_lock.lock());
+        let (lock, insert_lock_time_us) = measure_us!(self.insert_shreds_lock.lock().unwrap());
+        metrics.lock_elapsed_us = switch_lock_time_us.saturating_add(insert_lock_time_us);
 
         // 1. Backup the original block if needed
         let mut backup_measure = Measure::start("switch_block_from_alternate_backup");
@@ -3474,7 +3540,7 @@ impl Blockstore {
             .collect()
     }
 
-    pub fn get_data_shred_from_location(
+    fn get_data_shred_from_location(
         &self,
         slot: Slot,
         index: u64,
@@ -3488,9 +3554,32 @@ impl Blockstore {
         }
     }
 
+    /// Returns a data shred for a complete block identified by `block_id`.
+    pub fn get_data_shred_for_block_id(
+        &self,
+        slot: Slot,
+        index: u64,
+        block_id: Hash,
+    ) -> Result<Option<Vec<u8>>> {
+        let _lock = self.switch_block_lock.lock();
+        let Some(location) = self.get_block_location(slot, block_id)? else {
+            return Ok(None);
+        };
+        self.get_data_shred_from_location(slot, index, location)
+    }
+
+    /// Returns true if an alternate data shred for `block_id` has been stored.
+    pub fn has_alternate_data_shred(&self, slot: Slot, index: u64, block_id: Hash) -> Result<bool> {
+        Ok(self
+            .alt_index_cf
+            .get((slot, block_id))?
+            .map(|index_meta| index_meta.data().contains(index))
+            .unwrap_or(false))
+    }
+
     /// Gets all data shreds for a slot from the specified location.
     /// Returns shreds in index order starting from `start_index`.
-    pub fn get_data_shreds_for_slot_from_location(
+    fn get_data_shreds_for_slot_from_location(
         &self,
         slot: Slot,
         start_index: u64,
@@ -3673,7 +3762,7 @@ impl Blockstore {
         self.index_cf.get_pinned_t(slot)
     }
 
-    pub fn get_index_from_location(
+    fn get_index_from_location(
         &self,
         slot: Slot,
         location: BlockLocation,

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -6400,15 +6400,27 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     assert_eq!(double_merkle_meta.proofs.len(), 0);
 
     // Generate the proofs
-    let double_merkle_meta = blockstore
-        .get_double_merkle_meta_maybe_populate_proofs(slot, block_location)
+    let (double_merkle_meta, _slot_meta) = blockstore
+        .get_parent_repair_metadata(slot, expected_double_merkle_root)
         .unwrap()
         .unwrap();
+    assert_eq!(
+        blockstore
+            .get_block_location(slot, expected_double_merkle_root)
+            .unwrap(),
+        Some(block_location)
+    );
     let proof_size = get_proof_size(double_merkle_meta.fec_set_count as usize + 1) as usize;
     assert_eq!(
         double_merkle_meta.proofs.len(),
         4 * proof_size * SIZE_OF_MERKLE_PROOF_ENTRY
     ); // 3 FEC sets + 1 parent info
+    let cached_double_merkle_meta = blockstore
+        .double_merkle_meta_cf
+        .get((slot, block_location))
+        .unwrap()
+        .unwrap();
+    assert_eq!(cached_double_merkle_meta.proofs, double_merkle_meta.proofs);
 
     // Verify the proofs
     // FEC sets
@@ -6463,6 +6475,120 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
             .get_double_merkle_root(incomplete_slot, block_location)
             .unwrap()
             .is_none()
+    );
+}
+
+fn insert_test_block_at_location(
+    blockstore: &Blockstore,
+    slot: Slot,
+    parent_slot: Slot,
+    location: BlockLocation,
+) -> (Vec<Shred>, Hash) {
+    let (data_shreds, _) = setup_erasure_shreds(slot, parent_slot, 200);
+    let is_repaired = location != BlockLocation::Original;
+    let shreds = data_shreds
+        .iter()
+        .map(|shred| (Cow::Borrowed(shred), is_repaired, location));
+    let insert_results = blockstore
+        .do_insert_shreds(
+            shreds,
+            false,
+            None,
+            &mut BlockstoreInsertionMetrics::default(),
+        )
+        .unwrap();
+    assert!(insert_results.duplicate_shreds.is_empty());
+
+    let block_id = blockstore
+        .get_double_merkle_root(slot, location)
+        .unwrap()
+        .unwrap();
+    (data_shreds, block_id)
+}
+
+#[test]
+fn test_block_id_reads_remain_consistent_after_switch() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let slot = 1000;
+    let parent_slot = 990;
+
+    let (original_shreds, original_block_id) =
+        insert_test_block_at_location(&blockstore, slot, parent_slot, BlockLocation::Original);
+    let temporary_alternate_location = BlockLocation::Alternate {
+        block_id: Hash::new_unique(),
+    };
+    let (alternate_shreds, alternate_block_id) =
+        insert_test_block_at_location(&blockstore, slot, parent_slot, temporary_alternate_location);
+
+    assert_ne!(original_block_id, alternate_block_id);
+
+    blockstore
+        .switch_block_from_alternate(slot, temporary_alternate_location)
+        .unwrap();
+
+    assert_eq!(
+        blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .unwrap(),
+        Some(alternate_block_id)
+    );
+
+    let (slot_meta, location) = blockstore
+        .get_slot_meta_for_block_id(slot, alternate_block_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(location, BlockLocation::Original);
+    assert!(slot_meta.is_full());
+
+    let backup_location = BlockLocation::Alternate {
+        block_id: original_block_id,
+    };
+    let (slot_meta, location) = blockstore
+        .get_slot_meta_for_block_id(slot, original_block_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(location, backup_location);
+    assert!(slot_meta.is_full());
+
+    assert_eq!(
+        blockstore
+            .get_data_shred_for_block_id(slot, 0, alternate_block_id)
+            .unwrap()
+            .unwrap(),
+        alternate_shreds[0].payload().as_ref()
+    );
+    assert_eq!(
+        blockstore
+            .get_data_shred_for_block_id(slot, 0, original_block_id)
+            .unwrap()
+            .unwrap(),
+        original_shreds[0].payload().as_ref()
+    );
+
+    let (double_merkle_meta, slot_meta) = blockstore
+        .get_parent_repair_metadata(slot, original_block_id)
+        .unwrap()
+        .unwrap();
+    assert_eq!(double_merkle_meta.double_merkle_root, original_block_id);
+    assert!(!double_merkle_meta.proofs.is_empty());
+    assert!(slot_meta.is_full());
+
+    let (double_merkle_meta, merkle_root_meta) = blockstore
+        .get_fec_set_root_repair_metadata(slot, alternate_block_id, 0)
+        .unwrap()
+        .unwrap();
+    assert_eq!(double_merkle_meta.double_merkle_root, alternate_block_id);
+    assert_eq!(
+        merkle_root_meta.merkle_root().unwrap(),
+        alternate_shreds[0].merkle_root().unwrap()
+    );
+    assert!(!double_merkle_meta.proofs.is_empty());
+    assert_eq!(
+        blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .unwrap(),
+        Some(alternate_block_id)
     );
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7349,6 +7349,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "num_enum",
+ "parking_lot 0.12.2",
  "prost",
  "qualifier_attr",
  "rand 0.9.4",

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -581,21 +581,14 @@ impl ConsensusPoolService {
             }
 
             // Check if we've received the full block in blockstore
-            let Some(location) = ctx
+            let Some((slot_meta, _location)) = ctx
                 .blockstore
-                .get_block_location(block.slot, block.block_id)
+                .get_slot_meta_for_block_id(block.slot, block.block_id)
                 .expect("Blockstore operations must succeed")
             else {
                 // Block not yet received, keep waiting
                 return true;
             };
-
-            // Block has been received, get the parent meta
-            let slot_meta = ctx
-                .blockstore
-                .meta_from_location(block.slot, location)
-                .expect("Blockstore operations must succeed")
-                .expect("SlotMeta must exist if block location is present");
 
             let parent_block = Block {
                 slot: slot_meta


### PR DESCRIPTION
#### Problem
In Alpenglow repair related code we have a pattern of:
- Fetch the block location for `block_id`
- Use the location to then fetch other columns for the block (e.g. the repair proofs)

This can lead to a race condition if the block location is `Original`, as between these two steps, we could switch a block from an alternate column to the original column.

This could lead to us serving incorrect information.

#### Summary of Changes

- Add new helpers to get the relevant columns for `block_id` directly
- Introduce a new `switch_block_lock` and lock it in these new helpers
- lock the `switch_block_lock` when switching a block
- Reduce visibility for all the old `_location` helpers

#### Testing
Unit tests