### PR TITLE
Fix - Global program cache entry pruning and unloading

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -438,6 +438,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             | (
                                 ProgramCacheEntryType::Unloaded(_),
                                 ProgramCacheEntryType::Loaded(_),
+                            )
+                            | (
+                                ProgramCacheEntryType::Unloaded(_),
+                                ProgramCacheEntryType::FailedVerification(_),
                             ) => {}
                             _ => {
                                 // Something is wrong, I can feel it ...
@@ -1449,7 +1453,6 @@ pub(crate) mod tests {
             ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
         ),
         (
-            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
             ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
@@ -1504,6 +1507,12 @@ pub(crate) mod tests {
             BuiltinProgram::new_mock()
         )),
         new_loaded_entry(get_mock_program_runtime_environment())
+    )]
+    #[test_case(
+        ProgramCacheEntryType::Unloaded(ProgramRuntimeEnvironment::from(
+            BuiltinProgram::new_mock()
+        )),
+        ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment())
     )]
     #[test_case(
         ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -908,7 +908,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 // Certain entry types cannot be unloaded, such as tombstones, or already unloaded entries.
                 // For such entries, `to_unloaded()` will return None.
                 // These entry types do not occupy much memory.
-                if let Some(unloaded) = candidate.to_unloaded() {
+                if let Some(unloaded) = candidate
+                    .program
+                    .get_environment()
+                    .and_then(|env| candidate.to_unloaded(ProgramRuntimeEnvironment::clone(env)))
+                {
                     if candidate.stats.uses.load(Ordering::Relaxed) == 1 {
                         self.stats.one_hit_wonders.fetch_add(1, Ordering::Relaxed);
                     }
@@ -1059,7 +1063,11 @@ pub(crate) mod tests {
             current_slot.saturating_add(1),
             ProgramStatistics::default(),
         );
-        let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
+        let unloaded = Arc::new(
+            loaded
+                .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
+                .expect("Failed to unload the program"),
+        );
         cache.assign_program(&env, key, current_slot, unloaded.clone());
         unloaded
     }
@@ -2164,7 +2172,7 @@ pub(crate) mod tests {
             20,
             Arc::new(
                 new_test_entry(20, 21)
-                    .to_unloaded()
+                    .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
                     .expect("Failed to create unloaded program"),
             ),
         );
@@ -2282,7 +2290,11 @@ pub(crate) mod tests {
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             });
-            assert!(entry.to_unloaded().is_none());
+            assert!(
+                entry
+                    .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
+                    .is_none()
+            );
 
             // Check that unload_program_entry() does nothing for this entry
             let program_id = Pubkey::new_unique();
@@ -2297,7 +2309,9 @@ pub(crate) mod tests {
             ..Default::default()
         };
         let entry = new_test_entry_with_usage(1, 2, stats);
-        let unloaded_entry = entry.to_unloaded().unwrap();
+        let unloaded_entry = entry
+            .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
+            .unwrap();
         assert_eq!(unloaded_entry.deployment_slot, 1);
         assert_eq!(unloaded_entry.effective_slot, 2);
         assert_eq!(unloaded_entry.latest_access_slot.load(Ordering::Relaxed), 1);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -541,21 +541,47 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 false
                             }
                         })
-                        .filter(|entry| {
-                            // Remove outdated environment of previous feature set
-                            if let Some(new_environment) = new_environment.as_ref()
-                                && !Self::matches_environment(entry, new_environment)
-                            {
-                                self.stats
-                                    .prunes_environment
-                                    .fetch_add(1, Ordering::Relaxed);
-                                return false;
-                            }
-                            true
-                        })
                         .cloned()
                         .collect();
                     second_level.reverse();
+                    // Remove or adjust entries with outdated environment of previous feature set
+                    if let Some(new_environment) = new_environment.as_ref() {
+                        let mut index_in_second_level = 0;
+                        while let Some(entry) = second_level.get(index_in_second_level) {
+                            if !Self::matches_environment(entry, new_environment) {
+                                // second_level is sorted by deployment_slot first,
+                                // thus if the neighbors have a different deployment_slot
+                                // then no other entry with the same deployment_slot exists.
+                                let other_entry_with_same_deployment_slot_exists =
+                                    (index_in_second_level > 0
+                                        && second_level
+                                            .get(index_in_second_level.saturating_sub(1))
+                                            .map(|other_entry| {
+                                                other_entry.deployment_slot == entry.deployment_slot
+                                            })
+                                            .unwrap_or(false))
+                                        || second_level
+                                            .get(index_in_second_level.saturating_add(1))
+                                            .map(|other_entry| {
+                                                other_entry.deployment_slot == entry.deployment_slot
+                                            })
+                                            .unwrap_or(false);
+                                if other_entry_with_same_deployment_slot_exists {
+                                    self.stats
+                                        .prunes_environment
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    second_level.remove(index_in_second_level);
+                                    continue; // Don't increment index_in_second_level
+                                } else if let Some(unloaded_entry) = entry
+                                    .to_unloaded(ProgramRuntimeEnvironment::clone(new_environment))
+                                    && let Some(entry) = second_level.get_mut(index_in_second_level)
+                                {
+                                    *entry = Arc::new(unloaded_entry);
+                                }
+                            }
+                            index_in_second_level = index_in_second_level.saturating_add(1);
+                        }
+                    }
                 }
             }
         }
@@ -1734,32 +1760,24 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_prune_different_env() {
+    fn test_prune_with_two_environments_before_epoch_boundary() {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
         let env = get_mock_program_runtime_environment();
-
+        let new_env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {
             relation: BlockRelation::Ancestor,
         }));
-
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
         cache.assign_program(&env, program1, 10, new_test_entry(10, 10));
-        let new_env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
-        let upcoming_environment = Some(new_env.clone());
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 20,
             effective_slot: 20,
             ..Default::default()
         });
-        cache.assign_program(
-            &env,
-            program1,
-            updated_program.deployment_slot,
-            updated_program.clone(),
-        );
+        cache.assign_program(&env, program1, 20, updated_program.clone());
 
         // Test that there are 2 entries for the program
         assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 2);
@@ -1768,19 +1786,70 @@ pub(crate) mod tests {
 
         // Test that prune didn't remove the entry, since environments are different.
         assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 2);
+    }
 
-        cache.prune(22, upcoming_environment, &fork_graph.read().unwrap());
+    #[test]
+    fn test_prune_with_two_environments_after_epoch_boundary() {
+        let mut cache = ProgramCache::<TestForkGraph>::new(0);
+        let env = get_mock_program_runtime_environment();
+        let new_env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
+        let fork_graph = Arc::new(RwLock::new(TestForkGraph {
+            relation: BlockRelation::Ancestor,
+        }));
+        cache.set_fork_graph(Arc::downgrade(&fork_graph));
+        let program1 = Pubkey::new_unique();
 
-        // Test that prune removed 1 entry, since epoch changed
-        assert_eq!(cache.get_slot_versions_for_tests(&program1).len(), 1);
+        let old_program_old_env = Arc::new(ProgramCacheEntry {
+            program: new_loaded_entry(env.clone()),
+            deployment_slot: 10,
+            effective_slot: 11,
+            ..Default::default()
+        });
+        let old_program_new_env = Arc::new(ProgramCacheEntry {
+            program: new_loaded_entry(new_env.clone()),
+            deployment_slot: 10,
+            effective_slot: 11,
+            ..Default::default()
+        });
+        let new_program_old_env = Arc::new(ProgramCacheEntry {
+            program: new_loaded_entry(env.clone()),
+            deployment_slot: 20,
+            effective_slot: 21,
+            ..Default::default()
+        });
+        let new_program_new_env = Arc::new(ProgramCacheEntry {
+            program: new_loaded_entry(new_env.clone()),
+            deployment_slot: 20,
+            effective_slot: 21,
+            ..Default::default()
+        });
+        cache.assign_program(&env, program1, 10, old_program_old_env.clone());
+        cache.assign_program(&env, program1, 10, old_program_new_env.clone());
+        cache.assign_program(&env, program1, 20, new_program_old_env.clone());
+        let slot_versions = cache.get_slot_versions_for_tests(&program1);
+        assert_eq!(
+            &slot_versions,
+            &[
+                old_program_new_env.clone(),
+                old_program_old_env.clone(),
+                new_program_old_env.clone(),
+            ]
+        );
 
-        let entry = cache
-            .get_slot_versions_for_tests(&program1)
-            .first()
-            .expect("Failed to get the program")
-            .clone();
-        // Test that the correct entry remains in the cache
-        assert_eq!(entry, updated_program);
+        cache.prune(21, Some(new_env.clone()), &fork_graph.read().unwrap());
+        let slot_versions = cache.get_slot_versions_for_tests(&program1);
+        assert_eq!(
+            &slot_versions,
+            &[old_program_new_env.clone(), new_program_new_env.clone()],
+        );
+        assert!(matches!(
+            &slot_versions.first().unwrap().program,
+            ProgramCacheEntryType::Loaded(_)
+        ));
+        assert!(matches!(
+            &slot_versions.get(1).unwrap().program,
+            ProgramCacheEntryType::Unloaded(_)
+        ));
     }
 
     #[derive(Default)]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -909,13 +909,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     .find(|entry| entry == &remove_entry)
                     .expect("Program entry not found");
 
-                // Certain entry types cannot be unloaded, such as tombstones, or already unloaded entries.
-                // For such entries, `to_unloaded()` will return None.
-                // These entry types do not occupy much memory.
-                if let Some(unloaded) = candidate
-                    .program
-                    .get_environment()
-                    .and_then(|env| candidate.to_unloaded(ProgramRuntimeEnvironment::clone(env)))
+                // Only loaded entries shall be unloaded by eviction.
+                if let ProgramCacheEntryType::Loaded(_) = candidate.program
+                    && let Some(unloaded) = candidate.program.get_environment().and_then(|env| {
+                        candidate.to_unloaded(ProgramRuntimeEnvironment::clone(env))
+                    })
                 {
                     if candidate.stats.uses.load(Ordering::Relaxed) == 1 {
                         self.stats.one_hit_wonders.fetch_add(1, Ordering::Relaxed);
@@ -2285,9 +2283,7 @@ pub(crate) mod tests {
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
         let env = get_mock_program_runtime_environment();
         for program_cache_entry_type in [
-            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         ] {
             let entry = Arc::new(ProgramCacheEntry {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -548,36 +548,36 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     if let Some(new_environment) = new_environment.as_ref() {
                         let mut index_in_second_level = 0;
                         while let Some(entry) = second_level.get(index_in_second_level) {
-                            if !Self::matches_environment(entry, new_environment) {
-                                // second_level is sorted by deployment_slot first,
-                                // thus if the neighbors have a different deployment_slot
-                                // then no other entry with the same deployment_slot exists.
-                                let other_entry_with_same_deployment_slot_exists =
-                                    (index_in_second_level > 0
-                                        && second_level
-                                            .get(index_in_second_level.saturating_sub(1))
-                                            .map(|other_entry| {
-                                                other_entry.deployment_slot == entry.deployment_slot
-                                            })
-                                            .unwrap_or(false))
-                                        || second_level
-                                            .get(index_in_second_level.saturating_add(1))
-                                            .map(|other_entry| {
-                                                other_entry.deployment_slot == entry.deployment_slot
-                                            })
-                                            .unwrap_or(false);
-                                if other_entry_with_same_deployment_slot_exists {
-                                    self.stats
-                                        .prunes_environment
-                                        .fetch_add(1, Ordering::Relaxed);
-                                    second_level.remove(index_in_second_level);
-                                    continue; // Don't increment index_in_second_level
-                                } else if let Some(unloaded_entry) = entry
-                                    .to_unloaded(ProgramRuntimeEnvironment::clone(new_environment))
-                                    && let Some(entry) = second_level.get_mut(index_in_second_level)
-                                {
-                                    *entry = Arc::new(unloaded_entry);
-                                }
+                            if Self::matches_environment(entry, new_environment) {
+                                index_in_second_level = index_in_second_level.saturating_add(1);
+                                continue;
+                            }
+                            // second_level is sorted by deployment_slot first,
+                            // thus if the neighbors have a different deployment_slot
+                            // then no other entry with the same deployment_slot exists.
+                            let prev_entry = index_in_second_level
+                                .checked_sub(1)
+                                .and_then(|idx| second_level.get(idx));
+                            let next_entry = index_in_second_level
+                                .checked_add(1)
+                                .and_then(|idx| second_level.get(idx));
+                            let other_entry_with_same_deployment_slot_exists = prev_entry
+                                .map(|e| e.deployment_slot)
+                                == Some(entry.deployment_slot)
+                                || next_entry.map(|e| e.deployment_slot)
+                                    == Some(entry.deployment_slot);
+                            if other_entry_with_same_deployment_slot_exists {
+                                self.stats
+                                    .prunes_environment
+                                    .fetch_add(1, Ordering::Relaxed);
+                                second_level.remove(index_in_second_level);
+                                continue; // Don't increment index_in_second_level
+                            } else if let Some(unloaded_entry) = entry.to_unloaded_in_env(
+                                ProgramRuntimeEnvironment::clone(new_environment),
+                            ) && let Some(entry) =
+                                second_level.get_mut(index_in_second_level)
+                            {
+                                *entry = Arc::new(unloaded_entry);
                             }
                             index_in_second_level = index_in_second_level.saturating_add(1);
                         }
@@ -937,9 +937,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
 
                 // Only loaded entries shall be unloaded by eviction.
                 if let ProgramCacheEntryType::Loaded(_) = candidate.program
-                    && let Some(unloaded) = candidate.program.get_environment().and_then(|env| {
-                        candidate.to_unloaded(ProgramRuntimeEnvironment::clone(env))
-                    })
+                    && let Some(unloaded) = candidate.to_unloaded()
                 {
                     if candidate.stats.uses.load(Ordering::Relaxed) == 1 {
                         self.stats.one_hit_wonders.fetch_add(1, Ordering::Relaxed);
@@ -1091,11 +1089,7 @@ pub(crate) mod tests {
             current_slot.saturating_add(1),
             ProgramStatistics::default(),
         );
-        let unloaded = Arc::new(
-            loaded
-                .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
-                .expect("Failed to unload the program"),
-        );
+        let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
         cache.assign_program(&env, key, current_slot, unloaded.clone());
         unloaded
     }
@@ -2248,7 +2242,7 @@ pub(crate) mod tests {
             20,
             Arc::new(
                 new_test_entry(20, 21)
-                    .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
+                    .to_unloaded()
                     .expect("Failed to create unloaded program"),
             ),
         );
@@ -2364,11 +2358,7 @@ pub(crate) mod tests {
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             });
-            assert!(
-                entry
-                    .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
-                    .is_none()
-            );
+            assert!(entry.to_unloaded().is_none());
 
             // Check that unload_program_entry() does nothing for this entry
             let program_id = Pubkey::new_unique();
@@ -2383,9 +2373,7 @@ pub(crate) mod tests {
             ..Default::default()
         };
         let entry = new_test_entry_with_usage(1, 2, stats);
-        let unloaded_entry = entry
-            .to_unloaded(ProgramRuntimeEnvironment::clone(&env))
-            .unwrap();
+        let unloaded_entry = entry.to_unloaded().unwrap();
         assert_eq!(unloaded_entry.deployment_slot, 1);
         assert_eq!(unloaded_entry.effective_slot, 2);
         assert_eq!(unloaded_entry.latest_access_slot.load(Ordering::Relaxed), 1);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -546,41 +546,47 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     second_level.reverse();
                     // Remove or adjust entries with outdated environment of previous feature set
                     if let Some(new_environment) = new_environment.as_ref() {
+                        let retain_flags = (0..second_level.len())
+                            .map(|index_in_second_level| {
+                                let entry = second_level.get(index_in_second_level).unwrap();
+                                if Self::matches_environment(entry, new_environment) {
+                                    return true;
+                                }
+                                // second_level is sorted by deployment_slot first,
+                                // thus if the neighbors have a different deployment_slot
+                                // then no other entry with the same deployment_slot exists.
+                                let prev_entry = index_in_second_level
+                                    .checked_sub(1)
+                                    .and_then(|idx| second_level.get(idx));
+                                let next_entry = index_in_second_level
+                                    .checked_add(1)
+                                    .and_then(|idx| second_level.get(idx));
+                                let other_entry_with_same_deployment_slot_exists = prev_entry
+                                    .map(|e| e.deployment_slot)
+                                    == Some(entry.deployment_slot)
+                                    || next_entry.map(|e| e.deployment_slot)
+                                        == Some(entry.deployment_slot);
+                                if other_entry_with_same_deployment_slot_exists {
+                                    self.stats
+                                        .prunes_environment
+                                        .fetch_add(1, Ordering::Relaxed);
+                                    return false;
+                                } else if let Some(unloaded_entry) = entry.to_unloaded_in_env(
+                                    ProgramRuntimeEnvironment::clone(new_environment),
+                                ) && let Some(entry) =
+                                    second_level.get_mut(index_in_second_level)
+                                {
+                                    *entry = Arc::new(unloaded_entry);
+                                }
+                                true
+                            })
+                            .collect::<Vec<bool>>();
                         let mut index_in_second_level = 0;
-                        while let Some(entry) = second_level.get(index_in_second_level) {
-                            if Self::matches_environment(entry, new_environment) {
-                                index_in_second_level = index_in_second_level.saturating_add(1);
-                                continue;
-                            }
-                            // second_level is sorted by deployment_slot first,
-                            // thus if the neighbors have a different deployment_slot
-                            // then no other entry with the same deployment_slot exists.
-                            let prev_entry = index_in_second_level
-                                .checked_sub(1)
-                                .and_then(|idx| second_level.get(idx));
-                            let next_entry = index_in_second_level
-                                .checked_add(1)
-                                .and_then(|idx| second_level.get(idx));
-                            let other_entry_with_same_deployment_slot_exists = prev_entry
-                                .map(|e| e.deployment_slot)
-                                == Some(entry.deployment_slot)
-                                || next_entry.map(|e| e.deployment_slot)
-                                    == Some(entry.deployment_slot);
-                            if other_entry_with_same_deployment_slot_exists {
-                                self.stats
-                                    .prunes_environment
-                                    .fetch_add(1, Ordering::Relaxed);
-                                second_level.remove(index_in_second_level);
-                                continue; // Don't increment index_in_second_level
-                            } else if let Some(unloaded_entry) = entry.to_unloaded_in_env(
-                                ProgramRuntimeEnvironment::clone(new_environment),
-                            ) && let Some(entry) =
-                                second_level.get_mut(index_in_second_level)
-                            {
-                                *entry = Arc::new(unloaded_entry);
-                            }
+                        second_level.retain(|_entry| {
+                            let retain_flag = *retain_flags.get(index_in_second_level).unwrap();
                             index_in_second_level = index_in_second_level.saturating_add(1);
-                        }
+                            retain_flag
+                        });
                     }
                 }
             }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -286,7 +286,7 @@ impl ProgramCacheEntry {
         })
     }
 
-    pub fn to_unloaded(&self, environment: ProgramRuntimeEnvironment) -> Option<Self> {
+    pub fn to_unloaded_in_env(&self, environment: ProgramRuntimeEnvironment) -> Option<Self> {
         match &self.program {
             ProgramCacheEntryType::Loaded(_)
             | ProgramCacheEntryType::FailedVerification(_)
@@ -306,6 +306,12 @@ impl ProgramCacheEntry {
             stats: Arc::clone(&self.stats),
             latest_access_slot: AtomicU64::new(self.latest_access_slot.load(Ordering::Relaxed)),
         })
+    }
+
+    pub fn to_unloaded(&self) -> Option<Self> {
+        self.to_unloaded_in_env(ProgramRuntimeEnvironment::clone(
+            self.program.get_environment()?,
+        ))
     }
 
     /// Creates a new built-in program

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -84,7 +84,7 @@ impl From<ProgramCacheEntryOwner> for Pubkey {
     - Loaded => Loaded (with different account_owner)
 
     Eviction and unloading (in the same slot):
-    - Unloaded => Loaded in ProgramCache::assign_program
+    - Unloaded => Loaded / FailedVerification in ProgramCache::assign_program
     - Loaded => Unloaded in ProgramCache::unload_program_entry
 
     At epoch boundary (when feature set and environment changes):

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -285,7 +285,7 @@ impl ProgramCacheEntry {
         })
     }
 
-    pub fn to_unloaded(&self) -> Option<Self> {
+    pub fn to_unloaded(&self, environment: ProgramRuntimeEnvironment) -> Option<Self> {
         match &self.program {
             ProgramCacheEntryType::Loaded(_) => {}
             ProgramCacheEntryType::FailedVerification(_)
@@ -297,7 +297,7 @@ impl ProgramCacheEntry {
             }
         }
         Some(Self {
-            program: ProgramCacheEntryType::Unloaded(self.program.get_environment()?.clone()),
+            program: ProgramCacheEntryType::Unloaded(environment),
             account_owner: self.account_owner,
             account_size: self.account_size,
             deployment_slot: self.deployment_slot,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -287,11 +287,11 @@ impl ProgramCacheEntry {
 
     pub fn to_unloaded(&self, environment: ProgramRuntimeEnvironment) -> Option<Self> {
         match &self.program {
-            ProgramCacheEntryType::Loaded(_) => {}
-            ProgramCacheEntryType::FailedVerification(_)
-            | ProgramCacheEntryType::Closed
+            ProgramCacheEntryType::Loaded(_)
+            | ProgramCacheEntryType::FailedVerification(_)
+            | ProgramCacheEntryType::Unloaded(_) => {}
+            ProgramCacheEntryType::Closed
             | ProgramCacheEntryType::DelayVisibility
-            | ProgramCacheEntryType::Unloaded(_)
             | ProgramCacheEntryType::Builtin(_) => {
                 return None;
             }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -91,8 +91,9 @@ impl From<ProgramCacheEntryOwner> for Pubkey {
     - Loaded => FailedVerification in Bank::_new_from_parent
     - FailedVerification => Loaded in Bank::_new_from_parent
 
-    Through pruning (when on orphan fork or overshadowed on the rooted fork):
-    - Closed / Unloaded / Loaded / Builtin => Empty in ProgramCache::prune
+    Through pruning:
+    - Closed / Unloaded / Loaded / Builtin => Empty in ProgramCache::prune (when on orphan fork or overshadowed on the rooted fork)
+    - FailedVerification / Unloaded / Loaded => Unloaded in ProgramCache::prune (when on outdated program runtime environment)
 */
 
 /// Actual payload of [ProgramCacheEntry].


### PR DESCRIPTION
#### Problem


#### Summary of Changes

- Adds `ProgramRuntimeEnvironment` parameter to `ProgramCacheEntry::to_unloaded()`.
- Allows reloading to fail verification, so that unloaded entries can be inserted for a different environment.
- Allows unloading of already unloaded or failed verification entries, so that they can be inserted for a different environment.
- Unloads entries in first rooting with new environment to maintain `deployment_slot` fork graph nodes, effectively transplanting entries from the old program runtime environment to the new one.

#### Testing

- Adjusted `test_prune_different_env()` => `test_prune_with_two_environments_before_epoch_boundary()`.
- Added `test_prune_with_two_environments_after_epoch_boundary()`.