### PR TITLE
accounts-db: Removes agave_logger from tests

### DIFF
--- a/accounts-db/src/account_storage_reader.rs
+++ b/accounts-db/src/account_storage_reader.rs
@@ -241,7 +241,6 @@ mod tests {
         total_accounts: usize,
         number_of_accounts_to_remove: usize,
     ) {
-        agave_logger::setup();
         let (storage, _temp_dirs) =
             create_storage_for_storage_reader(0, AccountsFileProvider::AppendVec);
 

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1297,12 +1297,10 @@ mod tests {
 
     #[test]
     fn huge_clean() {
-        agave_logger::setup();
         let accounts_db = AccountsDb::new_single_for_tests();
         let accounts = Accounts::new(Arc::new(accounts_db));
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-        info!("storing...");
         for i in 0..2_000 {
             let pubkey = solana_pubkey::new_rand();
             let account = AccountSharedData::new(i + 1, 0, AccountSharedData::default().owner());
@@ -1310,12 +1308,7 @@ mod tests {
             accounts.store_for_tests(i, &old_pubkey, &zero_account);
             old_pubkey = pubkey;
             accounts.add_root_and_flush_write_cache(i);
-
-            if i % 1_000 == 0 {
-                info!("  store {i}");
-            }
         }
-        info!("done. cleaning...");
         accounts.accounts_db.clean_accounts_for_tests();
     }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1030,8 +1030,6 @@ fn test_account_grow() {
 
 #[test]
 fn test_clean_zero_lamport_and_dead_slot() {
-    agave_logger::setup();
-
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey1 = solana_pubkey::new_rand();
     let pubkey2 = solana_pubkey::new_rand();
@@ -1073,8 +1071,6 @@ fn test_clean_zero_lamport_and_dead_slot() {
 
 #[test]
 fn test_clean_dead_slot_with_obsolete_accounts() {
-    agave_logger::setup();
-
     // This test is triggering a scenario in reclaim_accounts where the entire slot is reclaimed
     // When an entire slot is reclaimed, it normally unrefs the pubkeys, while when individual
     // accounts are reclaimed it does not unref the pubkeys
@@ -1269,7 +1265,6 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
 
 #[test]
 fn test_shrink_zero_lamport_single_ref_account() {
-    agave_logger::setup();
     // note that 'None' checks the case based on the default value of `latest_full_snapshot_slot` in `AccountsDb`
     for latest_full_snapshot_slot in [None, Some(0), Some(1), Some(2)] {
         // store a zero and non-zero lamport account
@@ -1825,8 +1820,6 @@ fn test_alive_bytes_after_shrink_with_zero_lamport_single_ref_accounts() {
 
 #[test]
 fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
-    agave_logger::setup();
-
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey1 = solana_pubkey::new_rand();
     let pubkey2 = solana_pubkey::new_rand();
@@ -1874,8 +1867,6 @@ fn test_clean_multiple_zero_lamport_decrements_index_ref_count() {
 
 #[test]
 fn test_clean_zero_lamport_and_old_roots() {
-    agave_logger::setup();
-
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
@@ -1913,8 +1904,6 @@ fn test_clean_zero_lamport_and_old_roots() {
 
 #[test]
 fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
-    agave_logger::setup();
-
     let mut accounts = AccountsDb {
         account_indexes: spl_token_mint_index_enabled(),
         ..AccountsDb::new_with_config(
@@ -2054,8 +2043,6 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
 
 #[test]
 fn test_clean_max_slot_zero_lamport_account() {
-    agave_logger::setup();
-
     let accounts = AccountsDb::new_single_for_tests();
     let pubkey = solana_pubkey::new_rand();
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
@@ -2090,7 +2077,6 @@ fn assert_no_stores(accounts: &AccountsDb, slot: Slot) {
 
 #[test]
 fn test_accounts_db_purge_keep_live() {
-    agave_logger::setup();
     let some_lamport = 223;
     let zero_lamport = 0;
     let no_data = 0;
@@ -2171,7 +2157,6 @@ fn test_accounts_db_purge_keep_live() {
 
 #[test]
 fn test_accounts_db_purge1() {
-    agave_logger::setup();
     let some_lamport = 223;
     let zero_lamport = 0;
     let no_data = 0;
@@ -2202,7 +2187,6 @@ fn test_accounts_db_purge1() {
     accounts.print_accounts_stats("pre_purge");
 
     let ancestors = linear_ancestors(current_slot);
-    info!("ancestors: {ancestors:?}");
     let hash = accounts.calculate_accounts_lt_hash_at_startup_from_index(&ancestors);
 
     accounts.clean_accounts_for_tests();
@@ -2224,7 +2208,6 @@ fn test_accounts_db_purge1() {
 
 #[test]
 fn test_accountsdb_scan_accounts() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let key = Pubkey::default();
     let key0 = solana_pubkey::new_rand();
@@ -2269,7 +2252,6 @@ fn test_accountsdb_scan_accounts() {
 
 #[test]
 fn test_cleanup_key_not_removed() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let key = Pubkey::default();
@@ -2304,7 +2286,6 @@ fn test_cleanup_key_not_removed() {
 
 #[test]
 fn test_store_large_account() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let key = Pubkey::default();
@@ -2370,7 +2351,6 @@ fn test_hash_stored_account() {
 #[test]
 fn test_verify_bank_capitalization() {
     for pass in 0..2 {
-        agave_logger::setup();
         let db = AccountsDb::new_single_for_tests();
 
         let key = solana_pubkey::new_rand();
@@ -2409,7 +2389,6 @@ fn test_verify_bank_capitalization() {
 }
 #[test]
 fn test_storage_finder() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let key = solana_pubkey::new_rand();
     let lamports = 100;
@@ -2688,8 +2667,6 @@ fn test_shrink_all_slots_none() {
 
 #[test]
 fn test_shrink_candidate_slots() {
-    agave_logger::setup();
-
     let mut accounts = AccountsDb::new_single_for_tests();
 
     let pubkey_count = 30000;
@@ -2755,7 +2732,6 @@ fn test_shrink_candidate_slots() {
 /// bytes of the two remaining alive ancient accounts.
 #[test]
 fn test_shrink_candidate_slots_with_dead_ancient_account() {
-    agave_logger::setup();
     let epoch_schedule = EpochSchedule::default();
     let db = AccountsDb::new_single_for_tests();
     const ACCOUNT_DATA_SIZES: &[usize] = &[1000, 2000, 150];
@@ -2832,7 +2808,6 @@ fn test_shrink_candidate_slots_with_dead_ancient_account() {
 #[test]
 fn test_select_candidates_by_total_usage_no_candidates() {
     // no input candidates -- none should be selected
-    agave_logger::setup();
     let candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
 
@@ -2846,7 +2821,6 @@ fn test_select_candidates_by_total_usage_no_candidates() {
 #[test]
 fn test_select_candidates_by_total_usage_3_way_split_condition() {
     // three candidates, one selected for shrink, one is put back to the candidate list and one is ignored
-    agave_logger::setup();
     let mut candidates = ShrinkCandidates::default();
     let db = AccountsDb::new_single_for_tests();
 
@@ -2909,7 +2883,6 @@ fn test_select_candidates_by_total_usage_3_way_split_condition() {
 #[test]
 fn test_select_candidates_by_total_usage_2_way_split_condition() {
     // three candidates, 2 are selected for shrink, one is ignored
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
@@ -2969,7 +2942,6 @@ fn test_select_candidates_by_total_usage_2_way_split_condition() {
 #[test]
 fn test_select_candidates_by_total_usage_all_clean() {
     // 2 candidates, they must be selected to achieve the target alive ratio
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
     let mut candidates = ShrinkCandidates::default();
 
@@ -3110,7 +3082,6 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
 
 #[test]
 fn test_delete_dependencies() {
-    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let accounts_index = &accounts.accounts_index;
     let key0 = Pubkey::new_from_array([0u8; 32]);
@@ -3248,7 +3219,6 @@ fn test_account_balance_for_capitalization_native_program() {
 
 #[test]
 fn test_store_overhead() {
-    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let account = AccountSharedData::new(1, 0, &Pubkey::default());
     let pubkey = solana_pubkey::new_rand();
@@ -3256,13 +3226,11 @@ fn test_store_overhead() {
     accounts.add_root_and_flush_write_cache(0);
     let store = accounts.storage.get_slot_storage_entry(0).unwrap();
     let total_len = store.accounts.len();
-    info!("total: {total_len}");
     assert_eq!(total_len, STORE_META_OVERHEAD);
 }
 
 #[test]
 fn test_store_clean_after_shrink() {
-    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let epoch_schedule = EpochSchedule::default();
 
@@ -3329,7 +3297,6 @@ fn test_wrapping_storage_id() {
 #[test]
 #[should_panic(expected = "We've run out of storage ids!")]
 fn test_reuse_storage_id() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
@@ -4891,8 +4858,6 @@ fn start_load_thread(
 
 #[test]
 fn test_load_account_and_cache_flush_race() {
-    agave_logger::setup();
-
     let mut db = AccountsDb::new_single_for_tests();
     db.load_delay = RACY_SLEEP_MS;
     let db = Arc::new(db);
@@ -5066,7 +5031,6 @@ fn test_load_account_and_shrink_race_without_retry() {
 
 #[test]
 fn test_collect_uncleaned_slots_up_to_slot() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let slot1 = 11;
@@ -5096,7 +5060,6 @@ fn test_collect_uncleaned_slots_up_to_slot() {
 
 #[test]
 fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
-    agave_logger::setup();
     let db = AccountsDb::new_single_for_tests();
 
     let slot1 = 11;
@@ -5142,7 +5105,6 @@ fn test_remove_uncleaned_slots_and_collect_pubkeys_up_to_slot() {
 
 #[test]
 fn test_shrink_productive() {
-    agave_logger::setup();
     let accounts = AccountsDb::new_single_for_tests();
     let (_temp_dirs, path) = get_temp_accounts_paths(1).unwrap();
 
@@ -5177,8 +5139,6 @@ fn test_shrink_productive() {
 
 #[test]
 fn test_is_candidate_for_shrink() {
-    agave_logger::setup();
-
     let mut accounts = AccountsDb::new_single_for_tests();
     let (_temp_dirs, common_store_path) = get_temp_accounts_paths(1).unwrap();
     let store_file_size = 100_000;
@@ -5543,7 +5503,6 @@ define_accounts_db_test!(
 
 #[test]
 fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
-    agave_logger::setup();
     let slot = 10;
 
     struct TestParameters {
@@ -6096,7 +6055,6 @@ define_accounts_db_test!(test_get_sorted_potential_ancient_slots, |db| {
 
 #[test]
 fn test_shrink_collect_simple() {
-    agave_logger::setup();
     let account_counts = [
         1,
         SHRINK_COLLECT_CHUNK_SIZE,
@@ -6329,7 +6287,6 @@ fn test_shrink_collect_simple() {
 
 #[test]
 fn test_shrink_collect_with_obsolete_accounts() {
-    agave_logger::setup();
     let account_count = 100;
     let pubkeys: Vec<_> = iter::repeat_with(Pubkey::new_unique)
         .take(account_count)
@@ -6616,8 +6573,6 @@ pub(crate) fn create_db_with_storages_and_index(
     num_slots: usize,
     account_data_size: Option<u64>,
 ) -> (AccountsDb, Slot) {
-    agave_logger::setup();
-
     let db = AccountsDb::new_single_for_tests();
 
     // create a single append vec with a single account in a slot

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1731,7 +1731,6 @@ mod tests {
 
     #[test]
     fn test_update_new_slot() {
-        agave_logger::setup();
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
         let ancestors = Ancestors::from(vec![0]);
@@ -2024,7 +2023,6 @@ mod tests {
 
     #[test]
     fn test_reclaim_older_items_in_slot_list() {
-        agave_logger::setup();
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<u64, u64>::default_for_tests();
         let mut gc = ReclaimsSlotList::new();
@@ -2612,7 +2610,6 @@ mod tests {
 
     #[test]
     fn test_clean_rooted_entries_return() {
-        agave_logger::setup();
         let value = true;
         let key = solana_pubkey::new_rand();
         let key_unknown = solana_pubkey::new_rand();

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -554,7 +554,6 @@ mod tests {
 
     #[test]
     fn test_next_bucket_to_flush() {
-        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let visited = (0..bins)
@@ -577,7 +576,6 @@ mod tests {
 
     #[test]
     fn test_ages() {
-        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(0, test.current_age());
@@ -597,7 +595,6 @@ mod tests {
 
     #[test]
     fn test_age_increment() {
-        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         for age in 0..513 {
@@ -618,7 +615,6 @@ mod tests {
 
     #[test]
     fn test_throttle() {
-        agave_logger::setup();
         let bins = 128;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let bins = test.bins as u64;
@@ -829,7 +825,6 @@ mod tests {
 
     #[test]
     fn test_age_time() {
-        agave_logger::setup();
         let bins = 1;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         let threads = 2;
@@ -862,7 +857,6 @@ mod tests {
 
     #[test]
     fn test_age_broad() {
-        agave_logger::setup();
         let bins = 4;
         let test = BucketMapHolder::<u64, u64>::new(bins, &AccountsIndexConfig::default(), 1);
         assert_eq!(test.current_age(), 0);

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -2337,7 +2337,6 @@ mod tests {
 
     #[test]
     fn test_age() {
-        agave_logger::setup();
         let test = new_for_test::<u64>();
         assert!(test.get_should_age(test.storage.current_age()));
         assert_eq!(test.storage.count_buckets_flushed(), 0);
@@ -2360,7 +2359,6 @@ mod tests {
 
     #[test]
     fn test_update_slot_list_other_reclaim_old_slots() {
-        agave_logger::setup();
         let reclaim = UpsertReclaim::ReclaimOldSlots;
         let new_slot = 5;
         let info = 1;

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -88,7 +88,6 @@ mod tests {
 
     #[test]
     fn test_ancestors_permutations() {
-        agave_logger::setup();
         let mut ancestors = Ancestors::default();
         let mut hash = HashSet::new();
 
@@ -153,8 +152,6 @@ mod tests {
 
     #[test]
     fn test_ancestors_smaller() {
-        agave_logger::setup();
-
         for width in 0..34 {
             let mut hash = HashSet::new();
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1307,7 +1307,6 @@ mod tests {
         // n slots
         // m accounts per slot
         // divide into different ideal sizes so that we combine multiple slots sometimes and combine partial slots
-        agave_logger::setup();
         let total_accounts_per_storage = 10;
         let account_size = 184;
         for num_slots in 0..4 {
@@ -1415,7 +1414,6 @@ mod tests {
         // each account has different size
         // divide into different ideal sizes so that we combine multiple slots sometimes and combine partial slots
         // compare at end that all accounts are in result exactly once
-        agave_logger::setup();
         let total_accounts_per_storage = 10;
         let account_size = 184;
         for num_slots in 0..4 {
@@ -1626,8 +1624,6 @@ mod tests {
         // n storages
         // 1 account each
         // all accounts have 1 ref or all accounts have 2 refs
-        agave_logger::setup();
-
         let data_size = 48;
         let alive_bytes_per_slot = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
@@ -2145,7 +2141,6 @@ mod tests {
 
     #[test]
     fn test_calc_accounts_to_combine_opposite() {
-        agave_logger::setup();
         // 1 storage
         // 2 accounts
         // 1 with 1 ref
@@ -2878,7 +2873,6 @@ mod tests {
 
     #[test]
     fn test_truncate_to_max_storages() {
-        agave_logger::setup();
         for filter in [false, true] {
             let ideal_storage_size_large = get_ancient_append_vec_capacity();
             let mut infos = create_test_infos(1);
@@ -3499,8 +3493,6 @@ mod tests {
         // NOTE: The recycler has been removed.  Creating this many extra storages is no longer
         // necessary, but also does no harm either.
         const MAX_RECYCLE_STORES: usize = 1000;
-        agave_logger::setup();
-
         // When we pack ancient append vecs, the packed append vecs are recycled first if possible. This means they aren't dropped directly.
         // This test tests that we are releasing Arc refcounts for storages when we pack them into ancient append vecs.
         let db = AccountsDb::new_single_for_tests();

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1087,7 +1087,6 @@ mod tests {
         std::{
             io::{Seek as _, SeekFrom, Write as _},
             mem::ManuallyDrop,
-            time::Instant,
         },
         test_case::test_case,
     };
@@ -1423,7 +1422,6 @@ mod tests {
         let av = AppendVec::new(&path.path, 1024 * 1024);
         let size = 1000;
         let mut indexes = vec![];
-        let now = Instant::now();
         let mut sizes = vec![];
         for sample in 0..size {
             // sample + 1 is so sample = 0 won't be used.
@@ -1440,15 +1438,12 @@ mod tests {
                 .sum::<usize>();
             assert_eq!(sizes.iter().sum::<usize>(), stored_size);
         }
-        trace!("append time: {} ms", now.elapsed().as_millis());
 
-        let now = Instant::now();
         for _ in 0..size {
             let sample = rng().random_range(0..indexes.len());
             let account = create_test_account(sample + 1);
             assert_eq!(av.get_account_test(indexes[sample]).unwrap(), account);
         }
-        trace!("random read time: {} ms", now.elapsed().as_millis());
         assert_eq!(indexes.len(), size);
         assert_eq!(indexes[0], 0);
         assert_eq!(av.accounts_count(), size);
@@ -1456,7 +1451,6 @@ mod tests {
         let mut reader = new_scan_accounts_reader();
 
         let mut sample = 0;
-        let now = Instant::now();
         av.scan_accounts_stored_meta(&mut reader, |v| {
             let account = create_test_account(sample + 1);
             let recovered = create_account_shared_data(&v);
@@ -1464,7 +1458,6 @@ mod tests {
             sample += 1;
         })
         .expect("must scan accounts storage");
-        trace!("sequential read time: {} ms", now.elapsed().as_millis());
     }
 
     #[test]
@@ -1476,7 +1469,6 @@ mod tests {
         // So, the sanitizing on load behavior can be tested by capturing [u8] that would be created if such a write was possible (as it used to be).
         // The contents of [u8] written by an append vec cannot easily or reasonably change frequently since it has released a long time.
         /*
-            agave_logger::setup();
             // uncomment this code to generate the invalid append vec that will fail on load
             let file = get_append_vec_path("test_append");
             let path = &file.path;
@@ -1508,7 +1500,7 @@ mod tests {
             let mut reader = BufReader::new(f);
             let mut buffer = Vec::new();
             reader.read_to_end(&mut buffer).unwrap();
-            error!("{:?}", buffer);
+            println!("{:?}", buffer);
         */
 
         // create an invalid append vec file using known bytes

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -305,10 +305,7 @@ impl RollingBitField {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, log::*, solana_clock::Slot, solana_measure::measure::Measure,
-        std::collections::HashSet,
-    };
+    use {super::*, solana_clock::Slot, std::collections::HashSet};
 
     impl RollingBitField {
         pub fn clear(&mut self) {
@@ -318,7 +315,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_delete_non_excess() {
-        agave_logger::setup();
         let len = 16;
         let mut bitfield = RollingBitField::new(len);
         assert_eq!(bitfield.min(), None);
@@ -362,7 +358,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_insert_excess() {
-        agave_logger::setup();
         let len = 16;
         let mut bitfield = RollingBitField::new(len);
 
@@ -394,7 +389,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_permutations() {
-        agave_logger::setup();
         let mut bitfield = RollingBitField::new(2097152);
         let mut hash = HashSet::new();
 
@@ -415,29 +409,19 @@ mod tests {
 
         let max = slot + 1;
 
-        let mut time = Measure::start("");
         let mut count = 0;
         for slot in (min - 10)..max + 100 {
             if hash.contains(&slot) {
                 count += 1;
             }
         }
-        time.stop();
 
-        let mut time2 = Measure::start("");
         let mut count2 = 0;
         for slot in (min - 10)..max + 100 {
             if bitfield.contains(&slot) {
                 count2 += 1;
             }
         }
-        time2.stop();
-        info!(
-            "{}ms, {}ms, {} ratio",
-            time.as_ms(),
-            time2.as_ms(),
-            time.as_ns() / time2.as_ns()
-        );
         assert_eq!(count, count2);
     }
 
@@ -494,7 +478,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_insert_wide() {
-        agave_logger::setup();
         let width = 16;
         let start = 0;
         let mut tester = setup_wide(width, start);
@@ -513,7 +496,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_insert_wide_before() {
-        agave_logger::setup();
         let width = 16;
         let start = 100;
         let mut bitfield = setup_wide(width, start).bitfield;
@@ -528,7 +510,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_insert_wide_before_ok() {
-        agave_logger::setup();
         let width = 16;
         let start = 100;
         let mut bitfield = setup_wide(width, start).bitfield;
@@ -579,7 +560,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_excess2() {
-        agave_logger::setup();
         let width = 16;
         let mut tester = setup_empty(width);
         let slot = 100;
@@ -613,7 +593,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_excess() {
-        agave_logger::setup();
         // start at slot 0 or a separate, higher slot
         for width in [16, 4194304].iter() {
             let width = *width;
@@ -727,8 +706,6 @@ mod tests {
 
     #[test]
     fn test_bitfield_functionality() {
-        agave_logger::setup();
-
         // bitfield sizes are powers of 2, cycle through values of 1, 2, 4, .. 2^9
         for power in 0..10 {
             let max_bitfield_width = 2u64.pow(power);
@@ -890,8 +867,6 @@ mod tests {
     #[test]
     fn test_bitfield_smaller() {
         // smaller bitfield, fewer entries, including 0
-        agave_logger::setup();
-
         for width in 0..34 {
             let mut bitfield = RollingBitField::new(4096);
             let mut hash_set = HashSet::new();
@@ -911,29 +886,19 @@ mod tests {
 
             let max = slot + 1;
 
-            let mut time = Measure::start("");
             let mut count = 0;
             for slot in (min - 10)..max + 100 {
                 if hash_set.contains(&slot) {
                     count += 1;
                 }
             }
-            time.stop();
 
-            let mut time2 = Measure::start("");
             let mut count2 = 0;
             for slot in (min - 10)..max + 100 {
                 if bitfield.contains(&slot) {
                     count2 += 1;
                 }
             }
-            time2.stop();
-            info!(
-                "{}, {}, {}",
-                time.as_ms(),
-                time2.as_ms(),
-                time.as_ns() / time2.as_ns()
-            );
             assert_eq!(count, count2);
         }
     }


### PR DESCRIPTION
#### Problem

Many tests in accounts-db setup the agave logger. But (unit) tests should not do this.

IMO it is fine to add logging while developing a test, or debugging a test failure, but logging does not belong in tests otherwise.


#### Summary of Changes

Do not set up agave logger in tests.

Some tests also log values or time measurements; remove those logs as well.


#### Testing

Nothing additional.