### PR TITLE
tests(gossip): remove dependency on debug_assertions for constant values

### DIFF
--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -14,6 +14,7 @@ done
 echo "--- coverage: root (part 2)"
 "$git_root"/ci/test-coverage.sh \
   --features dev-context-only-utils \
+  --features solana-gossip/small-cluster-gossip \
   --lib \
   --bins \
   "${packages[@]}"

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -19,6 +19,7 @@ echo "--- coverage: coverage (part 3)"
 "$git_root"/ci/test-coverage.sh \
   --features frozen-abi \
   --features dev-context-only-utils \
+  --features solana-gossip/small-cluster-gossip \
   --workspace \
   --lib \
   --bins \

--- a/ci/stable/run-local-cluster-partially.sh
+++ b/ci/stable/run-local-cluster-partially.sh
@@ -23,6 +23,7 @@ source "$here"/common.sh
 _ cargo nextest run \
   --profile ci \
   --cargo-profile ci \
+  --features solana-gossip/small-cluster-gossip \
   --package solana-local-cluster \
   --test local_cluster \
   --partition hash:"$CURRENT/$TOTAL" \

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -34,6 +34,7 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
+small-cluster-gossip = []
 dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
     "solana-bloom/dev-context-only-utils",

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2712,6 +2712,94 @@ mod tests {
     }
 
     #[test]
+    fn test_pull_request_scan_cost() {
+        assert_eq!(pull_request_scan_cost(0, 0, 0), 8);
+        assert_eq!(pull_request_scan_cost(1_024, 6, 8), 128);
+        assert_eq!(pull_request_scan_cost(1_024, 6, 12), 192);
+        let crds_len = 1usize << (CRDS_SHARDS_BITS + 1);
+        assert_eq!(
+            pull_request_scan_cost(crds_len, CRDS_SHARDS_BITS + 1, 8),
+            16,
+        );
+    }
+
+    #[cfg(not(feature = "small-cluster-gossip"))]
+    #[test]
+    fn test_pull_request_scan_budget_production_config() {
+        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_CAPACITY, 1_048_576);
+        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC, 262_144);
+    }
+
+    #[cfg(feature = "small-cluster-gossip")]
+    #[test]
+    fn test_pull_request_scan_budget_small_cluster_config() {
+        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_CAPACITY, 8_192);
+        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC, 2_048);
+    }
+
+    #[test]
+    fn test_pull_request_scan_budget_exhaustion_isolated_per_ip() {
+        let keypair = Arc::new(Keypair::new());
+        let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
+        let mut cluster_info =
+            ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified);
+        // Keep the test independent of wall-clock refill.
+        cluster_info.pull_request_budget = KeyedRateLimiter::new(
+            GOSSIP_PULL_SCAN_BUDGET_CACHE_CAPACITY,
+            TokenBucket::new(
+                GOSSIP_PULL_SCAN_BUDGET_CAPACITY,
+                GOSSIP_PULL_SCAN_BUDGET_CAPACITY,
+                f64::MIN_POSITIVE,
+            ),
+            GOSSIP_PULL_SCAN_BUDGET_SHARD_COUNT,
+        );
+        let request = PullRequest {
+            pubkey: Pubkey::new_unique(),
+            addr: SocketAddr::from(([127, 0, 0, 1], 12_345)),
+            wallclock: timestamp(),
+            filter: CrdsFilter::new_rand(
+                crds_gossip_pull::MIN_NUM_BLOOM_ITEMS,
+                solana_packet::PACKET_DATA_SIZE,
+            ),
+        };
+        let second_ip_request = PullRequest {
+            pubkey: request.pubkey,
+            addr: SocketAddr::from(([127, 0, 0, 2], request.addr.port())),
+            wallclock: request.wallclock,
+            filter: request.filter.clone(),
+        };
+        request.filter.sanitize().unwrap();
+        let crds_len = crds_gossip_pull::MIN_NUM_BLOOM_ITEMS;
+        let cost = pull_request_scan_cost(
+            crds_len,
+            request.filter.get_mask_bits(),
+            request.filter.bloom_hash_count(),
+        );
+        let successful_requests = GOSSIP_PULL_SCAN_BUDGET_CAPACITY / cost;
+
+        assert!(cost <= GOSSIP_PULL_SCAN_BUDGET_CAPACITY);
+        assert_eq!(
+            cluster_info
+                .stats
+                .pull_request_scan_budget_exhausted
+                .load_relaxed(),
+            0,
+        );
+        for _ in 0..successful_requests {
+            assert!(cluster_info.try_consume_pull_request_scan_budget(&request, crds_len));
+        }
+        assert!(!cluster_info.try_consume_pull_request_scan_budget(&request, crds_len));
+        assert!(cluster_info.try_consume_pull_request_scan_budget(&second_ip_request, crds_len));
+        assert_eq!(
+            cluster_info
+                .stats
+                .pull_request_scan_budget_exhausted
+                .load_relaxed(),
+            1,
+        );
+    }
+
+    #[test]
     fn test_gossip_node() {
         //check that a gossip nodes always show up as spies
         let (node, _, _) = ClusterInfo::spy_node(solana_pubkey::new_rand(), 0);

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -25,6 +25,10 @@ impl Counter {
     pub(crate) fn add_relaxed(&self, x: u64) {
         self.0.fetch_add(x, Ordering::Relaxed);
     }
+    #[cfg(test)]
+    pub(crate) fn load_relaxed(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
     fn clear(&self) -> u64 {
         self.0.swap(0, Ordering::Relaxed)
     }

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -65,9 +65,9 @@ pub struct CrdsFilter {
     mask_bits: u32,
 }
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "small-cluster-gossip")]
 pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 512;
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "small-cluster-gossip"))]
 pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 65_536;
 
 // Loosest mask_bits floor accepted for incoming pull requests.
@@ -698,10 +698,11 @@ pub(crate) mod tests {
     };
 
     // Active filter slots per request set for these small-CRDS tests:
-    // `ceil(buckets / SAMPLE_RATE)`, with 1 bucket in debug and 64 in release.
-    #[cfg(debug_assertions)]
+    // `ceil(buckets / SAMPLE_RATE)`, with 1 bucket using the small-cluster
+    // feature and 64 in production.
+    #[cfg(feature = "small-cluster-gossip")]
     pub(crate) const MIN_NUM_BLOOM_FILTERS: usize = 1usize.div_ceil(super::SAMPLE_RATE);
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(feature = "small-cluster-gossip"))]
     pub(crate) const MIN_NUM_BLOOM_FILTERS: usize = 64usize.div_ceil(super::SAMPLE_RATE);
 
     impl CrdsGossipPull {
@@ -788,6 +789,39 @@ pub(crate) mod tests {
             let hash = Hash::new_unique();
             assert!(filter.test_mask(&hash));
         }
+    }
+
+    #[cfg(not(feature = "small-cluster-gossip"))]
+    #[test]
+    fn test_crds_filter_sanitize_production_mask_bits_floor() {
+        use solana_sanitize::{Sanitize, SanitizeError};
+
+        assert_eq!(MIN_NUM_BLOOM_ITEMS, 65_536);
+        assert_eq!(*MIN_PULL_REQUEST_MASK_BITS, 6);
+        let filter = CrdsFilter {
+            mask_bits: 5,
+            ..CrdsFilter::default()
+        };
+        assert_eq!(filter.sanitize(), Err(SanitizeError::InvalidValue));
+        let filter = CrdsFilter {
+            mask_bits: 6,
+            ..CrdsFilter::default()
+        };
+        assert_eq!(filter.sanitize(), Ok(()));
+    }
+
+    #[cfg(feature = "small-cluster-gossip")]
+    #[test]
+    fn test_crds_filter_sanitize_small_cluster_mask_bits_floor() {
+        use solana_sanitize::Sanitize;
+
+        assert_eq!(MIN_NUM_BLOOM_ITEMS, 512);
+        assert_eq!(*MIN_PULL_REQUEST_MASK_BITS, 0);
+        let filter = CrdsFilter {
+            mask_bits: 0,
+            ..CrdsFilter::default()
+        };
+        assert_eq!(filter.sanitize(), Ok(()));
     }
 
     #[test]

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -23,9 +23,9 @@ pub(crate) struct PushActiveSet([PushActiveSetEntry; NUM_PUSH_ACTIVE_SET_ENTRIES
 struct PushActiveSetEntry(IndexMap</*node:*/ Pubkey, /*origins:*/ ConcurrentBloom<Pubkey>>);
 
 impl PushActiveSet {
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "small-cluster-gossip")]
     const MIN_NUM_BLOOM_ITEMS: usize = 512;
-    #[cfg(not(debug_assertions))]
+    #[cfg(not(feature = "small-cluster-gossip"))]
     const MIN_NUM_BLOOM_ITEMS: usize = crate::cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY;
 
     pub(crate) fn get_nodes<'a>(

--- a/gossip/tests/conformance/helpers.rs
+++ b/gossip/tests/conformance/helpers.rs
@@ -187,7 +187,11 @@ pub(crate) fn make_pull_request_bytes(filter_bytes: &[u8], value_bytes: &[u8]) -
 /// so we construct and serialize the Rust object.
 pub(crate) fn make_crds_filter_bytes() -> Vec<u8> {
     use solana_gossip::crds_gossip_pull::CrdsFilter;
-    bincode::serialize(&CrdsFilter::new_rand(1, 128)).unwrap()
+    // A 128-byte bloom filter holds at most 178 items. 178 * 2^5 + 1 is the
+    // minimum item estimate for CrdsFilter::mask_bits to return 6.
+    let filter = CrdsFilter::new_rand(5_697, 128);
+    assert_eq!(filter.get_mask_bits(), 6);
+    bincode::serialize(&filter).unwrap()
 }
 
 /// Build a Vote CrdsData (variant 1).


### PR DESCRIPTION
#### Problem
Gossip constants such as `MIN_NUM_BLOOM_ITEMS` and `MIN_NUM_BLOOM_FILTERS` change between debug and release builds. This causes inconsistent behavior for downstream consumers (e..g solfuzz-agave) that rely on both debug and release builds.

#### Summary of Changes
Create a separate compile-time feature `small-cluster-gossip` which is enabled for tests but disabled for debug builds.

#### Testing
`gossip/src/crds_gossip_pull.rs`

#### Fixes
solfuzz-agave debug builds.
