### PR TITLE
conformance(syscall): use ConformanceCallback for cpis

### DIFF
--- a/svm/src/conformance/syscall.rs
+++ b/svm/src/conformance/syscall.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::conformance::{
-        callback::DefaultCallback,
+        callback::ConformanceCallback,
         err::{UnpackedResult, unpack_stable_result},
         instr::context::InstrContext,
         programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
@@ -92,7 +92,7 @@ pub fn execute_vm_syscall(input: ProtoSyscallContext) -> ProtoSyscallEffects {
         ..
     } = prepare_invoke_context_fields(
         &instr_context,
-        &DefaultCallback,
+        &ConformanceCallback,
         &loader_key,
         &sysvar_cache,
         &compute_budget,


### PR DESCRIPTION
#### Problem
CPIs into precompiles in the fuzzing harness are currently unsupported because the DefaultCallback returns `false` in their `is_precompile` check.

#### Summary of Changes
Use `ConformanceCallback` instead of `DefaultCallback` for syscalls.