### PR TITLE
votor: send own votes to rewards

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -339,7 +339,7 @@ impl Tvu {
                 SigVerifierChannels {
                     packet_receiver: bls_packet_receiver,
                     channel_to_repair: verified_voter_slots_sender,
-                    channel_to_reward: reward_votes_sender,
+                    channel_to_reward: reward_votes_sender.clone(),
                     channel_to_pool: consensus_message_sender,
                     channel_to_metrics: consensus_metrics_sender.clone(),
                 },
@@ -519,6 +519,7 @@ impl Tvu {
             event_sender: votor_event_sender.clone(),
             latest_switch_request: latest_switch_request.clone(),
             own_vote_sender: own_message_sender.clone(),
+            reward_votes_sender,
             repair_event_sender,
             event_receiver: votor_event_receiver,
             consensus_message_receiver,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -964,6 +964,7 @@ mod tests {
         agave_votor_messages::{
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, ConsensusMessage, VoteMessage},
             metric_types::ConsensusMetricsEventReceiver,
+            reward_certificate::AddVoteMessage,
             vote::Vote,
             wire::get_vote_payload_to_sign,
         },
@@ -1002,6 +1003,8 @@ mod tests {
         bls_receiver: Receiver<BLSOp>,
         commitment_receiver: Receiver<CommitmentAggregationData>,
         own_vote_receiver: Receiver<ConsensusMessage>,
+        #[allow(dead_code)] // Keep receiver alive to prevent SenderDisconnected errors
+        reward_votes_receiver: Receiver<AddVoteMessage>,
         bank_forks: Arc<RwLock<BankForks>>,
         my_bls_keypair: BLSKeypair,
         timer_manager: Arc<PlRwLock<TimerManager>>,
@@ -1069,6 +1072,7 @@ mod tests {
         let (bls_sender, bls_receiver) = bounded(1024);
         let (commitment_sender, commitment_receiver) = bounded(1024);
         let (own_vote_sender, own_vote_receiver) = bounded(1024);
+        let (reward_votes_sender, reward_votes_receiver) = bounded(1024);
         let (drop_bank_sender, drop_bank_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
         let (event_sender, _event_receiver) = bounded(1024);
@@ -1151,6 +1155,7 @@ mod tests {
             authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(my_vote_keypair)])),
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
+            reward_votes_sender,
             consensus_metrics_sender,
         };
 
@@ -1172,6 +1177,7 @@ mod tests {
             bls_receiver,
             commitment_receiver,
             own_vote_receiver,
+            reward_votes_receiver,
             bank_forks,
             my_bls_keypair,
             timer_manager,

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -8,10 +8,11 @@ use {
     agave_votor_messages::{
         consensus_message::{BLS_KEYPAIR_DERIVE_SEED, ConsensusMessage, VoteMessage},
         metric_types::ConsensusMetricsEventSender,
+        reward_certificate::AddVoteMessage,
         vote::Vote,
         wire::get_vote_payload_to_sign,
     },
-    crossbeam_channel::{SendError, Sender},
+    crossbeam_channel::{SendError, Sender, TrySendError},
     solana_bls_signatures::{BlsError, keypair::Keypair as BLSKeypair},
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
@@ -104,6 +105,9 @@ pub enum VoteError {
     #[error("Unable to send to certificate pool")]
     ConsensusPoolError(#[from] SendError<()>),
 
+    #[error("Channel to rewards container disconnected")]
+    RewardsChannelDisconnected,
+
     #[error("Commitment sender error {0}")]
     CommitmentSenderError(#[from] CommitmentError),
 
@@ -121,6 +125,7 @@ pub struct VotingContext {
     // The BLS keypair should always change with authorized_voter_keypairs.
     pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
     pub own_vote_sender: Sender<ConsensusMessage>,
+    pub reward_votes_sender: Sender<AddVoteMessage>,
     pub bls_sender: Sender<BLSOp>,
     pub commitment_sender: Sender<CommitmentAggregationData>,
     pub wait_to_vote_slot: Option<u64>,
@@ -279,8 +284,8 @@ fn handle_skippable_vote_error(err: VoteError, action: &str) -> Result<(), VoteE
 
 /// Build a normal push-vote BLS op.
 ///
-/// This updates vote history, sends the vote to the certificate pool thread for ingestion, and
-/// saves vote history for persistence.
+/// This updates vote history, sends the vote to the certificate pool and reward service for
+/// ingestion, and saves vote history for persistence.
 pub fn insert_vote_and_create_bls_message(
     vote: Vote,
     context: &mut VotingContext,
@@ -322,6 +327,18 @@ pub(crate) fn create_and_send_own_vote_message(
         .send(ConsensusMessage::Vote(vote_msg.clone()))
         .map_err(|_| SendError(()))?;
 
+    match context.reward_votes_sender.try_send(AddVoteMessage {
+        votes: vec![vote_msg.clone()],
+    }) {
+        Ok(()) => (),
+        Err(TrySendError::Full(_)) => {
+            warn!("Reward votes channel is full, dropping own vote {vote:?}");
+        }
+        Err(TrySendError::Disconnected(_)) => {
+            return Err(VoteError::RewardsChannelDisconnected);
+        }
+    }
+
     Ok(Some(vote_msg))
 }
 
@@ -343,7 +360,7 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::consensus_message::Block,
-        crossbeam_channel::bounded,
+        crossbeam_channel::{Receiver, bounded},
         solana_gossip::contact_info::ContactInfo,
         solana_hash::Hash,
         solana_net_utils::SocketAddrSpace,
@@ -376,20 +393,25 @@ mod tests {
         own_vote_sender: Sender<ConsensusMessage>,
         validator_keypairs: &[ValidatorVoteKeypairs],
         my_index: usize,
-    ) -> VotingContext {
-        let (voting_context, _) = setup_voting_context_and_bank_forks_with_forks(
-            own_vote_sender,
-            validator_keypairs,
-            my_index,
-        );
-        voting_context
+    ) -> (VotingContext, Receiver<AddVoteMessage>) {
+        let (voting_context, _, reward_votes_receiver) =
+            setup_voting_context_and_bank_forks_with_forks(
+                own_vote_sender,
+                validator_keypairs,
+                my_index,
+            );
+        (voting_context, reward_votes_receiver)
     }
 
     fn setup_voting_context_and_bank_forks_with_forks(
         own_vote_sender: Sender<ConsensusMessage>,
         validator_keypairs: &[ValidatorVoteKeypairs],
         my_index: usize,
-    ) -> (VotingContext, Arc<RwLock<BankForks>>) {
+    ) -> (
+        VotingContext,
+        Arc<RwLock<BankForks>>,
+        Receiver<AddVoteMessage>,
+    ) {
         // Can't have stake of 0, so start at 1 and go to 10. In descending order, so 0 has largest stake.
         let stakes: Vec<u64> = (1u64..=10).rev().map(|x| x.saturating_mul(100)).collect();
         let genesis = create_genesis_config_with_alpenglow_vote_accounts(
@@ -411,6 +433,7 @@ mod tests {
         let bls_sender = bounded(1024).0;
         let commitment_sender = bounded(1024).0;
         let consensus_metrics_sender = bounded(1024).0;
+        let (reward_votes_sender, reward_votes_receiver) = bounded(1024);
         let voting_context = VotingContext {
             cluster_info,
             vote_history: VoteHistory::new(my_keys.node_keypair.pubkey(), 0),
@@ -421,13 +444,14 @@ mod tests {
             )])),
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
+            reward_votes_sender,
             bls_sender,
             commitment_sender,
             wait_to_vote_slot: None,
             sharable_banks,
             consensus_metrics_sender,
         };
-        (voting_context, bank_forks)
+        (voting_context, bank_forks, reward_votes_receiver)
     }
 
     #[test]
@@ -438,7 +462,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
         let my_bls_keypair = BLSKeypair::derive_from_signer(
             &validator_keypairs[my_index].vote_keypair,
@@ -487,6 +511,12 @@ mod tests {
             ConsensusMessage::Vote(expected_message.clone())
         );
 
+        // Check that the reward service receives the vote.
+        assert_eq!(
+            reward_votes_receiver.recv().unwrap().votes,
+            vec![expected_message.clone()]
+        );
+
         let refresh_vote = Vote::new_notarization_vote(Block {
             slot: vote_slot,
             block_id,
@@ -498,6 +528,7 @@ mod tests {
         assert_eq!(refresh_result.vote.slot(), vote_slot);
         assert_eq!(refresh_result, expected_message);
         assert!(own_vote_receiver.try_recv().is_err());
+        assert!(reward_votes_receiver.try_recv().is_err());
     }
 
     #[test]
@@ -508,7 +539,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, _reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
         // If we haven't reached wait_to_vote_slot yet, return Ok(None)
@@ -537,7 +568,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, _reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
         // Empty authorized voter keypairs to simulate non voting node
@@ -576,7 +607,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, _reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
         // Wrong identity keypair should return HotSpare based on rank_map.node_pubkey.
@@ -608,7 +639,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, _reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
         // Wrong vote account pubkey
@@ -642,7 +673,7 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let mut voting_context =
+        let (mut voting_context, _reward_votes_receiver) =
             setup_voting_context_and_bank_forks(own_vote_sender, &validator_keypairs, my_index);
 
         // If we try to vote for a slot in the future, we should panic
@@ -662,11 +693,12 @@ mod tests {
             .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
             .collect::<Vec<_>>();
         let my_index = 0;
-        let (mut voting_context, bank_forks) = setup_voting_context_and_bank_forks_with_forks(
-            own_vote_sender,
-            &validator_keypairs,
-            my_index,
-        );
+        let (mut voting_context, bank_forks, _reward_votes_receiver) =
+            setup_voting_context_and_bank_forks_with_forks(
+                own_vote_sender,
+                &validator_keypairs,
+                my_index,
+            );
 
         // Set the stake of my_index to 0 in epoch 2
         // For epoch 2, make validator my_index to be zero stake, others have stake in ascending order, 1 < 2 < ... < 9

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -66,6 +66,7 @@ use {
     agave_votor_messages::{
         consensus_message::{Block, ConsensusMessage},
         metric_types::{ConsensusMetricsEventReceiver, ConsensusMetricsEventSender},
+        reward_certificate::AddVoteMessage,
     },
     crossbeam_channel::{Receiver, Sender},
     parking_lot::RwLock as PlRwLock,
@@ -115,6 +116,7 @@ pub struct VotorConfig {
     pub highest_parent_ready: Arc<RwLock<(Slot, Block)>>,
     pub event_sender: VotorEventSender,
     pub own_vote_sender: Sender<ConsensusMessage>,
+    pub reward_votes_sender: Sender<AddVoteMessage>,
     pub repair_event_sender: RepairEventSender,
     pub latest_switch_request: LatestSwitchRequest,
 
@@ -164,6 +166,7 @@ impl Votor {
             highest_parent_ready,
             event_sender,
             own_vote_sender,
+            reward_votes_sender,
             repair_event_sender,
             latest_switch_request,
             event_receiver,
@@ -202,6 +205,7 @@ impl Votor {
             authorized_voter_keypairs,
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
+            reward_votes_sender,
             bls_sender: bls_sender.clone(),
             commitment_sender: commitment_sender.clone(),
             wait_to_vote_slot,


### PR DESCRIPTION
#### Problem
A leader does not send their own vote to the rewards service.
This means they will never pack their own vote into the rewards aggregate.

#### Summary of Changes
Send it to the rewards service

#### Testing
CI

Fixes #13790