### PR TITLE
block_creation_loop: histogram eradication

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1073,16 +1073,7 @@ fn start_leader_wait_for_parent_replay(
         match maybe_start_leader(slot, parent_slot, parent_hash, ctx) {
             Ok(()) => {
                 slot_delay_start.stop();
-                let _ = ctx
-                    .slot_metrics
-                    .slot_delay_hist
-                    .increment(slot_delay_start.as_us())
-                    .inspect_err(|e| {
-                        error!(
-                            "{}: unable to increment slot delay histogram {e:?}",
-                            ctx.my_pubkey
-                        );
-                    });
+                ctx.slot_metrics.slot_delay_us = slot_delay_start.as_us();
 
                 ctx.slot_metrics.report();
                 return Ok(ctx

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1106,16 +1106,6 @@ fn start_leader_wait_for_parent_replay(
                 };
                 wait_start.stop();
                 ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
-                let _ = ctx
-                    .slot_metrics
-                    .replay_is_behind_wait_elapsed_hist
-                    .increment(wait_start.as_us())
-                    .inspect_err(|e| {
-                        error!(
-                            "{}: unable to increment replay is behind histogram {e:?}",
-                            ctx.my_pubkey
-                        );
-                    });
             }
             Err(StartLeaderError::ParentBlockIdMismatch {
                 expected, actual, ..
@@ -1140,10 +1130,6 @@ fn start_leader_wait_for_parent_replay(
                 }
                 wait_start.stop();
                 ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
-                let _ = ctx
-                    .slot_metrics
-                    .replay_is_behind_wait_elapsed_hist
-                    .increment(wait_start.as_us());
             }
             Err(e) => return Err(e),
         }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -607,11 +607,9 @@ fn produce_window(
         bank_completion_measure.stop();
         ctx.slot_metrics.report();
 
-        ctx.metrics.bank_timeout_completion_count += 1;
-        let _ = ctx
-            .metrics
-            .bank_timeout_completion_elapsed_hist
-            .increment(bank_completion_measure.as_us());
+        ctx.metrics
+            .bank_completion_timing_stats
+            .record(bank_completion_measure.as_us());
 
         // Produce our next slot
         slot += 1;
@@ -626,7 +624,7 @@ fn produce_window(
     }
 
     window_production_start.stop();
-    ctx.metrics.window_production_elapsed += window_production_start.as_us();
+    ctx.metrics.window_production_elapsed_us += window_production_start.as_us();
     Ok(())
 }
 

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -1,19 +1,43 @@
 //! Stats about the block creation loop
 use {
-    histogram::Histogram,
     solana_clock::Slot,
     solana_metrics::datapoint_info,
     std::time::{Duration, Instant},
 };
 
+/// Running min/mean/max of `bank_completion` durations, in microseconds.
+#[derive(Default)]
+pub(crate) struct BankCompletionTimingSamples {
+    min_us: u64,
+    max_us: u64,
+    sum_us: u64,
+    count: u64,
+}
+
+impl BankCompletionTimingSamples {
+    pub(crate) fn record(&mut self, elapsed_us: u64) {
+        self.min_us = if self.count == 0 {
+            elapsed_us
+        } else {
+            self.min_us.min(elapsed_us)
+        };
+        self.max_us = self.max_us.max(elapsed_us);
+        self.sum_us += elapsed_us;
+        self.count += 1;
+    }
+
+    fn mean(&self) -> u64 {
+        self.sum_us.checked_div(self.count).unwrap_or(0)
+    }
+}
+
 pub(crate) struct LoopMetrics {
     pub(crate) last_report: Instant,
     pub(crate) loop_count: u64,
-    pub(crate) bank_timeout_completion_count: u64,
     pub(crate) skipped_window_behind_parent_ready_count: u64,
 
-    pub(crate) window_production_elapsed: u64,
-    pub(crate) bank_timeout_completion_elapsed_hist: Histogram,
+    pub(crate) window_production_elapsed_us: u64,
+    pub(crate) bank_completion_timing_stats: BankCompletionTimingSamples,
 }
 
 impl Default for LoopMetrics {
@@ -21,10 +45,9 @@ impl Default for LoopMetrics {
         Self {
             last_report: Instant::now(),
             loop_count: 0,
-            bank_timeout_completion_count: 0,
             skipped_window_behind_parent_ready_count: 0,
-            window_production_elapsed: 0,
-            bank_timeout_completion_elapsed_hist: Histogram::default(),
+            window_production_elapsed_us: 0,
+            bank_completion_timing_stats: BankCompletionTimingSamples::default(),
         }
     }
 }
@@ -32,10 +55,9 @@ impl Default for LoopMetrics {
 impl LoopMetrics {
     fn is_empty(&self) -> bool {
         0 == self.loop_count
-            + self.bank_timeout_completion_count
-            + self.window_production_elapsed
+            + self.bank_completion_timing_stats.count
+            + self.window_production_elapsed_us
             + self.skipped_window_behind_parent_ready_count
-            + self.bank_timeout_completion_elapsed_hist.entries()
     }
 
     pub(crate) fn report(&mut self, report_interval: Duration) {
@@ -49,13 +71,13 @@ impl LoopMetrics {
                 "block-creation-loop-metrics",
                 ("loop_count", self.loop_count, i64),
                 (
-                    "bank_timeout_completion_count",
-                    self.bank_timeout_completion_count,
+                    "bank_completion_count",
+                    self.bank_completion_timing_stats.count,
                     i64
                 ),
                 (
-                    "window_production_elapsed",
-                    self.window_production_elapsed,
+                    "window_production_elapsed_us",
+                    self.window_production_elapsed_us,
                     i64
                 ),
                 (
@@ -64,31 +86,18 @@ impl LoopMetrics {
                     i64
                 ),
                 (
-                    "bank_timeout_completion_elapsed_90pct",
-                    self.bank_timeout_completion_elapsed_hist
-                        .percentile(90.0)
-                        .unwrap_or(0),
+                    "bank_completion_elapsed_us_min",
+                    self.bank_completion_timing_stats.min_us,
                     i64
                 ),
                 (
-                    "bank_timeout_completion_elapsed_mean",
-                    self.bank_timeout_completion_elapsed_hist
-                        .mean()
-                        .unwrap_or(0),
+                    "bank_completion_elapsed_us_mean",
+                    self.bank_completion_timing_stats.mean(),
                     i64
                 ),
                 (
-                    "bank_timeout_completion_elapsed_min",
-                    self.bank_timeout_completion_elapsed_hist
-                        .minimum()
-                        .unwrap_or(0),
-                    i64
-                ),
-                (
-                    "bank_timeout_completion_elapsed_max",
-                    self.bank_timeout_completion_elapsed_hist
-                        .maximum()
-                        .unwrap_or(0),
+                    "bank_completion_elapsed_us_max",
+                    self.bank_completion_timing_stats.max_us,
                     i64
                 ),
             );
@@ -131,7 +140,7 @@ impl SlotMetrics {
             ("already_have_bank_count", self.already_have_bank_count, i64),
             ("slot_delay_us", self.slot_delay_us, i64),
             (
-                "replay_is_behind_cumulative_wait_elapsed",
+                "replay_is_behind_cumulative_wait_elapsed_us",
                 self.replay_is_behind_cumulative_wait_elapsed,
                 i64
             ),

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -117,7 +117,6 @@ pub(crate) struct SlotMetrics {
 
     pub(crate) slot_delay_us: u64,
     pub(crate) replay_is_behind_cumulative_wait_elapsed: u64,
-    pub(crate) replay_is_behind_wait_elapsed_hist: Histogram,
 }
 
 impl SlotMetrics {
@@ -134,32 +133,6 @@ impl SlotMetrics {
             (
                 "replay_is_behind_cumulative_wait_elapsed",
                 self.replay_is_behind_cumulative_wait_elapsed,
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_90pct",
-                self.replay_is_behind_wait_elapsed_hist
-                    .percentile(90.0)
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_mean",
-                self.replay_is_behind_wait_elapsed_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_min",
-                self.replay_is_behind_wait_elapsed_hist
-                    .minimum()
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_max",
-                self.replay_is_behind_wait_elapsed_hist
-                    .maximum()
-                    .unwrap_or(0),
                 i64
             ),
         );

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -115,7 +115,7 @@ pub(crate) struct SlotMetrics {
     pub(crate) replay_is_behind_count: u64,
     pub(crate) already_have_bank_count: u64,
 
-    pub(crate) slot_delay_hist: Histogram,
+    pub(crate) slot_delay_us: u64,
     pub(crate) replay_is_behind_cumulative_wait_elapsed: u64,
     pub(crate) replay_is_behind_wait_elapsed_hist: Histogram,
 }
@@ -130,26 +130,7 @@ impl SlotMetrics {
             ("leader_handover_sad", self.leader_handover_sad, i64),
             ("replay_is_behind_count", self.replay_is_behind_count, i64),
             ("already_have_bank_count", self.already_have_bank_count, i64),
-            (
-                "slot_delay_90pct",
-                self.slot_delay_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_mean",
-                self.slot_delay_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_min",
-                self.slot_delay_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_max",
-                self.slot_delay_hist.maximum().unwrap_or(0),
-                i64
-            ),
+            ("slot_delay_us", self.slot_delay_us, i64),
             (
                 "replay_is_behind_cumulative_wait_elapsed",
                 self.replay_is_behind_cumulative_wait_elapsed,


### PR DESCRIPTION
#### Problem

- Histogram crate is cursed
- core/src/block_creation_loop.rs misuses it in a variety of exciting ways:
    - slot_delay_hist is a Histogram fed exactly one sample per report which kinda defeats the purpose.
    - replay_is_behind_wait_elapsed_hist basically tracked how long individual wait iterations were. On a sample set of ~2-3 we were computing p90 quantile...
    - bank_timeout_completion_elapsed_hist had ≤2 samples/interval (making percentiles meaningless). Also it does not actually track timeouts as such...

#### Summary of Changes
3 commits:
- collapsing slot_delay_hist to plain slot_delay_us
- dropping replay_is_behind_wait_elapsed_hist 
- replacing bank_timeout_completion_elapsed_hist with O(1) running min/mean/max computation

#### Testing

CI