### PR TITLE
feat(ci): honor channel pins in xtask channel-info

### DIFF
--- a/ci/xtask/src/commands/channel_info.rs
+++ b/ci/xtask/src/commands/channel_info.rs
@@ -35,9 +35,16 @@ pub async fn run(args: CommandArgs) -> Result<()> {
     .await?;
     let versions: BTreeMap<BranchVersion, Version> = heads.into_iter().zip(fetched).collect();
 
+    let pins = fetch::channel_pins(&client).await?;
     let branch = pick_env("CI_BASE_BRANCH").or_else(|| pick_env("CI_BRANCH"));
     let channel = pick_env("CHANNEL");
-    let info = derive_channels(&versions, &tags, branch.as_deref(), channel.as_deref())?;
+    let info = derive_channels(
+        &versions,
+        &tags,
+        branch.as_deref(),
+        channel.as_deref(),
+        &pins,
+    )?;
 
     if args.json {
         print_channel_info_json(&info)?;

--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -1,9 +1,12 @@
 use {
-    super::resolve::BranchVersion,
+    super::resolve::{BranchVersion, ChannelPins},
     anyhow::{Result, anyhow, bail},
     semver::Version,
     serde::Deserialize,
-    std::process::Command,
+    std::{
+        process::Command,
+        time::{SystemTime, UNIX_EPOCH},
+    },
 };
 
 const REMOTE: &str = "https://github.com/anza-xyz/agave.git";
@@ -65,6 +68,30 @@ struct WorkspaceSection {
 #[derive(Deserialize)]
 struct PackageSection {
     version: Version,
+}
+
+/// Fetch pin overrides from `master` (single source of truth for all
+/// branches). Cache-busted so a pin change takes effect at once; transport
+/// errors hard-fail rather than silently falling back to auto-resolution.
+pub async fn channel_pins(client: &reqwest::Client) -> Result<ChannelPins> {
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let url = format!("{RAW_BASE}/master/ci/channel-overrides");
+    let resp = client
+        .get(&url)
+        .query(&[("ts", ts)])
+        .send()
+        .await
+        .map_err(|e| anyhow!("GET {url}: {e}"))?
+        .error_for_status()
+        .map_err(|e| anyhow!("GET {url}: {e}"))?;
+    let raw = resp
+        .text()
+        .await
+        .map_err(|e| anyhow!("read body for {url}: {e}"))?;
+    ChannelPins::parse(&raw)
 }
 
 pub async fn workspace_version(client: &reqwest::Client, bv: BranchVersion) -> Result<Version> {

--- a/ci/xtask/src/commands/channel_info/resolve.rs
+++ b/ci/xtask/src/commands/channel_info/resolve.rs
@@ -58,6 +58,44 @@ pub fn stage_of(v: &Version) -> Result<Stage> {
     }
 }
 
+/// Manual channel pins parsed from `ci/channel-overrides` on master. A set pin
+/// forces the corresponding channel to a specific `vX.Y` line, overriding the
+/// version-derived value; `None` leaves auto-resolution in place.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ChannelPins {
+    pub beta: Option<BranchVersion>,
+    pub stable: Option<BranchVersion>,
+}
+
+impl ChannelPins {
+    pub fn parse(contents: &str) -> Result<Self> {
+        Ok(Self {
+            beta: extract_pin(contents, "PINNED_BETA_CHANNEL")?,
+            stable: extract_pin(contents, "PINNED_STABLE_CHANNEL")?,
+        })
+    }
+}
+
+fn extract_pin(contents: &str, key: &str) -> Result<Option<BranchVersion>> {
+    for line in contents.lines() {
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        if k.trim() != key {
+            continue;
+        }
+        let v = v.trim();
+        if v.is_empty() {
+            return Ok(None);
+        }
+        return v
+            .parse::<BranchVersion>()
+            .map(Some)
+            .map_err(|e| anyhow!("invalid {key} pin `{v}`: {e}"));
+    }
+    Ok(None)
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct ChannelInfo {
@@ -75,6 +113,7 @@ pub fn derive_channels(
     tags: &[Version],
     branch: Option<&str>,
     channel: Option<&str>,
+    pins: &ChannelPins,
 ) -> Result<ChannelInfo> {
     for (bv, v) in versions {
         if v.major != bv.major || v.minor != bv.minor {
@@ -96,6 +135,9 @@ pub fn derive_channels(
         Some(_) => (h1, h2),
         None => (None, None),
     };
+
+    let beta = pins.beta.or(beta);
+    let stable = pins.stable.or(stable);
 
     let beta = beta.ok_or_else(|| anyhow!("no BETA-eligible vX.Y head"))?;
 
@@ -185,7 +227,7 @@ mod tests {
     fn promotes_top_when_top_is_beta() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
 
-        let info = derive_channels(&vs, &[], None, None).unwrap();
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -195,7 +237,7 @@ mod tests {
     fn promotes_top_when_top_is_ga() {
         let vs = versions(&[(bv(4, 0), "4.0.5"), (bv(4, 1), "4.1.0")]);
 
-        let info = derive_channels(&vs, &[], None, None).unwrap();
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -209,7 +251,7 @@ mod tests {
             (bv(4, 1), "4.1.0-alpha.0"),
         ]);
 
-        let info = derive_channels(&vs, &[], None, None).unwrap();
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.beta_channel, "v4.0");
         assert_eq!(info.stable_channel, "v3.1");
@@ -219,7 +261,7 @@ mod tests {
     fn rc_top_is_promoted() {
         let vs = versions(&[(bv(4, 0), "4.0.10"), (bv(4, 1), "4.1.0-rc.2")]);
 
-        let info = derive_channels(&vs, &[], None, None).unwrap();
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.beta_channel, "v4.1");
         assert_eq!(info.stable_channel, "v4.0");
@@ -229,7 +271,7 @@ mod tests {
     fn rejects_mismatched_workspace_version() {
         let vs = versions(&[(bv(4, 0), "5.0.0")]);
 
-        let err = derive_channels(&vs, &[], None, None).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap_err();
 
         assert!(err.to_string().contains("does not match branch"));
     }
@@ -238,7 +280,7 @@ mod tests {
     fn rejects_unknown_prerelease_label() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-dev.0")]);
 
-        let err = derive_channels(&vs, &[], None, None).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap_err();
 
         assert!(err.to_string().contains("unknown prerelease label"));
     }
@@ -247,14 +289,15 @@ mod tests {
     fn rejects_when_only_alpha_top_and_nothing_below() {
         let vs = versions(&[(bv(4, 1), "4.1.0-alpha.0")]);
 
-        let err = derive_channels(&vs, &[], None, None).unwrap_err();
+        let err = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap_err();
 
         assert!(err.to_string().contains("no BETA-eligible"));
     }
 
     #[test]
     fn rejects_empty() {
-        let err = derive_channels(&BTreeMap::new(), &[], None, None).unwrap_err();
+        let err = derive_channels(&BTreeMap::new(), &[], None, None, &ChannelPins::default())
+            .unwrap_err();
 
         assert!(err.to_string().contains("no BETA-eligible"));
     }
@@ -264,7 +307,7 @@ mod tests {
         let vs = versions(&[(bv(3, 0), "3.0.5"), (bv(3, 1), "3.1.0-beta.0")]);
         let tags = vec![v("3.0.1"), v("3.0.5"), v("3.0.2"), v("2.9.9")];
 
-        let info = derive_channels(&vs, &tags, None, None).unwrap();
+        let info = derive_channels(&vs, &tags, None, None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.beta_channel_latest_tag, "");
         assert_eq!(info.stable_channel_latest_tag, "v3.0.5");
@@ -274,7 +317,7 @@ mod tests {
     fn channel_from_branch_match() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
 
-        let info = derive_channels(&vs, &[], Some("v4.1"), None).unwrap();
+        let info = derive_channels(&vs, &[], Some("v4.1"), None, &ChannelPins::default()).unwrap();
 
         assert_eq!(info.channel, "beta");
     }
@@ -283,7 +326,14 @@ mod tests {
     fn channel_env_var_wins() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
 
-        let info = derive_channels(&vs, &[], Some("master"), Some("stable")).unwrap();
+        let info = derive_channels(
+            &vs,
+            &[],
+            Some("master"),
+            Some("stable"),
+            &ChannelPins::default(),
+        )
+        .unwrap();
 
         assert_eq!(info.channel, "stable");
     }
@@ -291,7 +341,7 @@ mod tests {
     #[test]
     fn json_uses_screaming_snake_case_keys() {
         let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
-        let info = derive_channels(&vs, &[], None, None).unwrap();
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
 
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&info).unwrap()).unwrap();
@@ -303,6 +353,76 @@ mod tests {
         assert_eq!(json["STABLE_CHANNEL_LATEST_TAG"], "");
         assert_eq!(json["CHANNEL"], "");
         assert_eq!(json["CHANNEL_LATEST_TAG"], "");
+    }
+
+    #[test]
+    fn pin_overrides_auto_derived_channels() {
+        let vs = versions(&[
+            (bv(4, 0), "4.0.0"),
+            (bv(4, 1), "4.1.0"),
+            (bv(4, 2), "4.2.0-beta.0"),
+        ]);
+        let pins = ChannelPins {
+            beta: Some(bv(4, 1)),
+            stable: Some(bv(4, 0)),
+        };
+
+        let info = derive_channels(&vs, &[], None, None, &pins).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.1");
+        assert_eq!(info.stable_channel, "v4.0");
+    }
+
+    #[test]
+    fn empty_pins_leave_auto_resolution_intact() {
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
+
+        let info = derive_channels(&vs, &[], None, None, &ChannelPins::default()).unwrap();
+
+        assert_eq!(info.beta_channel, "v4.1");
+        assert_eq!(info.stable_channel, "v4.0");
+    }
+
+    #[test]
+    fn pinned_channel_picks_its_own_latest_tag() {
+        let vs = versions(&[(bv(4, 0), "4.0.0"), (bv(4, 1), "4.1.0-beta.0")]);
+        let tags = vec![v("4.0.3"), v("4.0.1")];
+        let pins = ChannelPins {
+            beta: None,
+            stable: Some(bv(4, 0)),
+        };
+
+        let info = derive_channels(&vs, &tags, None, None, &pins).unwrap();
+
+        assert_eq!(info.stable_channel, "v4.0");
+        assert_eq!(info.stable_channel_latest_tag, "v4.0.3");
+    }
+
+    #[test]
+    fn parse_reads_set_and_empty_pins() {
+        let contents = "\
+# comment line
+PINNED_BETA_CHANNEL=v4.1
+PINNED_STABLE_CHANNEL=
+";
+        let pins = ChannelPins::parse(contents).unwrap();
+
+        assert_eq!(pins.beta, Some(bv(4, 1)));
+        assert_eq!(pins.stable, None);
+    }
+
+    #[test]
+    fn parse_absent_keys_are_none() {
+        let pins = ChannelPins::parse("# nothing here\n").unwrap();
+
+        assert_eq!(pins, ChannelPins::default());
+    }
+
+    #[test]
+    fn parse_rejects_malformed_pin() {
+        let err = ChannelPins::parse("PINNED_BETA_CHANNEL=4.1\n").unwrap_err();
+
+        assert!(err.to_string().contains("invalid PINNED_BETA_CHANNEL pin"));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

channel-info command was supposed to replace pinned channel versions entirely. After further discussion in https://github.com/anza-xyz/agave/pull/12299#issuecomment-4594353340, it was decided to keep them for edge cases.

#### Summary of Changes

Port the pin overrides from ci/channel-info.sh into the xtask resolver.