### PR TITLE
ledger: pin StableAbi/wincode ABI for ShredType

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -224,7 +224,15 @@ pub enum Error {
 }
 
 #[repr(u8)]
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample, AbiEnumVisitor))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "7R7R5DNkXYiSA35A6p5Ej79TmHSAdLicCo5HUkRAMD9Z",
+        abi_serializer = "wincode",
+        test_roundtrip = "eq_and_wire",
+    )
+)]
 #[derive(
     Clone,
     Copy,


### PR DESCRIPTION
#### Problem
`ShredType` is missing auto-derived StableAbi digest / roundtrip test

#### Summary of Changes
`ShredType` is serialized only with wincode (u8 tag_encoding with explicit 0b1010_0101/0b0101_1010 tags); its serde Serialize is not on any live wire path and its bincode encoding would differ, so pin the wincode format only.
Add `StableAbi/StableAbiSample` + `frozen_abi(abi_serializer = "wincode", test_roundtrip = "eq_and_wire")`.

#### Testing
CI, this adds extra frozen-abi tests
