### PR TITLE
accounts-db: Uses written bytes in shrink and squash

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -235,11 +235,6 @@ impl AccountStorageEntry {
         self.accounts.len() as u64
     }
 
-    /// Returns the number of bytes, not accounts, this storage can hold
-    pub fn capacity(&self) -> u64 {
-        self.accounts.capacity()
-    }
-
     pub fn has_accounts(&self) -> bool {
         self.count() > 0
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -255,7 +255,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
 #[derive(Debug)]
 pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
     pub(crate) slot: Slot,
-    pub(crate) capacity: u64,
+    pub(crate) written_bytes: u64,
     pub(crate) pubkeys_to_unref: Vec<&'a Pubkey>,
     pub(crate) zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
     pub(crate) alive_accounts: T,
@@ -2707,7 +2707,7 @@ impl AccountsDb {
         let len = stored_accounts.len();
         let shrink_collect = Mutex::new(ShrinkCollect {
             slot,
-            capacity: *capacity,
+            written_bytes: *written_bytes,
             pubkeys_to_unref: Vec::with_capacity(len),
             zero_lamport_single_ref_pubkeys: Vec::new(),
             alive_accounts: T::with_capacity(len, slot),
@@ -2778,7 +2778,7 @@ impl AccountsDb {
             Ordering::Relaxed,
         );
         stats.bytes_removed.fetch_add(
-            capacity
+            written_bytes
                 .saturating_sub(alive_total_bytes as u64)
                 .saturating_sub(shrink_collect.tombstones_total_bytes as u64),
             Ordering::Relaxed,
@@ -3002,7 +3002,7 @@ impl AccountsDb {
 
         // This shouldn't happen if alive_bytes is accurate.
         // However, it is possible that the remaining alive bytes could be 0. In that case, the whole slot should be marked dead by clean.
-        if Self::should_not_shrink(total_rewrite_bytes as u64, shrink_collect.capacity)
+        if Self::should_not_shrink(total_rewrite_bytes as u64, shrink_collect.written_bytes)
             || total_rewrite_bytes == 0
         {
             if total_rewrite_bytes == 0 {
@@ -3013,9 +3013,9 @@ impl AccountsDb {
             if !shrink_collect.all_are_zero_lamports {
                 // if all are zero lamports, then we expect that we would like to mark the whole slot dead, but we cannot. That's clean's job.
                 info!(
-                    "Unexpected shrink for slot {} alive {} capacity {}, likely caused by a bug \
+                    "Unexpected shrink for slot {} alive {} written {}, likely caused by a bug \
                      for calculating alive bytes.",
-                    slot, shrink_collect.alive_total_bytes, shrink_collect.capacity
+                    slot, shrink_collect.alive_total_bytes, shrink_collect.written_bytes
                 );
             }
 
@@ -3034,7 +3034,7 @@ impl AccountsDb {
             shrink_collect.total_starting_accounts,
             total_accounts_after_shrink,
             shrink_collect.alive_total_bytes,
-            shrink_collect.capacity,
+            shrink_collect.written_bytes,
         );
 
         let mut stats_sub = ShrinkStatsSub::default();
@@ -3358,10 +3358,10 @@ impl AccountsDb {
         // for shrinking.
         if shrink_slots.len() < SHRINK_INSERT_ANCIENT_THRESHOLD {
             let mut ancients = self.best_ancient_slots_to_shrink.write().unwrap();
-            while let Some((slot, capacity)) = ancients.pop_front() {
+            while let Some((slot, written_bytes)) = ancients.pop_front() {
                 if let Some(store) = self.storage.get_slot_storage_entry(slot)
                     && !shrink_slots.contains(&slot)
-                    && capacity == store.capacity()
+                    && written_bytes == store.written_bytes()
                     && self.is_candidate_for_shrink(&store)
                 {
                     let ancient_bytes_added_to_shrink =

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -327,7 +327,7 @@ impl AccountFromStorage {
 
 pub struct GetUniqueAccountsResult {
     pub stored_accounts: Vec<AccountFromStorage>,
-    pub capacity: u64,
+    pub written_bytes: u64,
 }
 
 pub struct AccountsAddRootTiming {
@@ -2609,7 +2609,7 @@ impl AccountsDb {
         &self,
         store: &AccountStorageEntry,
     ) -> GetUniqueAccountsResult {
-        let capacity = store.capacity();
+        let written_bytes = store.written_bytes();
         let mut stored_accounts = Vec::with_capacity(store.count());
         store
             .accounts
@@ -2636,7 +2636,7 @@ impl AccountsDb {
 
         GetUniqueAccountsResult {
             stored_accounts,
-            capacity,
+            written_bytes,
         }
     }
 
@@ -2665,7 +2665,7 @@ impl AccountsDb {
 
         let GetUniqueAccountsResult {
             stored_accounts,
-            capacity,
+            written_bytes,
         } = unique_accounts;
 
         let mut index_read_elapsed = Measure::start("index_read_elapsed");

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6353,15 +6353,15 @@ fn test_shrink_collect_simple() {
                                 shrink_collect.tombstones_total_bytes,
                                 expected_tombstones.len() * AppendVec::calculate_stored_size(0)
                             );
-                            // expected_capacity is determined by what size append vec gets created when the write cache is flushed to an append vec.
-                            let mut expected_capacity =
+                            // expected_written_bytes is determined by what size append vec gets created when the write cache is flushed to an append vec.
+                            let mut expected_written_bytes =
                                 (account_count * AppendVec::calculate_stored_size(space)) as u64;
                             if append_opposite_zero_lamport_account && space != 0 {
                                 // zero lamport accounts always write space = 0
-                                expected_capacity -= space as u64;
+                                expected_written_bytes -= space as u64;
                             }
 
-                            assert_eq!(shrink_collect.capacity, expected_capacity);
+                            assert_eq!(shrink_collect.written_bytes, expected_written_bytes);
                             assert_eq!(shrink_collect.total_starting_accounts, account_count);
                             assert_eq!(
                                 shrink_collect.all_are_zero_lamports,

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -2834,7 +2834,7 @@ fn test_shrink_candidate_slots_with_dead_ancient_account() {
     // accounts it holds.  This is the data lengths of the
     // accounts plus the length of their metadata.
     assert_eq!(
-        created_accounts.capacity as usize,
+        created_accounts.written_bytes as usize,
         AppendVec::calculate_stored_size(1000) + AppendVec::calculate_stored_size(2000),
     );
     // The above check works only when the AppendVec storage is
@@ -6697,10 +6697,10 @@ fn get_one_ancient_append_vec_and_others_with_account_size(
     let after_store = db.get_storage_for_slot(slot1).unwrap();
     let GetUniqueAccountsResult {
         stored_accounts: after_stored_accounts,
-        capacity: after_capacity,
+        written_bytes: after_written_bytes,
         ..
     } = db.get_unique_accounts_from_storage(&after_store);
-    assert!(created_accounts.capacity <= after_capacity);
+    assert!(created_accounts.written_bytes <= after_written_bytes);
     assert_eq!(created_accounts.stored_accounts.len(), 1);
     // always 1 account: either we leave the append vec alone if it is all dead
     // or we create a new one and copy into it if account is alive

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -113,13 +113,6 @@ impl AccountsFile {
         }
     }
 
-    /// Returns the total number of bytes, *not accounts*, the AccountsFile can hold
-    pub fn capacity(&self) -> u64 {
-        match self {
-            Self::AppendVec(av) => av.capacity(),
-        }
-    }
-
     pub fn file_name(slot: Slot, id: AccountsFileId) -> String {
         format!("{slot}.{id}")
     }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2362,10 +2362,10 @@ mod tests {
         let after_store = db.storage.get_slot_storage_entry(slot1).unwrap();
         let GetUniqueAccountsResult {
             stored_accounts: after_stored_accounts,
-            capacity: after_capacity,
+            written_bytes: after_written_bytes,
             ..
         } = db.get_unique_accounts_from_storage(&after_store);
-        assert_eq!(created_accounts.capacity, after_capacity);
+        assert_eq!(created_accounts.written_bytes, after_written_bytes);
         assert_eq!(created_accounts.stored_accounts.len(), 1);
         // always 1 account: either we leave the append vec alone if it is all dead
         // or we create a new one and copy into it if account is alive

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -489,7 +489,7 @@ impl AccountsDb {
         // be re-packed together with other older/colder accounts.
         accounts_to_combine
             .accounts_to_combine
-            .sort_unstable_by_key(|a| a.capacity);
+            .sort_unstable_by_key(|a| a.written_bytes);
 
         // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
         // Note the `chain` below combining the 2 types of refs.
@@ -3803,7 +3803,7 @@ mod tests {
                 // irrelevant fields
                 zero_lamport_single_ref_pubkeys: Vec::default(),
                 slot: 0,
-                capacity: 0,
+                written_bytes: 0,
                 alive_accounts: ShrinkCollectAliveSeparatedByRefs {
                     one_ref: AliveAccounts::default(),
                     many_refs_this_is_newest_alive: AliveAccounts::default(),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -59,8 +59,8 @@ struct SlotInfo {
     storage: Arc<AccountStorageEntry>,
     /// slot of storage
     slot: Slot,
-    /// total capacity of storage
-    capacity: u64,
+    /// total bytes written in storage, before shrinking
+    written_bytes: u64,
     /// # alive bytes in storage *after* shrinking
     alive_bytes: u64,
     /// true if this should be shrunk due to ratio
@@ -103,8 +103,8 @@ impl AncientSlotInfos {
     ) -> bool {
         let mut was_randomly_shrunk = false;
         if alive_bytes_after_shrink > 0 {
-            let capacity = storage.accounts.capacity();
-            let should_shrink = if capacity > 0 {
+            let written_bytes = storage.written_bytes();
+            let should_shrink = if written_bytes > 0 {
                 if is_candidate_for_shrink {
                     true
                 } else if can_randomly_shrink && rng().random_range(0..10000) == 0 {
@@ -134,7 +134,7 @@ impl AncientSlotInfos {
             }
             self.all_infos.push(SlotInfo {
                 slot,
-                capacity,
+                written_bytes,
                 storage,
                 alive_bytes: alive_bytes_after_shrink,
                 should_shrink,
@@ -164,19 +164,19 @@ impl AncientSlotInfos {
         self.shrink_indexes.sort_unstable_by(|l, r| {
             let amount_shrunk = |index: &usize| {
                 let item = &self.all_infos[*index];
-                // alive_bytes assumes the accounts are aligned. `capacity` may
+                // alive_bytes assumes the accounts are aligned. `written_bytes` may
                 // not be aligned for the last account. Therefore, we need to
                 // align it.
-                let aligned_capacity = u64_align!(item.capacity as usize) as u64;
-                if aligned_capacity < item.alive_bytes {
+                let aligned_written_bytes = u64_align!(item.written_bytes as usize) as u64;
+                if aligned_written_bytes < item.alive_bytes {
                     // should not happen, but if it does, submit warn log it and continue
                     datapoint_warn!(
-                        "aligned_capacity_less_than_alive_bytes",
-                        ("aligned_capacity", aligned_capacity, i64),
+                        "aligned_written_bytes_less_than_alive_bytes",
+                        ("aligned_written_bytes", aligned_written_bytes, i64),
                         ("alive_bytes", item.alive_bytes, i64)
                     );
                 }
-                item.capacity.saturating_sub(item.alive_bytes)
+                item.written_bytes.saturating_sub(item.alive_bytes)
             };
             amount_shrunk(r).cmp(&amount_shrunk(l))
         });
@@ -204,7 +204,7 @@ impl AncientSlotInfos {
         for info_index in &self.shrink_indexes {
             let info = &mut self.all_infos[*info_index];
             self.best_slots_to_shrink
-                .push_back((info.slot, info.capacity));
+                .push_back((info.slot, info.written_bytes));
             if bytes_to_shrink_due_to_ratio.0 >= threshold_bytes {
                 // we exceeded the amount to shrink due to alive ratio, so don't shrink this one just due to 'should_shrink'
                 // It MAY be shrunk based on total capacity still.
@@ -315,7 +315,7 @@ impl AncientSlotInfos {
             r.is_high_slot
                 .cmp(&l.is_high_slot)
                 .then_with(|| r.should_shrink.cmp(&l.should_shrink))
-                .then_with(|| l.capacity.cmp(&r.capacity))
+                .then_with(|| l.written_bytes.cmp(&r.written_bytes))
         });
 
         // remove any storages we don't need to combine this pass to achieve
@@ -629,7 +629,7 @@ impl AccountsDb {
             .iter()
             .filter(|info| info.should_shrink)
             .map(|info| {
-                total_dead_bytes += info.capacity.saturating_sub(info.alive_bytes);
+                total_dead_bytes += info.written_bytes.saturating_sub(info.alive_bytes);
                 total_alive_bytes += info.alive_bytes;
             })
             .count()
@@ -1178,7 +1178,7 @@ mod tests {
             .map(|storage| SlotInfo {
                 storage: Arc::clone(storage),
                 slot: storage.slot(),
-                capacity: 0,
+                written_bytes: 0,
                 alive_bytes: 0,
                 should_shrink: false,
                 is_high_slot,
@@ -2333,7 +2333,7 @@ mod tests {
                     (
                         info.storage.id(),
                         info.slot,
-                        info.capacity,
+                        info.written_bytes,
                         info.alive_bytes,
                         info.should_shrink,
                     )
@@ -2661,7 +2661,7 @@ mod tests {
                 .map(|index| SlotInfo {
                     storage: Arc::clone(&storage),
                     slot: index as Slot,
-                    capacity: 1,
+                    written_bytes: 1,
                     alive_bytes: 1,
                     should_shrink: false,
                     is_high_slot: false,
@@ -2722,9 +2722,9 @@ mod tests {
                     .all_infos
                     .iter_mut()
                     .enumerate()
-                    .for_each(|(i, info)| info.capacity = 1 + i as u64);
+                    .for_each(|(i, info)| info.written_bytes = 1 + i as u64);
                 if reorder {
-                    infos.all_infos.last_mut().unwrap().capacity = 0; // sort to beginning
+                    infos.all_infos.last_mut().unwrap().written_bytes = 0; // sort to beginning
                 }
                 infos.all_infos.last_mut().unwrap().alive_bytes = ideal_storage_size_large;
                 // if we use max_storages = 3 or 4, then the low limit is 1 or 2. To get below 2 requires a result of 1, which packs everyone.
@@ -3279,7 +3279,7 @@ mod tests {
                         .enumerate()
                         .for_each(|(i, info)| {
                             info.should_shrink = true;
-                            info.capacity = ((i + 1) * 1000) as u64;
+                            info.written_bytes = ((i + 1) * 1000) as u64;
                         });
                     infos.all_infos[0].alive_bytes = 100;
                     infos.all_infos[1].alive_bytes = 900;
@@ -3342,7 +3342,7 @@ mod tests {
                         infos
                             .all_infos
                             .iter()
-                            .map(|info| (info.slot, info.capacity, info.alive_bytes))
+                            .map(|info| (info.slot, info.written_bytes, info.alive_bytes))
                             .collect::<Vec<_>>()
                     );
                 }
@@ -3358,11 +3358,11 @@ mod tests {
         let slot = 0;
 
         // info1 is first, equal, last
-        for info1_capacity in [0, 1, 2] {
+        for info1_written_bytes in [0, 1, 2] {
             let info1 = SlotInfo {
                 storage: storage.clone(),
                 slot,
-                capacity: info1_capacity,
+                written_bytes: info1_written_bytes,
                 alive_bytes: 0,
                 should_shrink: false,
                 is_high_slot: false,
@@ -3370,7 +3370,7 @@ mod tests {
             let info2 = SlotInfo {
                 storage: storage.clone(),
                 slot,
-                capacity: 2,
+                written_bytes: 2,
                 alive_bytes: 1,
                 should_shrink: false,
                 is_high_slot: false,
@@ -3383,8 +3383,8 @@ mod tests {
             infos.sort_shrink_indexes_by_bytes_saved();
             let first = &infos.all_infos[infos.shrink_indexes[0]];
             let second = &infos.all_infos[infos.shrink_indexes[1]];
-            let first_capacity = first.capacity - first.alive_bytes;
-            let second_capacity = second.capacity - second.alive_bytes;
+            let first_capacity = first.written_bytes - first.alive_bytes;
+            let second_capacity = second.written_bytes - second.alive_bytes;
             assert!(first_capacity >= second_capacity);
         }
     }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -2376,7 +2376,7 @@ mod tests {
     fn assert_storage_info(info: &SlotInfo, storage: &AccountStorageEntry, should_shrink: bool) {
         assert_eq!(storage.id(), info.storage.id());
         assert_eq!(storage.slot(), info.slot);
-        assert_eq!(storage.capacity(), info.capacity);
+        assert_eq!(storage.written_bytes(), info.written_bytes);
         assert_eq!(storage.alive_bytes(), info.alive_bytes as usize);
         assert_eq!(should_shrink, info.should_shrink);
     }


### PR DESCRIPTION
#### Problem

Following on after #13821 and #13852, continue removing calls to capacity(). 

More context:

While designing a new storage format, presizing, like how AppendVec does it, isn't useful. Back a long time ago, before the accounts write cache existed, AppendVecs were actually appended to. So a max capacity was used to enforce a size limit. Nowadays, we always write all the accounts at once, and never append. So the number of bytes written remains constant afterwards.

With a split file format, it is not clear how 'capacity' would work. Luckily, `capacity()` is mostly interchangeable with the number of bytes written in a storage.


#### Summary of Changes

For this PR, replace uses of capacity() with written_bytes() in the remaining spots of shrink and squash.

Specifically:
- GetUniqueAccountsResult::capacity
- ShrinkCollect::capacity
- SlotInfo::capacity

And then remove:
- AccountStorageEntry::capacity()
- AccountsFile::capacity()


#### Testing

I have a node running this branch and its metrics look normal/unchanged. Let me know if you'd like any posted here.
