### PR TITLE
agave-scheduling-utils: extract cost pacer

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -21,6 +21,7 @@ use {
         validator::SchedulerPacing,
     },
     agave_banking_stage_ingress_types::SchedulerPriorityFloor,
+    agave_scheduling_utils::cost_pacer::CostPacer,
     solana_clock::DEFAULT_MS_PER_SLOT,
     solana_cost_model::cost_tracker::SharedBlockCost,
     solana_measure::measure_us,
@@ -32,7 +33,7 @@ use {
             Arc,
             atomic::{AtomicBool, Ordering},
         },
-        time::{Duration, Instant},
+        time::Instant,
     },
 };
 
@@ -242,12 +243,10 @@ where
                         );
                     }
 
-                    CostPacer {
-                        block_limit,
+                    (
+                        CostPacer::new(block_limit, now, fill_time),
                         shared_block_cost,
-                        detection_time: now,
-                        fill_time,
-                    }
+                    )
                 });
             }
 
@@ -287,14 +286,14 @@ where
     fn process_transactions(
         &mut self,
         decision: &BufferedPacketsDecision,
-        cost_pacer: Option<&CostPacer>,
+        cost_pacer: Option<&(CostPacer, SharedBlockCost)>,
         now: &Instant,
     ) -> Result<usize, SchedulerError> {
         let scheduled = match decision {
             BufferedPacketsDecision::Consume(_bank) => {
-                let scheduling_budget = cost_pacer
-                    .expect("cost pacer must be set for Consume")
-                    .scheduling_budget(now);
+                let (cost_pacer, shared_block_cost) =
+                    cost_pacer.expect("cost pacer must be set for Consume");
+                let scheduling_budget = cost_pacer.scheduling_budget(now, shared_block_cost.load());
                 let (scheduling_summary, schedule_time_us) = measure_us!(
                     self.scheduler
                         .schedule(&mut self.container, scheduling_budget,)?
@@ -497,33 +496,6 @@ where
     }
 }
 
-struct CostPacer {
-    block_limit: u64,
-    shared_block_cost: SharedBlockCost,
-    detection_time: Instant,
-    fill_time: Option<Duration>,
-}
-
-impl CostPacer {
-    fn scheduling_budget(&self, current_time: &Instant) -> u64 {
-        let target = if let Some(fill_time) = &self.fill_time {
-            let time_since = current_time.saturating_duration_since(self.detection_time);
-            if time_since >= *fill_time {
-                self.block_limit
-            } else {
-                // on millisecond granularity, pace the cost linearly.
-                let allocation_per_milli = self.block_limit / fill_time.as_millis() as u64;
-                let millis_since_detection = time_since.as_millis() as u64;
-                allocation_per_milli * millis_since_detection
-            }
-        } else {
-            self.block_limit
-        };
-
-        target.saturating_sub(self.shared_block_cost.load())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -552,7 +524,10 @@ mod tests {
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::Transaction,
-        std::sync::{Arc, RwLock},
+        std::{
+            sync::{Arc, RwLock},
+            time::Duration,
+        },
     };
 
     fn create_channels<T>(num: usize) -> (Vec<Sender<T>>, Vec<Receiver<T>>) {
@@ -700,20 +675,19 @@ mod tests {
             .bank()
             .map(|bank| Duration::from_nanos_u128(bank.ns_per_slot))
             .unwrap();
+        let cost_pacer = (
+            CostPacer::new(
+                u64::MAX,
+                now.checked_sub(slot_time).unwrap(),
+                Some(slot_time.saturating_sub(Duration::from_millis(
+                    DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS,
+                ))),
+            ),
+            SharedBlockCost::new(0),
+        );
         assert!(
             scheduler_controller
-                .process_transactions(
-                    &decision,
-                    Some(&CostPacer {
-                        block_limit: u64::MAX,
-                        shared_block_cost: SharedBlockCost::new(0),
-                        detection_time: now.checked_sub(slot_time).unwrap(),
-                        fill_time: Some(slot_time.saturating_sub(Duration::from_millis(
-                            DEFAULT_SCHEDULER_PACING_NON_FILL_TIME_MILLIS
-                        ))),
-                    }),
-                    &now
-                )
+                .process_transactions(&decision, Some(&cost_pacer), &now)
                 .is_ok()
         );
     }

--- a/scheduling-utils/src/cost_pacer.rs
+++ b/scheduling-utils/src/cost_pacer.rs
@@ -1,0 +1,88 @@
+use std::time::{Duration, Instant};
+
+/// Releases a cost budget linearly over an optional fill time.
+pub struct CostPacer {
+    total_cost: u64,
+    detection_time: Instant,
+    fill_time: Option<Duration>,
+}
+
+impl CostPacer {
+    pub fn new(total_cost: u64, detection_time: Instant, fill_time: Option<Duration>) -> Self {
+        Self {
+            total_cost,
+            detection_time,
+            fill_time,
+        }
+    }
+
+    pub fn scheduling_budget(&self, current_time: &Instant, consumed_cost: u64) -> u64 {
+        let target = if let Some(fill_time) = &self.fill_time {
+            let time_since = current_time.saturating_duration_since(self.detection_time);
+            if time_since >= *fill_time {
+                self.total_cost
+            } else {
+                // on millisecond granularity, pace the cost linearly.
+                let fill_time_millis = u64::try_from(fill_time.as_millis())
+                    .unwrap_or(u64::MAX)
+                    .max(1);
+                let millis_since_detection =
+                    u64::try_from(time_since.as_millis()).unwrap_or(u64::MAX);
+                #[allow(clippy::arithmetic_side_effects)]
+                let target = self
+                    .total_cost
+                    .saturating_mul(millis_since_detection)
+                    .saturating_div(fill_time_millis);
+                target
+            }
+        } else {
+            self.total_cost
+        };
+
+        target.saturating_sub(consumed_cost)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn releases_cost_linearly() {
+        let start = Instant::now();
+        let pacer = CostPacer::new(1_000, start, Some(Duration::from_millis(100)));
+
+        assert_eq!(pacer.scheduling_budget(&start, 0), 0);
+        assert_eq!(
+            pacer.scheduling_budget(&start.checked_add(Duration::from_millis(25)).unwrap(), 0,),
+            250
+        );
+        assert_eq!(
+            pacer.scheduling_budget(&start.checked_add(Duration::from_millis(25)).unwrap(), 100,),
+            150
+        );
+        assert_eq!(
+            pacer.scheduling_budget(&start.checked_add(Duration::from_millis(100)).unwrap(), 400,),
+            600
+        );
+    }
+
+    #[test]
+    fn releases_cost_linearly_when_cost_is_less_than_fill_time_millis() {
+        let start = Instant::now();
+        let pacer = CostPacer::new(10, start, Some(Duration::from_millis(100)));
+
+        assert_eq!(
+            pacer.scheduling_budget(&start.checked_add(Duration::from_millis(50)).unwrap(), 0),
+            5
+        );
+    }
+
+    #[test]
+    fn disabled_pacing_releases_the_entire_budget() {
+        let now = Instant::now();
+        let pacer = CostPacer::new(1_000, now, None);
+
+        assert_eq!(pacer.scheduling_budget(&now, 400), 600);
+    }
+}

--- a/scheduling-utils/src/lib.rs
+++ b/scheduling-utils/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "agave-unstable-api")]
 
+pub mod cost_pacer;
 pub mod error;
 pub mod thread_aware_account_locks;
 


### PR DESCRIPTION
#### Problem
- Want to re-use cost-pacing in external scheduler

#### Summary of Changes
- Extract cost-pacing to scheduling-utils

#### Testing
- CI

Fixes #
