### PR TITLE
bls_sigverify: group incoming certs by type before verification

### DIFF
--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -22,7 +22,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::nonblocking::simple_qos::SimpleQosBanlist,
-    std::collections::HashSet,
+    std::collections::{HashMap, HashSet},
     thiserror::Error,
 };
 
@@ -39,34 +39,39 @@ enum CertVerifyError {
     TooFarInFuture { cert_slot: Slot, root_slot: Slot },
 }
 
+struct CertVerifyOutcome {
+    verified_cert: Option<Certificate>,
+    failures: Vec<(CertVerifyError, Pubkey)>,
+}
+
 /// Verifies certificates and sends the verified certificates to the consensus pool.
 ///
 /// Additionally inserts valid [`CertificateType`]s into `verified_certs_set`.
 /// Any certificate that fails verification will have its sender banlisted.
 ///
-/// Function expects that the caller has already deduped the certs to verify i.e.
-/// none of the certs appear in the [`verified_certs_set`].
+/// Function expects that the caller has already filtered any certs that appear in the
+/// [`verified_certs_set`] and grouped certs with the same [`CertificateType`]. Each group is
+/// verified until the first valid candidate is found.
 pub(super) fn verify_and_send_certificates(
     verified_certs_set: &mut HashSet<CertificateType>,
-    certs: Vec<CertPayload>,
+    cert_groups: HashMap<CertificateType, Vec<CertPayload>>,
     root_bank: &Bank,
     channel_to_pool: &Sender<SigVerifiedBatch>,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
 ) -> Result<SigVerifyCertStats, SigVerifyCertError> {
-    for cert in certs.iter().map(|cert_payload| &cert_payload.cert) {
-        debug_assert!(!verified_certs_set.contains(&cert.cert_type));
+    for cert_type in cert_groups.keys() {
+        debug_assert!(!verified_certs_set.contains(cert_type));
     }
     let mut measure = Measure::start("verify_and_send_certificates");
     let mut stats = SigVerifyCertStats::default();
 
-    if certs.is_empty() {
+    if cert_groups.is_empty() {
         return Ok(stats);
     }
 
-    stats.certs_to_sig_verify += certs.len() as u64;
     let messages = verify_certs(
-        certs,
+        cert_groups,
         root_bank,
         verified_certs_set,
         &mut stats,
@@ -83,13 +88,13 @@ pub(super) fn verify_and_send_certificates(
     Ok(stats)
 }
 
-/// Verifies certificates in `certs`, stores a local copy, and prepares them for forwarding.
+/// Verifies certificates in `cert_groups`, stores a local copy, and prepares them for forwarding.
 ///
 /// The valid certs are inserted into the [`verified_certs_set`].
 /// Invalid cert senders are banlisted.
 /// Returns a [`SigVerifiedBatch`] constructed from the valid certs.
 fn verify_certs(
-    certs: Vec<CertPayload>,
+    cert_groups: HashMap<CertificateType, Vec<CertPayload>>,
     root_bank: &Bank,
     verified_certs_set: &mut HashSet<CertificateType>,
     stats: &mut SigVerifyCertStats,
@@ -97,53 +102,84 @@ fn verify_certs(
     thread_pool: &ThreadPool,
 ) -> SigVerifiedBatch {
     let verified = thread_pool.install(|| {
-        certs
+        cert_groups
             .into_par_iter()
-            .map(|cert_payload| {
-                let res = verify_cert(cert_payload.cert, root_bank);
-                (res, cert_payload.sender_identity_pubkey)
+            .map(|(_, certs)| {
+                let num_certs = certs.len();
+                (num_certs, verify_cert_group(certs, root_bank))
             })
             .collect::<Vec<_>>()
     });
 
-    let certs = verified
-        .into_iter()
-        .filter_map(|(res, sender_identity_pubkey)| match res {
-            Ok(cert) => {
-                if !verified_certs_set.insert(cert.cert_type) {
-                    stats.unnecessary_certs_verified += 1;
-                }
-                Some(cert)
-            }
-            Err(e) => {
-                match &e {
-                    CertVerifyError::CertVerifyFailed(_) => {
-                        stats.banning_validator += 1;
-                        if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
-                            stats.already_banned += 1;
-                        } else {
-                            info!(
-                                "bls_cert_sigverify: banned sender={sender_identity_pubkey} due \
-                                 to error {e}"
-                            );
-                        }
-                    }
-                    CertVerifyError::TooFarInFuture { .. } => {}
-                }
+    let mut certs = Vec::new();
+    for (num_certs, outcome) in verified {
+        let num_certs_attempted = if outcome.verified_cert.is_some() {
+            outcome.failures.len().saturating_add(1)
+        } else {
+            outcome.failures.len()
+        };
+        stats.certs_to_sig_verify += num_certs_attempted as u64;
+        stats.redundant_certs_skipped += num_certs.saturating_sub(num_certs_attempted) as u64;
 
-                match e {
-                    CertVerifyError::CertVerifyFailed(_) => {
-                        stats.certificate_verification_failed += 1;
-                    }
-                    CertVerifyError::TooFarInFuture { .. } => {
-                        stats.too_far_in_future += 1;
-                    }
-                };
-                None
+        for (err, sender_identity_pubkey) in outcome.failures {
+            handle_cert_verify_error(err, sender_identity_pubkey, stats, banlist);
+        }
+
+        if let Some(cert) = outcome.verified_cert {
+            if verified_certs_set.insert(cert.cert_type) {
+                certs.push(cert);
+            } else {
+                stats.unnecessary_certs_verified += 1;
             }
-        })
-        .collect();
+        }
+    }
+
     SigVerifiedBatch::Certificates(certs)
+}
+
+fn verify_cert_group(certs: Vec<CertPayload>, root_bank: &Bank) -> CertVerifyOutcome {
+    let mut failures = Vec::new();
+
+    for cert_payload in certs {
+        match verify_cert(cert_payload.cert, root_bank) {
+            Ok(cert) => {
+                return CertVerifyOutcome {
+                    verified_cert: Some(cert),
+                    failures,
+                };
+            }
+            Err(err) => failures.push((err, cert_payload.sender_identity_pubkey)),
+        }
+    }
+
+    CertVerifyOutcome {
+        verified_cert: None,
+        failures,
+    }
+}
+
+fn handle_cert_verify_error(
+    err: CertVerifyError,
+    sender_identity_pubkey: Pubkey,
+    stats: &mut SigVerifyCertStats,
+    banlist: &SimpleQosBanlist,
+) {
+    match &err {
+        CertVerifyError::CertVerifyFailed(_) => {
+            stats.banning_validator += 1;
+            if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
+                stats.already_banned += 1;
+            } else {
+                info!(
+                    "bls_cert_sigverify: banned sender={sender_identity_pubkey} due to error {err}"
+                );
+            }
+            stats.certificate_verification_failed += 1;
+        }
+        CertVerifyError::TooFarInFuture { .. } => {
+            stats.too_far_in_future += 1;
+        }
+    }
 }
 
 fn verify_cert(

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -163,7 +163,7 @@ impl SigVerifier {
         let root_bank = self.sharable_banks.root();
         self.maybe_prune_caches(root_bank.slot());
 
-        let ((certs_to_verify, votes_to_verify), extract_msgs_us) =
+        let ((cert_groups, votes_to_verify), extract_msgs_us) =
             measure_us!(self.extract_and_filter_msgs(batches, &root_bank));
         self.stats
             .extract_filter_msgs_us
@@ -184,7 +184,7 @@ impl SigVerifier {
             || {
                 verify_and_send_certificates(
                     &mut self.verified_certs,
-                    certs_to_verify,
+                    cert_groups,
                     &root_bank,
                     &self.channels.channel_to_pool,
                     &self.banlist,
@@ -213,11 +213,11 @@ impl SigVerifier {
         batches: Vec<PacketBatch>,
         root_bank: &Bank,
     ) -> (
-        Vec<CertPayload>,
+        HashMap<CertificateType, Vec<CertPayload>>,
         HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
     ) {
         let root_slot = root_bank.slot();
-        let mut certs = Vec::new();
+        let mut cert_groups = HashMap::<CertificateType, Vec<CertPayload>>::new();
         let mut votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>> = HashMap::new();
         let mut num_pkts = 0u64;
         let my_shred_version = self.cluster_info.my_shred_version();
@@ -278,15 +278,18 @@ impl SigVerifier {
                         self.stats.num_generated_certs_received += 1;
                         continue;
                     }
-                    certs.push(CertPayload {
-                        cert,
-                        sender_identity_pubkey,
-                    });
+                    cert_groups
+                        .entry(cert.cert_type)
+                        .or_default()
+                        .push(CertPayload {
+                            cert,
+                            sender_identity_pubkey,
+                        });
                 }
             }
         }
         self.stats.num_pkts.add_sample(num_pkts);
-        (certs, votes)
+        (cert_groups, votes)
     }
 
     /// If this vote should be verified, then returns the sender's Pubkey and BlsPubkey.
@@ -1578,6 +1581,119 @@ mod tests {
         expect_no_receive(&ctx.pool_receiver);
         assert_eq!(ctx.verifier.stats.num_verified_certs_received.0, 1);
         assert_eq!(ctx.verifier.stats.cert_stats.certs_to_sig_verify.0, 0);
+    }
+
+    #[test]
+    fn test_same_type_certs_verify_until_first_valid() {
+        let mut ctx = TestContext::new();
+
+        let cert_type = CertificateType::Notarize(Block {
+            slot: 10,
+            block_id: Hash::new_unique(),
+        });
+        let cert1 = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
+            &ctx.validator_keypairs,
+            cert_type,
+            &(0..7).collect::<Vec<_>>(),
+        );
+        let cert2 = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
+            &ctx.validator_keypairs,
+            cert_type,
+            &(1..8).collect::<Vec<_>>(),
+        );
+        let packet_batches = messages_to_batches(
+            &[
+                ConsensusMessage::Certificate(cert1),
+                ConsensusMessage::Certificate(cert2),
+            ],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
+
+        ctx.verifier
+            .verify_and_send_batches(packet_batches)
+            .unwrap();
+
+        let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(batches.len(), 1);
+        match &batches[0] {
+            SigVerifiedBatch::Certificates(certs) => assert_eq!(certs.len(), 1),
+            rest => panic!("unexpected type: {rest:?}"),
+        }
+        assert_eq!(ctx.verifier.stats.cert_stats.certs_to_sig_verify.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.sig_verified_certs.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.redundant_certs_skipped.0, 1);
+        assert_eq!(
+            ctx.verifier.stats.cert_stats.unnecessary_certs_verified.0,
+            0
+        );
+    }
+
+    #[test]
+    fn test_same_type_certs_try_next_candidate_after_failure() {
+        let mut ctx = TestContext::new();
+
+        let cert_type = CertificateType::Notarize(Block {
+            slot: 10,
+            block_id: Hash::new_unique(),
+        });
+        let num_signers = 7;
+        let mut bitmap = BitVec::<u8, Lsb0>::new();
+        bitmap.resize(num_signers, false);
+        for i in 0..num_signers {
+            bitmap.set(i, true);
+        }
+        let invalid_cert = Certificate {
+            cert_type,
+            signature: Signature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: encode_base2(&bitmap).unwrap(),
+        };
+        let valid_cert = create_signed_certificate_message(
+            ctx.verifier.cluster_info.my_shred_version(),
+            &ctx.validator_keypairs,
+            cert_type,
+            &(0..num_signers).collect::<Vec<_>>(),
+        );
+        let invalid_sender = Pubkey::new_unique();
+        let valid_sender = Pubkey::new_unique();
+        let redundant_sender = Pubkey::new_unique();
+        let packet_batches = messages_to_batches_with_remote_pubkeys(
+            &[
+                (ConsensusMessage::Certificate(invalid_cert), invalid_sender),
+                (
+                    ConsensusMessage::Certificate(valid_cert.clone()),
+                    valid_sender,
+                ),
+                (ConsensusMessage::Certificate(valid_cert), redundant_sender),
+            ],
+            ctx.verifier.cluster_info.my_shred_version(),
+        );
+
+        ctx.verifier
+            .verify_and_send_batches(packet_batches)
+            .unwrap();
+
+        let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
+        assert_eq!(batches.len(), 1);
+        match &batches[0] {
+            SigVerifiedBatch::Certificates(certs) => assert_eq!(certs.len(), 1),
+            rest => panic!("unexpected type: {rest:?}"),
+        }
+        assert!(ctx.banlist.is_banned(&invalid_sender));
+        assert!(!ctx.banlist.is_banned(&valid_sender));
+        assert!(!ctx.banlist.is_banned(&redundant_sender));
+        assert_eq!(ctx.verifier.stats.cert_stats.certs_to_sig_verify.0, 2);
+        assert_eq!(ctx.verifier.stats.cert_stats.sig_verified_certs.0, 1);
+        assert_eq!(
+            ctx.verifier
+                .stats
+                .cert_stats
+                .certificate_verification_failed
+                .0,
+            1
+        );
+        assert_eq!(ctx.verifier.stats.cert_stats.redundant_certs_skipped.0, 1);
     }
 
     #[test]

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -185,13 +185,16 @@ impl SigVerifierStats {
 /// Stats from sigverifying certs.
 #[derive(Default, Debug)]
 pub(super) struct SigVerifyCertStats {
-    /// Number of certs [`verify_and_send_certificates`] was requested to verify the signature of.
+    /// Number of certs [`verify_and_send_certificates`] attempted to verify the signature of.
     pub(super) certs_to_sig_verify: Saturating<u64>,
     /// Number of certs [`verify_and_send_certificates`] successfully verified the signature of.
     pub(super) sig_verified_certs: Saturating<u64>,
     /// Number of certs that were verified unnecessarily because another cert of the same
     /// `CertificateType` was already verified.
     pub(super) unnecessary_certs_verified: Saturating<u64>,
+    /// Number of certs skipped because another cert of the same `CertificateType` was verified in
+    /// the same batch.
+    pub(super) redundant_certs_skipped: Saturating<u64>,
     /// Number of times we are banning a validator that was already banned.
     pub(super) already_banned: Saturating<u64>,
     /// Number of times we are banning a validator.
@@ -219,6 +222,7 @@ impl SigVerifyCertStats {
             certs_to_sig_verify,
             sig_verified_certs,
             unnecessary_certs_verified,
+            redundant_certs_skipped,
             already_banned,
             banning_validator,
             certificate_verification_failed,
@@ -231,6 +235,7 @@ impl SigVerifyCertStats {
         self.certs_to_sig_verify += certs_to_sig_verify;
         self.sig_verified_certs += sig_verified_certs;
         self.unnecessary_certs_verified += unnecessary_certs_verified;
+        self.redundant_certs_skipped += redundant_certs_skipped;
         self.already_banned += already_banned;
         self.banning_validator += banning_validator;
         self.certificate_verification_failed += certificate_verification_failed;
@@ -247,6 +252,7 @@ impl SigVerifyCertStats {
             certs_to_sig_verify,
             sig_verified_certs,
             unnecessary_certs_verified,
+            redundant_certs_skipped,
             already_banned,
             banning_validator,
             certificate_verification_failed,
@@ -266,6 +272,7 @@ impl SigVerifyCertStats {
                 unnecessary_certs_verified.0,
                 i64
             ),
+            ("redundant_certs_skipped", redundant_certs_skipped.0, i64),
             ("already_banned", already_banned.0, i64),
             ("banning_validator", banning_validator.0, i64),
             (


### PR DESCRIPTION
#### Problem
When we receive a burst of certificates in the bls sigverifier we do a lot of unnecessary work:

1. Filter out certificates we've already seen & verified
2. Verify every certificate in the batch

For the first burst of certificates in the slot, (1) doesn't do anything and we end up wasting time verifying multiple copies of the same certificate.


#### Summary of Changes
Instead:

1. Group certificates in the batch by cert type
2. Verify each group individually - terminating as soon as we verify a valid certificate
3. Ban any invalid certificate senders

This gives us better performance when we receive certificate bursts.
The performance if we receive an all invalid batch is worse, but this is remediated by the fact that we ban the invalid senders.

#### Testing
Testing using the modified BLS load generator https://github.com/AshwinSekar/solana/tree/bls-load-gen
4000 votes & 4000 certificates per slot (notarize + finalize) over 100 x 200ms slots

For uniform arrival (batch size ~1) we saw no improvement as expected
```
   Workload                                   Before median    After median                                     Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Uniform-arrival control,                         12.114s         11.892s        1.83% less, within run-to-run noise
```

The more impactful comparison is the certificate burst case.
This is the profile for how certificate distribution over the batches:
```
   Metric     Total packets    Certificates
  ━━━━━━━━━  ━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━
   Minimum               24               1
  ─────────  ───────────────  ──────────────
   Mean               170.6           138.6
  ─────────  ───────────────  ──────────────
   Median               174             142
  ─────────  ───────────────  ──────────────
   p95                  296             262
  ─────────  ───────────────  ──────────────
   Maximum              659             627

```

We see the old code struggle as batch sizes get larger (e.g. during a DOS attack):
```
  Overall wall-clock replay time certificate burst

   Revision        Min     Median        Max
  ━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━
   Before      20.010s    20.012s    52.192s
  ──────────  ─────────  ─────────  ─────────
   After       20.010s    20.010s    20.011s

  Sigverify processing time certificate burst

   Revision        Min     Median        Max
  ━━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━  ━━━━━━━━━
   Before      13.154s    13.495s    50.308s
  ──────────  ─────────  ─────────  ─────────
   After       10.955s    11.289s    11.816s

```

~ `16%` improvement on median sig verification time, and it cut the long tail on the bigger batch size timings (5x worst case speedup).

Without this change for this workload, the sigverifier could backup causing us to be slower than slot times.
With this change we finished verifying 100 slots within the 100 * 200ms = 20s window