### PR TITLE
accounts-db: Replaces calls to AccountStorageEntry::capacity()

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -362,7 +362,7 @@ impl<'a> AccountStoragesOrderer<'a> {
     ) -> Self {
         let len_range = 0..storages.len();
         let mut indices: Vec<_> = len_range.clone().collect();
-        indices.sort_unstable_by_key(|i| storages[*i].capacity());
+        indices.sort_unstable_by_key(|i| storages[*i].written_bytes());
         indices.iter_mut().for_each(|i| {
             *i = select_from_range_with_start_end_rates(len_range.clone(), *i, small_to_large_ratio)
         });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5854,9 +5854,8 @@ impl AccountsDb {
             .write_accounts(accounts_and_meta_to_store)
             .unwrap_or_else(|| {
                 panic!(
-                    "failed to write accounts to storage: slot! {slot}, id: {store_id}, capacity: \
-                     {} bytes, len: {} bytes, num accounts: {num_accounts}",
-                    storage.accounts.capacity(),
+                    "failed to write accounts to storage: slot! {slot}, id: {store_id}, len: {} \
+                     bytes, num accounts: {num_accounts}",
                     storage.accounts.len(),
                 )
             });
@@ -5864,9 +5863,8 @@ impl AccountsDb {
         assert_eq!(
             stored_accounts_info.offsets.len(),
             num_accounts,
-            "failed to write all accounts to storage! {slot}, id: {store_id}, capacity: {} bytes, \
-             len: {} bytes, num accounts written: {}, num accounts total: {num_accounts}",
-            storage.accounts.capacity(),
+            "failed to write all accounts to storage! {slot}, id: {store_id}, len: {} bytes, num \
+             accounts written: {}, num accounts total: {num_accounts}",
             storage.accounts.len(),
             stored_accounts_info.offsets.len(),
         );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4233,7 +4233,7 @@ impl AccountsDb {
         for remove_slot in removed_slots {
             // Remove the storage entries and collect some metrics
             if let Some(store) = self.storage.remove(remove_slot, false) {
-                total_removed_stored_bytes += store.accounts.capacity();
+                total_removed_stored_bytes += store.written_bytes();
                 all_removed_slot_storages.push(store);
             }
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6751,12 +6751,11 @@ impl AccountsDb {
         for slot in &slots {
             let entry = self.storage.get_slot_storage_entry(*slot).unwrap();
             info!(
-                "  slot: {} id: {} count: {} len: {} capacity: {}",
+                "  slot: {} id: {} count: {} len: {}",
                 slot,
                 entry.id(),
                 entry.count(),
                 entry.accounts.len(),
-                entry.accounts.capacity(),
             );
         }
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4800,7 +4800,7 @@ impl AccountsDb {
             oldest_slot = std::cmp::min(oldest_slot, slot);
 
             total_alive_bytes += store.alive_bytes();
-            total_bytes += store.capacity();
+            total_bytes += store.written_bytes();
         }
         info!(
             "total_stores: {total_count}, newest_slot: {newest_slot}, oldest_slot: {oldest_slot}"


### PR DESCRIPTION
#### Problem

While designing a new storage format, presizing, like how AppendVec does it, isn't useful. Back a long time ago, before the accounts write cache existed, AppendVecs were actually appended to. So a max capacity was used to enforce a size limit. Nowadays, we always write all the accounts at once, and never append. So the number of bytes written remains constant afterwards.

With a split file format, it is not clear how 'capacity' would work. Luckily, `capacity()` is mostly interchangeable with the number of bytes written in a storage.


#### Summary of Changes

This PR changes a number of callers to replace `capacity()` with `written_bytes()`. Each commit changes a single caller/fn:

- AccountStoragesOrderer::with_small_to_large_ratio()
- purge_dead_slots_from_storage()
- report_store_stats()
- print_count_and_status()
- write_accounts_to_storage()

This is not all the callers of `capacity()`. The `shrink` and `squash` paths have a lot more changes, so doing those in their own PR(s).

I recommend reviewing commit-by-commit.


#### Testing

I have a node running with a superset of this change (that also includes the `shrink` and `squash` changes).