### PR TITLE
xdp: inline + remove reexport

### DIFF
--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -2,7 +2,6 @@
 
 use {
     crate::{
-        XdpSender,
         cluster_info::{ClusterInfo, GOSSIP_CHANNEL_CAPACITY},
         cluster_info_metrics::submit_gossip_stats,
         contact_info::ContactInfo,
@@ -11,7 +10,7 @@ use {
     crossbeam_channel::{Sender, TrySendError},
     solana_keypair::Keypair,
     solana_net_utils::{
-        DEFAULT_IP_ECHO_SERVER_THREADS, SocketAddrSpace,
+        DEFAULT_IP_ECHO_SERVER_THREADS, PinnedXdpSender as XdpSender, SocketAddrSpace,
         multihomed_sockets::{BindIpAddrs, MultihomedSocketProvider, SocketProvider},
     },
     solana_perf::{packet::PacketBatch, recycler::Recycler},

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -34,8 +34,6 @@ pub mod restart_crds_values;
 mod sigverify_cache;
 pub mod weighted_shuffle;
 
-pub use solana_net_utils::PinnedXdpSender as XdpSender;
-
 #[macro_use]
 extern crate log;
 

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -605,12 +605,14 @@ impl Router {
         }
     }
 
+    #[inline]
     fn lookup_route_v4(&self, dest_ip: Ipv4Addr) -> Option<&Route<Ipv4Addr>> {
         self.ipv4_lpm
             .lookup(dest_ip)
             .and_then(|route_idx| self.routes.get(route_idx as usize))
     }
 
+    #[inline]
     pub fn route_v4(&self, dest_ip: Ipv4Addr) -> Result<NextHop, RouteError> {
         let route = self
             .lookup_route_v4(dest_ip)


### PR DESCRIPTION
This sprinkles a couple of inlines in places that weren't being inlined and removed an unnecessary reexport from gossip