### PR TITLE
refactor: solana-fee remove agave-feature-set dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8504,7 +8504,6 @@ dependencies = [
 name = "solana-fee"
 version = "4.3.0-alpha.0"
 dependencies = [
- "agave-feature-set",
  "solana-fee-structure",
  "solana-svm-transaction",
 ]

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -6,7 +6,6 @@ use {
         scheduler_messages::MaxAge,
     },
     smallvec::SmallVec,
-    solana_fee::FeeFeatures,
     solana_measure::measure_us,
     solana_poh::{
         poh_recorder::PohRecorderError,
@@ -484,7 +483,7 @@ impl Consumer {
             transaction,
             bank.fee_structure().lamports_per_signature,
             transaction_configuration.priority_fee_lamports,
-            FeeFeatures::from(bank.feature_set.as_ref()),
+            bank.fee_features(),
         );
         let (mut fee_payer_account, _slot) = bank
             .rc

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -1,7 +1,6 @@
 use {
     agave_transaction_view::transaction_view::SanitizedTransactionView,
     solana_cost_model::cost_model::CostModel,
-    solana_fee::FeeFeatures,
     solana_runtime::bank::{Bank, CollectorFeeDetails},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction,
@@ -46,7 +45,7 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
         transaction,
         bank.fee_structure().lamports_per_signature,
         transaction_configuration.priority_fee_lamports,
-        FeeFeatures::from(bank.feature_set.as_ref()),
+        bank.fee_features(),
     );
     let reward = bank
         .calculate_reward_and_burn_fee_details(&CollectorFeeDetails::from(fee_details))

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6761,7 +6761,6 @@ dependencies = [
 name = "solana-fee"
 version = "4.3.0-alpha.0"
 dependencies = [
- "agave-feature-set",
  "solana-fee-structure",
  "solana-svm-transaction",
 ]

--- a/fee/Cargo.toml
+++ b/fee/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 agave-unstable-api = []
 
 [dependencies]
-agave-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-svm-transaction = { workspace = true }
 

--- a/fee/src/lib.rs
+++ b/fee/src/lib.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "agave-unstable-api")]
-use {
-    agave_feature_set::FeatureSet, solana_fee_structure::FeeDetails,
-    solana_svm_transaction::svm_message::SVMStaticMessage,
-};
+use {solana_fee_structure::FeeDetails, solana_svm_transaction::svm_message::SVMStaticMessage};
 
 /// Bools indicating the activation of features relevant
 /// to the fee calculation.
@@ -12,12 +9,6 @@ use {
 // in the future. Keeping this struct will help keep things organized.
 #[derive(Copy, Clone)]
 pub struct FeeFeatures {}
-
-impl From<&FeatureSet> for FeeFeatures {
-    fn from(_feature_set: &FeatureSet) -> Self {
-        Self {}
-    }
-}
 
 /// Calculate fee for `SanitizedMessage`
 pub fn calculate_fee(

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6893,7 +6893,6 @@ dependencies = [
 name = "solana-fee"
 version = "4.3.0-alpha.0"
 dependencies = [
- "agave-feature-set",
  "solana-fee-structure",
  "solana-svm-transaction",
 ]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3788,7 +3788,7 @@ fn test_program_fees() {
         &sanitized_message,
         fee_structure.lamports_per_signature,
         prioritization_fee,
-        bank.feature_set.as_ref().into(),
+        bank.fee_features(),
     );
     bank_client
         .send_and_confirm_message(&[&mint_keypair], message)
@@ -3819,7 +3819,7 @@ fn test_program_fees() {
         &sanitized_message,
         fee_structure.lamports_per_signature,
         prioritization_fee,
-        bank.feature_set.as_ref().into(),
+        bank.fee_features(),
     );
     assert!(expected_normal_fee < expected_prioritized_fee);
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3304,6 +3304,11 @@ impl Bank {
         self.fee_rate_governor.lamports_per_signature
     }
 
+    /// Convert Agave's active feature set into the fee crate's narrowed feature view.
+    pub fn fee_features(&self) -> FeeFeatures {
+        FeeFeatures {}
+    }
+
     pub fn get_lamports_per_signature_for_blockhash(&self, hash: &Hash) -> Option<u64> {
         let blockhash_queue = self.blockhash_queue.read().unwrap();
         blockhash_queue.get_lamports_per_signature(hash)
@@ -3326,7 +3331,7 @@ impl Bank {
             message,
             self.fee_structure().lamports_per_signature,
             transaction_configuration.priority_fee_lamports,
-            FeeFeatures::from(self.feature_set.as_ref()),
+            self.fee_features(),
         ))
     }
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -5,7 +5,7 @@ use {
     solana_accounts_db::blockhash_queue::BlockhashQueue,
     solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
-    solana_fee::{FeeFeatures, calculate_fee_details},
+    solana_fee::calculate_fee_details,
     solana_nonce::state::{Data as NonceData, DurableNonce, State as NonceState},
     solana_nonce_account as nonce_account,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
@@ -148,7 +148,7 @@ impl Bank {
 
         let feature_set: &FeatureSet = &self.feature_set;
         let feature_snapshot = feature_set.snapshot();
-        let fee_features = FeeFeatures::from(feature_set);
+        let fee_features = self.fee_features();
 
         let raise_cpi_limit = feature_snapshot.raise_cpi_nesting_limit_to_8;
 

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -4,7 +4,6 @@ use {
     agave_reserved_account_keys::ReservedAccountKeys,
     log::debug,
     solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
-    solana_fee::FeeFeatures,
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_reward_info::RewardType,
@@ -86,7 +85,7 @@ impl Bank {
             transaction,
             self.fee_structure().lamports_per_signature,
             transaction_configuration.priority_fee_lamports,
-            FeeFeatures::from(self.feature_set.as_ref()),
+            self.fee_features(),
         );
         let FeeDistribution {
             deposit: reward,


### PR DESCRIPTION
#### Problem
- Calculating fees is useful in an external scheduler for determining priority
- We currently have a dependency on agave-feature-set, which makes extracting this generally useful crate impossible

#### Summary of Changes
- Remove fee dependency on agave-feature-set
- Add Bank::fee_features

#### Testing
- CI

Fixes #
