### PR TITLE
xdp: make umem sharable among threads

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         netlink::MacAddress,
         route::Router,
-        umem::{Frame, FrameOffset},
+        umem::{CompletedFrameOffset, Frame, FrameOffset},
     },
     libc::{
         AF_INET, IF_NAMESIZE, SIOCETHTOOL, SIOCGIFADDR, SIOCGIFHWADDR, SOCK_DGRAM, SYS_ioctl,
@@ -374,10 +374,10 @@ impl TxCompletionRing {
         }
     }
 
-    pub fn read(&mut self) -> Option<FrameOffset> {
+    pub fn read(&mut self) -> Option<CompletedFrameOffset> {
         let index = self.consumer.consume()? & self.size.saturating_sub(1);
         let index = unsafe { *self.mmap.desc.add(index as usize) } as usize;
-        Some(FrameOffset(index))
+        Some(CompletedFrameOffset(FrameOffset(index)))
     }
 
     pub fn commit(&mut self) {

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -34,7 +34,7 @@ impl<U: Umem> Socket<U> {
     #[allow(clippy::type_complexity)]
     pub fn new(
         dev_queue: DeviceQueue,
-        mut umem: U,
+        umem: U,
         zero_copy: bool,
         rx_fill_ring_size: usize,
         rx_ring_size: usize,
@@ -279,8 +279,8 @@ impl<U: Umem> Socket<U> {
         &self.dev_queue
     }
 
-    pub fn umem(&mut self) -> &mut U {
-        &mut self.umem
+    pub fn umem(&self) -> &U {
+        &self.umem
     }
 }
 

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -18,7 +18,7 @@ use {
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
         tx_loop::{self, TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
-        umem::{OwnedUmem, PageAlignedMemory},
+        umem::OwnedUmem,
     },
     agave_cpu_utils::{CpuId, cpu_affinity, set_cpu_affinity},
     arc_swap::ArcSwap,
@@ -267,7 +267,7 @@ pub struct TransmitterBuilder {}
 
 #[cfg(target_os = "linux")]
 pub struct TransmitterBuilder {
-    tx_loops: Vec<TxLoop<OwnedUmem<PageAlignedMemory>>>,
+    tx_loops: Vec<TxLoop<OwnedUmem>>,
     tx_channel_cap: usize,
     maybe_ebpf: Option<Ebpf>,
     atomic_router: Arc<ArcSwap<Router>>,

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -94,13 +94,13 @@ pub struct TxLoopBuilder<U: Umem> {
     umem: U,
 }
 
-impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
+impl TxLoopBuilder<OwnedUmem> {
     pub fn new(
         cpu_id: usize,
         queue_id: QueueId,
         config: TxLoopConfig,
         dev: &NetworkDevice,
-    ) -> TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
+    ) -> TxLoopBuilder<OwnedUmem> {
         let TxLoopConfig { zero_copy, src_mac } = config;
 
         log::info!(
@@ -151,7 +151,7 @@ impl TxLoopBuilder<OwnedUmem<PageAlignedMemory>> {
         }
     }
 
-    pub fn build(self) -> Result<TxLoop<OwnedUmem<PageAlignedMemory>>, io::Error> {
+    pub fn build(self) -> Result<TxLoop<OwnedUmem>, io::Error> {
         let TxLoopBuilder {
             cpu_id,
             zero_copy,
@@ -344,7 +344,7 @@ impl<U: Umem> TxLoop<U> {
         let TxLoop {
             cpu_id,
             src_mac,
-            mut socket,
+            socket,
             mut ring,
             mut completion,
         } = self;
@@ -398,8 +398,8 @@ impl<U: Umem> TxLoop<U> {
                         ring.sync(false);
 
                         // check if any frames were completed
-                        while let Some(frame_offset) = completion.read() {
-                            umem.release(frame_offset);
+                        while let Some(frame) = completion.read() {
+                            umem.release_completed(frame);
                         }
 
                         if ring.available() > 0 && umem.available() > 0 {
@@ -426,7 +426,7 @@ impl<U: Umem> TxLoop<U> {
                 let dst = addr.ip();
                 let Some(next_hop) = route_fn(&dst) else {
                     log::warn!("dropping packet: no route for peer {addr}");
-                    umem.release(frame.offset());
+                    umem.release(frame);
                     continue;
                 };
 
@@ -448,7 +448,7 @@ impl<U: Umem> TxLoop<U> {
                                 underlay_mtu = next_hop.mtu
                             );
                         }
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
@@ -458,15 +458,15 @@ impl<U: Umem> TxLoop<U> {
                             "dropping packet: GRE packet size {packet_len} exceeds frame size \
                              {umem_frame_size} for {addr}"
                         );
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
                     frame.set_len(packet_len);
-                    let packet = umem.map_frame_mut(&frame);
+                    let mut packet = umem.map_frame_mut(frame);
                     let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
                     if let Err(err) = construct_gre_packet(
-                        packet,
+                        &mut packet,
                         &src_mac,
                         &gre.mac_addr,
                         inner_src_ip,
@@ -478,9 +478,10 @@ impl<U: Umem> TxLoop<U> {
                         &gre.tunnel_info,
                     ) {
                         log::warn!("dropping packet: {err}");
-                        umem.release(frame.offset());
+                        umem.release(packet.into_frame());
                         continue;
                     }
+                    frame = packet.into_frame();
                 } else if let Some(vlan) = &next_hop.vlan {
                     // we need the MAC address to send the packet
                     let Some(dest_mac) = next_hop.mac_addr else {
@@ -489,7 +490,7 @@ impl<U: Umem> TxLoop<U> {
                              known MAC address",
                             next_hop.ip_addr
                         );
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     };
 
@@ -504,7 +505,7 @@ impl<U: Umem> TxLoop<U> {
                                 mtu = next_hop.mtu
                             );
                         }
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
@@ -514,12 +515,12 @@ impl<U: Umem> TxLoop<U> {
                             "dropping packet: VLAN packet size {packet_len} exceeds frame size \
                              {umem_frame_size} for {addr}"
                         );
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
                     frame.set_len(packet_len);
-                    let packet = umem.map_frame_mut(&frame);
+                    let mut packet = umem.map_frame_mut(frame);
 
                     // The route's preferred src is the IP assigned to the VLAN sub-interface,
                     // which is the right inner src for traffic egressing this VLAN. Fall back
@@ -527,7 +528,7 @@ impl<U: Umem> TxLoop<U> {
                     let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
 
                     if !construct_vlan_packet(
-                        packet,
+                        &mut packet,
                         &src_mac.0,
                         &dest_mac.0,
                         inner_src_ip,
@@ -540,9 +541,10 @@ impl<U: Umem> TxLoop<U> {
                         ecn,
                     ) {
                         log::warn!("dropping packet: VLAN frame did not fit in UMEM slot");
-                        umem.release(frame.offset());
+                        umem.release(packet.into_frame());
                         continue;
                     }
+                    frame = packet.into_frame();
                 } else {
                     // we need the MAC address to send the packet
                     let Some(dest_mac) = next_hop.mac_addr else {
@@ -551,7 +553,7 @@ impl<U: Umem> TxLoop<U> {
                              known MAC address",
                             next_hop.ip_addr
                         );
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     };
 
@@ -564,7 +566,7 @@ impl<U: Umem> TxLoop<U> {
                                 mtu = next_hop.mtu
                             );
                         }
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
@@ -574,15 +576,15 @@ impl<U: Umem> TxLoop<U> {
                             "dropping packet: packet size {packet_len} exceeds frame size \
                              {umem_frame_size} for {addr}"
                         );
-                        umem.release(frame.offset());
+                        umem.release(frame);
                         continue;
                     }
 
                     frame.set_len(packet_len);
-                    let packet = umem.map_frame_mut(&frame);
+                    let mut packet = umem.map_frame_mut(frame);
 
                     if !construct_packet(
-                        packet,
+                        &mut packet,
                         &src_mac.0,
                         &dest_mac.0,
                         src_ip,
@@ -593,9 +595,10 @@ impl<U: Umem> TxLoop<U> {
                         ecn,
                     ) {
                         log::warn!("dropping packet: frame did not fit in UMEM slot");
-                        umem.release(frame.offset());
+                        umem.release(packet.into_frame());
                         continue;
                     }
+                    frame = packet.into_frame();
                 }
 
                 ring.write(frame, 0)
@@ -627,8 +630,8 @@ impl<U: Umem> TxLoop<U> {
             );
 
             completion.sync(true);
-            while let Some(frame_offset) = completion.read() {
-                umem.release(frame_offset);
+            while let Some(frame) = completion.read() {
+                umem.release_completed(frame);
             }
 
             ring.sync(false);

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -293,7 +293,7 @@ impl<T> Clone for TxSender<T> {
 
 impl<T> Drop for TxSender<T> {
     fn drop(&mut self) {
-        self.queue.senders.fetch_sub(1, Ordering::Relaxed);
+        self.queue.senders.fetch_sub(1, Ordering::Release);
     }
 }
 
@@ -314,17 +314,13 @@ impl<T> Drop for TxReceiver<T> {
 
 impl<T> Receiver<T> for TxReceiver<T> {
     fn try_recv(&self) -> Result<T, TryRecvError> {
-        match self.queue.queue.pop() {
-            Some(item) => Ok(item),
-            // there is a potential race here if the last sender sends an item and then immediately
-            // drops. In that case we'll return Disconnected even though there's an item queued.
-            // That's fine since it's only a shutdown race and we don't guarantee packet delivery in
-            // any case.
-            None if self.queue.senders.load(Ordering::Relaxed) == 0 => {
-                Err(TryRecvError::Disconnected)
-            }
-            None => Err(TryRecvError::Empty),
+        if let Some(item) = self.queue.queue.pop() {
+            return Ok(item);
         }
+        if self.queue.senders.load(Ordering::Acquire) != 0 {
+            return Err(TryRecvError::Empty);
+        }
+        self.queue.queue.pop().ok_or(TryRecvError::Disconnected)
     }
 }
 

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -76,7 +76,7 @@ impl<'a> SliceUmem<'a> {
         debug_assert!(frame_size.is_power_of_two());
         let capacity = buffer.len() / frame_size as usize;
         Ok(Self {
-            available_frames: Vec::from_iter(0..capacity as u64),
+            available_frames: Vec::from_iter((0..capacity as u64).map(|i| i * frame_size as u64)),
             capacity,
             frame_size,
             buffer,
@@ -104,18 +104,17 @@ impl<'a> Umem for SliceUmem<'a> {
     }
 
     fn reserve(&mut self) -> Option<SliceUmemFrame<'a>> {
-        let index = self.available_frames.pop()?;
+        let offset = self.available_frames.pop()? as usize;
 
         Some(SliceUmemFrame {
-            offset: index as usize * self.frame_size as usize,
+            offset,
             len: 0,
             _buf: PhantomData,
         })
     }
 
     fn release(&mut self, frame: FrameOffset) {
-        let index = frame.0 / self.frame_size as usize;
-        self.available_frames.push(index as u64);
+        self.available_frames.push(frame.0 as u64);
     }
 
     fn capacity(&self) -> usize {
@@ -160,7 +159,7 @@ impl<T: DerefMut<Target = [u8]>> OwnedUmem<T> {
         Ok(Self {
             owned,
             frame_size,
-            available_frames: Vec::from_iter(0..capacity as u64),
+            available_frames: Vec::from_iter((0..capacity as u64).map(|i| i * frame_size as u64)),
             capacity,
         })
     }
@@ -186,17 +185,13 @@ impl<T: DerefMut<Target = [u8]>> Umem for OwnedUmem<T> {
     }
 
     fn reserve(&mut self) -> Option<OwnedUmemFrame> {
-        let index = self.available_frames.pop()?;
+        let offset = self.available_frames.pop()? as usize;
 
-        Some(OwnedUmemFrame {
-            offset: index as usize * self.frame_size as usize,
-            len: 0,
-        })
+        Some(OwnedUmemFrame { offset, len: 0 })
     }
 
     fn release(&mut self, frame: FrameOffset) {
-        let index = frame.0 / self.frame_size as usize;
-        self.available_frames.push(index as u64);
+        self.available_frames.push(frame.0 as u64);
     }
 
     fn capacity(&self) -> usize {

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
+    crossbeam_queue::ArrayQueue,
     libc::{_SC_PAGESIZE, munmap, sysconf},
     std::{
         ffi::c_void,
@@ -8,11 +9,14 @@ use {
         marker::PhantomData,
         ops::{Deref, DerefMut},
         ptr, slice,
+        sync::Arc,
     },
 };
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Debug)]
 pub struct FrameOffset(pub(crate) usize);
+
+pub struct CompletedFrameOffset(pub(crate) FrameOffset);
 
 pub trait Frame {
     fn offset(&self) -> FrameOffset;
@@ -25,22 +29,84 @@ pub trait Frame {
 
 pub trait Umem {
     type Frame: Frame;
+
     fn as_ptr(&self) -> *const u8;
-    fn as_mut_ptr(&mut self) -> *mut u8;
     fn len(&self) -> usize;
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
-    fn reserve(&mut self) -> Option<Self::Frame>;
-    fn release(&mut self, frame: FrameOffset);
+    fn reserve(&self) -> Option<Self::Frame>;
+    fn release(&self, frame: Self::Frame);
+    fn release_completed(&self, frame: CompletedFrameOffset);
     fn frame_size(&self) -> usize;
     fn capacity(&self) -> usize;
     fn available(&self) -> usize;
-    fn map_frame(&self, frame: &Self::Frame) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.as_ptr().add(frame.offset().0), frame.len()) }
+    fn map_frame_mut(&self, frame: Self::Frame) -> MappedFrameMut<'_, Self::Frame>;
+}
+
+impl<U: Umem> Umem for Arc<U> {
+    type Frame = U::Frame;
+
+    fn as_ptr(&self) -> *const u8 {
+        self.as_ref().as_ptr()
     }
-    fn map_frame_mut(&mut self, frame: &Self::Frame) -> &mut [u8] {
-        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr().add(frame.offset().0), frame.len()) }
+
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn reserve(&self) -> Option<Self::Frame> {
+        self.as_ref().reserve()
+    }
+
+    fn release(&self, frame: Self::Frame) {
+        self.as_ref().release(frame);
+    }
+
+    fn release_completed(&self, frame: CompletedFrameOffset) {
+        self.as_ref().release_completed(frame);
+    }
+
+    fn frame_size(&self) -> usize {
+        self.as_ref().frame_size()
+    }
+
+    fn capacity(&self) -> usize {
+        self.as_ref().capacity()
+    }
+
+    fn available(&self) -> usize {
+        self.as_ref().available()
+    }
+
+    fn map_frame_mut(&self, frame: Self::Frame) -> MappedFrameMut<'_, Self::Frame> {
+        self.as_ref().map_frame_mut(frame)
+    }
+}
+
+pub struct MappedFrameMut<'a, F> {
+    frame: F,
+    bytes: &'a mut [u8],
+}
+
+impl<F> MappedFrameMut<'_, F> {
+    pub fn into_frame(self) -> F {
+        let Self { frame, bytes: _ } = self;
+        frame
+    }
+}
+
+impl<F> Deref for MappedFrameMut<'_, F> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.bytes
+    }
+}
+
+impl<F> DerefMut for MappedFrameMut<'_, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.bytes
     }
 }
 
@@ -65,21 +131,28 @@ impl Frame for SliceUmemFrame<'_> {
 }
 
 pub struct SliceUmem<'a> {
-    buffer: &'a mut [u8],
+    buffer: *mut u8,
+    buffer_len: usize,
     frame_size: u32,
-    available_frames: Vec<u64>,
-    capacity: usize,
+    available_frames: ArrayQueue<FrameOffset>,
+    _buffer: PhantomData<&'a mut [u8]>,
 }
+
+// Safety: `SliceUmem` retains the exclusive borrow of `buffer`, and frame tokens ensure that
+// concurrent mappings refer to non aliasing regions.
+unsafe impl Send for SliceUmem<'_> {}
+unsafe impl Sync for SliceUmem<'_> {}
 
 impl<'a> SliceUmem<'a> {
     pub fn new(buffer: &'a mut [u8], frame_size: u32) -> Result<Self, io::Error> {
         debug_assert!(frame_size.is_power_of_two());
         let capacity = buffer.len() / frame_size as usize;
         Ok(Self {
-            available_frames: Vec::from_iter((0..capacity as u64).map(|i| i * frame_size as u64)),
-            capacity,
+            buffer: buffer.as_mut_ptr(),
+            buffer_len: buffer.len(),
+            available_frames: available_frames(capacity, frame_size),
             frame_size,
-            buffer,
+            _buffer: PhantomData,
         })
     }
 }
@@ -88,23 +161,19 @@ impl<'a> Umem for SliceUmem<'a> {
     type Frame = SliceUmemFrame<'a>;
 
     fn as_ptr(&self) -> *const u8 {
-        self.buffer.as_ptr()
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut u8 {
-        self.buffer.as_mut_ptr()
+        self.buffer.cast_const()
     }
 
     fn len(&self) -> usize {
-        self.buffer.len()
+        self.buffer_len
     }
 
     fn frame_size(&self) -> usize {
         self.frame_size as usize
     }
 
-    fn reserve(&mut self) -> Option<SliceUmemFrame<'a>> {
-        let offset = self.available_frames.pop()? as usize;
+    fn reserve(&self) -> Option<SliceUmemFrame<'a>> {
+        let FrameOffset(offset) = self.available_frames.pop()?;
 
         Some(SliceUmemFrame {
             offset,
@@ -113,16 +182,28 @@ impl<'a> Umem for SliceUmem<'a> {
         })
     }
 
-    fn release(&mut self, frame: FrameOffset) {
-        self.available_frames.push(frame.0 as u64);
+    fn release(&self, frame: Self::Frame) {
+        push_available_frame(&self.available_frames, frame.offset());
+    }
+
+    fn release_completed(&self, frame: CompletedFrameOffset) {
+        push_available_frame(&self.available_frames, frame.0);
     }
 
     fn capacity(&self) -> usize {
-        self.capacity
+        self.available_frames.capacity()
     }
 
     fn available(&self) -> usize {
         self.available_frames.len()
+    }
+
+    fn map_frame_mut(&self, frame: Self::Frame) -> MappedFrameMut<'_, Self::Frame> {
+        // Safety: `frame` is the ownership token for a reserved UMEM slot. This method consumes
+        // it, so safe callers cannot map or release the same slot again while `bytes` is live.
+        let bytes =
+            unsafe { slice::from_raw_parts_mut(self.buffer.add(frame.offset().0), frame.len()) };
+        MappedFrameMut { frame, bytes }
     }
 }
 
@@ -145,62 +226,83 @@ impl Frame for OwnedUmemFrame {
     }
 }
 
-pub struct OwnedUmem<T: DerefMut<Target = [u8]>> {
-    owned: T,
+pub struct OwnedUmem {
+    memory: PageAlignedMemory,
     frame_size: u32,
-    available_frames: Vec<u64>,
-    capacity: usize,
+    available_frames: ArrayQueue<FrameOffset>,
 }
 
-impl<T: DerefMut<Target = [u8]>> OwnedUmem<T> {
-    pub fn new(owned: T, frame_size: u32) -> Result<Self, io::Error> {
+impl OwnedUmem {
+    pub fn new(memory: PageAlignedMemory, frame_size: u32) -> Result<Self, io::Error> {
         debug_assert!(frame_size.is_power_of_two());
-        let capacity = owned.len() / frame_size as usize;
+        let capacity = memory.len / frame_size as usize;
         Ok(Self {
-            owned,
+            memory,
             frame_size,
-            available_frames: Vec::from_iter((0..capacity as u64).map(|i| i * frame_size as u64)),
-            capacity,
+            available_frames: available_frames(capacity, frame_size),
         })
     }
 }
 
-impl<T: DerefMut<Target = [u8]>> Umem for OwnedUmem<T> {
+impl Umem for OwnedUmem {
     type Frame = OwnedUmemFrame;
 
     fn as_ptr(&self) -> *const u8 {
-        self.owned.as_ptr()
-    }
-
-    fn as_mut_ptr(&mut self) -> *mut u8 {
-        self.owned.as_mut_ptr()
+        self.memory.ptr.cast_const()
     }
 
     fn len(&self) -> usize {
-        self.owned.len()
+        self.memory.len
     }
 
     fn frame_size(&self) -> usize {
         self.frame_size as usize
     }
 
-    fn reserve(&mut self) -> Option<OwnedUmemFrame> {
-        let offset = self.available_frames.pop()? as usize;
+    fn reserve(&self) -> Option<OwnedUmemFrame> {
+        let FrameOffset(offset) = self.available_frames.pop()?;
 
         Some(OwnedUmemFrame { offset, len: 0 })
     }
 
-    fn release(&mut self, frame: FrameOffset) {
-        self.available_frames.push(frame.0 as u64);
+    fn release(&self, frame: Self::Frame) {
+        push_available_frame(&self.available_frames, frame.offset());
+    }
+
+    fn release_completed(&self, frame: CompletedFrameOffset) {
+        push_available_frame(&self.available_frames, frame.0);
     }
 
     fn capacity(&self) -> usize {
-        self.capacity
+        self.available_frames.capacity()
     }
 
     fn available(&self) -> usize {
         self.available_frames.len()
     }
+
+    fn map_frame_mut(&self, frame: Self::Frame) -> MappedFrameMut<'_, Self::Frame> {
+        // Safety: `frame` is the ownership token for a reserved UMEM slot. This method consumes
+        // it, so safe callers cannot map or release the same slot again while `bytes` is live.
+        let bytes = unsafe {
+            slice::from_raw_parts_mut(self.memory.ptr.add(frame.offset().0), frame.len())
+        };
+        MappedFrameMut { frame, bytes }
+    }
+}
+
+fn available_frames(capacity: usize, frame_size: u32) -> ArrayQueue<FrameOffset> {
+    let available_frames = ArrayQueue::new(capacity);
+    for index in 0..capacity {
+        push_available_frame(&available_frames, FrameOffset(index * frame_size as usize));
+    }
+    available_frames
+}
+
+fn push_available_frame(available_frames: &ArrayQueue<FrameOffset>, offset: FrameOffset) {
+    available_frames
+        .push(offset)
+        .expect("available UMEM frame queue unexpectedly full");
 }
 
 #[derive(Debug)]
@@ -211,8 +313,10 @@ pub struct PageAlignedMemory {
     len: usize,
 }
 
-/// Safety: a `PageAlignedMemory` instance MUST only be resident in one thread at a time
+// Safety: `PageAlignedMemory` owns its mapping and may be moved between threads.
 unsafe impl Send for PageAlignedMemory {}
+// Safety: `PageAlignedMemory` doesn't expose interior mutability so it's safe to share between threads.
+unsafe impl Sync for PageAlignedMemory {}
 
 impl PageAlignedMemory {
     pub fn alloc(frame_size: usize, frame_count: usize) -> Result<Self, AllocError> {
@@ -287,5 +391,47 @@ impl Deref for PageAlignedMemory {
 impl DerefMut for PageAlignedMemory {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::umem::{CompletedFrameOffset, Frame, SliceUmem, Umem},
+        std::slice,
+    };
+
+    #[test]
+    fn test_map_frame() {
+        let mut buffer = [0; 16];
+        let umem = SliceUmem::new(&mut buffer, 8).unwrap();
+        let mut frame = umem.reserve().unwrap();
+        let offset = frame.offset().0;
+
+        frame.set_len(4);
+        let mut mapped = umem.map_frame_mut(frame);
+        mapped.copy_from_slice(&[1, 2, 3, 4]);
+        let frame = mapped.into_frame();
+
+        // Safety: `offset` came from a reserved frame and `frame.len()` bytes were initialized
+        // through the mapping above.
+        let bytes = unsafe { slice::from_raw_parts(umem.as_ptr().add(offset), frame.len()) };
+        assert_eq!(bytes, &[1, 2, 3, 4]);
+
+        umem.release(frame);
+        assert_eq!(umem.available(), umem.capacity());
+    }
+
+    #[test]
+    fn test_completion() {
+        let mut buffer = [0; 16];
+        let umem = SliceUmem::new(&mut buffer, 8).unwrap();
+        let offset = {
+            let frame = umem.reserve().unwrap();
+            frame.offset()
+        };
+        umem.release_completed(CompletedFrameOffset(offset));
+
+        assert_eq!(umem.available(), umem.capacity());
     }
 }


### PR DESCRIPTION
This makes umem sharable across threads. Last building block before moving routing and packet building out of the hot tx loop. See commit message for more details.