### PR TITLE
vote: remove pre-2.1.0 compatibility deserializer for VoteAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Release channels have their own copy of this changelog:
 #### Changes
 ### Validator
 #### Breaking
+* Loading a snapshot that contains an invalid vote account is now a hard error. Previously such
+  accounts were silently dropped for compatibility with snapshots created before v2.1.0.
 * Banking trace is now disabled by default. To enable, provide `--enable-banking-trace <max bytes>`.
 #### Deprecations
 * `--disable-banking-trace` is now deprecated and a no-op (banking trace is disabled by

--- a/runtime/tests/vote_account.rs
+++ b/runtime/tests/vote_account.rs
@@ -97,30 +97,29 @@ fn test_vote_accounts_deserialize() {
 #[test]
 fn test_vote_accounts_deserialize_invalid_account() {
     let mut rng = rand::rng();
-    // we'll populate the map with 1 valid and 2 invalid accounts, then ensure that we only get
-    // the valid one after deserialiation
+    // an invalid account in the serialized map must now be a hard deserialization error instead of
+    // being silently dropped (bad data)
     let mut vote_accounts_hash_map = HashMap::<Pubkey, (u64, AccountSharedData)>::new();
 
     let valid_account = new_rand_vote_account(&mut rng, None, true);
     vote_accounts_hash_map.insert(Pubkey::new_unique(), (0xAA, valid_account.clone()));
 
-    // bad data
     let invalid_account_data =
         AccountSharedData::new_data(42, &vec![0xFF; 42], &solana_sdk_ids::vote::id()).unwrap();
     vote_accounts_hash_map.insert(Pubkey::new_unique(), (0xBB, invalid_account_data));
 
-    // wrong owner
+    let data = bincode::serialize(&vote_accounts_hash_map).unwrap();
+    assert!(bincode::deserialize::<VoteAccounts>(&data).is_err());
+
+    // wrong owner is also a hard error
+    let mut vote_accounts_hash_map = HashMap::<Pubkey, (u64, AccountSharedData)>::new();
     let invalid_account_key =
         AccountSharedData::new_data(42, &valid_account.data().to_vec(), &Pubkey::new_unique())
             .unwrap();
     vote_accounts_hash_map.insert(Pubkey::new_unique(), (0xCC, invalid_account_key));
 
     let data = bincode::serialize(&vote_accounts_hash_map).unwrap();
-    let vote_accounts: VoteAccounts = bincode::deserialize(&data).unwrap();
-
-    assert_eq!(vote_accounts.len(), 1);
-    let (stake, _account) = vote_accounts.as_ref().values().next().unwrap();
-    assert_eq!(*stake, 0xAA);
+    assert!(bincode::deserialize::<VoteAccounts>(&data).is_err());
 }
 
 #[test]

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -10,11 +10,7 @@ use solana_frozen_abi::rand::{Rng, RngCore};
 use {
     crate::vote_state_view::VoteStateView,
     log::*,
-    serde::{
-        Deserialize, Serialize,
-        de::{MapAccess, Visitor},
-        ser::Serializer,
-    },
+    serde::{Deserialize, Deserializer, Serialize, ser::Serializer},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
@@ -22,7 +18,6 @@ use {
     std::{
         cmp::Ordering,
         collections::{HashMap, hash_map::Entry},
-        fmt,
         iter::FromIterator,
         mem,
         sync::{Arc, OnceLock},
@@ -68,7 +63,6 @@ pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
     field_qualifiers(vote_accounts(pub))
 )]
 pub struct VoteAccounts {
-    #[serde(deserialize_with = "deserialize_accounts_hash_map")]
     vote_accounts: Arc<VoteAccountsHashMap>,
     // Inner Arc is meant to implement copy-on-write semantics.
     #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
@@ -459,6 +453,16 @@ impl Serialize for VoteAccount {
     }
 }
 
+impl<'de> Deserialize<'de> for VoteAccount {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let account = AccountSharedData::deserialize(deserializer)?;
+        VoteAccount::try_from(account).map_err(serde::de::Error::custom)
+    }
+}
+
 impl<'a> From<&'a VoteAccount> for AccountSharedData {
     fn from(account: &'a VoteAccount) -> Self {
         account.0.account.clone()
@@ -543,53 +547,6 @@ impl FromIterator<(Pubkey, (/*stake:*/ u64, VoteAccount))> for VoteAccounts {
     {
         Self::from(Arc::new(HashMap::from_iter(iter)))
     }
-}
-
-// This custom deserializer is needed to ensure compatibility at snapshot loading with versions
-// before https://github.com/anza-xyz/agave/pull/2659 which would theoretically allow invalid vote
-// accounts in VoteAccounts.
-//
-// In the (near) future we should remove this custom deserializer and make it a hard error when we
-// find invalid vote accounts in snapshots.
-fn deserialize_accounts_hash_map<'de, D>(
-    deserializer: D,
-) -> Result<Arc<VoteAccountsHashMap>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct VoteAccountsVisitor;
-
-    impl<'de> Visitor<'de> for VoteAccountsVisitor {
-        type Value = Arc<VoteAccountsHashMap>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a map of vote accounts")
-        }
-
-        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
-        where
-            M: MapAccess<'de>,
-        {
-            let mut accounts = HashMap::new();
-
-            while let Some((pubkey, (stake, account))) =
-                access.next_entry::<Pubkey, (u64, AccountSharedData)>()?
-            {
-                match VoteAccount::try_from(account) {
-                    Ok(vote_account) => {
-                        accounts.insert(pubkey, (stake, vote_account));
-                    }
-                    Err(e) => {
-                        log::warn!("failed to deserialize vote account: {e}");
-                    }
-                }
-            }
-
-            Ok(Arc::new(accounts))
-        }
-    }
-
-    deserializer.deserialize_map(VoteAccountsVisitor)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
The custom `deserialize_accounts_hash_map` deserializer silently drops invalid vote accounts to stay compatible with snapshots from before #2659.

#### Summary of Changes
Replace it with a `Deserialize` impl for `VoteAccount` (mirroring its `Serialize` impl, which only handles the inner account) so an invalid vote account in a snapshot is now a hard deserialization error instead of being dropped. The wire format is unchanged.

#### Testing
* update test_vote_accounts_deserialize_invalid_account to assert the new hard-error behavior instead of the silent drop.
* CI: `frozen-abi` tests pass, since we already sample only valid votes (after https://github.com/anza-xyz/agave/pull/13831), so tests calculate digests and run serialization only on data that didn't trigger this code-path.
* ledger-tool verify after change