### PR TITLE
v4.1: pin spl-token-cli and cargo-build-sbf versions

### DIFF
--- a/scripts/cargo-build-sbf-version.sh
+++ b/scripts/cargo-build-sbf-version.sh
@@ -1,6 +1,6 @@
 # populate this on the stable branch
-cargoBuildSbfVersion=
-cargoTestSbfVersion=
+cargoBuildSbfVersion=4.1.0
+cargoTestSbfVersion=4.0.0
 
 maybeCargoBuildSbfVersionArg=
 if [[ -n "$cargoBuildSbfVersion" ]]; then

--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.6.1
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

Missed pinning these versions before advancing the channels, and now getting failing CI

#### Summary of Changes

Pin versions to latest releases.
