### PR TITLE
flh: reclassify some failure errors from hard -> soft

### DIFF
--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -119,6 +119,9 @@ fn is_update_parent_recoverable_replay_error(err: &BlockstoreProcessorError) -> 
         | BlockstoreProcessorError::InvalidTransaction(_)
         | BlockstoreProcessorError::UserTransactionsInVoteOnlyBank(_)
         | BlockstoreProcessorError::ChainedBlockIdFailure(_, _) => true,
+        BlockstoreProcessorError::FailedToLoadEntries(
+            BlockstoreError::InvalidShredData(_) | BlockstoreError::BlockAborted(_),
+        ) => true,
         BlockstoreProcessorError::BlockComponentProcessor(err) => {
             err.is_update_parent_recoverable_replay_error()
         }

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -98,6 +98,11 @@ pub enum BlockComponentProcessorError {
 }
 
 impl BlockComponentProcessorError {
+    /// Returns whether this error can come from an optimistic-parent prefix
+    /// that a later usable `UpdateParent` makes obsolete.
+    ///
+    /// This only determines soft-dead eligibility. Replay also verifies that
+    /// the failure occurred before the `UpdateParent`.
     pub fn is_update_parent_recoverable_replay_error(&self) -> bool {
         match self {
             BlockComponentProcessorError::MissingParentMarker
@@ -109,19 +114,19 @@ impl BlockComponentProcessorError {
             | BlockComponentProcessorError::NanosecondClockOutOfBounds
             | BlockComponentProcessorError::UnexpectedInitialUpdateParent
             | BlockComponentProcessorError::GenesisCertificateOutOfOrder
+            | BlockComponentProcessorError::GenesisCertificateAlreadyPopulated
+            | BlockComponentProcessorError::GenesisCertificateInAlpenglowCluster
+            | BlockComponentProcessorError::GenesisCertificateOnNonChild
+            | BlockComponentProcessorError::GenesisCertificateFailedVerification
+            | BlockComponentProcessorError::SpuriousUpdateParent
             | BlockComponentProcessorError::AbandonedBank(_)
             | BlockComponentProcessorError::InvalidRewardCerts(_)
             | BlockComponentProcessorError::UpdateBankFooter(_)
             | BlockComponentProcessorError::InvalidFinalizationCertificate(_) => true,
             BlockComponentProcessorError::BlockComponentPreMigration
-            | BlockComponentProcessorError::GenesisCertificateAlreadyPopulated
-            | BlockComponentProcessorError::GenesisCertificateInAlpenglowCluster
-            | BlockComponentProcessorError::GenesisCertificateOnNonChild
-            | BlockComponentProcessorError::GenesisCertificateFailedVerification
             | BlockComponentProcessorError::MissingBlockFooter
             | BlockComponentProcessorError::MissingGenesisCertificateMarker
             | BlockComponentProcessorError::MultipleUpdateParents
-            | BlockComponentProcessorError::SpuriousUpdateParent
             | BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(_) => false,
         }
     }


### PR DESCRIPTION
#### Problem
These failures were previously marked as hard failures (could not be revived via `UpdateParent`) but after inspection they should be soft failures.

To analyze, imagine 1 group replays from the prefix, while the other starts from the update parent.

#### Summary of Changes
Move these from hard -> soft failures

Fixes #13788 