### PR TITLE
accounts-db: Adds accounts file provider to AccountsDbConfig

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6825,33 +6825,15 @@ impl AccountsDb {
         AccountsDb::new_for_tests(Vec::new())
     }
 
-    pub fn new_single_for_tests_with_provider_and_config(
-        file_provider: AccountsFileProvider,
-        accounts_db_config: AccountsDbConfig,
-    ) -> Self {
-        AccountsDb::new_for_tests_with_provider_and_config(
-            Vec::new(),
-            file_provider,
-            accounts_db_config,
-        )
-    }
-
     pub fn new_for_tests(paths: Vec<PathBuf>) -> Self {
-        Self::new_for_tests_with_provider_and_config(
-            paths,
-            AccountsFileProvider::default(),
-            ACCOUNTS_DB_CONFIG_FOR_TESTING,
-        )
+        Self::new_for_tests_with_config(paths, ACCOUNTS_DB_CONFIG_FOR_TESTING)
     }
 
-    fn new_for_tests_with_provider_and_config(
+    pub fn new_for_tests_with_config(
         paths: Vec<PathBuf>,
-        accounts_file_provider: AccountsFileProvider,
         accounts_db_config: AccountsDbConfig,
     ) -> Self {
-        let mut db = AccountsDb::new_with_config(paths, accounts_db_config, None, Arc::default());
-        db.accounts_file_provider = accounts_file_provider;
-        db
+        Self::new_with_config(paths, accounts_db_config, None, Arc::default())
     }
 
     /// Return the number of slots marked with uncleaned pubkeys.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1146,7 +1146,7 @@ impl AccountsDb {
             dirty_stores: DashMap::default(),
             zero_lamport_accounts_to_purge_after_full_snapshot: DashSet::default(),
             latest_full_snapshot_slot_advanced_since_clean: AtomicBool::default(),
-            accounts_file_provider: AccountsFileProvider::default(),
+            accounts_file_provider: accounts_db_config.accounts_file_provider,
             latest_full_snapshot_slot: SeqLock::new(None),
             last_swept_full_snapshot_slot: AtomicU64::new(0),
             best_ancient_slots_to_shrink: RwLock::default(),

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -1,6 +1,7 @@
 use {
     super::{AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_THRESHOLD_OPTION},
     crate::{
+        accounts_file::AccountsFileProvider,
         accounts_index::{
             ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS, ACCOUNTS_INDEX_CONFIG_FOR_TESTING,
             AccountSecondaryIndexes, AccountsIndexConfig, ScanFilter,
@@ -41,6 +42,7 @@ pub struct AccountsDbConfig {
     pub num_background_threads: Option<NonZeroUsize>,
     /// Number of threads for foreground operations (`thread_pool_foreground`)
     pub num_foreground_threads: Option<NonZeroUsize>,
+    pub accounts_file_provider: AccountsFileProvider,
 }
 
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
@@ -61,6 +63,7 @@ pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormalTest,
     num_background_threads: None,
     num_foreground_threads: None,
+    accounts_file_provider: AccountsFileProvider::AppendVec,
 };
 
 pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig {
@@ -81,4 +84,5 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     scan_filter_for_shrinking: ScanFilter::OnlyAbnormal,
     num_background_threads: None,
     num_foreground_threads: None,
+    accounts_file_provider: AccountsFileProvider::AppendVec,
 };

--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -149,9 +149,12 @@ macro_rules! define_accounts_db_test {
         fn run_test($accounts_db: AccountsDb) {
             $inner
         }
-        let accounts_db = AccountsDb::new_single_for_tests_with_provider_and_config(
-            $accounts_file_provider,
-            ACCOUNTS_DB_CONFIG_FOR_TESTING,
+        let accounts_db = AccountsDb::new_for_tests_with_config(
+            Vec::new(),
+            AccountsDbConfig {
+                accounts_file_provider: $accounts_file_provider,
+                ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+            },
         );
         run_test(accounts_db);
     };
@@ -640,8 +643,8 @@ fn test_flush_slots_with_reclaim_old_slots() {
 #[test]
 fn test_flush_defers_write_through_until_all_cached_slots_drop() {
     // Build an AccountsDb whose index has IndexLimit::Threshold so write-through is enabled.
-    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
-        AccountsFileProvider::AppendVec,
+    let db = AccountsDb::new_for_tests_with_config(
+        Vec::new(),
         AccountsDbConfig {
             index: Some(AccountsIndexConfig {
                 index_limit: IndexLimit::Threshold(IndexLimitThreshold {
@@ -728,8 +731,8 @@ fn test_flush_does_not_write_through_when_write_through_disabled() {
 /// drops its last cached slot.
 #[test]
 fn test_purge_unrooted_slot_writes_through_surviving_entry() {
-    let db = AccountsDb::new_single_for_tests_with_provider_and_config(
-        AccountsFileProvider::AppendVec,
+    let db = AccountsDb::new_for_tests_with_config(
+        Vec::new(),
         AccountsDbConfig {
             index: Some(AccountsIndexConfig {
                 index_limit: IndexLimit::Threshold(IndexLimitThreshold {

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -5,6 +5,7 @@ use {
     solana_account_decoder::{UiAccountEncoding, UiDataSliceConfig},
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+        accounts_file::AccountsFileProvider,
         accounts_index::{
             AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT,
             IndexLimit, IndexLimitThreshold, ScanFilter,
@@ -384,6 +385,7 @@ pub fn get_accounts_db_config(
         scan_filter_for_shrinking,
         num_background_threads: None,
         num_foreground_threads: None,
+        accounts_file_provider: AccountsFileProvider::AppendVec,
     }
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -19,6 +19,7 @@ use {
     rand::{rng, seq::SliceRandom},
     solana_accounts_db::{
         accounts_db::{AccountShrinkThreshold, AccountsDbConfig},
+        accounts_file::AccountsFileProvider,
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD,
             DEFAULT_NUM_ENTRIES_TO_EVICT, IndexLimit, IndexLimitThreshold, ScanFilter,
@@ -712,6 +713,7 @@ pub fn execute(
         scan_filter_for_shrinking,
         num_background_threads: Some(accounts_db_background_threads),
         num_foreground_threads: Some(accounts_db_foreground_threads),
+        accounts_file_provider: AccountsFileProvider::AppendVec,
     };
 
     let on_start_geyser_plugin_config_files = if matches.is_present("geyser_plugin_config") {


### PR DESCRIPTION
#### Problem

We are in the process of adding a new storage file format. Eventually we'll want a way to opt-in and turn it on via CLI. The precedent for that is via the AccountsDbConfig.

Right now AccountsDb::new_with_config() hard codes the accounts file provider field to what the default is on AccountsFileProvider. So it isn't configurable.

Additionally, we'll want tests to exercise the new file format as well. There are some test constructors that accept an AccountsFileProvider param in addition to an AccountsDbConfig. Why the divergent paths?


#### Summary of Changes

Add accounts file provider to AccountsDbConfig and kill two birds with one stone.

Commit by commit:
- Adds AccountsFileProvider to AccountsDbConfig
- AccountsDb::new_with_config() gets accounts file provider from accounts_db_config
- Removes accounts file provider param from AccountsDb test constructors


#### Testing

Nothing additional.