### PR TITLE
Remove intermediate copy on tombstone insertion

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -189,12 +189,20 @@ impl AccountStorageEntry {
         self.zero_lamport_single_ref_offsets.read().unwrap().len() + self.num_tombstones()
     }
 
-    /// Batch-insert tombstone offsets.
-    pub(crate) fn batch_insert_tombstone_offsets(&self, offsets: &[Offset]) {
+    /// Batch-insert tombstone offsets, taking the offsets lock once.
+    /// Returns the number of offsets inserted.
+    pub(crate) fn batch_insert_tombstone_offsets(
+        &self,
+        offsets: impl IntoIterator<Item = Offset>,
+    ) -> usize {
         let mut tombstone_offsets = self.tombstone_offsets.write().unwrap();
+        let mut num_inserted = 0;
         for offset in offsets {
-            tombstone_offsets.insert(*offset);
+            if tombstone_offsets.insert(offset) {
+                num_inserted += 1;
+            }
         }
+        num_inserted
     }
 
     /// Locks the tombstone offset set with a read lock and returns it with the guard.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5684,9 +5684,7 @@ impl AccountsDb {
         }
         let tombstone_infos =
             self.write_accounts_to_storage(tombstones.target_slot(), new_storage, &tombstones);
-        let tombstone_offsets: Vec<_> = tombstone_infos.iter().map(|info| info.offset()).collect();
-        new_storage.batch_insert_tombstone_offsets(&tombstone_offsets);
-        tombstone_offsets.len()
+        new_storage.batch_insert_tombstone_offsets(tombstone_infos.iter().map(|info| info.offset()))
     }
 
     /// Stores accounts in the storage and updates the index.

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -1538,7 +1538,7 @@ fn test_shrink_collect_carries_forward_existing_tombstones() {
             }
         })
         .unwrap();
-    storage.batch_insert_tombstone_offsets(&[tombstone_offset.unwrap()]);
+    storage.batch_insert_tombstone_offsets([tombstone_offset.unwrap()]);
     assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 1);
 
     // Newer than the latest full snapshot: the tombstone must be carried forward, not dropped and
@@ -1620,7 +1620,7 @@ fn test_fully_tombstoned_storage_reclaim() {
             tombstone_offsets.push(offset);
         })
         .unwrap();
-    storage.batch_insert_tombstone_offsets(&tombstone_offsets);
+    storage.batch_insert_tombstone_offsets(tombstone_offsets);
 
     // The storage reads as entirely tombstones / fully removable.
     assert!(storage.has_only_tombstones());


### PR DESCRIPTION
#### Problem
Tombstones are copied and then fed into the insert tombstone function. 

#### Summary of Changes
- Pass in an iterator and map them rather than copying them

#### Testing
- Passed test suite. 

Fixes #
