### PR TITLE
Clean test-sbf installation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,7 @@ Create a PR that makes the following updates to [CHANGELOG.md](https://github.co
 #### Newly Promoted Stable (Former Beta) Branch
 
 1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
-1. Pin the cargo-build-sbf and cargo-test-sbf versions in the newly promoted stable branch by setting `cargoBuildSbfVersion` and `cargoTestSbfVersion` in scripts/cargo-build-sbf-version.sh to the latest release that depends on the stable branch (usually this will be the latest releases).
+1. Pin the cargo-build-sbf versions in the newly promoted stable branch by setting `cargoBuildSbfVersion` in scripts/cargo-build-sbf-version.sh to the latest release that depends on the stable branch (usually this will be the latest releases).
 
 #### Newly Created Beta Branch
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -121,7 +121,7 @@ Create a PR that makes the following updates to [CHANGELOG.md](https://github.co
 #### Newly Promoted Stable (Former Beta) Branch
 
 1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
-1. Pin the cargo-build-sbf versions in the newly promoted stable branch by setting `cargoBuildSbfVersion` in scripts/cargo-build-sbf-version.sh to the latest release that depends on the stable branch (usually this will be the latest releases).
+1. Pin the cargo-build-sbf version in the newly promoted stable branch by setting `cargoBuildSbfVersion` in scripts/cargo-build-sbf-version.sh to the latest release that depends on the stable branch (usually this will be the latest releases).
 
 #### Newly Created Beta Branch
 

--- a/ci/check-install-all.sh
+++ b/ci/check-install-all.sh
@@ -9,7 +9,3 @@ if [[ -z $cargoBuildSbfVersion ]]; then
     echo "On the stable channel, cargoBuildSbfVersion must be set in scripts/cargo-build-sbf-version.sh"
     exit 1
 fi
-if [[ -z $cargoTestSbfVersion ]]; then
-    echo "On the stable channel, cargoTestSbfVersion must be set in scripts/cargo-build-sbf-version.sh"
-    exit 1
-fi

--- a/scripts/cargo-build-sbf-version.sh
+++ b/scripts/cargo-build-sbf-version.sh
@@ -1,15 +1,8 @@
 # populate this on the stable branch
 cargoBuildSbfVersion=
-cargoTestSbfVersion=
 
 maybeCargoBuildSbfVersionArg=
 if [[ -n "$cargoBuildSbfVersion" ]]; then
     # shellcheck disable=SC2034
     maybeCargoBuildSbfVersionArg="--version $cargoBuildSbfVersion"
-fi
-
-maybeCargoTestSbfVersionArg=
-if [[ -n "$cargoTestSbfVersion" ]]; then
-    # shellcheck disable=SC2034
-    maybeCargoTestSbfVersionArg="--version $cargoTestSbfVersion"
 fi


### PR DESCRIPTION
#### Problem

`cargo-build-sbf` now ships with `cargo-test-sbf` in the same crate, so we don't need to install

#### Summary of Changes

1. Update scripts to reflect the fact that a separate installation of `test-sbf` is no longer necessary.
2. Update `RELEASE.md`

#### Testing

No testing was done.