### PR TITLE
chore(toolchain): bump to rust 1.97

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-04-11
+  nightly_version=2026-05-22
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.0"


### PR DESCRIPTION
#### Problem
New toolchain available

#### Summary of Changes
Bump rust to 1.97 and nightly to 2026-05-22

#### Testing
Running devbox validator for a few hours, CI
