### PR TITLE
geyser: add semver-safe bank_id notification methods

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -110,46 +110,6 @@ pub struct ReplicaAccountInfoV3<'a> {
     pub txn: Option<&'a SanitizedTransaction>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[repr(C)]
-/// Information about an account being updated
-/// (extended with reference to transaction doing this update and bank id)
-pub struct ReplicaAccountInfoV4<'a> {
-    /// The Pubkey for the account
-    pub pubkey: &'a [u8],
-
-    /// The lamports for the account
-    pub lamports: u64,
-
-    /// The Pubkey of the owner program account
-    pub owner: &'a [u8],
-
-    /// This account's data contains a loaded program (and is now read-only)
-    pub executable: bool,
-
-    /// The epoch at which this account will next owe rent
-    pub rent_epoch: u64,
-
-    /// The data held in this account.
-    pub data: &'a [u8],
-
-    /// A global monotonically increasing atomic number, which can be used
-    /// to tell the order of the account update. For example, when an
-    /// account is updated in the same slot multiple times, the update
-    /// with higher write_version should supersede the one with lower
-    /// write_version.
-    pub write_version: u64,
-
-    /// Reference to transaction causing this account modification
-    pub txn: Option<&'a SanitizedTransaction>,
-
-    /// The id of the bank that processed the account update.
-    ///
-    /// This is `None` for account updates restored from a snapshot because they
-    /// are not associated with a live bank.
-    pub bank_id: Option<BankId>,
-}
-
 /// A wrapper to future-proof ReplicaAccountInfo handling.
 /// If there were a change to the structure of ReplicaAccountInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -160,9 +120,7 @@ pub enum ReplicaAccountInfoVersions<'a> {
     V0_0_1(&'a ReplicaAccountInfo<'a>),
     #[deprecated]
     V0_0_2(&'a ReplicaAccountInfoV2<'a>),
-    #[deprecated]
     V0_0_3(&'a ReplicaAccountInfoV3<'a>),
-    V0_0_4(&'a ReplicaAccountInfoV4<'a>),
 }
 
 /// Information about a transaction
@@ -225,32 +183,6 @@ pub struct ReplicaTransactionInfoV3<'a> {
     pub index: usize,
 }
 
-/// Information about a transaction, including index in block and bank id
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct ReplicaTransactionInfoV4<'a> {
-    /// The transaction signature, used for identifying the transaction.
-    pub signature: &'a Signature,
-
-    /// The transaction message hash, used for identifying the transaction.
-    pub message_hash: &'a Hash,
-
-    /// Indicates if the transaction is a simple vote transaction.
-    pub is_vote: bool,
-
-    /// The versioned transaction.
-    pub transaction: &'a VersionedTransaction,
-
-    /// Metadata of the transaction status.
-    pub transaction_status_meta: &'a TransactionStatusMeta,
-
-    /// The transaction's index in the block
-    pub index: usize,
-
-    /// The id of the bank that processed the transaction.
-    pub bank_id: BankId,
-}
-
 /// A wrapper to future-proof ReplicaTransactionInfo handling.
 /// If there were a change to the structure of ReplicaTransactionInfo,
 /// there would be new enum entry for the newer version, forcing
@@ -261,9 +193,7 @@ pub enum ReplicaTransactionInfoVersions<'a> {
     V0_0_1(&'a ReplicaTransactionInfo<'a>),
     #[deprecated]
     V0_0_2(&'a ReplicaTransactionInfoV2<'a>),
-    #[deprecated]
     V0_0_3(&'a ReplicaTransactionInfoV3<'a>),
-    V0_0_4(&'a ReplicaTransactionInfoV4<'a>),
 }
 
 /// Information about a transaction after deshredding (when entries are formed from shreds).
@@ -361,26 +291,6 @@ pub struct ReplicaEntryInfoV2<'a> {
     pub starting_transaction_index: usize,
 }
 
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct ReplicaEntryInfoV3<'a> {
-    /// The slot number of the block containing this Entry
-    pub slot: Slot,
-    /// The id of the bank that executed this Entry.
-    pub bank_id: BankId,
-    /// The Entry's index in the block
-    pub index: usize,
-    /// The number of hashes since the previous Entry
-    pub num_hashes: u64,
-    /// The Entry's SHA-256 hash, generated from the previous Entry's hash with
-    /// `solana_entry::entry::next_hash()`
-    pub hash: &'a [u8],
-    /// The number of executed transactions in the Entry
-    pub executed_transaction_count: u64,
-    /// The index-in-block of the first executed transaction in this Entry
-    pub starting_transaction_index: usize,
-}
-
 /// A wrapper to future-proof ReplicaEntryInfo handling. To make a change to the structure of
 /// ReplicaEntryInfo, add an new enum variant wrapping a newer version, which will force plugin
 /// implementations to handle the change.
@@ -388,9 +298,7 @@ pub struct ReplicaEntryInfoV3<'a> {
 pub enum ReplicaEntryInfoVersions<'a> {
     #[deprecated]
     V0_0_1(&'a ReplicaEntryInfo<'a>),
-    #[deprecated]
     V0_0_2(&'a ReplicaEntryInfoV2<'a>),
-    V0_0_3(&'a ReplicaEntryInfoV3<'a>),
 }
 
 #[derive(Clone, Debug)]
@@ -447,22 +355,6 @@ pub struct ReplicaBlockInfoV4<'a> {
     pub entry_count: u64,
 }
 
-/// Extending ReplicaBlockInfoV4 by sending bank id.
-#[derive(Clone, Debug)]
-#[repr(C)]
-pub struct ReplicaBlockInfoV5<'a> {
-    pub parent_slot: Slot,
-    pub parent_blockhash: &'a str,
-    pub slot: Slot,
-    pub bank_id: BankId,
-    pub blockhash: &'a str,
-    pub rewards: &'a RewardsAndNumPartitions,
-    pub block_time: Option<UnixTimestamp>,
-    pub block_height: Option<u64>,
-    pub executed_transaction_count: u64,
-    pub entry_count: u64,
-}
-
 #[repr(u32)]
 pub enum ReplicaBlockInfoVersions<'a> {
     #[deprecated]
@@ -471,9 +363,7 @@ pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
     #[deprecated]
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
-    #[deprecated]
     V0_0_4(&'a ReplicaBlockInfoV4<'a>),
-    V0_0_5(&'a ReplicaBlockInfoV5<'a>),
 }
 
 /// A snapshot of a validator's gossip contact info at a point in time.
@@ -702,6 +592,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// When `is_startup` is true, it indicates the account is loaded from
     /// snapshots when the validator starts up. When `is_startup` is false,
     /// the account is updated during transaction processing.
+    #[deprecated]
     #[allow(unused_variables)]
     fn update_account(
         &self,
@@ -710,6 +601,26 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         is_startup: bool,
     ) -> Result<()> {
         Ok(())
+    }
+
+    /// Called when an account is updated at a slot.
+    /// When `is_startup` is true, it indicates the account is loaded from
+    /// snapshots when the validator starts up. When `is_startup` is false,
+    /// the account is updated during transaction processing.
+    ///
+    /// `bank_id` identifies the concrete bank instance associated with the
+    /// account update, when available. This out-of-band argument is temporary;
+    /// a future major release will carry it in a new account info enum variant.
+    #[allow(deprecated)]
+    #[allow(unused_variables)]
+    fn update_account_v4(
+        &self,
+        account: ReplicaAccountInfoVersions,
+        slot: Slot,
+        is_startup: bool,
+        bank_id: Option<BankId>,
+    ) -> Result<()> {
+        self.update_account(account, slot, is_startup)
     }
 
     /// Called when all accounts are notified of during startup.
@@ -752,6 +663,7 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     }
 
     /// Called when a transaction is processed in a slot.
+    #[deprecated]
     #[allow(unused_variables)]
     fn notify_transaction(
         &self,
@@ -761,16 +673,64 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// Called when a transaction is processed in a slot.
+    ///
+    /// `bank_id` identifies the concrete bank instance that processed the
+    /// transaction, when available. This out-of-band argument is temporary; a
+    /// future major release will carry it in a new transaction info enum variant.
+    #[allow(deprecated)]
+    #[allow(unused_variables)]
+    fn notify_transaction_v4(
+        &self,
+        transaction: ReplicaTransactionInfoVersions,
+        slot: Slot,
+        bank_id: Option<BankId>,
+    ) -> Result<()> {
+        self.notify_transaction(transaction, slot)
+    }
+
     /// Called when an entry is executed.
+    #[deprecated]
     #[allow(unused_variables)]
     fn notify_entry(&self, entry: ReplicaEntryInfoVersions) -> Result<()> {
         Ok(())
     }
 
+    /// Called when an entry is executed.
+    ///
+    /// `bank_id` identifies the concrete bank instance that executed the entry,
+    /// when available. This out-of-band argument is temporary; a future major
+    /// release will carry it in a new entry info enum variant.
+    #[allow(deprecated)]
+    #[allow(unused_variables)]
+    fn notify_entry_v3(
+        &self,
+        entry: ReplicaEntryInfoVersions,
+        bank_id: Option<BankId>,
+    ) -> Result<()> {
+        self.notify_entry(entry)
+    }
+
     /// Called when block's metadata is updated.
+    #[deprecated]
     #[allow(unused_variables)]
     fn notify_block_metadata(&self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
         Ok(())
+    }
+
+    /// Called when block's metadata is updated.
+    ///
+    /// `bank_id` identifies the concrete bank instance associated with the block
+    /// metadata, when available. This out-of-band argument is temporary; a future
+    /// major release will carry it in a new block info enum variant.
+    #[allow(deprecated)]
+    #[allow(unused_variables)]
+    fn notify_block_metadata_v5(
+        &self,
+        blockinfo: ReplicaBlockInfoVersions,
+        bank_id: Option<BankId>,
+    ) -> Result<()> {
+        self.notify_block_metadata(blockinfo)
     }
 
     /// Called when a validator's gossip contact info is learned or updated.

--- a/geyser-plugin-manager/src/accounts_update_notifier.rs
+++ b/geyser-plugin-manager/src/accounts_update_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaAccountInfoV4, ReplicaAccountInfoVersions,
+        ReplicaAccountInfoV3, ReplicaAccountInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -35,14 +35,9 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
         pubkey: &Pubkey,
         write_version: u64,
     ) {
-        let account_info = self.accountinfo_from_shared_account_data(
-            Some(bank_id),
-            account,
-            txn,
-            pubkey,
-            write_version,
-        );
-        self.notify_plugins_of_account_update(account_info, slot, false);
+        let account_info =
+            self.accountinfo_from_shared_account_data(account, txn, pubkey, write_version);
+        self.notify_plugins_of_account_update(account_info, slot, false, Some(bank_id));
     }
 
     fn notify_account_restore_from_snapshot(
@@ -53,7 +48,7 @@ impl AccountsUpdateNotifierInterface for AccountsUpdateNotifierImpl {
     ) {
         let mut account = self.accountinfo_from_account_for_geyser(account);
         account.write_version = write_version;
-        self.notify_plugins_of_account_update(account, slot, true);
+        self.notify_plugins_of_account_update(account, slot, true, None);
     }
 
     fn notify_end_of_restore_from_snapshot(&self) {
@@ -95,13 +90,12 @@ impl AccountsUpdateNotifierImpl {
 
     fn accountinfo_from_shared_account_data<'a>(
         &self,
-        bank_id: Option<BankId>,
         account: &'a AccountSharedData,
         txn: &'a Option<&'a SanitizedTransaction>,
         pubkey: &'a Pubkey,
         write_version: u64,
-    ) -> ReplicaAccountInfoV4<'a> {
-        ReplicaAccountInfoV4 {
+    ) -> ReplicaAccountInfoV3<'a> {
+        ReplicaAccountInfoV3 {
             pubkey: pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -110,15 +104,14 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version,
             txn: *txn,
-            bank_id,
         }
     }
 
     fn accountinfo_from_account_for_geyser<'a>(
         &self,
         account: &'a AccountForGeyser<'_>,
-    ) -> ReplicaAccountInfoV4<'a> {
-        ReplicaAccountInfoV4 {
+    ) -> ReplicaAccountInfoV3<'a> {
+        ReplicaAccountInfoV3 {
             pubkey: account.pubkey.as_ref(),
             lamports: account.lamports(),
             owner: account.owner().as_ref(),
@@ -127,15 +120,15 @@ impl AccountsUpdateNotifierImpl {
             data: account.data(),
             write_version: 0, // can/will be populated afterwards
             txn: None,
-            bank_id: None,
         }
     }
 
     fn notify_plugins_of_account_update(
         &self,
-        account: ReplicaAccountInfoV4,
+        account: ReplicaAccountInfoV3,
         slot: Slot,
         is_startup: bool,
+        bank_id: Option<BankId>,
     ) {
         let plugin_manager = self.plugin_manager.load();
 
@@ -146,10 +139,11 @@ impl AccountsUpdateNotifierImpl {
             if !plugin.account_data_notifications_enabled() {
                 continue;
             }
-            match plugin.update_account(
-                ReplicaAccountInfoVersions::V0_0_4(&account),
+            match plugin.update_account_v4(
+                ReplicaAccountInfoVersions::V0_0_3(&account),
                 slot,
                 is_startup,
+                bank_id,
             ) {
                 Err(err) => {
                     error!(
@@ -203,19 +197,17 @@ mod tests {
             self.name
         }
 
-        fn update_account(
+        fn update_account_v4(
             &self,
             account: ReplicaAccountInfoVersions,
             _slot: Slot,
             _is_startup: bool,
+            bank_id: Option<BankId>,
         ) -> agave_geyser_plugin_interface::geyser_plugin_interface::Result<()> {
-            let ReplicaAccountInfoVersions::V0_0_4(account) = account else {
-                panic!("expected V0_0_4 account info");
+            let ReplicaAccountInfoVersions::V0_0_3(_account) = account else {
+                panic!("expected V0_0_3 account info");
             };
-            self.account_update_bank_ids
-                .lock()
-                .unwrap()
-                .push(account.bank_id);
+            self.account_update_bank_ids.lock().unwrap().push(bank_id);
             self.account_update_count.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,7 +4,7 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV5, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -44,7 +44,6 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
             parent_slot,
             parent_blockhash,
             slot,
-            bank_id,
             blockhash,
             &rewards,
             block_time,
@@ -54,8 +53,8 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
         );
 
         for plugin in plugin_manager.plugins.iter() {
-            let block_info = ReplicaBlockInfoVersions::V0_0_5(&block_info);
-            match plugin.notify_block_metadata(block_info) {
+            let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
+            match plugin.notify_block_metadata_v5(block_info, Some(bank_id)) {
                 Err(err) => {
                     error!(
                         "Failed to update block metadata at slot {}, error: {} to plugin {}",
@@ -111,19 +110,17 @@ impl BlockMetadataNotifierImpl {
         parent_slot: u64,
         parent_blockhash: &'a str,
         slot: u64,
-        bank_id: BankId,
         blockhash: &'a str,
         rewards: &'a RewardsAndNumPartitions,
         block_time: Option<UnixTimestamp>,
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-    ) -> ReplicaBlockInfoV5<'a> {
-        ReplicaBlockInfoV5 {
+    ) -> ReplicaBlockInfoV4<'a> {
+        ReplicaBlockInfoV4 {
             parent_slot,
             parent_blockhash,
             slot,
-            bank_id,
             blockhash,
             rewards,
             block_time,
@@ -149,7 +146,7 @@ mod tests {
         std::sync::{Arc, Mutex},
     };
 
-    type BlockMetadataUpdate = (u64, BankId, u64, u64);
+    type BlockMetadataUpdate = (u64, Option<BankId>, u64, u64);
 
     #[derive(Debug)]
     struct TestBlockMetadataPlugin {
@@ -161,13 +158,17 @@ mod tests {
             "test-block-metadata-plugin"
         }
 
-        fn notify_block_metadata(&self, blockinfo: ReplicaBlockInfoVersions) -> Result<()> {
-            let ReplicaBlockInfoVersions::V0_0_5(blockinfo) = blockinfo else {
-                panic!("expected V0_0_5 block info");
+        fn notify_block_metadata_v5(
+            &self,
+            blockinfo: ReplicaBlockInfoVersions,
+            bank_id: Option<BankId>,
+        ) -> Result<()> {
+            let ReplicaBlockInfoVersions::V0_0_4(blockinfo) = blockinfo else {
+                panic!("expected V0_0_4 block info");
             };
             self.updates.lock().unwrap().push((
                 blockinfo.slot,
-                blockinfo.bank_id,
+                bank_id,
                 blockinfo.executed_transaction_count,
                 blockinfo.entry_count,
             ));
@@ -216,6 +217,6 @@ mod tests {
             false,
         );
 
-        assert_eq!(*updates.lock().unwrap(), vec![(42, 9, 7, 3)]);
+        assert_eq!(*updates.lock().unwrap(), vec![(42, Some(9), 7, 3)]);
     }
 }

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaEntryInfoV3, ReplicaEntryInfoVersions,
+        ReplicaEntryInfoV2, ReplicaEntryInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -31,13 +31,15 @@ impl EntryNotifier for EntryNotifierImpl {
         }
 
         let entry_info =
-            Self::build_replica_entry_info(slot, bank_id, index, entry, starting_transaction_index);
+            Self::build_replica_entry_info(slot, index, entry, starting_transaction_index);
 
         for plugin in plugin_manager.plugins.iter() {
             if !plugin.entry_notifications_enabled() {
                 continue;
             }
-            match plugin.notify_entry(ReplicaEntryInfoVersions::V0_0_3(&entry_info)) {
+            match plugin
+                .notify_entry_v3(ReplicaEntryInfoVersions::V0_0_2(&entry_info), Some(bank_id))
+            {
                 Err(err) => {
                     error!(
                         "Failed to notify entry, error: ({}) to plugin {}",
@@ -60,14 +62,12 @@ impl EntryNotifierImpl {
 
     fn build_replica_entry_info(
         slot: Slot,
-        bank_id: BankId,
         index: usize,
         entry: &'_ EntrySummary,
         starting_transaction_index: usize,
-    ) -> ReplicaEntryInfoV3<'_> {
-        ReplicaEntryInfoV3 {
+    ) -> ReplicaEntryInfoV2<'_> {
+        ReplicaEntryInfoV2 {
             slot,
-            bank_id,
             index,
             num_hashes: entry.num_hashes,
             hash: entry.hash.as_ref(),
@@ -89,7 +89,7 @@ mod tests {
         std::sync::{Arc, Mutex},
     };
 
-    type EntryUpdate = (Slot, BankId, usize, usize);
+    type EntryUpdate = (Slot, Option<BankId>, usize, usize);
 
     #[derive(Debug)]
     struct TestEntryPlugin {
@@ -102,13 +102,17 @@ mod tests {
             "test-entry-plugin"
         }
 
-        fn notify_entry(&self, entry: ReplicaEntryInfoVersions) -> Result<()> {
-            let ReplicaEntryInfoVersions::V0_0_3(entry) = entry else {
-                panic!("expected V0_0_3 entry info");
+        fn notify_entry_v3(
+            &self,
+            entry: ReplicaEntryInfoVersions,
+            bank_id: Option<BankId>,
+        ) -> Result<()> {
+            let ReplicaEntryInfoVersions::V0_0_2(entry) = entry else {
+                panic!("expected V0_0_2 entry info");
             };
             self.updates.lock().unwrap().push((
                 entry.slot,
-                entry.bank_id,
+                bank_id,
                 entry.index,
                 entry.starting_transaction_index,
             ));
@@ -158,7 +162,7 @@ mod tests {
 
         notifier.notify_entry(42, 9, 3, &entry, 7);
 
-        assert_eq!(*enabled_updates.lock().unwrap(), vec![(42, 9, 3, 7)]);
+        assert_eq!(*enabled_updates.lock().unwrap(), vec![(42, Some(9), 3, 7)]);
         assert!(disabled_updates.lock().unwrap().is_empty());
     }
 }

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,7 +2,7 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV4, ReplicaTransactionInfoVersions,
+        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
@@ -36,7 +36,6 @@ impl TransactionNotifier for TransactionNotifierImpl {
         transaction: &VersionedTransaction,
     ) {
         let transaction_log_info = Self::build_replica_transaction_info(
-            bank_id,
             index,
             signature,
             message_hash,
@@ -55,9 +54,10 @@ impl TransactionNotifier for TransactionNotifierImpl {
             if !plugin.transaction_notifications_enabled() {
                 continue;
             }
-            match plugin.notify_transaction(
-                ReplicaTransactionInfoVersions::V0_0_4(&transaction_log_info),
+            match plugin.notify_transaction_v4(
+                ReplicaTransactionInfoVersions::V0_0_3(&transaction_log_info),
                 slot,
+                Some(bank_id),
             ) {
                 Err(err) => {
                     error!(
@@ -83,16 +83,14 @@ impl TransactionNotifierImpl {
     }
 
     fn build_replica_transaction_info<'a>(
-        bank_id: BankId,
         index: usize,
         signature: &'a Signature,
         message_hash: &'a Hash,
         is_vote: bool,
         transaction_status_meta: &'a TransactionStatusMeta,
         transaction: &'a VersionedTransaction,
-    ) -> ReplicaTransactionInfoV4<'a> {
-        ReplicaTransactionInfoV4 {
-            bank_id,
+    ) -> ReplicaTransactionInfoV3<'a> {
+        ReplicaTransactionInfoV3 {
             index,
             message_hash,
             signature,


### PR DESCRIPTION
#### Problem
#13545 accidentally included breaking changes in the geyser plugin interface before a major release.

See #13545 and #13702 for discussion.

#### Summary of Changes
Reverted #13545 and added new APIs for geyser plugin interface to pass along `bank_id`:
- `update_account_v4`
- `notify_transaction_v4`
- `notify_entry_v3`
- `notify_block_metadata_v5`

This is in line with #13545 which introduced `update_slot_status_v2` for the same reason.

The default implementations call the original APIs, which are now marked as deprecated. Upon major agave release, the original APIs will be restored and bank_id will be included in their respective enum info types.

#### Testing
Updated each respective `TestXXXPlugin` to use new APIs.