### PR TITLE
refactor(snapshot): extract SlotAccountStorageEntries, de-genericize AccountsDbFields

### DIFF
--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -81,10 +81,27 @@ pub(crate) use {
 const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;
 type MaxStreamSizeConfig = wincode::config::Configuration<true, MAX_STREAM_SIZE>;
 
+/// A slot paired with its account storage entries, used as the `slot -> [entry]` map item on both
+/// the read path ([`AccountsDbFields`]) and the write ABI type [`SerializableAccountsDbForAbi`].
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Debug, Serialize, Deserialize, SchemaWrite)]
+pub(crate) struct SlotAccountStorageEntries {
+    slot: Slot,
+    /// In a real snapshot this always holds exactly one entry; it is sampled as an arbitrary
+    /// (`0..=5`-length) collection only to keep the abi digest compatible with the current one.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "solana_frozen_abi::stable_abi::sample_collection_sized(rng, \
+                                  solana_frozen_abi::stable_abi::context::SequenceLenRange::new(0.\
+                                  .=5))")
+    )]
+    entries: SmallVec<[SerializableAccountStorageEntry; 1]>,
+}
+
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug, Deserialize)]
-pub(crate) struct AccountsDbFields<T>(
-    Vec<(Slot, SmallVec<[T; 1]>)>,
+pub(crate) struct AccountsDbFields(
+    Vec<SlotAccountStorageEntries>,
     u64, // unused, formerly write_version
     Slot,
     BankHashInfo,
@@ -331,15 +348,15 @@ impl SnapshotBankFields {
 /// Helper type to wrap AccountsDbFields when reconstructing AccountsDb from either just a full
 /// snapshot, or both a full and incremental snapshot
 #[derive(Debug)]
-pub struct SnapshotAccountsDbFields<T> {
-    full_snapshot_accounts_db_fields: AccountsDbFields<T>,
-    incremental_snapshot_accounts_db_fields: Option<AccountsDbFields<T>>,
+pub struct SnapshotAccountsDbFields {
+    full_snapshot_accounts_db_fields: AccountsDbFields,
+    incremental_snapshot_accounts_db_fields: Option<AccountsDbFields>,
 }
 
-impl<T> SnapshotAccountsDbFields<T> {
+impl SnapshotAccountsDbFields {
     pub(crate) fn new(
-        full_snapshot_accounts_db_fields: AccountsDbFields<T>,
-        incremental_snapshot_accounts_db_fields: Option<AccountsDbFields<T>>,
+        full_snapshot_accounts_db_fields: AccountsDbFields,
+        incremental_snapshot_accounts_db_fields: Option<AccountsDbFields>,
     ) -> Self {
         Self {
             full_snapshot_accounts_db_fields,
@@ -394,9 +411,7 @@ where
         .deserialize_from::<R, T>(reader)
 }
 
-fn deserialize_accounts_db_fields<R>(
-    stream: &mut BufReader<R>,
-) -> Result<AccountsDbFields<SerializableAccountStorageEntry>, Error>
+fn deserialize_accounts_db_fields<R>(stream: &mut BufReader<R>) -> Result<AccountsDbFields, Error>
 where
     R: Read,
 {
@@ -456,13 +471,7 @@ pub struct ExtraFieldsToSerialize {
 
 fn deserialize_bank_fields<R>(
     mut stream: &mut BufReader<R>,
-) -> Result<
-    (
-        BankFieldsToDeserialize,
-        AccountsDbFields<SerializableAccountStorageEntry>,
-    ),
-    Error,
->
+) -> Result<(BankFieldsToDeserialize, AccountsDbFields), Error>
 where
     R: Read,
 {
@@ -500,26 +509,14 @@ where
 
 pub(crate) fn fields_from_stream<R: Read>(
     snapshot_stream: &mut BufReader<R>,
-) -> std::result::Result<
-    (
-        BankFieldsToDeserialize,
-        AccountsDbFields<SerializableAccountStorageEntry>,
-    ),
-    Error,
-> {
+) -> std::result::Result<(BankFieldsToDeserialize, AccountsDbFields), Error> {
     deserialize_bank_fields(snapshot_stream)
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 pub(crate) fn fields_from_streams(
     snapshot_streams: &mut SnapshotStreams<impl Read>,
-) -> std::result::Result<
-    (
-        SnapshotBankFields,
-        SnapshotAccountsDbFields<SerializableAccountStorageEntry>,
-    ),
-    Error,
-> {
+) -> std::result::Result<(SnapshotBankFields, SnapshotAccountsDbFields), Error> {
     let (full_snapshot_bank_fields, full_snapshot_accounts_db_fields) =
         fields_from_stream(snapshot_streams.full_snapshot_stream)?;
     let (incremental_snapshot_bank_fields, incremental_snapshot_accounts_db_fields) =
@@ -664,8 +661,7 @@ struct SerializableBankSnapshot<E> {
     abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]
-type SerializableBankSnapshotForAbi =
-    SerializableBankSnapshot<Vec<(Slot, Vec<SerializableAccountStorageEntry>)>>;
+type SerializableBankSnapshotForAbi = SerializableBankSnapshot<Vec<SlotAccountStorageEntries>>;
 
 /// Serializes bank snapshot with `serializer`
 pub fn serialize_bank_snapshot_with<S>(
@@ -794,23 +790,19 @@ impl SerializableAccountsDb<()> {
         bank_hash_stats: BankHashStats,
     ) -> SerializableAccountsDb<
         SerializableExactIteratorView<
-            impl ExactSizeIterator<Item = (Slot, SmallVec<[SerializableAccountStorageEntry; 1]>)>
-            + Clone
-            + '_,
+            impl ExactSizeIterator<Item = SlotAccountStorageEntries> + Clone + '_,
         >,
     > {
         // Stream the storage entries as a `slot -> [entry]` map, each slot's single entry kept
         // inline in a `SmallVec`. `SerializableExactIteratorView` re-creates the iterator on each
         // serialization, so nothing is materialized.
         let accounts_storage_entries =
-            SerializableExactIteratorView(account_storage_entries.iter().map(
-                move |entry| -> (Slot, SmallVec<[SerializableAccountStorageEntry; 1]>) {
-                    (
-                        entry.slot(),
-                        smallvec![SerializableAccountStorageEntry::new(entry, slot)],
-                    )
-                },
-            ));
+            SerializableExactIteratorView(account_storage_entries.iter().map(move |entry| {
+                SlotAccountStorageEntries {
+                    slot: entry.slot(),
+                    entries: smallvec![SerializableAccountStorageEntry::new(entry, slot)],
+                }
+            }));
         let bank_hash_info = BankHashInfo {
             unused_accounts_delta_hash: [0; 32],
             unused_accounts_hash: [0; 32],
@@ -837,8 +829,7 @@ impl SerializableAccountsDb<()> {
     abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]
-type SerializableAccountsDbForAbi =
-    SerializableAccountsDb<Vec<(Slot, Vec<SerializableAccountStorageEntry>)>>;
+type SerializableAccountsDbForAbi = SerializableAccountsDb<Vec<SlotAccountStorageEntries>>;
 
 /// This struct contains side-info while reconstructing the bank from fields
 #[derive(Debug)]
@@ -851,9 +842,9 @@ pub(crate) struct ReconstructedBankInfo {
 }
 
 #[expect(clippy::too_many_arguments)]
-pub(crate) fn reconstruct_bank_from_fields<E>(
+pub(crate) fn reconstruct_bank_from_fields(
     bank_fields: SnapshotBankFields,
-    snapshot_accounts_db_fields: SnapshotAccountsDbFields<E>,
+    snapshot_accounts_db_fields: SnapshotAccountsDbFields,
     genesis_config: &GenesisConfig,
     runtime_config: &RuntimeConfig,
     account_paths: &[PathBuf],
@@ -1066,8 +1057,8 @@ pub struct ReconstructedAccountsDbInfo {
     pub bank_hash_stats: BankHashStats,
 }
 
-fn reconstruct_accountsdb_from_fields<E>(
-    snapshot_accounts_db_fields: SnapshotAccountsDbFields<E>,
+fn reconstruct_accountsdb_from_fields(
+    snapshot_accounts_db_fields: SnapshotAccountsDbFields,
     account_paths: &[PathBuf],
     storage_and_next_append_vec_id: StorageAndNextAccountsFileId,
     limit_load_slot_count_from_snapshot: Option<usize>,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -5,8 +5,8 @@ use {
         bank::BankFieldsToDeserialize,
         serde_snapshot::{
             self, AccountsDbFields, ExtraFieldsToSerialize, SerdeObsoleteAccountsMap,
-            SerializableAccountStorageEntry, SnapshotAccountsDbFields, SnapshotBankFields,
-            SnapshotStreams, StorageListItem, StoragesList,
+            SnapshotAccountsDbFields, SnapshotBankFields, SnapshotStreams, StorageListItem,
+            StoragesList,
         },
         snapshot_package::BankSnapshotPackage,
         snapshot_utils::snapshot_storage_rebuilder::{
@@ -222,7 +222,7 @@ pub struct UnarchivedSnapshot {
     unpack_dir: TempDir,
     pub storage: AccountStorageMap,
     pub bank_fields: BankFieldsToDeserialize,
-    pub(crate) accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
+    pub(crate) accounts_db_fields: AccountsDbFields,
     pub unpacked_snapshots_dir_and_version: UnpackedSnapshotsDirAndVersion,
     pub measure_untar: Measure,
 }
@@ -233,7 +233,7 @@ pub struct UnarchivedSnapshots {
     pub full_storage: AccountStorageMap,
     pub incremental_storage: Option<AccountStorageMap>,
     pub bank_fields: SnapshotBankFields,
-    pub accounts_db_fields: SnapshotAccountsDbFields<SerializableAccountStorageEntry>,
+    pub accounts_db_fields: SnapshotAccountsDbFields,
     pub full_unpacked_snapshots_dir_and_version: UnpackedSnapshotsDirAndVersion,
     pub incremental_unpacked_snapshots_dir_and_version: Option<UnpackedSnapshotsDirAndVersion>,
     pub full_measure_untar: Measure,
@@ -1153,7 +1153,7 @@ fn get_version_and_snapshot_files(
 struct SnapshotFieldsBundle {
     snapshot_version: SnapshotVersion,
     bank_fields: BankFieldsToDeserialize,
-    accounts_db_fields: AccountsDbFields<SerializableAccountStorageEntry>,
+    accounts_db_fields: AccountsDbFields,
     append_vec_files: Vec<FileInfo>,
 }
 
@@ -1476,11 +1476,7 @@ pub(crate) fn rebuild_storages_from_snapshot_dir(
     snapshot_info: &BankSnapshotInfo,
     account_paths: &[PathBuf],
     next_append_vec_id: Arc<AtomicAccountsFileId>,
-) -> Result<(
-    AccountStorageMap,
-    BankFieldsToDeserialize,
-    AccountsDbFields<SerializableAccountStorageEntry>,
-)> {
+) -> Result<(AccountStorageMap, BankFieldsToDeserialize, AccountsDbFields)> {
     let bank_snapshot_dir = &snapshot_info.snapshot_dir;
 
     // With fastboot_version >= 2, obsolete accounts are tracked and stored in the snapshot


### PR DESCRIPTION
#### Problem
The `<T>`/`<E>` on `AccountsDbFields, SnapshotAccountsDbFields`, and the
reconstruct_* functions was only ever `SerializableAccountStorageEntry` —
unbounded plumbing that added noise without buying any generality.

#### Summary of Changes
Remove generic parameters on those structs / functions.
Extract the `slot -> [entry]` map item, previously a bare tuple, into a
named `SlotAccountStorageEntries` struct now shared by the read path, the write
iterator, and the ABI types. The named field lets it carry a `StableAbi` sampling
override. Wire format and abi digests are unchanged.

#### Testing
CI / frozen-abi tests keep the same `abi_digest`
