### PR TITLE
xdp: multi threaded routing and packet building

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -833,7 +833,9 @@ impl RepairService {
             let num_pkts = batch.len();
             if let Some(xdp) = xdp_sender {
                 for (i, (bytes, addr)) in batch.into_iter().enumerate() {
-                    if let Err(e) = xdp.try_send(i, addr, Bytes::from(bytes)) {
+                    if let Err(e) =
+                        xdp.send_timeout(i, addr, Bytes::from(bytes), Duration::from_millis(5))
+                    {
                         warn!("repair xdp send failed: {e:?}");
                     }
                 }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -441,11 +441,11 @@ impl ResponseSender for GossipXdpSender {
                 Ok(()) => {
                     num_sent += 1;
                 }
-                Err(TrySendError::Full(_)) => {
+                Err(TrySendError::Full(_, _)) => {
                     num_dropped_full += 1;
                     continue;
                 }
-                Err(TrySendError::Disconnected(_)) => {
+                Err(TrySendError::Disconnected(_, _)) => {
                     num_dropped_disconnected += 1;
                     continue;
                 }

--- a/gossip/src/gossip_service.rs
+++ b/gossip/src/gossip_service.rs
@@ -10,8 +10,8 @@ use {
     crossbeam_channel::Sender,
     solana_keypair::Keypair,
     solana_net_utils::{
-        DEFAULT_IP_ECHO_SERVER_THREADS, PinnedXdpSender as XdpSender, SocketAddrSpace,
-        TrySendError,
+        DEFAULT_IP_ECHO_SERVER_THREADS, PinnedXdpSender as XdpSender, SendTimeoutError,
+        SocketAddrSpace,
         multihomed_sockets::{BindIpAddrs, MultihomedSocketProvider, SocketProvider},
     },
     solana_perf::{packet::PacketBatch, recycler::Recycler},
@@ -430,41 +430,43 @@ impl ResponseSender for GossipXdpSender {
         });
 
         let mut num_sent = 0;
-        let mut num_dropped_full = 0;
+        let mut num_dropped_timeout = 0;
         let mut num_dropped_disconnected = 0;
 
         for (idx, (payload, addr)) in packets.enumerate() {
-            match self
-                .0
-                .try_send(idx, addr, bytes::Bytes::copy_from_slice(payload))
-            {
+            match self.0.send_timeout(
+                idx,
+                addr,
+                bytes::Bytes::copy_from_slice(payload),
+                Duration::from_millis(5),
+            ) {
                 Ok(()) => {
                     num_sent += 1;
                 }
-                Err(TrySendError::Full(_, _)) => {
-                    num_dropped_full += 1;
+                Err(SendTimeoutError::Timeout(_, _)) => {
+                    num_dropped_timeout += 1;
                     continue;
                 }
-                Err(TrySendError::Disconnected(_, _)) => {
+                Err(SendTimeoutError::Disconnected(_, _)) => {
                     num_dropped_disconnected += 1;
                     continue;
                 }
             }
         }
 
-        let num_failed = num_dropped_full + num_dropped_disconnected;
+        let num_failed = num_dropped_timeout + num_dropped_disconnected;
         if num_failed > 0 {
             let kind = if num_dropped_disconnected != 0 {
                 io::ErrorKind::BrokenPipe
             } else {
-                io::ErrorKind::WouldBlock
+                io::ErrorKind::TimedOut
             };
             return Err(SendPktsError::IoError(
                 io::Error::new(
                     kind,
                     format!(
                         "XDP sender failed to enqueue {num_failed} out of {num_total} gossip \
-                         packets ({num_dropped_full} full queue, {num_dropped_disconnected} \
+                         packets ({num_dropped_timeout} timed out, {num_dropped_disconnected} \
                          disconnected)",
                         num_total = num_sent + num_failed
                     ),

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -19,7 +19,7 @@ pub mod token_bucket;
 pub mod tooling_for_tests;
 
 pub use {
-    agave_xdp::transmitter::TrySendError,
+    agave_xdp::transmitter::{SendTimeoutError, TrySendError},
     ip_echo_client::IpEchoClientError,
     ip_echo_server::{
         DEFAULT_IP_ECHO_SERVER_THREADS, IpEchoServer, MAX_PORT_COUNT_PER_MESSAGE, ip_echo_server,

--- a/net-utils/src/pinned_xdp_sender.rs
+++ b/net-utils/src/pinned_xdp_sender.rs
@@ -1,6 +1,10 @@
 //! This module defines [`PinnedXdpSender`] which is a convenience wrapper around
 //! [`agave_xdp::transmitter::XdpSender`] for the case when source address is fixed.
-use {agave_xdp::transmitter as tx, bytes::Bytes, std::net::SocketAddrV4};
+use {
+    agave_xdp::transmitter as tx,
+    bytes::Bytes,
+    std::{net::SocketAddrV4, time::Duration},
+};
 
 /// [`PinnedXdpSender`] simplifies sending packets over XDP
 /// when source address is fixed for all items.
@@ -16,15 +20,17 @@ impl PinnedXdpSender {
     }
 
     #[inline]
-    pub fn try_send(
+    pub fn send_timeout(
         &self,
         sender_index: usize,
         addr: impl Into<tx::XdpAddrs>,
         payload: Bytes,
-    ) -> Result<(), tx::TrySendError<tx::BytesTxPacket>> {
-        self.sender.try_send(
+        timeout: Duration,
+    ) -> Result<(), tx::SendTimeoutError<tx::BytesTxPacket>> {
+        self.sender.send_timeout(
             sender_index,
             tx::BytesTxPacket::new(self.src_addr, addr, None, payload),
+            timeout,
         )
     }
 }

--- a/streamer/src/quic_socket.rs
+++ b/streamer/src/quic_socket.rs
@@ -192,8 +192,8 @@ impl AsyncUdpSocket for QuicXdpTxSocket {
             .try_send(src_ip, t.destination, t.ecn, payload)
         {
             Ok(()) => Ok(()),
-            Err(TrySendError::Full(_)) => Err(io::ErrorKind::WouldBlock.into()),
-            Err(TrySendError::Disconnected(_)) => Err(io::ErrorKind::BrokenPipe.into()),
+            Err(TrySendError::Full(_, _)) => Err(io::ErrorKind::WouldBlock.into()),
+            Err(TrySendError::Disconnected(_, _)) => Err(io::ErrorKind::BrokenPipe.into()),
         }
     }
 

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -29,7 +29,7 @@ use {
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SendTimeoutError, SocketAddrSpace},
     solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::MAX_LEADER_SCHEDULE_STAKES, bank_forks::BankForks},
@@ -606,10 +606,20 @@ pub fn broadcast_shreds(
         BroadcastSocket::Xdp(s) => {
             let mut send_xdp_time = Measure::start("send_xdp");
             for (idx, (payload, addr)) in packets.into_iter().enumerate() {
-                if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
-                    log::warn!("xdp channel full: {e:?}");
-                    transmit_stats.dropped_packets_xdp += 1;
-                    result = Err(Error::XdpChannelFull);
+                match s.send_timeout(idx, addr, payload.bytes.clone(), Duration::from_millis(5)) {
+                    Ok(()) => (),
+                    Err(e @ SendTimeoutError::Timeout(_, _)) => {
+                        log::warn!("xdp send failed: {e:?}");
+                        transmit_stats.dropped_packets_xdp += 1;
+                        // we keep going and only fail if all the sends fail
+                        result = Err(Error::XdpChannelFull);
+                    }
+                    // the errors here are a mess but Error::Send causes broadcast stage to
+                    // exit, which is what we want when the channel is disconnected
+                    Err(SendTimeoutError::Disconnected(_, _)) => {
+                        result = Err(Error::Send);
+                        break;
+                    }
                 }
             }
             send_xdp_time.stop();

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -522,17 +522,24 @@ fn retransmit_shred(
     let num_addrs = addrs.len();
     let num_nodes = match socket {
         RetransmitSocket::Xdp(sender) => {
-            let mut sent = num_addrs;
-            if num_addrs > 0
-                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes)
-            {
-                log::warn!("xdp channel full: {e:?}");
-                stats
-                    .num_shreds_dropped_xdp_full
-                    .fetch_add(num_addrs, Ordering::Relaxed);
-                sent = 0;
+            if num_addrs == 0 {
+                0
+            } else {
+                match sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes) {
+                    Ok(()) => num_addrs,
+                    Err(solana_net_utils::TrySendError::Full(_, num_unsent)) => {
+                        log::warn!("xdp channel full");
+                        stats
+                            .num_shreds_dropped_xdp_full
+                            .fetch_add(num_unsent, Ordering::Relaxed);
+                        num_addrs - num_unsent
+                    }
+                    Err(solana_net_utils::TrySendError::Disconnected(_, num_unsent)) => {
+                        log::warn!("xdp channel disconnected");
+                        num_addrs - num_unsent
+                    }
+                }
             }
-            sent
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -22,7 +22,7 @@ use {
         shred::{self, ShredFlags, ShredId, ShredType},
     },
     solana_measure::measure::Measure,
-    solana_net_utils::SocketAddrSpace,
+    solana_net_utils::{SendTimeoutError, SocketAddrSpace},
     solana_perf::deduper::Deduper,
     solana_pubkey::Pubkey,
     solana_rpc::{
@@ -525,16 +525,21 @@ fn retransmit_shred(
             if num_addrs == 0 {
                 0
             } else {
-                match sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes) {
+                match sender.send_timeout(
+                    key.index() as usize,
+                    addrs.to_vec(),
+                    shred.bytes,
+                    Duration::from_millis(5),
+                ) {
                     Ok(()) => num_addrs,
-                    Err(solana_net_utils::TrySendError::Full(_, num_unsent)) => {
-                        log::warn!("xdp channel full");
+                    Err(SendTimeoutError::Timeout(_, num_unsent)) => {
+                        log::warn!("xdp send timed out");
                         stats
                             .num_shreds_dropped_xdp_full
                             .fetch_add(num_unsent, Ordering::Relaxed);
                         num_addrs - num_unsent
                     }
-                    Err(solana_net_utils::TrySendError::Disconnected(_, num_unsent)) => {
+                    Err(SendTimeoutError::Disconnected(_, num_unsent)) => {
                         log::warn!("xdp channel disconnected");
                         num_addrs - num_unsent
                     }

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -25,7 +25,7 @@ use {
     arrayvec::ArrayVec,
     aya::Ebpf,
     log::info,
-    std::{net::Ipv4Addr, thread::Builder},
+    std::{hint, net::Ipv4Addr, thread::Builder, time::Instant},
 };
 
 #[cfg(target_os = "linux")]
@@ -141,6 +141,15 @@ pub enum TrySendError<T> {
     Disconnected(T, usize),
 }
 
+/// Error returned when a timed XDP send does not enqueue every destination.
+///
+/// The `usize` is the number of unsent destinations.
+#[derive(Debug)]
+pub enum SendTimeoutError<T> {
+    Timeout(T, usize),
+    Disconnected(T, usize),
+}
+
 #[cfg(target_os = "linux")]
 #[derive(Clone)]
 pub struct XdpSender {
@@ -226,6 +235,66 @@ impl XdpSender {
         {
             let _ = sender_index;
             Err(TrySendError::Disconnected(packet, 0))
+        }
+    }
+
+    /// Sends a `packet`.
+    ///
+    /// If sending takes longer than `timeout`, the operation is aborted and an error is returned.
+    pub fn send_timeout(
+        &self,
+        sender_index: usize,
+        packet: BytesTxPacket,
+        timeout: Duration,
+    ) -> Result<(), SendTimeoutError<BytesTxPacket>> {
+        #[cfg(target_os = "linux")]
+        {
+            const SPINS_BEFORE_YIELD: usize = 64;
+
+            let started = Instant::now();
+            let idx = sender_index
+                .checked_rem(self.queues.len())
+                .expect("XdpSender::queues should not be empty");
+            let queue = &self.queues[idx];
+            let router = self.atomic_router.load();
+            let mut dst_index = 0;
+            let mut spins = 0;
+
+            while dst_index < packet.dst_addrs.as_ref().len() {
+                let addr = packet.dst_addrs.as_ref()[dst_index];
+                #[allow(clippy::arithmetic_side_effects)]
+                match self.try_send_one(queue, &router, &packet, addr) {
+                    Ok(()) => {
+                        dst_index += 1;
+                        spins = 0;
+                    }
+                    Err(tx_loop::TrySendError::Disconnected(())) => {
+                        let num_unsent = packet.dst_addrs.as_ref().len().saturating_sub(dst_index);
+                        return Err(SendTimeoutError::Disconnected(packet, num_unsent));
+                    }
+                    Err(tx_loop::TrySendError::Full(())) => {
+                        if started.elapsed() >= timeout {
+                            let num_unsent =
+                                packet.dst_addrs.as_ref().len().saturating_sub(dst_index);
+                            return Err(SendTimeoutError::Timeout(packet, num_unsent));
+                        }
+                        if spins < SPINS_BEFORE_YIELD {
+                            spins += 1;
+                            hint::spin_loop();
+                        } else {
+                            spins = 0;
+                            thread::yield_now();
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = (sender_index, timeout);
+            Err(SendTimeoutError::Disconnected(packet, 0))
         }
     }
 

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "linux")]
-pub use crate::tx_loop::TrySendError;
 use {
     crate::ecn_codepoint::EcnCodepoint,
     bytes::Bytes,
@@ -8,6 +6,7 @@ use {
         net::{SocketAddr, SocketAddrV4},
         sync::{Arc, atomic::AtomicBool},
         thread,
+        time::Duration,
     },
 };
 #[cfg(target_os = "linux")]
@@ -15,22 +14,18 @@ use {
     crate::{
         device::{NetworkDevice, QueueId},
         load_xdp_program,
+        netlink::MacAddress,
         route::{RouteTable, Router, RoutingTables},
         route_monitor::RouteMonitor,
-        tx_loop::{self, TxLoop, TxLoopBuilder, TxLoopConfigBuilder, TxPacket},
-        umem::OwnedUmem,
+        tx_loop::{self, PacketBuildParams, TxLoop, TxLoopBuilder, TxSender, build_packet},
+        umem::{Frame, OwnedUmem, OwnedUmemFrame, Umem},
     },
     agave_cpu_utils::{CpuId, cpu_affinity, set_cpu_affinity},
     arc_swap::ArcSwap,
     arrayvec::ArrayVec,
     aya::Ebpf,
-    crossbeam_queue::ArrayQueue,
     log::info,
-    std::{
-        net::{IpAddr, Ipv4Addr},
-        thread::Builder,
-        time::Duration,
-    },
+    std::{net::Ipv4Addr, thread::Builder},
 };
 
 #[cfg(target_os = "linux")]
@@ -48,7 +43,7 @@ pub struct QueueCpuBinding {
     pub cpu: usize,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct XdpConfig {
     pub interface: Option<String>,
     /// NIC-queue -> CPU-core bindings. One TX worker is created per entry, in
@@ -56,25 +51,6 @@ pub struct XdpConfig {
     /// inferred from position, so callers can target arbitrary hardware queues.
     pub queues: Vec<QueueCpuBinding>,
     pub zero_copy: bool,
-    // The capacity of the channel that sits between senders and each XDP thread that enqueues
-    // packets to the NIC.
-    pub tx_channel_cap: usize,
-}
-
-impl XdpConfig {
-    // A nice round number
-    const DEFAULT_TX_CHANNEL_CAP: usize = 1_000_000;
-}
-
-impl Default for XdpConfig {
-    fn default() -> Self {
-        Self {
-            interface: None,
-            queues: vec![],
-            zero_copy: false,
-            tx_channel_cap: Self::DEFAULT_TX_CHANNEL_CAP,
-        }
-    }
 }
 
 impl XdpConfig {
@@ -87,7 +63,6 @@ impl XdpConfig {
             interface: interface.map(|s| s.into()),
             queues,
             zero_copy,
-            tx_channel_cap: XdpConfig::DEFAULT_TX_CHANNEL_CAP,
         }
     }
 }
@@ -104,6 +79,7 @@ pub struct BytesTxPacket {
 }
 
 #[cfg(not(target_os = "linux"))]
+#[derive(Debug)]
 pub struct BytesTxPacket;
 
 #[cfg(target_os = "linux")]
@@ -143,52 +119,45 @@ impl BytesTxPacket {
     pub fn set_allow_mtu_overflow(&mut self, _allow: bool) {}
 }
 
-#[cfg(not(target_os = "linux"))]
-pub enum TrySendError<T> {
-    Full(T),
-    Disconnected(T),
+#[cfg(target_os = "linux")]
+impl std::fmt::Debug for BytesTxPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BytesTxPacket")
+            .field("src_addr", &self.src_addr)
+            .field("num_destinations", &self.dst_addrs.as_ref().len())
+            .field("ecn", &self.ecn)
+            .field("allow_mtu_overflow", &self.allow_mtu_overflow)
+            .field("payload_len", &self.payload.len())
+            .finish()
+    }
 }
 
-#[cfg(not(target_os = "linux"))]
-impl std::fmt::Debug for TrySendError<BytesTxPacket> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TrySendError::Full(_) => write!(f, "TrySendError::Full"),
-            TrySendError::Disconnected(_) => write!(f, "TrySendError::Disconnected"),
-        }
-    }
+/// Error returned when an XDP packet cannot be fully enqueued.
+///
+/// The second field is the number of unsent destinations.
+#[derive(Debug)]
+pub enum TrySendError<T> {
+    Full(T, usize),
+    Disconnected(T, usize),
 }
 
 #[cfg(target_os = "linux")]
-impl TxPacket for BytesTxPacket {
-    type Addrs = XdpAddrs;
-    type Payload = Bytes;
-
-    fn dst_addrs(&self) -> &Self::Addrs {
-        &self.dst_addrs
-    }
-
-    fn payload(&self) -> &Self::Payload {
-        &self.payload
-    }
-
-    fn src_addr(&self) -> SocketAddrV4 {
-        self.src_addr
-    }
-
-    fn ecn(&self) -> Option<EcnCodepoint> {
-        self.ecn
-    }
-
-    fn allow_mtu_overflow(&self) -> bool {
-        self.allow_mtu_overflow
-    }
-}
-
 #[derive(Clone)]
 pub struct XdpSender {
-    #[cfg(target_os = "linux")]
-    senders: Vec<tx_loop::TxSender<BytesTxPacket>>,
+    queues: Vec<TxQueue>,
+    atomic_router: Arc<ArcSwap<Router>>,
+    src_mac: MacAddress,
+}
+
+#[cfg(not(target_os = "linux"))]
+#[derive(Clone)]
+pub struct XdpSender;
+
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+struct TxQueue {
+    sender: TxSender<OwnedUmemFrame>,
+    umem: Arc<OwnedUmem>,
 }
 
 pub enum XdpAddrs {
@@ -221,6 +190,7 @@ impl AsRef<[SocketAddr]> for XdpAddrs {
 }
 
 impl XdpSender {
+    /// Attempts to send a `packet` without blocking.
     #[inline]
     pub fn try_send(
         &self,
@@ -230,20 +200,93 @@ impl XdpSender {
         #[cfg(target_os = "linux")]
         {
             let idx = sender_index
-                .checked_rem(self.senders.len())
-                .expect("XdpSender::senders should not be empty");
-            self.senders[idx].try_send(packet)
+                .checked_rem(self.queues.len())
+                .expect("XdpSender::queues should not be empty");
+            let queue = &self.queues[idx];
+            let router = self.atomic_router.load();
+
+            for (i, addr) in packet.dst_addrs.as_ref().iter().enumerate() {
+                let addr = *addr;
+                match self.try_send_one(queue, &router, &packet, addr) {
+                    Ok(_) => {}
+                    Err(tx_loop::TrySendError::Full(())) => {
+                        let num_unsent = packet.dst_addrs.as_ref().len().saturating_sub(i);
+                        return Err(TrySendError::Full(packet, num_unsent));
+                    }
+                    Err(tx_loop::TrySendError::Disconnected(())) => {
+                        let num_unsent = packet.dst_addrs.as_ref().len().saturating_sub(i);
+                        return Err(TrySendError::Disconnected(packet, num_unsent));
+                    }
+                };
+            }
+
+            Ok(())
         }
         #[cfg(not(target_os = "linux"))]
         {
             let _ = sender_index;
-            Err(TrySendError::Disconnected(packet))
+            Err(TrySendError::Disconnected(packet, 0))
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn try_send_one(
+        &self,
+        queue: &TxQueue,
+        router: &Router,
+        packet: &BytesTxPacket,
+        addr: SocketAddr,
+    ) -> Result<(), tx_loop::TrySendError<()>> {
+        let SocketAddr::V4(dst_addr) = addr else {
+            panic!("IPv6 not supported");
+        };
+        let Ok(next_hop) = router.route_v4(*dst_addr.ip()) else {
+            log::warn!("dropping packet: no route for peer {addr}");
+            return Ok(());
+        };
+
+        let Some(mut frame) = queue.umem.reserve() else {
+            return Err(tx_loop::TrySendError::Full(()));
+        };
+        frame.set_len(queue.umem.frame_size());
+
+        let mut mapped = queue.umem.map_frame_mut(frame);
+        let Some(packet_len) = build_packet(PacketBuildParams {
+            packet: &mut mapped,
+            src_mac: &self.src_mac,
+            src_addr: packet.src_addr,
+            dst_addr,
+            next_hop: &next_hop,
+            payload: packet.payload.as_ref(),
+            ecn: packet.ecn,
+            allow_mtu_overflow: packet.allow_mtu_overflow,
+        }) else {
+            queue.umem.release(mapped.into_frame());
+            return Ok(());
+        };
+
+        let mut frame = mapped.into_frame();
+        frame.set_len(packet_len);
+
+        if let Err(err) = queue.sender.try_send(frame) {
+            match err {
+                tx_loop::TrySendError::Full(frame) => {
+                    queue.umem.release(frame);
+                    Err(tx_loop::TrySendError::Full(()))
+                }
+                tx_loop::TrySendError::Disconnected(frame) => {
+                    queue.umem.release(frame);
+                    Err(tx_loop::TrySendError::Disconnected(()))
+                }
+            }
+        } else {
+            Ok(())
         }
     }
 
     pub fn len(&self) -> usize {
         #[cfg(target_os = "linux")]
-        return self.senders.len();
+        return self.queues.len();
 
         #[cfg(not(target_os = "linux"))]
         0
@@ -251,7 +294,7 @@ impl XdpSender {
 
     pub fn is_empty(&self) -> bool {
         #[cfg(target_os = "linux")]
-        return self.senders.is_empty();
+        return self.queues.is_empty();
 
         #[cfg(not(target_os = "linux"))]
         true
@@ -260,6 +303,8 @@ impl XdpSender {
 
 pub struct Transmitter {
     threads: Vec<thread::JoinHandle<()>>,
+    #[cfg(target_os = "linux")]
+    _maybe_ebpf: Option<Ebpf>,
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -267,8 +312,8 @@ pub struct TransmitterBuilder {}
 
 #[cfg(target_os = "linux")]
 pub struct TransmitterBuilder {
-    tx_loops: Vec<TxLoop<OwnedUmem>>,
-    tx_channel_cap: usize,
+    tx_loops: Vec<TxLoop<Arc<OwnedUmem>>>,
+    src_mac: MacAddress,
     maybe_ebpf: Option<Ebpf>,
     atomic_router: Arc<ArcSwap<Router>>,
     route_monitor_handle: thread::JoinHandle<()>,
@@ -291,7 +336,6 @@ impl TransmitterBuilder {
             interface: maybe_interface,
             queues,
             zero_copy,
-            tx_channel_cap,
         } = config;
 
         let dev = Arc::new(if let Some(interface) = maybe_interface {
@@ -299,10 +343,6 @@ impl TransmitterBuilder {
         } else {
             NetworkDevice::new_from_default_route().unwrap()
         });
-
-        let mut tx_loop_config_builder = TxLoopConfigBuilder::new();
-        tx_loop_config_builder.zero_copy(zero_copy);
-        let tx_loop_config = tx_loop_config_builder.build_with_src_device(&dev);
 
         let reserved_cores = queues
             .iter()
@@ -324,12 +364,8 @@ impl TransmitterBuilder {
             // is allocated to the correct numa node
             let cpu = CpuId::new(binding.cpu)?;
             set_cpu_affinity(None, [cpu])?;
-            let tx_loop_builder = TxLoopBuilder::new(
-                binding.cpu,
-                QueueId(binding.queue as u64),
-                tx_loop_config.clone(),
-                &dev,
-            );
+            let tx_loop_builder =
+                TxLoopBuilder::new(binding.cpu, QueueId(binding.queue as u64), zero_copy, &dev);
             // migrate main thread back off of the last xdp reserved cpu
             set_cpu_affinity(None, unreserved_cores.iter().copied())?;
             tx_loop_builders.push(tx_loop_builder);
@@ -389,7 +425,7 @@ impl TransmitterBuilder {
 
         Ok(Self {
             tx_loops,
-            tx_channel_cap,
+            src_mac: dev.mac_addr()?,
             maybe_ebpf,
             atomic_router,
             route_monitor_handle,
@@ -403,76 +439,40 @@ impl TransmitterBuilder {
 
     #[cfg(target_os = "linux")]
     pub fn build(self) -> (Transmitter, XdpSender) {
-        const DROP_CHANNEL_CAP: usize = 1_000_000;
-
         let Self {
             tx_loops,
-            tx_channel_cap,
+            src_mac,
             maybe_ebpf,
             atomic_router,
             route_monitor_handle,
         } = self;
 
-        let drop_queue = Arc::new(ArrayQueue::new(DROP_CHANNEL_CAP));
         let mut threads = vec![route_monitor_handle];
 
-        threads.push(
-            Builder::new()
-                .name("solTransmDrop".to_owned())
-                .spawn({
-                    let drop_queue = Arc::clone(&drop_queue);
-                    move || {
-                        loop {
-                            // drop shreds in a dedicated thread so that we never lock/madvise() from
-                            // the xdp thread
-                            match drop_queue.pop() {
-                                Some(i) => {
-                                    drop(i);
-                                }
-                                None if Arc::strong_count(&drop_queue) == 1 => break,
-                                None => {
-                                    thread::sleep(Duration::from_millis(1));
-                                }
-                            }
-                        }
-                        // move the ebpf program here so it stays attached until we exit
-                        drop(maybe_ebpf);
-                    }
-                })
-                .unwrap(),
-        );
-
-        let mut senders = vec![];
+        let mut queues = vec![];
         for (i, tx_loop) in tx_loops.into_iter().enumerate() {
-            let (sender, receiver) = tx_loop::channel(tx_channel_cap);
-            let drop_queue = Arc::clone(&drop_queue);
-            let atomic_router = Arc::clone(&atomic_router);
+            let umem = Arc::clone(tx_loop.umem());
+            let (sender, receiver) = tx_loop::channel(tx_loop.umem_tx_capacity());
             threads.push(
                 Builder::new()
                     .name(format!("solTransmIO{i:02}"))
-                    .spawn(move || {
-                        tx_loop.run(
-                            receiver,
-                            move |item| {
-                                if let Err(item) = drop_queue.push(item) {
-                                    drop(item);
-                                }
-                            },
-                            move |ip| {
-                                let r = atomic_router.load();
-                                match ip {
-                                    IpAddr::V4(ip) => r.route_v4(*ip).ok(),
-                                    IpAddr::V6(_) => None,
-                                }
-                            },
-                        )
-                    })
+                    .spawn(move || tx_loop.run(receiver))
                     .unwrap(),
             );
-            senders.push(sender);
+            queues.push(TxQueue { sender, umem });
         }
 
-        (Transmitter { threads }, XdpSender { senders })
+        (
+            Transmitter {
+                threads,
+                _maybe_ebpf: maybe_ebpf,
+            },
+            XdpSender {
+                queues,
+                atomic_router,
+                src_mac,
+            },
+        )
     }
 }
 

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -23,7 +23,7 @@ use {
     std::{
         error::Error,
         fmt, io,
-        net::{IpAddr, SocketAddr, SocketAddrV4},
+        net::SocketAddrV4,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -33,76 +33,21 @@ use {
     },
 };
 
-pub struct TxLoopConfigBuilder {
-    zero_copy: bool,
-    maybe_src_mac: Option<MacAddress>,
-}
-
-impl TxLoopConfigBuilder {
-    pub fn new() -> Self {
-        Self {
-            zero_copy: false,
-            maybe_src_mac: None,
-        }
-    }
-
-    pub fn zero_copy(&mut self, enable: bool) -> &mut Self {
-        self.zero_copy = enable;
-        self
-    }
-
-    pub fn override_src_mac(&mut self, mac: MacAddress) -> &mut Self {
-        self.maybe_src_mac = Some(mac);
-        self
-    }
-
-    pub fn build_with_src_device(self, src_device: &NetworkDevice) -> TxLoopConfig {
-        let Self {
-            zero_copy,
-            maybe_src_mac,
-        } = self;
-
-        let src_mac = maybe_src_mac.unwrap_or_else(|| {
-            // if no source MAC is provided, use the device's MAC address
-            src_device
-                .mac_addr()
-                .expect("no src_mac provided, device must have a MAC address")
-        });
-
-        TxLoopConfig { zero_copy, src_mac }
-    }
-}
-
-impl Default for TxLoopConfigBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct TxLoopConfig {
-    zero_copy: bool,
-    src_mac: MacAddress,
-}
-
 pub struct TxLoopBuilder<U: Umem> {
     cpu_id: usize,
     zero_copy: bool,
-    src_mac: MacAddress,
     queue: DeviceQueue,
     tx_size: usize,
     umem: U,
 }
 
-impl TxLoopBuilder<OwnedUmem> {
+impl TxLoopBuilder<Arc<OwnedUmem>> {
     pub fn new(
         cpu_id: usize,
         queue_id: QueueId,
-        config: TxLoopConfig,
+        zero_copy: bool,
         dev: &NetworkDevice,
-    ) -> TxLoopBuilder<OwnedUmem> {
-        let TxLoopConfig { zero_copy, src_mac } = config;
-
+    ) -> TxLoopBuilder<Arc<OwnedUmem>> {
         log::info!(
             "starting xdp loop on {} queue {queue_id:?} cpu {cpu_id}",
             dev.name()
@@ -139,23 +84,21 @@ impl TxLoopBuilder<OwnedUmem> {
                     PageAlignedMemory::alloc(frame_size, frame_count)
                 })
                 .unwrap();
-        let umem = OwnedUmem::new(memory, frame_size as u32).unwrap();
+        let umem = Arc::new(OwnedUmem::new(memory, frame_size as u32).unwrap());
 
         TxLoopBuilder {
             cpu_id,
             zero_copy,
-            src_mac,
             queue,
             tx_size,
             umem,
         }
     }
 
-    pub fn build(self) -> Result<TxLoop<OwnedUmem>, io::Error> {
+    pub fn build(self) -> Result<TxLoop<Arc<OwnedUmem>>, io::Error> {
         let TxLoopBuilder {
             cpu_id,
             zero_copy,
-            src_mac,
             queue,
             tx_size,
             umem,
@@ -170,6 +113,9 @@ impl TxLoopBuilder<OwnedUmem> {
                 );
                 err
             })?;
+        // this is the umem capacity available for tx, after the fill ring is populated during
+        // socket creation
+        let umem_tx_capacity = socket.umem().available();
 
         let Tx {
             // this is where we'll queue frames
@@ -181,42 +127,20 @@ impl TxLoopBuilder<OwnedUmem> {
 
         Ok(TxLoop {
             cpu_id,
-            src_mac,
             socket,
             ring,
             completion,
+            umem_tx_capacity,
         })
     }
 }
 
 pub struct TxLoop<U: Umem> {
     cpu_id: usize,
-    src_mac: MacAddress,
     socket: Socket<U>,
     ring: TxRing<U::Frame>,
     completion: TxCompletionRing,
-}
-
-/// [`TxPacket`] represents a packet to transmit via XDP to a list of addresses with the provided
-/// `payload` and source address.
-pub trait TxPacket {
-    type Addrs: AsRef<[SocketAddr]>;
-    type Payload: AsRef<[u8]>;
-
-    /// List of destination addresses to which the packet should be sent.
-    fn dst_addrs(&self) -> &Self::Addrs;
-
-    /// Payload of the packet to be sent.
-    fn payload(&self) -> &Self::Payload;
-
-    /// Source address used when sending the packet.
-    fn src_addr(&self) -> SocketAddrV4;
-
-    /// Explicit congestion notification bits to set on the packet.
-    fn ecn(&self) -> Option<EcnCodepoint>;
-
-    /// Returns true when this packet is expected to occasionally exceed the route MTU.
-    fn allow_mtu_overflow(&self) -> bool;
+    umem_tx_capacity: usize,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -325,12 +249,17 @@ impl<T> Receiver<T> for TxReceiver<T> {
 }
 
 impl<U: Umem> TxLoop<U> {
-    pub fn run<T, Rx, D, R>(self, receiver: Rx, mut drop_item: D, route_fn: R)
+    pub fn umem(&self) -> &U {
+        self.socket.umem()
+    }
+
+    pub fn umem_tx_capacity(&self) -> usize {
+        self.umem_tx_capacity
+    }
+
+    pub fn run<Rx>(self, receiver: Rx)
     where
-        T: TxPacket,
-        Rx: Receiver<T>,
-        D: FnMut(T),
-        R: Fn(&IpAddr) -> Option<NextHop>,
+        Rx: Receiver<U::Frame>,
     {
         // How long we sleep waiting to receive packets from the channel.
         const RECV_TIMEOUT: Duration = Duration::from_nanos(1000);
@@ -343,30 +272,31 @@ impl<U: Umem> TxLoop<U> {
 
         let TxLoop {
             cpu_id,
-            src_mac,
             socket,
             mut ring,
             mut completion,
+            umem_tx_capacity,
         } = self;
 
         // each queue is bound to its own CPU core
         set_cpu_affinity(None, [agave_cpu_utils::CpuId::new(cpu_id).unwrap()]).unwrap();
 
         let umem = socket.umem();
-        let umem_tx_capacity = umem.available();
-        let umem_frame_size = umem.frame_size();
 
         // How many descriptors are written into the TX ring but not yet committed.
         let mut written_uncommitted = 0;
 
         let mut timeouts = 0;
         loop {
-            let item = match receiver.try_recv() {
-                Ok(item) => {
+            let frame = match receiver.try_recv() {
+                Ok(frame) => {
                     timeouts = 0;
-                    item
+                    frame
                 }
                 Err(TryRecvError::Empty) => {
+                    release_completed(umem, &mut completion);
+                    ring.sync(false);
+
                     if timeouts < MAX_TIMEOUTS {
                         timeouts += 1;
                         thread::sleep(RECV_TIMEOUT);
@@ -381,70 +311,40 @@ impl<U: Umem> TxLoop<U> {
                 Err(TryRecvError::Disconnected) => break,
             };
 
-            let src_addr = item.src_addr();
-            let ecn = item.ecn();
-            let can_overflow_mtu = item.allow_mtu_overflow();
-            for addr in item.dst_addrs().as_ref() {
-                if ring.available() == 0 || umem.available() == 0 {
-                    commit_pending(&mut ring, &mut written_uncommitted);
-                    kick(&ring);
+            if ring.available() == 0 {
+                commit_pending(&mut ring, &mut written_uncommitted);
+                kick(&ring);
 
-                    // loop until we have space for the next packet
-                    loop {
-                        completion.sync(true);
-                        // we haven't written any frames so we only need to sync the consumer position
-                        ring.sync(false);
+                // loop until we have space for the next frame
+                loop {
+                    release_completed(umem, &mut completion);
+                    // we haven't written any frames so we only need to sync the consumer position
+                    ring.sync(false);
 
-                        // check if any frames were completed
-                        while let Some(frame) = completion.read() {
-                            umem.release_completed(frame);
-                        }
-
-                        if ring.available() > 0 && umem.available() > 0 {
-                            // we have space for the next packet, break out of the loop
-                            break;
-                        }
-
-                        // queues are full, if NEEDS_WAKEUP is set kick the driver so hopefully it'll
-                        // complete some work
-                        kick(&ring);
+                    if ring.available() > 0 {
+                        // we have space for the next frame, break out of the loop
+                        break;
                     }
-                }
 
-                // at this point we're guaranteed to have a frame to write the next packet into and
-                // a slot in the ring to submit it
-                let frame = umem.reserve().unwrap();
-                let Some(frame) = build_packet(
-                    umem,
-                    PacketBuildParams {
-                        frame,
-                        src_mac: &src_mac,
-                        src_addr,
-                        dst_addr: addr,
-                        payload: item.payload().as_ref(),
-                        ecn,
-                        can_overflow_mtu,
-                        umem_frame_size,
-                    },
-                    &route_fn,
-                ) else {
-                    continue;
-                };
-
-                ring.write(frame, 0)
-                    .map_err(|_| "ring full")
-                    // this should never happen as we check for available slots above
-                    .expect("failed to write to ring");
-
-                written_uncommitted += 1;
-
-                // check if it's time to publish descriptors and kick the driver
-                if written_uncommitted >= BATCH_SIZE {
-                    commit_pending(&mut ring, &mut written_uncommitted);
+                    // queues are full, if NEEDS_WAKEUP is set kick the driver so hopefully it'll
+                    // complete some work
                     kick(&ring);
                 }
             }
-            drop_item(item);
+
+            ring.write(frame, 0)
+                .map_err(|_| "ring full")
+                // this should never happen as we check for available slots above
+                .expect("failed to write to ring");
+
+            written_uncommitted += 1;
+
+            // check if it's time to publish descriptors and kick the driver
+            if written_uncommitted >= BATCH_SIZE {
+                commit_pending(&mut ring, &mut written_uncommitted);
+                kick(&ring);
+                release_completed(umem, &mut completion);
+            }
         }
         commit_pending(&mut ring, &mut written_uncommitted);
         kick(&ring);
@@ -459,70 +359,50 @@ impl<U: Umem> TxLoop<U> {
                 ring.capacity()
             );
 
-            completion.sync(true);
-            while let Some(frame) = completion.read() {
-                umem.release_completed(frame);
-            }
-
+            release_completed(umem, &mut completion);
             ring.sync(false);
             kick(&ring);
         }
     }
 }
 
-struct PacketBuildParams<'a, F> {
-    frame: F,
-    src_mac: &'a MacAddress,
-    src_addr: SocketAddrV4,
-    dst_addr: &'a SocketAddr,
-    payload: &'a [u8],
-    ecn: Option<EcnCodepoint>,
-    can_overflow_mtu: bool,
-    umem_frame_size: usize,
+pub struct PacketBuildParams<'a> {
+    pub packet: &'a mut [u8],
+    pub src_mac: &'a MacAddress,
+    pub src_addr: SocketAddrV4,
+    pub dst_addr: SocketAddrV4,
+    pub next_hop: &'a NextHop,
+    pub payload: &'a [u8],
+    pub ecn: Option<EcnCodepoint>,
+    pub allow_mtu_overflow: bool,
 }
 
-#[inline]
-fn build_packet<U, R>(
-    umem: &U,
-    params: PacketBuildParams<'_, U::Frame>,
-    route_fn: &R,
-) -> Option<U::Frame>
-where
-    U: Umem,
-    R: Fn(&IpAddr) -> Option<NextHop>,
-{
+pub fn build_packet(params: PacketBuildParams<'_>) -> Option<usize> {
     let PacketBuildParams {
-        mut frame,
+        packet,
         src_mac,
         src_addr,
         dst_addr: addr,
+        next_hop,
         payload,
         ecn,
-        can_overflow_mtu,
-        umem_frame_size,
+        allow_mtu_overflow,
     } = params;
+
     let src_ip = src_addr.ip();
     let src_port = src_addr.port();
-    let IpAddr::V4(dst_ip) = addr.ip() else {
-        panic!("IPv6 not supported");
-    };
-
+    let dst_ip = addr.ip();
+    let dst_port = addr.port();
     let len = payload.len();
+    let umem_frame_size = packet.len();
 
-    let dst = addr.ip();
-    let Some(next_hop) = route_fn(&dst) else {
-        log::warn!("dropping packet: no route for peer {addr}");
-        umem.release(frame);
-        return None;
-    };
-
-    if let Some(gre) = &next_hop.gre {
+    if let Some(gre) = next_hop.gre.as_ref() {
         let l3_inner_packet_len = INNER_PACKET_HEADER_SIZE + len;
         let l3_outer_gre_packet_len = IP_HEADER_SIZE + GRE_HEADER_BASE_SIZE + l3_inner_packet_len;
 
         if l3_inner_packet_len > gre.mtu as usize || l3_outer_gre_packet_len > next_hop.mtu as usize
         {
-            if !can_overflow_mtu {
+            if !allow_mtu_overflow {
                 log::warn!(
                     "dropping packet: GRE payload exceeds MTU for {addr}: L3 inner packet length \
                      {l3_inner_packet_len}, L3 outer GRE packet length {l3_outer_gre_packet_len}, \
@@ -531,7 +411,6 @@ where
                     underlay_mtu = next_hop.mtu
                 );
             }
-            umem.release(frame);
             return None;
         }
 
@@ -541,31 +420,30 @@ where
                 "dropping packet: GRE packet size {packet_len} exceeds frame size \
                  {umem_frame_size} for {addr}"
             );
-            umem.release(frame);
             return None;
         }
 
-        frame.set_len(packet_len);
-        let mut packet = umem.map_frame_mut(frame);
-        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
+        let inner_src_ip = next_hop.preferred_src_ip.unwrap_or(*src_ip);
         if let Err(err) = construct_gre_packet(
-            &mut packet,
+            packet,
             src_mac,
             &gre.mac_addr,
-            inner_src_ip,
-            &dst_ip,
+            &inner_src_ip,
+            dst_ip,
             src_port,
-            addr.port(),
+            dst_port,
             payload,
             ecn,
             &gre.tunnel_info,
         ) {
             log::warn!("dropping packet: {err}");
-            umem.release(packet.into_frame());
             return None;
         }
-        frame = packet.into_frame();
-    } else if let Some(vlan) = &next_hop.vlan {
+
+        return Some(packet_len);
+    }
+
+    if let Some(vlan) = next_hop.vlan {
         // we need the MAC address to send the packet
         let Some(dest_mac) = next_hop.mac_addr else {
             log::warn!(
@@ -573,7 +451,6 @@ where
                  address",
                 next_hop.ip_addr
             );
-            umem.release(frame);
             return None;
         };
 
@@ -581,13 +458,12 @@ where
         // is the same as the untagged path.
         let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
         if l3_packet_len > next_hop.mtu as usize {
-            if !can_overflow_mtu {
+            if !allow_mtu_overflow {
                 log::warn!(
                     "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} for {addr}",
                     mtu = next_hop.mtu
                 );
             }
-            umem.release(frame);
             return None;
         }
 
@@ -597,92 +473,87 @@ where
                 "dropping packet: VLAN packet size {packet_len} exceeds frame size \
                  {umem_frame_size} for {addr}"
             );
-            umem.release(frame);
             return None;
         }
-
-        frame.set_len(packet_len);
-        let mut packet = umem.map_frame_mut(frame);
 
         // The route's preferred src is the IP assigned to the VLAN sub-interface,
         // which is the right inner src for traffic egressing this VLAN. Fall back
         // to the device's src IP if the route did not carry one.
-        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
-
+        let inner_src_ip = next_hop.preferred_src_ip.unwrap_or(*src_ip);
         if !construct_vlan_packet(
-            &mut packet,
+            packet,
             &src_mac.0,
             &dest_mac.0,
-            inner_src_ip,
-            &dst_ip,
+            &inner_src_ip,
+            dst_ip,
             src_port,
-            addr.port(),
+            dst_port,
             vlan.vid,
             vlan.pcp,
             payload,
             ecn,
         ) {
             log::warn!("dropping packet: VLAN frame did not fit in UMEM slot");
-            umem.release(packet.into_frame());
-            return None;
-        }
-        frame = packet.into_frame();
-    } else {
-        // we need the MAC address to send the packet
-        let Some(dest_mac) = next_hop.mac_addr else {
-            log::warn!(
-                "dropping packet: peer {addr} must be routed through {} which has no known MAC \
-                 address",
-                next_hop.ip_addr
-            );
-            umem.release(frame);
-            return None;
-        };
-
-        let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
-        if l3_packet_len > next_hop.mtu as usize {
-            if !can_overflow_mtu {
-                log::warn!(
-                    "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} for {addr}",
-                    mtu = next_hop.mtu
-                );
-            }
-            umem.release(frame);
             return None;
         }
 
-        let packet_len = PACKET_HEADER_SIZE + len;
-        if packet_len > umem_frame_size {
-            log::warn!(
-                "dropping packet: packet size {packet_len} exceeds frame size {umem_frame_size} \
-                 for {addr}"
-            );
-            umem.release(frame);
-            return None;
-        }
-
-        frame.set_len(packet_len);
-        let mut packet = umem.map_frame_mut(frame);
-
-        if !construct_packet(
-            &mut packet,
-            &src_mac.0,
-            &dest_mac.0,
-            src_ip,
-            &dst_ip,
-            src_port,
-            addr.port(),
-            payload,
-            ecn,
-        ) {
-            log::warn!("dropping packet: frame did not fit in UMEM slot");
-            umem.release(packet.into_frame());
-            return None;
-        }
-        frame = packet.into_frame();
+        return Some(packet_len);
     }
 
-    Some(frame)
+    // we need the MAC address to send the packet
+    let Some(dest_mac) = next_hop.mac_addr else {
+        log::warn!(
+            "dropping packet: peer {addr} must be routed through {} which has no known MAC address",
+            next_hop.ip_addr
+        );
+        return None;
+    };
+
+    let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
+    if l3_packet_len > next_hop.mtu as usize {
+        if !allow_mtu_overflow {
+            log::warn!(
+                "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} for {addr}",
+                mtu = next_hop.mtu
+            );
+        }
+        return None;
+    }
+
+    let packet_len = PACKET_HEADER_SIZE + len;
+    if packet_len > umem_frame_size {
+        log::warn!(
+            "dropping packet: packet size {packet_len} exceeds frame size {umem_frame_size} for \
+             {addr}"
+        );
+        return None;
+    }
+
+    if !construct_packet(
+        packet,
+        &src_mac.0,
+        &dest_mac.0,
+        src_ip,
+        dst_ip,
+        src_port,
+        dst_port,
+        payload,
+        ecn,
+    ) {
+        log::warn!("dropping packet: frame did not fit in UMEM slot");
+        return None;
+    }
+
+    Some(packet_len)
+}
+
+#[inline(always)]
+fn release_completed<U: Umem>(umem: &U, completion: &mut TxCompletionRing) {
+    completion.sync(false);
+    while let Some(frame) = completion.read() {
+        umem.release_completed(frame);
+    }
+    completion.commit();
 }
 
 #[inline(always)]

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -382,8 +382,6 @@ impl<U: Umem> TxLoop<U> {
             };
 
             let src_addr = item.src_addr();
-            let src_ip = src_addr.ip();
-            let src_port = src_addr.port();
             let ecn = item.ecn();
             let can_overflow_mtu = item.allow_mtu_overflow();
             for addr in item.dst_addrs().as_ref() {
@@ -415,191 +413,23 @@ impl<U: Umem> TxLoop<U> {
 
                 // at this point we're guaranteed to have a frame to write the next packet into and
                 // a slot in the ring to submit it
-                let mut frame = umem.reserve().unwrap();
-                let IpAddr::V4(dst_ip) = addr.ip() else {
-                    panic!("IPv6 not supported");
-                };
-
-                let payload = item.payload().as_ref();
-                let len = payload.len();
-
-                let dst = addr.ip();
-                let Some(next_hop) = route_fn(&dst) else {
-                    log::warn!("dropping packet: no route for peer {addr}");
-                    umem.release(frame);
+                let frame = umem.reserve().unwrap();
+                let Some(frame) = build_packet(
+                    umem,
+                    PacketBuildParams {
+                        frame,
+                        src_mac: &src_mac,
+                        src_addr,
+                        dst_addr: addr,
+                        payload: item.payload().as_ref(),
+                        ecn,
+                        can_overflow_mtu,
+                        umem_frame_size,
+                    },
+                    &route_fn,
+                ) else {
                     continue;
                 };
-
-                if let Some(gre) = &next_hop.gre {
-                    let l3_inner_packet_len = INNER_PACKET_HEADER_SIZE + len;
-                    let l3_outer_gre_packet_len =
-                        IP_HEADER_SIZE + GRE_HEADER_BASE_SIZE + l3_inner_packet_len;
-
-                    if l3_inner_packet_len > gre.mtu as usize
-                        || l3_outer_gre_packet_len > next_hop.mtu as usize
-                    {
-                        if !can_overflow_mtu {
-                            log::warn!(
-                                "dropping packet: GRE payload exceeds MTU for {addr}: L3 inner \
-                                 packet length {l3_inner_packet_len}, L3 outer GRE packet length \
-                                 {l3_outer_gre_packet_len}, MTU: {mtu}, underlay_mtu: \
-                                 {underlay_mtu}.",
-                                mtu = gre.mtu,
-                                underlay_mtu = next_hop.mtu
-                            );
-                        }
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    let packet_len = gre_packet_size(len);
-                    if packet_len > umem_frame_size {
-                        log::warn!(
-                            "dropping packet: GRE packet size {packet_len} exceeds frame size \
-                             {umem_frame_size} for {addr}"
-                        );
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    frame.set_len(packet_len);
-                    let mut packet = umem.map_frame_mut(frame);
-                    let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
-                    if let Err(err) = construct_gre_packet(
-                        &mut packet,
-                        &src_mac,
-                        &gre.mac_addr,
-                        inner_src_ip,
-                        &dst_ip,
-                        src_port,
-                        addr.port(),
-                        payload,
-                        ecn,
-                        &gre.tunnel_info,
-                    ) {
-                        log::warn!("dropping packet: {err}");
-                        umem.release(packet.into_frame());
-                        continue;
-                    }
-                    frame = packet.into_frame();
-                } else if let Some(vlan) = &next_hop.vlan {
-                    // we need the MAC address to send the packet
-                    let Some(dest_mac) = next_hop.mac_addr else {
-                        log::warn!(
-                            "dropping packet: peer {addr} must be routed through {} which has no \
-                             known MAC address",
-                            next_hop.ip_addr
-                        );
-                        umem.release(frame);
-                        continue;
-                    };
-
-                    // The 802.1Q tag is added at L2, so the L3 size compared against the MTU
-                    // is the same as the untagged path.
-                    let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
-                    if l3_packet_len > next_hop.mtu as usize {
-                        if !can_overflow_mtu {
-                            log::warn!(
-                                "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} \
-                                 for {addr}",
-                                mtu = next_hop.mtu
-                            );
-                        }
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    let packet_len = VLAN_PACKET_HEADER_SIZE + len;
-                    if packet_len > umem_frame_size {
-                        log::warn!(
-                            "dropping packet: VLAN packet size {packet_len} exceeds frame size \
-                             {umem_frame_size} for {addr}"
-                        );
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    frame.set_len(packet_len);
-                    let mut packet = umem.map_frame_mut(frame);
-
-                    // The route's preferred src is the IP assigned to the VLAN sub-interface,
-                    // which is the right inner src for traffic egressing this VLAN. Fall back
-                    // to the device's src IP if the route did not carry one.
-                    let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
-
-                    if !construct_vlan_packet(
-                        &mut packet,
-                        &src_mac.0,
-                        &dest_mac.0,
-                        inner_src_ip,
-                        &dst_ip,
-                        src_port,
-                        addr.port(),
-                        vlan.vid,
-                        vlan.pcp,
-                        payload,
-                        ecn,
-                    ) {
-                        log::warn!("dropping packet: VLAN frame did not fit in UMEM slot");
-                        umem.release(packet.into_frame());
-                        continue;
-                    }
-                    frame = packet.into_frame();
-                } else {
-                    // we need the MAC address to send the packet
-                    let Some(dest_mac) = next_hop.mac_addr else {
-                        log::warn!(
-                            "dropping packet: peer {addr} must be routed through {} which has no \
-                             known MAC address",
-                            next_hop.ip_addr
-                        );
-                        umem.release(frame);
-                        continue;
-                    };
-
-                    let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
-                    if l3_packet_len > next_hop.mtu as usize {
-                        if !can_overflow_mtu {
-                            log::warn!(
-                                "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} \
-                                 for {addr}",
-                                mtu = next_hop.mtu
-                            );
-                        }
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    let packet_len = PACKET_HEADER_SIZE + len;
-                    if packet_len > umem_frame_size {
-                        log::warn!(
-                            "dropping packet: packet size {packet_len} exceeds frame size \
-                             {umem_frame_size} for {addr}"
-                        );
-                        umem.release(frame);
-                        continue;
-                    }
-
-                    frame.set_len(packet_len);
-                    let mut packet = umem.map_frame_mut(frame);
-
-                    if !construct_packet(
-                        &mut packet,
-                        &src_mac.0,
-                        &dest_mac.0,
-                        src_ip,
-                        &dst_ip,
-                        src_port,
-                        addr.port(),
-                        payload,
-                        ecn,
-                    ) {
-                        log::warn!("dropping packet: frame did not fit in UMEM slot");
-                        umem.release(packet.into_frame());
-                        continue;
-                    }
-                    frame = packet.into_frame();
-                }
 
                 ring.write(frame, 0)
                     .map_err(|_| "ring full")
@@ -638,6 +468,221 @@ impl<U: Umem> TxLoop<U> {
             kick(&ring);
         }
     }
+}
+
+struct PacketBuildParams<'a, F> {
+    frame: F,
+    src_mac: &'a MacAddress,
+    src_addr: SocketAddrV4,
+    dst_addr: &'a SocketAddr,
+    payload: &'a [u8],
+    ecn: Option<EcnCodepoint>,
+    can_overflow_mtu: bool,
+    umem_frame_size: usize,
+}
+
+#[inline]
+fn build_packet<U, R>(
+    umem: &U,
+    params: PacketBuildParams<'_, U::Frame>,
+    route_fn: &R,
+) -> Option<U::Frame>
+where
+    U: Umem,
+    R: Fn(&IpAddr) -> Option<NextHop>,
+{
+    let PacketBuildParams {
+        mut frame,
+        src_mac,
+        src_addr,
+        dst_addr: addr,
+        payload,
+        ecn,
+        can_overflow_mtu,
+        umem_frame_size,
+    } = params;
+    let src_ip = src_addr.ip();
+    let src_port = src_addr.port();
+    let IpAddr::V4(dst_ip) = addr.ip() else {
+        panic!("IPv6 not supported");
+    };
+
+    let len = payload.len();
+
+    let dst = addr.ip();
+    let Some(next_hop) = route_fn(&dst) else {
+        log::warn!("dropping packet: no route for peer {addr}");
+        umem.release(frame);
+        return None;
+    };
+
+    if let Some(gre) = &next_hop.gre {
+        let l3_inner_packet_len = INNER_PACKET_HEADER_SIZE + len;
+        let l3_outer_gre_packet_len = IP_HEADER_SIZE + GRE_HEADER_BASE_SIZE + l3_inner_packet_len;
+
+        if l3_inner_packet_len > gre.mtu as usize || l3_outer_gre_packet_len > next_hop.mtu as usize
+        {
+            if !can_overflow_mtu {
+                log::warn!(
+                    "dropping packet: GRE payload exceeds MTU for {addr}: L3 inner packet length \
+                     {l3_inner_packet_len}, L3 outer GRE packet length {l3_outer_gre_packet_len}, \
+                     MTU: {mtu}, underlay_mtu: {underlay_mtu}.",
+                    mtu = gre.mtu,
+                    underlay_mtu = next_hop.mtu
+                );
+            }
+            umem.release(frame);
+            return None;
+        }
+
+        let packet_len = gre_packet_size(len);
+        if packet_len > umem_frame_size {
+            log::warn!(
+                "dropping packet: GRE packet size {packet_len} exceeds frame size \
+                 {umem_frame_size} for {addr}"
+            );
+            umem.release(frame);
+            return None;
+        }
+
+        frame.set_len(packet_len);
+        let mut packet = umem.map_frame_mut(frame);
+        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
+        if let Err(err) = construct_gre_packet(
+            &mut packet,
+            src_mac,
+            &gre.mac_addr,
+            inner_src_ip,
+            &dst_ip,
+            src_port,
+            addr.port(),
+            payload,
+            ecn,
+            &gre.tunnel_info,
+        ) {
+            log::warn!("dropping packet: {err}");
+            umem.release(packet.into_frame());
+            return None;
+        }
+        frame = packet.into_frame();
+    } else if let Some(vlan) = &next_hop.vlan {
+        // we need the MAC address to send the packet
+        let Some(dest_mac) = next_hop.mac_addr else {
+            log::warn!(
+                "dropping packet: peer {addr} must be routed through {} which has no known MAC \
+                 address",
+                next_hop.ip_addr
+            );
+            umem.release(frame);
+            return None;
+        };
+
+        // The 802.1Q tag is added at L2, so the L3 size compared against the MTU
+        // is the same as the untagged path.
+        let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
+        if l3_packet_len > next_hop.mtu as usize {
+            if !can_overflow_mtu {
+                log::warn!(
+                    "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} for {addr}",
+                    mtu = next_hop.mtu
+                );
+            }
+            umem.release(frame);
+            return None;
+        }
+
+        let packet_len = VLAN_PACKET_HEADER_SIZE + len;
+        if packet_len > umem_frame_size {
+            log::warn!(
+                "dropping packet: VLAN packet size {packet_len} exceeds frame size \
+                 {umem_frame_size} for {addr}"
+            );
+            umem.release(frame);
+            return None;
+        }
+
+        frame.set_len(packet_len);
+        let mut packet = umem.map_frame_mut(frame);
+
+        // The route's preferred src is the IP assigned to the VLAN sub-interface,
+        // which is the right inner src for traffic egressing this VLAN. Fall back
+        // to the device's src IP if the route did not carry one.
+        let inner_src_ip = next_hop.preferred_src_ip.as_ref().unwrap_or(src_ip);
+
+        if !construct_vlan_packet(
+            &mut packet,
+            &src_mac.0,
+            &dest_mac.0,
+            inner_src_ip,
+            &dst_ip,
+            src_port,
+            addr.port(),
+            vlan.vid,
+            vlan.pcp,
+            payload,
+            ecn,
+        ) {
+            log::warn!("dropping packet: VLAN frame did not fit in UMEM slot");
+            umem.release(packet.into_frame());
+            return None;
+        }
+        frame = packet.into_frame();
+    } else {
+        // we need the MAC address to send the packet
+        let Some(dest_mac) = next_hop.mac_addr else {
+            log::warn!(
+                "dropping packet: peer {addr} must be routed through {} which has no known MAC \
+                 address",
+                next_hop.ip_addr
+            );
+            umem.release(frame);
+            return None;
+        };
+
+        let l3_packet_len = IP_HEADER_SIZE + UDP_HEADER_SIZE + len;
+        if l3_packet_len > next_hop.mtu as usize {
+            if !can_overflow_mtu {
+                log::warn!(
+                    "dropping packet: packet size {l3_packet_len} exceeds MTU {mtu} for {addr}",
+                    mtu = next_hop.mtu
+                );
+            }
+            umem.release(frame);
+            return None;
+        }
+
+        let packet_len = PACKET_HEADER_SIZE + len;
+        if packet_len > umem_frame_size {
+            log::warn!(
+                "dropping packet: packet size {packet_len} exceeds frame size {umem_frame_size} \
+                 for {addr}"
+            );
+            umem.release(frame);
+            return None;
+        }
+
+        frame.set_len(packet_len);
+        let mut packet = umem.map_frame_mut(frame);
+
+        if !construct_packet(
+            &mut packet,
+            &src_mac.0,
+            &dest_mac.0,
+            src_ip,
+            &dst_ip,
+            src_port,
+            addr.port(),
+            payload,
+            ecn,
+        ) {
+            log::warn!("dropping packet: frame did not fit in UMEM slot");
+            umem.release(packet.into_frame());
+            return None;
+        }
+        frame = packet.into_frame();
+    }
+
+    Some(frame)
 }
 
 #[inline(always)]

--- a/xdp/tests/transmitter_smoke.rs
+++ b/xdp/tests/transmitter_smoke.rs
@@ -358,8 +358,8 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
     );
     transmitter
         .sender()
-        .try_send(0, packet)
-        .expect("queue packet through XdpSender::try_send");
+        .send_timeout(0, packet, Duration::from_millis(5))
+        .expect("queue packet through XdpSender::send_timeout");
 
     let received = receiver
         .recv_matching_udp(
@@ -422,8 +422,8 @@ fn transmitter_sends_udp_payload_over_gre_tunnel_in_copy_mode() {
     );
     transmitter
         .sender()
-        .try_send(0, packet)
-        .expect("queue packet through XdpSender::try_send");
+        .send_timeout(0, packet, Duration::from_millis(5))
+        .expect("queue packet through XdpSender::send_timeout");
 
     let received = receiver
         .recv_matching_gre_udp(

--- a/xdp/tests/transmitter_smoke.rs
+++ b/xdp/tests/transmitter_smoke.rs
@@ -336,7 +336,7 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
     let payload = Bytes::from_static(b"agave-xdp-transmitter-smoke");
 
     let exit = Arc::new(AtomicBool::new(false));
-    let mut config = XdpConfig::new(
+    let config = XdpConfig::new(
         Some(common::LEFT_IFACE.to_string()),
         vec![QueueCpuBinding {
             queue: 0,
@@ -344,7 +344,6 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
         }],
         false,
     );
-    config.tx_channel_cap = 16;
 
     let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
         .expect("build copy-mode transmitter")
@@ -401,7 +400,7 @@ fn transmitter_sends_udp_payload_over_gre_tunnel_in_copy_mode() {
     let payload = Bytes::from_static(b"agave-xdp-transmitter-gre-smoke");
 
     let exit = Arc::new(AtomicBool::new(false));
-    let mut config = XdpConfig::new(
+    let config = XdpConfig::new(
         Some(common::LEFT_IFACE.to_string()),
         vec![QueueCpuBinding {
             queue: 0,
@@ -409,7 +408,6 @@ fn transmitter_sends_udp_payload_over_gre_tunnel_in_copy_mode() {
         }],
         false,
     );
-    config.tx_channel_cap = 16;
 
     let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
         .expect("build copy-mode transmitter")


### PR DESCRIPTION
This moves routing and packet building out from the hot XDP tx loop back to the threads that enqueue packets. This achieves two things: it removes expensive code from the hot tx loop AND moves it back to the code that enqueues packets, which happens from multiple threads, so scales better. 

The senders call `xdp_sender.send_timeout(packet, timeout)` and if a frame can't be acquired within the timeout, the send fails. This moves back pressure to the queues upstream of the code sending packets, as it should be. The exception is the quinn sender which must never block.