### PR TITLE
refactor(ci): consume channel-info via xtask --json

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -9,7 +9,14 @@ export PS4="++"
 #
 # Restore target/ from the previous CI build on this machine
 #
-eval "$(ci/channel-info.sh)"
+channel_info="$(cargo xtask channel-info --json)"
+EDGE_CHANNEL="$(jq -r '.EDGE_CHANNEL' <<<"$channel_info")"
+BETA_CHANNEL="$(jq -r '.BETA_CHANNEL' <<<"$channel_info")"
+BETA_CHANNEL_LATEST_TAG="$(jq -r '.BETA_CHANNEL_LATEST_TAG' <<<"$channel_info")"
+STABLE_CHANNEL="$(jq -r '.STABLE_CHANNEL' <<<"$channel_info")"
+STABLE_CHANNEL_LATEST_TAG="$(jq -r '.STABLE_CHANNEL_LATEST_TAG' <<<"$channel_info")"
+CHANNEL="$(jq -r '.CHANNEL' <<<"$channel_info")"
+CHANNEL_LATEST_TAG="$(jq -r '.CHANNEL_LATEST_TAG' <<<"$channel_info")"
 export EDGE_CHANNEL
 export BETA_CHANNEL
 export BETA_CHANNEL_LATEST_TAG

--- a/ci/channel_restriction.sh
+++ b/ci/channel_restriction.sh
@@ -7,7 +7,7 @@ set -ex
 
 [[ -n $CI_TAG ]] && exit 0
 
-eval "$(ci/channel-info.sh)"
+CHANNEL="$(cargo xtask channel-info --json | jq -r '.CHANNEL')"
 
 for acceptable_channel in "$@"; do
   if [[ "$CHANNEL" == "$acceptable_channel" ]]; then

--- a/ci/publish-installer.sh
+++ b/ci/publish-installer.sh
@@ -10,7 +10,7 @@ if [[ -n $DO_NOT_PUBLISH_TAR ]]; then
 fi
 
 # check channel and tag
-eval "$(ci/channel-info.sh)"
+CHANNEL="$(cargo xtask channel-info --json | jq -r '.CHANNEL')"
 
 if [[ -n "$CI_TAG" ]]; then
   CHANNEL_OR_TAG=$CI_TAG

--- a/ci/publish-metrics-dashboard.sh
+++ b/ci/publish-metrics-dashboard.sh
@@ -34,8 +34,9 @@ EOF
 fi
 
 
-ci/channel-info.sh
-eval "$(ci/channel-info.sh)"
+channel_info="$(cargo xtask channel-info --json)"
+EDGE_CHANNEL="$(jq -r '.EDGE_CHANNEL' <<<"$channel_info")"
+BETA_CHANNEL="$(jq -r '.BETA_CHANNEL' <<<"$channel_info")"
 
 case $PUBLISH_CHANNEL in
 edge)

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -10,7 +10,9 @@ cd "$(dirname "$0")/.."
 source ci/_
 source ci/rust-version.sh stable
 source ci/rust-version.sh nightly
-eval "$(ci/channel-info.sh)"
+channel_info="$(cargo xtask channel-info --json)"
+EDGE_CHANNEL="$(jq -r '.EDGE_CHANNEL' <<<"$channel_info")"
+CHANNEL="$(jq -r '.CHANNEL' <<<"$channel_info")"
 
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings -A incomplete_features"

--- a/ci/test-stable.sh
+++ b/ci/test-stable.sh
@@ -49,7 +49,10 @@ source scripts/ulimit-n.sh
 source ci/common/limit-threads.sh
 
 # get channel info
-eval "$(ci/channel-info.sh)"
+channel_info="$(cargo xtask channel-info --json)"
+EDGE_CHANNEL="$(jq -r '.EDGE_CHANNEL' <<<"$channel_info")"
+BETA_CHANNEL="$(jq -r '.BETA_CHANNEL' <<<"$channel_info")"
+STABLE_CHANNEL="$(jq -r '.STABLE_CHANNEL' <<<"$channel_info")"
 
 #shellcheck source=ci/common/shared-functions.sh
 source ci/common/shared-functions.sh


### PR DESCRIPTION
#### Problem

Automatic channel detection still relies on the inadequate `ci/channel-info.sh` script and manual overrides.
For reference, and in-depth explanation, see https://github.com/anza-xyz/agave/pull/12299#issuecomment-4594353340 

#### Summary of Changes

Point the Linux buildkite channel-info consumers at `cargo xtask channel-info --json` + jq instead of `eval "$(ci/channel-info.sh)"`, dropping arbitrary-shell eval and scoping each caller to the fields it uses. The Windows path still uses the bash script, so it stays for now.

This PR is part of the WIP for #12450 and executes the cut-over to xtask for most of the CI pipelines.