### PR TITLE
parent_ready_tracker: allow tracking on root for genesis

### DIFF
--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -384,8 +384,7 @@ impl ConsensusPool {
                 });
                 self.migration_status.set_genesis_certificate(genesis_cert);
                 // The genesis block is automatically certified
-                self.parent_ready_tracker
-                    .add_new_notar_fallback_or_stronger(block, events);
+                self.parent_ready_tracker.add_genesis(block, events);
             }
         }
     }
@@ -710,7 +709,7 @@ impl ConsensusPool {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
+        super::{parent_ready_tracker::BlockProductionParent, *},
         crate::tests::get_cluster_info,
         agave_votor_messages::{
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
@@ -2251,6 +2250,49 @@ mod tests {
             slot: 12,
             parent_block
         } if parent_block == &Block { slot: 11, block_id: hash }))
+        );
+    }
+
+    #[test]
+    fn test_genesis_certificate_at_root_seeds_parent_ready() {
+        let mut ctx = TestContext::new();
+        let parent_bank = ctx.bank_forks.read().unwrap().root_bank();
+        let root_bank = create_bank(63, parent_bank, SlotLeader::new_unique());
+        let root_block_id = Hash::new_unique();
+        root_bank.set_block_id(Some(root_block_id));
+        root_bank.freeze();
+        let root_block = Block {
+            slot: root_bank.slot(),
+            block_id: root_block_id,
+        };
+        let mut events = vec![];
+
+        ctx.pool.maybe_prune(root_block.slot);
+        assert_eq!(
+            ctx.pool
+                .parent_ready_tracker
+                .block_production_parent(root_block.slot + 1),
+            BlockProductionParent::ParentNotReady
+        );
+
+        ctx.pool
+            .add_message(
+                &root_bank,
+                &Pubkey::new_unique(),
+                ConsensusMessage::Certificate(Certificate {
+                    cert_type: CertificateType::Genesis(root_block),
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                    bitmap: dummy_bitmap(),
+                }),
+                &mut events,
+            )
+            .unwrap();
+
+        assert_eq!(
+            ctx.pool
+                .parent_ready_tracker
+                .block_production_parent(root_block.slot + 1),
+            BlockProductionParent::Parent(root_block)
         );
     }
 

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -111,7 +111,9 @@ impl ParentReadyTracker {
         }
     }
 
-    /// Adds a new notarize fallback certificate, we can use Notarize/NotarizeFallback/FastFinalize
+    /// Adds a new notarize fallback certificate from observing a  Notarize/NotarizeFallback/FastFinalize cert
+    ///
+    /// Ignore certificates <= our current root
     pub(super) fn add_new_notar_fallback_or_stronger(
         &mut self,
         block: Block,
@@ -121,6 +123,17 @@ impl ParentReadyTracker {
             return;
         }
 
+        self.add_notar_fallback_or_stronger(block, events);
+    }
+
+    /// Adds a notarize fallback certificate for the genesis block.
+    ///
+    /// The genesis block can be the current root.
+    pub(super) fn add_genesis(&mut self, block: Block, events: &mut Vec<VotorEvent>) {
+        self.add_notar_fallback_or_stronger(block, events);
+    }
+
+    fn add_notar_fallback_or_stronger(&mut self, block: Block, events: &mut Vec<VotorEvent>) {
         let status = self.slot_statuses.entry(block.slot).or_default();
         if status.notar_fallbacks.contains(&block) {
             return;
@@ -247,7 +260,6 @@ impl ParentReadyTracker {
             .and_then(|ss| ss.parents_ready.iter().min().copied())
         {
             Some(parent) => BlockProductionParent::Parent(parent),
-            // TODO: this will be plugged in for optimistic block production
             None => BlockProductionParent::ParentNotReady,
         }
     }
@@ -381,6 +393,40 @@ mod tests {
         assert!(tracker.parent_ready(root_slot + 3, root_block));
         assert!(tracker.parent_ready(root_slot + 5, block));
         assert_eq!(tracker.highest_parent_ready(), root_slot + 5);
+    }
+
+    #[test]
+    fn root_notar_fallback_seeds_parent_ready() {
+        let cluster_info = get_cluster_info(Keypair::new());
+        let startup_root = Block::default();
+        let root_slot = 63;
+        let migration_genesis = Block {
+            slot: root_slot,
+            block_id: Hash::new_unique(),
+        };
+        let mut tracker = new_tracker(cluster_info, startup_root);
+        let mut events = vec![];
+
+        tracker.set_root(root_slot);
+        assert_eq!(
+            tracker.block_production_parent(root_slot + 1),
+            BlockProductionParent::ParentNotReady
+        );
+
+        tracker.add_new_notar_fallback_or_stronger(migration_genesis, &mut events);
+        assert!(events.is_empty());
+        assert_eq!(
+            tracker.block_production_parent(root_slot + 1),
+            BlockProductionParent::ParentNotReady
+        );
+
+        tracker.add_genesis(migration_genesis, &mut vec![]);
+        assert!(tracker.parent_ready(root_slot + 1, migration_genesis));
+        assert_eq!(tracker.highest_parent_ready(), root_slot + 1);
+        assert_eq!(
+            tracker.block_production_parent(root_slot + 1),
+            BlockProductionParent::Parent(migration_genesis)
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
The first leader post Alpenglow genesis could potentially panic:

1. The migration period lasts for so long that the Alpenglow genesis block gets rooted (32+ slots of migration)
2. After migration we initialize the parent ready tracker with the genesis block (in this case the root)
3. We filter slots <= root so the parent ready tracker ignores the update
4. When the first leader looks to produce their block, the parent ready tracker will not have a parent for them
5. We panic

#### Summary of Changes
Relax the `<=` root filtering only for the genesis block

#### Testing
CI

Fixes https://github.com/anza-xyz/agave/issues/13748