### PR TITLE
program-runtime: Add conditional `pub` qualifier to `process_precompile`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -606,6 +606,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     /// Processes a precompile instruction
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn process_precompile(
         &mut self,
         program_id: &Pubkey,


### PR DESCRIPTION
#### Problem

PR #13618 refactored the `InvokeContext` API and made `process_precompile` private, but developer tooling might need access to it (see Mollusk https://github.com/anza-xyz/mollusk/pull/277).

#### Summary of Changes

Conditionally expose `InvokeContext::process_precompile` when `"dev-context-only utils"` is enabled.

#### Testing

No runtime logic changes; this is a visibility-only change gated by feature flag.