### PR TITLE
ci(xtask): resolve correct latest beta tag

### DIFF
--- a/ci/xtask/src/commands/channel_info/fetch.rs
+++ b/ci/xtask/src/commands/channel_info/fetch.rs
@@ -44,12 +44,14 @@ pub fn release_tags() -> Result<Vec<Version>> {
     Ok(lines
         .iter()
         .filter_map(|l| strip_ref(l, "refs/tags/"))
-        .filter_map(|name| {
-            let stripped = name.strip_prefix('v')?;
-            let v = Version::parse(stripped).ok()?;
-            (v.pre.is_empty() && v.build.is_empty()).then_some(v)
-        })
+        .filter_map(|name| parse_release_tag(&name))
         .collect())
+}
+
+fn parse_release_tag(name: &str) -> Option<Version> {
+    let stripped = name.strip_prefix('v')?;
+    let version = Version::parse(stripped).ok()?;
+    Some(version)
 }
 
 #[derive(Deserialize)]
@@ -83,4 +85,28 @@ pub async fn workspace_version(client: &reqwest::Client, bv: BranchVersion) -> R
     let parsed: CargoToml =
         toml::from_str(&raw).map_err(|e| anyhow!("failed to parse Cargo.toml at {url}: {e}"))?;
     Ok(parsed.workspace.package.version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_final_and_prerelease_tags() {
+        assert_eq!(parse_release_tag("v4.2.0"), Version::parse("4.2.0").ok());
+        assert_eq!(
+            parse_release_tag("v4.2.0-beta.1"),
+            Version::parse("4.2.0-beta.1").ok()
+        );
+    }
+
+    #[test]
+    fn parses_build_tags_and_rejects_non_release_tags() {
+        assert_eq!(
+            parse_release_tag("v4.2.0+build.1"),
+            Version::parse("4.2.0+build.1").ok()
+        );
+        assert_eq!(parse_release_tag("4.2.0"), None);
+        assert_eq!(parse_release_tag("v4.2.0^{}"), None);
+    }
 }

--- a/ci/xtask/src/commands/channel_info/resolve.rs
+++ b/ci/xtask/src/commands/channel_info/resolve.rs
@@ -262,12 +262,21 @@ mod tests {
     #[test]
     fn picks_latest_tag_per_channel() {
         let vs = versions(&[(bv(3, 0), "3.0.5"), (bv(3, 1), "3.1.0-beta.0")]);
-        let tags = vec![v("3.0.1"), v("3.0.5"), v("3.0.2"), v("2.9.9")];
+        let tags = vec![
+            v("3.0.1"),
+            v("3.0.5"),
+            v("3.0.6"),
+            v("3.1.0-alpha.0"),
+            v("3.1.0-alpha.1"),
+            v("3.1.0-beta.0"),
+            v("3.1.0-beta.1"),
+            v("2.9.9"),
+        ];
 
         let info = derive_channels(&vs, &tags, None, None).unwrap();
 
-        assert_eq!(info.beta_channel_latest_tag, "");
-        assert_eq!(info.stable_channel_latest_tag, "v3.0.5");
+        assert_eq!(info.beta_channel_latest_tag, "v3.1.0-beta.1");
+        assert_eq!(info.stable_channel_latest_tag, "v3.0.6");
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`cargo xtask channel-info --json` prints empty `BETA_CHANNEL_LATEST_TAG`

```
{
  "EDGE_CHANNEL": "master",
  "BETA_CHANNEL": "v4.2",
  "BETA_CHANNEL_LATEST_TAG": "",
  "STABLE_CHANNEL": "v4.1",
  "STABLE_CHANNEL_LATEST_TAG": "v4.1.2",
  "CHANNEL": "",
  "CHANNEL_LATEST_TAG": ""
}
```


#### Summary of Changes

I guess we should print something like 🤔 

```
{
  "EDGE_CHANNEL": "master",
  "BETA_CHANNEL": "v4.2",
  "BETA_CHANNEL_LATEST_TAG": "v4.2.0-beta.1",
  "STABLE_CHANNEL": "v4.1",
  "STABLE_CHANNEL_LATEST_TAG": "v4.1.2",
  "CHANNEL": "",
  "CHANNEL_LATEST_TAG": ""
}
```