### PR TITLE
replay: break ties for switch bank events by lowest block id

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -34,7 +34,8 @@ use {
     },
     agave_votor::{
         event::{
-            CompletedBlock, LatestSwitchRequest, LeaderWindowInfo, VotorEvent, VotorEventSender,
+            CompletedBlock, LatestSwitchRequest, LeaderWindowInfo, SwitchBankEvent, VotorEvent,
+            VotorEventSender,
         },
         root_utils,
         vote_history_storage::SavedVoteHistory,
@@ -2393,7 +2394,7 @@ impl ReplayStage {
     fn process_switch_bank_events(
         my_pubkey: &Pubkey,
         latest_switch_request: &LatestSwitchRequest,
-        pending_switch: &mut Option<Block>,
+        pending_switch: &mut Option<SwitchBankEvent>,
         blockstore: &Blockstore,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
@@ -2401,31 +2402,33 @@ impl ReplayStage {
     ) -> Result<(), BlockstoreError> {
         let root = bank_forks.read().unwrap().root();
 
-        if let Some(block) = latest_switch_request
+        if let Some(event) = latest_switch_request
             .take()
-            .map(|ev| ev.block())
-            .filter(|block| block.slot > root)
+            .filter(|event| event.block().slot > root)
         {
+            let block = event.block();
             match pending_switch {
                 None => {
                     trace!("{my_pubkey}: Setting empty pending_switch to ({block:?})");
-                    *pending_switch = Some(block);
+                    *pending_switch = Some(event);
                 }
-                Some(pending_switch_block) => {
-                    if block.slot >= pending_switch_block.slot {
+                Some(pending_switch_event) => {
+                    if event > *pending_switch_event {
                         trace!(
-                            "{my_pubkey}: Overwriting previous switch request \
-                             {pending_switch_block:?} with ({block:?})"
+                            "{my_pubkey}: Overwriting previous switch request {:?} with \
+                             ({block:?})",
+                            pending_switch_event.block(),
                         );
-                        *pending_switch_block = block;
+                        *pending_switch_event = event;
                     }
                 }
             }
         };
 
-        let Some(block) = *pending_switch else {
+        let Some(event) = *pending_switch else {
             return Ok(());
         };
+        let block = event.block();
 
         if bank_forks.read().unwrap().block_id(block.slot) == Some(block.block_id) {
             // Nothing to switch

--- a/votor/src/event.rs
+++ b/votor/src/event.rs
@@ -4,6 +4,7 @@ use {
     solana_clock::Slot,
     solana_runtime::bank::Bank,
     std::{
+        cmp::Ordering,
         sync::{Arc, Mutex},
         time::Instant,
     },
@@ -137,7 +138,7 @@ impl RepairEvent {
 }
 
 /// Event sent to replay_stage when a bank needs to be switched as a result of a ParentReady.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SwitchBankEvent {
     /// We need to switch any existing banks to this bank including ancestors.
     Switch { block: Block },
@@ -148,6 +149,24 @@ impl SwitchBankEvent {
         match self {
             SwitchBankEvent::Switch { block } => *block,
         }
+    }
+}
+
+// We tie break slot by block_id, preferring the lower block_id
+impl Ord for SwitchBankEvent {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let block = self.block();
+        let other_block = other.block();
+        match block.slot.cmp(&other_block.slot) {
+            Ordering::Equal => other_block.block_id.cmp(&block.block_id),
+            ordering => ordering,
+        }
+    }
+}
+
+impl PartialOrd for SwitchBankEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -174,5 +193,42 @@ impl LatestSwitchRequest {
     /// Atomically takes the current request, leaving the cell empty.
     pub fn take(&self) -> Option<SwitchBankEvent> {
         self.0.lock().unwrap().take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_hash::Hash};
+
+    fn block(slot: u64, id_byte: u8) -> Block {
+        let mut bytes = [0; 32];
+        bytes[31] = id_byte;
+        Block {
+            slot,
+            block_id: Hash::new_from_array(bytes),
+        }
+    }
+
+    fn switch(block: Block) -> SwitchBankEvent {
+        SwitchBankEvent::Switch { block }
+    }
+
+    #[test]
+    fn latest_switch_request_advances_by_slot_with_lowest_block_id_tie_breaker() {
+        let latest = LatestSwitchRequest::default();
+        let slot_3_high = switch(block(3, 9));
+        let slot_3_low = switch(block(3, 3));
+        let slot_2 = switch(block(2, 1));
+        let slot_4 = switch(block(4, 255));
+
+        assert_eq!(latest.try_advance(slot_3_high), None);
+        assert_eq!(latest.try_advance(slot_2), None);
+        assert_eq!(latest.take(), Some(slot_3_high));
+
+        assert_eq!(latest.try_advance(slot_3_high), None);
+        assert_eq!(latest.try_advance(slot_3_low), Some(slot_3_high));
+        assert_eq!(latest.try_advance(slot_3_high), None);
+        assert_eq!(latest.try_advance(slot_4), Some(slot_3_low));
+        assert_eq!(latest.take(), Some(slot_4));
     }
 }


### PR DESCRIPTION
#### Problem
When there are 2 `ParentReady`s for a slot with the same parent slot #, we attempt to switch the bank for the parent.
We break the tie here by selecting the parent with the  maximum block id.

When selecting a parent for leader window production we break the tie by using the minimum block id.
https://github.com/anza-xyz/agave/blob/f3d262195ecea5e92d0f5dcbc1d7515fabda8933/votor/src/consensus_pool/parent_ready_tracker.rs#L237-L247

This means the bank we switch will not be the parent we select and can cause a malicious actor to submit a duplicate block with the hopes of causing our leader window to be skipped.

#### Summary of Changes
Break the tie for bank switch by minimum block id as well.