### PR TITLE
Drop SysvarSerialize pt 2: replace loader-v3 account helpers

### DIFF
--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -15,7 +15,6 @@ use {
     bip39::{Language, Mnemonic},
     clap::{App, AppSettings, Arg, ArgMatches, SubCommand},
     log::*,
-    solana_account::state_traits::StateMut,
     solana_account_decoder::{UiAccount, UiAccountEncoding, UiDataSliceConfig},
     solana_clap_utils::{
         self,
@@ -1323,7 +1322,7 @@ async fn process_program_deploy(
             true
         } else if let Ok(UpgradeableLoaderState::Program {
             programdata_address,
-        }) = account.state()
+        }) = bincode::deserialize(&account.data)
         {
             if let Some(account) = rpc_client
                 .get_account_with_commitment(&programdata_address, config.commitment)
@@ -1333,7 +1332,7 @@ async fn process_program_deploy(
                 if let Ok(UpgradeableLoaderState::ProgramData {
                     slot: _,
                     upgrade_authority_address: program_authority_pubkey,
-                }) = account.state()
+                }) = bincode::deserialize(&account.data)
                 {
                     if program_authority_pubkey.is_none() {
                         return Err(
@@ -1539,7 +1538,9 @@ async fn fetch_buffer_program_data(
         .into());
     }
 
-    if let Ok(UpgradeableLoaderState::Buffer { authority_address }) = account.state() {
+    if let Ok(UpgradeableLoaderState::Buffer { authority_address }) =
+        bincode::deserialize(&account.data)
+    {
         if authority_address.is_none() {
             return Err(format!("Buffer {buffer_pubkey} is immutable").into());
         }
@@ -1923,7 +1924,9 @@ async fn get_buffers(
             "It should be impossible at this point for the account data not to be decodable. \
              Ensure that the account was fetched using a binary encoding.",
         );
-        if let Ok(UpgradeableLoaderState::Buffer { authority_address }) = account.state() {
+        if let Ok(UpgradeableLoaderState::Buffer { authority_address }) =
+            bincode::deserialize(&account.data)
+        {
             buffers.push(CliUpgradeableBuffer {
                 address: address.to_string(),
                 authority: authority_address
@@ -1979,7 +1982,7 @@ async fn get_programs(
         if let Ok(UpgradeableLoaderState::ProgramData {
             slot,
             upgrade_authority_address,
-        }) = programdata_account.state()
+        }) = bincode::deserialize(&programdata_account.data)
         {
             let mut bytes = vec![2, 0, 0, 0];
             bytes.extend_from_slice(programdata_address.as_ref());
@@ -2065,7 +2068,7 @@ async fn process_show(
             } else if account.owner == bpf_loader_upgradeable::id() {
                 if let Ok(UpgradeableLoaderState::Program {
                     programdata_address,
-                }) = account.state()
+                }) = bincode::deserialize(&account.data)
                 {
                     if let Some(programdata_account) = rpc_client
                         .get_account_with_commitment(&programdata_address, config.commitment)
@@ -2075,7 +2078,7 @@ async fn process_show(
                         if let Ok(UpgradeableLoaderState::ProgramData {
                             upgrade_authority_address,
                             slot,
-                        }) = programdata_account.state()
+                        }) = bincode::deserialize(&programdata_account.data)
                         {
                             Ok(config
                                 .output_format
@@ -2100,7 +2103,7 @@ async fn process_show(
                         Err(format!("Program {account_pubkey} has been closed").into())
                     }
                 } else if let Ok(UpgradeableLoaderState::Buffer { authority_address }) =
-                    account.state()
+                    bincode::deserialize(&account.data)
                 {
                     Ok(config
                         .output_format
@@ -2160,7 +2163,7 @@ async fn process_dump(
             } else if account.owner == bpf_loader_upgradeable::id() {
                 if let Ok(UpgradeableLoaderState::Program {
                     programdata_address,
-                }) = account.state()
+                }) = bincode::deserialize(&account.data)
                 {
                     if let Some(programdata_account) = rpc_client
                         .get_account_with_commitment(&programdata_address, config.commitment)
@@ -2168,7 +2171,7 @@ async fn process_dump(
                         .value
                     {
                         if let Ok(UpgradeableLoaderState::ProgramData { .. }) =
-                            programdata_account.state()
+                            bincode::deserialize(&programdata_account.data)
                         {
                             let offset = UpgradeableLoaderState::size_of_programdata_metadata();
                             let program_data = &programdata_account.data[offset..];
@@ -2181,7 +2184,9 @@ async fn process_dump(
                     } else {
                         Err(format!("Program {account_pubkey} has been closed").into())
                     }
-                } else if let Ok(UpgradeableLoaderState::Buffer { .. }) = account.state() {
+                } else if let Ok(UpgradeableLoaderState::Buffer { .. }) =
+                    bincode::deserialize(&account.data)
+                {
                     let offset = UpgradeableLoaderState::size_of_buffer_metadata();
                     let program_data = &account.data[offset..];
                     let mut f = File::create(output_location)?;
@@ -2269,7 +2274,7 @@ async fn process_close(
             .await?
             .value
         {
-            match account.state() {
+            match bincode::deserialize(&account.data) {
                 Ok(UpgradeableLoaderState::Buffer { authority_address }) => {
                     if authority_address != Some(authority_signer.pubkey()) {
                         return Err(format!(
@@ -2315,7 +2320,7 @@ async fn process_close(
                         if let Ok(UpgradeableLoaderState::ProgramData {
                             slot: _,
                             upgrade_authority_address: authority_pubkey,
-                        }) = account.state()
+                        }) = bincode::deserialize(&account.data)
                         {
                             if authority_pubkey != Some(authority_signer.pubkey()) {
                                 Err(format!(
@@ -2423,7 +2428,7 @@ async fn process_extend_program(
         return Err(format!("Account {program_pubkey} is not an upgradeable program").into());
     }
 
-    let programdata_pubkey = match program_account.state() {
+    let programdata_pubkey = match bincode::deserialize(&program_account.data) {
         Ok(UpgradeableLoaderState::Program {
             programdata_address: programdata_pubkey,
         }) => Ok(programdata_pubkey),
@@ -2441,7 +2446,7 @@ async fn process_extend_program(
         None => Err(format!("Program {program_pubkey} is closed")),
     }?;
 
-    let upgrade_authority_address = match programdata_account.state() {
+    let upgrade_authority_address = match bincode::deserialize(&programdata_account.data) {
         Ok(UpgradeableLoaderState::ProgramData {
             slot: _,
             upgrade_authority_address,
@@ -2952,7 +2957,7 @@ async fn extend_program_data_if_needed(
         return Ok(());
     };
 
-    let upgrade_authority_address = match program_data_account.state() {
+    let upgrade_authority_address = match bincode::deserialize(&program_data_account.data) {
         Ok(UpgradeableLoaderState::ProgramData {
             slot: _,
             upgrade_authority_address,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -4,7 +4,7 @@ use {
     agave_feature_set::{enable_alt_bn128_syscall, loader_v3_minimum_extend_program_size},
     assert_matches::assert_matches,
     serde_json::Value,
-    solana_account::{ReadableAccount, state_traits::StateMut},
+    solana_account::ReadableAccount,
     solana_borsh::v1::try_from_slice_unchecked,
     solana_cli::{
         cli::{CliCommand, CliConfig, process_command},
@@ -1204,7 +1204,7 @@ async fn test_cli_program_deploy_with_authority() {
     if let UpgradeableLoaderState::ProgramData {
         slot: _,
         upgrade_authority_address,
-    } = programdata_account.state().unwrap()
+    } = bincode::deserialize(&programdata_account.data).unwrap()
     {
         assert_eq!(upgrade_authority_address, None);
     } else {
@@ -1407,7 +1407,7 @@ async fn test_cli_program_upgrade_auto_extend(skip_preflight: bool) {
     if let UpgradeableLoaderState::ProgramData {
         slot: _,
         upgrade_authority_address,
-    } = programdata_account.state().unwrap()
+    } = bincode::deserialize(&programdata_account.data).unwrap()
     {
         assert_eq!(upgrade_authority_address, None);
     } else {
@@ -1919,7 +1919,9 @@ async fn test_cli_program_write_buffer() {
     let buffer_account = rpc_client.get_account(&new_buffer_pubkey).await.unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -1964,7 +1966,9 @@ async fn test_cli_program_write_buffer() {
         .unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2034,7 +2038,9 @@ async fn test_cli_program_write_buffer() {
         .unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(authority_keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2074,7 +2080,9 @@ async fn test_cli_program_write_buffer() {
     let buffer_account = rpc_client.get_account(&buffer_pubkey).await.unwrap();
     assert_eq!(buffer_account.lamports, minimum_balance_for_buffer_default);
     assert_eq!(buffer_account.owner, bpf_loader_upgradeable::id());
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(authority_keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2420,7 +2428,9 @@ async fn test_cli_program_set_buffer_authority() {
         .get_account(&buffer_keypair.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2452,7 +2462,9 @@ async fn test_cli_program_set_buffer_authority() {
         .get_account(&buffer_keypair.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(new_buffer_authority.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2513,7 +2525,9 @@ async fn test_cli_program_set_buffer_authority() {
         .get_account(&buffer_keypair.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(buffer_keypair.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -2608,7 +2622,9 @@ async fn test_cli_program_mismatch_buffer_authority() {
         .get_account(&buffer_keypair.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(buffer_authority.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -3195,7 +3211,9 @@ async fn create_buffer_with_offline_authority<'a>(
         .get_account(&buffer_signer.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(online_signer.pubkey()));
     } else {
         panic!("not a buffer account");
@@ -3214,7 +3232,9 @@ async fn create_buffer_with_offline_authority<'a>(
         .get_account(&buffer_signer.pubkey())
         .await
         .unwrap();
-    if let UpgradeableLoaderState::Buffer { authority_address } = buffer_account.state().unwrap() {
+    if let UpgradeableLoaderState::Buffer { authority_address } =
+        bincode::deserialize(&buffer_account.data).unwrap()
+    {
         assert_eq!(authority_address, Some(offline_signer.pubkey()));
     } else {
         panic!("not a buffer account");

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "agave-snapshots",
  "agave-votor",
  "assert_cmd",
+ "bincode",
  "chrono",
  "clap",
  "crossbeam-channel",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -25,6 +25,7 @@ agave-logger = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
+bincode = { workspace = true }
 chrono = { workspace = true, features = ["default"] }
 clap = { workspace = true }
 crossbeam-channel = { workspace = true }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -4,9 +4,7 @@ use {
     log::*,
     serde::{Deserialize, Serialize},
     serde_json::Result,
-    solana_account::{
-        AccountSharedData, create_account_shared_data_for_test, state_traits::StateMut,
-    },
+    solana_account::{AccountSharedData, create_account_shared_data_for_test},
     solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay},
     solana_clock::Slot,
     solana_ledger::blockstore_options::AccessType,
@@ -415,7 +413,7 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
                         if bpf_loader_upgradeable::check_id(&owner)
                             && let Ok(UpgradeableLoaderState::Program {
                                 programdata_address,
-                            }) = account.state()
+                            }) = bincode::deserialize(account.data())
                         {
                             debug!("Program data address {programdata_address}");
                             if bank

--- a/programs/bpf-loader-tests/tests/common.rs
+++ b/programs/bpf-loader-tests/tests/common.rs
@@ -2,7 +2,7 @@
 
 use {
     agave_feature_set::loader_v3_minimum_extend_program_size,
-    solana_account::{AccountSharedData, state_traits::StateMut},
+    solana_account::{AccountSharedData, WritableAccount},
     solana_instruction::{Instruction, error::InstructionError},
     solana_keypair::Keypair,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
@@ -83,8 +83,7 @@ pub async fn add_upgradeable_loader_account(
         account_data_len,
         &id(),
     );
-    account
-        .set_state(account_state)
+    bincode::serialize_into(account.data_as_mut_slice(), account_state)
         .expect("state failed to serialize into account data");
     account_callback(&mut account);
     context.set_account(account_address, &account);

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -520,9 +520,7 @@ pub(crate) mod tests {
         agave_feature_set::FeatureSet,
         agave_snapshots::snapshot_config::SnapshotConfig,
         assert_matches::assert_matches,
-        solana_account::{
-            AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
-        },
+        solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
         solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
         solana_builtins::{
             BUILTINS,
@@ -718,7 +716,8 @@ pub(crate) mod tests {
 
             // Program account has the correct state, with a pointer to its program
             // data address.
-            let program_account_state: UpgradeableLoaderState = program_account.state().unwrap();
+            let program_account_state: UpgradeableLoaderState =
+                bincode::deserialize(program_account.data()).unwrap();
             assert_eq!(
                 program_account_state,
                 UpgradeableLoaderState::Program {
@@ -1085,7 +1084,7 @@ pub(crate) mod tests {
         let program_data_address = get_program_data_address(&builtin_id);
         let program_data_account = bank.get_account(&program_data_address).unwrap();
         let program_data_account_state: UpgradeableLoaderState =
-            program_data_account.state().unwrap();
+            bincode::deserialize(program_data_account.data()).unwrap();
         assert_eq!(
             program_data_account_state,
             UpgradeableLoaderState::ProgramData {
@@ -1259,7 +1258,7 @@ pub(crate) mod tests {
         let program_data_address = get_program_data_address(&program_address);
         let program_data_account = bank.get_account(&program_data_address).unwrap();
         let program_data_account_state: UpgradeableLoaderState =
-            program_data_account.state().unwrap();
+            bincode::deserialize(program_data_account.data()).unwrap();
         assert_eq!(
             program_data_account_state,
             UpgradeableLoaderState::ProgramData {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5862,12 +5862,14 @@ fn test_bank_load_program() {
         programdata_data_offset + elf.len(),
         &bpf_loader_upgradeable::id(),
     );
-    programdata_account
-        .set_state(&UpgradeableLoaderState::ProgramData {
+    bincode::serialize_into(
+        programdata_account.data_as_mut_slice(),
+        &UpgradeableLoaderState::ProgramData {
             slot: 42,
             upgrade_authority_address: None,
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
     programdata_account.data_as_mut_slice()[programdata_data_offset..].copy_from_slice(&elf);
     programdata_account.set_rent_epoch(1);
     bank.store_account_and_update_capitalization(&program_key, &program_account);
@@ -5973,11 +5975,13 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
             UpgradeableLoaderState::size_of_buffer(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
-        account
-            .set_state(&UpgradeableLoaderState::Buffer {
+        bincode::serialize_into(
+            account.data_as_mut_slice(),
+            &UpgradeableLoaderState::Buffer {
                 authority_address: Some(upgrade_authority_keypair.pubkey()),
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         account
             .data_as_mut_slice()
             .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
@@ -6101,7 +6105,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         post_program_account.data().len(),
         UpgradeableLoaderState::size_of_program()
     );
-    let state: UpgradeableLoaderState = post_program_account.state().unwrap();
+    let state: UpgradeableLoaderState = bincode::deserialize(post_program_account.data()).unwrap();
     assert_eq!(
         state,
         UpgradeableLoaderState::Program {
@@ -6114,7 +6118,8 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         post_programdata_account.owner(),
         &bpf_loader_upgradeable::id()
     );
-    let state: UpgradeableLoaderState = post_programdata_account.state().unwrap();
+    let state: UpgradeableLoaderState =
+        bincode::deserialize(post_programdata_account.data()).unwrap();
     assert_eq!(
         state,
         UpgradeableLoaderState::ProgramData {
@@ -11517,11 +11522,13 @@ fn test_deploy_last_epoch_slot() {
             UpgradeableLoaderState::size_of_buffer(program_len),
             &bpf_loader_upgradeable::id(),
         );
-        account
-            .set_state(&UpgradeableLoaderState::Buffer {
+        bincode::serialize_into(
+            account.data_as_mut_slice(),
+            &UpgradeableLoaderState::Buffer {
                 authority_address: Some(upgrade_authority_keypair.pubkey()),
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         account
             .data_as_mut_slice()
             .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)
@@ -11972,11 +11979,13 @@ fn test_bpf_loader_upgradeable_deploy_with_more_than_255_accounts() {
             UpgradeableLoaderState::size_of_buffer(elf.len()),
             &bpf_loader_upgradeable::id(),
         );
-        account
-            .set_state(&UpgradeableLoaderState::Buffer {
+        bincode::serialize_into(
+            account.data_as_mut_slice(),
+            &UpgradeableLoaderState::Buffer {
                 authority_address: Some(upgrade_authority_keypair.pubkey()),
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         account
             .data_as_mut_slice()
             .get_mut(UpgradeableLoaderState::size_of_buffer_metadata()..)

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -10,7 +10,7 @@ use {
         iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
         prelude::ParallelSlice,
     },
-    solana_account::{ReadableAccount, state_traits::StateMut},
+    solana_account::ReadableAccount,
     solana_accounts_db::{
         account_storage_entry::AccountStorageEntry,
         accounts_db::{AccountsDb, GetUniqueAccountsResult, UpdateIndexThreadSelection},
@@ -176,7 +176,7 @@ impl<'a> SnapshotMinimizer<'a> {
             .filter_map(|account| {
                 if let Ok(UpgradeableLoaderState::Program {
                     programdata_address,
-                }) = account.state()
+                }) = bincode::deserialize(account.data())
                 {
                     Some(programdata_address)
                 } else {

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -24,7 +24,6 @@ agave-unstable-api = []
 conformance = [
     "dep:agave-feature-set",
     "dep:agave-precompiles",
-    "dep:bincode",
     "dep:prost",
     "dep:protosol",
     "dep:solana-poseidon",
@@ -36,7 +35,6 @@ conformance = [
     "solana-pubkey/default",
 ]
 dev-context-only-utils = [
-    "dep:bincode",
     "dep:qualifier_attr",
     "dep:solana-bpf-loader-program",
     "dep:solana-compute-budget",
@@ -68,7 +66,7 @@ svm-internal = ["dep:qualifier_attr"]
 agave-feature-set = { workspace = true, optional = true }
 agave-precompiles = { workspace = true, optional = true }
 ahash = { workspace = true }
-bincode = { workspace = true, optional = true }
+bincode = { workspace = true }
 log = { workspace = true }
 percentage = { workspace = true }
 prost = { version = "0.11", optional = true }
@@ -125,7 +123,6 @@ xxhash-rust = { workspace = true, optional = true, features = ["xxh64"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-bincode = { workspace = true }
 env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 openssl = { workspace = true }

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -8,9 +8,7 @@ use {
         transaction_error_metrics::TransactionErrorMetrics,
     },
     ahash::{AHashMap, AHashSet},
-    solana_account::{
-        Account, AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
-    },
+    solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
     solana_clock::Slot,
     solana_fee_structure::FeeDetails,
     solana_instruction::{BorrowedAccountMeta, BorrowedInstruction},
@@ -564,7 +562,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
             if bpf_loader_upgradeable::check_id(account.owner())
                 && let Ok(UpgradeableLoaderState::Program {
                     programdata_address,
-                }) = account.state()
+                }) = bincode::deserialize(account.data())
             {
                 // ...its programdata was not already counted and will not later be counted...
                 if !account_keys.iter().any(|key| programdata_address == *key)
@@ -2663,11 +2661,13 @@ mod tests {
                     }
 
                     if has_programdata || rng.random() {
-                        account
-                            .set_state(&UpgradeableLoaderState::Program {
+                        bincode::serialize_into(
+                            account.data_as_mut_slice(),
+                            &UpgradeableLoaderState::Program {
                                 programdata_address,
-                            })
-                            .unwrap();
+                            },
+                        )
+                        .unwrap();
                     }
                 }
 

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "metrics")]
 use solana_program_runtime::program_metrics::LoadProgramMetrics;
 use {
-    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
     solana_loader_v3_interface::state::UpgradeableLoaderState,
@@ -53,7 +53,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
     } else if bpf_loader_upgradeable::check_id(program_account.owner()) {
         if let Ok(UpgradeableLoaderState::Program {
             programdata_address,
-        }) = program_account.state()
+        }) = bincode::deserialize(program_account.data())
         {
             if let Some((programdata_account, _slot)) =
                 callbacks.get_account_shared_data(&programdata_address)
@@ -62,7 +62,7 @@ pub(crate) fn load_program_accounts<CB: TransactionProcessingCallback>(
                     if let Ok(UpgradeableLoaderState::ProgramData {
                         slot,
                         upgrade_authority_address: _,
-                    }) = programdata_account.state()
+                    }) = bincode::deserialize(programdata_account.data())
                     {
                         ProgramAccountLoadResult::ProgramOfLoaderV3(
                             program_account,
@@ -220,7 +220,7 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
         ProgramCacheEntryOwner::LoaderV3 => {
             if let Ok(UpgradeableLoaderState::Program {
                 programdata_address,
-            }) = program.state()
+            }) = bincode::deserialize(program.data())
             {
                 let (programdata, _slot) = callbacks
                     .get_account_shared_data(&programdata_address)
@@ -228,7 +228,7 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
                 if let Ok(UpgradeableLoaderState::ProgramData {
                     slot,
                     upgrade_authority_address: _,
-                }) = programdata.state()
+                }) = bincode::deserialize(programdata.data())
                 {
                     return Ok(slot);
                 }


### PR DESCRIPTION
Continuing to break down https://github.com/anza-xyz/agave/pull/12245 into smaller PR chunks for easier review. Progresses https://github.com/anza-xyz/agave/issues/10672.

This removes `solana_account::StateMut` usage for loader-v3 account state. Note that `UpgradeableLoaderState` doesn't support wincode in the current `solana-loader-v3-interface` version used in Agave. v8 does, but it comes with API changes/migrating work. For that reason, using bincode here.

| Offending code | Why it blocks `SysvarSerialize` removal | Replacement |
|---|---|---|
| `StateMut::state::<UpgradeableLoaderState>` | Requires `solana-account/bincode`, which depends on `solana-sysvar` | `bincode::deserialize` |
| `StateMut::set_state(&UpgradeableLoaderState)` | Requires `solana-account/bincode` for account-state writes | `bincode::serialize_into` |

