### PR TITLE
validator: deprecate tpu forwards 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Release channels have their own copy of this changelog:
   backward compatibility, but account storages are always accessed via file I/O.
 * `--accounts-db-cache-limit-mb` is now deprecated. Use `--accounts-db-write-cache-limit` instead.
 * `--experimental-poh-pinned-cpu-core` is now deprecated. Use `--poh-pinned-cpu-core` instead.
+* TPU-forward is now deprecated and will be removed in v4.3. The related validator arguments are
+  `--public-tpu-forwards-address`, `--tpu-max-fwd-staked-connections`,
+  `--tpu-max-fwd-unstaked-connections`, and `--tpu-transaction-forward-receive-threads`.
 #### Changes
 * Turbine shred ingestion now rejects shreds more than half an epoch in the future (previously up to 2 full epochs ahead was accepted).
 * When XDP is enabled, gossip egress does not support private and loopback addresses. Operators running with `--allow-private-addr` must also pass `--no-xdp`.

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -234,6 +234,47 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Controls the TPU connection pool size per remote address"),
          usage_warning:"This parameter is misleading, avoid setting it",
     );
+    add_arg!(
+        // deprecated in v4.2.0
+        Arg::with_name("tpu_max_fwd_staked_connections")
+            .long("tpu-max-fwd-staked-connections")
+            .takes_value(true)
+            .validator(is_parsable::<u32>)
+            .help("Controls the max concurrent connections for TPU-forward from staked nodes."),
+        usage_warning: "TPU Forwards will be deprecated as of v4.2.0 and removed in v4.3.0",
+    );
+    add_arg!(
+        // deprecated in v4.2.0
+        Arg::with_name("tpu_max_fwd_unstaked_connections")
+            .long("tpu-max-fwd-unstaked-connections")
+            .takes_value(true)
+            .validator(is_parsable::<u32>)
+            .help("Controls the max concurrent connections for TPU-forward from unstaked nodes."),
+        usage_warning: "TPU Forwards will be deprecated as of v4.2.0 and removed in v4.3.0",
+    );
+    add_arg!(
+        // deprecated in v4.2.0
+        Arg::with_name("tpu_transaction_forward_receive_threads")
+            .long("tpu-transaction-forward-receive-threads")
+            .takes_value(true)
+            .value_name("NUMBER")
+            .validator(|num| is_within_range(num, 1..=num_cpus::get()))
+            .help("Number of threads to use for receiving transactions on the TPU forwards port"),
+        usage_warning: "TPU Forwards will be deprecated as of v4.2.0 and removed in v4.3.0",
+    );
+    add_arg!(
+        // deprecated in v4.2.0
+        Arg::with_name("public_tpu_forwards_addr")
+            .long("public-tpu-forwards-address")
+            .value_name("HOST:PORT")
+            .takes_value(true)
+            .validator(solana_net_utils::is_host_port)
+            .help(
+                "Specify TPU Forwards QUIC address to advertise in gossip [default: ask \
+                 --entrypoint or localhostwhen --entrypoint is not provided]",
+            ),
+        usage_warning: "TPU Forwards will be deprecated as of v4.2.0 and removed in v4.3.0",
+    );
     res
 }
 

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -258,7 +258,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("tpu-transaction-forward-receive-threads")
             .takes_value(true)
             .value_name("NUMBER")
-            .validator(|num| is_within_range(num, 1..=num_cpus::get()))
+            .validator(|num| solana_clap_utils::input_validators::is_within_range(num, 1..=num_cpus::get()))
             .help("Number of threads to use for receiving transactions on the TPU forwards port"),
         usage_warning: "TPU Forwards will be deprecated as of v4.2.0 and removed in v4.3.0",
     );


### PR DESCRIPTION
#### Description

This PR brings TPU forwards deprecation as pre-requirement to remove these in 4.3.0.

ref: https://discord.com/channels/428295358100013066/977244255212937306/1524988474158223410

#### Summary of Changes
* Updated the changelog for v4.2.0.
* Added the following arguments to the deprecated arguments list:

  * `--public-tpu-forwards-address`
  * `--tpu-max-fwd-staked-connections`
  * `--tpu-max-fwd-unstaked-connections`
  * `--tpu-transaction-forward-receive-threads`
