### PR TITLE
feat(snapshot): read bank snapshot as one struct with matching abi digest

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -572,7 +572,7 @@ impl Default for BankFieldsToDeserialize {
             fee_rate_governor: FeeRateGovernor::default(),
             epoch_schedule: EpochSchedule::default(),
             inflation: Inflation::default(),
-            stakes: DeserializableStakes {
+            stakes: DeserializableDelegationStakes {
                 vote_accounts: VoteAccounts::default(),
                 stake_delegations: Vec::default(),
                 unused: u64::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -70,7 +70,8 @@ use {
             MaxAllowableDrift, calculate_stake_weighted_timestamp,
         },
         stakes::{
-            DelegatedStakes, DeserializableStakes, SerdeStakesToStakeFormat, Stakes, StakesCache,
+            DelegatedStakes, DeserializableDelegationStakes, SerdeStakesToStakeFormat, Stakes,
+            StakesCache,
         },
         status_cache::{SlotDelta, StatusCache},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
@@ -535,7 +536,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) fee_rate_governor: FeeRateGovernor,
     pub(crate) epoch_schedule: EpochSchedule,
     pub(crate) inflation: Inflation,
-    pub(crate) stakes: DeserializableStakes<Delegation>,
+    pub(crate) stakes: DeserializableDelegationStakes,
     /// Transformed into `HashMap<Epoch, VersionedEpochStakes>` in `serde_snapshot` and passed to
     /// `Bank::new_from_snapshot` as separate parameter for performance (conversion is time consuming)
     pub(crate) versioned_epoch_stakes: Vec<(Epoch, DeserializableVersionedEpochStakes)>,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -27,7 +27,10 @@ use {
         stake_delegation::effective_stake,
         stake_history::StakeHistory,
         stake_utils,
-        stakes::{DeserializableStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat, Stakes},
+        stakes::{
+            DeserializableDelegationStakes, InvalidCacheEntryReason, SerdeStakesToStakeFormat,
+            Stakes,
+        },
     },
     agave_feature_set::{self as feature_set, FeatureSet},
     agave_reserved_account_keys::ReservedAccount,
@@ -12485,7 +12488,7 @@ fn test_new_for_txn_tests_system_transfer() {
         );
     }
 
-    let stakes = DeserializableStakes {
+    let stakes = DeserializableDelegationStakes {
         vote_accounts: VoteAccounts::default(),
         stake_delegations: vec![],
         unused: 0,
@@ -12662,7 +12665,7 @@ fn test_new_for_block_tests_with_vote_account() {
         );
     }
 
-    let stakes_deser = DeserializableStakes {
+    let stakes_deser = DeserializableDelegationStakes {
         vote_accounts: VoteAccounts::default(),
         stake_delegations: vec![],
         unused: 0,

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -48,7 +48,7 @@ use {
         bank::{Bank, BankFieldsToDeserialize, BankRc},
         epoch_stakes::VersionedEpochStakes,
         stake_history::StakeHistory,
-        stakes::{DeserializableStakes, SerdeStakesToStakeFormat, Stakes},
+        stakes::{DeserializableDelegationStakes, SerdeStakesToStakeFormat, Stakes},
     },
     agave_feature_set::FeatureSet,
     solana_account::AccountSharedData,
@@ -137,7 +137,7 @@ pub fn execute_txn(
 
     // `new_for_txn_tests` ignores `stakes`/`versioned_epoch_stakes`, but the
     // struct still has to be constructed.
-    let stakes = DeserializableStakes {
+    let stakes = DeserializableDelegationStakes {
         vote_accounts: VoteAccounts::default(),
         stake_delegations: vec![],
         unused: 0,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -200,15 +200,42 @@ pub struct NodeVoteAccounts {
 ///
 /// Its bincode serializaiton format is identical as `VersionedEpochStakes`, but allows faster
 /// deserialization by ignoring serialized stake delegations entirely.
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(Serialize, AbiEnumVisitor, StableAbi, StableAbiSample)
+)]
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) enum DeserializableVersionedEpochStakes {
     Current {
+        #[cfg_attr(
+            feature = "frozen-abi",
+            stable_abi_sample(with = "stable_abi_sample_deserializable_epoch_stakes(rng)")
+        )]
         stakes: DeserializableEpochStakes,
         total_stake: u64,
         node_id_to_vote_accounts: NodeIdToVoteAccounts,
         epoch_authorized_voters: EpochAuthorizedVoters,
     },
+}
+
+/// Draws in `EpochStakes` declaration order (`epoch` first, not wire order) so the sample matches
+/// the serialize side; the serializer injects empty `stake_delegations`/zero `unused`, mirrored here.
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_deserializable_epoch_stakes(
+    rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized),
+) -> DeserializableEpochStakes {
+    use solana_frozen_abi::stable_abi::StableAbi;
+    let epoch = Epoch::random(rng);
+    let vote_accounts = VoteAccounts::random(rng);
+    let stake_history = StakeHistory::random(rng);
+    DeserializableEpochStakes {
+        vote_accounts,
+        _stake_delegations: Vec::new(),
+        _unused: 0,
+        epoch,
+        stake_history,
+    }
 }
 
 #[derive(Clone, Debug, Serialize, SchemaWrite)]
@@ -471,12 +498,16 @@ impl From<SerdeStakesToStakeFormat> for EpochStakes {
 /// Customization of EpochStakes for snapshot deserialization.
 ///
 /// Needed because snapshots contain additional fields no longer present in EpochStakes.
+// Sampling is overridden at the parent (`DeserializableVersionedEpochStakes::Current.stakes`), so
+// only `Serialize` is needed here.
+#[cfg_attr(feature = "frozen-abi", derive(Serialize))]
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct DeserializableEpochStakes {
     vote_accounts: VoteAccounts,
+    // Read-and-discarded (always empty); the serialize side writes it empty too.
     #[serde(deserialize_with = "deserialize_and_ignore_stake_delegations")]
-    _stake_delegations: (),
+    _stake_delegations: Vec<(Pubkey, Stake)>,
     _unused: u64,
     epoch: Epoch,
     stake_history: StakeHistory,
@@ -502,14 +533,16 @@ impl From<DeserializableEpochStakes> for EpochStakes {
 /// Snapshot epoch stakes contain delegations, but the main EpochStakes no longer uses them.
 /// This fn does custom deserialization to visit-and-ignore the delegations,
 /// avoiding the need to construct an expensive imbl::HashMap.
-fn deserialize_and_ignore_stake_delegations<'de, D>(deserializer: D) -> Result<(), D::Error>
+fn deserialize_and_ignore_stake_delegations<'de, D>(
+    deserializer: D,
+) -> Result<Vec<(Pubkey, Stake)>, D::Error>
 where
     D: Deserializer<'de>,
 {
     struct IgnoredStakeDelegationsVisitor;
 
     impl<'de> Visitor<'de> for IgnoredStakeDelegationsVisitor {
-        type Value = ();
+        type Value = Vec<(Pubkey, Stake)>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("a sequence of serialized stake delegations")
@@ -522,7 +555,7 @@ where
             while seq.next_element::<(Pubkey, Stake)>()?.is_some() {
                 // nothing to do here, ignore the delegations
             }
-            Ok(())
+            Ok(Vec::new())
         }
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "frozen-abi")]
+use solana_frozen_abi::stable_abi;
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 use std::{
     ffi::{CStr, CString},
@@ -10,7 +12,9 @@ use {
         runtime_config::RuntimeConfig,
         snapshot_utils::StorageAndNextAccountsFileId,
         stake_account::StakeAccount,
-        stakes::{DeserializableStakes, Stakes, serialize_stake_accounts_to_delegation_format},
+        stakes::{
+            DeserializableDelegationStakes, Stakes, serialize_stake_accounts_to_delegation_format,
+        },
     },
     agave_fs::FileInfo,
     agave_snapshots::error::SnapshotError,
@@ -98,7 +102,10 @@ pub(crate) struct SlotAccountStorageEntries {
     entries: SmallVec<[SerializableAccountStorageEntry; 1]>,
 }
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, Serialize, StableAbi, StableAbiSample)
+)]
 #[derive(Debug, Deserialize)]
 pub(crate) struct AccountsDbFields(
     Vec<SlotAccountStorageEntries>,
@@ -150,9 +157,9 @@ struct UnusedAccounts {
     unused3: HashMap<Pubkey, u64>,
 }
 
-// Deserializable version of Bank which need not be serializable,
-// because it's handled by SerializableVersionedBank.
-// So, sync fields with it!
+// Deserializable version of Bank; keep fields synced with SerializableVersionedBank.
+// frozen-abi Serialize exists only to pin the read-path abi digest (see DeserializableBankSnapshot).
+#[cfg_attr(feature = "frozen-abi", derive(Serialize, StableAbi, StableAbiSample))]
 #[derive(Clone, Deserialize)]
 struct DeserializableVersionedBank {
     blockhash_queue: BlockhashQueue,
@@ -183,7 +190,7 @@ struct DeserializableVersionedBank {
     _unused_rent_collector: UnusedRentCollector,
     epoch_schedule: EpochSchedule,
     inflation: Inflation,
-    stakes: DeserializableStakes<Delegation>,
+    stakes: DeserializableDelegationStakes,
     _unused_accounts: UnusedAccounts,
     unused_epoch_stakes: HashMap<Epoch, ()>,
     is_delta: bool,
@@ -411,6 +418,7 @@ where
         .deserialize_from::<R, T>(reader)
 }
 
+#[cfg(test)]
 fn deserialize_accounts_db_fields<R>(stream: &mut BufReader<R>) -> Result<AccountsDbFields, Error>
 where
     R: Read,
@@ -424,7 +432,10 @@ where
 /// ExtraFieldsToSerialize with the exception that new "extra fields" should be
 /// added to this struct a minor release before they are added to the serialize
 /// struct.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, Serialize, StableAbi, StableAbiSample)
+)]
 #[derive(Clone, Debug, Deserialize)]
 struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
@@ -434,6 +445,12 @@ struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
     _unused_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
+    // Match the serialize side's `HashMap<u64, VersionedEpochStakes>`, which samples `0..=1` entries.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "stable_abi::sample_collection_sized(rng, \
+                                  stable_abi::context::SequenceLenMax(1))")
+    )]
     versioned_epoch_stakes: Vec<(u64, DeserializableVersionedEpochStakes)>,
     #[serde(deserialize_with = "default_on_eof")]
     accounts_lt_hash: Option<SerdeAccountsLtHash>,
@@ -469,42 +486,70 @@ pub struct ExtraFieldsToSerialize {
     pub block_id: Option<Hash>,
 }
 
+/// Deserializable counterpart of [`SerializableBankSnapshot`], read as one struct (bincode reads
+/// the parts sequentially, matching separate reads).
+///
+/// Its frozen-abi digest must equal [`SerializableBankSnapshotForAbi`]'s, so the read and write
+/// wire formats can't diverge.
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(Serialize, StableAbi, StableAbiSample),
+    frozen_abi(
+        abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
+        abi_serializer = "bincode",
+        test_roundtrip = "wire_only"
+    )
+)]
+#[derive(Deserialize)]
+struct DeserializableBankSnapshot {
+    bank: DeserializableVersionedBank,
+    accounts_db: AccountsDbFields,
+    extra_fields: ExtraFieldsToDeserialize,
+}
+
+impl DeserializableBankSnapshot {
+    /// Folds the extra fields into the bank fields; errors if `unused_epoch_stakes` is non-empty.
+    fn into_fields(self) -> Result<(BankFieldsToDeserialize, AccountsDbFields), Error> {
+        let Self {
+            bank,
+            accounts_db,
+            extra_fields,
+        } = self;
+        if !bank.unused_epoch_stakes.is_empty() {
+            return Err(Box::new(bincode::ErrorKind::Custom(
+                "Expected deserialized bank's unused_epoch_stakes field to be empty".to_string(),
+            )));
+        }
+        let mut bank_fields = BankFieldsToDeserialize::from(bank);
+        let ExtraFieldsToDeserialize {
+            lamports_per_signature,
+            _unused_incremental_snapshot_persistence,
+            _unused_epoch_accounts_hash,
+            versioned_epoch_stakes,
+            accounts_lt_hash,
+            block_id,
+        } = extra_fields;
+
+        bank_fields.fee_rate_governor = bank_fields
+            .fee_rate_governor
+            .clone_with_lamports_per_signature(lamports_per_signature);
+        bank_fields.versioned_epoch_stakes = versioned_epoch_stakes;
+        bank_fields.accounts_lt_hash = accounts_lt_hash
+            .expect("snapshot must have accounts_lt_hash")
+            .into();
+        bank_fields.block_id = block_id;
+
+        Ok((bank_fields, accounts_db))
+    }
+}
+
 fn deserialize_bank_fields<R>(
-    mut stream: &mut BufReader<R>,
+    stream: &mut BufReader<R>,
 ) -> Result<(BankFieldsToDeserialize, AccountsDbFields), Error>
 where
     R: Read,
 {
-    let deserializable_bank = deserialize_from::<_, DeserializableVersionedBank>(&mut stream)?;
-    if !deserializable_bank.unused_epoch_stakes.is_empty() {
-        return Err(Box::new(bincode::ErrorKind::Custom(
-            "Expected deserialized bank's unused_epoch_stakes field to be empty".to_string(),
-        )));
-    }
-    let mut bank_fields = BankFieldsToDeserialize::from(deserializable_bank);
-    let accounts_db_fields = deserialize_accounts_db_fields(stream)?;
-    let extra_fields = deserialize_from(stream)?;
-
-    // Process extra fields
-    let ExtraFieldsToDeserialize {
-        lamports_per_signature,
-        _unused_incremental_snapshot_persistence,
-        _unused_epoch_accounts_hash,
-        versioned_epoch_stakes,
-        accounts_lt_hash,
-        block_id,
-    } = extra_fields;
-
-    bank_fields.fee_rate_governor = bank_fields
-        .fee_rate_governor
-        .clone_with_lamports_per_signature(lamports_per_signature);
-    bank_fields.versioned_epoch_stakes = versioned_epoch_stakes;
-    bank_fields.accounts_lt_hash = accounts_lt_hash
-        .expect("snapshot must have accounts_lt_hash")
-        .into();
-    bank_fields.block_id = block_id;
-
-    Ok((bank_fields, accounts_db_fields))
+    deserialize_from::<_, DeserializableBankSnapshot>(stream)?.into_fields()
 }
 
 pub(crate) fn fields_from_stream<R: Read>(

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -40,7 +40,7 @@ use {
 
 mod serde_stakes;
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-pub(crate) use serde_stakes::DeserializableStakes;
+pub(crate) use serde_stakes::DeserializableDelegationStakes;
 pub use serde_stakes::SerdeStakesToStakeFormat;
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) use serde_stakes::serialize_stake_accounts_to_delegation_format;
@@ -336,13 +336,13 @@ impl Stakes<StakeAccount> {
         }
     }
 
-    /// Creates a Stake<StakeAccount> from DeserializableStakes<Delegation> by loading the
+    /// Creates a Stake<StakeAccount> from DeserializableDelegationStakes by loading the
     /// full account state for respective stake pubkeys. get_account function
     /// should return the account at the respective slot where stakes where
     /// cached.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn load_from_deserialized_delegations<F>(
-        stakes: DeserializableStakes<Delegation>,
+        stakes: DeserializableDelegationStakes,
         get_account: F,
     ) -> Result<Self, Error>
     where
@@ -842,9 +842,9 @@ pub(crate) mod tests {
         solana_vote_program::vote_state,
     };
 
-    impl<T: Clone> Stakes<T> {
+    impl Stakes<Delegation> {
         /// Convert deserialized stakes into runtime stakes representation
-        pub(crate) fn from_deserialized(stakes: DeserializableStakes<T>) -> Self {
+        pub(crate) fn from_deserialized(stakes: DeserializableDelegationStakes) -> Self {
             Self {
                 vote_accounts: stakes.vote_accounts,
                 stake_delegations: ImblHashMap::from_iter(stakes.stake_delegations),

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -7,7 +7,7 @@ use {
     serde::{Deserialize, Serialize, Serializer, ser::SerializeMap},
     solana_clock::Epoch,
     solana_pubkey::Pubkey,
-    solana_stake_interface::state::Stake,
+    solana_stake_interface::state::{Delegation, Stake},
     solana_vote::vote_account::VoteAccounts,
     std::{collections::HashMap, sync::Arc},
 };
@@ -184,14 +184,33 @@ impl Serialize for SerdeStakeAccountMapToStakeFormat {
 /// Its bincode serializaiton format is identical as Stakes<T>, but allows faster
 /// deserialization without creating imbl::HashMap (such conversion is deferred until
 /// data is actually needed).
+#[cfg_attr(feature = "frozen-abi", derive(Serialize, StableAbi, StableAbiSample))]
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-pub(crate) struct DeserializableStakes<T> {
+pub(crate) struct DeserializableDelegationStakes {
     pub vote_accounts: VoteAccounts,
-    pub stake_delegations: Vec<(Pubkey, T)>,
+    // Sampled as `StakeAccount`s (as the serialize side does) reduced to the written `Delegation`.
+    #[cfg_attr(
+        feature = "frozen-abi",
+        stable_abi_sample(with = "stable_abi_sample_stake_delegations(rng)")
+    )]
+    pub stake_delegations: Vec<(Pubkey, Delegation)>,
     pub unused: u64,
     pub epoch: Epoch,
     pub stake_history: StakeHistory,
+}
+
+#[cfg(feature = "frozen-abi")]
+fn stable_abi_sample_stake_delegations(
+    rng: &mut (impl solana_frozen_abi::rand::RngCore + ?Sized),
+) -> Vec<(Pubkey, Delegation)> {
+    use solana_frozen_abi::stable_abi::{context::SequenceLenMax, sample_collection_sized};
+    let stake_accounts: Vec<(Pubkey, StakeAccount)> =
+        sample_collection_sized(rng, SequenceLenMax(1));
+    stake_accounts
+        .into_iter()
+        .map(|(pubkey, account)| (pubkey, *account.delegation()))
+        .collect()
 }
 
 #[cfg(test)]
@@ -202,55 +221,9 @@ mod tests {
         rand::Rng,
         serde::Deserialize,
         solana_rent::Rent,
-        solana_stake_interface::state::Delegation,
         solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
         solana_vote_program::vote_state,
     };
-
-    #[test]
-    fn test_serde_stakes_to_stake_format() {
-        let mut stake_delegations = ImblHashMap::new();
-        let vote_pubkey = Pubkey::new_unique();
-        let node_pubkey = Pubkey::new_unique();
-        stake_delegations.insert(
-            Pubkey::new_unique(),
-            StakeAccount::try_from(stake_utils::create_stake_account(
-                &Pubkey::new_unique(),
-                &vote_pubkey,
-                &vote_state::create_v4_account_with_authorized(
-                    &node_pubkey,
-                    &vote_pubkey,
-                    [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
-                    &vote_pubkey,
-                    0,
-                    &vote_pubkey,
-                    0,
-                    &node_pubkey,
-                    1_000_000_000,
-                ),
-                &Rent::default(),
-                1_000_000_000,
-            ))
-            .unwrap(),
-        );
-
-        let stake_account_stakes = Stakes {
-            vote_accounts: VoteAccounts::default(),
-            stake_delegations,
-            delegated_stakes: ImblHashMap::default(),
-            unused: 0,
-            epoch: 0,
-            stake_history: StakeHistory::default(),
-        };
-
-        let wrapped_stakes = SerdeStakesToStakeFormat::Account(stake_account_stakes.clone());
-        let serialized_stakes = bincode::serialize(&wrapped_stakes).unwrap();
-        let stake_stakes = Stakes::from_deserialized(
-            bincode::deserialize::<DeserializableStakes<Stake>>(&serialized_stakes).unwrap(),
-        );
-        let expected_stake_stakes = Stakes::<Stake>::from(stake_account_stakes);
-        assert_eq!(expected_stake_stakes, stake_stakes);
-    }
 
     #[test]
     fn test_serde_stakes_to_delegation_format() {
@@ -265,7 +238,7 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct DeserializableDummy {
             head: String,
-            stakes: DeserializableStakes<Delegation>,
+            stakes: DeserializableDelegationStakes,
             tail: String,
         }
 
@@ -326,7 +299,7 @@ mod tests {
         assert_eq!(other.stakes.stake_history, stakes.stake_history);
 
         assert!(other.stakes.stake_delegations.len() >= 50);
-        // DeserializableStakes doesn't preserve same order of elements as Stakes, compare converted
+        // DeserializableDelegationStakes doesn't preserve same order of elements as Stakes, compare converted
         let other_stakes = Stakes::from_deserialized(other.stakes);
         assert_eq!(other_stakes, dummy.stakes.into());
     }


### PR DESCRIPTION
#### Problem
Validation that snapshot serialize and deserialize formats match is lacking. Since both paths currently take quire divergent paths it's important to get a more systematic safety net, which will open up migration of deserialization to wincode. 

#### Summary of Changes
Introduce `DeserializableBankSnapshot`, the deserialize counterpart of `SerializableBankSnapshot`, and read the bank/accounts-db/extra fields through it as a single struct instead of three separate reads (byte-identical, since bincode reads the parts sequentially).

Pin its `frozen-abi` digest and assert it equals `SerializableBankSnapshotForAbi`'s, so the read and write wire formats cannot drift apart. To make the digests match, the deserialize structs gain frozen-abi-only `Serialize/StableAbi` impls and their sampling is aligned with the serialize side (stake delegations drawn as `StakeAccount`s and reduced to `Delegation`; epoch stakes drawn in `EpochStakes` field order with the serializer's injected empty delegations and zero unused).

De-genericize `DeserializableStakes` to `DeserializableDelegationStakes` (it was only ever used with `Delegation` outside one now-removed stake-format test), which lets its delegation sampling live as a field-level override.

#### Testing
CI / frozen-abi tests gain capability of checking abi_digest for the deserialization impl.