### PR TITLE
chore: xdp: delete dead code

### DIFF
--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -225,7 +225,6 @@ pub struct DeviceQueue {
     if_index: u32,
     queue_id: QueueId,
     ring_sizes: Option<RingSizes>,
-    completion: Option<TxCompletionRing>,
 }
 
 impl DeviceQueue {
@@ -234,7 +233,6 @@ impl DeviceQueue {
             if_index,
             queue_id,
             ring_sizes,
-            completion: None,
         }
     }
 
@@ -244,10 +242,6 @@ impl DeviceQueue {
 
     pub fn id(&self) -> QueueId {
         self.queue_id
-    }
-
-    pub fn tx_completion(&mut self) -> Option<&TxCompletionRing> {
-        self.completion.as_ref()
     }
 
     pub fn ring_sizes(&self) -> Option<RingSizes> {

--- a/xdp/src/lib.rs
+++ b/xdp/src/lib.rs
@@ -47,14 +47,3 @@ pub fn interface_ipv4(interface: &str) -> Result<Ipv4Addr, io::Error> {
 pub fn interface_ipv4(_interface: &str) -> Result<Ipv4Addr, io::Error> {
     unimplemented!()
 }
-
-/// Returns the IPv4 address of the device associated with the default route.
-#[cfg(target_os = "linux")]
-pub fn default_device_ipv4() -> Result<Ipv4Addr, io::Error> {
-    crate::device::NetworkDevice::new_from_default_route()?.ipv4_addr()
-}
-
-#[cfg(not(target_os = "linux"))]
-pub fn default_device_ipv4() -> Result<Ipv4Addr, io::Error> {
-    unimplemented!()
-}

--- a/xdp/src/route.rs
+++ b/xdp/src/route.rs
@@ -24,9 +24,6 @@ pub enum RouteError {
     #[error("missing output interface in route")]
     MissingOutputInterface,
 
-    #[error("could not resolve MAC address")]
-    MacResolutionError,
-
     #[error("unknown interface index {0}")]
     UnknownInterfaceIndex(u32),
 }

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -64,20 +64,7 @@ pub struct XdpConfig {
 impl XdpConfig {
     // A nice round number
     const DEFAULT_TX_CHANNEL_CAP: usize = 1_000_000;
-}
 
-impl Default for XdpConfig {
-    fn default() -> Self {
-        Self {
-            interface: None,
-            queues: vec![],
-            zero_copy: false,
-            tx_channel_cap: Self::DEFAULT_TX_CHANNEL_CAP,
-        }
-    }
-}
-
-impl XdpConfig {
     pub fn new(
         interface: Option<impl Into<String>>,
         queues: Vec<QueueCpuBinding>,

--- a/xdp/src/umem.rs
+++ b/xdp/src/umem.rs
@@ -380,20 +380,6 @@ impl Drop for PageAlignedMemory {
     }
 }
 
-impl Deref for PageAlignedMemory {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
-    }
-}
-
-impl DerefMut for PageAlignedMemory {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {


### PR DESCRIPTION
#### Problem
 agave-xdp has some code that is clearly dead now:
- DeviceQueue::completion is always None by construction
- default_device_ipv4 has no callers
- MacResolutionError is never emitted
- PageAlignedMemory implementations of Deref and DerefMut are no longer used

#### Summary of Changes

rm dead code.

Stuff related to Rx is also largely dead, but was deliberately kept around.

#### Testing

CI