### PR TITLE
solana-client: add send_and_confirm_transactions_in_parallel_v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7887,6 +7887,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-udp-client",
@@ -7898,7 +7899,9 @@ name = "solana-client-test"
 version = "4.3.0-alpha.1"
 dependencies = [
  "agave-logger",
+ "async-trait",
  "futures-util",
+ "log",
  "serde_json",
  "solana-client",
  "solana-clock",
@@ -7908,6 +7911,7 @@ dependencies = [
  "solana-message",
  "solana-native-token",
  "solana-net-utils",
+ "solana-packet 4.2.0",
  "solana-pubkey 4.2.0",
  "solana-pubsub-client",
  "solana-rpc",
@@ -7918,8 +7922,11 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-system-transaction",
  "solana-test-validator",
+ "solana-tpu-client-next",
  "solana-transaction-status",
  "solana-version",
+ "spl-memo-interface",
+ "test-case",
  "tokio",
  "tungstenite",
 ]

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -37,15 +37,21 @@ solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
+test-case = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+async-trait = { workspace = true }
+log = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
+solana-packet = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
+spl-memo-interface = { workspace = true }
 
 [lints]
 workspace = true

--- a/client-test/tests/send_and_confirm_transactions_in_parallel.rs
+++ b/client-test/tests/send_and_confirm_transactions_in_parallel.rs
@@ -1,22 +1,43 @@
 use {
+    async_trait::async_trait,
     solana_client::{
         nonblocking::tpu_client::TpuClient,
         rpc_config::RpcSendTransactionConfig,
         send_and_confirm_transactions_in_parallel::{
-            SendAndConfirmConfigV2, send_and_confirm_transactions_in_parallel_blocking_v2,
+            SendAndConfirmConfigV2, SendAndConfirmConfigV3, SendTransport,
+            send_and_confirm_transactions_in_parallel_blocking_v2,
+            send_and_confirm_transactions_in_parallel_v3,
         },
     },
     solana_commitment_config::CommitmentConfig,
     solana_keypair::Keypair,
-    solana_message::Message,
+    solana_message::{Message, VersionedMessage},
     solana_native_token::LAMPORTS_PER_SOL,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SocketAddrSpace, sockets},
+    solana_packet::PACKET_DATA_SIZE,
     solana_pubkey::Pubkey,
-    solana_rpc_client::rpc_client::RpcClient,
+    solana_rpc_client::{
+        nonblocking::rpc_client::RpcClient as NonblockingRpcClient, rpc_client::RpcClient,
+    },
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
     solana_test_validator::TestValidator,
-    std::sync::Arc,
+    solana_tpu_client_next::{
+        client_builder::ClientBuilder,
+        connection_workers_scheduler::{ConnectionWorkersSchedulerError, WorkersBroadcaster},
+        leader_updater::create_pinned_leader_updater,
+        transaction_batch::TransactionBatch,
+        workers_cache::WorkersCache,
+    },
+    spl_memo_interface::{instruction::build_memo, v3 as memo_program},
+    std::{
+        net::SocketAddr,
+        num::NonZeroUsize,
+        sync::Arc,
+        time::{Duration, Instant},
+    },
+    test_case::test_case,
+    tokio::runtime::Runtime,
 };
 
 const NUM_TRANSACTIONS: usize = 1000;
@@ -165,5 +186,155 @@ fn test_send_and_confirm_transactions_in_parallel_with_tpu_client() {
             .unwrap()
             .value,
         original_alice_balance - sum - total_fees
+    );
+}
+
+/// Builds a memo message with a `memo_data_len`-byte payload. `tag` is embedded
+/// in the memo so that every message has a distinct signature (and is therefore
+/// not deduped by the TPU). `memo_data_len` must be at least 8 bytes.
+fn tagged_memo_message(payer: &Pubkey, memo_data_len: usize, tag: usize) -> Message {
+    let mut memo = vec![b'a'; memo_data_len];
+    // Zero-padded decimal keeps the memo valid UTF-8 while making it unique.
+    let tag = format!("{tag:016}");
+    memo[..tag.len()].copy_from_slice(tag.as_bytes());
+    Message::new(&[build_memo(&memo_program::id(), &memo, &[])], Some(payer))
+}
+
+/// [`BackpressuredBroadcaster`] sends transactions to all the workers, awaiting
+/// free capacity on each worker's channel instead of dropping the batch when
+/// the channel is full (as the default `NonblockingBroadcaster` does).
+///
+/// Note: leaders in the fanout are served sequentially, so a particularly slow
+/// leader delays delivery to the remaining leaders in the same batch.
+struct BackpressuredBroadcaster;
+
+#[async_trait]
+impl WorkersBroadcaster for BackpressuredBroadcaster {
+    async fn send_to_workers(
+        &self,
+        workers: &mut WorkersCache,
+        leaders: &[SocketAddr],
+        transaction_batch: TransactionBatch,
+    ) -> Result<(), ConnectionWorkersSchedulerError> {
+        for leader in leaders {
+            // Unlike `try_send_transactions_to_address`, this awaits until the
+            // worker channel has room, so a full channel never surfaces as an
+            // error and the batch is not dropped.
+            let send_res = workers
+                .send_transactions_to_address(leader, transaction_batch.clone())
+                .await;
+            if let Err(err) = send_res {
+                log::debug!("Failed to send transactions to {leader:?}, worker send error: {err}.");
+                // `send_transactions_to_address` already evicts the worker on
+                // `ReceiverDropped`; the remaining errors (`WorkerNotFound`,
+                // `ShutdownError`) are transient/expected and non-fatal here.
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Submits a large burst of maximum-size transactions through the tpu-client-next
+/// transport of `send_and_confirm_transactions_in_parallel_v3` and asserts every
+/// one lands.
+#[allow(clippy::arithmetic_side_effects)]
+#[test_case(true; "Use staked connection")]
+#[test_case(false; "Use unstaked connection")]
+fn test_send_and_confirm_transactions_in_parallel_v3(staked: bool) {
+    /// Total wire bytes to push through the transport.
+    const TARGET_TOTAL_BYTES: usize = 10 * 1024 * 1024;
+    /// Each transaction is packet-sized, so this many of them ~= the target.
+    const NUM_MAX_SIZE_MESSAGES: usize = TARGET_TOTAL_BYTES.div_ceil(PACKET_DATA_SIZE);
+    /// Serialized size of the signatures for a legacy
+    /// transaction with one signer (which is what we send here)
+    const SIGNED_TX_SIGNATURES_LEN: usize = 1 + 64;
+    agave_logger::setup();
+
+    let signer = Keypair::new();
+    let test_validator =
+        TestValidator::start_with_config(signer.pubkey(), None, SocketAddrSpace::Unspecified);
+    let signer = if staked {
+        test_validator.cluster_info().keypair().insecure_clone()
+    } else {
+        signer
+    };
+    let fee_payer = signer.pubkey();
+
+    let rpc_client = Arc::new(NonblockingRpcClient::new_with_commitment(
+        test_validator.rpc_url(),
+        CommitmentConfig::confirmed(),
+    ));
+    let runtime = Runtime::new().unwrap();
+
+    // Figure out padding for memo so its transaction fills a packet
+    let empty_memo = Message::new(
+        &[build_memo(&memo_program::id(), &[], &[])],
+        Some(&fee_payer),
+    );
+    let empty_memo_len = SIGNED_TX_SIGNATURES_LEN + empty_memo.serialize().len();
+    let memo_padding_len = PACKET_DATA_SIZE - empty_memo_len - 1;
+
+    let messages: Vec<VersionedMessage> = (0..NUM_MAX_SIZE_MESSAGES)
+        .map(|tag| VersionedMessage::Legacy(tagged_memo_message(&fee_payer, memo_padding_len, tag)))
+        .collect();
+    let mut total_wire_bytes = 0usize;
+    for message in &messages {
+        let tx_len = SIGNED_TX_SIGNATURES_LEN + message.serialize().len();
+        assert!(
+            (PACKET_DATA_SIZE - 2..=PACKET_DATA_SIZE).contains(&tx_len),
+            "each transaction must be packet-sized, got {tx_len} bytes"
+        );
+        total_wire_bytes += tx_len;
+    }
+
+    let bind_socket = sockets::bind_to_localhost_unique().unwrap();
+    let leader_updater = create_pinned_leader_updater(*test_validator.tpu_quic());
+
+    let (transaction_sender, client) = runtime.block_on(async {
+        ClientBuilder::new(leader_updater)
+            .bind_socket(bind_socket)
+            .identity(&signer)
+            // Apply backpressure instead of dropping batches on a
+            // full worker channel.
+            .broadcaster(BackpressuredBroadcaster)
+            .build()
+            .expect("Failed to build TPU client")
+    });
+    //std::thread::sleep(Duration::from_secs(5));
+    log::info!(
+        "sending {NUM_MAX_SIZE_MESSAGES} transactions ({:.2} MB wire) over tpu-client-next",
+        total_wire_bytes as f64 / (1024.0 * 1024.0)
+    );
+    let started = Instant::now();
+    let result = runtime.block_on(send_and_confirm_transactions_in_parallel_v3(
+        rpc_client.clone(),
+        // TPU-only: never fall back to RPC for sending.
+        SendTransport::Tpu(transaction_sender),
+        messages,
+        &[&signer],
+        SendAndConfirmConfigV3 {
+            with_spinner: true,
+            // Large bursts may outlive a single blockhash; allow re-signing.
+            max_sign_attempts: NonZeroUsize::new(16).unwrap(),
+            // Recheck landing / resend at most once a second.
+            check_interval: Duration::from_secs(1),
+            // Pace at ~333 TPS: a single write-locked account saturates at
+            // around 250 TPS, we could send more and just retransmit but why?.
+            send_interval: Duration::from_millis(3),
+        },
+    ));
+    let elapsed = started.elapsed();
+    runtime.block_on(async {
+        let _ = client.shutdown().await;
+    });
+
+    let transaction_errors = result.expect("all transactions must land within the resign window");
+    assert_eq!(transaction_errors.len(), NUM_MAX_SIZE_MESSAGES);
+    log::info!(
+        "landed {NUM_MAX_SIZE_MESSAGES} transactions ({:.2} MB) in {:.2}s ({:.2} MB/s, {:.0} tx/s)",
+        total_wire_bytes as f64 / TARGET_TOTAL_BYTES as f64,
+        elapsed.as_secs_f64(),
+        total_wire_bytes as f64 / TARGET_TOTAL_BYTES as f64 / elapsed.as_secs_f64(),
+        NUM_MAX_SIZE_MESSAGES as f64 / elapsed.as_secs_f64(),
     );
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -44,6 +44,7 @@ solana-streamer = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tls-utils = { workspace = true }
 solana-tpu-client = { workspace = true, features = ["default"] }
+solana-tpu-client-next = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-udp-client = { workspace = true }

--- a/client/src/send_and_confirm_transactions_in_parallel.rs
+++ b/client/src/send_and_confirm_transactions_in_parallel.rs
@@ -7,7 +7,7 @@ use {
     dashmap::DashMap,
     futures_util::future::join_all,
     solana_hash::Hash,
-    solana_message::Message,
+    solana_message::{Message, VersionedMessage},
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::spinner::{self, SendTransactionProgress},
     solana_rpc_client_api::{
@@ -19,16 +19,23 @@ use {
     solana_signature::Signature,
     solana_signer::{SignerError, signers::Signers},
     solana_tpu_client::tpu_client::{Result, TpuSenderError},
-    solana_transaction::Transaction,
+    solana_tpu_client_next::client_builder::TransactionSender,
+    solana_transaction::versioned::VersionedTransaction,
     solana_transaction_error::TransactionError,
     std::{
+        future::Future,
+        num::NonZeroUsize,
         sync::{
             Arc,
             atomic::{AtomicU64, AtomicUsize, Ordering},
         },
         time::Duration,
     },
-    tokio::{sync::RwLock, task::JoinHandle},
+    tokio::{
+        sync::{Notify, RwLock},
+        task::JoinHandle,
+        time::sleep,
+    },
 };
 
 const BLOCKHASH_REFRESH_RATE: Duration = Duration::from_secs(5);
@@ -40,10 +47,45 @@ const SEND_TIMEOUT_INTERVAL: Duration = Duration::from_secs(5);
 
 type QuicTpuClient = TpuClient<QuicPool, QuicConnectionManager, QuicConfig>;
 
+/// Abstracts sending a single serialized transaction to the current leader's
+/// TPU, so the send & confirm engine can drive either the legacy
+/// connection-cache [`QuicTpuClient`] or the [`TransactionSender`] from
+/// `tpu-client-next`.
+trait WireTransactionSender: Send + Sync {
+    /// Returns `true` if the transaction was handed off to the transport.
+    fn send(&self, wire_transaction: Vec<u8>) -> impl Future<Output = bool> + Send;
+}
+
+impl WireTransactionSender for QuicTpuClient {
+    fn send(&self, wire_transaction: Vec<u8>) -> impl Future<Output = bool> + Send {
+        let fut = self.send_wire_transaction(wire_transaction);
+        async move {
+            tokio::time::timeout(SEND_TIMEOUT_INTERVAL, fut)
+                .await
+                .unwrap_or(false)
+        }
+    }
+}
+
+impl WireTransactionSender for TransactionSender {
+    // tpu-client-next is fire-and-forget: a successful local enqueue here means nothing.
+    // The future returned here will only resolve to false if tpu-client-next
+    // instance is dropped.
+    fn send(&self, wire_transaction: Vec<u8>) -> impl Future<Output = bool> + Send {
+        let sender = self.clone();
+        async move {
+            sender
+                .send_transactions_in_batch(vec![wire_transaction])
+                .await
+                .is_ok()
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct TransactionData {
     last_valid_block_height: u64,
-    message: Message,
+    message: VersionedMessage,
     index: usize,
     serialized_transaction: Vec<u8>,
 }
@@ -62,6 +104,70 @@ pub struct SendAndConfirmConfigV2 {
     pub rpc_send_transaction_config: RpcSendTransactionConfig,
 }
 
+pub enum SendTransport {
+    /// Send directly to the leader through tpu-client-next.
+    Tpu(TransactionSender),
+    /// Send through RPC.
+    Rpc(RpcSendTransactionConfig),
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct SendAndConfirmConfigV3 {
+    /// Shows a spinner with progress in the console while sending.
+    pub with_spinner: bool,
+    /// Maximum number of signing passes to make before giving up. A new
+    /// signing pass is made whenever blockhash expires.
+    pub max_sign_attempts: NonZeroUsize,
+    /// How long to wait between checking whether transactions have landed (and
+    /// resending those that have not). Should be at least a slot.
+    pub check_interval: Duration,
+    /// Delay between consecutive transactions within a send pass. Transaction
+    /// `n` is delayed by `n * send_interval`, capping the per-pass send rate at
+    /// `1 / send_interval`.
+    pub send_interval: Duration,
+}
+const DEFAULT_MAX_SIGN_ATTEMPTS: NonZeroUsize = NonZeroUsize::new(1).unwrap();
+const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+impl Default for SendAndConfirmConfigV3 {
+    fn default() -> Self {
+        Self {
+            with_spinner: false,
+            max_sign_attempts: DEFAULT_MAX_SIGN_ATTEMPTS,
+            check_interval: DEFAULT_CHECK_INTERVAL,
+            send_interval: SEND_INTERVAL,
+        }
+    }
+}
+
+/// Internal configuration shared by the v2 and v3 entry points.
+struct ParallelSendConfig {
+    with_spinner: bool,
+    max_sign_attempts: NonZeroUsize,
+    rpc_send_transaction_config: Option<RpcSendTransactionConfig>,
+    // only the legacy v2 API sets this.
+    dedupe_signers: bool,
+    send_interval: Duration,
+    check_interval: Duration,
+}
+
+impl From<SendAndConfirmConfigV2> for ParallelSendConfig {
+    fn from(config: SendAndConfirmConfigV2) -> Self {
+        Self {
+            with_spinner: config.with_spinner,
+            max_sign_attempts: config
+                .resign_txs_count
+                .and_then(NonZeroUsize::new)
+                .unwrap_or(DEFAULT_MAX_SIGN_ATTEMPTS),
+            // v2 always sends over RPC when the TPU transport is absent or fails.
+            rpc_send_transaction_config: Some(config.rpc_send_transaction_config),
+            dedupe_signers: true,
+            send_interval: SEND_INTERVAL,
+            check_interval: DEFAULT_CHECK_INTERVAL,
+        }
+    }
+}
+
 /// Sends and confirms transactions concurrently in a sync context
 pub fn send_and_confirm_transactions_in_parallel_blocking_v2<T: Signers + ?Sized>(
     rpc_client: Arc<BlockingRpcClient>,
@@ -70,12 +176,12 @@ pub fn send_and_confirm_transactions_in_parallel_blocking_v2<T: Signers + ?Sized
     signers: &T,
     config: SendAndConfirmConfigV2,
 ) -> Result<Vec<Option<TransactionError>>> {
-    let fut = send_and_confirm_transactions_in_parallel_v2(
+    let fut = send_and_confirm_transactions_in_parallel_impl(
         rpc_client.get_inner_client().clone(),
         tpu_client,
-        messages,
+        messages.iter().cloned().map(VersionedMessage::Legacy),
         signers,
-        config,
+        config.into(),
     );
     tokio::task::block_in_place(|| rpc_client.runtime().block_on(fut))
 }
@@ -111,12 +217,16 @@ fn create_transaction_confirmation_task(
     unconfirmed_transaction_map: Arc<DashMap<Signature, TransactionData>>,
     errors_map: Arc<DashMap<usize, TransactionError>>,
     num_confirmed_transactions: Arc<AtomicUsize>,
+    check_interval: Duration,
+    confirmation_signal: Arc<Notify>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         // check transactions that are not expired or have just expired between two checks
         let mut last_block_height = current_block_height.load(Ordering::Relaxed);
 
         loop {
+            // we sleep before first check to give sender a chance
+            tokio::time::sleep(check_interval).await;
             if !unconfirmed_transaction_map.is_empty() {
                 let current_block_height = current_block_height.load(Ordering::Relaxed);
                 let transactions_to_verify: Vec<Signature> = unconfirmed_transaction_map
@@ -160,7 +270,8 @@ fn create_transaction_confirmation_task(
 
                 last_block_height = current_block_height;
             }
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            // Wake the resend loop with a fresh view of what has landed.
+            confirmation_signal.notify_one();
         }
     })
 }
@@ -173,6 +284,16 @@ struct SendingContext {
     num_confirmed_transactions: Arc<AtomicUsize>,
     total_transactions: usize,
     current_block_height: Arc<AtomicU64>,
+    /// Delay between consecutive transactions within a send pass. Transaction
+    /// `n` is delayed by `n * send_interval`, so this caps the per-pass send
+    /// rate at `1 / send_interval`.
+    send_interval: Duration,
+    /// Liveness fallback for the resend loop when the confirmation task is not
+    /// signaling (e.g. RPC stalled). The signal below is the primary driver.
+    check_interval: Duration,
+    /// Signaled by the confirmation task after each poll, so the resend loop
+    /// only resends once it has a fresh view of what has landed.
+    confirmation_signal: Arc<Notify>,
 }
 fn progress_from_context_and_block_height(
     context: &SendingContext,
@@ -190,35 +311,38 @@ fn progress_from_context_and_block_height(
     }
 }
 
-async fn send_transaction_with_rpc_fallback(
+async fn send_transaction_with_rpc_fallback<S: WireTransactionSender>(
     rpc_client: &RpcClient,
-    tpu_client: &Option<QuicTpuClient>,
-    transaction: Transaction,
+    tpu_client: &Option<S>,
+    transaction: VersionedTransaction,
     serialized_transaction: Vec<u8>,
     context: &SendingContext,
     index: usize,
-    rpc_send_transaction_config: RpcSendTransactionConfig,
+    rpc_send_transaction_config: Option<RpcSendTransactionConfig>,
 ) -> Result<()> {
-    let send_over_rpc = if let Some(tpu_client) = tpu_client {
-        !tokio::time::timeout(
-            SEND_TIMEOUT_INTERVAL,
-            tpu_client.send_wire_transaction(serialized_transaction),
+    // Prefer to send directly to the leader when possible.
+    let handed_off_over_tpu = match tpu_client {
+        Some(tpu_client) => tpu_client.send(serialized_transaction).await,
+        None => false,
+    };
+    if handed_off_over_tpu {
+        return Ok(());
+    }
+    // The hand-off failed or there is no TPU transport.
+    // The expect can only panic in v3 version of the API where RPC send config is mutually
+    // exclusive with TPU send config.
+    let rpc_send_transaction_config = rpc_send_transaction_config
+        .expect("TPU client must outlive the transaction sending process.");
+
+    if let Err(e) = rpc_client
+        .send_transaction_with_config(
+            &transaction,
+            RpcSendTransactionConfig {
+                preflight_commitment: Some(rpc_client.commitment().commitment),
+                ..rpc_send_transaction_config
+            },
         )
         .await
-        .unwrap_or(false)
-    } else {
-        true
-    };
-    if send_over_rpc
-        && let Err(e) = rpc_client
-            .send_transaction_with_config(
-                &transaction,
-                RpcSendTransactionConfig {
-                    preflight_commitment: Some(rpc_client.commitment().commitment),
-                    ..rpc_send_transaction_config
-                },
-            )
-            .await
     {
         match e.kind() {
             ErrorKind::Io(_) | ErrorKind::Reqwest(_) => {
@@ -259,27 +383,69 @@ async fn send_transaction_with_rpc_fallback(
     Ok(())
 }
 
-async fn sign_all_messages_and_send<T: Signers + ?Sized>(
+/// Signs `message` with `signers`.
+///
+/// When `dedupe_signers` is set, a signer that appears more than once (e.g. the
+/// same key used as both fee payer and authority) is tolerated by matching each
+/// required signer against the `signers` entry with that pubkey. The
+/// legacy [`solana_transaction::Transaction::try_sign`] deduplicated signers
+/// this way, but [`VersionedTransaction::try_new`] rejects the redundant entry
+/// as `TooManySigners`. This flag preserves the old behavior for the deprecated
+/// v2 API; v3 callers get the strict `try_new` semantics.
+fn sign_versioned_message<T: Signers + ?Sized>(
+    message: VersionedMessage,
+    signers: &T,
+    dedupe_signers: bool,
+) -> std::result::Result<VersionedTransaction, SignerError> {
+    // Once send_and_confirm_transactions_in_parallel_v2 is retired, this fn should be retired,
+    // and the segment below inlined into callers.
+    if !dedupe_signers {
+        return VersionedTransaction::try_new(message, signers);
+    }
+    let signer_keys = signers.try_pubkeys()?;
+    let unordered_signatures = signers.try_sign_message(&message.serialize())?;
+    let account_keys = message.static_account_keys();
+    let num_required_signatures = message.header().num_required_signatures as usize;
+    let signatures = account_keys
+        .get(..num_required_signatures)
+        .ok_or_else(|| SignerError::InvalidInput("invalid message".to_string()))?
+        .iter()
+        .map(|required_key| {
+            signer_keys
+                .iter()
+                .position(|key| key == required_key)
+                .and_then(|i| unordered_signatures.get(i).copied())
+                .ok_or(SignerError::NotEnoughSigners)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(VersionedTransaction {
+        signatures,
+        message,
+    })
+}
+
+async fn sign_all_messages_and_send<T: Signers + ?Sized, S: WireTransactionSender>(
     progress_bar: &Option<indicatif::ProgressBar>,
     rpc_client: &RpcClient,
-    tpu_client: &Option<QuicTpuClient>,
-    messages_with_index: Vec<(usize, Message)>,
+    tpu_client: &Option<S>,
+    messages_with_index: Vec<(usize, VersionedMessage)>,
     signers: &T,
+    dedupe_signers: bool,
     context: &SendingContext,
-    rpc_send_transaction_config: RpcSendTransactionConfig,
+    rpc_send_transaction_config: Option<RpcSendTransactionConfig>,
 ) -> Result<()> {
     let current_transaction_count = messages_with_index.len();
     let mut futures = vec![];
     // send all the transaction messages
-    for (counter, (index, message)) in messages_with_index.iter().enumerate() {
-        let mut transaction = Transaction::new_unsigned(message.clone());
+    for (counter, (index, message)) in messages_with_index.into_iter().enumerate() {
         futures.push(async move {
-            tokio::time::sleep(SEND_INTERVAL.saturating_mul(counter as u32)).await;
+            sleep(context.send_interval.saturating_mul(counter as u32)).await;
             let blockhashdata = *context.blockhash_data_rw.read().await;
 
+            let mut message = message;
+            message.set_recent_blockhash(blockhashdata.blockhash);
             // we have already checked if all transactions are signable.
-            transaction
-                .try_sign(signers, blockhashdata.blockhash)
+            let transaction = sign_versioned_message(message.clone(), signers, dedupe_signers)
                 .expect("Transaction should be signable");
             let serialized_transaction =
                 serialize(&transaction).expect("Transaction should serialize");
@@ -289,10 +455,10 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
             context.unconfirmed_transaction_map.insert(
                 signature,
                 TransactionData {
-                    index: *index,
+                    index,
                     serialized_transaction: serialized_transaction.clone(),
                     last_valid_block_height: blockhashdata.last_valid_block_height,
-                    message: message.clone(),
+                    message,
                 },
             );
             if let Some(progress_bar) = progress_bar {
@@ -315,7 +481,7 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
                 transaction,
                 serialized_transaction,
                 context,
-                *index,
+                index,
                 rpc_send_transaction_config,
             )
             .await
@@ -329,9 +495,11 @@ async fn sign_all_messages_and_send<T: Signers + ?Sized>(
     Ok(())
 }
 
-async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
+async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu<
+    S: WireTransactionSender,
+>(
     progress_bar: &Option<indicatif::ProgressBar>,
-    tpu_client: &Option<QuicTpuClient>,
+    tpu_client: &Option<S>,
     context: &SendingContext,
 ) {
     let unconfirmed_transaction_map = context.unconfirmed_transaction_map.clone();
@@ -358,6 +526,14 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
         while !unconfirmed_transaction_map.is_empty()
             && current_block_height.load(Ordering::Relaxed) <= max_valid_block_height
         {
+            // Resend only after the confirmation task reports a fresh view of
+            // what has landed. The timeout is a liveness fallback in case the
+            // confirmation task stalls, so the loop can still re-check its exit
+            // condition (e.g. blockhash expiry).
+            tokio::select! {
+                () = context.confirmation_signal.notified() => {}
+                () = tokio::time::sleep(context.check_interval.saturating_mul(2)) => {}
+            }
             let block_height = current_block_height.load(Ordering::Relaxed);
 
             if let Some(tpu_client) = tpu_client {
@@ -376,8 +552,6 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
                     context,
                 )
                 .await;
-            } else {
-                tokio::time::sleep(Duration::from_millis(100)).await;
             }
             if let Some(max_valid_block_height_in_remaining_transaction) =
                 unconfirmed_transaction_map
@@ -391,9 +565,9 @@ async fn confirm_transactions_till_block_height_and_resend_unexpired_transaction
     }
 }
 
-async fn send_staggered_transactions(
+async fn send_staggered_transactions<S: WireTransactionSender>(
     progress_bar: &Option<indicatif::ProgressBar>,
-    tpu_client: &QuicTpuClient,
+    tpu_client: &S,
     wire_transactions: Vec<Vec<u8>>,
     last_valid_block_height: u64,
     context: &SendingContext,
@@ -403,7 +577,7 @@ async fn send_staggered_transactions(
         .into_iter()
         .enumerate()
         .map(|(counter, transaction)| async move {
-            tokio::time::sleep(SEND_INTERVAL.saturating_mul(counter as u32)).await;
+            tokio::time::sleep(context.send_interval.saturating_mul(counter as u32)).await;
             if let Some(progress_bar) = progress_bar {
                 let progress =
                     progress_from_context_and_block_height(context, last_valid_block_height);
@@ -416,17 +590,14 @@ async fn send_staggered_transactions(
                     ),
                 );
             }
-            tokio::time::timeout(
-                SEND_TIMEOUT_INTERVAL,
-                tpu_client.send_wire_transaction(transaction),
-            )
-            .await
+            tpu_client.send(transaction).await
         })
         .collect::<Vec<_>>();
     join_all(futures).await;
 }
 
-/// Sends and confirms transactions concurrently
+/// Sends and confirms transactions concurrently using the legacy
+/// connection-cache [`QuicTpuClient`] as the TPU transport.
 ///
 /// The sending and confirmation of transactions is done in parallel tasks
 /// The method signs transactions just before sending so that blockhash does not
@@ -438,6 +609,76 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
     signers: &T,
     config: SendAndConfirmConfigV2,
 ) -> Result<Vec<Option<TransactionError>>> {
+    send_and_confirm_transactions_in_parallel_impl(
+        rpc_client,
+        tpu_client,
+        messages.iter().cloned().map(VersionedMessage::Legacy),
+        signers,
+        config.into(),
+    )
+    .await
+}
+
+/// Sends and confirms transactions.
+///
+/// `rpc_client` is used to target the leader and confirm landing.
+/// `transport` selects how transactions are sent.
+/// `signers` should provide unique private keys to sign transactions.
+///
+/// Transactions are signed with a fresh blockhash if necessary to guarantee
+/// eventual landing.
+///
+/// With TPU transport, set the RPC client commitment to Confirmed to minimize
+/// retransmit latency.
+pub async fn send_and_confirm_transactions_in_parallel_v3<T, M>(
+    rpc_client: Arc<RpcClient>,
+    transport: SendTransport,
+    messages: M,
+    signers: &T,
+    config: SendAndConfirmConfigV3,
+) -> Result<Vec<Option<TransactionError>>>
+where
+    T: Signers + ?Sized,
+    M: IntoIterator<Item = VersionedMessage>,
+{
+    let (tpu_transaction_sender, rpc_send_transaction_config) = match transport {
+        SendTransport::Tpu(sender) => (Some(sender), None),
+        SendTransport::Rpc(rpc_config) => (None, Some(rpc_config)),
+    };
+    send_and_confirm_transactions_in_parallel_impl(
+        rpc_client,
+        tpu_transaction_sender,
+        messages,
+        signers,
+        ParallelSendConfig {
+            with_spinner: config.with_spinner,
+            max_sign_attempts: config.max_sign_attempts,
+            rpc_send_transaction_config,
+            dedupe_signers: false,
+            // Pace sends client-side: the transport backpressures to its own
+            // capacity, but the leader still drops transactions it cannot ingest
+            // fast enough, so full-rate sending just fuels resends.
+            send_interval: config.send_interval,
+            check_interval: config.check_interval,
+        },
+    )
+    .await
+}
+
+async fn send_and_confirm_transactions_in_parallel_impl<T, S, M>(
+    rpc_client: Arc<RpcClient>,
+    tpu_transaction_sender: Option<S>,
+    messages: M,
+    signers: &T,
+    config: ParallelSendConfig,
+) -> Result<Vec<Option<TransactionError>>>
+where
+    T: Signers + ?Sized,
+    S: WireTransactionSender,
+    M: IntoIterator<Item = VersionedMessage>,
+{
+    let messages: Vec<VersionedMessage> = messages.into_iter().collect();
+
     // get current blockhash and corresponding last valid block height
     let (blockhash, last_valid_block_height) = rpc_client
         .get_latest_blockhash_with_commitment(rpc_client.commitment())
@@ -451,8 +692,9 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
     messages
         .iter()
         .map(|x| {
-            let mut transaction = Transaction::new_unsigned(x.clone());
-            transaction.try_sign(signers, blockhash)
+            let mut message = x.clone();
+            message.set_recent_blockhash(blockhash);
+            sign_versioned_message(message, signers, config.dedupe_signers).map(|_| ())
         })
         .collect::<std::result::Result<Vec<()>, SignerError>>()?;
 
@@ -476,6 +718,7 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
     let unconfirmed_transasction_map = Arc::new(DashMap::<Signature, TransactionData>::new());
     let error_map = Arc::new(DashMap::new());
     let num_confirmed_transactions = Arc::new(AtomicUsize::new(0));
+    let confirmation_signal = Arc::new(Notify::new());
     // tasks which confirms the transactions that were sent
     let transaction_confirming_task = create_transaction_confirmation_task(
         rpc_client.clone(),
@@ -483,12 +726,13 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
         unconfirmed_transasction_map.clone(),
         error_map.clone(),
         num_confirmed_transactions.clone(),
+        config.check_interval,
+        confirmation_signal.clone(),
     );
 
     // transaction sender task
     let total_transactions = messages.len();
     let mut initial = true;
-    let signing_count = config.resign_txs_count.unwrap_or(1);
     let context = SendingContext {
         unconfirmed_transaction_map: unconfirmed_transasction_map.clone(),
         blockhash_data_rw: blockhash_data_rw.clone(),
@@ -496,11 +740,14 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
         current_block_height: current_block_height.clone(),
         error_map: error_map.clone(),
         total_transactions,
+        send_interval: config.send_interval,
+        check_interval: config.check_interval,
+        confirmation_signal,
     };
 
-    for expired_blockhash_retries in (0..signing_count).rev() {
+    for expired_blockhash_retries in (0..config.max_sign_attempts.get()).rev() {
         // only send messages which have not been confirmed
-        let messages_with_index: Vec<(usize, Message)> = if initial {
+        let messages_with_index: Vec<(usize, VersionedMessage)> = if initial {
             initial = false;
             messages.iter().cloned().enumerate().collect()
         } else {
@@ -521,16 +768,17 @@ pub async fn send_and_confirm_transactions_in_parallel_v2<T: Signers + ?Sized>(
         sign_all_messages_and_send(
             &progress_bar,
             &rpc_client,
-            &tpu_client,
+            &tpu_transaction_sender,
             messages_with_index,
             signers,
+            config.dedupe_signers,
             &context,
             config.rpc_send_transaction_config,
         )
         .await?;
         confirm_transactions_till_block_height_and_resend_unexpired_transaction_over_tpu(
             &progress_bar,
-            &tpu_client,
+            &tpu_transaction_sender,
             &context,
         )
         .await;

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6274,6 +6274,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-udp-client",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6425,6 +6425,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-udp-client",

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -258,11 +258,6 @@ impl WorkersCache {
     /// If the worker for the peer is disconnected or fails, it
     /// is removed from the cache. If no worker exists for the peer,
     /// it returns [`WorkersCacheError::WorkerNotFound`].
-    #[allow(
-        dead_code,
-        reason = "This method will be used in the upcoming changes to implement optional \
-                  backpressure on the sender."
-    )]
     pub async fn send_transactions_to_address(
         &mut self,
         peer: &SocketAddr,


### PR DESCRIPTION

#### Problem
Solana program deploy is in poor state ( https://github.com/anza-xyz/agave/issues/7744). One of the reasons 
is that solana-client::send_and_confirm_transactions_in_parallel_v2
- uses connection cache
- only supports legacy txs (which is bad for program deploy that could use 4KB transactions)
- resign_txs_count = Some(0) footgun caused the function to silently do nothing

It is also public API, not behind agave-unstable-api, so semver rules apply. 
#### Summary of Changes

This PR does not modify send_and_confirm_transactions_in_parallel_v2, and adds send_and_confirm_transactions_in_parallel_v3 instead, which

- uses tpu-client-next or RPC (but not both which was silly);
- allows sending VersionedTransaction (so up to 4KB + v1 transactions etc etc);
- has API with fewer footguns around resign_txs_count, RPC fallback etc;
- Allows deliberately tuning the pacing and confirmation schedule.

#### Testing

Added new integration test.

#### Next PR:

* Switch program-deploy to v3 API
* Deprecate v2 API
* Change some of the internals of send_and_confirm_transactions_in_parallel so transactions we have not yet managed to confirm never get retried.

