### PR TITLE
Use temporary directories for accounts-db tests

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -516,8 +516,8 @@ fn select_from_range_with_start_end_rates(
 mod tests {
     use {
         super::*,
-        crate::accounts_file::AccountsFileProvider,
-        std::{iter, path::Path},
+        crate::{accounts_db::get_temp_accounts_paths, accounts_file::AccountsFileProvider},
+        std::iter,
         tempfile::TempDir,
     };
 
@@ -551,19 +551,19 @@ mod tests {
         assert!(storage.get_account_storage_entry(slot, id).is_none());
 
         // add a map store
-        let common_store_path = Path::new("");
+        let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
         let store_file_size = 4000;
         let store_file_size2 = store_file_size * 2;
         // 2 append vecs with same id, but different sizes
         let entry = Arc::new(AccountStorageEntry::new(
-            common_store_path,
+            &common_store_path[0],
             slot,
             id,
             store_file_size,
             AccountsFileProvider::AppendVec,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
-            common_store_path,
+            &common_store_path[0],
             slot,
             id,
             store_file_size2,
@@ -810,13 +810,14 @@ mod tests {
     fn test_get_if() {
         let storage = AccountStorage::default();
         assert!(storage.get_if(|_, _| true).is_empty());
+        let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
 
         // add some entries
         let ids = [123, 456, 789];
         for id in ids {
             let slot = id as Slot;
             let entry = AccountStorageEntry::new(
-                Path::new(""),
+                &common_store_path[0],
                 slot,
                 id,
                 5000,

--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -514,12 +514,7 @@ fn select_from_range_with_start_end_rates(
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::{accounts_db::get_temp_accounts_paths, accounts_file::AccountsFileProvider},
-        std::iter,
-        tempfile::TempDir,
-    };
+    use {super::*, crate::accounts_file::AccountsFileProvider, std::iter, tempfile::TempDir};
 
     fn new_test_storage() -> (TempDir, Arc<AccountStorageEntry>) {
         new_test_storage_with(0, 0)
@@ -551,19 +546,19 @@ mod tests {
         assert!(storage.get_account_storage_entry(slot, id).is_none());
 
         // add a map store
-        let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
+        let common_store_path = TempDir::new().unwrap();
         let store_file_size = 4000;
         let store_file_size2 = store_file_size * 2;
         // 2 append vecs with same id, but different sizes
         let entry = Arc::new(AccountStorageEntry::new(
-            &common_store_path[0],
+            common_store_path.path(),
             slot,
             id,
             store_file_size,
             AccountsFileProvider::AppendVec,
         ));
         let entry2 = Arc::new(AccountStorageEntry::new(
-            &common_store_path[0],
+            common_store_path.path(),
             slot,
             id,
             store_file_size2,
@@ -810,14 +805,14 @@ mod tests {
     fn test_get_if() {
         let storage = AccountStorage::default();
         assert!(storage.get_if(|_, _| true).is_empty());
-        let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
+        let common_store_path = TempDir::new().unwrap();
 
         // add some entries
         let ids = [123, 456, 789];
         for id in ids {
             let slot = id as Slot;
             let entry = AccountStorageEntry::new(
-                &common_store_path[0],
+                common_store_path.path(),
                 slot,
                 id,
                 5000,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -116,9 +116,10 @@ fn create_store_for_shrink_tests(
     file_size: u64,
     alive_bytes: usize,
     num_zero_lamport_single_ref_accounts: usize,
-) -> Arc<AccountStorageEntry> {
+) -> (Vec<TempDir>, Arc<AccountStorageEntry>) {
+    let (temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store = Arc::new(AccountStorageEntry::new(
-        Path::new(""),
+        &common_store_path[0],
         slot,
         slot as AccountsFileId,
         file_size,
@@ -129,7 +130,7 @@ fn create_store_for_shrink_tests(
     for offset in 0..num_zero_lamport_single_ref_accounts {
         store.insert_zero_lamport_single_ref_account_offset(offset);
     }
-    store
+    (temp_dirs, store)
 }
 
 /// Macro to define tests for all permutations of accounts-db configs
@@ -1674,7 +1675,7 @@ fn test_alive_bytes_after_shrink() {
     // note the initial alive bytes should be big enough so that subtracting
     // all the zero lamport single ref accounts does not saturate at zero.
     let initial_alive_bytes = 123_456;
-    let store = create_store_for_shrink_tests(
+    let (_temp_dirs, store) = create_store_for_shrink_tests(
         &accounts_db,
         slot,
         4096, // <-- file size
@@ -2849,12 +2850,12 @@ fn test_select_candidates_by_total_usage_3_way_split_condition() {
     let mut candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
 
-    let common_store_path = Path::new("");
+    let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store_file_size = 100;
 
     let store1_slot = 11;
     let store1 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store1_slot,
         store1_slot as AccountsFileId,
         store_file_size,
@@ -2866,7 +2867,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition() {
 
     let store2_slot = 22;
     let store2 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store2_slot,
         store2_slot as AccountsFileId,
         store_file_size,
@@ -2880,7 +2881,7 @@ fn test_select_candidates_by_total_usage_3_way_split_condition() {
 
     let store3_slot = 33;
     let store3 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store3_slot,
         store3_slot as AccountsFileId,
         store_file_size,
@@ -2912,12 +2913,12 @@ fn test_select_candidates_by_total_usage_2_way_split_condition() {
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
-    let common_store_path = Path::new("");
+    let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store_file_size = 100;
 
     let store1_slot = 11;
     let store1 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store1_slot,
         store1_slot as AccountsFileId,
         store_file_size,
@@ -2929,7 +2930,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition() {
 
     let store2_slot = 22;
     let store2 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store2_slot,
         store2_slot as AccountsFileId,
         store_file_size,
@@ -2943,7 +2944,7 @@ fn test_select_candidates_by_total_usage_2_way_split_condition() {
 
     let store3_slot = 33;
     let store3 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store3_slot,
         store3_slot as AccountsFileId,
         store_file_size,
@@ -2972,12 +2973,12 @@ fn test_select_candidates_by_total_usage_all_clean() {
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
-    let common_store_path = Path::new("");
+    let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store_file_size = 100;
 
     let store1_slot = 11;
     let store1 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store1_slot,
         store1_slot as AccountsFileId,
         store_file_size,
@@ -2991,7 +2992,7 @@ fn test_select_candidates_by_total_usage_all_clean() {
 
     let store2_slot = 22;
     let store2 = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         store2_slot,
         store2_slot as AccountsFileId,
         store_file_size,
@@ -3023,7 +3024,7 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
     let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
 
     let slot_with_zlsr = 11;
-    let store_with_zlsr = create_store_for_shrink_tests(
+    let (_temp_dirs_with_zlsr, store_with_zlsr) = create_store_for_shrink_tests(
         &accounts_db,
         slot_with_zlsr,
         file_size as u64,
@@ -3033,7 +3034,7 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
     shrink_candidates.insert(slot_with_zlsr);
 
     let slot_no_zlsr = 22;
-    let store_no_zlsr = create_store_for_shrink_tests(
+    let (_temp_dirs_no_zlsr, store_no_zlsr) = create_store_for_shrink_tests(
         &accounts_db,
         slot_no_zlsr,
         file_size as u64,
@@ -5143,12 +5144,13 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
 fn test_shrink_productive() {
     agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
-    let path = Path::new("");
+    let (_temp_dirs, path) = get_temp_accounts_paths(1).unwrap();
+
     let file_size = 100;
     let slot = 11;
 
     let store = Arc::new(AccountStorageEntry::new(
-        path,
+        &path[0],
         slot,
         slot as AccountsFileId,
         file_size,
@@ -5158,7 +5160,7 @@ fn test_shrink_productive() {
     assert!(!accounts.is_shrinking_productive(&store));
 
     let store = Arc::new(AccountStorageEntry::new(
-        path,
+        &path[0],
         slot,
         slot as AccountsFileId,
         file_size,
@@ -5178,10 +5180,10 @@ fn test_is_candidate_for_shrink() {
     agave_logger::setup();
 
     let mut accounts = AccountsDb::new_single_for_tests();
-    let common_store_path = Path::new("");
+    let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store_file_size = 100_000;
     let entry = Arc::new(AccountStorageEntry::new(
-        common_store_path,
+        &common_store_path[0],
         0,
         1,
         store_file_size,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -116,10 +116,10 @@ fn create_store_for_shrink_tests(
     file_size: u64,
     alive_bytes: usize,
     num_zero_lamport_single_ref_accounts: usize,
-) -> (Vec<TempDir>, Arc<AccountStorageEntry>) {
-    let (temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
+) -> (TempDir, Arc<AccountStorageEntry>) {
+    let temp_dir = TempDir::new().unwrap();
     let store = Arc::new(AccountStorageEntry::new(
-        &common_store_path[0],
+        temp_dir.path(),
         slot,
         slot as AccountsFileId,
         file_size,
@@ -130,7 +130,7 @@ fn create_store_for_shrink_tests(
     for offset in 0..num_zero_lamport_single_ref_accounts {
         store.insert_zero_lamport_single_ref_account_offset(offset);
     }
-    (temp_dirs, store)
+    (temp_dir, store)
 }
 
 /// Macro to define tests for all permutations of accounts-db configs
@@ -1675,7 +1675,7 @@ fn test_alive_bytes_after_shrink() {
     // note the initial alive bytes should be big enough so that subtracting
     // all the zero lamport single ref accounts does not saturate at zero.
     let initial_alive_bytes = 123_456;
-    let (_temp_dirs, store) = create_store_for_shrink_tests(
+    let (_temp_dir, store) = create_store_for_shrink_tests(
         &accounts_db,
         slot,
         4096, // <-- file size
@@ -3024,7 +3024,7 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
     let file_size = AppendVec::calculate_stored_size(0) * num_zero_lamport_single_ref_accounts;
 
     let slot_with_zlsr = 11;
-    let (_temp_dirs_with_zlsr, store_with_zlsr) = create_store_for_shrink_tests(
+    let (_temp_dir_with_zlsr, store_with_zlsr) = create_store_for_shrink_tests(
         &accounts_db,
         slot_with_zlsr,
         file_size as u64,
@@ -3034,7 +3034,7 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
     shrink_candidates.insert(slot_with_zlsr);
 
     let slot_no_zlsr = 22;
-    let (_temp_dirs_no_zlsr, store_no_zlsr) = create_store_for_shrink_tests(
+    let (_temp_dir_no_zlsr, store_no_zlsr) = create_store_for_shrink_tests(
         &accounts_db,
         slot_no_zlsr,
         file_size as u64,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2685,13 +2685,14 @@ mod tests {
     fn test_serialize_deserialize_account_storage_entries(num_storages: u64) {
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
+        let storage_dir = tempfile::tempdir().unwrap();
         let snapshot_slot = num_storages + 1 as Slot;
 
         // Create AccountStorageEntries
         let mut snapshot_storages = Vec::new();
         for i in 0..num_storages {
             let storage = Arc::new(AccountStorageEntry::new(
-                &PathBuf::new(),
+                storage_dir.path(),
                 i,        // Incrementing slot
                 i as u32, // Incrementing id
                 1024,
@@ -2727,6 +2728,7 @@ mod tests {
     fn test_serialize_obsolete_accounts_too_large_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
+        let storage_dir = tempfile::tempdir().unwrap();
         let num_storages = 10;
         let snapshot_slot = num_storages + 1 as Slot;
 
@@ -2734,7 +2736,7 @@ mod tests {
         let mut snapshot_storages = Vec::new();
         for i in 0..num_storages {
             let storage = Arc::new(AccountStorageEntry::new(
-                &PathBuf::new(),
+                storage_dir.path(),
                 i,        // Incrementing slot
                 i as u32, // Incrementing id
                 1024,
@@ -2762,6 +2764,7 @@ mod tests {
     fn test_deserialize_obsolete_accounts_too_large_file() {
         let temp_dir = tempfile::tempdir().unwrap();
         let bank_snapshot_dir = temp_dir.path();
+        let storage_dir = tempfile::tempdir().unwrap();
         let num_storages = 10;
         let snapshot_slot = num_storages + 1 as Slot;
 
@@ -2769,7 +2772,7 @@ mod tests {
         let mut snapshot_storages = Vec::new();
         for i in 0..num_storages {
             let storage = Arc::new(AccountStorageEntry::new(
-                &PathBuf::new(),
+                storage_dir.path(),
                 i,        // Incrementing slot
                 i as u32, // Incrementing id
                 1024,


### PR DESCRIPTION
#### Problem
Many accounts db tests just use Path::new(""). This creates the chance for a collision with other tests using the same directories which causes intermittent failures in CI

#### Summary of Changes
- Use Randomized directories for all tests

#### Testing
- Ran tests under stress and didn't see a failure. 
- Added a debug assert that blank paths were not passed in for the accountStorageEntry::new directory 

Fixes #
