### PR TITLE
chore(toolchain): bump to rust 1.97.1

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-04-11
+  nightly_version=2026-05-22
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96.1"
+channel = "1.97.1"


### PR DESCRIPTION
#### Problem
Rust 1.97.0 bump was reverted (#13766) due to https://github.com/rust-lang/rust/issues/159035

#### Summary of Changes
A fixed toolchain was released, bump to it (1.97.1). Keep nightly version the same, it is only used for tests

#### Testing
CI
