### PR TITLE
bls_sigverify: process certificates from block markers for unstaked

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -288,7 +288,7 @@ impl Tvu {
             bounded(MAX_IN_FLIGHT_CONSENSUS_EVENTS);
         let generated_cert_types = Arc::new(GeneratedCertTypes::default());
         let (certificate_sender, certificate_receiver) = bounded(MAX_CERTIFICATES_FROM_BLOCKSTORE);
-        blockstore.set_certificate_sender(certificate_sender);
+        blockstore.set_certificate_sender(certificate_sender, migration_status.clone());
 
         let bls_sigverify_threads = {
             let (bls_packet_sender, bls_packet_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -132,8 +132,10 @@
 use {
     crate::entry::{Entry, MaxDataShredsLen},
     agave_votor_messages::{
-        certificate::{CertSignature, GenesisCert},
+        certificate::{CertSignature, CertificateType, GenesisCert},
+        consensus_message::Block,
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
+        unverified_vote_message::UnverifiedCertificate,
     },
     solana_bls_signatures::{
         BlsError, Signature as BLSSignature, SignatureCompressed as BLSSignatureCompressed,
@@ -141,6 +143,7 @@ use {
     },
     solana_clock::Slot,
     solana_hash::Hash,
+    solana_perf::packet::packet_config,
     std::mem::MaybeUninit,
     wincode::{
         ReadResult, SchemaRead, SchemaWrite, TypeMeta, WriteResult,
@@ -592,10 +595,92 @@ unsafe impl<'de, C: Config> SchemaRead<'de, C> for BlockComponent {
     }
 }
 
+/// Try to parse a Genesis certificate from a data shred payload
+pub fn genesis_certificate_from_shred(
+    payload: &[u8],
+    shred_version: u16,
+) -> Option<UnverifiedCertificate> {
+    if !BlockComponent::infer_is_block_marker(payload).unwrap_or(false) {
+        return None;
+    }
+    let BlockComponent::BlockMarker(VersionedBlockMarker::V1(marker)) =
+        wincode::config::deserialize_exact(payload, packet_config()).ok()?
+    else {
+        return None;
+    };
+    let BlockMarkerV1::GenesisCertificate(marker) = marker else {
+        return None;
+    };
+    let GenesisCertBlockMarker {
+        slot,
+        block_id,
+        bls_signature,
+        bitmap,
+    } = marker.into_inner();
+    if bitmap.len() > GenesisCertBlockMarker::MAX_BITMAP_SIZE {
+        return None;
+    }
+    Some(UnverifiedCertificate {
+        cert_type: CertificateType::Genesis(Block { slot, block_id }),
+        signature: bls_signature,
+        bitmap,
+        shred_version,
+    })
+}
+
+/// Converts a block footer finalization certificate into certificates ready for BLS verification.
+///
+/// A fast-finalization footer produces one `FinalizeFast` certificate. A slow-finalization footer
+/// produces the corresponding `Notarize` and `Finalize` certificates.
+pub fn finalization_certificates_from_footer(
+    block_final_cert: BlockFinalizationCert,
+    shred_version: u16,
+) -> Option<Vec<UnverifiedCertificate>> {
+    let BlockFinalizationCert {
+        slot,
+        block_id,
+        final_aggregate,
+        notar_aggregate,
+    } = block_final_cert;
+    let block = Block { slot, block_id };
+
+    let final_signature = final_aggregate.uncompress_signature().ok()?;
+    let final_bitmap = final_aggregate.into_bitmap();
+    if let Some(notar_aggregate) = notar_aggregate {
+        let notar_signature = notar_aggregate.uncompress_signature().ok()?;
+        let notar_bitmap = notar_aggregate.into_bitmap();
+        Some(vec![
+            UnverifiedCertificate {
+                cert_type: CertificateType::Notarize(block),
+                signature: notar_signature,
+                bitmap: notar_bitmap,
+                shred_version,
+            },
+            UnverifiedCertificate {
+                cert_type: CertificateType::Finalize(slot),
+                signature: final_signature,
+                bitmap: final_bitmap,
+                shred_version,
+            },
+        ])
+    } else {
+        Some(vec![UnverifiedCertificate {
+            cert_type: CertificateType::FinalizeFast(block),
+            signature: final_signature,
+            bitmap: final_bitmap,
+            shred_version,
+        }])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE, std::iter::repeat_n,
+        super::*,
+        solana_bls_signatures::{
+            BLS_SIGNATURE_AFFINE_SIZE, Keypair as BlsKeypair, Signature as BlsSignature,
+        },
+        std::iter::repeat_n,
         wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT,
     };
 
@@ -612,6 +697,118 @@ mod tests {
             skip_reward_cert: None,
             notar_reward_cert: None,
         }
+    }
+
+    fn test_votes_aggregate(payload: &[u8], bitmap: Vec<u8>) -> (VotesAggregate, BlsSignature) {
+        let signature: BlsSignature = BlsKeypair::new().sign(payload).into();
+        let aggregate = VotesAggregate::from_cert_signature(CertSignature { signature, bitmap });
+        (aggregate, signature)
+    }
+
+    #[test]
+    fn parse_genesis_certificate_from_shred() {
+        let parent_slot = 41;
+        let block_id = Hash::new_unique();
+        let shred_version = 123;
+        let signature: BlsSignature = BlsKeypair::new().sign(b"genesis").into();
+        let bitmap = vec![0xa5; 64];
+        let marker = GenesisCertBlockMarker {
+            slot: parent_slot,
+            block_id,
+            bls_signature: signature,
+            bitmap: bitmap.clone(),
+        };
+        let component = BlockComponent::new_block_marker(
+            VersionedBlockMarker::from_genesis_cert_block_marker(marker),
+        );
+        let payload = wincode::serialize(&component).unwrap();
+
+        let certificate = genesis_certificate_from_shred(&payload, shred_version).unwrap();
+        assert_eq!(
+            certificate.cert_type,
+            CertificateType::Genesis(Block {
+                slot: parent_slot,
+                block_id,
+            })
+        );
+        assert_eq!(certificate.signature, signature);
+        assert_eq!(certificate.bitmap, bitmap);
+        assert_eq!(certificate.shred_version, shred_version);
+
+        let mut payload_with_trailing_data = payload;
+        payload_with_trailing_data.push(0);
+        assert!(
+            genesis_certificate_from_shred(&payload_with_trailing_data, shred_version,).is_none()
+        );
+    }
+
+    #[test]
+    fn finalization_certificates_from_fast_footer() {
+        let slot = 42;
+        let block_id = Hash::new_unique();
+        let shred_version = 123;
+        let final_bitmap = vec![0x11; 64];
+        let (final_aggregate, final_signature) =
+            test_votes_aggregate(b"fast-finalize", final_bitmap.clone());
+        let certificates = finalization_certificates_from_footer(
+            BlockFinalizationCert {
+                slot,
+                block_id,
+                final_aggregate,
+                notar_aggregate: None,
+            },
+            shred_version,
+        )
+        .unwrap();
+
+        let [certificate] = certificates.as_slice() else {
+            panic!("expected one fast-finalization certificate");
+        };
+        assert_eq!(
+            certificate.cert_type,
+            CertificateType::FinalizeFast(Block { slot, block_id })
+        );
+        assert_eq!(certificate.signature, final_signature);
+        assert_eq!(certificate.bitmap, final_bitmap);
+        assert_eq!(certificate.shred_version, shred_version);
+    }
+
+    #[test]
+    fn finalization_certificates_from_slow_footer() {
+        let slot = 42;
+        let block_id = Hash::new_unique();
+        let shred_version = 123;
+        let final_bitmap = vec![0x11; 64];
+        let notar_bitmap = vec![0x22; 64];
+        let (final_aggregate, final_signature) =
+            test_votes_aggregate(b"finalize", final_bitmap.clone());
+        let (notar_aggregate, notar_signature) =
+            test_votes_aggregate(b"notarize", notar_bitmap.clone());
+        let certificates = finalization_certificates_from_footer(
+            BlockFinalizationCert {
+                slot,
+                block_id,
+                final_aggregate,
+                notar_aggregate: Some(notar_aggregate),
+            },
+            shred_version,
+        )
+        .unwrap();
+
+        let [notarize, finalize] = certificates.as_slice() else {
+            panic!("expected notarize and finalize certificates");
+        };
+        assert_eq!(
+            notarize.cert_type,
+            CertificateType::Notarize(Block { slot, block_id })
+        );
+        assert_eq!(notarize.signature, notar_signature);
+        assert_eq!(notarize.bitmap, notar_bitmap);
+        assert_eq!(notarize.shred_version, shred_version);
+        assert_eq!(finalize.cert_type, CertificateType::Finalize(slot));
+        assert_eq!(finalize.signature, final_signature);
+        assert_eq!(finalize.bitmap, final_bitmap);
+        assert_eq!(finalize.shred_version, shred_version);
     }
 
     #[test]

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -44,7 +44,9 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_entry::{
         block_component::{
-            BlockComponent, VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
+            BlockComponent, VersionedBlockFooter, VersionedBlockHeader, VersionedBlockMarker,
+            VersionedUpdateParent, finalization_certificates_from_footer,
+            genesis_certificate_from_shred,
         },
         entry::{Entry, create_ticks},
     },
@@ -117,6 +119,7 @@ pub const MAX_COMPLETED_SLOTS_IN_CHANNEL: usize = 100_000;
 /// a latency event rather than the only source of truth. Keep this small enough
 /// that Tower validators do not pay a large idle-memory cost for the channel.
 pub const MAX_UPDATE_PARENT_SIGNALS: usize = 4_096;
+const GENESIS_BLOCK_MARKER_SHRED_INDEX: u64 = DATA_SHREDS_PER_FEC_BLOCK as u64;
 // Update parent events are expected to be rare, so a small cache to avoid
 // hitting blockstore should suffice here. The "DoS" attack to cause cache churn
 // and misses is also expensive because it would involve malicious leader giving
@@ -131,6 +134,56 @@ pub type UpdateParentReceiver = Receiver<UpdateParentSignal>;
 type UpdateParentShredParentKey = (BlockLocation, Slot, u32);
 type UpdateParentShredParentCache =
     LruCache<UpdateParentShredParentKey, /* parent used for shred filtering */ Slot>;
+
+struct SignalUpdates {
+    should_signal: bool,
+    newly_completed_slots_with_last_index: Vec<(u64, u64)>,
+    update_parent_signals: Vec<UpdateParentSignal>,
+}
+
+#[derive(Debug)]
+struct CertificateForwarder {
+    /// The certificate along with the slot # of the block it was present in
+    sender: Sender<(Slot, UnverifiedCertificate)>,
+    migration_status: Arc<MigrationStatus>,
+}
+
+impl CertificateForwarder {
+    fn try_forward_certificate(&self, carrier_slot: Slot, certificate: UnverifiedCertificate) {
+        // It's fine to try send here as these certificates are not critical
+        let _ = self.sender.try_send((carrier_slot, certificate));
+    }
+
+    fn maybe_forward_genesis_certificate(&self, shred: &Shred) {
+        if self.migration_status.is_in_migration()
+            && let Some(certificate) = shred
+                .data()
+                .ok()
+                .and_then(|payload| genesis_certificate_from_shred(payload, shred.version()))
+        {
+            self.try_forward_certificate(shred.slot(), certificate);
+        }
+    }
+
+    fn maybe_forward_block_footer_certificate(
+        &self,
+        blockstore: &Blockstore,
+        slot: Slot,
+        last_index: u64,
+    ) {
+        if !self.migration_status.should_allow_block_markers(slot) {
+            return;
+        }
+        match blockstore.get_block_footer_certificates(slot, last_index) {
+            Ok(certificates) => {
+                for certificate in certificates {
+                    self.try_forward_certificate(slot, certificate);
+                }
+            }
+            Err(err) => warn!("failed to read block footer certificate for slot {slot}: {err}"),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct UpdateParentSignal {
@@ -339,7 +392,7 @@ pub struct Blockstore {
     /// parent. This tiny cache avoids a blockstore lookup for each later shred
     /// in small insertion batches.
     update_parent_shred_parent_cache: Mutex<UpdateParentShredParentCache>,
-    certificate_sender: OnceLock<Sender<(Slot, UnverifiedCertificate)>>,
+    certificate_forwarder: OnceLock<CertificateForwarder>,
     pub lowest_cleanup_slot: RwLock<Slot>,
     // A sender that feeds into the BlockstoreCleanupService request channel
     // to enable manual Blockstore purge requests to be issued
@@ -588,9 +641,16 @@ impl Blockstore {
     /// the slot in the certificate is the block being certified. The carrier slot is needed to
     /// check whether block markers were active and to attribute an invalid certificate to the
     /// leader that included it.
-    pub fn set_certificate_sender(&self, sender: Sender<(Slot, UnverifiedCertificate)>) {
-        self.certificate_sender
-            .set(sender)
+    pub fn set_certificate_sender(
+        &self,
+        sender: Sender<(Slot, UnverifiedCertificate)>,
+        migration_status: Arc<MigrationStatus>,
+    ) {
+        self.certificate_forwarder
+            .set(CertificateForwarder {
+                sender,
+                migration_status,
+            })
             .expect("certificate sender already set");
     }
 
@@ -684,7 +744,7 @@ impl Blockstore {
             update_parent_shred_parent_cache: Mutex::new(LruCache::new(
                 UPDATE_PARENT_SHRED_PARENT_CACHE_CAPACITY,
             )),
-            certificate_sender: OnceLock::new(),
+            certificate_forwarder: OnceLock::new(),
             insert_shreds_lock: Mutex::<()>::default(),
             switch_block_lock: SwitchBlockLock(FairMutex::new(())),
             max_root,
@@ -2021,17 +2081,12 @@ impl Blockstore {
         &self,
         shred_insertion_tracker: &mut ShredInsertionTracker,
         metrics: &mut BlockstoreInsertionMetrics,
-    ) -> Result<(
-        /* signal slot updates */ bool,
-        /* slots updated */ Vec<u64>,
-        /* update parent signals */ Vec<UpdateParentSignal>,
-    )> {
+    ) -> Result<SignalUpdates> {
         let mut start = Measure::start("Commit Working Sets");
-        let (should_signal, newly_completed_slots, update_parent_signals) = self
-            .commit_slot_meta_working_set(
-                &shred_insertion_tracker.slot_meta_working_set,
-                &mut shred_insertion_tracker.write_batch,
-            )?;
+        let signal_updates = self.commit_slot_meta_working_set(
+            &shred_insertion_tracker.slot_meta_working_set,
+            &mut shred_insertion_tracker.write_batch,
+        )?;
 
         for (erasure_set, working_erasure_meta) in &shred_insertion_tracker.erasure_metas {
             if !working_erasure_meta.should_write() {
@@ -2076,7 +2131,7 @@ impl Blockstore {
         start.stop();
         metrics.commit_working_sets_elapsed_us += start.as_us();
 
-        Ok((should_signal, newly_completed_slots, update_parent_signals))
+        Ok(signal_updates)
     }
 
     /// The main helper function that performs the shred insertion logic
@@ -2198,8 +2253,11 @@ impl Blockstore {
         // Compute DoubleMerkleMeta for any newly completed slots so it's committed atomically
         self.compute_double_merkle_meta_for_newly_completed_slots(&mut shred_insertion_tracker)?;
 
-        let (should_signal, newly_completed_slots, update_parent_signals) =
-            self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
+        let SignalUpdates {
+            should_signal,
+            newly_completed_slots_with_last_index,
+            update_parent_signals,
+        } = self.commit_updates_to_write_batch(&mut shred_insertion_tracker, metrics)?;
 
         // Write out the accumulated batch.
         let mut start = Measure::start("Write Batch");
@@ -2207,12 +2265,18 @@ impl Blockstore {
         start.stop();
         metrics.write_batch_elapsed_us += start.as_us();
 
+        if let Some(forwarder) = self.certificate_forwarder.get() {
+            for (slot, last_index) in newly_completed_slots_with_last_index.iter() {
+                forwarder.maybe_forward_block_footer_certificate(self, *slot, *last_index);
+            }
+        }
+
         send_signals(
             &self.new_shreds_signals.lock().unwrap(),
             &self.completed_slots_senders.lock().unwrap(),
             &self.update_parent_signals.lock().unwrap(),
             should_signal,
-            newly_completed_slots,
+            newly_completed_slots_with_last_index,
             update_parent_signals,
         );
 
@@ -2744,6 +2808,12 @@ impl Blockstore {
     ) -> std::result::Result<(), InsertDataShredError> {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
+
+        if shred_index == GENESIS_BLOCK_MARKER_SHRED_INDEX
+            && let Some(forwarder) = self.certificate_forwarder.get()
+        {
+            forwarder.maybe_forward_genesis_certificate(&shred);
+        }
 
         let ShredInsertionTracker {
             index_working_set,
@@ -5757,13 +5827,9 @@ impl Blockstore {
         &self,
         slot_meta_working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         write_batch: &mut WriteBatch,
-    ) -> Result<(
-        /* signal slot updates */ bool,
-        /* slots updated */ Vec<u64>,
-        /* update parent signals */ Vec<UpdateParentSignal>,
-    )> {
+    ) -> Result<SignalUpdates> {
         let mut should_signal = false;
-        let mut newly_completed_slots = vec![];
+        let mut newly_completed_slots_with_last_index = vec![];
         let mut update_parent_signals = Vec::new();
         let completed_slots_senders = self.completed_slots_senders.lock().unwrap();
 
@@ -5774,8 +5840,17 @@ impl Blockstore {
             assert!(slot_meta_entry.did_insert_occur);
             let meta: &SlotMeta = &RefCell::borrow(&*slot_meta_entry.new_slot_meta);
             let meta_backup = &slot_meta_entry.old_slot_meta;
-            if !completed_slots_senders.is_empty() && is_newly_completed_slot(meta, meta_backup) {
-                newly_completed_slots.push(slot);
+
+            // Only for original blocks that are now complete, notify receivers
+            if location == BlockLocation::Original
+                && !completed_slots_senders.is_empty()
+                && is_newly_completed_slot(meta, meta_backup)
+            {
+                newly_completed_slots_with_last_index.push((
+                    slot,
+                    meta.last_index
+                        .expect("newly completed slot has last index"),
+                ));
             }
             // Check if the working copy of the metadata has changed
             if Some(meta) != meta_backup.as_ref() {
@@ -5795,7 +5870,11 @@ impl Blockstore {
             }
         }
 
-        Ok((should_signal, newly_completed_slots, update_parent_signals))
+        Ok(SignalUpdates {
+            should_signal,
+            newly_completed_slots_with_last_index,
+            update_parent_signals,
+        })
     }
 
     /// Obtain the SlotMeta from the in-memory slot_meta_working_set or load
@@ -5935,6 +6014,50 @@ impl Blockstore {
         let shreds = entries_to_test_shreds(&entries, bank.slot(), bank.parent_slot(), true, 0);
         self.insert_shreds(shreds, false).unwrap();
     }
+
+    fn get_block_footer_certificates(
+        &self,
+        slot: Slot,
+        last_index: u64,
+    ) -> Result<Vec<UnverifiedCertificate>> {
+        let fec_set_size = DATA_SHREDS_PER_FEC_BLOCK as u32;
+        let Some(final_fec_start) = u32::try_from(last_index)
+            .ok()
+            .and_then(|index| index.checked_add(1))
+            .and_then(|end| end.checked_sub(fec_set_size))
+        else {
+            return Ok(vec![]);
+        };
+        let Some(footer_fec_start) = final_fec_start.checked_sub(fec_set_size) else {
+            return Ok(vec![]);
+        };
+        let completed_ranges = std::iter::once(footer_fec_start..final_fec_start).collect();
+        let components =
+            self.get_slot_components_in_block(slot, &completed_ranges, /*slot_meta:*/ None)?;
+        let [BlockComponent::BlockMarker(VersionedBlockMarker::V1(marker))] = components.as_slice()
+        else {
+            return Ok(vec![]);
+        };
+        let Some(VersionedBlockFooter::V1(footer)) = marker.as_block_footer() else {
+            return Ok(vec![]);
+        };
+        let Some(certificate) = footer.block_final_cert.clone() else {
+            return Ok(vec![]);
+        };
+
+        let shred_bytes = self
+            .get_data_shred(slot, u64::from(footer_fec_start))?
+            .ok_or(BlockstoreError::MissingShred(
+                slot,
+                u64::from(footer_fec_start),
+            ))?;
+        let shred = Shred::new_from_serialized_shred(shred_bytes).map_err(|err| {
+            BlockstoreError::InvalidShredData(format!(
+                "could not deserialize block footer shred in slot {slot}: {err}"
+            ))
+        })?;
+        Ok(finalization_certificates_from_footer(certificate, shred.version()).unwrap_or_default())
+    }
 }
 
 // Updates the `completed_data_indexes` with a new shred `new_shred_index`.
@@ -6006,7 +6129,7 @@ fn send_signals(
     completed_slots_senders: &[Sender<Vec<u64>>],
     update_parent_senders: &[UpdateParentSender],
     should_signal: bool,
-    newly_completed_slots: Vec<u64>,
+    newly_completed_slots: Vec<(u64, u64)>,
     update_parent_signals: Vec<UpdateParentSignal>,
 ) {
     if should_signal {
@@ -6024,14 +6147,12 @@ fn send_signals(
     }
 
     if !completed_slots_senders.is_empty() && !newly_completed_slots.is_empty() {
-        let mut slots: Vec<_> = (0..completed_slots_senders.len() - 1)
-            .map(|_| newly_completed_slots.clone())
+        let slots: Vec<_> = newly_completed_slots
+            .into_iter()
+            .map(|(slot, _)| slot)
             .collect();
-
-        slots.push(newly_completed_slots);
-
-        for (signal, slots) in completed_slots_senders.iter().zip(slots) {
-            let res = signal.try_send(slots);
+        for signal in completed_slots_senders {
+            let res = signal.try_send(slots.clone());
             if let Err(TrySendError::Full(_)) = res {
                 datapoint_error!(
                     "blockstore_error",

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -475,6 +475,14 @@ impl Shred {
         }
     }
 
+    /// Returns the application data carried by a data shred.
+    pub fn data(&self) -> Result<&[u8], Error> {
+        match self {
+            Self::ShredCode(_) => Err(Error::InvalidShredType),
+            Self::ShredData(shred) => shred.data(),
+        }
+    }
+
     pub fn index(&self) -> u32 {
         self.common_header().index
     }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -28,7 +28,10 @@ use {
         node::Node,
     },
     solana_keypair::Keypair,
-    solana_ledger::{create_new_tmp_ledger, shred::Shred},
+    solana_ledger::{
+        create_new_tmp_ledger,
+        shred::{Shred, filter::TurbineMode},
+    },
     solana_message::Message,
     solana_native_token::LAMPORTS_PER_SOL,
     solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
@@ -37,9 +40,12 @@ use {
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_rpc_client::rpc_client::RpcClient,
-    solana_runtime::genesis_utils::{
-        GenesisConfigInfo, ValidatorVoteKeypairs,
-        create_genesis_config_with_vote_accounts_and_cluster_type,
+    solana_runtime::{
+        bank_forks::BankForks,
+        genesis_utils::{
+            GenesisConfigInfo, ValidatorVoteKeypairs,
+            create_genesis_config_with_vote_accounts_and_cluster_type,
+        },
     },
     solana_shred_version::compute_shred_version,
     solana_signer::Signer,
@@ -85,6 +91,9 @@ pub struct ClusterConfig {
     pub validator_configs: Vec<ValidatorConfig>,
     /// Number of nodes that are unstaked and not voting (a.k.a listening)
     pub num_listeners: u64,
+    /// Optional turbine mode shared by all listener nodes. When unset, listeners inherit the
+    /// bootstrap validator's turbine mode.
+    pub listener_turbine_mode: Option<TurbineMode>,
     /// List of tuples (pubkeys, in_genesis) of each node if specified. If
     /// `in_genesis` == true, the validator's vote and stake accounts
     //  will be inserted into the genesis block instead of warming up through
@@ -129,6 +138,7 @@ impl Default for ClusterConfig {
         ClusterConfig {
             validator_configs: vec![],
             num_listeners: 0,
+            listener_turbine_mode: None,
             validator_keys: None,
             node_stakes: vec![],
             mint_lamports: DEFAULT_MINT_LAMPORTS,
@@ -467,6 +477,10 @@ impl LocalCluster {
 
         let mut listener_config = safe_clone_config(&config.validator_configs[0]);
         listener_config.voting_disabled = true;
+        listener_config.wait_for_supermajority = None;
+        if let Some(turbine_mode) = &config.listener_turbine_mode {
+            listener_config.turbine_mode = turbine_mode.clone();
+        }
         (0..config.num_listeners).for_each(|_| {
             cluster.add_validator_listener(
                 &listener_config,
@@ -900,16 +914,7 @@ impl LocalCluster {
         node_stakes: &[u64],
     ) {
         let alive_node_contact_infos = self.discover_nodes(socket_addr_space, test_name);
-        let bank_forks = self
-            .validators
-            .values()
-            .find_map(|validator_info| {
-                validator_info
-                    .validator
-                    .as_ref()
-                    .map(|validator| Arc::clone(&validator.bank_forks))
-            })
-            .expect("cluster must contain a running validator");
+        let bank_forks = self.bank_forks();
         info!("{test_name} looking for new notarized votes on all nodes");
         cluster_tests::check_for_new_notarized_votes(
             compute_shred_version(&self.genesis_config.hash(), None),
@@ -922,6 +927,18 @@ impl LocalCluster {
             bank_forks,
         );
         info!("{test_name} done waiting for notarized votes");
+    }
+
+    pub fn bank_forks(&self) -> Arc<RwLock<BankForks>> {
+        self.validators
+            .values()
+            .find_map(|validator_info| {
+                validator_info
+                    .validator
+                    .as_ref()
+                    .map(|validator| Arc::clone(&validator.bank_forks))
+            })
+            .expect("cluster must contain a running validator")
     }
 
     pub fn check_no_new_roots(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6143,6 +6143,7 @@ fn test_alpenglow_basic_equivocation() {
     let node_b_turbine_mode = TurbineMode::new(TurbineModeKind::TurbineDisabled);
     let mut b_validator_config = safe_clone_config(&a_validator_config);
     b_validator_config.turbine_mode = node_b_turbine_mode.clone();
+    let unstaked_turbine_mode = TurbineMode::new(TurbineModeKind::TurbineDisabled);
 
     // Equivocate every other slot, one shred per FEC set
     let last_duplicate = 20;
@@ -6166,6 +6167,8 @@ fn test_alpenglow_basic_equivocation() {
                 .zip(iter::repeat_with(|| true))
                 .collect(),
         ),
+        num_listeners: 1,
+        listener_turbine_mode: Some(unstaked_turbine_mode.clone()),
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
         skip_warmup_slots: true,
@@ -6202,11 +6205,12 @@ fn test_alpenglow_basic_equivocation() {
         sleep(Duration::from_secs(1));
     }
 
-    // Turn turbine back on, now the low staked node will be able to catchup
+    // Turn turbine back on, now the low-staked and unstaked nodes will be able to catch up
     node_b_turbine_mode.set(TurbineModeKind::Enabled);
+    unstaked_turbine_mode.set(TurbineModeKind::Enabled);
 
-    // Ensure all nodes are rooting
-    // Although the low staked node might be behind while the leader is equivocating,
+    // Ensure all nodes (including the unstaked) are rooting
+    // Although the low staked nodes might be behind while the leader is equivocating,
     // once the leader stops equivocating it will be able to catch up
     cluster.check_for_new_roots(
         32,
@@ -6217,6 +6221,7 @@ fn test_alpenglow_basic_equivocation() {
 
 fn test_alpenglow_migration(
     num_nodes: usize,
+    num_listeners: u64,
     test_name: &str,
     leader_schedule: &[usize],
 ) -> (
@@ -6249,6 +6254,7 @@ fn test_alpenglow_migration(
         validator_configs: make_identical_validator_configs(&validator_config, num_nodes),
         validator_keys: Some(keys.clone().into_iter().zip(iter::repeat(true)).collect()),
         node_stakes: node_stakes.clone(),
+        num_listeners,
         slots_per_epoch,
         stakers_slot_offset: slots_per_epoch,
         // So we don't have to wait so long
@@ -6268,11 +6274,12 @@ fn test_alpenglow_migration(
     // Create local cluster with alpenglow accounts but feature not activated
     let cluster = LocalCluster::new(&mut cluster_config, SocketAddrSpace::Unspecified);
 
-    let validator_keys: Vec<Arc<Keypair>> = cluster
-        .validators
-        .values()
-        .map(|v| v.info.keypair.clone())
-        .collect();
+    let validator_keys: Vec<Arc<Keypair>> =
+        keys.iter().map(|keys| keys.node_keypair.clone()).collect();
+    let staked_node_contact_infos = validator_keys
+        .iter()
+        .map(|keypair| cluster.get_contact_info(&keypair.pubkey()).unwrap().clone())
+        .collect_vec();
 
     let client = RpcClient::new_socket_with_commitment(
         cluster.entry_point_info.rpc().unwrap(),
@@ -6307,17 +6314,19 @@ fn test_alpenglow_migration(
 
     info!("Migration slot reached, checking for notarized votes");
 
-    // Check for new notarized votes
-    cluster.check_for_new_notarized_votes(
+    // Check that the staked nodes are sending new notarized votes
+    cluster_tests::check_for_new_notarized_votes(
+        compute_shred_version(&cluster.genesis_config.hash(), None),
         4,
+        &staked_node_contact_infos,
         test_name,
-        SocketAddrSpace::Unspecified,
         vote_listener_addr,
         &validator_keys,
         &node_stakes,
+        cluster.bank_forks(),
     );
 
-    // Additionally ensure that roots are being made
+    // Additionally ensure that roots are being made on all nodes (including unstaked)
     cluster.check_for_new_roots(8, test_name, SocketAddrSpace::Unspecified);
     (cluster, keys, migration_slot)
 }
@@ -6327,7 +6336,14 @@ fn test_alpenglow_migration(
 #[test]
 #[serial]
 fn test_alpenglow_migration_1() {
-    test_alpenglow_migration(1, "test_alpenglow_migration_1", &[4]);
+    test_alpenglow_migration(1, 0, "test_alpenglow_migration_1", &[4]);
+}
+
+/// An unstaked listener learns the genesis certificate from the first Alpenglow block and roots.
+#[test]
+#[serial]
+fn test_alpenglow_migration_1_with_unstaked_node() {
+    test_alpenglow_migration(1, 1, "test_alpenglow_migration_1_with_unstaked_node", &[4]);
 }
 
 /// Multi-node migration into Alpenglow, including notarized-vote and root production
@@ -6335,7 +6351,7 @@ fn test_alpenglow_migration_1() {
 #[test]
 #[serial]
 fn test_alpenglow_migration_4() {
-    test_alpenglow_migration(4, "test_alpenglow_migration_4", &[4, 4, 4, 4]);
+    test_alpenglow_migration(4, 0, "test_alpenglow_migration_4", &[4, 4, 4, 4]);
 }
 
 #[test]
@@ -6344,7 +6360,7 @@ fn test_alpenglow_restart_post_migration() {
     let test_name = "test_alpenglow_restart_post_migration";
 
     // Start a 2 node cluster and have it go through the migration
-    let (mut cluster, _, _) = test_alpenglow_migration(2, test_name, &[4, 4]);
+    let (mut cluster, _, _) = test_alpenglow_migration(2, 0, test_name, &[4, 4]);
 
     // Now restart one of the nodes. This causes the cluster to temporarily halt
     let node_pubkey = cluster.get_node_pubkeys()[0];
@@ -6371,7 +6387,7 @@ fn test_alpenglow_missed_migration_entirely() {
     // Critical that the third node is not in the leader schedule, as since
     // we clear blockstore later, we could end up producing duplicate blocks
     let (mut cluster, validator_keys, migration_slot) =
-        test_alpenglow_migration(3, test_name, &[4, 4, 0]);
+        test_alpenglow_migration(3, 0, test_name, &[4, 4, 0]);
 
     // Now kill the second node
     let node_pubkey = validator_keys[2].node_keypair.pubkey();


### PR DESCRIPTION
#### Problem
Currently unstaked nodes can have issues participating in the migration or during equivocation events
```
4999 (AG genesis block) - 5000 (TowerBFT)
                      \ - 5000 (Alpenglow) - ...
```

Since they do not participate in A2A, they never receive the genesis certificate and thus do not have the signal to clear the tower BFT version of 5000.

The Alpenglow version of 5000 contains the `GenesisBlockMarker` with the certificiate, but they do not replay this block as they already have an existing block.

This is a smaller subset of the larger issue that any sort of equivocation event is not processable by unstaked nodes.
In an equivocation event, it's not the Genesis certificate that we need, but a finalization certificate so that block id repair + switch bank can occur.

#### Summary of Changes
1. We know that shred 32 contains the `GenesisBlockMarker`
2. If we are `in_migration()`, parse shred 32 for a genesis certificate and send to bls sigverify
3. We know that the block footer is the penultimate FEC set
4. If we are post migration, parse the penultimate FEC set for newly completed slots and send to bls sigverify


#### Testing
Creates a migration test with an unstaked node. Test failed before.
Update the equivocation test with an unstaked node. Test failed before.

Fixes #https://github.com/anza-xyz/agave/issues/13751