### PR TITLE
Streamer: drop histogram

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10854,7 +10854,6 @@ dependencies = [
  "clap 4.5.31",
  "crossbeam-channel",
  "futures 0.3.32",
- "histogram",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8461,7 +8461,6 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "futures 0.3.32",
- "histogram",
  "indexmap",
  "itertools 0.14.0",
  "libc",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9420,7 +9420,6 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "futures 0.3.32",
- "histogram",
  "indexmap",
  "itertools 0.14.0",
  "libc",

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -27,7 +27,6 @@ agave-xdp = { workspace = true }
 bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures = { workspace = true }
-histogram = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -10,7 +10,6 @@ use {
         sendmmsg::{SendPktsError, batch_send},
     },
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
-    histogram::Histogram,
     solana_measure::measure::Measure,
     solana_net_utils::{
         SocketAddrSpace,
@@ -323,14 +322,29 @@ impl StreamerSendStats {
     ) {
         const MAX_REPORT_ENTRIES: usize = 5;
         let sample_ms = sample_duration.map(|d| d.as_millis()).unwrap_or_default();
-        let mut hist = Histogram::default();
         let mut byte_sum = 0;
         let mut pkt_count = 0;
-        host_map.iter().for_each(|(_addr, host_stats)| {
-            hist.increment(host_stats.bytes).unwrap();
-            byte_sum += host_stats.bytes;
-            pkt_count += host_stats.count;
-        });
+        let mut host_bytes: Vec<u64> = host_map
+            .iter()
+            .map(|(_addr, host_stats)| {
+                byte_sum += host_stats.bytes;
+                pkt_count += host_stats.count;
+                host_stats.bytes
+            })
+            .collect();
+        host_bytes.sort_unstable();
+
+        let percentile = |p: f64| -> u64 {
+            let n = host_bytes.len();
+            if n == 0 {
+                return 0;
+            }
+            let idx = ((p / 100.0) * n as f64).ceil() as usize;
+            host_bytes[idx.saturating_sub(1).min(n - 1)]
+        };
+        let mean = byte_sum
+            .checked_div(host_bytes.len() as u64)
+            .unwrap_or_default();
 
         datapoint_info!(
             name,
@@ -340,34 +354,18 @@ impl StreamerSendStats {
             ("streamer-send-pkt_count_total", pkt_count, i64),
             (
                 "streamer-send-host_bytes_min",
-                hist.minimum().unwrap_or_default(),
+                host_bytes.first().copied().unwrap_or_default(),
                 i64
             ),
             (
                 "streamer-send-host_bytes_max",
-                hist.maximum().unwrap_or_default(),
+                host_bytes.last().copied().unwrap_or_default(),
                 i64
             ),
-            (
-                "streamer-send-host_bytes_mean",
-                hist.mean().unwrap_or_default(),
-                i64
-            ),
-            (
-                "streamer-send-host_bytes_90pct",
-                hist.percentile(90.0).unwrap_or_default(),
-                i64
-            ),
-            (
-                "streamer-send-host_bytes_50pct",
-                hist.percentile(50.0).unwrap_or_default(),
-                i64
-            ),
-            (
-                "streamer-send-host_bytes_10pct",
-                hist.percentile(10.0).unwrap_or_default(),
-                i64
-            ),
+            ("streamer-send-host_bytes_mean", mean, i64),
+            ("streamer-send-host_bytes_90pct", percentile(90.0), i64),
+            ("streamer-send-host_bytes_50pct", percentile(50.0), i64),
+            ("streamer-send-host_bytes_10pct", percentile(10.0), i64),
         );
 
         let num_entries = host_map.len();

--- a/streamer/src/streamer.rs
+++ b/streamer/src/streamer.rs
@@ -325,8 +325,8 @@ impl StreamerSendStats {
         let mut byte_sum = 0;
         let mut pkt_count = 0;
         let mut host_bytes: Vec<u64> = host_map
-            .iter()
-            .map(|(_addr, host_stats)| {
+            .values()
+            .map(|host_stats| {
                 byte_sum += host_stats.bytes;
                 pkt_count += host_stats.count;
                 host_stats.bytes
@@ -389,15 +389,13 @@ impl StreamerSendStats {
             return;
         }
 
-        let host_map = std::mem::take(&mut self.host_map);
+        let capacity = self.host_map.len();
+        let host_map = std::mem::replace(&mut self.host_map, HashMap::with_capacity(capacity));
         let _ = sender.send(Box::new(move || {
             Self::report_stats(name, host_map, elapsed);
         }));
 
-        *self = Self {
-            since: Some(Instant::now()),
-            ..Self::default()
-        };
+        self.since = Some(Instant::now());
     }
 
     fn record(&mut self, pkt: PacketRef) {


### PR DESCRIPTION
#### Problem

Cleaning up the streamer crate.
- histogram crate is cursed, it is a dep we pull to replace 4 LoC.

#### Summary of Changes

- inline the logic we need
- drop the dep
- save some mallocs

#### Testing

CI