### PR TITLE
Revert "chore(toolchain): bump to rust 1.97 (#13733)"

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-05-22
+  nightly_version=2026-04-11
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.96.1"


### PR DESCRIPTION
#### Problem
1.97 has a miscompilaton bug
https://github.com/rust-lang/rust/issues/159035

(note: as of now it seems 1.96 does too, but 1.97 surfaces it more)

#### Summary of Changes
This reverts commit e6ee8fb0a8b4a27e83a21aaffe475c33f1d7f65c.

#### Testing
CI
