### PR TITLE
epoch stakes: allows lookup stake from identity pubkey

### DIFF
--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -48,9 +48,14 @@ pub struct BLSPubkeyStakeEntry {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyToRankMap {
+    /// stores a mapping from the bls pubkey to the node's rank.
     rank_map: HashMap<BLSPubkeyCompressed, u16>,
+    /// stores a mapping from the vote account pubkey to the node's rank.
     vote_pubkey_to_rank: HashMap<Pubkey, u16>,
+    node_pubkey_map: HashMap<Pubkey, BLSPubkeyStakeEntry>,
+    /// a mapping from rank to [`BLSPubkeyStakeEntry`].
     sorted_pubkeys: Vec<BLSPubkeyStakeEntry>,
+    /// Total stake delegated to this validator.
     total_stake: NonZero<u64>,
 }
 
@@ -64,6 +69,7 @@ impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
             vote_pubkey_to_rank: HashMap::new(),
             sorted_pubkeys: Vec::new(),
             total_stake: NonZero::new(1).unwrap(),
+            node_pubkey_map: HashMap::new(),
         }
     }
 }
@@ -135,17 +141,20 @@ impl BLSPubkeyToRankMap {
             HashMap::with_capacity(keys_stake_entry_with_compressed.len());
         let mut vote_pubkey_to_rank_map =
             HashMap::with_capacity(keys_stake_entry_with_compressed.len());
+        let mut node_pubkey_map = HashMap::with_capacity(keys_stake_entry_with_compressed.len());
         for (rank, (entry, bls_pubkey_compressed)) in
             keys_stake_entry_with_compressed.into_iter().enumerate()
         {
             vote_pubkey_to_rank_map.insert(entry.vote_account_pubkey, rank as u16);
             bls_pubkey_to_rank_map.insert(bls_pubkey_compressed, rank as u16);
+            node_pubkey_map.insert(entry.node_pubkey, entry.clone());
             sorted_pubkeys.push(entry);
         }
         Self {
             rank_map: bls_pubkey_to_rank_map,
             vote_pubkey_to_rank: vote_pubkey_to_rank_map,
             sorted_pubkeys,
+            node_pubkey_map,
             total_stake,
         }
     }
@@ -173,6 +182,10 @@ impl BLSPubkeyToRankMap {
 
     pub fn get_pubkey_stake_entry(&self, index: usize) -> Option<&BLSPubkeyStakeEntry> {
         self.sorted_pubkeys.get(index)
+    }
+
+    pub fn node_pubkey_to_stake_entry(&self, node_pubkey: &Pubkey) -> Option<&BLSPubkeyStakeEntry> {
+        self.node_pubkey_map.get(node_pubkey)
     }
 }
 


### PR DESCRIPTION
#### Problem

- When a validator sends a vote, it includes it rank in the vote message.  The rank is not signed so we need to do a signature check on the msg to validate that the validator included the right rank in the message.
- Since the messages are sent over authenticated channels, the receiver knows the sender's identity pubkey so if we could look up the relevant information using the identity pubkey, the vote messages will no longer need to include a rank.
- In #13381 we want to do prefiltering of conflicting votes before we verify them and so it is important that we do not rely on the rank to do the filtering as a malicious validator can put in bogus ranks in the messages.


#### Summary of Changes

Introduces a mapping between node identity to `BLSPubkeyStakeEntry` in epoch stakes that can be used to look up a validator's stake and other information using its node identity.  This will be used in #13381.  Subsequently, we will also be able to remove the rank from the vote messages.


#### Testing

Just CI