### PR TITLE
gossip: unify bloom filter consts across release and debug

### DIFF
--- a/ci/coverage/part-2.sh
+++ b/ci/coverage/part-2.sh
@@ -14,7 +14,6 @@ done
 echo "--- coverage: root (part 2)"
 "$git_root"/ci/test-coverage.sh \
   --features dev-context-only-utils \
-  --features solana-gossip/small-cluster-gossip \
   --lib \
   --bins \
   "${packages[@]}"

--- a/ci/coverage/part-3.sh
+++ b/ci/coverage/part-3.sh
@@ -19,7 +19,6 @@ echo "--- coverage: coverage (part 3)"
 "$git_root"/ci/test-coverage.sh \
   --features frozen-abi \
   --features dev-context-only-utils \
-  --features solana-gossip/small-cluster-gossip \
   --workspace \
   --lib \
   --bins \

--- a/ci/stable/run-local-cluster-partially.sh
+++ b/ci/stable/run-local-cluster-partially.sh
@@ -23,7 +23,6 @@ source "$here"/common.sh
 _ cargo nextest run \
   --profile ci \
   --cargo-profile ci \
-  --features solana-gossip/small-cluster-gossip \
   --package solana-local-cluster \
   --test local_cluster \
   --partition hash:"$CURRENT/$TOTAL" \

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -34,7 +34,6 @@ frozen-abi = [
     "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
-small-cluster-gossip = []
 dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
     "solana-bloom/dev-context-only-utils",

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2714,18 +2714,10 @@ mod tests {
         );
     }
 
-    #[cfg(not(feature = "small-cluster-gossip"))]
     #[test]
     fn test_pull_request_scan_budget_production_config() {
         assert_eq!(GOSSIP_PULL_SCAN_BUDGET_CAPACITY, 1_048_576);
         assert_eq!(GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC, 262_144);
-    }
-
-    #[cfg(feature = "small-cluster-gossip")]
-    #[test]
-    fn test_pull_request_scan_budget_small_cluster_config() {
-        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_CAPACITY, 8_192);
-        assert_eq!(GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC, 2_048);
     }
 
     #[test]

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -65,9 +65,6 @@ pub struct CrdsFilter {
     mask_bits: u32,
 }
 
-#[cfg(feature = "small-cluster-gossip")]
-pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 512;
-#[cfg(not(feature = "small-cluster-gossip"))]
 pub(crate) const MIN_NUM_BLOOM_ITEMS: usize = 65_536;
 
 // Loosest mask_bits floor accepted for incoming pull requests.
@@ -692,12 +689,7 @@ pub(crate) mod tests {
         test_case::test_case,
     };
 
-    // Active filter slots per request set for these small-CRDS tests:
-    // `ceil(buckets / SAMPLE_RATE)`, with 1 bucket using the small-cluster
-    // feature and 64 in production.
-    #[cfg(feature = "small-cluster-gossip")]
-    pub(crate) const MIN_NUM_BLOOM_FILTERS: usize = 1usize.div_ceil(super::SAMPLE_RATE);
-    #[cfg(not(feature = "small-cluster-gossip"))]
+    // Active filter slots per request set for these tests:
     pub(crate) const MIN_NUM_BLOOM_FILTERS: usize = 64usize.div_ceil(super::SAMPLE_RATE);
 
     impl CrdsGossipPull {
@@ -786,9 +778,8 @@ pub(crate) mod tests {
         }
     }
 
-    #[cfg(not(feature = "small-cluster-gossip"))]
     #[test]
-    fn test_crds_filter_sanitize_production_mask_bits_floor() {
+    fn test_crds_filter_sanitize_mask_bits_floor() {
         use solana_sanitize::{Sanitize, SanitizeError};
 
         assert_eq!(MIN_NUM_BLOOM_ITEMS, 65_536);
@@ -800,20 +791,6 @@ pub(crate) mod tests {
         assert_eq!(filter.sanitize(), Err(SanitizeError::InvalidValue));
         let filter = CrdsFilter {
             mask_bits: 6,
-            ..CrdsFilter::default()
-        };
-        assert_eq!(filter.sanitize(), Ok(()));
-    }
-
-    #[cfg(feature = "small-cluster-gossip")]
-    #[test]
-    fn test_crds_filter_sanitize_small_cluster_mask_bits_floor() {
-        use solana_sanitize::Sanitize;
-
-        assert_eq!(MIN_NUM_BLOOM_ITEMS, 512);
-        assert_eq!(*MIN_PULL_REQUEST_MASK_BITS, 0);
-        let filter = CrdsFilter {
-            mask_bits: 0,
             ..CrdsFilter::default()
         };
         assert_eq!(filter.sanitize(), Ok(()));

--- a/gossip/src/push_active_set.rs
+++ b/gossip/src/push_active_set.rs
@@ -23,9 +23,6 @@ pub(crate) struct PushActiveSet([PushActiveSetEntry; NUM_PUSH_ACTIVE_SET_ENTRIES
 struct PushActiveSetEntry(IndexMap</*node:*/ Pubkey, /*origins:*/ ConcurrentBloom<Pubkey>>);
 
 impl PushActiveSet {
-    #[cfg(feature = "small-cluster-gossip")]
-    const MIN_NUM_BLOOM_ITEMS: usize = 512;
-    #[cfg(not(feature = "small-cluster-gossip"))]
     const MIN_NUM_BLOOM_ITEMS: usize = crate::cluster_info::CRDS_UNIQUE_PUBKEY_CAPACITY;
 
     pub(crate) fn get_nodes<'a>(


### PR DESCRIPTION
#### Problem
we have different constants for release and debug builds. i think it was done a long time ago to reduce test time. but let's get accurate tests over reducing test time

#### Summary of Changes
make constants uniform between release and debug
remove small-cluster-gossip feature since no longer needed

#### Testing
ci