### PR TITLE
fix: poh running fast under load

### DIFF
--- a/entry/src/poh.rs
+++ b/entry/src/poh.rs
@@ -59,7 +59,8 @@ impl Poh {
     pub fn target_poh_time(&self, target_ns_per_tick: u64) -> Instant {
         assert!(self.hashes_per_tick > 0);
         let offset_tick_ns = target_ns_per_tick * self.tick_number;
-        let offset_ns = target_ns_per_tick * self.num_hashes / self.hashes_per_tick;
+        let hashes_since_tick = self.hashes_per_tick - self.remaining_hashes_until_tick;
+        let offset_ns = target_ns_per_tick * hashes_since_tick / self.hashes_per_tick;
         self.slot_start_time + Duration::from_nanos(offset_ns + offset_tick_ns)
     }
 
@@ -189,13 +190,30 @@ mod tests {
                 poh.target_poh_time(target_ns_per_tick),
                 poh.slot_start_time + Duration::from_nanos(target_ns_per_tick * 2)
             );
-            poh.num_hashes = 3;
+            assert!(!poh.hash(3));
             assert_eq!(
                 poh.target_poh_time(target_ns_per_tick),
                 poh.slot_start_time
                     + Duration::from_nanos(target_ns_per_tick * 2 + target_ns_per_tick * 3 / 5)
             );
         }
+    }
+
+    #[test]
+    fn test_target_poh_time_after_record() {
+        let target_ns_per_tick = 100;
+        let mut poh = Poh::new(Hash::default(), Some(10));
+        assert!(!poh.hash(3));
+
+        assert_matches!(
+            poh.record(Hash::default()),
+            Some(PohEntry { num_hashes: 4, .. })
+        );
+        assert_eq!(poh.num_hashes, 0);
+        assert_eq!(
+            poh.target_poh_time(target_ns_per_tick),
+            poh.slot_start_time + Duration::from_nanos(40)
+        );
     }
 
     #[test]

--- a/poh/src/poh_service.rs
+++ b/poh/src/poh_service.rs
@@ -439,6 +439,13 @@ impl PohService {
             .unwrap_or(false)
     }
 
+    /// Returns the target PoH time if it is still in the future, or `None` if it
+    /// has already been reached.
+    fn poh_wait_target(poh: &Poh, target_ns_per_tick: u64, now: Instant) -> Option<Instant> {
+        let target = poh.target_poh_time(target_ns_per_tick);
+        (target > now).then_some(target)
+    }
+
     // returns true if we need to tick
     fn record_or_hash(
         next_record: &mut Option<Record>,
@@ -497,10 +504,31 @@ impl PohService {
                 lock_time.stop();
                 timing.total_lock_time_ns += lock_time.as_ns();
                 loop {
+                    // Records take priority over pacing. Processing them may move PoH ahead of
+                    // wall clock, so re-evaluate the current progress before every hash batch.
+                    if let Ok(record) = record_receiver.try_recv() {
+                        *next_record = Some(record);
+                        break;
+                    }
+
+                    let wait_start = Instant::now();
+                    if let Some(ideal_time) =
+                        Self::poh_wait_target(&poh_l, target_ns_per_tick, wait_start)
+                    {
+                        drop(poh_l);
+                        while ideal_time > Instant::now() {
+                            if let Ok(record) = record_receiver.try_recv() {
+                                *next_record = Some(record);
+                                break;
+                            }
+                        }
+                        timing.total_sleep_us += wait_start.elapsed().as_micros() as u64;
+                        break;
+                    }
+
                     timing.num_hashes += hashes_per_batch;
                     let mut hash_time = Measure::start("hash");
                     let should_tick = poh_l.hash(hashes_per_batch);
-                    let ideal_time = poh_l.target_poh_time(target_ns_per_tick);
                     hash_time.stop();
 
                     // shutdown if another batch would push us over the shutdown threshold.
@@ -518,31 +546,6 @@ impl PohService {
                         // nothing else can be done. tick required.
                         return true;
                     }
-                    // check to see if a record request has been sent
-                    if let Ok(record) = record_receiver.try_recv() {
-                        // remember the record we just received as the next record to occur
-                        *next_record = Some(record);
-                        break;
-                    }
-                    // check to see if we need to wait to catch up to ideal
-                    let wait_start = Instant::now();
-                    if ideal_time <= wait_start {
-                        // no, keep hashing. We still hold the lock.
-                        continue;
-                    }
-
-                    // busy wait, polling for new records and after dropping poh lock (reset can occur, for example)
-                    drop(poh_l);
-                    while ideal_time > Instant::now() {
-                        // check to see if a record request has been sent
-                        if let Ok(record) = record_receiver.try_recv() {
-                            // remember the record we just received as the next record to occur
-                            *next_record = Some(record);
-                            break;
-                        }
-                    }
-                    timing.total_sleep_us += wait_start.elapsed().as_micros() as u64;
-                    break;
                 }
             }
         };
@@ -725,6 +728,41 @@ mod tests {
         solana_transaction::versioned::VersionedTransaction,
         std::time::Duration,
     };
+
+    #[test]
+    fn test_poh_progress_pacing_after_records() {
+        let target_ns_per_tick = 80;
+        let mut poh = Poh::new(Hash::default(), Some(8));
+        let wall_clock = poh.target_poh_time(target_ns_per_tick);
+
+        // Records are accepted even though each one advances PoH ahead of this fixed wall clock.
+        for _ in 0..3 {
+            assert!(poh.record(Hash::new_unique()).is_some());
+            assert_eq!(
+                PohService::poh_wait_target(&poh, target_ns_per_tick, wall_clock),
+                Some(poh.target_poh_time(target_ns_per_tick)),
+            );
+        }
+
+        // Hashing resumes only once wall clock justifies the progress made by the records.
+        let recorded_progress_time = poh.target_poh_time(target_ns_per_tick);
+        assert_eq!(
+            PohService::poh_wait_target(&poh, target_ns_per_tick, recorded_progress_time),
+            None,
+        );
+
+        // After one bounded hash batch, the service re-evaluates the new progress target.
+        assert!(!poh.hash(1));
+        let hashed_progress_time = poh.target_poh_time(target_ns_per_tick);
+        assert_eq!(
+            PohService::poh_wait_target(&poh, target_ns_per_tick, recorded_progress_time),
+            Some(hashed_progress_time),
+        );
+        assert_eq!(
+            PohService::poh_wait_target(&poh, target_ns_per_tick, hashed_progress_time),
+            None,
+        );
+    }
 
     #[test]
     fn test_poh_service_record_race() {


### PR DESCRIPTION
#### Problem
- In a recent load test I noticed PoH was hashing faster than expected, and went at normal speed if no transactions were present.
- `Poh::target_poh_time` used `num_hashes` to estimate progress through the current tick
- Recording an entry resets `num_hashes` to preserve the correct `num_hashes` for the next entry
- mid-tick records therefore caused the pacing target to regress, allowing PoH to hash ahead if under load
- we unconditionally do a hash batch after receiving a record, regardless of the schedule. if we receive many records this puts us ahead of schedule

#### Summary of Changes
- Derive current tick progress from `hashes_per_tick - remaining_hashes_until_tick`
- Add a test verifying that pacing retains progress after a record
- update existing pacing test to advance poh through .hash() fn
	- otherwise the state is inconsistent since `remaining_hashes_until_tick` is not set 
- check if we should hash before hashing, not after

#### Testing


Fixes #
