### PR TITLE
Drop `SysvarSerialize` pt 1: replace account helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7352,7 +7352,7 @@ dependencies = [
  "solana-signature",
  "solana-signer",
  "solana-system-interface 3.2.0",
- "solana-sysvar",
+ "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -7360,6 +7360,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-serde",
+ "wincode",
 ]
 
 [[package]]
@@ -7961,6 +7962,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -8442,6 +8444,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -9065,6 +9068,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -10236,6 +10240,7 @@ dependencies = [
  "solana-transaction",
  "thiserror 2.0.18",
  "tokio",
+ "wincode",
 ]
 
 [[package]]
@@ -10802,6 +10807,7 @@ dependencies = [
  "solana-sysvar",
  "solana-transaction",
  "solana-version",
+ "wincode",
 ]
 
 [[package]]
@@ -11253,6 +11259,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-history",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -11798,6 +11805,8 @@ dependencies = [
  "solana-serialize-utils",
  "solana-short-vec",
  "solana-system-interface 3.2.0",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -33,7 +33,7 @@ solana-address-lookup-table-interface = { workspace = true, features = [
 ] }
 solana-clock = { workspace = true }
 solana-config-interface = { workspace = true, features = ["bincode"] }
-solana-epoch-schedule = { workspace = true }
+solana-epoch-schedule = { workspace = true, features = ["serde"] }
 solana-fee-calculator = { workspace = true }
 solana-instruction = { workspace = true }
 solana-loader-v3-interface = { workspace = true, features = ["serde"] }
@@ -47,7 +47,7 @@ solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-slot-history = { workspace = true, features = ["wincode"] }
 solana-stake-history = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode"] }
-solana-sysvar = { workspace = true }
+solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-vote-interface = { workspace = true, features = ["bincode"] }
 solana-zk-sdk-pod = { workspace = true }
 spl-generic-token = { workspace = true }
@@ -61,7 +61,6 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 spl-pod = { workspace = true }

--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -5,7 +5,6 @@ use {
         StringAmount, UiFeeCalculator,
         parse_account_data::{ParsableAccount, ParseAccountError},
     },
-    bincode::deserialize,
     bv::BitVec,
     serde::{Deserialize, Serialize},
     solana_clock::{Clock, Epoch, Slot, UnixTimestamp},
@@ -19,6 +18,7 @@ use {
     solana_sysvar::{
         epoch_rewards::EpochRewards, last_restart_slot::LastRestartSlot, rewards::Rewards,
     },
+    wincode::deserialize,
 };
 
 pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, ParseAccountError> {
@@ -270,18 +270,23 @@ mod test {
     #[allow(deprecated)]
     use solana_sysvar::recent_blockhashes::IterItem;
     use {
-        super::*,
-        solana_account::{Account, create_account_for_test},
-        solana_fee_calculator::FeeCalculator,
-        solana_hash::Hash,
-        solana_stake_history::SIZE,
+        super::*, solana_account::Account, solana_fee_calculator::FeeCalculator, solana_hash::Hash,
     };
+
+    fn create_account_for_test<T>(value: &T, size: usize) -> Account
+    where
+        T: wincode::Serialize<Src = T>,
+    {
+        let mut account = Account::new(1, size, &sysvar::id());
+        wincode::serialize_into(&mut account.data[..], value).unwrap();
+        account
+    }
 
     #[test]
     fn test_parse_sysvars() {
         let hash = Hash::new_from_array([1; 32]);
 
-        let clock_sysvar = create_account_for_test(&Clock::default());
+        let clock_sysvar = create_account_for_test(&Clock::default(), solana_clock::SIZE);
         assert_eq!(
             parse_sysvar(&clock_sysvar.data, &sysvar::clock::id()).unwrap(),
             SysvarAccountType::Clock(UiClock::default()),
@@ -294,7 +299,8 @@ mod test {
             first_normal_epoch: 1,
             first_normal_slot: 12,
         };
-        let epoch_schedule_sysvar = create_account_for_test(&epoch_schedule);
+        let epoch_schedule_sysvar =
+            create_account_for_test(&epoch_schedule, solana_epoch_schedule::SIZE);
         assert_eq!(
             parse_sysvar(&epoch_schedule_sysvar.data, &sysvar::epoch_schedule::id()).unwrap(),
             SysvarAccountType::EpochSchedule(epoch_schedule),
@@ -302,7 +308,7 @@ mod test {
 
         #[allow(deprecated)]
         {
-            let fees_sysvar = create_account_for_test(&Fees::default());
+            let fees_sysvar = create_account_for_test(&Fees::default(), solana_sysvar::fees::SIZE);
             assert_eq!(
                 parse_sysvar(&fees_sysvar.data, &sysvar::fees::id()).unwrap(),
                 SysvarAccountType::Fees(UiFees::default()),
@@ -310,7 +316,10 @@ mod test {
 
             let recent_blockhashes: RecentBlockhashes =
                 vec![IterItem(0, &hash, 10)].into_iter().collect();
-            let recent_blockhashes_sysvar = create_account_for_test(&recent_blockhashes);
+            let recent_blockhashes_sysvar = create_account_for_test(
+                &recent_blockhashes,
+                solana_sysvar::recent_blockhashes::SIZE,
+            );
             assert_eq!(
                 parse_sysvar(
                     &recent_blockhashes_sysvar.data,
@@ -328,13 +337,14 @@ mod test {
             lamports_per_byte: 10,
             ..Default::default()
         };
-        let rent_sysvar = create_account_for_test(&rent);
+        let rent_sysvar = create_account_for_test(&rent, solana_rent::SIZE);
         assert_eq!(
             parse_sysvar(&rent_sysvar.data, &sysvar::rent::id()).unwrap(),
             SysvarAccountType::Rent(rent.into()),
         );
 
-        let rewards_sysvar = create_account_for_test(&Rewards::default());
+        let rewards_sysvar =
+            create_account_for_test(&Rewards::default(), solana_sysvar::rewards::SIZE);
         assert_eq!(
             parse_sysvar(&rewards_sysvar.data, &sysvar::rewards::id()).unwrap(),
             SysvarAccountType::Rewards(UiRewards::default()),
@@ -342,7 +352,7 @@ mod test {
 
         let mut slot_hashes = SlotHashes::default();
         slot_hashes.add(1, hash);
-        let slot_hashes_sysvar = create_account_for_test(&slot_hashes);
+        let slot_hashes_sysvar = create_account_for_test(&slot_hashes, solana_slot_hashes::SIZE);
         assert_eq!(
             parse_sysvar(&slot_hashes_sysvar.data, &sysvar::slot_hashes::id()).unwrap(),
             SysvarAccountType::SlotHashes(vec![UiSlotHashEntry {
@@ -353,7 +363,7 @@ mod test {
 
         let mut slot_history = SlotHistory::default();
         slot_history.add(42);
-        let slot_history_sysvar = create_account_for_test(&slot_history);
+        let slot_history_sysvar = create_account_for_test(&slot_history, solana_slot_history::SIZE);
         assert_eq!(
             parse_sysvar(&slot_history_sysvar.data, &sysvar::slot_history::id()).unwrap(),
             SysvarAccountType::SlotHistory(UiSlotHistory {
@@ -370,7 +380,7 @@ mod test {
         };
         stake_history.add(1, stake_history_entry.clone());
         let stake_history_sysvar =
-            Account::new_data_with_space(1, &stake_history, SIZE, &sysvar::id()).unwrap();
+            create_account_for_test(&stake_history, solana_stake_history::SIZE);
         assert_eq!(
             parse_sysvar(&stake_history_sysvar.data, &sysvar::stake_history::id()).unwrap(),
             SysvarAccountType::StakeHistory(vec![UiStakeHistoryEntry {
@@ -388,7 +398,8 @@ mod test {
         let last_restart_slot = LastRestartSlot {
             last_restart_slot: 1282,
         };
-        let last_restart_slot_account = create_account_for_test(&last_restart_slot);
+        let last_restart_slot_account =
+            create_account_for_test(&last_restart_slot, solana_sysvar::last_restart_slot::SIZE);
         assert_eq!(
             parse_sysvar(
                 &last_restart_slot_account.data,
@@ -407,7 +418,8 @@ mod test {
             active: true,
             ..EpochRewards::default()
         };
-        let epoch_rewards_sysvar = create_account_for_test(&epoch_rewards);
+        let epoch_rewards_sysvar =
+            create_account_for_test(&epoch_rewards, solana_sysvar::epoch_rewards::SIZE);
         assert_eq!(
             parse_sysvar(&epoch_rewards_sysvar.data, &sysvar::epoch_rewards::id()).unwrap(),
             SysvarAccountType::EpochRewards(epoch_rewards.into()),

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -62,7 +62,7 @@ solana-address-lookup-table-interface = { workspace = true, features = [
 solana-bucket-map = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-fee-calculator = { workspace = true, features = ["wincode"] }
+solana-fee-calculator = { workspace = true, features = ["serde", "wincode"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -3191,13 +3191,6 @@ fn test_delete_dependencies() {
 }
 
 #[test]
-fn test_account_balance_for_capitalization_sysvar() {
-    let normal_sysvar =
-        solana_account::create_account_for_test(&solana_slot_history::SlotHistory::default());
-    assert_eq!(normal_sysvar.lamports(), 1);
-}
-
-#[test]
 fn test_account_balance_for_capitalization_native_program() {
     let normal_native_program = create_loadable_account_for_test("foo");
     assert_eq!(normal_native_program.lamports(), 1);

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -24,7 +24,7 @@ agave-unstable-api = []
 [dependencies]
 borsh = { workspace = true }
 futures = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true }
 solana-banks-interface = { workspace = true }
 solana-clock = { workspace = true }
 solana-commitment-config = { workspace = true }
@@ -32,9 +32,9 @@ solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["sysvar", "wincode"] }
 solana-signature = { workspace = true }
-solana-sysvar = { workspace = true, features = ["bincode"] }
+solana-sysvar-id = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
@@ -42,6 +42,7 @@ tarpc = { workspace = true, features = ["full"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-serde = { workspace = true, features = ["bincode"] }
+wincode = { workspace = true }
 
 [dev-dependencies]
 solana-banks-server = { path = "../banks-server", features = ["agave-unstable-api"] }

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -13,7 +13,7 @@ pub use {
 use {
     borsh::BorshDeserialize,
     futures::future::join_all,
-    solana_account::{Account, from_account},
+    solana_account::Account,
     solana_banks_interface::{
         BanksRequest, BanksResponse, BanksTransactionResultWithMetadata,
         BanksTransactionResultWithSimulation,
@@ -26,7 +26,7 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_signature::Signature,
-    solana_sysvar::SysvarSerialize,
+    solana_sysvar_id::SysvarId,
     solana_transaction::versioned::VersionedTransaction,
     tarpc::{
         ClientMessage, Response, Transport,
@@ -183,14 +183,16 @@ impl BanksClient {
     }
 
     /// Return the cluster Sysvar
-    pub async fn get_sysvar<T: SysvarSerialize>(&self) -> Result<T, BanksClientError> {
+    pub async fn get_sysvar<T>(&self) -> Result<T, BanksClientError>
+    where
+        T: wincode::DeserializeOwned<Dst = T> + SysvarId,
+    {
         let sysvar = self
             .get_account(T::id())
             .await?
             .ok_or(BanksClientError::ClientError("Sysvar not present"))?;
-        from_account::<T, _>(&sysvar).ok_or(BanksClientError::ClientError(
-            "Failed to deserialize sysvar",
-        ))
+        wincode::deserialize(&sysvar.data)
+            .map_err(|_| BanksClientError::ClientError("Failed to deserialize sysvar"))
     }
 
     /// Return the cluster rent

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,7 +58,7 @@ solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }
 solana-cli-output = { workspace = true }
 solana-client = { workspace = true }
-solana-clock = { workspace = true }
+solana-clock = { workspace = true, features = ["wincode"] }
 solana-cluster-type = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-compute-budget-interface = { workspace = true, features = ["borsh"] }
@@ -78,7 +78,7 @@ solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-remote-wallet = { workspace = true, features = ["keystone"] }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode"] }
 solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-rpc-client-nonce-utils = { workspace = true, features = ["clap"] }
@@ -88,8 +88,8 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-signer-store = { workspace = true }
 solana-slot-history = { workspace = true, features = ["wincode"] }
-solana-stake-history = { workspace = true }
-solana-stake-interface = { workspace = true }
+solana-stake-history = { workspace = true, features = ["wincode"] }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-tpu-client = { workspace = true, features = ["default"] }
@@ -110,6 +110,7 @@ solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-con
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-nonce-account = { workspace = true }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -1,7 +1,6 @@
 use {
     crate::cli::{CliCommand, CliCommandInfo, CliConfig, CliError, ProcessResult},
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
-    solana_account::from_account,
     solana_address_lookup_table_interface::{
         self as address_lookup_table,
         instruction::{
@@ -558,9 +557,8 @@ async fn process_create_lookup_table(
         .get_account_with_commitment(&sysvar::clock::id(), CommitmentConfig::finalized())
         .await?;
     let clock_account = get_clock_result.value.expect("Clock account doesn't exist");
-    let clock: Clock = from_account(&clock_account).ok_or_else(|| {
-        CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
-    })?;
+    let clock: Clock = wincode::deserialize(&clock_account.data)
+        .map_err(|_| CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string()))?;
 
     let payer_address = payer_signer.pubkey();
     let (create_lookup_table_ix, lookup_table_address) =

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -7,7 +7,6 @@ use {
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand, value_t, value_t_or_exit},
     console::style,
     serde::{Deserialize, Serialize},
-    solana_account::{from_account, state_traits::StateMut},
     solana_clap_utils::{input_parsers::*, input_validators::*},
     solana_cli_output::{
         cli_clientid::CliClientId,
@@ -910,7 +909,7 @@ pub async fn process_cluster_date(rpc_client: &RpcClient, config: &CliConfig<'_>
         .get_account_with_commitment(&sysvar::clock::id(), config.commitment)
         .await?;
     if let Some(clock_account) = result.value {
-        let clock: Clock = from_account(&clock_account).ok_or_else(|| {
+        let clock: Clock = wincode::deserialize(&clock_account.data).map_err(|_| {
             CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
         })?;
         let block_time = CliBlockTime {
@@ -1703,12 +1702,11 @@ pub async fn process_show_stakes(
     let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
     let clock_account = rpc_client.get_account(&sysvar::clock::id()).await?;
     let rent_account = rpc_client.get_account(&sysvar::rent::id()).await?;
-    let clock: Clock = from_account(&clock_account).ok_or_else(|| {
-        CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
-    })?;
-    let rent: Rent = rent_account.deserialize_data()?;
+    let clock: Clock = wincode::deserialize(&clock_account.data)
+        .map_err(|_| CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string()))?;
+    let rent: Rent = wincode::deserialize(&rent_account.data)?;
     let stake_history: StakeHistory =
-        bincode::deserialize(&stake_history_account.data).map_err(|_| {
+        wincode::deserialize(&stake_history_account.data).map_err(|_| {
             CliError::RpcRequestError("Failed to deserialize stake history".to_string())
         })?;
     let new_rate_activation_epoch = get_feature_activation_epoch(
@@ -1731,7 +1729,7 @@ pub async fn process_show_stakes(
             "It should be impossible at this point for the account data not to be decodable. \
              Ensure that the account was fetched using a binary encoding.",
         );
-        if let Ok(stake_state) = stake_account.state() {
+        if let Ok(stake_state) = wincode::deserialize::<StakeStateV2>(&stake_account.data) {
             let rent_exempt_balance = rent.minimum_balance(stake_account.data.len()).max(1);
 
             match stake_state {
@@ -2168,7 +2166,7 @@ pub async fn process_calculate_rent(
         );
     }
     let rent_account = rpc_client.get_account(&sysvar::rent::id()).await?;
-    let rent: Rent = rent_account.deserialize_data()?;
+    let rent: Rent = wincode::deserialize(&rent_account.data)?;
     let rent_exempt_minimum_lamports = rent.minimum_balance(data_length);
     let cli_rent_calculation = CliRentCalculation {
         lamports_per_byte_year: 0,

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -746,7 +746,7 @@ mod tests {
     use {
         super::*,
         crate::{clap_app::get_clap_app, cli::parse_command},
-        solana_account::{Account, state_traits::StateMut},
+        solana_account::{Account, WritableAccount},
         solana_keypair::{Keypair, read_keypair_file, write_keypair},
         solana_nonce::{
             self as nonce,
@@ -1158,9 +1158,11 @@ mod tests {
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_from_array([42u8; 32]));
         let data = nonce::state::Data::new(Pubkey::from([1u8; 32]), durable_nonce, 42);
-        nonce_account
-            .set_state(&Versions::new(State::Initialized(data.clone())))
-            .unwrap();
+        wincode::serialize_into(
+            nonce_account.data_as_mut_slice(),
+            &Versions::new(State::Initialized(data.clone())),
+        )
+        .unwrap();
         assert_eq!(
             state_from_account(&nonce_account),
             Ok(State::Initialized(data))
@@ -1188,9 +1190,11 @@ mod tests {
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_from_array([42u8; 32]));
         let data = nonce::state::Data::new(Pubkey::from([1u8; 32]), durable_nonce, 42);
-        nonce_account
-            .set_state(&Versions::new(State::Initialized(data.clone())))
-            .unwrap();
+        wincode::serialize_into(
+            nonce_account.data_as_mut_slice(),
+            &Versions::new(State::Initialized(data.clone())),
+        )
+        .unwrap();
         let state = state_from_account(&nonce_account).unwrap();
         assert_eq!(data_from_state(&state), Ok(&data));
         assert_eq!(data_from_account(&nonce_account), Ok(data));

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -14,7 +14,7 @@ use {
         spend_utils::{SpendAmount, resolve_spend_tx_and_check_account_balances},
     },
     clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, SubCommand, value_t},
-    solana_account::{Account, from_account, state_traits::StateMut},
+    solana_account::Account,
     solana_clap_utils::{
         ArgConstant,
         compute_budget::{COMPUTE_UNIT_PRICE_ARG, ComputeUnitLimit, compute_unit_price_arg},
@@ -1754,7 +1754,7 @@ pub async fn process_deactivate_stake_account(
             .into());
         }
 
-        let vote_account_address = match stake_account.state() {
+        let vote_account_address = match wincode::deserialize::<StakeStateV2>(&stake_account.data) {
             Ok(stake_state) => match stake_state {
                 StakeStateV2::Stake(_, stake, _) => stake.delegation.voter_pubkey,
                 _ => {
@@ -2585,7 +2585,7 @@ async fn get_stake_account_state(
         ))
         .into());
     }
-    stake_account.state().map_err(|err| {
+    wincode::deserialize(&stake_account.data).map_err(|err| {
         CliError::RpcRequestError(format!(
             "Account data could not be deserialized to stake state: {err}"
         ))
@@ -2745,15 +2745,15 @@ pub async fn get_account_stake_state(
             "{stake_account_address:?} is not a stake account",
         )));
     }
-    match stake_account.state() {
+    match wincode::deserialize::<StakeStateV2>(&stake_account.data) {
         Ok(stake_state) => {
             let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
-            let stake_history: StakeHistory = bincode::deserialize(&stake_history_account.data)
+            let stake_history: StakeHistory = wincode::deserialize(&stake_history_account.data)
                 .map_err(|_| {
                     CliError::RpcRequestError("Failed to deserialize stake history".to_string())
                 })?;
             let clock_account = rpc_client.get_account(&clock::id()).await?;
-            let clock: Clock = from_account(&clock_account).ok_or_else(|| {
+            let clock: Clock = wincode::deserialize(&clock_account.data).map_err(|_| {
                 CliError::RpcRequestError("Failed to deserialize clock sysvar".to_string())
             })?;
             let new_rate_activation_epoch = get_feature_activation_epoch(
@@ -2818,7 +2818,7 @@ pub async fn process_show_stake_history(
 ) -> ProcessResult {
     let stake_history_account = rpc_client.get_account(&stake_history::id()).await?;
     let stake_history =
-        bincode::deserialize::<StakeHistory>(&stake_history_account.data).map_err(|_| {
+        wincode::deserialize::<StakeHistory>(&stake_history_account.data).map_err(|_| {
             CliError::RpcRequestError("Failed to deserialize stake history".to_string())
         })?;
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6310,6 +6310,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -6696,6 +6697,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -7113,6 +7115,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -7923,6 +7926,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-sdk-ids",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -8748,6 +8752,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-history",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -9125,6 +9130,8 @@ dependencies = [
  "solana-serialize-utils",
  "solana-short-vec",
  "solana-system-interface 3.2.0",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -57,6 +57,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
+solana-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6069,7 +6069,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-rent",
  "solana-signature",
- "solana-sysvar",
+ "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error",
@@ -6077,6 +6077,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-serde",
+ "wincode",
 ]
 
 [[package]]
@@ -6460,6 +6461,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -6852,6 +6854,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -7298,6 +7301,7 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -8219,6 +8223,7 @@ dependencies = [
  "solana-rpc-client",
  "solana-sdk-ids",
  "thiserror 2.0.18",
+ "wincode",
 ]
 
 [[package]]
@@ -9761,6 +9766,7 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-history",
  "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]
@@ -10194,6 +10200,8 @@ dependencies = [
  "solana-serialize-utils",
  "solana-short-vec",
  "solana-system-interface 3.2.0",
+ "solana-wincode-varint",
+ "wincode",
 ]
 
 [[package]]

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -21,16 +21,17 @@ clap = ["dep:clap", "dep:solana-clap-utils"]
 
 [dependencies]
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"], optional = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true }
 solana-clap-utils = { workspace = true, optional = true }
 solana-commitment-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
-solana-nonce = { workspace = true, features = ["serde"] }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-sdk-ids = { workspace = true }
 thiserror = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/rpc-client-nonce-utils/src/blockhash_query.rs
+++ b/rpc-client-nonce-utils/src/blockhash_query.rs
@@ -351,11 +351,14 @@ mod tests {
             durable_nonce,
             fee_calculator: nonce_fee_calc,
         };
-        let nonce_account = Account::new_data_with_space(
+        let mut nonce_account = Account::new(
             42,
-            &nonce::versions::Versions::new(nonce::state::State::Initialized(data)),
             nonce::state::State::size(),
             &solana_sdk_ids::system_program::id(),
+        );
+        wincode::serialize_into(
+            &mut nonce_account.data[..],
+            &nonce::versions::Versions::new(nonce::state::State::Initialized(data)),
         )
         .unwrap();
         let nonce_pubkey = Pubkey::from([4u8; 32]);

--- a/rpc-client-nonce-utils/src/nonblocking/blockhash_query.rs
+++ b/rpc-client-nonce-utils/src/nonblocking/blockhash_query.rs
@@ -371,11 +371,14 @@ mod tests {
             durable_nonce,
             fee_calculator: nonce_fee_calc,
         };
-        let nonce_account = Account::new_data_with_space(
+        let mut nonce_account = Account::new(
             42,
-            &nonce::versions::Versions::new(nonce::state::State::Initialized(data)),
             nonce::state::State::size(),
             &solana_sdk_ids::system_program::id(),
+        );
+        wincode::serialize_into(
+            &mut nonce_account.data[..],
+            &nonce::versions::Versions::new(nonce::state::State::Initialized(data)),
         )
         .unwrap();
         let nonce_pubkey = Pubkey::from([4u8; 32]);

--- a/rpc-client-nonce-utils/src/nonblocking/mod.rs
+++ b/rpc-client-nonce-utils/src/nonblocking/mod.rs
@@ -3,7 +3,7 @@
 pub mod blockhash_query;
 
 use {
-    solana_account::{Account, ReadableAccount, state_traits::StateMut},
+    solana_account::{Account, ReadableAccount},
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_nonce::{
@@ -122,11 +122,10 @@ pub fn account_identity_ok<T: ReadableAccount>(account: &T) -> Result<(), Error>
 /// # })?;
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
-    account: &T,
-) -> Result<State, Error> {
+pub fn state_from_account<T: ReadableAccount>(account: &T) -> Result<State, Error> {
     account_identity_ok(account)?;
-    let versions = StateMut::<Versions>::state(account).map_err(|_| Error::InvalidAccountData)?;
+    let versions: Versions =
+        wincode::deserialize(account.data()).map_err(|_| Error::InvalidAccountData)?;
     Ok(State::from(versions))
 }
 
@@ -217,9 +216,7 @@ pub fn state_from_account<T: ReadableAccount + StateMut<Versions>>(
 /// # })?;
 /// # Ok::<(), anyhow::Error>(())
 /// ```
-pub fn data_from_account<T: ReadableAccount + StateMut<Versions>>(
-    account: &T,
-) -> Result<Data, Error> {
+pub fn data_from_account<T: ReadableAccount>(account: &T) -> Result<Data, Error> {
     state_from_account(account).and_then(|ref s| data_from_state(s).cloned())
 }
 

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -43,10 +43,11 @@ solana-rpc-client = { workspace = true, features = ["default"] }
 solana-rpc-client-api = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
-solana-stake-interface = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-sysvar = { workspace = true }
 solana-transaction = { workspace = true }
 solana-version = { workspace = true }
+wincode = { workspace = true }
 
 [dev-dependencies]
 solana-client-traits = { workspace = true }

--- a/stake-accounts/src/stake_accounts.rs
+++ b/stake-accounts/src/stake_accounts.rs
@@ -1,5 +1,5 @@
 use {
-    solana_account::{ReadableAccount, state_traits::StateMut},
+    solana_account::ReadableAccount,
     solana_clock::SECONDS_PER_DAY,
     solana_instruction::Instruction,
     solana_message::Message,
@@ -17,13 +17,11 @@ pub(crate) fn derive_stake_account_address(base_pubkey: &Pubkey, i: usize) -> Pu
     Pubkey::create_with_seed(base_pubkey, &i.to_string(), &stake::program::id()).unwrap()
 }
 
-fn from<T: ReadableAccount + StateMut<StakeStateV2>>(account: &T) -> Option<StakeStateV2> {
-    account.state().ok()
+fn from<T: ReadableAccount>(account: &T) -> Option<StakeStateV2> {
+    wincode::deserialize(account.data()).ok()
 }
 
-pub(crate) fn lockup_from<T: ReadableAccount + StateMut<StakeStateV2>>(
-    account: &T,
-) -> Option<Lockup> {
+pub(crate) fn lockup_from<T: ReadableAccount>(account: &T) -> Option<Lockup> {
     from(account).and_then(|state: StakeStateV2| state.lockup())
 }
 

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -130,6 +130,7 @@ libsecp256k1 = { workspace = true }
 openssl = { workspace = true }
 rand = { workspace = true }
 shuttle = { workspace = true }
+solana-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -16,8 +16,8 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 agave-unstable-api = []
-bincode = ["dep:bincode", "serde", "solana-account/bincode"]
-dev-context-only-utils = ["bincode", "solana-account/dev-context-only-utils", "dep:qualifier_attr"]
+bincode = ["dep:bincode", "serde"]
+dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
 serde = ["serde/derive", "solana-pubkey/serde"]
 wincode = ["dep:wincode", "solana-pubkey/wincode"]
 

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -41,7 +41,7 @@ log = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { version = "0.9.4", optional = true }
 serde = { workspace = true, features = ["rc"] }
-solana-account = { workspace = true, features = ["bincode", "wincode"] }
+solana-account = { workspace = true, features = ["serde", "wincode"] }
 solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
@@ -51,7 +51,7 @@ solana-frozen-abi = { workspace = true, optional = true, features = [
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
-solana-hash = { workspace = true }
+solana-hash = { workspace = true, features = ["copy"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-packet = { workspace = true }
@@ -62,7 +62,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
-solana-vote-interface = { workspace = true, features = ["bincode"] }
+solana-vote-interface = { workspace = true, features = ["bincode", "wincode"] }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 

--- a/vote/benches/vote_account.rs
+++ b/vote/benches/vote_account.rs
@@ -27,12 +27,13 @@ fn new_rand_vote_account<R: Rng>(
         unix_timestamp: rng.random(),
     };
     let vote_state = VoteStateV4::new_with_defaults(&vote_pubkey, &vote_init, &clock);
-    let account = AccountSharedData::new_data(
+    let data = wincode::serialize(&VoteStateVersions::new_v4(vote_state.clone())).unwrap();
+    let mut account = AccountSharedData::new(
         rng.random(), // lamports
-        &VoteStateVersions::new_v4(vote_state.clone()),
+        data.len(),
         &solana_sdk_ids::vote::id(), // owner
-    )
-    .unwrap();
+    );
+    account.set_data_from_slice(&data);
     (account, vote_state)
 }
 

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -149,12 +149,13 @@ impl VoteAccount {
             &Pubkey::new_unique(),
             &clock,
         );
-        let account = AccountSharedData::new_data(
+        let data = wincode::serialize(&VoteStateVersions::new_v4(vote_state)).unwrap();
+        let mut account = AccountSharedData::new(
             rng.random(), // lamports
-            &VoteStateVersions::new_v4(vote_state),
+            data.len(),
             &solana_sdk_ids::vote::id(), // owner
-        )
-        .unwrap();
+        );
+        account.set_data_from_slice(&data);
         VoteAccount::try_from(account).unwrap()
     }
 }


### PR DESCRIPTION
Given the size and staleness of https://github.com/anza-xyz/agave/pull/12245, rebasing was quite painful. Breaking down this work into smaller PR chunks for easier review. Progresses https://github.com/anza-xyz/agave/issues/10672. Also swapped bincode for wincode where I could.

| Offending code | Why it blocks `SysvarSerialize` removal | Replacement |
|---|---|---|
| `BanksClient::get_sysvar<T: SysvarSerialize>` | Directly requires the trait | `SysvarId + wincode::DeserializeOwned` |
| `solana_account::from_account` | Decodes through `SysvarSerialize` and bincode | `wincode::deserialize` |
| `solana_account::create_account_for_test` | Uses `SysvarSerialize` to size and encode sysvars | Local wincode fixture with canonical `SIZE` |
| `solana-account/bincode` features | Transitively enable `solana-sysvar/bincode` | Type-specific wincode features |
| `StateMut::state` | Requires `solana-account/bincode` | `wincode::deserialize` |
| `StateMut::set_state` and bincode constructors | Require `solana-account/bincode` for account writes | Wincode serialization |