### PR TITLE
bls-sigverifier: improves keep_vote()

### DIFF
--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -19,23 +19,21 @@ use {
         unverified_vote_message::{
             DecodedWireConsensusMessage, UnverifiedCertificate, UnverifiedVoteMessage,
         },
-        vote::Vote,
         wire::{VersionedWireConsensusMessage, VotePayloadToSign},
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError, select},
     log::error,
     rayon::{ThreadPool, ThreadPoolBuilder},
-    solana_bls_signatures::pubkey::{PopVerified, PubkeyAffine as BlsPubkeyAffine},
-    solana_clock::Slot,
+    solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_measure::measure_us,
     solana_perf::packet::packet_config,
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::SharableBanks},
+    solana_runtime::{bank::Bank, bank_forks::SharableBanks, epoch_stakes::BLSPubkeyToRankMap},
     solana_streamer::{nonblocking::simple_qos::SimpleQosBanlist, packet::PacketBatch},
     std::{
-        collections::{HashMap, HashSet},
+        collections::{HashMap, HashSet, hash_map::Entry},
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
@@ -91,6 +89,11 @@ pub fn spawn_service(
         .unwrap()
 }
 
+struct ExtractedMsgs {
+    certs: HashMap<CertificateType, Vec<CertPayload>>,
+    votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
+}
+
 struct SigVerifier {
     migration_status: Arc<MigrationStatus>,
     banlist: Arc<SimpleQosBanlist>,
@@ -102,11 +105,13 @@ struct SigVerifier {
     verified_certs: HashSet<CertificateType>,
     /// Tracks when the cache was last pruned.
     last_checked_root_slot: Slot,
+    last_checked_root_epoch: Epoch,
     cluster_info: Arc<ClusterInfo>,
     leader_schedule: Arc<LeaderScheduleCache>,
     /// thread pool to use for all parallel tasks
     thread_pool: ThreadPool,
     generated_cert_types: Arc<GeneratedCertTypes>,
+    rank_map_cache: HashMap<Epoch, Arc<BLSPubkeyToRankMap>>,
 }
 
 impl SigVerifier {
@@ -134,10 +139,12 @@ impl SigVerifier {
             stats: SigVerifierStats::new(root_slot),
             verified_certs: HashSet::new(),
             last_checked_root_slot: 0,
+            last_checked_root_epoch: 0,
             cluster_info,
             leader_schedule,
             thread_pool,
             generated_cert_types,
+            rank_map_cache: HashMap::new(),
         }
     }
 
@@ -184,9 +191,9 @@ impl SigVerifier {
         certificates: Vec<(Slot, UnverifiedCertificate)>,
     ) -> Result<(), SigVerifyError> {
         let root_bank = self.sharable_banks.root();
-        self.maybe_prune_caches(root_bank.slot());
+        self.maybe_prune_caches(&root_bank);
 
-        let ((cert_groups, votes_to_verify), extract_msgs_us) =
+        let (extracted_msgs, extract_msgs_us) =
             measure_us!(self.extract_and_filter_msgs(batches, certificates, &root_bank));
         self.stats
             .extract_filter_msgs_us
@@ -195,7 +202,7 @@ impl SigVerifier {
         let (votes_result, certs_result) = self.thread_pool.join(
             || {
                 verify_and_send_votes(
-                    votes_to_verify,
+                    extracted_msgs.votes,
                     &root_bank,
                     &self.cluster_info,
                     &self.leader_schedule,
@@ -207,7 +214,7 @@ impl SigVerifier {
             || {
                 verify_and_send_certificates(
                     &mut self.verified_certs,
-                    cert_groups,
+                    extracted_msgs.certs,
                     &root_bank,
                     &self.channels.channel_to_pool,
                     &self.banlist,
@@ -224,10 +231,18 @@ impl SigVerifier {
         Ok(())
     }
 
-    fn maybe_prune_caches(&mut self, root_slot: Slot) {
+    fn maybe_prune_caches(&mut self, root_bank: &Bank) {
+        let root_slot = root_bank.slot();
+        let root_epoch = root_bank.epoch();
         if self.last_checked_root_slot < root_slot {
             self.last_checked_root_slot = root_slot;
             self.verified_certs.retain(|cert| cert.slot() >= root_slot);
+        }
+        if self.last_checked_root_epoch < root_epoch {
+            self.last_checked_root_epoch = root_epoch;
+            // Keeping previous epoch as we need to look up slots older than root_slot for rewards.
+            self.rank_map_cache
+                .retain(|epoch, _| *epoch >= root_epoch.saturating_sub(1));
         }
     }
 
@@ -259,10 +274,7 @@ impl SigVerifier {
         batches: Vec<PacketBatch>,
         certificates: Vec<(Slot, UnverifiedCertificate)>,
         root_bank: &Bank,
-    ) -> (
-        HashMap<CertificateType, Vec<CertPayload>>,
-        HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>>,
-    ) {
+    ) -> ExtractedMsgs {
         let root_slot = root_bank.slot();
         let mut cert_groups = HashMap::<CertificateType, Vec<CertPayload>>::new();
         let mut votes: HashMap<VotePayloadToSign, Vec<UnverifiedVotePayload>> = HashMap::new();
@@ -295,21 +307,14 @@ impl SigVerifier {
 
             match decoded_msg {
                 DecodedWireConsensusMessage::Vote(unverified_vote) => {
-                    if let Some((sender_vote_account_pubkey, sender_bls_pubkey)) =
-                        self.keep_vote(&unverified_vote.vote, &unverified_vote, root_bank)
+                    if let Some(payload) =
+                        self.keep_vote(unverified_vote, sender_identity_pubkey, root_bank)
                     {
                         let vote_payload_to_sign = VotePayloadToSign::new_from_vote(
-                            unverified_vote.vote,
-                            unverified_vote.shred_version,
+                            payload.vote_message.vote,
+                            payload.vote_message.shred_version,
                         );
-                        votes.entry(vote_payload_to_sign).or_default().push(
-                            UnverifiedVotePayload {
-                                vote_message: unverified_vote,
-                                sender_bls_pubkey,
-                                sender_vote_account_pubkey,
-                                sender_identity_pubkey,
-                            },
-                        );
+                        votes.entry(vote_payload_to_sign).or_default().push(payload);
                     }
                 }
                 DecodedWireConsensusMessage::Certificate(cert) => {
@@ -350,39 +355,68 @@ impl SigVerifier {
             self.add_certificate_to_group(&mut cert_groups, certificate, sender_identity_pubkey);
         }
         self.stats.num_pkts.add_sample(num_pkts);
-        (cert_groups, votes)
+        ExtractedMsgs {
+            certs: cert_groups,
+            votes,
+        }
     }
 
-    /// If this vote should be verified, then returns the sender's Pubkey and BlsPubkey.
+    /// If this vote should be verified, then returns the [`UnverifiedVotePayload`].
     fn keep_vote(
         &mut self,
-        vote: &Vote,
-        msg: &UnverifiedVoteMessage,
+        msg: UnverifiedVoteMessage,
+        sender_identity_pubkey: Pubkey,
         root_bank: &Bank,
-    ) -> Option<(Pubkey, PopVerified<BlsPubkeyAffine>)> {
+    ) -> Option<UnverifiedVotePayload> {
         let root_slot = root_bank.slot();
-        let Some(rank_map) = root_bank.get_rank_map(vote.slot()) else {
-            self.stats.discard_vote_no_epoch_stakes += 1;
+        let vote_slot = msg.vote.slot();
+        if vote_slot > root_slot.saturating_add(NUM_SLOTS_FOR_VERIFY) {
+            self.stats.vote_too_far_in_future += 1;
             return None;
+        }
+        if vote_slot <= root_slot
+            && !rewards_wants_vote(
+                &self.cluster_info,
+                &self.leader_schedule,
+                root_slot,
+                &msg.vote,
+            )
+        {
+            self.stats.num_old_votes_received += 1;
+            return None;
+        }
+        // Genesis votes should be allowed on the TowerBFT root
+        if vote_slot == root_slot && !msg.vote.is_genesis_vote() {
+            self.stats.num_old_votes_received += 1;
+            return None;
+        }
+        let vote_epoch = root_bank.epoch_schedule().get_epoch(vote_slot);
+        let rank_map = match self.rank_map_cache.entry(vote_epoch) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let Some(rank_map) = root_bank.get_rank_map(vote_slot) else {
+                    self.stats.discard_vote_no_epoch_stakes += 1;
+                    return None;
+                };
+                entry.insert(rank_map.clone())
+            }
         };
         let entry = rank_map
-            .get_pubkey_stake_entry(msg.rank.into())
+            .node_pubkey_to_stake_entry(&sender_identity_pubkey)
             .or_else(|| {
                 self.stats.discard_vote_invalid_rank += 1;
                 None
             })?;
-        let ret = Some((entry.vote_account_pubkey, entry.bls_pubkey));
-        if vote.slot() > root_slot
-            // Genesis votes should be allowed on the TowerBFT root
-         || (vote.is_genesis_vote() && vote.slot() >= root_slot)
-        {
-            return ret;
+        let rank = rank_map.get_rank_for_vote_pubkey(&entry.vote_account_pubkey)?;
+        if *rank != msg.rank {
+            return None;
         }
-        if rewards_wants_vote(&self.cluster_info, &self.leader_schedule, root_slot, vote) {
-            return ret;
-        }
-        self.stats.num_old_votes_received += 1;
-        None
+        Some(UnverifiedVotePayload {
+            vote_message: msg,
+            sender_bls_pubkey: entry.bls_pubkey,
+            sender_vote_account_pubkey: entry.vote_account_pubkey,
+            sender_identity_pubkey,
+        })
     }
 }
 
@@ -669,11 +703,11 @@ mod tests {
             Bank::new_from_parent(ctx.verifier.sharable_banks.root(), SlotLeader::default(), 5);
         ctx.verifier.migration_status.enable_alpenglow_for_tests();
 
-        let (cert_groups, votes) =
+        let extracted_msgs =
             ctx.verifier
                 .extract_and_filter_msgs(vec![], vec![certificate], &root_bank);
-        assert!(cert_groups.is_empty());
-        assert!(votes.is_empty());
+        assert!(extracted_msgs.certs.is_empty());
+        assert!(extracted_msgs.votes.is_empty());
         assert_eq!(ctx.verifier.stats.num_old_certs_received.0, 1);
     }
 
@@ -826,7 +860,7 @@ mod tests {
             ))
             .unwrap();
 
-        assert_eq!(ctx.verifier.stats.discard_vote_no_epoch_stakes.0, 1);
+        assert_eq!(ctx.verifier.stats.vote_too_far_in_future.0, 1);
 
         // Expect no messages since the packet was malformed
         expect_no_receive(&ctx.pool_receiver);
@@ -2072,7 +2106,7 @@ mod tests {
             .verify_and_send_batches(packet_batches)
             .unwrap();
         assert_eq!(ctx.verifier.stats.cert_stats.too_far_in_future.0, 1);
-        assert_eq!(ctx.verifier.stats.vote_stats.too_far_in_future.0, 1);
+        assert_eq!(ctx.verifier.stats.vote_too_far_in_future.0, 1);
     }
 
     fn messages_to_batches(

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -208,12 +208,9 @@ fn verify_votes(
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
 ) -> Vec<VerifiedVotePayload> {
-    // Filter votes too far in the future.
-    if vote_payload_to_sign.slot() > root_bank.slot().saturating_add(NUM_SLOTS_FOR_VERIFY) {
-        stats.too_far_in_future += unverified_votes.len() as u64;
-        return vec![];
-    }
-
+    debug_assert!(
+        vote_payload_to_sign.slot() <= root_bank.slot().saturating_add(NUM_SLOTS_FOR_VERIFY)
+    );
     // Fallback to individual verification
     let ((verified_votes, invalid_remote_pubkeys), time_us) =
         measure_us!(verify_individual_votes(unverified_votes, thread_pool));

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -68,8 +68,10 @@ pub(super) struct SigVerifierStats {
     pub(super) num_verified_certs_received: Saturating<u64>,
     /// Number of certs received that the node has already generated.
     pub(super) num_generated_certs_received: Saturating<u64>,
+    /// Number of times a vote was too far in the future and discarded.
+    pub(super) vote_too_far_in_future: Saturating<u64>,
     /// Last time the stats were reported.
-    pub(super) last_report: Reporting,
+    last_report: Reporting,
 }
 
 impl SigVerifierStats {
@@ -88,6 +90,7 @@ impl SigVerifierStats {
             num_verified_certs_received: Saturating(0),
             num_generated_certs_received: Saturating(0),
             verify_and_send_batch_us: WelfordStats::default(),
+            vote_too_far_in_future: Saturating(0),
             last_report: Reporting::new(root_slot),
         }
     }
@@ -118,6 +121,7 @@ impl SigVerifierStats {
             discard_vote_invalid_rank,
             discard_vote_no_epoch_stakes,
             verify_and_send_batch_us,
+            vote_too_far_in_future,
             last_report: _,
         } = self;
 
@@ -175,6 +179,7 @@ impl SigVerifierStats {
                 verify_and_send_batch_us.count(),
                 i64
             ),
+            ("vote_too_far_in_future", vote_too_far_in_future.0, i64),
             ("num_pkts_max", num_pkts.maximum().unwrap_or(0), i64),
             ("num_pkts_mean", num_pkts.mean().unwrap_or(0), i64),
             ("num_pkts_count", num_pkts.count(), i64),
@@ -307,8 +312,6 @@ pub(super) struct SigVerifyVoteStats {
     /// Number of votes [`verify_and_send_votes`] successfully verified the signature of.
     pub(super) sig_verified_votes: Saturating<u64>,
 
-    /// Number of times the cert was too far in the future and discarded.
-    pub(super) too_far_in_future: Saturating<u64>,
     /// Number of times we are banning a validator that was already banned.
     pub(super) already_banned: Saturating<u64>,
     /// Number of times we are banning a validator.
@@ -347,7 +350,6 @@ impl SigVerifyVoteStats {
         let Self {
             votes_to_sig_verify,
             sig_verified_votes,
-            too_far_in_future,
             already_banned,
             banning_validator,
             metrics_sent,
@@ -365,7 +367,6 @@ impl SigVerifyVoteStats {
         } = other;
         self.votes_to_sig_verify += votes_to_sig_verify;
         self.sig_verified_votes += sig_verified_votes;
-        self.too_far_in_future += too_far_in_future;
         self.already_banned += already_banned;
         self.banning_validator += banning_validator;
         self.metrics_sent += metrics_sent;
@@ -388,7 +389,6 @@ impl SigVerifyVoteStats {
         let Self {
             votes_to_sig_verify,
             sig_verified_votes,
-            too_far_in_future,
             already_banned,
             banning_validator,
             metrics_sent,
@@ -408,7 +408,6 @@ impl SigVerifyVoteStats {
             "bls_vote_sigverify_stats",
             ("votes_to_sig_verify", votes_to_sig_verify.0, i64),
             ("sig_verified_votes", sig_verified_votes.0, i64),
-            ("too_far_in_future", too_far_in_future.0, i64),
             ("already_banned", already_banned.0, i64),
             ("banning_validator", banning_validator.0, i64),
             ("metrics_sent", metrics_sent.0, i64),


### PR DESCRIPTION
#### Problem

- keep_vote performs some "cheap" checks later e.g. the vote is too far in the future or too old.  Performing them earlier will allow us to discard invalid votes more quickly.
- Under normal conditions, we will probably see a lot of votes for the same slot and most probably the same epoch.  Looking up the rank_map from the bank results in a few hashmap lookups.  Instead, we can cache them to reduce the number of lookups.  The cache will also be used in https://github.com/anza-xyz/agave/pull/13381.


#### Summary of Changes

- Changes the ordering of checks in keep_vote
- Uses a rank_map cache in keep_vote


#### Testing

Just CI