### PR TITLE
accounts-db: add AccountStorageEntry::num_tombstones()

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -186,8 +186,7 @@ impl AccountStorageEntry {
     /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
     /// (`tombstone_offsets`). Used for shrink-productivity accounting.
     pub(crate) fn num_zero_lamport_single_ref_accounts(&self) -> usize {
-        self.zero_lamport_single_ref_offsets.read().unwrap().len()
-            + self.tombstone_offsets.read().unwrap().len()
+        self.zero_lamport_single_ref_offsets.read().unwrap().len() + self.num_tombstones()
     }
 
     /// Batch-insert tombstone offsets.
@@ -203,10 +202,15 @@ impl AccountStorageEntry {
         self.tombstone_offsets.read().unwrap()
     }
 
+    /// Number of tombstone offsets in the storage.
+    pub(crate) fn num_tombstones(&self) -> usize {
+        self.tombstone_offsets.read().unwrap().len()
+    }
+
     /// True if every alive account in this storage is a tombstone. Such a storage holds no live
     /// index entries (tombstones were removed from the index when created), so it is fully dead.
     pub(crate) fn has_only_tombstones(&self) -> bool {
-        let num_tombstones = self.tombstone_offsets.read().unwrap().len();
+        let num_tombstones = self.num_tombstones();
         num_tombstones > 0 && self.count() == num_tombstones
     }
 

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1467,7 +1467,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
     );
 
     // it is recorded on the new storage's tombstone list, not the zero-lamport-single-ref list
-    assert_eq!(new_storage1.tombstone_offsets_read_lock().len(), 1);
+    assert_eq!(new_storage1.num_tombstones(), 1);
     assert!(
         new_storage1
             .zero_lamport_single_ref_offsets()


### PR DESCRIPTION
#### Problem
Getting the number of tombstones is a common operation, but there is no dedicated API

#### Summary of Changes
- Create One 

#### Testing
- NIL

Fixes #
