### PR TITLE
Update rpc/std to use new api of tpu-client-next

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -23,7 +23,9 @@ use {
     solana_send_transaction_service::{
         send_transaction_service::{Config, SendTransactionService, TransactionInfo},
         tpu_info::NullTpuInfo,
-        transaction_client::TpuClientNextClient,
+        transaction_client::{
+            TpuSender, create_client as create_tpu_client, create_leader_updater,
+        },
     },
     solana_signature::Signature,
     solana_transaction::{
@@ -439,7 +441,7 @@ fn create_client(
     maybe_runtime: Option<Handle>,
     my_tpu_address: SocketAddr,
     exit: Arc<AtomicBool>,
-) -> TpuClientNextClient {
+) -> TpuSender {
     let runtime_handle = maybe_runtime.unwrap_or_else(|| {
         Handle::try_current().expect("runtime handle not provided, and not inside Tokio runtime")
     });
@@ -465,16 +467,17 @@ fn create_client(
     });
 
     let leader_forward_count = 0;
-    TpuClientNextClient::new::<NullTpuInfo>(
+    let leader_updater = create_leader_updater::<NullTpuInfo>(None, my_tpu_address, None);
+    let (tpu_sender, _client) = create_tpu_client(
         runtime_handle,
-        my_tpu_address,
-        None,
-        None,
+        leader_updater,
         leader_forward_count,
         None,
         bind_socket,
         cancel,
     )
+    .expect("Should be able to create TPU client.");
+    tpu_sender
 }
 
 pub async fn start_tcp_server(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -479,12 +479,13 @@ impl JsonRpcRequestProcessor {
             ..
         } = config;
         let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
-        let client = create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
+        let (tpu_sender, _client) =
+            create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
 
         SendTransactionService::new(
             bank_forks.clone(),
             transaction_receiver,
-            client,
+            tpu_sender,
             SendTransactionServiceConfig {
                 retry_rate_ms: 1_000,
                 leader_forward_count: 1,
@@ -6978,11 +6979,12 @@ pub mod tests {
             runtime.clone(),
         );
 
-        let client = create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
+        let (tpu_sender, _client) =
+            create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
         SendTransactionService::new(
             bank_forks.clone(),
             receiver,
-            client,
+            tpu_sender,
             SendTransactionServiceConfig {
                 retry_rate_ms: 1_000,
                 leader_forward_count: 1,
@@ -7270,7 +7272,8 @@ pub mod tests {
             ..
         } = config;
         let runtime = service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj);
-        let client = create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
+        let (tpu_sender, _client) =
+            create_client_for_tests(runtime.handle().clone(), my_tpu_address, None, 1);
         let (request_processor, receiver) = JsonRpcRequestProcessor::new(
             config,
             None,
@@ -7294,7 +7297,7 @@ pub mod tests {
         SendTransactionService::new(
             bank_forks,
             receiver,
-            client,
+            tpu_sender,
             SendTransactionServiceConfig {
                 retry_rate_ms: 1_000,
                 leader_forward_count: 1,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -41,7 +41,7 @@ use {
     },
     solana_send_transaction_service::{
         send_transaction_service::{self, SendTransactionService},
-        transaction_client::{TpuClientNextClient, TransactionClient},
+        transaction_client::{TpuClient, TpuSender, create_client, create_leader_updater},
     },
     solana_storage_bigtable::CredentialType,
     solana_tls_utils::NotifyKeyUpdate,
@@ -530,16 +530,19 @@ impl JsonRpcService {
                 "Invalid {:?} socket address for TPU",
                 Protocol::QUIC
             ))?;
-        let client = TpuClientNextClient::new(
-            client_runtime,
+        let leader_updater = create_leader_updater(
+            leader_info,
             my_tpu_address,
             config.send_transaction_service_config.tpu_peers.clone(),
-            leader_info,
+        );
+        let (tpu_sender, client) = create_client(
+            client_runtime,
+            leader_updater,
             config.send_transaction_service_config.leader_forward_count,
             Some(identity_keypair),
             tpu_client_socket,
             cancel,
-        );
+        )?;
 
         let json_rpc_service = Self::new(
             config.rpc_addr,
@@ -558,6 +561,7 @@ impl JsonRpcService {
             config.send_transaction_service_config,
             config.max_slots,
             config.leader_schedule_cache,
+            tpu_sender,
             client,
             config.max_complete_transaction_status_slot,
             config.prioritization_fee_cache,
@@ -567,14 +571,7 @@ impl JsonRpcService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn new<
-        Client: TransactionClient
-            + NotifyKeyUpdate
-            + Clone
-            + std::marker::Send
-            + std::marker::Sync
-            + 'static,
-    >(
+    fn new(
         rpc_addr: SocketAddr,
         config: JsonRpcConfig,
         snapshot_config: Option<SnapshotConfig>,
@@ -591,7 +588,8 @@ impl JsonRpcService {
         send_transaction_service_config: send_transaction_service::Config,
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        client: Client,
+        tpu_sender: TpuSender,
+        client: TpuClient,
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         runtime: Arc<TokioRuntime>,
@@ -691,7 +689,7 @@ impl JsonRpcService {
         let _send_transaction_service = Arc::new(SendTransactionService::new(
             bank_forks.clone(),
             receiver,
-            client.clone(),
+            tpu_sender,
             send_transaction_service_config,
             exit,
         ));
@@ -887,7 +885,7 @@ mod tests {
             ..send_transaction_service::Config::default()
         };
 
-        let client = create_client_for_tests(
+        let (tpu_sender, client) = create_client_for_tests(
             runtime.handle().clone(),
             tpu_address,
             send_transaction_service_config.tpu_peers.clone(),
@@ -910,6 +908,7 @@ mod tests {
             send_transaction_service_config,
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),
+            tpu_sender,
             client,
             Arc::new(AtomicU64::default()),
             Some(Arc::new(PrioritizationFeeCache::default())),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -3,7 +3,7 @@ use {
         send_transaction_service_stats::{
             SendTransactionServiceStats, SendTransactionServiceStatsReport,
         },
-        transaction_client::TransactionClient,
+        transaction_client::TpuSender,
     },
     crossbeam_channel::{Receiver, RecvTimeoutError},
     itertools::Itertools,
@@ -157,10 +157,10 @@ impl Default for Config {
 pub const MAX_RETRY_SLEEP_MS: u64 = 1000;
 
 impl SendTransactionService {
-    pub fn new<Client: TransactionClient + Clone + std::marker::Send + 'static>(
+    pub fn new(
         bank_forks: Arc<RwLock<BankForks>>,
         receiver: Receiver<TransactionInfo>,
-        client: Client,
+        tpu_sender: TpuSender,
         config: Config,
         exit: Arc<AtomicBool>,
     ) -> Self {
@@ -170,7 +170,7 @@ impl SendTransactionService {
 
         let receive_txn_thread = Self::receive_txn_thread(
             receiver,
-            client.clone(),
+            tpu_sender.clone(),
             retry_transactions.clone(),
             config.clone(),
             stats_report.clone(),
@@ -179,7 +179,7 @@ impl SendTransactionService {
 
         let retry_thread = Self::retry_thread(
             bank_forks,
-            client,
+            tpu_sender,
             retry_transactions,
             config,
             stats_report,
@@ -193,9 +193,9 @@ impl SendTransactionService {
     }
 
     /// Thread responsible for receiving transactions from RPC clients.
-    fn receive_txn_thread<Client: TransactionClient + std::marker::Send + 'static>(
+    fn receive_txn_thread(
         receiver: Receiver<TransactionInfo>,
-        client: Client,
+        tpu_sender: TpuSender,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
         Config {
             batch_send_rate_ms,
@@ -260,8 +260,8 @@ impl SendTransactionService {
                         let wire_transactions = transactions
                             .values()
                             .map(|transaction_info| transaction_info.wire_transaction.clone())
-                            .collect::<Vec<Vec<u8>>>();
-                        client.send_transactions_in_batch(wire_transactions, stats);
+                            .collect();
+                        tpu_sender.send_transactions_in_batch(wire_transactions, stats);
                         let last_sent_time = Instant::now();
                         {
                             // take a lock of retry_transactions and move the batch to the retry set.
@@ -307,9 +307,9 @@ impl SendTransactionService {
     }
 
     /// Thread responsible for retrying transactions
-    fn retry_thread<Client: TransactionClient + std::marker::Send + 'static>(
+    fn retry_thread(
         bank_forks: Arc<RwLock<BankForks>>,
-        client: Client,
+        tpu_sender: TpuSender,
         retry_transactions: Arc<Mutex<HashMap<Signature, TransactionInfo>>>,
         config: Config,
         stats_report: Arc<SendTransactionServiceStatsReport>,
@@ -344,7 +344,7 @@ impl SendTransactionService {
                             &working_bank,
                             &root_bank,
                             &mut transactions,
-                            &client,
+                            &tpu_sender,
                             &config,
                             stats,
                         );
@@ -367,11 +367,11 @@ impl SendTransactionService {
     }
 
     /// Retry transactions sent before.
-    fn process_transactions<Client: TransactionClient + std::marker::Send + 'static>(
+    fn process_transactions(
         working_bank: &Bank,
         root_bank: &Bank,
         transactions: &mut HashMap<Signature, TransactionInfo>,
-        client: &Client,
+        tpu_sender: &TpuSender,
         &Config {
             retry_rate_ms,
             service_max_retries,
@@ -509,7 +509,7 @@ impl SendTransactionService {
             let iter = wire_transactions.chunks(batch_size);
             for chunk in &iter {
                 let chunk = chunk.collect();
-                client.send_transactions_in_batch(chunk, stats);
+                tpu_sender.send_transactions_in_batch(chunk, stats);
             }
         }
 
@@ -556,13 +556,13 @@ mod test {
         let bank_forks = BankForks::new_rw_arc(bank);
         let (sender, receiver) = bounded(1024);
 
-        let client =
+        let (tpu_sender, client) =
             create_client_for_tests(Handle::current(), "127.0.0.1:0".parse().unwrap(), None, 1);
 
         let send_transaction_service = SendTransactionService::new(
             bank_forks,
             receiver,
-            client.clone(),
+            tpu_sender.clone(),
             Config {
                 retry_rate_ms: 1000,
                 ..Config::default()
@@ -572,7 +572,7 @@ mod test {
 
         drop(sender);
         send_transaction_service.join().unwrap();
-        client.cancel();
+        client.shutdown().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -594,12 +594,12 @@ mod test {
         };
 
         let exit = Arc::new(AtomicBool::new(false));
-        let client =
+        let (tpu_sender, client) =
             create_client_for_tests(Handle::current(), "127.0.0.1:0".parse().unwrap(), None, 1);
         let _send_transaction_service = SendTransactionService::new(
             bank_forks,
             receiver,
-            client.clone(),
+            tpu_sender.clone(),
             Config {
                 retry_rate_ms: 1000,
                 ..Config::default()
@@ -609,9 +609,12 @@ mod test {
 
         sender.send(dummy_tx_info()).unwrap();
 
+        let runtime_handle = Handle::current();
         thread::spawn(move || {
             exit.store(true, Ordering::Relaxed);
-            client.cancel();
+            runtime_handle.spawn(async move {
+                let _ = client.shutdown().await;
+            });
         });
 
         let mut option = Ok(());
@@ -703,7 +706,7 @@ mod test {
             ),
         );
 
-        let client = create_client_for_tests(
+        let (tpu_sender, client) = create_client_for_tests(
             Handle::current(),
             "127.0.0.1:0".parse().unwrap(),
             config.tpu_peers.clone(),
@@ -713,7 +716,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -744,7 +747,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -775,7 +778,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -806,7 +809,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -839,7 +842,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -884,7 +887,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -897,7 +900,7 @@ mod test {
                 ..ProcessTransactionsResult::default()
             }
         );
-        client.cancel();
+        client.shutdown().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -989,7 +992,7 @@ mod test {
             ),
         );
         let stats = SendTransactionServiceStats::default();
-        let client = create_client_for_tests(
+        let (tpu_sender, client) = create_client_for_tests(
             Handle::current(),
             "127.0.0.1:0".parse().unwrap(),
             config.tpu_peers.clone(),
@@ -999,7 +1002,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1029,7 +1032,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1061,7 +1064,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1091,7 +1094,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1122,7 +1125,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1153,7 +1156,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1186,7 +1189,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1214,7 +1217,7 @@ mod test {
             &working_bank,
             &root_bank,
             &mut transactions,
-            &client,
+            &tpu_sender,
             &config,
             &stats,
         );
@@ -1226,6 +1229,6 @@ mod test {
                 ..ProcessTransactionsResult::default()
             }
         );
-        client.cancel();
+        client.shutdown().await.unwrap();
     }
 }

--- a/send-transaction-service/src/test_utils.rs
+++ b/send-transaction-service/src/test_utils.rs
@@ -2,7 +2,10 @@
 //! with the client type.
 
 use {
-    crate::{tpu_info::NullTpuInfo, transaction_client::TpuClientNextClient},
+    crate::{
+        tpu_info::NullTpuInfo,
+        transaction_client::{TpuClient, TpuSender, create_client, create_leader_updater},
+    },
     solana_net_utils::sockets::{bind_to, localhost_port_range_for_tests},
     std::net::{IpAddr, Ipv4Addr, SocketAddr},
     tokio::runtime::Handle,
@@ -14,18 +17,18 @@ pub fn create_client_for_tests(
     my_tpu_address: SocketAddr,
     tpu_peers: Option<Vec<SocketAddr>>,
     leader_forward_count: u64,
-) -> TpuClientNextClient {
+) -> (TpuSender, TpuClient) {
     let port_range = localhost_port_range_for_tests();
     let bind_socket = bind_to(IpAddr::V4(Ipv4Addr::LOCALHOST), port_range.0)
         .expect("Should be able to open UdpSocket for tests.");
-    TpuClientNextClient::new::<NullTpuInfo>(
+    let leader_updater = create_leader_updater::<NullTpuInfo>(None, my_tpu_address, tpu_peers);
+    create_client(
         runtime_handle,
-        my_tpu_address,
-        tpu_peers,
-        None,
+        leader_updater,
         leader_forward_count,
         None,
         bind_socket,
         CancellationToken::new(),
     )
+    .expect("Should be able to create TPU client for tests.")
 }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -6,12 +6,7 @@ use {
     solana_measure::measure::Measure,
     solana_tls_utils::NotifyKeyUpdate,
     solana_tpu_client_next::{
-        ConnectionWorkersScheduler,
-        connection_workers_scheduler::{
-            BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
-        },
-        leader_updater::LeaderUpdater,
-        transaction_batch::TransactionBatch,
+        Client, ClientBuilder, ClientError, TransactionSender, leader_updater::LeaderUpdater,
     },
     std::{
         net::{SocketAddr, UdpSocket},
@@ -19,13 +14,7 @@ use {
         sync::atomic::Ordering,
         time::{Duration, Instant},
     },
-    tokio::{
-        runtime::Handle,
-        sync::{
-            mpsc::{self},
-            watch,
-        },
-    },
+    tokio::runtime::Handle,
     tokio_util::sync::CancellationToken,
 };
 
@@ -37,16 +26,43 @@ const MAX_CONNECTIONS: NonZeroUsize = NonZeroUsize::new(1024).unwrap();
 pub trait TpuInfoWithSendStatic: TpuInfo + std::marker::Send + 'static {}
 impl<T> TpuInfoWithSendStatic for T where T: TpuInfo + std::marker::Send + 'static {}
 
-pub trait TransactionClient {
-    fn send_transactions_in_batch(
+/// The leader info refresh rate.
+pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
+
+const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(3);
+
+/// A synchronous adapter that schedules transaction batches on a Tokio runtime.
+#[derive(Clone)]
+pub struct TpuSender {
+    runtime_handle: Handle,
+    sender: TransactionSender,
+}
+
+impl TpuSender {
+    pub fn send_transactions_in_batch(
         &self,
         wire_transactions: Vec<Vec<u8>>,
         stats: &SendTransactionServiceStats,
-    );
-}
+    ) {
+        let mut measure = Measure::start("send-us");
+        self.runtime_handle.spawn({
+            let sender = self.sender.clone();
+            async move {
+                if sender
+                    .send_transactions_in_batch(wire_transactions)
+                    .await
+                    .is_err()
+                {
+                    warn!("Failed to send transactions to channel: it is closed.");
+                }
+            }
+        });
 
-/// The leader info refresh rate.
-pub const LEADER_INFO_REFRESH_RATE_MS: u64 = 1000;
+        measure.stop();
+        stats.send_us.fetch_add(measure.as_us(), Ordering::Relaxed);
+        stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
 
 /// A struct responsible for holding up-to-date leader information
 /// used for sending transactions.
@@ -95,141 +111,77 @@ where
     }
 }
 
-/// `TpuClientNextClient` provides an interface for managing the
-/// [`ConnectionWorkersScheduler`].
-///
-/// It allows:
-/// * Create and initializes the scheduler with runtime configurations,
-/// * Send transactions to the connection scheduler,
-/// * Update the validator identity keypair and propagate the changes to the
-///   scheduler. Most of the complexity of this structure arises from this
-///   functionality.
-#[derive(Clone)]
-pub struct TpuClientNextClient {
+pub struct TpuClient(Client);
+
+impl TpuClient {
+    pub async fn shutdown(self) -> Result<(), ClientError> {
+        self.0.shutdown().await
+    }
+}
+
+impl NotifyKeyUpdate for TpuClient {
+    fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn core::error::Error>> {
+        self.0
+            .update_identity(identity)
+            .map_err(|e| Box::new(e) as Box<dyn core::error::Error>)
+    }
+}
+
+pub fn create_client(
     runtime_handle: Handle,
-    sender: mpsc::Sender<TransactionBatch>,
-    update_certificate_sender: watch::Sender<Option<StakeIdentity>>,
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    leader_updater: Box<dyn LeaderUpdater>,
+    leader_forward_count: u64,
+    identity: Option<&Keypair>,
+    bind_socket: UdpSocket,
     cancel: CancellationToken,
-}
-
-const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(3);
-impl TpuClientNextClient {
-    pub fn new<T>(
-        runtime_handle: Handle,
-        my_tpu_address: SocketAddr,
-        tpu_peers: Option<Vec<SocketAddr>>,
-        leader_info: Option<T>,
-        leader_forward_count: u64,
-        identity: Option<&Keypair>,
-        bind_socket: UdpSocket,
-        cancel: CancellationToken,
-    ) -> Self
-    where
-        T: TpuInfoWithSendStatic + Clone,
-    {
-        // The channel size represents 8s worth of transactions at a rate of
-        // 1000 tps, assuming batch size is 64.
-        let (sender, receiver) = mpsc::channel(128);
-
-        let (update_certificate_sender, update_certificate_receiver) = watch::channel(None);
-
-        let leader_info_provider = CurrentLeaderInfo::new(leader_info);
-        let leader_updater: SendTransactionServiceLeaderUpdater<T> =
-            SendTransactionServiceLeaderUpdater {
-                leader_info_provider,
-                my_tpu_address,
-                tpu_peers,
-            };
-        let config = Self::create_config(bind_socket, identity, leader_forward_count as usize);
-
-        let scheduler = ConnectionWorkersScheduler::new(
-            Box::new(leader_updater),
-            receiver,
-            update_certificate_receiver,
-            cancel.clone(),
-        );
-        // leaking handle to this task, as it will run until the cancel signal is received
-        runtime_handle.spawn(scheduler.get_stats().report_to_influxdb(
-            "send-transaction-service-TPU-client",
-            METRICS_REPORTING_INTERVAL,
-            cancel.clone(),
-        ));
-        let _handle = runtime_handle.spawn(scheduler.run(config));
-        Self {
-            runtime_handle,
-            sender,
-            update_certificate_sender,
-            #[cfg(any(test, feature = "dev-context-only-utils"))]
-            cancel,
-        }
-    }
-
-    fn create_config(
-        bind_socket: UdpSocket,
-        stake_identity: Option<&Keypair>,
-        leader_forward_count: usize,
-    ) -> ConnectionWorkersSchedulerConfig {
-        ConnectionWorkersSchedulerConfig {
-            bind: BindTarget::Socket(bind_socket),
-            stake_identity: stake_identity.map(StakeIdentity::new),
-            num_connections: MAX_CONNECTIONS,
-            skip_check_transaction_age: true,
-            // experimentally found parameter values
-            worker_channel_size: 64,
-            max_reconnect_attempts: 4,
-            // We open connection to one more leader in advance, which time-wise means ~1.6s
-            leaders_fanout: Fanout {
-                connect: leader_forward_count + 1,
-                send: leader_forward_count,
-            },
-            override_initial_congestion_window: None,
-        }
-    }
-
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
-    pub fn cancel(&self) {
-        self.cancel.cancel();
-    }
-}
-
-impl NotifyKeyUpdate for TpuClientNextClient {
-    fn update_key(&self, identity: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        let stake_identity = StakeIdentity::new(identity);
-        self.update_certificate_sender
-            .send(Some(stake_identity))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
-    }
-}
-
-impl TransactionClient for TpuClientNextClient {
-    fn send_transactions_in_batch(
-        &self,
-        wire_transactions: Vec<Vec<u8>>,
-        stats: &SendTransactionServiceStats,
-    ) {
-        let mut measure = Measure::start("send-us");
-        self.runtime_handle.spawn({
-            let sender = self.sender.clone();
-            async move {
-                let res = sender.send(TransactionBatch::new(wire_transactions)).await;
-                if res.is_err() {
-                    warn!("Failed to send transaction to channel: it is closed.");
-                }
-            }
+) -> Result<(TpuSender, TpuClient), String> {
+    let sender_runtime_handle = runtime_handle.clone();
+    let client_builder = ClientBuilder::new(leader_updater)
+        .runtime_handle(runtime_handle)
+        .bind_socket(bind_socket)
+        .leader_send_fanout(leader_forward_count as usize)
+        .identity(identity)
+        .max_cache_size(MAX_CONNECTIONS)
+        .cancel_token(cancel)
+        .worker_channel_size(64)
+        .sender_channel_size(128)
+        .max_reconnect_attempts(4)
+        .metric_reporter(|stats, cancel| async move {
+            stats
+                .report_to_influxdb(
+                    "send-transaction-service-TPU-client",
+                    METRICS_REPORTING_INTERVAL,
+                    cancel,
+                )
+                .await;
         });
 
-        measure.stop();
-        stats.send_us.fetch_add(measure.as_us(), Ordering::Relaxed);
-        stats.send_attempt_count.fetch_add(1, Ordering::Relaxed);
-    }
+    let (sender, client) = client_builder.build().map_err(|e| e.to_string())?;
+    Ok((
+        TpuSender {
+            runtime_handle: sender_runtime_handle,
+            sender,
+        },
+        TpuClient(client),
+    ))
 }
 
-#[derive(Clone)]
-pub struct SendTransactionServiceLeaderUpdater<T: TpuInfoWithSendStatic> {
+struct SendTransactionServiceLeaderUpdater<T: TpuInfoWithSendStatic> {
     leader_info_provider: CurrentLeaderInfo<T>,
     my_tpu_address: SocketAddr,
     tpu_peers: Option<Vec<SocketAddr>>,
+}
+
+pub fn create_leader_updater<T: TpuInfoWithSendStatic>(
+    leader_info: Option<T>,
+    my_tpu_address: SocketAddr,
+    tpu_peers: Option<Vec<SocketAddr>>,
+) -> Box<dyn LeaderUpdater> {
+    Box::new(SendTransactionServiceLeaderUpdater {
+        leader_info_provider: CurrentLeaderInfo::new(leader_info),
+        my_tpu_address,
+        tpu_peers,
+    })
 }
 
 #[async_trait]


### PR DESCRIPTION
#### Problem

`SendTransactionService` uses old API of tpu-client-next. This is blocking refactoring in tpu-client-next.

#### Summary of Changes

In this PR, I use new builder-based API of tpu-client-next and remove unnecessary abstractions that were there from ConnectionCache times. No functional changes
