### PR TITLE
xdp: use array queue for the recv channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,7 +578,6 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
- "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -450,7 +450,6 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
- "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -7,10 +7,11 @@ use {
         contact_info::ContactInfo,
         epoch_specs::EpochSpecs,
     },
-    crossbeam_channel::{Sender, TrySendError},
+    crossbeam_channel::Sender,
     solana_keypair::Keypair,
     solana_net_utils::{
         DEFAULT_IP_ECHO_SERVER_THREADS, PinnedXdpSender as XdpSender, SocketAddrSpace,
+        TrySendError,
         multihomed_sockets::{BindIpAddrs, MultihomedSocketProvider, SocketProvider},
     },
     solana_perf::{packet::PacketBatch, recycler::Recycler},

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -19,6 +19,7 @@ pub mod token_bucket;
 pub mod tooling_for_tests;
 
 pub use {
+    agave_xdp::transmitter::TrySendError,
     ip_echo_client::IpEchoClientError,
     ip_echo_server::{
         DEFAULT_IP_ECHO_SERVER_THREADS, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE, ip_echo_server,

--- a/net-utils/src/pinned_xdp_sender.rs
+++ b/net-utils/src/pinned_xdp_sender.rs
@@ -1,9 +1,6 @@
 //! This module defines [`PinnedXdpSender`] which is a convenience wrapper around
 //! [`agave_xdp::transmitter::XdpSender`] for the case when source address is fixed.
-use {
-    agave_xdp::transmitter as tx, bytes::Bytes, crossbeam_channel::TrySendError,
-    std::net::SocketAddrV4,
-};
+use {agave_xdp::transmitter as tx, bytes::Bytes, std::net::SocketAddrV4};
 
 /// [`PinnedXdpSender`] simplifies sending packets over XDP
 /// when source address is fixed for all items.
@@ -24,7 +21,7 @@ impl PinnedXdpSender {
         sender_index: usize,
         addr: impl Into<tx::XdpAddrs>,
         payload: Bytes,
-    ) -> Result<(), TrySendError<tx::BytesTxPacket>> {
+    ) -> Result<(), tx::TrySendError<tx::BytesTxPacket>> {
         self.sender.try_send(
             sender_index,
             tx::BytesTxPacket::new(self.src_addr, addr, None, payload),

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -438,7 +438,6 @@ dependencies = [
  "aya",
  "bytes",
  "caps",
- "crossbeam-channel",
  "crossbeam-queue",
  "libc",
  "log",

--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -3,10 +3,9 @@
 use {
     agave_xdp::{
         ecn_codepoint::EcnCodepoint as XdpEcnCodepoint,
-        transmitter::{BytesTxPacket, XdpSender},
+        transmitter::{BytesTxPacket, TrySendError, XdpSender},
     },
     bytes::Bytes,
-    crossbeam_channel::TrySendError,
     quinn::{
         AsyncUdpSocket, Runtime, TokioRuntime, UdpPoller,
         udp::{EcnCodepoint as QuinnEcnCodepoint, RecvMeta, Transmit},

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -20,7 +20,6 @@ agave-unstable-api = []
 agave-cpu-utils = { workspace = true }
 arc-swap = { workspace = true }
 bytes = { workspace = true }
-crossbeam-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -1,7 +1,8 @@
+#[cfg(target_os = "linux")]
+pub use crate::tx_loop::TrySendError;
 use {
     crate::ecn_codepoint::EcnCodepoint,
     bytes::Bytes,
-    crossbeam_channel::{Sender, TrySendError},
     std::{
         error::Error,
         net::{SocketAddr, SocketAddrV4},
@@ -16,7 +17,7 @@ use {
         load_xdp_program,
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
-        tx_loop::{TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
+        tx_loop::{self, TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
         umem::{OwnedUmem, PageAlignedMemory},
     },
     agave_cpu_utils::{CpuId, cpu_affinity, set_cpu_affinity},
@@ -142,6 +143,22 @@ impl BytesTxPacket {
     pub fn set_allow_mtu_overflow(&mut self, _allow: bool) {}
 }
 
+#[cfg(not(target_os = "linux"))]
+pub enum TrySendError<T> {
+    Full(T),
+    Disconnected(T),
+}
+
+#[cfg(not(target_os = "linux"))]
+impl std::fmt::Debug for TrySendError<BytesTxPacket> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrySendError::Full(_) => write!(f, "TrySendError::Full"),
+            TrySendError::Disconnected(_) => write!(f, "TrySendError::Disconnected"),
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 impl TxPacket for BytesTxPacket {
     type Addrs = XdpAddrs;
@@ -170,7 +187,8 @@ impl TxPacket for BytesTxPacket {
 
 #[derive(Clone)]
 pub struct XdpSender {
-    senders: Vec<Sender<BytesTxPacket>>,
+    #[cfg(target_os = "linux")]
+    senders: Vec<tx_loop::TxSender<BytesTxPacket>>,
 }
 
 pub enum XdpAddrs {
@@ -209,18 +227,34 @@ impl XdpSender {
         sender_index: usize,
         packet: BytesTxPacket,
     ) -> Result<(), TrySendError<BytesTxPacket>> {
-        let idx = sender_index
-            .checked_rem(self.senders.len())
-            .expect("XdpSender::senders should not be empty");
-        self.senders[idx].try_send(packet)
+        #[cfg(target_os = "linux")]
+        {
+            let idx = sender_index
+                .checked_rem(self.senders.len())
+                .expect("XdpSender::senders should not be empty");
+            self.senders[idx].try_send(packet)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = sender_index;
+            Err(TrySendError::Disconnected(packet))
+        }
     }
 
     pub fn len(&self) -> usize {
-        self.senders.len()
+        #[cfg(target_os = "linux")]
+        return self.senders.len();
+
+        #[cfg(not(target_os = "linux"))]
+        0
     }
 
     pub fn is_empty(&self) -> bool {
-        self.senders.is_empty()
+        #[cfg(target_os = "linux")]
+        return self.senders.is_empty();
+
+        #[cfg(not(target_os = "linux"))]
+        true
     }
 }
 
@@ -364,10 +398,7 @@ impl TransmitterBuilder {
 
     #[cfg(not(target_os = "linux"))]
     pub fn build(self) -> (Transmitter, XdpSender) {
-        (
-            Transmitter { threads: vec![] },
-            XdpSender { senders: vec![] },
-        )
+        (Transmitter { threads: vec![] }, XdpSender {})
     }
 
     #[cfg(target_os = "linux")]
@@ -413,7 +444,7 @@ impl TransmitterBuilder {
 
         let mut senders = vec![];
         for (i, tx_loop) in tx_loops.into_iter().enumerate() {
-            let (sender, receiver) = crossbeam_channel::bounded(tx_channel_cap);
+            let (sender, receiver) = tx_loop::channel(tx_channel_cap);
             let drop_queue = Arc::clone(&drop_queue);
             let atomic_router = Arc::clone(&atomic_router);
             threads.push(

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -18,7 +18,6 @@ use {
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     agave_cpu_utils::set_cpu_affinity,
-    crossbeam_channel::{Receiver, TryRecvError},
     libc::{_SC_PAGESIZE, sysconf},
     std::{
         io,
@@ -214,10 +213,30 @@ pub trait TxPacket {
     fn allow_mtu_overflow(&self) -> bool;
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum TryRecvError {
+    Empty,
+    Disconnected,
+}
+
+pub trait Receiver<T> {
+    fn try_recv(&self) -> Result<T, TryRecvError>;
+}
+
+impl<T> Receiver<T> for crossbeam_channel::Receiver<T> {
+    fn try_recv(&self) -> Result<T, TryRecvError> {
+        self.try_recv().map_err(|err| match err {
+            crossbeam_channel::TryRecvError::Empty => TryRecvError::Empty,
+            crossbeam_channel::TryRecvError::Disconnected => TryRecvError::Disconnected,
+        })
+    }
+}
+
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T, D, R>(self, receiver: Receiver<T>, mut drop_item: D, route_fn: R)
+    pub fn run<T, Rx, D, R>(self, receiver: Rx, mut drop_item: D, route_fn: R)
     where
         T: TxPacket,
+        Rx: Receiver<T>,
         D: FnMut(T),
         R: Fn(&IpAddr) -> Option<NextHop>,
     {

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -18,10 +18,16 @@ use {
         umem::{Frame, OwnedUmem, PageAlignedMemory, Umem},
     },
     agave_cpu_utils::set_cpu_affinity,
+    crossbeam_queue::ArrayQueue,
     libc::{_SC_PAGESIZE, sysconf},
     std::{
-        io,
+        error::Error,
+        fmt, io,
         net::{IpAddr, SocketAddr, SocketAddrV4},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         thread,
         time::Duration,
     },
@@ -213,22 +219,112 @@ pub trait TxPacket {
     fn allow_mtu_overflow(&self) -> bool;
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TryRecvError {
     Empty,
     Disconnected,
 }
 
+pub enum TrySendError<T> {
+    Full(T),
+    Disconnected(T),
+}
+
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full(_) => f.write_str("Full(..)"),
+            Self::Disconnected(_) => f.write_str("Disconnected(..)"),
+        }
+    }
+}
+
+impl<T> fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full(_) => f.write_str("sending into a full XDP transmit channel"),
+            Self::Disconnected(_) => f.write_str("sending into a closed XDP transmit channel"),
+        }
+    }
+}
+
+impl<T> Error for TrySendError<T> {}
+
 pub trait Receiver<T> {
     fn try_recv(&self) -> Result<T, TryRecvError>;
 }
 
-impl<T> Receiver<T> for crossbeam_channel::Receiver<T> {
+pub struct TxSender<T> {
+    queue: Arc<SharedQueue<T>>,
+}
+
+pub struct TxReceiver<T> {
+    queue: Arc<SharedQueue<T>>,
+}
+
+struct SharedQueue<T> {
+    queue: ArrayQueue<T>,
+    senders: AtomicUsize,
+    receivers: AtomicUsize,
+}
+
+pub fn channel<T>(capacity: usize) -> (TxSender<T>, TxReceiver<T>) {
+    let queue = Arc::new(SharedQueue {
+        queue: ArrayQueue::new(capacity),
+        senders: AtomicUsize::new(1),
+        receivers: AtomicUsize::new(1),
+    });
+    (
+        TxSender {
+            queue: Arc::clone(&queue),
+        },
+        TxReceiver { queue },
+    )
+}
+
+impl<T> Clone for TxSender<T> {
+    fn clone(&self) -> Self {
+        self.queue.senders.fetch_add(1, Ordering::Relaxed);
+        Self {
+            queue: Arc::clone(&self.queue),
+        }
+    }
+}
+
+impl<T> Drop for TxSender<T> {
+    fn drop(&mut self) {
+        self.queue.senders.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl<T> TxSender<T> {
+    pub fn try_send(&self, item: T) -> Result<(), TrySendError<T>> {
+        if self.queue.receivers.load(Ordering::Relaxed) == 0 {
+            return Err(TrySendError::Disconnected(item));
+        }
+        self.queue.queue.push(item).map_err(TrySendError::Full)
+    }
+}
+
+impl<T> Drop for TxReceiver<T> {
+    fn drop(&mut self) {
+        self.queue.receivers.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl<T> Receiver<T> for TxReceiver<T> {
     fn try_recv(&self) -> Result<T, TryRecvError> {
-        self.try_recv().map_err(|err| match err {
-            crossbeam_channel::TryRecvError::Empty => TryRecvError::Empty,
-            crossbeam_channel::TryRecvError::Disconnected => TryRecvError::Disconnected,
-        })
+        match self.queue.queue.pop() {
+            Some(item) => Ok(item),
+            // there is a potential race here if the last sender sends an item and then immediately
+            // drops. In that case we'll return Disconnected even though there's an item queued.
+            // That's fine since it's only a shutdown race and we don't guarantee packet delivery in
+            // any case.
+            None if self.queue.senders.load(Ordering::Relaxed) == 0 => {
+                Err(TryRecvError::Disconnected)
+            }
+            None => Err(TryRecvError::Empty),
+        }
     }
 }
 
@@ -614,5 +710,61 @@ fn kick_error(e: std::io::Error) {
         _ => {
             log::error!("network interface driver error: {e:?}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tx_loop::{Receiver, TryRecvError, TrySendError, channel};
+
+    #[test]
+    fn test_send_full() {
+        let (sender, _receiver) = channel(1);
+
+        assert!(sender.try_send(1).is_ok());
+        match sender.try_send(2) {
+            Err(TrySendError::Full(item)) => assert_eq!(item, 2),
+            result => panic!("expected full queue, got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn test_send_disconnected() {
+        let (sender, receiver) = channel(1);
+        drop(receiver);
+
+        match sender.try_send(1) {
+            Err(TrySendError::Disconnected(item)) => assert_eq!(item, 1),
+            result => panic!("expected disconnected queue, got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn test_recv_disconnected() {
+        let (sender, receiver) = channel(1);
+        sender
+            .try_send(1)
+            .expect("send item before dropping sender");
+        drop(sender);
+
+        assert_eq!(receiver.try_recv().expect("receive queued item"), 1);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
+    }
+
+    #[test]
+    fn test_recv_waits_for_cloned_sender() {
+        let (sender, receiver) = channel::<i32>(1);
+        let sender_clone = sender.clone();
+        drop(sender);
+
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+        drop(sender_clone);
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(TryRecvError::Disconnected)
+        ));
     }
 }


### PR DESCRIPTION
Similar to #13658, this switches the recv channel to ArrayQueue too. Split in two commits, the first one abstracts the channel, still leaving the old crossbeam channel impl, second commit switches the impl.