### PR TITLE
solana-client: start deprecations

### DIFF
--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -163,6 +163,7 @@ impl ConnectionCache {
         }
     }
 
+    #[deprecated(since = "4.3.0", note = "ConnectionCache is deprecated")]
     pub fn get_nonblocking_connection(&self, addr: &SocketAddr) -> NonblockingClientConnection {
         match self {
             Self::Quic(cache) => {

--- a/client/src/nonblocking/tpu_client.rs
+++ b/client/src/nonblocking/tpu_client.rs
@@ -1,6 +1,5 @@
 pub use solana_tpu_client::nonblocking::tpu_client::{LeaderTpuService, TpuSenderError};
 use {
-    crate::{connection_cache::ConnectionCache, tpu_client::TpuClientConfig},
     solana_connection_cache::connection_cache::{
         ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
         NewConnectionConfig,
@@ -9,7 +8,10 @@ use {
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::signers::Signers,
-    solana_tpu_client::nonblocking::tpu_client::{Result, TpuClient as BackendTpuClient},
+    solana_tpu_client::{
+        nonblocking::tpu_client::{Result, TpuClient as BackendTpuClient},
+        tpu_client::TpuClientConfig,
+    },
     solana_transaction::{Transaction, versioned::VersionedTransaction},
     solana_transaction_error::{TransactionError, TransportResult},
     std::sync::Arc,
@@ -86,15 +88,19 @@ impl TpuClient<QuicPool, QuicConnectionManager, QuicConfig> {
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let connection_cache = match ConnectionCache::new(name) {
-            ConnectionCache::Quic(cache) => cache,
-            ConnectionCache::Udp(_) => {
-                return Err(TpuSenderError::Custom(String::from(
-                    "Invalid default connection cache",
-                )));
-            }
-        };
-        Self::new_with_connection_cache(rpc_client, websocket_url, config, connection_cache).await
+        let connection_manager = QuicConnectionManager::new_with_connection_config(
+            QuicConfig::new().expect("QUIC client config must be constructible"),
+        );
+        Ok(Self {
+            tpu_client: BackendTpuClient::new(
+                name,
+                rpc_client,
+                websocket_url,
+                config,
+                connection_manager,
+            )
+            .await?,
+        })
     }
 }
 
@@ -122,11 +128,16 @@ where
         })
     }
 
+    #[deprecated(
+        since = "4.3.0",
+        note = "prefer send_and_confirm_transactions_in_parallel_v3"
+    )]
     pub async fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,
     ) -> Result<Vec<Option<TransactionError>>> {
+        #[allow(deprecated)]
         self.tpu_client
             .send_and_confirm_messages_with_spinner(messages, signers)
             .await

--- a/client/src/tpu_client.rs
+++ b/client/src/tpu_client.rs
@@ -1,5 +1,8 @@
+pub use solana_tpu_client::{
+    nonblocking::tpu_client::TpuSenderError,
+    tpu_client::{DEFAULT_FANOUT_SLOTS, MAX_FANOUT_SLOTS, TpuClientConfig},
+};
 use {
-    crate::connection_cache::ConnectionCache,
     solana_connection_cache::connection_cache::{
         ConnectionCache as BackendConnectionCache, ConnectionManager, ConnectionPool,
         NewConnectionConfig,
@@ -13,10 +16,6 @@ use {
     solana_transaction_error::{TransactionError, TransportResult},
     solana_udp_client::{UdpConfig, UdpConnectionManager, UdpPool},
     std::sync::Arc,
-};
-pub use {
-    crate::nonblocking::tpu_client::TpuSenderError,
-    solana_tpu_client::tpu_client::{DEFAULT_FANOUT_SLOTS, MAX_FANOUT_SLOTS, TpuClientConfig},
 };
 
 pub enum TpuClientWrapper {
@@ -83,15 +82,18 @@ impl TpuClient<QuicPool, QuicConnectionManager, QuicConfig> {
         websocket_url: &str,
         config: TpuClientConfig,
     ) -> Result<Self> {
-        let connection_cache = match ConnectionCache::new("connection_cache_tpu_client") {
-            ConnectionCache::Quic(cache) => cache,
-            ConnectionCache::Udp(_) => {
-                return Err(TpuSenderError::Custom(String::from(
-                    "Invalid default connection cache",
-                )));
-            }
-        };
-        Self::new_with_connection_cache(rpc_client, websocket_url, config, connection_cache)
+        let connection_manager = QuicConnectionManager::new_with_connection_config(
+            QuicConfig::new().expect("QUIC client config must be constructible"),
+        );
+        Ok(Self {
+            tpu_client: BackendTpuClient::new(
+                "connection_cache_tpu_client",
+                rpc_client,
+                websocket_url,
+                config,
+                connection_manager,
+            )?,
+        })
     }
 }
 
@@ -117,12 +119,16 @@ where
             )?,
         })
     }
-
+    #[deprecated(
+        since = "4.3.0",
+        note = "prefer send_and_confirm_transactions_in_parallel_v3"
+    )]
     pub fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
         messages: &[Message],
         signers: &T,
     ) -> Result<Vec<Option<TransactionError>>> {
+        #[allow(deprecated)]
         self.tpu_client
             .send_and_confirm_messages_with_spinner(messages, signers)
     }

--- a/tpu-client/src/nonblocking/tpu_client.rs
+++ b/tpu-client/src/nonblocking/tpu_client.rs
@@ -542,6 +542,10 @@ where
         })
     }
 
+    #[deprecated(
+        since = "4.3.0",
+        note = "prefer solana_client::send_and_confirm_transactions_in_parallel_v3"
+    )]
     #[cfg(feature = "spinner")]
     pub async fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -215,6 +215,10 @@ where
         })
     }
 
+    #[deprecated(
+        since = "4.3.0",
+        note = "prefer send_and_confirm_transactions_in_parallel_v3"
+    )]
     #[cfg(feature = "spinner")]
     pub fn send_and_confirm_messages_with_spinner<T: Signers + ?Sized>(
         &self,
@@ -222,6 +226,7 @@ where
         signers: &T,
     ) -> Result<Vec<Option<TransactionError>>> {
         self.invoke(
+            #[allow(deprecated)]
             self.tpu_client
                 .send_and_confirm_messages_with_spinner(messages, signers),
         )


### PR DESCRIPTION
#### Problem

solana-client and tpu-client have a bunch of cursed code bound to ConnectionCache. There is no test coverage and none of it is used in the validator. Implementations are rather unfortunate and better ones are available.
#### Summary of Changes

- Start deprecating stuff for which alternative via tpu-client-next is available.
- No externally impactful functional or API changes (except for deprecation).
- Caveat: connection pool size dropped from 4 to 2 (agave uses 1, even 2 is overkill and wastes validator resources).

#### Testing

CI


