### PR TITLE
clippy: useless_borrows_in_formatting in keygen.rs

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -835,10 +835,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                                             format!("{}.json", keypair.pubkey()),
                                         )
                                         .unwrap();
-                                        println!(
-                                            "Wrote keypair to {}",
-                                            &format!("{}.json", keypair.pubkey())
-                                        );
+                                        println!("Wrote keypair to {}.json", keypair.pubkey());
                                     }
                                     if use_mnemonic {
                                         let divider =


### PR DESCRIPTION
#### Problem

New clippy warnings 🫠 

```
warning: `format!` in `println!` args
   --> keygen/src/keygen.rs:838:41
    |
838 | / ...                   println!(
839 | | ...                       "Wrote keypair to {}",
840 | | ...                       format!("{}.json", keypair.pubkey())
841 | | ...                   );
    | |_______________________^
    |
    = help: combine the `format!(..)` arguments with the outer `println!(..)` call
    = help: or consider changing `format!` to `format_args!`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#format_in_format_args
    = note: `#[warn(clippy::format_in_format_args)]` on by default

warning: `solana-keygen` (bin "solana-keygen" test) generated 1 warning
```


#### Summary of Changes

Inline the formatting. 


#### Testing

Nothing additional.