### PR TITLE
enforce strict nonce size in svm with simple check

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -35,7 +35,7 @@ use {
         state::{DurableNonce, State as NonceState},
         versions::Versions as NonceVersions,
     },
-    solana_nonce_account::{SystemAccountKind, get_system_account_kind, verify_nonce_account},
+    solana_nonce_account::verify_nonce_account,
     solana_program_runtime::{
         execution_budget::{
             SVMTransactionExecutionAndFeeBudgetLimits, SVMTransactionExecutionCost,
@@ -854,9 +854,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             return Err(TransactionError::AccountNotFound);
         };
 
-        if strict_nonce_size_check
-            && get_system_account_kind(&nonce_account) != Some(SystemAccountKind::Nonce)
-        {
+        if strict_nonce_size_check && nonce_account.data().len() != NonceState::size() {
             error_counters.blockhash_not_found += 1;
             return Err(TransactionError::BlockhashNotFound);
         }


### PR DESCRIPTION
#### Problem
when `strict_nonce_size_check` is enabled, the only thing we need to check is size; full nonce validation follows immediately, so the partial validation of `get_system_account_kind()` is superfluous

#### Summary of Changes
remove it. this mirrors the fix in https://github.com/anza-xyz/agave/pull/13439. given https://github.com/anza-xyz/solana-sdk/pull/817 there is no longer a meaningful perf reason to avoid `get_system_account_kind()`, but its checks are not needed
