### PR TITLE
conformance(gossip): expose harness crate under conformance feature

### DIFF
--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -52,6 +52,6 @@ extern crate solana_metrics;
 pub use protocol::gossip_decode_to_effects;
 
 #[cfg(feature = "conformance")]
-mod harness;
+pub mod harness;
 
 mod wire_format_tests;


### PR DESCRIPTION
#### Problem
The gossip `harness` module is private under the `conformance` feature.

#### Summary of Changes
Make the module public under `conformance`.

#### Testing
N/A
