### PR TITLE
feat(banking_trace): add StableAbi for TimedTracedEvent

### DIFF
--- a/core/src/banking_trace.rs
+++ b/core/src/banking_trace.rs
@@ -68,13 +68,27 @@ pub struct BankingTracer {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample),
-    frozen_abi(digest = "DY2zjwewCSNansb5xwtoxkCcNuXbVmWZe3U9nNH2kzNz")
+    derive(AbiExample, StableAbi, StableAbiSample, PartialEq),
+    frozen_abi(
+        api_digest = "DY2zjwewCSNansb5xwtoxkCcNuXbVmWZe3U9nNH2kzNz",
+        abi_digest = "HS75JiZzndk2y6Az92iEFMwqGj5eWzXpsExVtTveqyZV",
+        test_roundtrip = "eq_and_wire",
+    )
 )]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct TimedTracedEvent(pub std::time::SystemTime, pub TracedEvent);
+pub struct TimedTracedEvent(
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "SystemTime::UNIX_EPOCH + Duration::from_nanos(rng.next_u64())")
+    )]
+    pub SystemTime,
+    pub TracedEvent,
+);
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, PartialEq)
+)]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum TracedEvent {
     PacketBatch(ChannelLabel, BankingPacketBatch),
@@ -83,7 +97,7 @@ pub enum TracedEvent {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, PartialEq)
 )]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum ChannelLabel {

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -34,6 +34,7 @@ dev-context-only-utils = [
 frozen-abi = [
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
+    "solana-packet/frozen-abi",
     "solana-short-vec/frozen-abi",
     "solana-vote-program/frozen-abi",
 ]

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -73,9 +73,13 @@ where
 }
 
 /// Representation of a packet used in TPU.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BytesPacket {
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "solana_frozen_abi::stable_abi::sample_collection(rng)")
+    )]
     buffer: Bytes,
     meta: Meta,
 }
@@ -166,7 +170,10 @@ impl BytesPacket {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum PacketBatch {
     Pinned(RecycledPacketBatch),
@@ -638,7 +645,7 @@ impl IndexedParallelIterator for PacketBatchParIterMut<'_> {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RecycledPacketBatch {
     packets: RecycledVec<Packet>,
@@ -814,7 +821,7 @@ fn to_packet_batches_for_tests<T: Serialize>(items: &[T]) -> Vec<PacketBatch> {
     to_packet_batches(items, NUM_PACKETS)
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BytesPacketBatch {
     packets: Vec<BytesPacket>,

--- a/perf/src/recycled_vec.rs
+++ b/perf/src/recycled_vec.rs
@@ -12,10 +12,11 @@ use {
 
 // A vector wrapper which preallocates vector to be used
 // with a recycler
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct RecycledVec<T: Default + Clone + Sized> {
     x: Vec<T>,
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
     #[serde(skip)]
     recycler: Weak<RecyclerX<RecycledVec<T>>>,
 }


### PR DESCRIPTION
#### Problem
`TimedTracedEvent` is root for serialized format, which is not tested with frozen-abi digests or rountrip tests.

#### Summary of Changes
Convert the top-level banking-trace event type to `StableAbi` so its wire ABI is pinned for the wincode migration. `TimedTracedEvent` gains `StableAbi/StableAbiSample` and an `abi_digest` (bincode, eq_and_wire); the pre-existing digest is kept as api_digest. 
Inner types also get stable abi derives, including struts in `perf` crate.

#### Testing
CI, added frozen-abi tests
