### PR TITLE
votor: remove blocking send when voting service is lagging

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -38,7 +38,6 @@ use {
             VotorEventSender,
         },
         root_utils,
-        vote_history_storage::SavedVoteHistory,
         voting_service::BLSOp,
         voting_utils::{self, GenerateVoteTxResult},
     },
@@ -1774,14 +1773,10 @@ impl ReplayStage {
                     "{} Alpenglow migration: Casting genesis vote for ({block:?})",
                     identity_keypair.pubkey()
                 );
-                // If sending fails that means the channel is disconnected and we are shutting down
-                let _ = own_message_sender.send(ConsensusMessage::Vote(vote_msg.clone()));
-                let _ = bls_sender.send(BLSOp::PushVote {
+                // Unlikely that these channels are backed up, but even so we have refresh logic on the genesis vote
+                let _ = own_message_sender.try_send(ConsensusMessage::Vote(vote_msg.clone()));
+                let _ = bls_sender.try_send(BLSOp::PushVote {
                     vote: Arc::new(vote_msg),
-                    saved_vote_history:
-                        agave_votor::vote_history_storage::SavedVoteHistoryVersions::Current(
-                            SavedVoteHistory::default(),
-                        ),
                 });
             }
             e => {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -599,7 +599,6 @@ impl Tvu {
         let bls_voting_service = BLSVotingService::new(
             bls_receiver,
             cluster_info.clone(),
-            vote_history_storage,
             bls_connection_cache,
             bank_forks.clone(),
             highest_finalized,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -197,7 +197,15 @@ impl EventHandler {
             let mut send_votes_batch_time = Measure::start("send_votes_batch");
             for vote in votes {
                 local_context.stats.incr_vote(&vote);
-                vctx.bls_sender.send(vote).map_err(|_| SendError(()))?;
+                match vctx.bls_sender.try_send(vote) {
+                    Ok(_) => (),
+                    Err(TrySendError::Full(_)) => {
+                        warn!("Vote propagation is backed up, skipping send");
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        return Err(EventLoopError::ReceiverDisconnected(RecvError));
+                    }
+                }
             }
             send_votes_batch_time.stop();
             local_context.stats.send_votes_batch_time_us = local_context
@@ -1017,6 +1025,9 @@ mod tests {
         root_context: RootContext,
         local_context: LocalContext,
         bls_ops: Vec<BLSOp>,
+        vote_history_storage: Arc<FileVoteHistoryStorage>,
+        // Keep the temp directory alive for `vote_history_storage`.
+        _vote_history_storage_dir: TempDir,
     }
 
     struct DirectBankForksController {
@@ -1127,10 +1138,14 @@ mod tests {
         });
         let highest_parent_ready = Arc::new(RwLock::default());
 
+        let vote_history_storage_dir = TempDir::new().unwrap();
+        let vote_history_storage = Arc::new(FileVoteHistoryStorage::new(
+            vote_history_storage_dir.path().to_path_buf(),
+        ));
         let shared_context = SharedContext {
             cluster_info: cluster_info.clone(),
             bank_forks: bank_forks.clone(),
-            vote_history_storage: Arc::new(FileVoteHistoryStorage::default()),
+            vote_history_storage: vote_history_storage.clone(),
             leader_window_info_sender,
             blockstore: blockstore.clone(),
             highest_parent_ready: highest_parent_ready.clone(),
@@ -1149,6 +1164,7 @@ mod tests {
             vote_account_pubkey: my_vote_keypair.pubkey(),
             wait_to_vote_slot: None,
             authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(my_vote_keypair)])),
+            vote_history_storage: vote_history_storage.clone(),
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             consensus_metrics_sender,
@@ -1186,6 +1202,8 @@ mod tests {
             root_context,
             local_context,
             bls_ops: vec![],
+            vote_history_storage,
+            _vote_history_storage_dir: vote_history_storage_dir,
         }
     }
 
@@ -1504,12 +1522,11 @@ mod tests {
             &mut self,
             new_identity: &Keypair,
         ) -> PathBuf {
-            let file_vote_history_storage = FileVoteHistoryStorage::default();
             let saved_vote_history =
                 SavedVoteHistory::new(&VoteHistory::new(new_identity.pubkey(), 0), &new_identity)
                     .unwrap();
             assert!(
-                file_vote_history_storage
+                self.vote_history_storage
                     .store(&SavedVoteHistoryVersions::from(saved_vote_history),)
                     .is_ok()
             );
@@ -1517,7 +1534,7 @@ mod tests {
                 .set_keypair(Arc::new(new_identity.insecure_clone()));
 
             self.send_set_identity_event();
-            file_vote_history_storage.filename(&new_identity.pubkey())
+            self.vote_history_storage.filename(&new_identity.pubkey())
         }
     }
 
@@ -2263,10 +2280,7 @@ mod tests {
         let mut test_context = setup();
         let old_identity = test_context.cluster_info.keypair().insecure_clone();
         let new_identity = Keypair::new();
-        let temp_dir = TempDir::new().unwrap();
-        let vote_history_storage =
-            Arc::new(FileVoteHistoryStorage::new(temp_dir.path().to_path_buf()));
-        test_context.shared_context.vote_history_storage = vote_history_storage.clone();
+        let vote_history_storage = test_context.vote_history_storage.clone();
 
         let new_vote_history = VoteHistory::new(new_identity.pubkey(), 0);
         let saved_vote_history = SavedVoteHistory::new(&new_vote_history, &new_identity).unwrap();

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        staked_validators_cache::StakedValidatorsCache,
-        vote_history_storage::{SavedVoteHistoryVersions, VoteHistoryStorage},
-    },
+    crate::staked_validators_cache::StakedValidatorsCache,
     agave_votor_messages::{
         certificate::Certificate, consensus_message::VoteMessage,
         wire::VersionedWireConsensusMessage,
@@ -12,7 +9,6 @@ use {
     solana_clock::Slot,
     solana_connection_cache::client_connection::ClientConnection,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank_forks::BankForks, validated_block_finalization::ValidatedBlockFinalizationCert,
@@ -52,19 +48,10 @@ const STANDSTILL_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug)]
 pub enum BLSOp {
-    PushVote {
-        vote: Arc<VoteMessage>,
-        saved_vote_history: SavedVoteHistoryVersions,
-    },
-    PushCertificates {
-        certificates: Vec<Arc<Certificate>>,
-    },
-    RefreshVotes {
-        votes: Vec<Arc<VoteMessage>>,
-    },
-    RefreshCertificates {
-        certificates: Vec<Arc<Certificate>>,
-    },
+    PushVote { vote: Arc<VoteMessage> },
+    PushCertificates { certificates: Vec<Arc<Certificate>> },
+    RefreshVotes { votes: Vec<Arc<VoteMessage>> },
+    RefreshCertificates { certificates: Vec<Arc<Certificate>> },
 }
 
 #[derive(Debug)]
@@ -268,7 +255,6 @@ impl VotingService {
     pub fn new(
         bls_receiver: Receiver<BLSOp>,
         cluster_info: Arc<ClusterInfo>,
-        vote_history_storage: Arc<dyn VoteHistoryStorage>,
         connection_cache: Arc<ConnectionCache>,
         bank_forks: Arc<RwLock<BankForks>>,
         highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -312,7 +298,6 @@ impl VotingService {
                     };
                     Self::handle_bls_op(
                         &cluster_info,
-                        vote_history_storage.as_ref(),
                         bls_op,
                         &connection_cache,
                         &additional_listeners,
@@ -424,7 +409,6 @@ impl VotingService {
 
     fn handle_bls_op(
         cluster_info: &ClusterInfo,
-        vote_history_storage: &dyn VoteHistoryStorage,
         bls_op: BLSOp,
         connection_cache: &ConnectionCache,
         additional_listeners: &[SocketAddr],
@@ -432,17 +416,7 @@ impl VotingService {
         standstill_queue: &mut StandstillRefreshQueue,
     ) {
         match bls_op {
-            BLSOp::PushVote {
-                vote,
-                saved_vote_history,
-            } => {
-                let mut measure = Measure::start("alpenglow vote history save");
-                if let Err(err) = vote_history_storage.store(&saved_vote_history) {
-                    error!("Unable to save vote history to storage: {err:?}");
-                    std::process::exit(1);
-                }
-                measure.stop();
-                trace!("{measure}");
+            BLSOp::PushVote { vote, .. } => {
                 let msg = VersionedWireConsensusMessage::new_from_vote(
                     Arc::unwrap_or_clone(vote),
                     cluster_info.my_shred_version(),
@@ -500,9 +474,6 @@ impl VotingService {
 mod tests {
     use {
         super::*,
-        crate::vote_history_storage::{
-            NullVoteHistoryStorage, SavedVoteHistory, SavedVoteHistoryVersions,
-        },
         agave_votor_messages::{
             certificate::{Certificate, CertificateType},
             consensus_message::{ConsensusMessage, VoteMessage},
@@ -661,7 +632,6 @@ mod tests {
             VotingService::new(
                 bls_receiver,
                 cluster_info.clone(),
-                Arc::new(NullVoteHistoryStorage::default()),
                 Arc::new(ConnectionCache::new_quic(
                     "TestAlpenglowConnectionCache",
                     10,
@@ -684,7 +654,6 @@ mod tests {
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank: 1,
         }),
-        saved_vote_history: SavedVoteHistoryVersions::Current(SavedVoteHistory::default()),
     }, ConsensusMessage::Vote(VoteMessage {
         vote: Vote::new_skip_vote(5),
         signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         commitment::{CommitmentAggregationData, CommitmentError},
         vote_history::{VoteHistory, VoteHistoryError},
-        vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions},
+        vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions, VoteHistoryStorage},
         voting_service::BLSOp,
     },
     agave_votor_messages::{
@@ -118,6 +118,7 @@ pub struct VotingContext {
     pub vote_account_pubkey: Pubkey,
     pub identity_keypair: Arc<Keypair>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+    pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
     // The BLS keypair should always change with authorized_voter_keypairs.
     pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
     pub own_vote_sender: Sender<ConsensusMessage>,
@@ -296,11 +297,13 @@ pub fn insert_vote_and_create_bls_message(
 
     let saved_vote_history =
         SavedVoteHistory::new(&context.vote_history, &context.identity_keypair)?;
+    context
+        .vote_history_storage
+        .store(&SavedVoteHistoryVersions::from(saved_vote_history))?;
 
     // Return vote for sending
     Ok(Some(BLSOp::PushVote {
         vote: Arc::new(vote_msg),
-        saved_vote_history: SavedVoteHistoryVersions::from(saved_vote_history),
     }))
 }
 
@@ -342,6 +345,7 @@ pub fn generate_refresh_vote_message(
 mod tests {
     use {
         super::*,
+        crate::vote_history_storage::NullVoteHistoryStorage,
         agave_votor_messages::consensus_message::Block,
         crossbeam_channel::bounded,
         solana_gossip::contact_info::ContactInfo,
@@ -419,6 +423,7 @@ mod tests {
             authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(
                 my_keys.vote_keypair.insecure_clone(),
             )])),
+            vote_history_storage: Arc::new(NullVoteHistoryStorage::default()),
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             bls_sender,
@@ -459,23 +464,9 @@ mod tests {
             .unwrap();
         let expected_message =
             generate_expected_consensus_message(&voting_context, vote, &my_bls_keypair);
-        if let BLSOp::PushVote {
-            vote,
-            saved_vote_history,
-        } = result
-        {
+        if let BLSOp::PushVote { vote } = result {
             let msg = Arc::unwrap_or_clone(vote);
             assert_eq!(msg, expected_message);
-            assert_eq!(
-                saved_vote_history,
-                SavedVoteHistoryVersions::from(
-                    SavedVoteHistory::new(
-                        &voting_context.vote_history,
-                        &voting_context.identity_keypair
-                    )
-                    .unwrap()
-                )
-            );
         } else {
             panic!("Expected BLSOp::VotePush, got {result:?}");
         }

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -189,7 +189,7 @@ impl Votor {
             cluster_info: cluster_info.clone(),
             highest_parent_ready,
             leader_window_info_sender,
-            vote_history_storage,
+            vote_history_storage: vote_history_storage.clone(),
             repair_event_sender: repair_event_sender.clone(),
             latest_switch_request,
         };
@@ -200,6 +200,7 @@ impl Votor {
             vote_account_pubkey: vote_account,
             identity_keypair,
             authorized_voter_keypairs,
+            vote_history_storage,
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             bls_sender: bls_sender.clone(),


### PR DESCRIPTION
#### Problem
When having network problems, the voting service could get backed up. 
We have  2000 outstanding task semaphore and each async send has a 10s timeout. If there's a lot of messages to propagate and offline peers we could backup and end up lagging.

This backpressures into event handler and causes consensus to stall.
It's fine to drop votes in this case, they can always be refreshed if we StandStill.

#### Summary of Changes
Change the blocking send to a try send

While doing this i realized we only save the vote history in voting_service... which is kind of silly considering we already have the vote history when we create the vote.
More importantly even if we skip sending the vote we still need to make sure our vote history is saved for accuracy when we restart.
Refactored to save the vote history inline - bonus is we can remove the fake save from the migration pathway.