### PR TITLE
tpu-client-next integration for program deploy 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7712,6 +7712,7 @@ dependencies = [
  "agave-logger",
  "agave-votor-messages",
  "assert_matches",
+ "async-trait",
  "bincode",
  "bip39",
  "bs58",
@@ -7779,6 +7780,7 @@ dependencies = [
  "solana-system-interface 3.2.0",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-tpu-client-next",
  "solana-transaction",
  "solana-transaction-error",
  "solana-transaction-status",
@@ -7789,6 +7791,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util 0.7.18",
  "wincode",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,6 +35,7 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 agave-feature-set = { workspace = true }
 agave-logger = { workspace = true }
 agave-votor-messages = { workspace = true }
+async-trait = { workspace = true }
 bincode = { workspace = true }
 bip39 = { workspace = true }
 bs58 = { workspace = true }
@@ -71,6 +72,7 @@ solana-keypair = { workspace = true }
 solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-nonce = { workspace = true }
 solana-offchain-message = { workspace = true, features = ["verify"] }
 solana-packet = { workspace = true }
@@ -93,6 +95,7 @@ solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-tpu-client = { workspace = true, features = ["default"] }
+solana-tpu-client-next = { workspace = true, features = ["websocket-node-address-service"] }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
@@ -101,6 +104,7 @@ solana-vote-program = { workspace = true }
 spl-memo-interface = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -32,11 +32,8 @@ use {
         CliUpgradeableProgramClosed, CliUpgradeableProgramExtended, CliUpgradeablePrograms,
         ReturnSignersConfig, return_signers_with_config,
     },
-    solana_client::{
-        connection_cache::ConnectionCache,
-        send_and_confirm_transactions_in_parallel::{
-            SendAndConfirmConfigV2, send_and_confirm_transactions_in_parallel_v2,
-        },
+    solana_client::send_and_confirm_transactions_in_parallel::{
+        SendAndConfirmConfigV3, SendTransport, send_and_confirm_transactions_in_parallel_v3,
     },
     solana_commitment_config::CommitmentConfig,
     solana_instruction::{Instruction, error::InstructionError},
@@ -46,7 +43,8 @@ use {
         instruction::{self as loader_v3_instruction, MINIMUM_EXTEND_PROGRAM_BYTES},
         state::UpgradeableLoaderState,
     },
-    solana_message::Message,
+    solana_message::{Message, VersionedMessage},
+    solana_net_utils::bind_to_unspecified,
     solana_packet::PACKET_DATA_SIZE,
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionBudget, invoke_context::InvokeContext,
@@ -67,25 +65,38 @@ use {
     solana_signer::Signer,
     solana_syscalls::create_program_runtime_environment,
     solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, error::SystemError},
-    solana_tpu_client::tpu_client::TpuClientConfig,
+    solana_tpu_client_next::{
+        ClientBuilder, connection_workers_scheduler::NonblockingBroadcaster,
+        node_address_service::LeaderTpuCacheServiceConfig,
+        websocket_node_address_service::WebsocketNodeAddressService,
+    },
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     std::{
         fs::File,
         io::{Read, Write},
         mem::size_of,
-        num::Saturating,
+        num::{NonZeroUsize, Saturating},
         path::PathBuf,
         rc::Rc,
         str::FromStr,
         sync::Arc,
+        time::Duration,
     },
+    tokio_util::sync::CancellationToken,
 };
 
 pub const CLOSE_PROGRAM_WARNING: &str = "WARNING! Closed programs cannot be recreated at the same \
                                          program id. Once a program is closed, it can never be \
                                          invoked again. To proceed with closing, rerun the \
                                          `close` command with the `--bypass-warning` flag";
+
+/// Time taken by confirmation engine between checks. See
+/// [SendAndConfirmConfigV3::check_interval]
+const CHECK_INTERVAL: Duration = Duration::from_secs(1);
+/// Time buffer between consequent transaction being sent . See
+/// [SendAndConfirmConfigV3::send_interval]
+const SEND_INTERVAL: Duration = Duration::from_millis(5);
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ProgramCliCommand {
@@ -1380,7 +1391,6 @@ async fn process_program_deploy(
             let program_data = read_and_verify_elf(program_location, feature_set)?;
             let program_len = program_data.len();
 
-            // If a buffer was provided, check if it has already been created and set up properly
             let buffer_program_data = if buffer_provided {
                 fetch_buffer_program_data(
                     &rpc_client,
@@ -1427,12 +1437,15 @@ async fn process_program_deploy(
         ))
         .await?;
 
+    if do_initial_deploy && program_signer.is_none() {
+        return Err("Initial deployments require a keypair be provided for the program id".into());
+    }
+    if !buffer_provided {
+        // always report ephemeral mnemonic, so that users always have a way to resume in case of
+        // process crash
+        report_ephemeral_mnemonic(buffer_words, buffer_mnemonic, &buffer_pubkey);
+    }
     let result = if do_initial_deploy {
-        if program_signer.is_none() {
-            return Err(
-                "Initial deployments require a keypair be provided for the program id".into(),
-            );
-        }
         do_process_program_deploy(
             rpc_client.clone(),
             config,
@@ -1486,11 +1499,6 @@ async fn process_program_deploy(
             &BlockhashQuery::default(),
         )
         .await?;
-    }
-    if result.is_err() && !buffer_provided {
-        // We might have deployed "temporary" buffer but failed to deploy our program from this
-        // buffer, reporting this to the user - so he can retry deploying re-using same buffer.
-        report_ephemeral_mnemonic(buffer_words, buffer_mnemonic, &buffer_pubkey);
     }
     result
 }
@@ -3082,6 +3090,22 @@ async fn check_payer(
     Ok(())
 }
 
+fn dedup_signers<'a>(signers: &[&'a dyn Signer]) -> Vec<&'a dyn Signer> {
+    let mut seen = Vec::with_capacity(signers.len());
+    signers
+        .iter()
+        .filter(|signer| {
+            let pubkey = signer.pubkey();
+            let is_new = !seen.contains(&pubkey);
+            if is_new {
+                seen.push(pubkey);
+            }
+            is_new
+        })
+        .copied()
+        .collect()
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn send_deploy_messages(
     rpc_client: Arc<RpcClient>,
@@ -3163,59 +3187,63 @@ async fn send_deploy_messages(
                         .clone_from(&message.instructions[ix_index].data);
                 }
             }
-        }
 
-        let connection_cache = {
-            #[cfg(feature = "dev-context-only-utils")]
-            let cache = ConnectionCache::new_quic_for_tests("connection_cache_cli_program_quic", 1);
-            #[cfg(not(feature = "dev-context-only-utils"))]
-            let cache = ConnectionCache::new_quic("connection_cache_cli_program_quic", 1);
-            let ConnectionCache::Quic(cache) = cache else {
-                unreachable!("by construction")
-            };
-            cache
-        };
-        let transaction_errors = {
-            // `solana_client` type currently required by `send_and_confirm_transactions_in_parallel_v2`
-            let tpu_client_fut =
-                solana_client::nonblocking::tpu_client::TpuClient::new_with_connection_cache(
-                    rpc_client.clone(),
-                    config.websocket_url.as_str(),
-                    TpuClientConfig::default(),
-                    connection_cache,
-                );
-            let tpu_client = if use_rpc {
-                None
+            // Holds the scheduler alive for the duration of the send.
+            let _tpu_client;
+            let cancel_token = CancellationToken::new();
+            let transport = if use_rpc {
+                SendTransport::Rpc(config.send_transaction_config)
             } else {
-                Some(
-                    tpu_client_fut
-                        .await
-                        .expect("Should return a valid tpu client"),
+                let node_address_service = WebsocketNodeAddressService::run(
+                    rpc_client.clone(),
+                    config.websocket_url.clone(),
+                    LeaderTpuCacheServiceConfig::default(),
+                    cancel_token.child_token(),
                 )
+                .await?;
+
+                let bind_socket = bind_to_unspecified()?;
+
+                let (transaction_sender, client) =
+                    ClientBuilder::new(Box::new(node_address_service))
+                        .cancel_token(cancel_token.clone())
+                        .bind_socket(bind_socket)
+                        .broadcaster(NonblockingBroadcaster)
+                        .build()
+                        .expect("Failed to build TPU client");
+                _tpu_client = client;
+                SendTransport::Tpu(transaction_sender)
             };
-            send_and_confirm_transactions_in_parallel_v2(
+
+            let versioned_write_messages = write_messages.into_iter().map(VersionedMessage::Legacy);
+
+            let transaction_errors = send_and_confirm_transactions_in_parallel_v3(
                 rpc_client.clone(),
-                tpu_client,
-                &write_messages,
-                &[fee_payer_signer, write_signer],
-                SendAndConfirmConfigV2 {
-                    resign_txs_count: Some(max_sign_attempts),
+                transport,
+                versioned_write_messages,
+                &dedup_signers(&[fee_payer_signer, write_signer]),
+                SendAndConfirmConfigV3 {
                     with_spinner: true,
-                    rpc_send_transaction_config: config.send_transaction_config,
+                    max_sign_attempts: NonZeroUsize::new(max_sign_attempts)
+                        .ok_or("--max-sign-attempts must be at least 1")?,
+                    check_interval: CHECK_INTERVAL,
+                    send_interval: SEND_INTERVAL,
                 },
             )
             .await
-        }
-        .map_err(|err| format!("Data writes to account failed: {err}"))?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+            .map_err(|err| format!("Data writes to account failed: {err}"))?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
-        if !transaction_errors.is_empty() {
-            for transaction_error in &transaction_errors {
-                error!("{transaction_error:?}");
+            if !transaction_errors.is_empty() {
+                for transaction_error in &transaction_errors {
+                    error!("{transaction_error:?}");
+                }
+                return Err(
+                    format!("{} write transactions failed", transaction_errors.len()).into(),
+                );
             }
-            return Err(format!("{} write transactions failed", transaction_errors.len()).into());
         }
     }
 
@@ -3231,16 +3259,15 @@ async fn send_deploy_messages(
         let mut signers = final_signers.to_vec();
         signers.push(fee_payer_signer);
         final_tx.try_sign(&signers, blockhash)?;
-        return Ok(Some(
-            rpc_client
-                .send_and_confirm_transaction_with_spinner_and_config(
-                    &final_tx,
-                    config.commitment,
-                    config.send_transaction_config,
-                )
-                .await
-                .map_err(|e| format!("Deploying program failed: {e}"))?,
-        ));
+        let result = rpc_client
+            .send_and_confirm_transaction_with_spinner_and_config(
+                &final_tx,
+                config.commitment,
+                config.send_transaction_config,
+            )
+            .await
+            .map_err(|e| format!("Deploying program failed: {e}"))?;
+        return Ok(Some(result));
     }
 
     Ok(None)


### PR DESCRIPTION
#### Problem
Problem statement as described in #7744 . This PR aims to improve reliability and performance of the program deploy path of the cli

#### Summary of Changes

1. Integrate new upstream api
2. always report user mnemonic (UX improvement)
3. bumps down transaction send interval from 10ms to 5 ms. Increases TPS to ~ 200 TPS

#### Testing
Changes tested with existing test harness under cli/tests/program.rs, and recommended scripts mentioned in CONTRIBUTING.md

# Test setup
programs used:
- jupiter-v6 (large) -> 2,892,224 bytes
- token-2022 (medium) -> 1,382,016 bytes
- token (small) -> 108,600 bytes

to create a degraded network setup, the following strategy has been used:

netns to create 2 seperate network namespaces, for cli and `solana-test-validator` respectively.

qdisc netem to control egress and degradation

for network degradation metrics have been collected as such:
  | condition | netem (per hop) | RTT | loss per hop |
  |---|---|---|---|
  | clean | none | 0 | 0% |
  | d00_l1 | loss random 1% | 0 | 1% |
  | d25_l0 | delay 25ms | 50ms | 0% |
  | d25_l1 | delay 25ms, loss random 1% | 50ms | 1% |
  | d25_l3 | delay 25ms, loss random 3% | 50ms | 3% |
  | d25_l5 | delay 25ms, loss random 5% | 50ms | 5% |
  | d50_l1 | delay 50ms, loss random 1% | 100ms | 1% |
  | d100_l1 | delay 100ms, loss random 1% | 200ms | 1% |

RTT = 2 x configured per hop delay (applied each of veth pair). loss is per hop too

 sample size = 3 programs * 8 profiles * 20 deploys each * 2 (base and changes) = 960
 
NOTE: bursty-loss (gemodel) profiles were also tested; dropped from this PR because
  the failure counts were too small to compare arms and one result was contaminated by a
  harness verification artifact. Follow-up planned.
 
# Results
## RTT and packet loss sweep
<img width="2440" height="2158" alt="image" src="https://github.com/user-attachments/assets/3505de27-6fde-4b1a-926b-c60ecba23cdc" />

note: clear strong wins as network degrades for larger programs

<img width="2561" height="2160" alt="image" src="https://github.com/user-attachments/assets/33d3e9ec-00b1-4098-9fdf-801e36537272" />

note: cdf across the board shows marked improvement, and the distribution is healthier

Fixes #

This patch introduces 3 changes: 
1. integrating the `send_and_confirm_transaction_in_parallel_v3` by @alexpyattaev that uses tpu client next as the transport.
2. always report user mnemonic, so that user has recovery path in case of crash
3. Decreases send interval between transaction sends from 10 ms to 5 ms 
