### PR TITLE
perf(runtime): Store snapshot stake delegations in `IndexMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,6 +3986,8 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
  "rayon",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -10190,6 +10192,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "libc",
  "libsecp256k1",
@@ -10252,6 +10255,7 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-native-token",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet 4.2.0",
@@ -13326,6 +13330,7 @@ checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "bv",
  "bytes",
+ "indexmap 2.14.0",
  "pastey",
  "proc-macro2",
  "quote",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -3339,6 +3339,8 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
  "rayon",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -7932,6 +7934,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -7986,6 +7989,7 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-native-token",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet 4.2.0",
@@ -10505,6 +10509,7 @@ checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "bv",
  "bytes",
+ "indexmap",
  "pastey",
  "proc-macro2",
  "quote",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3312,6 +3312,8 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
  "rayon",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8160,6 +8162,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "imbl",
+ "indexmap",
  "itertools 0.14.0",
  "libc",
  "log",
@@ -8214,6 +8217,7 @@ dependencies = [
  "solana-message",
  "solana-metrics",
  "solana-native-token",
+ "solana-nohash-hasher",
  "solana-nonce",
  "solana-nonce-account",
  "solana-packet 4.2.0",
@@ -11620,6 +11624,7 @@ checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
 dependencies = [
  "bv",
  "bytes",
+ "indexmap",
  "pastey",
  "proc-macro2",
  "quote",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -79,6 +79,7 @@ crossbeam-channel = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }
+indexmap = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
@@ -142,6 +143,7 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
+solana-nohash-hasher = { workspace = true }
 solana-nonce = { workspace = true }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-packet = { workspace = true }
@@ -192,7 +194,7 @@ strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
-wincode = { workspace = true, features = ["smallvec"] }
+wincode = { workspace = true, features = ["indexmap", "smallvec"] }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1760,7 +1760,7 @@ impl Bank {
         // update vote accounts with warmed up stakes before saving a
         // snapshot of stakes in epoch stakes
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations = stakes.stake_delegations().indexed();
         let (
             (
                 stake_history,
@@ -5402,6 +5402,29 @@ impl Bank {
             ("slot", slot, i64),
             ("total_us", total_us, i64),
         );
+        let (snapshot_len, overrides_len, additions_len, removals_len) =
+            self.stakes_cache.stake_delegation_map_sizes();
+        datapoint_info!(
+            "bank-stake-delegations",
+            ("slot", slot, i64),
+            ("epoch", self.epoch(), i64),
+            ("snapshot_len", snapshot_len, i64),
+            (
+                "overlay_len",
+                overrides_len.saturating_add(additions_len),
+                i64
+            ),
+            ("overrides_len", overrides_len, i64),
+            ("additions_len", additions_len, i64),
+            ("removals_len", removals_len, i64),
+            (
+                "effective_len",
+                snapshot_len
+                    .saturating_add(additions_len)
+                    .saturating_sub(removals_len),
+                i64
+            ),
+        );
         info!(
             "bank frozen: {slot} hash: {hash} signature_count: {} last_blockhash: {} \
              capitalization: {}, accounts_lt_hash checksum: {accounts_lt_hash_checksum}, stats: \
@@ -5796,6 +5819,10 @@ impl Bank {
     pub fn vote_accounts(&self) -> Arc<VoteAccountsHashMap> {
         let stakes = self.stakes_cache.stakes();
         Arc::from(stakes.vote_accounts())
+    }
+
+    pub(crate) fn update_stake_delegations_snapshot(&self) {
+        self.stakes_cache.update_stake_delegations_snapshot();
     }
 
     /// Vote account for the given vote account pubkey.

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -24,7 +24,7 @@ use {
         reward_info::RewardInfo,
         stake_account::StakeAccount,
         stake_delegation::delegation_effective_stake,
-        stakes::Stakes,
+        stakes::{IndexedStakeDelegations, Stakes},
     },
     log::{debug, info},
     rayon::{
@@ -299,7 +299,7 @@ impl Bank {
     pub(in crate::bank) fn calculate_rewards(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&Pubkey, &StakeAccount<Delegation>)>,
+        stake_delegations: IndexedStakeDelegations<'_, StakeAccount<Delegation>>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
@@ -468,10 +468,10 @@ impl Bank {
     }
 
     /// Calculate rewards from previous epoch to prepare for partitioned distribution.
-    pub(super) fn calculate_rewards_for_partitioning<'a>(
+    pub(super) fn calculate_rewards_for_partitioning(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: IndexedStakeDelegations<'_, StakeAccount<Delegation>>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         reward_epoch_delegated_stakes: RewardEpochDelegatedStakes,
@@ -533,10 +533,10 @@ impl Bank {
 
     /// Calculate epoch reward and return stake rewards and commissions.
     #[allow(clippy::too_many_arguments)]
-    fn calculate_validator_rewards<'a>(
+    fn calculate_validator_rewards(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: IndexedStakeDelegations<'_, StakeAccount<Delegation>>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         epoch_inflation_rewards: u64,
@@ -586,7 +586,7 @@ impl Bank {
     ) -> EpochRewardCalculateParamInfo<'a> {
         // Use `stakes` for stake-related info
         let stake_history = stakes.history().clone();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations = stakes.stake_delegations().indexed();
 
         // Use the VAT-filtered vote-account snapshot from epoch_stakes.
         // Recalculation should match the vote-account admission policy used for
@@ -769,10 +769,10 @@ impl Bank {
     /// Calculates epoch rewards for stake/commission accounts
     /// Returns commission accounts, stake rewards, and the sum of all stake rewards in lamports
     #[allow(clippy::too_many_arguments)]
-    fn calculate_stake_rewards_and_commissions<'a>(
+    fn calculate_stake_rewards_and_commissions(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: IndexedStakeDelegations<'_, StakeAccount<Delegation>>,
         cached_vote_accounts: CachedVoteAccounts<'_>,
         rewarded_epoch: Epoch,
         point_value: PointValue,
@@ -802,14 +802,18 @@ impl Bank {
         // Producing the stake reward with rayon triggers a lot of
         // (re)allocations. To avoid that, we allocate it at the start and
         // pass `stake_rewards.spare_capacity_mut()` as one of iterators.
-        let stake_delegations_len = stake_delegations.len();
+        let stake_delegations_len = stake_delegations.len_unfiltered();
         let mut stake_rewards = PartitionedStakeRewards::with_capacity(stake_delegations_len);
         let rewards_accumulator: RewardsAccumulator = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_unfiltered()
                 .zip(&mut stake_rewards.spare_capacity_mut()[..stake_delegations_len])
                 .with_min_len(500)
-                .filter_map(|((stake_pubkey, stake_account), reward_ref)| {
+                .filter_map(|(stake_delegation, reward_ref)| {
+                    let Some((stake_pubkey, stake_account)) = stake_delegation else {
+                        reward_ref.write(None);
+                        return None;
+                    };
                     let block_reward = if block_revenue_sharing {
                         calculate_block_reward(
                             rewarded_epoch,
@@ -851,7 +855,7 @@ impl Bank {
                             let stake_reward = inflation.stake_reward;
                             (
                                 Some(PartitionedStakeReward {
-                                    stake_pubkey: **stake_pubkey,
+                                    stake_pubkey: *stake_pubkey,
                                     inflation,
                                     block_reward,
                                 }),
@@ -867,7 +871,7 @@ impl Bank {
                             let stake_reward = 0;
                             (
                                 Some(PartitionedStakeReward {
-                                    stake_pubkey: **stake_pubkey,
+                                    stake_pubkey: *stake_pubkey,
                                     inflation: InflationReward {
                                         stake,
                                         stake_reward,
@@ -931,10 +935,10 @@ impl Bank {
 
     /// Calculates epoch reward points from stake/vote accounts.
     /// Returns reward lamports and points for the epoch or none if points == 0.
-    fn calculate_reward_points_partitioned<'a>(
+    fn calculate_reward_points_partitioned(
         &self,
         stake_history: &StakeHistory,
-        stake_delegations: &Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+        stake_delegations: &IndexedStakeDelegations<'_, StakeAccount<Delegation>>,
         cached_vote_accounts: &CachedVoteAccounts<'_>,
         epoch_inflation_rewards: u64,
         ag_epoch_type: &AlpenglowEpochType,
@@ -969,7 +973,7 @@ impl Bank {
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
         let (points, measure_us) = measure_us!(thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_filtered()
                 .map(|(_stake_pubkey, stake_account)| {
                     let vote_pubkey = stake_account.delegation().voter_pubkey;
 

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -10,6 +10,7 @@ use {
         },
         stake_account::StakeAccount,
         stake_delegation::delegation_effective_stake,
+        stakes::StakeDelegationsMaps,
     },
     log::error,
     serde::{Deserialize, Serialize},
@@ -17,7 +18,6 @@ use {
     solana_accounts_db::stake_rewards::{StakeReward, StakeRewardInfo},
     solana_clock::Epoch,
     solana_measure::measure_us,
-    solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_reward_info::RewardType,
     solana_stake_history::StakeHistory,
@@ -240,7 +240,7 @@ impl Bank {
         distribution_epoch: u64,
         stake_history: &StakeHistory,
         new_warmup_cooldown_rate_epoch: Option<Epoch>,
-        stakes_cache_accounts: &imbl::HashMap<Pubkey, StakeAccount<Delegation>>,
+        stakes_cache_accounts: &StakeDelegationsMaps<StakeAccount<Delegation>>,
         partitioned_stake_reward: &PartitionedStakeReward,
         rent: &Rent,
         adjust_delegations_for_rent: bool,
@@ -449,6 +449,7 @@ mod tests {
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_native_token::LAMPORTS_PER_SOL,
+        solana_pubkey::Pubkey,
         solana_reward_info::RewardType,
         solana_stake_history::StakeHistoryEntry,
         solana_stake_interface::{
@@ -814,23 +815,24 @@ mod tests {
             },
             block_reward,
         };
-        let stakes_cache = bank.stakes_cache.stakes();
-        let stakes_cache_accounts = stakes_cache.stake_delegations();
-        assert_eq!(
-            Bank::build_updated_stake_reward(
-                distribution_epoch,
-                &stake_history,
-                new_warmup_cooldown_rate_epoch,
-                stakes_cache_accounts,
-                &partitioned_stake_reward,
-                &rent,
-                adjust_delegations_for_rent,
-                true,
-            )
-            .unwrap_err(),
-            DistributionError::AccountNotFound
-        );
-        drop(stakes_cache);
+        {
+            let stakes_cache = bank.stakes_cache.stakes();
+            let stakes_cache_accounts = stakes_cache.stake_delegations();
+            assert_eq!(
+                Bank::build_updated_stake_reward(
+                    distribution_epoch,
+                    &stake_history,
+                    new_warmup_cooldown_rate_epoch,
+                    stakes_cache_accounts,
+                    &partitioned_stake_reward,
+                    &rent,
+                    adjust_delegations_for_rent,
+                    true,
+                )
+                .unwrap_err(),
+                DistributionError::AccountNotFound
+            );
+        }
 
         let overflowing_account = Pubkey::new_unique();
         let mut stake_account = AccountSharedData::new(
@@ -855,23 +857,24 @@ mod tests {
             },
             block_reward,
         };
-        let stakes_cache = bank.stakes_cache.stakes();
-        let stakes_cache_accounts = stakes_cache.stake_delegations();
-        assert_eq!(
-            Bank::build_updated_stake_reward(
-                distribution_epoch,
-                &stake_history,
-                new_warmup_cooldown_rate_epoch,
-                stakes_cache_accounts,
-                &partitioned_stake_reward,
-                &rent,
-                adjust_delegations_for_rent,
-                true,
-            )
-            .unwrap_err(),
-            DistributionError::ArithmeticOverflow
-        );
-        drop(stakes_cache);
+        {
+            let stakes_cache = bank.stakes_cache.stakes();
+            let stakes_cache_accounts = stakes_cache.stake_delegations();
+            assert_eq!(
+                Bank::build_updated_stake_reward(
+                    distribution_epoch,
+                    &stake_history,
+                    new_warmup_cooldown_rate_epoch,
+                    stakes_cache_accounts,
+                    &partitioned_stake_reward,
+                    &rent,
+                    adjust_delegations_for_rent,
+                    true,
+                )
+                .unwrap_err(),
+                DistributionError::ArithmeticOverflow
+            );
+        }
 
         let successful_account = Pubkey::new_unique();
         let starting_stake = new_stake.delegation.stake - stake_reward;
@@ -906,47 +909,48 @@ mod tests {
             },
             block_reward,
         };
-        let stakes_cache = bank.stakes_cache.stakes();
-        let stakes_cache_accounts = stakes_cache.stake_delegations();
-        let expected_lamports = starting_lamports + stake_reward + block_reward;
-        let mut expected_stake_account = AccountSharedData::new(
-            expected_lamports,
-            StakeStateV2::size_of(),
-            &solana_stake_interface::program::id(),
-        );
-        expected_stake_account
-            .set_state(&StakeStateV2::Stake(
-                Meta::default(),
-                new_stake,
-                StakeFlags::default(),
-            ))
-            .unwrap();
+        {
+            let stakes_cache = bank.stakes_cache.stakes();
+            let stakes_cache_accounts = stakes_cache.stake_delegations();
+            let expected_lamports = starting_lamports + stake_reward + block_reward;
+            let mut expected_stake_account = AccountSharedData::new(
+                expected_lamports,
+                StakeStateV2::size_of(),
+                &solana_stake_interface::program::id(),
+            );
+            expected_stake_account
+                .set_state(&StakeStateV2::Stake(
+                    Meta::default(),
+                    new_stake,
+                    StakeFlags::default(),
+                ))
+                .unwrap();
 
-        let expected_stake_reward = StakeReward {
-            stake_pubkey: successful_account,
-            stake_account: expected_stake_account,
-            stake_reward_info: StakeRewardInfo {
-                reward_type: RewardType::Staking,
-                lamports: (stake_reward + block_reward) as i64,
-                post_balance: expected_lamports,
-                commission_bps: Some(commission_bps),
-            },
-        };
-        assert_eq!(
-            Bank::build_updated_stake_reward(
-                distribution_epoch,
-                &stake_history,
-                new_warmup_cooldown_rate_epoch,
-                stakes_cache_accounts,
-                &partitioned_stake_reward,
-                &rent,
-                adjust_delegations_for_rent,
-                true,
-            )
-            .unwrap(),
-            expected_stake_reward
-        );
-        drop(stakes_cache);
+            let expected_stake_reward = StakeReward {
+                stake_pubkey: successful_account,
+                stake_account: expected_stake_account,
+                stake_reward_info: StakeRewardInfo {
+                    reward_type: RewardType::Staking,
+                    lamports: (stake_reward + block_reward) as i64,
+                    post_balance: expected_lamports,
+                    commission_bps: Some(commission_bps),
+                },
+            };
+            assert_eq!(
+                Bank::build_updated_stake_reward(
+                    distribution_epoch,
+                    &stake_history,
+                    new_warmup_cooldown_rate_epoch,
+                    stakes_cache_accounts,
+                    &partitioned_stake_reward,
+                    &rent,
+                    adjust_delegations_for_rent,
+                    true,
+                )
+                .unwrap(),
+                expected_stake_reward
+            );
+        }
 
         let deactivating_account = Pubkey::new_unique();
         let deactivating_stake = Stake {
@@ -991,6 +995,7 @@ mod tests {
             },
             block_reward: 0,
         };
+        bank.squash();
         let stakes_cache = bank.stakes_cache.stakes();
         let stakes_cache_accounts = stakes_cache.stake_delegations();
         let expected_lamports = starting_lamports + stake_reward;

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -7,7 +7,7 @@ use {
     super::Bank,
     crate::{
         inflation_rewards::points::PointValue, reward_info::RewardInfo,
-        stake_account::StakeAccount, stake_history::StakeHistory,
+        stake_account::StakeAccount, stake_history::StakeHistory, stakes::IndexedStakeDelegations,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
@@ -321,7 +321,7 @@ pub(super) struct CachedVoteAccounts<'a> {
 /// hold reward calc info to avoid recalculation across functions
 pub(super) struct EpochRewardCalculateParamInfo<'a> {
     pub(super) stake_history: StakeHistory,
-    pub(super) stake_delegations: Vec<(&'a Pubkey, &'a StakeAccount<Delegation>)>,
+    pub(super) stake_delegations: IndexedStakeDelegations<'a, StakeAccount<Delegation>>,
     pub(super) cached_vote_accounts: CachedVoteAccounts<'a>,
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -651,7 +651,7 @@ impl Bank {
         reward_calc_tracer: Option<impl RewardCalcTracer>,
     ) -> StakeDelegationsMap {
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let stake_delegations = stakes.stake_delegations().indexed();
         // Obtain all unique voter pubkeys from stake delegations.
         fn merge(mut acc: HashSet<Pubkey>, other: HashSet<Pubkey>) -> HashSet<Pubkey> {
             if acc.len() < other.len() {
@@ -662,7 +662,8 @@ impl Bank {
         }
         let voter_pubkeys = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_unfiltered()
+                .flatten()
                 .fold(
                     HashSet::default,
                     |mut voter_pubkeys, (_stake_pubkey, stake_account)| {
@@ -712,7 +713,7 @@ impl Bank {
                 .collect()
         });
         // Join stake accounts with vote-accounts.
-        for (stake_pubkey, stake_account) in stake_delegations.into_iter() {
+        for (stake_pubkey, stake_account) in stakes.stake_delegations().iter() {
             let delegation = stake_account.delegation();
             let Some(mut vote_delegations) =
                 stake_delegations_map.get_mut(&delegation.voter_pubkey)
@@ -3301,13 +3302,19 @@ fn test_bank_cloned_stake_delegations() {
         genesis_config.add_account(pubkey, account);
     }
 
-    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    assert_eq!(bank.stakes_cache.stake_delegation_counts(), (1, 0, 0));
     bank.squash();
+    assert_eq!(bank.stakes_cache.stake_delegation_counts(), (1, 0, 0));
     let bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), 1);
+    assert_eq!(bank.stakes_cache.stake_delegation_counts(), (1, 0, 0));
 
-    let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
-    assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
-    // to have a stake delegation
+    {
+        let stakes = bank.stakes_cache.stakes();
+        let stake_delegations = stakes.stake_delegations();
+        assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
+        // to have a stake delegation
+    }
 
     let (vote_balance, stake_balance) = {
         let rent = &bank.rent_collector().rent;
@@ -3358,9 +3365,46 @@ fn test_bank_cloned_stake_delegations() {
 
     bank.process_transaction(&transaction).unwrap();
 
-    let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
+    assert_eq!(bank.stakes_cache.stake_delegation_counts(), (1, 1, 0));
+    {
+        let stakes = bank.stakes_cache.stakes();
+        let stake_delegations = stakes.stake_delegations();
+        assert_eq!(stake_delegations.len(), 2);
+        assert!(stake_delegations.get(&stake_keypair.pubkey()).is_some());
+    }
+
+    let bank_slot = bank.slot();
+    let bank = bank_forks
+        .write()
+        .unwrap()
+        .insert(bank)
+        .clone_without_scheduler();
+    bank_forks.write().unwrap().set_root(bank_slot, None, None);
+    assert_eq!(bank.stakes_cache.stake_delegation_counts(), (1, 1, 0));
+    let stakes = bank.stakes_cache.stakes();
+    let stake_delegations = stakes.stake_delegations();
     assert_eq!(stake_delegations.len(), 2);
     assert!(stake_delegations.get(&stake_keypair.pubkey()).is_some());
+    drop(stakes);
+
+    let next_epoch_slot = bank
+        .epoch_schedule()
+        .get_first_slot_in_epoch(bank.epoch() + 1);
+    let next_epoch_bank = Bank::new_from_parent(bank, SlotLeader::new_unique(), next_epoch_slot);
+    assert_ne!(next_epoch_bank.stakes_cache.stake_delegation_counts().1, 0);
+    let next_epoch_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert(next_epoch_bank)
+        .clone_without_scheduler();
+    bank_forks
+        .write()
+        .unwrap()
+        .set_root(next_epoch_slot, None, None);
+    assert_eq!(
+        next_epoch_bank.stakes_cache.stake_delegation_counts(),
+        (2, 0, 0)
+    );
 }
 
 #[test]

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -499,6 +499,8 @@ impl BankForks {
             {
                 self.migration_status.alpenglow_rooted_new_epoch(new_epoch);
             }
+
+            root_bank.update_stake_delegations_snapshot();
         }
         let root_tx_count = root_bank
             .parents_iter()

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "dev-context-only-utils")]
-use qualifier_attr::qualifiers;
 use {
     crate::{stake_history::StakeHistory, stakes::SerdeStakesToStakeFormat},
     serde::{
@@ -23,6 +21,8 @@ use {
     },
     wincode::{ReadResult, SchemaRead, SchemaWrite, WriteResult, config::Config, io::Reader},
 };
+#[cfg(feature = "dev-context-only-utils")]
+use {indexmap::IndexMap, qualifier_attr::qualifiers};
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
 pub type EpochAuthorizedVoters = HashMap<Pubkey, Pubkey>;
@@ -291,7 +291,7 @@ impl VersionedEpochStakes {
             SerdeStakesToStakeFormat::Account(crate::stakes::Stakes::new_for_tests(
                 0,
                 solana_vote::vote_account::VoteAccounts::from(Arc::new(vote_accounts_hash_map)),
-                imbl::HashMap::default(),
+                Arc::new(IndexMap::default()),
             )),
             leader_schedule_epoch,
         )
@@ -989,7 +989,7 @@ pub(crate) mod tests {
         let stakes = Stakes::new_for_tests(
             epoch,
             vote_accounts,
-            imbl::HashMap::from_iter([(stake_pubkey, stake_account)]),
+            Arc::new(IndexMap::from_iter([(stake_pubkey, stake_account)])),
         );
 
         // ensure stake delegations start off *not* empty

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -23,7 +23,7 @@ use {
     solana_clock::Epoch,
     solana_leader_schedule::SlotLeader,
     solana_nohash_hasher::BuildNoHashHasher,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_stake_interface::{
         program as stake_program,
         state::{Delegation, StakeActivationStatus},
@@ -219,7 +219,7 @@ impl StakesCache {
     }
 }
 
-pub(crate) type StakeDelegationsSnapshot<T> = IndexMap<Pubkey, T, AHashRandomState>;
+pub(crate) type StakeDelegationsSnapshot<T> = IndexMap<Pubkey, T, PubkeyHasherBuilder>;
 
 /// Indexed overlay view of stake delegations.
 ///
@@ -230,7 +230,7 @@ pub(crate) struct IndexedStakeDelegations<'a, T: Clone> {
     snapshot: Arc<StakeDelegationsSnapshot<T>>,
     overrides: HashMap<&'a usize, &'a T, BuildNoHashHasher<usize>>,
     additions: Vec<(&'a Pubkey, &'a T)>,
-    removals: HashSet<&'a Pubkey>,
+    removals: HashSet<&'a Pubkey, PubkeyHasherBuilder>,
 }
 
 impl<'a, T: Clone + Sync> IndexedStakeDelegations<'a, T> {
@@ -286,7 +286,7 @@ pub(crate) struct StakeDelegationsIter<'a, T: Clone> {
         &'a ImblHashMap<usize, T, BuildNoHashHasher<usize>, DefaultSharedPtr>,
     stake_delegations_additions:
         imbl::hashmap::Iter<'a, Pubkey, T, imbl::shared_ptr::DefaultSharedPtr>,
-    stake_delegations_removals: &'a ImblHashSet<Pubkey, AHashRandomState, DefaultSharedPtr>,
+    stake_delegations_removals: &'a ImblHashSet<Pubkey, PubkeyHasherBuilder, DefaultSharedPtr>,
     remaining_removals: usize,
 }
 
@@ -367,13 +367,13 @@ pub(crate) struct StakeDelegationsMaps<T: Clone> {
     /// They can be applied to the snapshot via
     /// [`Self::update_stake_delegations_snapshot`].
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
-    additions: ImblHashMap<Pubkey, T, AHashRandomState, DefaultSharedPtr>,
+    additions: ImblHashMap<Pubkey, T, PubkeyHasherBuilder, DefaultSharedPtr>,
 
     /// Stale delegation removals of `stake_delegations_snapshot` elements,
     /// that come from committed transactions. The removals are applied with
     /// [`Self::update_stake_delegations_snapshot`].
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
-    removals: ImblHashSet<Pubkey, AHashRandomState, DefaultSharedPtr>,
+    removals: ImblHashSet<Pubkey, PubkeyHasherBuilder, DefaultSharedPtr>,
 }
 
 impl<T: Clone> Default for StakeDelegationsMaps<T> {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -9,15 +9,20 @@ use {
         stake_delegation::{delegation_activation_status, delegation_effective_stake},
         stake_history::StakeHistory,
     },
-    imbl::HashMap as ImblHashMap,
+    ahash::RandomState as AHashRandomState,
+    imbl::{
+        GenericHashMap as ImblHashMap, GenericHashSet as ImblHashSet, shared_ptr::DefaultSharedPtr,
+    },
+    indexmap::IndexMap,
     log::error,
     num_derive::ToPrimitive,
     rayon::{ThreadPool, prelude::*},
-    serde::Serialize,
+    serde::{Serialize, Serializer, ser::SerializeMap},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::utils::create_account_shared_data,
     solana_clock::Epoch,
     solana_leader_schedule::SlotLeader,
+    solana_nohash_hasher::BuildNoHashHasher,
     solana_pubkey::Pubkey,
     solana_stake_interface::{
         program as stake_program,
@@ -26,16 +31,19 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::state::VoteStateVersions,
     std::{
-        collections::HashMap,
+        borrow::Cow,
+        collections::{HashMap, HashSet},
+        iter::Enumerate,
         sync::{Arc, RwLock, RwLockReadGuard},
     },
     thiserror::Error,
-    wincode::{SchemaWrite, containers::FromIntoIterator, len::BincodeLen},
+    wincode::SchemaWrite,
 };
 #[cfg(feature = "dev-context-only-utils")]
 use {
     qualifier_attr::{field_qualifiers, qualifiers},
     solana_stake_interface::state::Stake,
+    std::collections::BTreeMap,
 };
 
 mod serde_stakes;
@@ -69,7 +77,7 @@ pub enum InvalidCacheEntryReason {
 }
 
 type StakeAccount = stake_account::StakeAccount<Delegation>;
-pub(crate) type DelegatedStakes = ImblHashMap<Pubkey, u64>;
+pub(crate) type DelegatedStakes = ImblHashMap<Pubkey, u64, AHashRandomState, DefaultSharedPtr>;
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Default, Debug)]
@@ -182,6 +190,506 @@ impl StakesCache {
         let mut stakes = self.0.write().unwrap();
         stakes.refresh_delegated_stakes(new_rate_activation_epoch, use_fixed_point_stake_math);
     }
+
+    pub(crate) fn update_stake_delegations_snapshot(&self) {
+        self.0.write().unwrap().update_stake_delegations_snapshot();
+    }
+
+    pub(crate) fn stake_delegation_map_sizes(&self) -> (usize, usize, usize, usize) {
+        let stakes = self.0.read().unwrap();
+        let StakeDelegationsMaps {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        } = &stakes.stake_delegations;
+        (
+            snapshot.len(),
+            overrides.len(),
+            additions.len(),
+            removals.len(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stake_delegation_counts(&self) -> (usize, usize, usize) {
+        let (snapshot_len, _overrides_len, additions_len, removals_len) =
+            self.stake_delegation_map_sizes();
+        (snapshot_len, additions_len, removals_len)
+    }
+}
+
+pub(crate) type StakeDelegationsSnapshot<T> = IndexMap<Pubkey, T, AHashRandomState>;
+
+/// Indexed overlay view of stake delegations.
+///
+/// Unrooted delegations override rooted delegations with the same pubkey. Unrooted delegations
+/// without a rooted counterpart are appended after the rooted entries, and unrooted removals hide
+/// rooted entries until the fork is squashed.
+pub(crate) struct IndexedStakeDelegations<'a, T: Clone> {
+    snapshot: Arc<StakeDelegationsSnapshot<T>>,
+    overrides: HashMap<&'a usize, &'a T, BuildNoHashHasher<usize>>,
+    additions: Vec<(&'a Pubkey, &'a T)>,
+    removals: HashSet<&'a Pubkey>,
+}
+
+impl<'a, T: Clone + Sync> IndexedStakeDelegations<'a, T> {
+    pub(crate) fn len_unfiltered(&self) -> usize {
+        let Self {
+            snapshot,
+            additions,
+            ..
+        } = self;
+        snapshot.len().wrapping_add(additions.len())
+    }
+
+    /// Pending rooted removals yield `None` so the iterator remains indexed.
+    pub(crate) fn par_iter_unfiltered(
+        &self,
+    ) -> impl IndexedParallelIterator<Item = Option<(&Pubkey, &T)>> {
+        let Self {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+            ..
+        } = self;
+        snapshot
+            .par_iter()
+            .enumerate()
+            .map(move |(index, (pubkey, snapshot_stake_delegation))| {
+                (!removals.contains(pubkey)).then(|| {
+                    let stake_delegation = overrides
+                        .get(&index)
+                        // Doesn't actually copy, but dereferences `&&T` to `&T`.
+                        .copied()
+                        .unwrap_or(snapshot_stake_delegation);
+                    (pubkey, stake_delegation)
+                })
+            })
+            .chain(
+                additions
+                    .par_iter()
+                    .map(|&(pubkey, stake_delegation)| Some((pubkey, stake_delegation))),
+            )
+    }
+
+    pub(crate) fn par_iter_filtered(&self) -> impl ParallelIterator<Item = (&Pubkey, &T)> {
+        self.par_iter_unfiltered().flatten()
+    }
+}
+
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+pub(crate) struct StakeDelegationsIter<'a, T: Clone> {
+    stake_delegations_snapshot: Enumerate<indexmap::map::Iter<'a, Pubkey, T>>,
+    stake_delegations_overrides:
+        &'a ImblHashMap<usize, T, BuildNoHashHasher<usize>, DefaultSharedPtr>,
+    stake_delegations_additions:
+        imbl::hashmap::Iter<'a, Pubkey, T, imbl::shared_ptr::DefaultSharedPtr>,
+    stake_delegations_removals: &'a ImblHashSet<Pubkey, AHashRandomState, DefaultSharedPtr>,
+    remaining_removals: usize,
+}
+
+impl<'a, T: Clone> Iterator for StakeDelegationsIter<'a, T> {
+    type Item = (&'a Pubkey, &'a T);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            stake_delegations_snapshot,
+            stake_delegations_overrides,
+            stake_delegations_additions,
+            stake_delegations_removals,
+            remaining_removals,
+        } = self;
+        let stake_delegation = loop {
+            if let Some((index, (pubkey, snapshot_stake_delegation))) =
+                stake_delegations_snapshot.next()
+            {
+                if stake_delegations_removals.contains(pubkey) {
+                    *remaining_removals = remaining_removals
+                        .checked_sub(1)
+                        .expect("encountered more stake delegation removals than expected");
+                    continue;
+                }
+                let stake_delegation = stake_delegations_overrides
+                    .get(&index)
+                    .unwrap_or(snapshot_stake_delegation);
+                break (pubkey, stake_delegation);
+            } else if let Some((pubkey, stake_delegation)) = stake_delegations_additions.next() {
+                break (pubkey, stake_delegation);
+            } else {
+                return None;
+            }
+        };
+        Some(stake_delegation)
+    }
+}
+
+impl<'a, T: Clone> ExactSizeIterator for StakeDelegationsIter<'a, T> {
+    fn len(&self) -> usize {
+        let Self {
+            stake_delegations_snapshot,
+            stake_delegations_additions,
+            remaining_removals,
+            ..
+        } = self;
+        stake_delegations_snapshot
+            .len()
+            .wrapping_add(stake_delegations_additions.len())
+            .wrapping_sub(*remaining_removals)
+    }
+}
+
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+pub(crate) struct StakeDelegationsMaps<T: Clone> {
+    /// Snapshot of stake delegations, that can be updated with new entries
+    /// from `stake_delegations_overrides`, `stake_delegations_additions`, and
+    /// `stake_delegations_removals` via [`Self::update_stake_delegations_snapshot`].
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(
+            with = "Arc::new(sample_collection_sized::<StakeDelegationsSnapshot<T>, (Pubkey, \
+                    T)>(rng, SequenceLenMax(1)))"
+        )
+    )]
+    snapshot: Arc<StakeDelegationsSnapshot<T>>,
+
+    /// Overrides of stake delegations from `stake_delegations_snapshot`, that
+    /// come from committed transactions. They can be applied to the snapshot
+    /// via [`Self::update_stake_delegations_snapshot`].
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
+    overrides: ImblHashMap<usize, T, BuildNoHashHasher<usize>, DefaultSharedPtr>,
+
+    /// Additions of stake delegations that are not part of
+    /// `stake_delegations_snapshot`, that come from commited transactions.
+    /// They can be applied to the snapshot via
+    /// [`Self::update_stake_delegations_snapshot`].
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
+    additions: ImblHashMap<Pubkey, T, AHashRandomState, DefaultSharedPtr>,
+
+    /// Stale delegation removals of `stake_delegations_snapshot` elements,
+    /// that come from committed transactions. The removals are applied with
+    /// [`Self::update_stake_delegations_snapshot`].
+    #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
+    removals: ImblHashSet<Pubkey, AHashRandomState, DefaultSharedPtr>,
+}
+
+impl<T: Clone> Default for StakeDelegationsMaps<T> {
+    fn default() -> Self {
+        Self {
+            snapshot: Arc::new(StakeDelegationsSnapshot::default()),
+            overrides: ImblHashMap::default(),
+            additions: ImblHashMap::default(),
+            removals: ImblHashSet::default(),
+        }
+    }
+}
+
+impl<T: Clone + Serialize> Serialize for StakeDelegationsMaps<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.len()))?;
+        for (pubkey, stake_delegation) in self {
+            map.serialize_entry(pubkey, stake_delegation)?;
+        }
+        map.end()
+    }
+}
+
+impl<'a, T: Clone> StakeDelegationsMaps<T> {
+    fn update_snapshot(&mut self) {
+        if self.overrides.is_empty() && self.additions.is_empty() && self.removals.is_empty() {
+            return;
+        }
+        let Self {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        } = self;
+        let snapshot = Arc::make_mut(snapshot);
+        for (ix, new_stake_delegation) in std::mem::take(overrides) {
+            let (_, old_stake_delegation) = snapshot.get_index_mut(ix).unwrap_or_else(|| {
+                panic!(
+                    "index `{ix}` present in `stake_delegation_overrides` does not exist in \
+                     `stake_delegations_snapshot`"
+                )
+            });
+            *old_stake_delegation = new_stake_delegation;
+        }
+        for pubkey in std::mem::take(removals) {
+            snapshot.swap_remove(&pubkey);
+        }
+        for (pubkey, stake_delegation) in std::mem::take(additions) {
+            snapshot.insert(pubkey, stake_delegation);
+        }
+    }
+
+    pub(crate) fn get(&self, pubkey: &Pubkey) -> Option<&T> {
+        let Self {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        } = self;
+        additions.get(pubkey).or_else(|| {
+            if let Some((index, _pubkey, snapshot_stake_delegation)) = snapshot.get_full(pubkey) {
+                if removals.contains(pubkey) {
+                    None
+                } else {
+                    Some(overrides.get(&index).unwrap_or(snapshot_stake_delegation))
+                }
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        let Self {
+            snapshot,
+            additions,
+            removals,
+            ..
+        } = self;
+        snapshot
+            .len()
+            .wrapping_add(additions.len())
+            .wrapping_sub(removals.len())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns an iterator of stake delegations.
+    ///
+    /// # Performance
+    ///
+    /// Stake delegations consist of a snapshot represented by `[IndexMap]` and
+    /// overlay changes represented by `[imbl::HashMap]`s. `[imbl::HashMap]` is
+    /// a [hash array mapped trie (HAMT)][hamt], which means that inserts,
+    /// deletions and lookups are average-case O(1) and worst-case O(log n).
+    /// However, the performance of iterations is poor due to depth-first
+    /// traversal and jumps. Currently it's also impossible to iterate over it
+    /// with [`rayon`].
+    ///
+    /// This method is a good choice if the caller iterates over stake
+    /// delegations only once. If there more subsequent iterations needed,
+    /// use [`StakeDelegationsMaps::indexed`].
+    ///
+    /// [hamt]: https://en.wikipedia.org/wiki/Hash_array_mapped_trie
+    pub(crate) fn iter(&'a self) -> StakeDelegationsIter<'a, T> {
+        self.into_iter()
+    }
+
+    /// Collects stake delegations into an [`IndexedStakeDelegations`],
+    /// which then can be used for multiple subsequent iterations and/or
+    /// indexed parallel iteration with [`rayon`].
+    ///
+    /// # Performance
+    ///
+    /// The execution of this method collects elements of multiple [`imbl::HashMap`]
+    /// fields, which are [hash array mapped tries (HAMT)][hamt], so that
+    /// operation involves a depth-first traversal with jumps. However, it's
+    /// still a reasonable tradeoff if the caller iterates over these elements
+    /// multiple times or wants to use [`rayon`].
+    ///
+    /// [hamt]: https://en.wikipedia.org/wiki/Hash_array_mapped_trie
+    pub(crate) fn indexed(&'a self) -> IndexedStakeDelegations<'a, T> {
+        let Self {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+            ..
+        } = self;
+        let snapshot = Arc::clone(snapshot);
+        // Getting a value from `StakeDelegationsMaps` is an O(log n) operation. Given
+        // that we have to perform a lookup for every element from
+        // `stake_delegations_snapshot`, that would slow down every iteration.
+        // To avoid that, collect the values into a regular `HashMap`. The
+        // tradeoff of collecting once for faster iterations.
+        let overrides = overrides.iter().collect();
+        // Iterating over `StakeDelegationsMaps` is also slow, and involves a
+        // depth-first traversal with jumps. Similarly, collect it once, so
+        // then iteration becomes faster.
+        let additions = additions.iter().collect();
+        let removals = removals.iter().collect();
+        IndexedStakeDelegations {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        }
+    }
+}
+
+impl<'a> StakeDelegationsMaps<StakeAccount> {
+    fn upsert_stake_delegation(
+        &'a mut self,
+        stake_pubkey: Pubkey,
+        stake_account: StakeAccount,
+    ) -> Option<Cow<'a, StakeAccount>> {
+        let Self {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        } = self;
+        match snapshot.get_full(&stake_pubkey) {
+            Some((index, _pubkey, snapshot_stake_account)) => {
+                if removals.remove(&stake_pubkey).is_some() {
+                    // If the old stake account was already removed, it means
+                    // that it was already subtracted. Insert the replacement,
+                    // but don't return the old account.
+                    overrides.insert(index, stake_account);
+                    None
+                } else {
+                    // Insert new `stake_account` to the overrides.
+                    // After insertion, we need to subtract the old stake - which
+                    // might be represented either by an already existing override
+                    // entry, or the snapshot entry.
+                    let old_stake_account = overrides
+                        .insert(index, stake_account)
+                        .map(Cow::Owned)
+                        .unwrap_or_else(|| Cow::Borrowed(snapshot_stake_account));
+                    Some(old_stake_account)
+                }
+            }
+            None => {
+                // Check if stake exists in additions by removing and re-inserting
+                // This is necessary because `ImblHashMap` doesn't provide a get+insert atomically
+                if let Some(old_stake_account) = additions.remove(&stake_pubkey) {
+                    // Stake already existed - re-insert new account and return old
+                    // old_stake_account is already owned, just return it wrapped in Cow
+                    additions.insert(stake_pubkey, stake_account);
+                    Some(Cow::Owned(old_stake_account))
+                } else {
+                    // New stake - just insert
+                    additions.insert(stake_pubkey, stake_account);
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl<'a, T: Clone> IntoIterator for &'a StakeDelegationsMaps<T> {
+    type Item = <Self::IntoIter as Iterator>::Item;
+    type IntoIter = StakeDelegationsIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let StakeDelegationsMaps {
+            snapshot: stake_delegations_snapshot,
+            overrides: stake_delegations_overrides,
+            additions: stake_delegations_additions,
+            removals: stake_delegations_removals,
+        } = self;
+        let stake_delegations_snapshot = stake_delegations_snapshot.iter().enumerate();
+        let stake_delegations_additions = stake_delegations_additions.iter();
+        StakeDelegationsIter {
+            stake_delegations_snapshot,
+            stake_delegations_overrides,
+            stake_delegations_additions,
+            stake_delegations_removals,
+            remaining_removals: stake_delegations_removals.len(),
+        }
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl<T: Clone + PartialEq> PartialEq for StakeDelegationsMaps<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // Collect into `BTreeMap` to ensure the same order.
+        let self_stakes: BTreeMap<_, _> = self.iter().collect();
+        let other_stakes: BTreeMap<_, _> = other.iter().collect();
+        self_stakes.eq(&other_stakes)
+    }
+}
+
+mod wincode_compat {
+    use {
+        super::{Pubkey, StakeDelegationsIter, StakeDelegationsMaps},
+        std::borrow::Borrow,
+        wincode::{
+            SchemaWrite, WriteResult, config::Config, containers::FromIntoIterator, len::BincodeLen,
+        },
+    };
+
+    // A wrapper bridging `StakeDelegationsMaps` with wincode.
+    //
+    // Wincode's `containers::FromIntoIterator` has the following trait bounds
+    // for the wrapped type `Coll`:
+    //
+    // - `Coll: IntoIterator`
+    // - `for<'a> &'a Coll: IntoIterator<Item: SchemaWrite<C>, IntoIter: ExactSizeIterator>`
+    //
+    // Which practically means that `Coll` needs the following `impl` blocks:
+    //
+    // - `impl IntoIterator for Coll`
+    // - `impl IntoIterator for &'a Coll`
+    //
+    // Implementing the first one for `StakeDelegationsMaps<T>` is difficult,
+    // because:
+    //
+    // - We can't move out of the `Arc<StakeDelegationsSnapshot<T>>` to yield
+    //   owned `(Pubkey, T)` pair from it.
+    // - Yielding references is not possible, since `self` and all its
+    //   non-`Arc` fields would be owned inside the `into_iter()` method and we
+    //   can't return references to the local values.
+    //
+    // It would be great if `FromIntoIterator` worked for types having only
+    // `impl IntoIterator for &'a Coll`, but until that happens, we need to
+    // use this workaround.
+    pub(crate) struct StakeDelegationsMapsRef<'a, T: Clone>(&'a StakeDelegationsMaps<T>);
+
+    impl<'a, T: Clone> IntoIterator for StakeDelegationsMapsRef<'a, T> {
+        type Item = <Self::IntoIter as Iterator>::Item;
+        type IntoIter = StakeDelegationsIter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
+    }
+
+    impl<'a, T: Clone> IntoIterator for &StakeDelegationsMapsRef<'a, T> {
+        type Item = <Self::IntoIter as Iterator>::Item;
+        type IntoIter = StakeDelegationsIter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
+    }
+
+    unsafe impl<C: Config, T: Clone> SchemaWrite<C> for StakeDelegationsMaps<T>
+    where
+        C: Config,
+        T: Clone + SchemaWrite<C>,
+        for<'a> (&'a Pubkey, &'a T): Borrow<(&'a Pubkey, &'a <T as SchemaWrite<C>>::Src)>,
+    {
+        type Src = Self;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            let stake_delegations = StakeDelegationsMapsRef(src);
+            <FromIntoIterator<StakeDelegationsMapsRef<'_, T>, BincodeLen> as SchemaWrite<C>>::size_of(
+                &stake_delegations,
+            )
+        }
+
+        fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
+            let stake_delegations = StakeDelegationsMapsRef(src);
+            <FromIntoIterator<StakeDelegationsMapsRef<'_, T>, BincodeLen> as SchemaWrite<C>>::write(
+                writer,
+                &stake_delegations,
+            )
+        }
+    }
 }
 
 /// The generic type T is either Delegation or StakeAccount.
@@ -192,7 +700,7 @@ impl StakesCache {
 /// the need to load the stake account from accounts-db when working with
 /// stake-delegations.
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Default, Clone, PartialEq, Debug, Serialize, SchemaWrite)]
+#[derive(Default, Clone, Debug, Serialize, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(
@@ -204,17 +712,13 @@ impl StakesCache {
         stake_history(pub),
     )
 )]
+#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct Stakes<T: Clone> {
     /// vote accounts
     vote_accounts: VoteAccounts,
 
     /// stake_delegations
-    #[cfg_attr(
-        feature = "frozen-abi",
-        stable_abi_sample(with = "sample_collection_sized(rng, SequenceLenMax(1))")
-    )]
-    #[wincode(with = "FromIntoIterator<ImblHashMap<Pubkey, T>, BincodeLen>")]
-    stake_delegations: ImblHashMap<Pubkey, T>,
+    stake_delegations: StakeDelegationsMaps<T>,
 
     /// current effective stake delegated to each vote account pubkey
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
@@ -237,7 +741,7 @@ impl<T: Clone> Stakes<T> {
         Stakes {
             vote_accounts,
             epoch,
-            stake_delegations: ImblHashMap::new(),
+            stake_delegations: StakeDelegationsMaps::default(),
             delegated_stakes: DelegatedStakes::default(),
             unused: 0,
             stake_history: StakeHistory::default(),
@@ -264,6 +768,10 @@ impl<T: Clone> Stakes<T> {
         self.vote_accounts.staked_nodes()
     }
 
+    fn update_stake_delegations_snapshot(&mut self) {
+        self.stake_delegations.update_snapshot();
+    }
+
     /// Destructure self and return the fields needed by EpochStakes
     pub(crate) fn into_epoch_stakes_fields(self) -> (Epoch, VoteAccounts, StakeHistory) {
         let Self {
@@ -287,7 +795,7 @@ impl Stakes<StakeAccount> {
         let stake_history = StakeHistory::default();
         let mut vote_accounts = VoteAccountsHashMap::default();
         let mut delegated_stakes = DelegatedStakes::default();
-        let mut stake_delegations = ImblHashMap::new();
+        let mut snapshot = IndexMap::default();
         let epoch = 0;
 
         for (pubkey, account) in accounts {
@@ -317,7 +825,7 @@ impl Stakes<StakeAccount> {
                 if stake != 0 {
                     *delegated_stakes.entry(delegation.voter_pubkey).or_default() += stake;
                 }
-                stake_delegations.insert(*pubkey, stake_account);
+                snapshot.insert(*pubkey, stake_account);
             }
         }
 
@@ -326,9 +834,16 @@ impl Stakes<StakeAccount> {
             vote_accounts.add_stake(vote_pubkey, *stake);
         }
 
+        let snapshot = Arc::new(snapshot);
+
         Self {
             vote_accounts,
-            stake_delegations,
+            stake_delegations: StakeDelegationsMaps {
+                snapshot,
+                overrides: ImblHashMap::new(),
+                additions: ImblHashMap::default(),
+                removals: ImblHashSet::default(),
+            },
             delegated_stakes,
             unused: 0,
             epoch,
@@ -348,13 +863,14 @@ impl Stakes<StakeAccount> {
     where
         F: Fn(&Pubkey) -> Option<AccountSharedData> + Sync,
     {
-        let stake_delegations = stakes
+        let snapshot = stakes
             .stake_delegations
             .into_par_iter()
             // We use fold/reduce to aggregate the results, which does a bit more work than calling
-            // collect()/collect_vec_list() and then imbl::HashMap::from_iter(collected.into_iter()),
-            // but it does it in background threads, so effectively it's faster.
-            .try_fold(ImblHashMap::new, |mut map, (pubkey, delegation)| {
+            // collect()/collect_vec_list(), then IndexMap::from_iter(collected.into_iter()) and
+            // imbl::HashMap::from_iter(collected.into_iter()), but it does it in background threads,
+            // so effectively it's faster.
+            .try_fold(IndexMap::default, |mut map, (pubkey, delegation)| {
                 let Some(stake_account) = get_account(&pubkey) else {
                     return Err(Error::StakeAccountNotFound(pubkey));
                 };
@@ -381,7 +897,11 @@ impl Stakes<StakeAccount> {
                     Err(Error::InvalidDelegation(pubkey))
                 }
             })
-            .try_reduce(ImblHashMap::new, |a, b| Ok(a.union(b)))?;
+            .try_reduce(IndexMap::default, |mut a, b| {
+                a.extend(b);
+                Ok(a)
+            })?;
+        let snapshot = Arc::new(snapshot);
 
         // Assert that cached vote accounts are consistent with accounts-db.
         //
@@ -400,7 +920,12 @@ impl Stakes<StakeAccount> {
 
         Ok(Self {
             vote_accounts: stakes.vote_accounts.clone(),
-            stake_delegations,
+            stake_delegations: StakeDelegationsMaps {
+                snapshot,
+                overrides: ImblHashMap::new(),
+                additions: ImblHashMap::default(),
+                removals: ImblHashSet::default(),
+            },
             delegated_stakes: DelegatedStakes::default(),
             unused: stakes.unused,
             epoch: stakes.epoch,
@@ -412,14 +937,19 @@ impl Stakes<StakeAccount> {
     pub fn new_for_tests(
         epoch: Epoch,
         vote_accounts: VoteAccounts,
-        stake_delegations: ImblHashMap<Pubkey, StakeAccount>,
+        snapshot: Arc<StakeDelegationsSnapshot<StakeAccount>>,
     ) -> Self {
         let stake_history = StakeHistory::default();
         let delegated_stakes =
-            Self::calculate_delegated_stakes(&stake_delegations, epoch, &stake_history, None, true);
+            Self::calculate_delegated_stakes(snapshot.values(), epoch, &stake_history, None, true);
         Self {
             vote_accounts,
-            stake_delegations,
+            stake_delegations: StakeDelegationsMaps {
+                snapshot,
+                overrides: ImblHashMap::new(),
+                additions: ImblHashMap::default(),
+                removals: ImblHashSet::default(),
+            },
             delegated_stakes,
             unused: 0,
             epoch,
@@ -436,7 +966,7 @@ impl Stakes<StakeAccount> {
         next_epoch: Epoch,
         thread_pool: &ThreadPool,
         new_rate_activation_epoch: Option<Epoch>,
-        stake_delegations: &[(&Pubkey, &StakeAccount)],
+        stake_delegations: &IndexedStakeDelegations<'_, StakeAccount>,
         use_fixed_point_stake_math: bool,
     ) -> (
         StakeHistory,
@@ -448,7 +978,7 @@ impl Stakes<StakeAccount> {
         // prev epoch.
         let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
             stake_delegations
-                .par_iter()
+                .par_iter_filtered()
                 .fold(
                     || (StakeActivationStatus::default(), HashMap::default()),
                     |(acc, mut delegated_stakes), (_stake_pubkey, stake_account)| {
@@ -514,15 +1044,15 @@ impl Stakes<StakeAccount> {
         self.delegated_stakes = delegated_stakes;
     }
 
-    fn calculate_delegated_stakes(
-        stake_delegations: &ImblHashMap<Pubkey, StakeAccount>,
+    fn calculate_delegated_stakes<'a>(
+        stake_delegations: impl IntoIterator<Item = &'a StakeAccount>,
         epoch: Epoch,
         stake_history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
     ) -> DelegatedStakes {
         let mut delegated_stakes = DelegatedStakes::new();
-        for stake_account in stake_delegations.values() {
+        for stake_account in stake_delegations {
             let delegation = stake_account.delegation();
             let stake = delegation_effective_stake(
                 delegation,
@@ -543,13 +1073,15 @@ impl Stakes<StakeAccount> {
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
     ) {
-        self.delegated_stakes = Self::calculate_delegated_stakes(
-            &self.stake_delegations,
+        let stake_delegations = self.stake_delegations().iter();
+        let delegated_stakes = Self::calculate_delegated_stakes(
+            stake_delegations.map(|(_pubkey, stake_account)| stake_account),
             self.epoch,
             &self.stake_history,
             new_rate_activation_epoch,
             use_fixed_point_stake_math,
         );
+        self.delegated_stakes = delegated_stakes;
     }
 
     fn add_delegated_stake(&mut self, voter_pubkey: Pubkey, stake: u64) {
@@ -585,19 +1117,59 @@ impl Stakes<StakeAccount> {
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
     ) {
-        if let Some(stake_account) = self.stake_delegations.remove(stake_pubkey) {
-            let removed_delegation = stake_account.delegation();
-            let removed_stake = delegation_effective_stake(
-                removed_delegation,
+        let Self {
+            stake_delegations, ..
+        } = self;
+        let StakeDelegationsMaps {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        } = stake_delegations;
+        let (voter_pubkey, stake) = if let Some(stake_account) = additions.remove(stake_pubkey) {
+            // The stake delegation we're removing is added in
+            // `stake_delegations_additions`.
+            let delegation = stake_account.delegation();
+            let voter_pubkey = delegation.voter_pubkey;
+            let stake = delegation_effective_stake(
+                delegation,
                 self.epoch,
                 &self.stake_history,
                 new_rate_activation_epoch,
                 use_fixed_point_stake_math,
             );
-            self.sub_delegated_stake(&removed_delegation.voter_pubkey, removed_stake);
-            self.vote_accounts
-                .sub_stake(&removed_delegation.voter_pubkey, removed_stake);
-        }
+            (voter_pubkey, stake)
+        } else if let Some((ix, _, stake_account)) = snapshot.get_full(stake_pubkey) {
+            // The stake delegation we're removing is present in
+            // `stake_delegations_snapshot`, schedule its removal.
+            if removals.insert(*stake_pubkey).is_some() {
+                // The snapshot entry is already masked and its stake has
+                // already been subtracted.
+                return;
+            }
+            // Check whether it was updated in `stake_delegation_overrides`.
+            // If yes, use the up-to-date value for calculating the
+            // effective stake.
+            let stake_account = overrides
+                .remove(&ix)
+                .map(Cow::Owned)
+                .unwrap_or(Cow::Borrowed(stake_account));
+
+            let delegation = stake_account.delegation();
+            let voter_pubkey = delegation.voter_pubkey;
+            let stake = delegation_effective_stake(
+                delegation,
+                self.epoch,
+                &self.stake_history,
+                new_rate_activation_epoch,
+                use_fixed_point_stake_math,
+            );
+            (voter_pubkey, stake)
+        } else {
+            return;
+        };
+        self.sub_delegated_stake(&voter_pubkey, stake);
+        self.vote_accounts.sub_stake(&voter_pubkey, stake);
     }
 
     fn upsert_vote_account(
@@ -634,60 +1206,34 @@ impl Stakes<StakeAccount> {
             new_rate_activation_epoch,
             use_fixed_point_stake_math,
         );
-        match self.stake_delegations.insert(stake_pubkey, stake_account) {
-            None => {
+        if let Some(old_stake_account) = self
+            .stake_delegations
+            .upsert_stake_delegation(stake_pubkey, stake_account)
+        {
+            let old_delegation = old_stake_account.delegation();
+            let old_voter_pubkey = old_delegation.voter_pubkey;
+            let old_stake = delegation_effective_stake(
+                old_delegation,
+                self.epoch,
+                &self.stake_history,
+                new_rate_activation_epoch,
+                use_fixed_point_stake_math,
+            );
+            if voter_pubkey != old_voter_pubkey || stake != old_stake {
+                self.sub_delegated_stake(&old_voter_pubkey, old_stake);
                 self.add_delegated_stake(voter_pubkey, stake);
+                self.vote_accounts.sub_stake(&old_voter_pubkey, old_stake);
                 self.vote_accounts.add_stake(&voter_pubkey, stake);
             }
-            Some(old_stake_account) => {
-                let old_delegation = old_stake_account.delegation();
-                let old_voter_pubkey = old_delegation.voter_pubkey;
-                let old_stake = delegation_effective_stake(
-                    old_delegation,
-                    self.epoch,
-                    &self.stake_history,
-                    new_rate_activation_epoch,
-                    use_fixed_point_stake_math,
-                );
-                if voter_pubkey != old_voter_pubkey || stake != old_stake {
-                    self.sub_delegated_stake(&old_voter_pubkey, old_stake);
-                    self.add_delegated_stake(voter_pubkey, stake);
-                    self.vote_accounts.sub_stake(&old_voter_pubkey, old_stake);
-                    self.vote_accounts.add_stake(&voter_pubkey, stake);
-                }
-            }
+        } else {
+            // New stake delegation - add to delegated_stakes and vote_accounts
+            self.add_delegated_stake(voter_pubkey, stake);
+            self.vote_accounts.add_stake(&voter_pubkey, stake);
         }
     }
 
-    /// Returns a reference to the map of stake delegations.
-    ///
-    /// # Performance
-    ///
-    /// `[imbl::HashMap]` is a [hash array mapped trie (HAMT)][hamt], which means
-    /// that inserts, deletions and lookups are average-case O(1) and
-    /// worst-case O(log n). However, the performance of iterations is poor due
-    /// to depth-first traversal and jumps. Currently it's also impossible to
-    /// iterate over it with [`rayon`].
-    ///
-    /// [hamt]: https://en.wikipedia.org/wiki/Hash_array_mapped_trie
-    pub(crate) fn stake_delegations(&self) -> &ImblHashMap<Pubkey, StakeAccount> {
+    pub(crate) fn stake_delegations(&self) -> &StakeDelegationsMaps<StakeAccount> {
         &self.stake_delegations
-    }
-
-    /// Collects stake delegations into a vector, which then can be used for
-    /// parallel iteration with [`rayon`].
-    ///
-    /// # Performance
-    ///
-    /// The execution of this method takes ~200ms and it collects elements of
-    /// the [`imbl::HashMap`], which is a [hash array mapped trie (HAMT)][hamt],
-    /// so that operation involves a depth-first traversal with jumps. However,
-    /// it's still a reasonable tradeoff if the caller iterates over these
-    /// elements.
-    ///
-    /// [hamt]: https://en.wikipedia.org/wiki/Hash_array_mapped_trie
-    pub(crate) fn stake_delegations_vec(&self) -> Vec<(&Pubkey, &StakeAccount)> {
-        self.stake_delegations.iter().collect()
     }
 
     pub(crate) fn highest_staked_node(&self) -> Option<SlotLeader> {
@@ -714,13 +1260,33 @@ macro_rules! impl_stake_format_conversion {
                     epoch,
                     stake_history,
                 } = stakes;
-                let stake_delegations = stake_delegations
+                let StakeDelegationsMaps {
+                    snapshot,
+                    overrides,
+                    additions,
+                    removals,
+                } = stake_delegations;
+                let snapshot = snapshot
+                    .iter()
+                    .map(|(pubkey, $binding)| (*pubkey, $expr))
+                    .collect();
+                let snapshot = Arc::new(snapshot);
+                let overrides = overrides
+                    .into_iter()
+                    .map(|(pubkey, $binding)| (pubkey, $expr))
+                    .collect();
+                let additions = additions
                     .into_iter()
                     .map(|(pubkey, $binding)| (pubkey, $expr))
                     .collect();
                 Self {
                     vote_accounts,
-                    stake_delegations,
+                    stake_delegations: StakeDelegationsMaps {
+                        snapshot,
+                        overrides,
+                        additions,
+                        removals,
+                    },
                     delegated_stakes: DelegatedStakes::default(),
                     unused,
                     epoch,
@@ -757,7 +1323,7 @@ fn refresh_vote_accounts(
     thread_pool: &ThreadPool,
     epoch: Epoch,
     vote_accounts: &VoteAccounts,
-    stake_delegations: &[(&Pubkey, &StakeAccount)],
+    stake_delegations: &IndexedStakeDelegations<'_, StakeAccount>,
     stake_history: &StakeHistory,
     new_rate_activation_epoch: Option<Epoch>,
     use_fixed_point_stake_math: bool,
@@ -773,7 +1339,8 @@ fn refresh_vote_accounts(
     }
     let delegated_stakes = thread_pool.install(|| {
         stake_delegations
-            .par_iter()
+            .par_iter_unfiltered()
+            .flatten()
             .fold(
                 DelegatedStakes::default,
                 |mut delegated_stakes, (_stake_pubkey, stake_account)| {
@@ -823,15 +1390,247 @@ pub(crate) mod tests {
     impl Stakes<Delegation> {
         /// Convert deserialized stakes into runtime stakes representation
         pub(crate) fn from_deserialized(stakes: DeserializableDelegationStakes) -> Self {
+            let DeserializableDelegationStakes {
+                vote_accounts,
+                stake_delegations,
+                unused,
+                epoch,
+                stake_history,
+            } = stakes;
+            let stake_delegations = StakeDelegationsMaps {
+                snapshot: Arc::new(IndexMap::from_iter(stake_delegations)),
+                overrides: ImblHashMap::default(),
+                additions: ImblHashMap::default(),
+                removals: ImblHashSet::default(),
+            };
             Self {
-                vote_accounts: stakes.vote_accounts,
-                stake_delegations: ImblHashMap::from_iter(stakes.stake_delegations),
+                vote_accounts,
+                stake_delegations,
                 delegated_stakes: DelegatedStakes::default(),
-                unused: stakes.unused,
-                epoch: stakes.epoch,
-                stake_history: stakes.stake_history,
+                unused,
+                epoch,
+                stake_history,
             }
         }
+    }
+
+    #[test]
+    fn test_stake_delegations_view_overlay() {
+        let root_only = Pubkey::new_unique();
+        let overridden = Pubkey::new_unique();
+        let removed = Pubkey::new_unique();
+        let unrooted_only = Pubkey::new_unique();
+
+        let snapshot =
+            StakeDelegationsSnapshot::from_iter([(root_only, 1), (overridden, 2), (removed, 3)]);
+        let overridden_ix = snapshot.get_index_of(&overridden).unwrap();
+        let snapshot = Arc::new(snapshot);
+        let overrides = ImblHashMap::from_iter([(overridden_ix, 20)]);
+        let additions = ImblHashMap::from_iter([(unrooted_only, 30)]);
+        let removals = ImblHashSet::from_iter([(removed)]);
+        let stake_delegations = StakeDelegationsMaps {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        };
+        let expected = HashMap::from([(root_only, 1), (overridden, 20), (unrooted_only, 30)]);
+
+        assert_eq!(stake_delegations.len(), expected.len());
+        assert_eq!(stake_delegations.get(&removed), None);
+        let serialized_delegations = bincode::serialize(&stake_delegations).unwrap();
+        let deserialized_delegations: HashMap<Pubkey, u64> =
+            bincode::deserialize(&serialized_delegations).unwrap();
+        assert_eq!(deserialized_delegations, expected);
+
+        let mut serial_delegations_iter = stake_delegations.iter();
+        assert_eq!(serial_delegations_iter.len(), 3);
+        assert_eq!(
+            serial_delegations_iter
+                .next()
+                .map(|(pubkey, stake_delegation)| (*pubkey, *stake_delegation)),
+            Some((root_only, 1))
+        );
+        assert_eq!(serial_delegations_iter.len(), 2);
+        assert_eq!(
+            serial_delegations_iter
+                .next()
+                .map(|(pubkey, stake_delegation)| (*pubkey, *stake_delegation)),
+            Some((overridden, 20))
+        );
+        assert_eq!(serial_delegations_iter.len(), 1);
+        assert_eq!(
+            serial_delegations_iter
+                .next()
+                .map(|(pubkey, stake_delegation)| (*pubkey, *stake_delegation)),
+            Some((unrooted_only, 30))
+        );
+        assert_eq!(serial_delegations_iter.len(), 0);
+        assert_eq!(serial_delegations_iter.next(), None);
+
+        let serial_delegations = stake_delegations.iter().collect::<Vec<_>>();
+        assert_eq!(serial_delegations.len(), expected.len());
+        assert_eq!(
+            serial_delegations
+                .into_iter()
+                .map(|(pubkey, stake_delegation)| (*pubkey, *stake_delegation))
+                .collect::<HashMap<_, _>>(),
+            expected,
+        );
+
+        let indexed = stake_delegations.indexed();
+        let parallel_delegation_slots = indexed.par_iter_unfiltered().collect::<Vec<_>>();
+        assert_eq!(
+            parallel_delegation_slots.len(),
+            expected.len().saturating_add(1)
+        );
+        assert_eq!(
+            parallel_delegation_slots
+                .iter()
+                .filter(|stake_delegation| stake_delegation.is_none())
+                .count(),
+            1,
+        );
+        let parallel_delegations = parallel_delegation_slots
+            .into_iter()
+            .flatten()
+            .map(|(pubkey, stake_delegation)| (*pubkey, *stake_delegation))
+            .collect::<Vec<_>>();
+        assert_eq!(parallel_delegations.len(), expected.len());
+        assert_eq!(
+            parallel_delegations.into_iter().collect::<HashMap<_, _>>(),
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_upsert_stake_delegation_after_removal() {
+        let rent = Rent::default();
+        let stake_pubkey = Pubkey::new_unique();
+        let old_vote_pubkey = Pubkey::new_unique();
+        let new_vote_pubkey = Pubkey::new_unique();
+        let old_stake_account = StakeAccount::try_from(create_stake_account(
+            10,
+            &old_vote_pubkey,
+            &stake_pubkey,
+            &rent,
+        ))
+        .unwrap();
+        let new_stake_account = StakeAccount::try_from(create_stake_account(
+            20,
+            &new_vote_pubkey,
+            &stake_pubkey,
+            &rent,
+        ))
+        .unwrap();
+        let mut stake_delegations = StakeDelegationsMaps {
+            snapshot: Arc::new(StakeDelegationsSnapshot::from_iter([(
+                stake_pubkey,
+                old_stake_account,
+            )])),
+            removals: ImblHashSet::from_iter([stake_pubkey]),
+            ..StakeDelegationsMaps::default()
+        };
+
+        // The removed delegation was already subtracted, so the re-insert must be treated as new.
+        assert!(
+            stake_delegations
+                .upsert_stake_delegation(stake_pubkey, new_stake_account)
+                .is_none()
+        );
+
+        assert!(stake_delegations.removals.is_empty());
+        assert_eq!(stake_delegations.overrides.len(), 1);
+        assert_eq!(stake_delegations.len(), 1);
+        let reinserted_stake_account = stake_delegations.get(&stake_pubkey).unwrap();
+        assert_eq!(
+            reinserted_stake_account.delegation().voter_pubkey,
+            new_vote_pubkey
+        );
+        assert_eq!(reinserted_stake_account.delegation().stake, 20);
+    }
+
+    #[test]
+    fn test_root_stake_delegations() {
+        let root_only = Pubkey::new_unique();
+        let overridden = Pubkey::new_unique();
+        let removed = Pubkey::new_unique();
+        let unrooted_only = Pubkey::new_unique();
+
+        let mut snapshot = StakeDelegationsSnapshot::default();
+        snapshot.insert(root_only, 1);
+        snapshot.insert(overridden, 2);
+        let overridden_ix = snapshot.get_index_of(&overridden).unwrap();
+        snapshot.insert(removed, 3);
+        let snapshot = Arc::new(snapshot);
+        let overrides = ImblHashMap::from_iter([(overridden_ix, 20)]);
+        let additions = ImblHashMap::from_iter([(unrooted_only, 30)]);
+        let removals = ImblHashSet::from_iter([(removed)]);
+        let stake_delegations = StakeDelegationsMaps {
+            snapshot,
+            overrides,
+            additions,
+            removals,
+        };
+        let mut stakes = Stakes::<u64> {
+            stake_delegations,
+            ..Stakes::default()
+        };
+        let sibling_fork = stakes.clone();
+
+        stakes.update_stake_delegations_snapshot();
+
+        let Stakes {
+            stake_delegations, ..
+        } = stakes;
+        let StakeDelegationsMaps {
+            snapshot: updated_snapshot,
+            overrides: updated_overrides,
+            additions: updated_additions,
+            removals: updated_removals,
+        } = stake_delegations;
+        assert_eq!(updated_snapshot.len(), 3);
+        assert_eq!(updated_snapshot.get(&root_only), Some(&1));
+        assert_eq!(updated_snapshot.get(&overridden), Some(&20));
+        assert_eq!(updated_snapshot.get(&removed), None);
+        assert_eq!(updated_snapshot.get(&unrooted_only), Some(&30));
+        assert!(updated_overrides.is_empty());
+        assert!(updated_additions.is_empty());
+        assert!(updated_removals.is_empty());
+
+        let Stakes {
+            stake_delegations: sibling_fork_stake_delegations,
+            ..
+        } = sibling_fork;
+        let StakeDelegationsMaps {
+            snapshot: sibling_fork_snapshot,
+            overrides: sibling_fork_overrides,
+            additions: sibling_fork_additions,
+            removals: sibling_fork_removals,
+        } = sibling_fork_stake_delegations;
+        assert_eq!(sibling_fork_snapshot.len(), 3);
+        assert_eq!(sibling_fork_snapshot.get(&overridden), Some(&2));
+        assert_eq!(sibling_fork_overrides.get(&overridden_ix), Some(&20));
+        assert_eq!(
+            sibling_fork_additions.iter().collect::<Vec<_>>(),
+            [(&unrooted_only, &30)]
+        );
+        assert!(sibling_fork_removals.contains(&removed));
+    }
+
+    #[test]
+    fn test_root_all_stake_delegations_removed() {
+        let removed = Pubkey::new_unique();
+        let mut stake_delegations = StakeDelegationsMaps {
+            snapshot: Arc::new(StakeDelegationsSnapshot::from_iter([(removed, 1)])),
+            removals: ImblHashSet::from_iter([removed]),
+            ..StakeDelegationsMaps::default()
+        };
+
+        assert!(stake_delegations.is_empty());
+        stake_delegations.update_snapshot();
+        assert!(stake_delegations.snapshot.is_empty());
+        assert!(stake_delegations.removals.is_empty());
     }
 
     //  set up some dummies for a staked node     ((     vote      )  (     stake     ))
@@ -1194,7 +1993,7 @@ pub(crate) mod tests {
         let next_epoch = 3;
         let (stake_history, vote_accounts, delegated_stakes, effective_delegated_stakes) = {
             let stakes = stakes_cache.stakes();
-            let stake_delegations = stakes.stake_delegations_vec();
+            let stake_delegations = stakes.stake_delegations().indexed();
             stakes.calculate_activated_stake(
                 next_epoch,
                 &thread_pool,
@@ -1256,6 +2055,31 @@ pub(crate) mod tests {
             let vote_accounts = stakes.vote_accounts();
             assert!(vote_accounts.get(&vote_pubkey).is_some());
             assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey), 0);
+        }
+    }
+
+    #[test]
+    fn test_remove_snapshot_stake_delegation_is_idempotent() {
+        let stakes_cache = StakesCache::default();
+        let rent = Rent::default();
+        let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
+            create_staked_node_accounts(10, &rent);
+
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.update_stake_delegations_snapshot();
+
+        let invalid_stake_account = AccountSharedData::new(1, 0, &stake::program::id());
+        stakes_cache.check_and_store(&stake_pubkey, &invalid_stake_account, None, true);
+
+        // Removing the same snapshot-backed delegation again must be a no-op.
+        stakes_cache.check_and_store(&stake_pubkey, &invalid_stake_account, None, true);
+        {
+            let stakes = stakes_cache.stakes();
+            let vote_accounts = stakes.vote_accounts();
+            assert!(vote_accounts.get(&vote_pubkey).is_some());
+            assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey), 0);
+            assert_eq!(stakes.stake_delegations().len(), 0);
         }
     }
 }

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -4,8 +4,7 @@ use qualifier_attr::qualifiers;
 use wincode::SchemaWrite;
 use {
     super::{StakeAccount, Stakes},
-    crate::stake_history::StakeHistory,
-    imbl::HashMap as ImblHashMap,
+    crate::{stake_history::StakeHistory, stakes::StakeDelegationsMaps},
     serde::{Deserialize, Serialize, Serializer, ser::SerializeMap},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
@@ -153,7 +152,7 @@ struct SerdeStakeAccountsToStakeFormat {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-struct SerdeStakeAccountMapToDelegationFormat(ImblHashMap<Pubkey, StakeAccount>);
+struct SerdeStakeAccountMapToDelegationFormat(StakeDelegationsMaps<StakeAccount>);
 impl Serialize for SerdeStakeAccountMapToDelegationFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -168,7 +167,7 @@ impl Serialize for SerdeStakeAccountMapToDelegationFormat {
 }
 
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
-struct SerdeStakeAccountMapToStakeFormat(ImblHashMap<Pubkey, StakeAccount>);
+struct SerdeStakeAccountMapToStakeFormat(StakeDelegationsMaps<StakeAccount>);
 impl Serialize for SerdeStakeAccountMapToStakeFormat {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
#### Problem

`ImblHashMap` supports cheap cloning and updates across forks, but its HAMT layout makes iteration relatively slow.

#### Summary of Changes

Most stake delegations are rooted, while individual forks typically contain only a small overlay of changes. Store the rooted state in a dense `Arc<IndexMap>` shared across forks, and retain `ImblHashMap` for unrooted updates.

The unrooted state overlays rooted entries until the bank is squashed. At squash time, pending removals are applied and unrooted updates are merged into the rooted map.

This preserves cheap per-fork updates while making iteration over the dominant rooted state faster and suitable for indexed parallel iteration.

Assisted-by: codex + gpt-5.5 / gpt-5.6-sol
Assisted-by: qwen-code + llama.cpp + hf.co/unsloth/Qwen3.6-27B-MTP-GGUF:UD-Q4_K_XL

#### Testing

Profiled with slowlana.

Before:

<img width="4088" height="2418" alt="profile_ale" src="https://github.com/user-attachments/assets/851da7d6-b6e2-4642-ba82-36586548e9a5" />

After:

<img width="3700" height="1152" alt="profile1" src="https://github.com/user-attachments/assets/83a898a8-d673-4c7e-8de7-97a7152fa654" />
