### PR TITLE
clippy(ledger-tool): fix warnings around & and return use

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -668,7 +668,7 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
     debug!("from_slot: {from_slot}, to_slot: {to_slot}");
 
     if from_slot > to_slot {
-        return Err("starting slot should be less than or equal to ending slot")?;
+        Err("starting slot should be less than or equal to ending slot")?;
     }
 
     let source_bigtable = get_bigtable(GetBigtableArgs {

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -696,7 +696,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 };
                 println!(
                     "{:>20} {:>44} {:>32} {:>13}",
-                    slot, &hash_str, &time_str, !contains_nonvote
+                    slot, hash_str, time_str, !contains_nonvote
                 );
             }
         }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -1207,7 +1207,7 @@ impl AccountsScanner {
             if let Some(serializer) = seq_serializer {
                 serializer.serialize_element(&cli_account).unwrap();
             } else {
-                print!("{}", &cli_account);
+                print!("{cli_account}");
                 // CliAccount doesn't print the account data payload so handle
                 // that separately. If --no-account-data was specified,
                 // output_config.data_slice_config will have been created to

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -75,9 +75,9 @@ fn load_accounts(path: &Path) -> Result<Input> {
     let file = File::open(path).unwrap();
     let input: Input = serde_json::from_reader(file)?;
     info!("Program input:");
-    info!("program_id: {}", &input.program_id);
-    info!("accounts {:?}", &input.accounts);
-    info!("instruction_data {:?}", &input.instruction_data);
+    info!("program_id: {}", input.program_id);
+    info!("accounts {:?}", input.accounts);
+    info!("instruction_data {:?}", input.instruction_data);
     info!("----------------------------------------");
     Ok(input)
 }


### PR DESCRIPTION
#### Problem
Newer clippy surfaces possible syntax simplifications

#### Summary of Changes
Fix unnecessary return and & 

#### Testing
CI, clippy with 1.97.0-beta + nightly
