### PR TITLE
Refactor - isolate completed replay accounting

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -233,6 +233,15 @@ struct BankReplayResultTracker {
     bank_replay_tracker: Option<BankReplayTracker>,
 }
 
+struct CompletedBankReplay {
+    // Metrics around replaying this bank.
+    replay_stats: Arc<RwLock<ReplaySlotStats>>,
+    // Accounting around replaying this bank.
+    replay_progress: Arc<RwLock<ConfirmationProgress>>,
+    // True when the bank completed via the unified scheduler path.
+    is_unified_scheduler_enabled: bool,
+}
+
 struct ProcessActiveBanksContext {
     bank_forks: Arc<RwLock<BankForks>>,
     blockstore: Arc<Blockstore>,
@@ -3807,6 +3816,92 @@ impl ReplayStage {
         }
     }
 
+    fn complete_scheduler_replay(
+        bank: &BankWithScheduler,
+        replay_stats: &RwLock<ReplaySlotStats>,
+    ) -> (Result<(), BlockstoreProcessorError>, bool) {
+        let Some((result, completed_execute_timings)) = bank.wait_for_completed_scheduler() else {
+            return (Ok(()), false);
+        };
+
+        let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
+            completed_execute_timings,
+        );
+        replay_stats
+            .write()
+            .unwrap()
+            .batch_execute
+            .accumulate(metrics, true);
+
+        (
+            result.map_err(BlockstoreProcessorError::InvalidTransaction),
+            true,
+        )
+    }
+
+    fn complete_replay_verification(
+        replay_stats: &RwLock<ReplaySlotStats>,
+        replay_progress: &RwLock<ConfirmationProgress>,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<(), BlockstoreProcessorError> {
+        let mut poh_verify_elapsed = 0;
+        let mut tx_verify_elapsed = 0;
+        let (verify_result, async_verification) = {
+            let mut replay_progress = replay_progress.write().unwrap();
+            (
+                replay_progress.wait_for_all_verification_results(
+                    &mut poh_verify_elapsed,
+                    &mut tx_verify_elapsed,
+                ),
+                replay_progress.take_async_verification(),
+            )
+        };
+
+        {
+            let mut stats = replay_stats.write().unwrap();
+            stats.poh_verify_elapsed += poh_verify_elapsed;
+            stats.transaction_verify_elapsed += tx_verify_elapsed;
+        }
+
+        Self::recycle_async_verification(async_verification_freelist, async_verification);
+        verify_result
+    }
+
+    fn complete_bank_replay(
+        process_active_banks_context: &ProcessActiveBanksContext,
+        bank: &BankWithScheduler,
+        bank_progress: &mut ForkProgress,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) -> Result<CompletedBankReplay, BlockstoreProcessorError> {
+        let replay_stats = bank_progress.replay_stats.clone();
+
+        let (replay_result, is_unified_scheduler_enabled) =
+            Self::complete_scheduler_replay(bank, &replay_stats);
+        let verify_result = Self::complete_replay_verification(
+            &replay_stats,
+            &bank_progress.replay_progress,
+            async_verification_freelist,
+        );
+
+        // Send this whether the block was valid or not. It is only used to
+        // release buffered votes, if any.
+        let _ =
+            process_active_banks_context
+                .replay_vote_sender
+                .send(ReplayVoteMessage::BankComplete {
+                    replay_bank_id: bank.bank_id(),
+                    replay_slot: bank.slot(),
+                });
+
+        replay_result.and(verify_result)?;
+
+        Ok(CompletedBankReplay {
+            replay_stats,
+            replay_progress: bank_progress.replay_progress.clone(),
+            is_unified_scheduler_enabled,
+        })
+    }
+
     fn process_replay_results(
         process_active_banks_context: &ProcessActiveBanksContext,
         progress: &mut ProgressMap,
@@ -3877,74 +3972,28 @@ impl ReplayStage {
                     .get_mut(&bank.slot())
                     .expect("Bank fork progress entry missing for completed bank");
 
-                let replay_stats = bank_progress.replay_stats.clone();
-                let mut is_unified_scheduler_enabled = false;
-
-                let replay_res = if let Some((result, completed_execute_timings)) =
-                    bank.wait_for_completed_scheduler()
-                {
-                    // It's guaranteed that wait_for_completed_scheduler() returns Some(_), iff the
-                    // unified scheduler is enabled for the bank.
-                    is_unified_scheduler_enabled = true;
-                    let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
-                        completed_execute_timings,
-                    );
-                    replay_stats
-                        .write()
-                        .unwrap()
-                        .batch_execute
-                        .accumulate(metrics, is_unified_scheduler_enabled);
-
-                    result.map_err(BlockstoreProcessorError::InvalidTransaction)
-                } else {
-                    Ok(())
-                };
-                let verify_res = {
-                    let mut poh_verify_elapsed = 0;
-                    let mut tx_verify_elapsed = 0;
-                    let (res, async_verification) = {
-                        let mut replay_progress = bank_progress.replay_progress.write().unwrap();
-                        (
-                            replay_progress.wait_for_all_verification_results(
-                                &mut poh_verify_elapsed,
-                                &mut tx_verify_elapsed,
+                let completed_replay = match Self::complete_bank_replay(
+                    process_active_banks_context,
+                    bank,
+                    bank_progress,
+                    async_verification_freelist,
+                ) {
+                    Ok(completed_replay) => completed_replay,
+                    Err(err) => {
+                        mark_replay_dead_slot(
+                            bank,
+                            &err,
+                            progress,
+                            &mut process_active_banks_context.dead_slot_context(
+                                duplicate_slots_to_repair,
+                                purge_repair_slot_counter,
+                                tbft_structs.as_deref_mut(),
                             ),
-                            replay_progress.take_async_verification(),
-                        )
-                    };
-                    {
-                        let mut stats = replay_stats.write().unwrap();
-                        stats.poh_verify_elapsed += poh_verify_elapsed;
-                        stats.transaction_verify_elapsed += tx_verify_elapsed;
+                        );
+                        // don't try to run the remaining normal processing for the completed bank
+                        continue;
                     }
-                    Self::recycle_async_verification(
-                        async_verification_freelist,
-                        async_verification,
-                    );
-                    res
                 };
-                // we send this whether the block was valid or not. It's only
-                // used to release buffered votes if any.
-                let _ = process_active_banks_context.replay_vote_sender.send(
-                    ReplayVoteMessage::BankComplete {
-                        replay_bank_id: bank.bank_id(),
-                        replay_slot: bank.slot(),
-                    },
-                );
-                if let Err(err) = replay_res.and(verify_res) {
-                    mark_replay_dead_slot(
-                        bank,
-                        &err,
-                        progress,
-                        &mut process_active_banks_context.dead_slot_context(
-                            duplicate_slots_to_repair,
-                            purge_repair_slot_counter,
-                            tbft_structs.as_deref_mut(),
-                        ),
-                    );
-                    // don't try to run the remaining normal processing for the completed bank
-                    continue;
-                }
                 let is_leader_block = Self::leader_is_me(bank.leader_id(), my_pubkey);
 
                 // The block id is the merkle root of the last data shred
@@ -4016,9 +4065,8 @@ impl ReplayStage {
                     continue;
                 }
 
-                let r_replay_stats = replay_stats.read().unwrap();
-                let replay_progress = bank_progress.replay_progress.clone();
-                let r_replay_progress = replay_progress.read().unwrap();
+                let r_replay_stats = completed_replay.replay_stats.read().unwrap();
+                let r_replay_progress = completed_replay.replay_progress.read().unwrap();
                 debug!(
                     "bank {} has completed replay from blockstore, contribute to update cost with \
                      {:?}",
@@ -4205,7 +4253,7 @@ impl ReplayStage {
                     r_replay_progress.num_entries,
                     r_replay_progress.num_shreds,
                     bank_complete_time.as_us(),
-                    is_unified_scheduler_enabled,
+                    completed_replay.is_unified_scheduler_enabled,
                 );
             } else {
                 trace!(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -233,6 +233,11 @@ struct BankReplayResultTracker {
     bank_replay_tracker: Option<BankReplayTracker>,
 }
 
+enum SchedulerReplayOutcome {
+    NoSchedulerReplay,
+    SchedulerReplayCompleted(Result<(), BlockstoreProcessorError>),
+}
+
 struct CompletedBankReplay {
     // Metrics around replaying this bank.
     replay_stats: Arc<RwLock<ReplaySlotStats>>,
@@ -3819,9 +3824,9 @@ impl ReplayStage {
     fn complete_scheduler_replay(
         bank: &BankWithScheduler,
         replay_stats: &RwLock<ReplaySlotStats>,
-    ) -> (Result<(), BlockstoreProcessorError>, bool) {
+    ) -> SchedulerReplayOutcome {
         let Some((result, completed_execute_timings)) = bank.wait_for_completed_scheduler() else {
-            return (Ok(()), false);
+            return SchedulerReplayOutcome::NoSchedulerReplay;
         };
 
         let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
@@ -3833,9 +3838,8 @@ impl ReplayStage {
             .batch_execute
             .accumulate(metrics, true);
 
-        (
+        SchedulerReplayOutcome::SchedulerReplayCompleted(
             result.map_err(BlockstoreProcessorError::InvalidTransaction),
-            true,
         )
     }
 
@@ -3875,8 +3879,11 @@ impl ReplayStage {
     ) -> Result<CompletedBankReplay, BlockstoreProcessorError> {
         let replay_stats = bank_progress.replay_stats.clone();
 
-        let (replay_result, is_unified_scheduler_enabled) =
-            Self::complete_scheduler_replay(bank, &replay_stats);
+        let scheduler_replay_outcome = Self::complete_scheduler_replay(bank, &replay_stats);
+        let is_unified_scheduler_enabled = matches!(
+            scheduler_replay_outcome,
+            SchedulerReplayOutcome::SchedulerReplayCompleted(_)
+        );
         let verify_result = Self::complete_replay_verification(
             &replay_stats,
             &bank_progress.replay_progress,
@@ -3893,6 +3900,10 @@ impl ReplayStage {
                     replay_slot: bank.slot(),
                 });
 
+        let replay_result = match scheduler_replay_outcome {
+            SchedulerReplayOutcome::NoSchedulerReplay => Ok(()),
+            SchedulerReplayOutcome::SchedulerReplayCompleted(replay_result) => replay_result,
+        };
         replay_result.and(verify_result)?;
 
         Ok(CompletedBankReplay {

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -16,8 +16,8 @@ use {
         consensus_message::Block,
     },
     blockstore_processor::{
-        ConfirmationProgress, ProcessOptions, confirm_full_slot, fill_blockstore_slot_with_ticks,
-        process_bank_0,
+        AsyncVerificationProgress, ConfirmationProgress, ProcessOptions, confirm_full_slot,
+        fill_blockstore_slot_with_ticks, process_bank_0,
     },
     crossbeam_channel::bounded,
     itertools::Itertools,
@@ -1081,6 +1081,95 @@ fn test_dead_slot_on_complete_bank_replay_err() {
 #[test]
 fn test_dead_slot_on_complete_bank_verify_err() {
     do_test_dead_slot_on_complete_bank(CompleteBankFailure::VerifyError);
+}
+
+#[test]
+fn test_complete_replay_verification_recycles_async_verification() {
+    let replay_stats = RwLock::new(ReplaySlotStats::default());
+    {
+        let mut replay_stats = replay_stats.write().unwrap();
+        replay_stats.poh_verify_elapsed = 11;
+        replay_stats.transaction_verify_elapsed = 17;
+    }
+    let replay_progress = RwLock::new(ConfirmationProgress::new_with_async_verification(
+        Hash::new_unique(),
+        Some(AsyncVerificationProgress::new()),
+    ));
+    let mut async_verification_freelist = Vec::new();
+
+    assert_matches!(
+        ReplayStage::complete_replay_verification(
+            &replay_stats,
+            &replay_progress,
+            &mut async_verification_freelist,
+        ),
+        Ok(())
+    );
+
+    assert_eq!(async_verification_freelist.len(), 1);
+    assert!(
+        replay_progress
+            .write()
+            .unwrap()
+            .take_async_verification()
+            .is_none()
+    );
+    let replay_stats = replay_stats.read().unwrap();
+    assert_eq!(replay_stats.poh_verify_elapsed, 11);
+    assert_eq!(replay_stats.transaction_verify_elapsed, 17);
+}
+
+#[test]
+fn test_complete_bank_replay_sends_bank_complete() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None);
+    let bank_forks = vote_simulator.bank_forks;
+    let bank = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+        bank_forks.clone(),
+        blockstore,
+        replay_vote_sender,
+    );
+    let mut bank_progress = ForkProgress::new(
+        bank.last_blockhash(),
+        None,
+        None,
+        0,
+        0,
+        Some(AsyncVerificationProgress::new()),
+    );
+    let mut async_verification_freelist = Vec::new();
+
+    let completed_replay = ReplayStage::complete_bank_replay(
+        &process_active_banks_context,
+        &bank,
+        &mut bank_progress,
+        &mut async_verification_freelist,
+    )
+    .unwrap();
+
+    assert!(!completed_replay.is_unified_scheduler_enabled);
+    assert!(Arc::ptr_eq(
+        &completed_replay.replay_stats,
+        &bank_progress.replay_stats
+    ));
+    assert!(Arc::ptr_eq(
+        &completed_replay.replay_progress,
+        &bank_progress.replay_progress
+    ));
+    assert_eq!(async_verification_freelist.len(), 1);
+    assert_eq!(
+        replay_vote_receiver.try_recv(),
+        Ok(ReplayVoteMessage::BankComplete {
+            replay_bank_id: bank.bank_id(),
+            replay_slot: bank.slot(),
+        })
+    );
+    assert!(replay_vote_receiver.try_recv().is_err());
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

`process_replay_results` can be more readable, the completed-replay accounting can be more clear.
(part of https://github.com/anza-xyz/agave/pull/12895)

#### Summary of Changes
- no behavior change
- isolated completed-replay accounting behind `complete_bank_replay`
- add tests

#### Testing
Added tests for new functions, CI

Fixes #
