### PR TITLE
Cleanup SIMD-406

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -178,7 +178,6 @@ fn simulate_transaction(
         Some(false), // is_simple_vote_tx
         bank,
         bank.get_reserved_account_keys(),
-        bank.feature_set.snapshot().limit_instruction_accounts,
     ) {
         Err(err) => {
             return BanksTransactionResultWithSimulation {

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -505,7 +505,6 @@ pub(crate) mod external {
                 Self::parse_transactions_and_populate_initial_check_responses(
                     message,
                     &batch,
-                    &root_bank,
                     responses_ptr,
                 )
             };
@@ -776,15 +775,13 @@ pub(crate) mod external {
         unsafe fn parse_transactions_and_populate_initial_check_responses<'a>(
             message: &PackToWorkerMessage,
             batch: &TransactionPtrBatch,
-            bank: &Bank,
             responses_ptr: NonNull<CheckResponse>,
         ) -> (
             ArrayVec<Result<(), TransactionViewError>, MAX_TRANSACTIONS_PER_MESSAGE>,
             ArrayVec<TxView, MAX_TRANSACTIONS_PER_MESSAGE>,
             &'a mut [CheckResponse],
         ) {
-            let sanitize_config =
-                sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
+            let sanitize_config = sanitize_config();
             let mut parsing_results = ArrayVec::new();
             let mut parsed_transactions = ArrayVec::new();
             for (tx_ptr, _) in batch.iter() {
@@ -977,8 +974,7 @@ pub(crate) mod external {
             ArrayVec<Tx, MAX_TRANSACTIONS_PER_MESSAGE>,
             ArrayVec<MaxAge, MAX_TRANSACTIONS_PER_MESSAGE>,
         ) {
-            let sanitize_config =
-                sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
+            let sanitize_config = sanitize_config();
             let transaction_account_lock_limit = bank.get_transaction_account_lock_limit();
 
             let mut translation_results = ArrayVec::new();
@@ -1455,7 +1451,7 @@ pub(crate) mod external {
                         &simple_tx[..],
                         &bank,
                         bank.get_transaction_account_lock_limit(),
-                        &sanitize_config(true),
+                        &sanitize_config(),
                     )
                     .ok()
                     .unwrap()
@@ -1643,10 +1639,8 @@ pub(crate) mod external {
 
             let parsing_results = [Ok(()), Err(TransactionViewError::ParseError), Ok(())];
             let parsed_transactions = [
-                SanitizedTransactionView::try_new_sanitized(&tx1[..], &sanitize_config(true))
-                    .unwrap(),
-                SanitizedTransactionView::try_new_sanitized(&tx2[..], &sanitize_config(true))
-                    .unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx1[..], &sanitize_config()).unwrap(),
+                SanitizedTransactionView::try_new_sanitized(&tx2[..], &sanitize_config()).unwrap(),
             ];
             bank.store_account(
                 &parsed_transactions[1].static_account_keys()[0],
@@ -1696,7 +1690,7 @@ pub(crate) mod external {
             ) -> RuntimeTransaction<ResolvedTransactionView<&'_ [u8]>> {
                 RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
                     RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
-                        SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true))
+                        SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config())
                             .unwrap(),
                         solana_transaction::sanitized::MessageHash::Compute,
                         Some(false),
@@ -3300,7 +3294,6 @@ mod tests {
                 None,
                 loader,
                 &HashSet::default(),
-                bank.feature_set.snapshot().limit_instruction_accounts,
             )
             .unwrap()
         };

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1429,7 +1429,6 @@ mod tests {
             Some(false),
             bank.as_ref(),
             &ReservedAccountKeys::empty_key_set(),
-            bank.feature_set.snapshot().limit_instruction_accounts,
         )
         .unwrap();
         let batch_transactions_inner = [&sanitized_tx]

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -108,7 +108,7 @@ impl LatestValidatorVote {
 
         let vote = SanitizedTransactionView::try_new_sanitized(
             std::sync::Arc::new(packet.data(..).unwrap().to_vec()),
-            &solana_runtime_transaction::sanitize_config::sanitize_config(true),
+            &solana_runtime_transaction::sanitize_config::sanitize_config(),
         )
         .unwrap();
 

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -247,8 +247,7 @@ impl TransactionViewReceiveAndBuffer {
         // If outside holding window, do not parse.
         let should_parse = !matches!(decision, BufferedPacketsDecision::Forward);
 
-        let sanitize_config =
-            sanitize_config(root_bank.feature_set.snapshot().limit_instruction_accounts);
+        let sanitize_config = sanitize_config();
         let transaction_account_lock_limit = working_bank.get_transaction_account_lock_limit();
 
         // Create temporary batches of transactions to be age-checked.

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -487,7 +487,7 @@ mod tests {
         let reserved_addresses = HashSet::default();
         let packet_parser = |data, priority, cost| {
             let view =
-                SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true)).unwrap();
+                SanitizedTransactionView::try_new_sanitized(data, &sanitize_config()).unwrap();
             let view = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 view,
                 MessageHash::Compute,

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -81,7 +81,7 @@ impl VotePacketReceiver {
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) -> Result<(), RecvTimeoutError> {
         let start = Instant::now();
-        let sanitize_config = sanitize_config(true);
+        let sanitize_config = sanitize_config();
         let mut stats = ReceiveAndBufferStats::default();
 
         let packet_batch = self.banking_packet_receiver.recv_timeout(recv_timeout)?;

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -514,7 +514,7 @@ pub(crate) mod tests {
     fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
         SanitizedTransactionView::try_new_sanitized(
             Arc::new(packet.buffer().to_vec()),
-            &sanitize_config(true),
+            &sanitize_config(),
         )
         .unwrap()
     }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -266,8 +266,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
         is_tpu_vote_batch: bool,
         bank: &Bank,
     ) {
-        let sanitize_config =
-            sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
+        let sanitize_config = sanitize_config();
         for packet in packet_batch
             .iter()
             .filter(|p| initial_packet_meta_filter(p.meta()))

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -71,8 +71,7 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
 /// Returns `None` if the bytes don't parse as a valid transaction, in which
 /// case the caller should leave the packet to downstream stages to reject.
 pub(crate) fn calculate_priority_from_bytes(bank: &Bank, data: &[u8]) -> Option<u64> {
-    let config = sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts);
-    let view = SanitizedTransactionView::try_new_sanitized(data, &config).ok()?;
+    let view = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config()).ok()?;
     let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
         view,
         MessageHash::Compute,
@@ -175,11 +174,8 @@ mod tests {
 
         let from_bytes = priority_from(&bank, &bytes);
 
-        let view = SanitizedTransactionView::try_new_sanitized(
-            &bytes[..],
-            &sanitize_config(bank.feature_set.snapshot().limit_instruction_accounts),
-        )
-        .unwrap();
+        let view =
+            SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config()).unwrap();
         let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
             view,
             MessageHash::Compute,

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -324,7 +324,6 @@ mod tests {
             Some(true),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
-            true,
         )
         .unwrap();
 
@@ -379,7 +378,6 @@ mod tests {
             Some(false),
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
-            true,
         )
         .unwrap();
 

--- a/entry/benches/verify_signatures.rs
+++ b/entry/benches/verify_signatures.rs
@@ -36,7 +36,6 @@ fn build_unverified_signatures(num_transactions: usize) -> UnverifiedSignatures 
             None,
             SimpleAddressLoader::Disabled,
             &ReservedAccountKeys::empty_key_set(),
-            true,
         )
     };
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -694,7 +694,6 @@ mod tests {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
-                    true,
                 )
             }
         };
@@ -727,7 +726,6 @@ mod tests {
                     None,
                     SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
-                    true,
                 )
             };
         let txs =

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1442,6 +1442,10 @@ pub mod remove_simple_vote_from_cost_model {
     solana_pubkey::declare_id!("2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a");
 }
 
+pub mod limit_instruction_accounts {
+    solana_pubkey::declare_id!("6aHuNsUmwSzCEMjrBzBCYaxHAyAcQBjVES92JigHBDuC");
+}
+
 pub mod block_revenue_sharing {
     solana_pubkey::declare_id!("B1ockRevenueSharing111111111111111111111111");
 }
@@ -2551,6 +2555,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             remove_simple_vote_from_cost_model::id(),
             "stop use static SimpleVote transaction cost, issue #10227",
+        ),
+        (
+            limit_instruction_accounts::id(),
+            "SIMD-0406: Maximum instruction accounts",
         ),
         (
             block_revenue_sharing::id(),

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -72,7 +72,6 @@ pub struct FeatureSnapshot {
     pub set_lamports_per_byte_to_5080: bool,
     pub set_lamports_per_byte_to_2575: bool,
     pub set_lamports_per_byte_to_1322: bool,
-    pub limit_instruction_accounts: bool,
     pub block_revenue_sharing: bool,
     pub vote_account_initialize_v2: bool,
     pub validator_admission_ticket: bool,
@@ -173,7 +172,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             set_lamports_per_byte_to_5080: is_active(&set_lamports_per_byte_to_5080::ID),
             set_lamports_per_byte_to_2575: is_active(&set_lamports_per_byte_to_2575::ID),
             set_lamports_per_byte_to_1322: is_active(&set_lamports_per_byte_to_1322::ID),
-            limit_instruction_accounts: is_active(&limit_instruction_accounts::ID),
             block_revenue_sharing: is_active(&block_revenue_sharing::ID),
             vote_account_initialize_v2: is_active(&vote_account_initialize_v2::ID),
             validator_admission_ticket: is_active(&validator_admission_ticket::ID),
@@ -1444,10 +1442,6 @@ pub mod remove_simple_vote_from_cost_model {
     solana_pubkey::declare_id!("2GCrNXbzmt4xrwdcKS2RdsLzsgu4V5zHAemW57pcHT6a");
 }
 
-pub mod limit_instruction_accounts {
-    solana_pubkey::declare_id!("6aHuNsUmwSzCEMjrBzBCYaxHAyAcQBjVES92JigHBDuC");
-}
-
 pub mod block_revenue_sharing {
     solana_pubkey::declare_id!("B1ockRevenueSharing111111111111111111111111");
 }
@@ -2557,10 +2551,6 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             remove_simple_vote_from_cost_model::id(),
             "stop use static SimpleVote transaction cost, issue #10227",
-        ),
-        (
-            limit_instruction_accounts::id(),
-            "SIMD-0406: Maximum instruction accounts",
         ),
         (
             block_revenue_sharing::id(),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -468,7 +468,6 @@ fn compute_slot_cost(
                     None,
                     SimpleAddressLoader::Disabled,
                     &reserved_account_keys.active,
-                    feature_set.snapshot().limit_instruction_accounts,
                 )
                 .map_err(|err| {
                     warn!("Failed to compute cost of transaction: {err:?}");

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -28,8 +28,7 @@ fn verify_packet(packet: &mut PacketRefMut, reject_non_vote: bool, enable_tx_v1:
     };
 
     let (is_simple_vote_tx, verified) = {
-        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config(true))
-        else {
+        let Ok(view) = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config()) else {
             return false;
         };
 
@@ -606,7 +605,7 @@ mod tests {
             let packet = BytesPacket::from_data(tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                &sanitize_config(true),
+                &sanitize_config(),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -619,7 +618,7 @@ mod tests {
             let packet = BytesPacket::from_data(tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                &sanitize_config(true),
+                &sanitize_config(),
             )
             .unwrap();
             assert!(is_simple_vote_transaction_view(&view));
@@ -632,7 +631,7 @@ mod tests {
 
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                &sanitize_config(true),
+                &sanitize_config(),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -657,7 +656,7 @@ mod tests {
             let packet = BytesPacket::from_data(tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                &sanitize_config(true),
+                &sanitize_config(),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));
@@ -672,7 +671,7 @@ mod tests {
             let packet = BytesPacket::from_data(tx).unwrap();
             let view = SanitizedTransactionView::try_new_sanitized(
                 packet.as_ref().data(..).unwrap(),
-                &sanitize_config(true),
+                &sanitize_config(),
             )
             .unwrap();
             assert!(!is_simple_vote_transaction_view(&view));

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3896,10 +3896,6 @@ pub mod rpc_full {
                 unsanitized_tx,
                 preflight_bank,
                 preflight_bank.get_reserved_account_keys(),
-                preflight_bank
-                    .feature_set
-                    .snapshot()
-                    .limit_instruction_accounts,
             )?;
             let blockhash = *transaction.message().recent_blockhash();
             let message_hash = *transaction.message_hash();
@@ -4057,12 +4053,8 @@ pub mod rpc_full {
                 });
             }
 
-            let transaction = sanitize_transaction(
-                unsanitized_tx,
-                bank,
-                bank.get_reserved_account_keys(),
-                bank.feature_set.snapshot().limit_instruction_accounts,
-            )?;
+            let transaction =
+                sanitize_transaction(unsanitized_tx, bank, bank.get_reserved_account_keys())?;
 
             let verification_error = if sig_verify {
                 transaction.verify().err()
@@ -4480,7 +4472,6 @@ fn sanitize_transaction(
     transaction: VersionedTransaction,
     address_loader: impl AddressLoader,
     reserved_account_keys: &HashSet<Pubkey>,
-    enable_instruction_accounts_limit: bool,
 ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
     RuntimeTransaction::try_create(
         transaction,
@@ -4488,7 +4479,6 @@ fn sanitize_transaction(
         None,
         address_loader,
         reserved_account_keys,
-        enable_instruction_accounts_limit,
     )
     .map_err(|err| Error::invalid_params(format!("invalid transaction: {err}")))
 }
@@ -9382,7 +9372,6 @@ pub mod tests {
                 unsanitary_versioned_tx,
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
-                true,
             )
             .unwrap_err(),
             expect58
@@ -9408,7 +9397,6 @@ pub mod tests {
                 versioned_tx,
                 SimpleAddressLoader::Disabled,
                 &ReservedAccountKeys::empty_key_set(),
-                true,
             )
             .unwrap_err(),
             Error::invalid_params(

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -81,7 +81,6 @@ impl RuntimeTransaction<SanitizedTransaction> {
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
         reserved_account_keys: &HashSet<Pubkey>,
-        enable_instruction_accounts_limit: bool,
     ) -> Result<Self> {
         if tx.message.instructions().len()
             > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
@@ -89,11 +88,9 @@ impl RuntimeTransaction<SanitizedTransaction> {
             return Err(solana_transaction_error::TransactionError::SanitizeFailure);
         }
 
-        if enable_instruction_accounts_limit {
-            for instr in tx.message.instructions() {
-                if instr.accounts.len() > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION {
-                    return Err(solana_transaction_error::TransactionError::SanitizeFailure);
-                }
+        for instr in tx.message.instructions() {
+            if instr.accounts.len() > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION {
+                return Err(solana_transaction_error::TransactionError::SanitizeFailure);
             }
         }
 
@@ -158,14 +155,12 @@ impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
 impl RuntimeTransaction<SanitizedTransaction> {
     pub fn from_transaction_for_tests(transaction: solana_transaction::Transaction) -> Self {
         let versioned_transaction = VersionedTransaction::from(transaction);
-        let enable_instruction_accounts_limit = true;
         Self::try_create(
             versioned_transaction,
             MessageHash::Compute,
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
-            enable_instruction_accounts_limit,
         )
         .expect("failed to create RuntimeTransaction from Transaction")
     }
@@ -426,7 +421,6 @@ mod tests {
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
-            true,
         );
         assert!(result.is_ok());
 
@@ -448,7 +442,6 @@ mod tests {
             None,
             solana_message::SimpleAddressLoader::Disabled,
             &HashSet::new(),
-            true,
         );
         assert_eq!(
             result.err(),

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -282,7 +282,7 @@ mod tests {
         let hash = Hash::new_unique();
         let transaction = SanitizedTransactionView::try_new_sanitized(
             &serialized_transaction[..],
-            &sanitize_config(true),
+            &sanitize_config(),
         )
         .unwrap();
         let static_runtime_transaction =
@@ -317,7 +317,7 @@ mod tests {
         ) {
             let bytes = wincode::serialize(&original_transaction).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config(true))
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config())
                     .unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
@@ -385,7 +385,7 @@ mod tests {
             let bytes =
                 wincode::serialize(&original_transaction.to_versioned_transaction()).unwrap();
             let transaction_view =
-                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config(true))
+                SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config())
                     .unwrap();
             let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 transaction_view,
@@ -475,7 +475,7 @@ mod tests {
             .unwrap();
         let transaction_view = SanitizedTransactionView::try_new_sanitized(
             &serialized_transaction[..],
-            &sanitize_config(true),
+            &sanitize_config(),
         )
         .unwrap();
         let runtime_transaction = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(

--- a/runtime-transaction/src/sanitize_config.rs
+++ b/runtime-transaction/src/sanitize_config.rs
@@ -11,15 +11,11 @@ use {
 };
 
 /// Returns the [`SanitizeConfig`] with current protocol limits.
-///
-/// `enable_instruction_accounts_limit` should reflect the
-/// `limit_instruction_accounts` (SIMD-406) feature activation.
-pub fn sanitize_config(enable_instruction_accounts_limit: bool) -> SanitizeConfig {
+pub fn sanitize_config() -> SanitizeConfig {
     SanitizeConfig {
         min_requested_heap_size: MIN_HEAP_FRAME_BYTES,
         max_requested_heap_size: MAX_HEAP_FRAME_BYTES,
         max_instructions: MAX_INSTRUCTION_TRACE_LENGTH,
-        max_accounts_per_instruction: enable_instruction_accounts_limit
-            .then_some(MAX_ACCOUNTS_PER_INSTRUCTION),
+        max_accounts_per_instruction: MAX_ACCOUNTS_PER_INSTRUCTION,
     }
 }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3677,8 +3677,6 @@ impl Bank {
         &self,
         txs: Vec<VersionedTransaction>,
     ) -> Result<TransactionBatch<'_, '_, RuntimeTransaction<SanitizedTransaction>>> {
-        let enable_instruction_account_limit =
-            self.feature_set.snapshot().limit_instruction_accounts;
         let sanitized_txs = txs
             .into_iter()
             .map(|tx| {
@@ -3688,7 +3686,6 @@ impl Bank {
                     None,
                     self,
                     self.get_reserved_account_keys(),
-                    enable_instruction_account_limit,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -3798,13 +3795,9 @@ impl Bank {
             // no writable keys are reserved.
             self.check_reserved_keys(transaction)?;
 
-            if self.feature_set.snapshot().limit_instruction_accounts {
-                for instr in transaction.instructions_iter() {
-                    if instr.accounts.len()
-                        > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION
-                    {
-                        return Err(solana_transaction_error::TransactionError::SanitizeFailure);
-                    }
+            for instr in transaction.instructions_iter() {
+                if instr.accounts.len() > solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION {
+                    return Err(solana_transaction_error::TransactionError::SanitizeFailure);
                 }
             }
         }
@@ -5557,9 +5550,6 @@ impl Bank {
             _ => PACKET_DATA_SIZE,
         } as u64;
 
-        let enable_instruction_account_limit =
-            self.feature_set.snapshot().limit_instruction_accounts;
-
         // WARNING: Any pending features added here most likely must also be checked in
         //          `Bank::resanitize_transaction_minimally`.
         let sanitized_tx = {
@@ -5589,7 +5579,6 @@ impl Bank {
                 None,
                 self,
                 self.get_reserved_account_keys(),
-                enable_instruction_account_limit,
             )
         }?;
 

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -619,7 +619,6 @@ mod tests {
             None,
             address_loader,
             &ReservedAccountKeys::empty_key_set(),
-            true,
         );
         rt.unwrap()
     }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9116,15 +9116,11 @@ fn test_verify_transactions_instruction_limit() {
     );
 }
 
-#[test_case(false; "pre_simd406_limit_instruction_accounts")]
-#[test_case(true; "simd406_limit_instruction_accounts")]
-fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
+#[test]
+fn test_verify_transactions_accounts_limit() {
     let GenesisConfigInfo { genesis_config, .. } =
         create_genesis_config_with_leader(42, &solana_pubkey::new_rand(), 42);
-    let mut bank = Bank::new_for_tests(&genesis_config);
-    if !simd_406_enabled {
-        bank.deactivate_feature(&feature_set::limit_instruction_accounts::id());
-    }
+    let bank = Bank::new_for_tests(&genesis_config);
 
     let recent_blockhash = Hash::new_unique();
     let keypair = Keypair::new();
@@ -9148,17 +9144,10 @@ fn test_verify_transactions_accounts_limit(simd_406_enabled: bool) {
     );
     let tx = Transaction::new(&[&keypair], message, recent_blockhash);
 
-    if simd_406_enabled {
-        assert_matches!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure)
-        );
-    } else {
-        assert!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .is_ok()
-        );
-    }
+    assert_matches!(
+        bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+        Err(TransactionError::SanitizeFailure)
+    );
 }
 
 #[test]

--- a/runtime/src/conformance/cost.rs
+++ b/runtime/src/conformance/cost.rs
@@ -58,7 +58,6 @@ fn runtime_transaction_from_proto(
         None,
         SimpleAddressLoader::Disabled,
         &std::collections::HashSet::new(),
-        true,
     )
     .expect("failed to create RuntimeTransaction")
 }

--- a/scheduling-utils/src/bridge/bindings.rs
+++ b/scheduling-utils/src/bridge/bindings.rs
@@ -165,7 +165,7 @@ where
         let tx = unsafe { TransactionPtr::from_raw_parts(ptr, tx.len()) };
 
         // Sanitize the transaction, drop it immediately if it fails sanitization.
-        match SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true)) {
+        match SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config()) {
             Ok(tx) => {
                 let key = self.state.insert(TransactionState {
                     dead: false,
@@ -255,8 +255,7 @@ where
             };
 
             // Sanitize the transaction, drop it immediately if it fails sanitization.
-            let Ok(tx) = SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config(true))
-            else {
+            let Ok(tx) = SanitizedTransactionView::try_new_sanitized(tx, &sanitize_config()) else {
                 // SAFETY:
                 // - We own `tx` exclusively.
                 // - The previous `TransactionPtr` has been dropped by `try_new_sanitized`.

--- a/transaction-view/benches/transaction_view.rs
+++ b/transaction-view/benches/transaction_view.rs
@@ -27,7 +27,7 @@ const SANITIZE_CONFIG: SanitizeConfig = SanitizeConfig {
     min_requested_heap_size: 32 * 1024,
     max_requested_heap_size: 256 * 1024,
     max_instructions: 64,
-    max_accounts_per_instruction: Some(255),
+    max_accounts_per_instruction: 255,
 };
 
 fn serialize_transactions(transactions: Vec<VersionedTransaction>) -> Vec<Vec<u8>> {

--- a/transaction-view/src/resolved_transaction_view.rs
+++ b/transaction-view/src/resolved_transaction_view.rs
@@ -277,7 +277,7 @@ mod tests {
             min_requested_heap_size: 32 * 1024,
             max_requested_heap_size: 256 * 1024,
             max_instructions: 64,
-            max_accounts_per_instruction: Some(255),
+            max_accounts_per_instruction: 255,
         }
     }
 

--- a/transaction-view/src/sanitize.rs
+++ b/transaction-view/src/sanitize.rs
@@ -19,8 +19,7 @@ pub struct SanitizeConfig {
     /// SIMD-160: maximum number of top-level instructions.
     pub max_instructions: usize,
     /// SIMD-406: maximum number of accounts per instruction.
-    /// `None` means the limit is not enforced.
-    pub max_accounts_per_instruction: Option<usize>,
+    pub max_accounts_per_instruction: usize,
 }
 
 pub(crate) fn sanitize(
@@ -178,9 +177,7 @@ fn sanitize_instructions(
             }
         }
 
-        if let Some(max_accounts_per_instruction) = config.max_accounts_per_instruction
-            && instruction.accounts.len() > max_accounts_per_instruction
-        {
+        if instruction.accounts.len() > config.max_accounts_per_instruction {
             return Err(TransactionViewError::SanitizeError);
         }
     }
@@ -233,7 +230,7 @@ mod tests {
             min_requested_heap_size: 32 * 1024,
             max_requested_heap_size: 256 * 1024,
             max_instructions: 64,
-            max_accounts_per_instruction: Some(255),
+            max_accounts_per_instruction: 255,
         }
     }
 


### PR DESCRIPTION
#### Problem

SIMD-406 (feature `6aHuNsUmwSzCEMjrBzBCYaxHAyAcQBjVES92JigHBDuC`) was activated on main net in epoch 1000.

#### Summary of Changes

Remove feature gate, and clean up related usages.

#### Testing

I adapted the necessary test to not test the deactivated feature anymore.
