### PR TITLE
version: pin StableAbi/wincode ABI for Version

### DIFF
--- a/version/src/v4.rs
+++ b/version/src/v4.rs
@@ -156,7 +156,15 @@ impl PackedMinor {
     }
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(StableAbi))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(StableAbi),
+    frozen_abi(
+        abi_digest = "CAvtbh3st7PCvB93NjvDDQj1tBz82BmYPL4cNXMByfLX",
+        abi_serializer = ["bincode", "wincode"],
+        test_roundtrip = "eq_and_wire",
+    )
+)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
     major: u16,


### PR DESCRIPTION
#### Problem
v4 Version derives StableAbi with a hand-written Distribution sampler and has manual tests proving serialization behavior / roundtrip. This can now be extended and automated with `StableAbi`: `abi_digest` and `test_roundtrip`.

#### Summary of Changes
Pin the format with `abi_digest` against both serializers (`abi_serializer = ["bincode", "wincode"]`) plus an `eq_and_wire` roundtrip.

(Note: I'm not removing any existing test, this will be considered once we start stripping down bincode dependency completely)

#### Testing
This extends testing, CI.
