### PR TITLE
feat(snapshot): add wincode schemas for bank snapshot read-path types

### DIFF
--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -17,10 +17,11 @@ use {
     std::{
         collections::HashMap,
         fmt,
+        mem::MaybeUninit,
         num::NonZero,
         sync::{Arc, OnceLock},
     },
-    wincode::{SchemaRead, SchemaWrite, WriteResult},
+    wincode::{ReadResult, SchemaRead, SchemaWrite, WriteResult, config::Config, io::Reader},
 };
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
@@ -202,9 +203,9 @@ pub struct NodeVoteAccounts {
 /// deserialization by ignoring serialized stake delegations entirely.
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(Serialize, AbiEnumVisitor, StableAbi, StableAbiSample)
+    derive(Serialize, SchemaWrite, AbiEnumVisitor, StableAbi, StableAbiSample)
 )]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, SchemaRead)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) enum DeserializableVersionedEpochStakes {
     Current {
@@ -499,18 +500,49 @@ impl From<SerdeStakesToStakeFormat> for EpochStakes {
 ///
 /// Needed because snapshots contain additional fields no longer present in EpochStakes.
 // Sampling is overridden at the parent (`DeserializableVersionedEpochStakes::Current.stakes`), so
-// only `Serialize` is needed here.
-#[cfg_attr(feature = "frozen-abi", derive(Serialize))]
-#[derive(Clone, Debug, Deserialize)]
+// no StableAbi/StableAbiSample is needed here.
+#[cfg_attr(feature = "frozen-abi", derive(Serialize, SchemaWrite))]
+#[derive(Clone, Debug, Deserialize, SchemaRead)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct DeserializableEpochStakes {
     vote_accounts: VoteAccounts,
     // Read-and-discarded (always empty); the serialize side writes it empty too.
     #[serde(deserialize_with = "deserialize_and_ignore_stake_delegations")]
+    #[wincode(with = "IgnoredStakeDelegations")]
     _stake_delegations: Vec<(Pubkey, Stake)>,
     _unused: u64,
     epoch: Epoch,
     stake_history: StakeHistory,
+}
+
+/// wincode `with` schema for the ignored stake delegations: reads and discards the wire's
+/// length-prefixed `Vec<(Pubkey, Stake)>`, yielding an empty `Vec`; writes it back through `Vec`
+/// (always empty, matching the serialize side).
+struct IgnoredStakeDelegations;
+
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for IgnoredStakeDelegations {
+    type Dst = Vec<(Pubkey, Stake)>;
+
+    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        <Vec<(Pubkey, Stake)> as SchemaRead<'de, C>>::get(reader)?;
+        dst.write(Vec::new());
+        Ok(())
+    }
+}
+
+#[cfg(feature = "frozen-abi")]
+unsafe impl<C: Config> SchemaWrite<C> for IgnoredStakeDelegations {
+    type Src = Vec<(Pubkey, Stake)>;
+
+    const TYPE_META: wincode::TypeMeta = <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::TYPE_META;
+
+    fn size_of(src: &Self::Src) -> WriteResult<usize> {
+        <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::size_of(src)
+    }
+
+    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
+        <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::write(writer, src)
+    }
 }
 
 impl From<DeserializableEpochStakes> for EpochStakes {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -85,10 +85,65 @@ pub(crate) use {
 const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;
 type MaxStreamSizeConfig = wincode::config::Configuration<true, MAX_STREAM_SIZE>;
 
+/// wincode read helpers mirroring serde's `default_on_eof` for the snapshot read-path structs.
+mod wincode_compat {
+    use {
+        std::{marker::PhantomData, mem::MaybeUninit},
+        wincode::{
+            ReadError, ReadResult, SchemaRead, SchemaWrite, WriteResult,
+            config::Config,
+            io::{ReadError as IoReadError, Reader, Writer},
+        },
+    };
+
+    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the reader is
+    /// exhausted (EOF), for backward compatibility when new fields are appended to a struct.
+    /// Equivalent to `#[serde(deserialize_with = "default_on_eof")]`.
+    pub(super) struct DefaultOnEmptyRead<T>(PhantomData<T>);
+
+    // Note: TYPE_META is left dynamic, since during reading both 0-size or non-0-size reads are
+    // allowed, so trusted readers can't rely on encoding to be static sized.
+    unsafe impl<'de, C: Config, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaRead<'de, C>,
+        T::Dst: Default,
+    {
+        type Dst = T::Dst;
+
+        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
+            match <T as SchemaRead<'de, C>>::read(reader, dst) {
+                Ok(()) => Ok(()),
+                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
+                    dst.write(Self::Dst::default());
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    unsafe impl<C: Config, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
+    where
+        T: SchemaWrite<C>,
+    {
+        type Src = T::Src;
+
+        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
+
+        fn size_of(src: &Self::Src) -> WriteResult<usize> {
+            <T as SchemaWrite<C>>::size_of(src)
+        }
+
+        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
+            <T as SchemaWrite<C>>::write(writer, src)
+        }
+    }
+}
+
 /// A slot paired with its account storage entries, used as the `slot -> [entry]` map item on both
 /// the read path ([`AccountsDbFields`]) and the write ABI type [`SerializableAccountsDbForAbi`].
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Serialize, Deserialize, SchemaWrite)]
+#[derive(Debug, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 pub(crate) struct SlotAccountStorageEntries {
     slot: Slot,
     /// In a real snapshot this always holds exactly one entry; it is sampled as an arbitrary
@@ -104,9 +159,9 @@ pub(crate) struct SlotAccountStorageEntries {
 
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, Serialize, StableAbi, StableAbiSample)
+    derive(AbiExample, Serialize, SchemaWrite, StableAbi, StableAbiSample)
 )]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, SchemaRead)]
 pub(crate) struct AccountsDbFields(
     Vec<SlotAccountStorageEntries>,
     u64, // unused, formerly write_version
@@ -114,9 +169,11 @@ pub(crate) struct AccountsDbFields(
     BankHashInfo,
     /// all slots that were roots within the last epoch
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Vec<Slot>>")]
     Vec<Slot>,
     /// slots that were roots within the last epoch for which we care about the hash value
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Vec<(Slot, Hash)>>")]
     Vec<(Slot, Hash)>,
 );
 
@@ -158,9 +215,13 @@ struct UnusedAccounts {
 }
 
 // Deserializable version of Bank; keep fields synced with SerializableVersionedBank.
-// frozen-abi Serialize exists only to pin the read-path abi digest (see DeserializableBankSnapshot).
-#[cfg_attr(feature = "frozen-abi", derive(Serialize, StableAbi, StableAbiSample))]
-#[derive(Clone, Deserialize)]
+// frozen-abi Serialize/SchemaWrite exist only to pin the read-path abi digest (see
+// DeserializableBankSnapshot).
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(Serialize, SchemaWrite, StableAbi, StableAbiSample)
+)]
+#[derive(Clone, Deserialize, SchemaRead)]
 struct DeserializableVersionedBank {
     blockhash_queue: BlockhashQueue,
     _unused_ancestors: HashMap<Slot, usize>,
@@ -434,17 +495,25 @@ where
 /// struct.
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(AbiExample, Serialize, StableAbi, StableAbiSample)
+    derive(AbiExample, Serialize, SchemaWrite, StableAbi, StableAbiSample)
 )]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, SchemaRead)]
 struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u64>")]
     lamports_per_signature: u64,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(
+        with = "wincode_compat::DefaultOnEmptyRead<Option<UnusedIncrementalSnapshotPersistence>>"
+    )]
     _unused_incremental_snapshot_persistence: Option<UnusedIncrementalSnapshotPersistence>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Hash>>")]
     _unused_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(
+        with = "wincode_compat::DefaultOnEmptyRead<Vec<(u64, DeserializableVersionedEpochStakes)>>"
+    )]
     // Match the serialize side's `HashMap<u64, VersionedEpochStakes>`, which samples `0..=1` entries.
     #[cfg_attr(
         feature = "frozen-abi",
@@ -453,8 +522,10 @@ struct ExtraFieldsToDeserialize {
     )]
     versioned_epoch_stakes: Vec<(u64, DeserializableVersionedEpochStakes)>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<SerdeAccountsLtHash>>")]
     accounts_lt_hash: Option<SerdeAccountsLtHash>,
     #[serde(deserialize_with = "default_on_eof")]
+    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Hash>>")]
     block_id: Option<Hash>,
 }
 
@@ -493,14 +564,14 @@ pub struct ExtraFieldsToSerialize {
 /// wire formats can't diverge.
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(Serialize, StableAbi, StableAbiSample),
+    derive(Serialize, SchemaWrite, StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
-        abi_serializer = "bincode",
+        abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "wire_only"
     )
 )]
-#[derive(Deserialize)]
+#[derive(Deserialize, SchemaRead)]
 struct DeserializableBankSnapshot {
     bank: DeserializableVersionedBank,
     accounts_db: AccountsDbFields,

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
+#[cfg(feature = "frozen-abi")]
+use wincode::SchemaWrite;
 use {
     super::{StakeAccount, Stakes},
     crate::stake_history::StakeHistory,
@@ -10,6 +12,7 @@ use {
     solana_stake_interface::state::{Delegation, Stake},
     solana_vote::vote_account::VoteAccounts,
     std::{collections::HashMap, sync::Arc},
+    wincode::SchemaRead,
 };
 
 /// Wrapper struct with custom serialization to support serializing
@@ -184,8 +187,11 @@ impl Serialize for SerdeStakeAccountMapToStakeFormat {
 /// Its bincode serializaiton format is identical as Stakes<T>, but allows faster
 /// deserialization without creating imbl::HashMap (such conversion is deferred until
 /// data is actually needed).
-#[cfg_attr(feature = "frozen-abi", derive(Serialize, StableAbi, StableAbiSample))]
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(Serialize, SchemaWrite, StableAbi, StableAbiSample)
+)]
+#[derive(Clone, Debug, Deserialize, SchemaRead)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 pub(crate) struct DeserializableDelegationStakes {
     pub vote_accounts: VoteAccounts,

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -23,7 +23,9 @@ use {
         sync::{Arc, OnceLock},
     },
     thiserror::Error,
-    wincode::{TypeMeta, WriteResult},
+    wincode::{
+        ReadError, ReadResult, SchemaRead, TypeMeta, WriteResult, config::Config, io::Reader,
+    },
 };
 #[cfg(any(feature = "dev-context-only-utils", feature = "frozen-abi"))]
 use {
@@ -57,7 +59,7 @@ struct VoteAccountInner {
 
 pub type VoteAccountsHashMap = HashMap<Pubkey, (/*stake:*/ u64, VoteAccount)>;
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
-#[derive(Debug, Serialize, Deserialize, SchemaWrite)]
+#[derive(Debug, Serialize, Deserialize, SchemaRead, SchemaWrite)]
 #[cfg_attr(
     feature = "dev-context-only-utils",
     field_qualifiers(vote_accounts(pub))
@@ -460,6 +462,21 @@ impl<'de> Deserialize<'de> for VoteAccount {
     {
         let account = AccountSharedData::deserialize(deserializer)?;
         VoteAccount::try_from(account).map_err(serde::de::Error::custom)
+    }
+}
+
+// Read-counterpart of the custom `SchemaWrite` above: read the inner `AccountSharedData` (the only
+// thing written) and rebuild the parsed `vote_state_view` via `try_from`, mirroring the `Deserialize`
+// impl. `VoteAccounts` then derives `SchemaRead` on top of this, just like the serde path.
+unsafe impl<'de, C: Config> SchemaRead<'de, C> for VoteAccount {
+    type Dst = Self;
+
+    fn read(reader: impl Reader<'de>, dst: &mut mem::MaybeUninit<Self::Dst>) -> ReadResult<()> {
+        let account = <AccountSharedData as SchemaRead<'de, C>>::get(reader)?;
+        let vote_account = VoteAccount::try_from(account)
+            .map_err(|_| ReadError::InvalidValue("invalid vote account"))?;
+        dst.write(vote_account);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
#### Problem
wincode will provide faster deserialization.

#### Summary of Changes
Add wincode `SchemaRead`/`SchemaWrite` impls to the bank snapshot read-path types via derives, plus:
  - a `DefaultOnEmptyRead<T>` helper mirroring serde's default_on_eof,
  - a `VoteAccount` `SchemaRead`/`SchemaWrite` pair
  - an `IgnoredStakeDelegations` schema that reads-and-discards the delegations.

Pin `DeserializableBankSnapshot`'s frozen-abi digest against both bincode and wincode (still asserting it equals `SerializableBankSnapshotForAbi`'s) so the wincode wire format is verified to match bincode. Stakes / epoch-stakes `StableAbi` sampling is overridden to reproduce the serialize side's exact draw sequence.

The read path still deserializes with bincode; switching it to wincode is a separate commit.

#### Testing
frozen-abi tests

Fixes #