### PR TITLE
Add external error code for partial batch cancelled by consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Release channels have their own copy of this changelog:
 * Validators running without `--full-rpc-api` and with snapshot generation disabled no longer
   store transaction signature keys in the status cache. Message hashes remain cached for duplicate
   transaction detection.
+* External scheduler execution responses now report `PARTIAL_BATCH_CANCELLED` for
+  `CommitCancelled` errors in non-all-or-nothing batches. All-or-nothing batches continue to use
+  `ALL_OR_NOTHING_BATCH_FAILURE`.
 ### SDK
 #### Breaking
 * solana-program-test: syscall getters (e.g. `Rent::get()`, `Clock::get()`) and `solana_sysvar::get_sysvar()` now return

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -121,7 +121,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
             bank,
             &work.transactions,
             &work.max_ages,
-            ExecutionFlags {
+            &ExecutionFlags {
                 drop_on_failure: false,
                 all_or_nothing: false,
             },
@@ -425,13 +425,11 @@ pub(crate) mod external {
 
                 return Ok(false);
             }
-            let all_or_nothing = execution_flags.all_or_nothing;
-
             let output = self.consumer.process_and_record_aged_transactions(
                 bank,
                 &transactions,
                 &max_ages,
-                execution_flags,
+                &execution_flags,
             );
 
             self.metrics.update_for_consume(&output);
@@ -459,7 +457,7 @@ pub(crate) mod external {
                     &transactions,
                     &commit_results,
                     bank,
-                    all_or_nothing,
+                    &execution_flags,
                 ),
             )?;
 
@@ -600,7 +598,7 @@ pub(crate) mod external {
             transactions: &'a [impl TransactionWithMeta],
             commit_results: &'a [CommitTransactionDetails],
             bank: &'a Bank,
-            all_or_nothing: bool,
+            execution_flags: &'a ExecutionFlags,
         ) -> impl ExactSizeIterator<Item = ExecutionResponse> + 'a {
             assert_eq!(transactions.len(), commit_results.len());
             let mut transactions_iterator = transactions.iter();
@@ -617,7 +615,12 @@ pub(crate) mod external {
                         let commit_details = commit_result_iterator.next().expect(
                             "commit result iterator must contain element for each sent transaction",
                         );
-                        Self::response_from_commit_details(tx, commit_details, bank, all_or_nothing)
+                        Self::response_from_commit_details(
+                            tx,
+                            commit_details,
+                            bank,
+                            execution_flags,
+                        )
                     }
                     Err(err) => ExecutionResponse {
                         execution_slot: bank.slot(),
@@ -1066,7 +1069,7 @@ pub(crate) mod external {
             tx: &impl TransactionWithMeta,
             commit_details: &CommitTransactionDetails,
             bank: &Bank,
-            all_or_nothing: bool,
+            execution_flags: &ExecutionFlags,
         ) -> ExecutionResponse {
             match commit_details {
                 CommitTransactionDetails::Committed {
@@ -1090,7 +1093,7 @@ pub(crate) mod external {
                     execution_slot: bank.slot(),
                     not_included_reason: transaction_error_to_not_included_reason(
                         transaction_error,
-                        all_or_nothing,
+                        execution_flags.all_or_nothing,
                     ),
                     cost_units: 0,
                     fee_payer_balance: 0,
@@ -1459,6 +1462,7 @@ pub(crate) mod external {
                     .0
                 })
                 .collect::<Vec<_>>();
+            let execution_flags = ExecutionFlags::default();
 
             let responses = ExternalWorker::consume_response_iterator(
                 &[
@@ -1489,7 +1493,7 @@ pub(crate) mod external {
                     ),
                 ],
                 &bank,
-                false,
+                &execution_flags,
             )
             .collect::<Vec<_>>();
 
@@ -1545,15 +1549,33 @@ pub(crate) mod external {
             .0;
             let commit_details =
                 CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled);
+            let all_or_nothing_flags = ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: true,
+            };
+            let partial_batch_flags = ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+            };
 
             assert_eq!(
-                ExternalWorker::response_from_commit_details(&tx, &commit_details, &bank, true)
-                    .not_included_reason,
+                ExternalWorker::response_from_commit_details(
+                    &tx,
+                    &commit_details,
+                    &bank,
+                    &all_or_nothing_flags,
+                )
+                .not_included_reason,
                 not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE
             );
             assert_eq!(
-                ExternalWorker::response_from_commit_details(&tx, &commit_details, &bank, false)
-                    .not_included_reason,
+                ExternalWorker::response_from_commit_details(
+                    &tx,
+                    &commit_details,
+                    &bank,
+                    &partial_batch_flags,
+                )
+                .not_included_reason,
                 not_included_reasons::PARTIAL_BATCH_CANCELLED
             );
         }

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -425,6 +425,7 @@ pub(crate) mod external {
 
                 return Ok(false);
             }
+            let all_or_nothing = execution_flags.all_or_nothing;
 
             let output = self.consumer.process_and_record_aged_transactions(
                 bank,
@@ -458,6 +459,7 @@ pub(crate) mod external {
                     &transactions,
                     &commit_results,
                     bank,
+                    all_or_nothing,
                 ),
             )?;
 
@@ -598,6 +600,7 @@ pub(crate) mod external {
             transactions: &'a [impl TransactionWithMeta],
             commit_results: &'a [CommitTransactionDetails],
             bank: &'a Bank,
+            all_or_nothing: bool,
         ) -> impl ExactSizeIterator<Item = ExecutionResponse> + 'a {
             assert_eq!(transactions.len(), commit_results.len());
             let mut transactions_iterator = transactions.iter();
@@ -614,7 +617,7 @@ pub(crate) mod external {
                         let commit_details = commit_result_iterator.next().expect(
                             "commit result iterator must contain element for each sent transaction",
                         );
-                        Self::response_from_commit_details(tx, commit_details, bank)
+                        Self::response_from_commit_details(tx, commit_details, bank, all_or_nothing)
                     }
                     Err(err) => ExecutionResponse {
                         execution_slot: bank.slot(),
@@ -1063,6 +1066,7 @@ pub(crate) mod external {
             tx: &impl TransactionWithMeta,
             commit_details: &CommitTransactionDetails,
             bank: &Bank,
+            all_or_nothing: bool,
         ) -> ExecutionResponse {
             match commit_details {
                 CommitTransactionDetails::Committed {
@@ -1086,6 +1090,7 @@ pub(crate) mod external {
                     execution_slot: bank.slot(),
                     not_included_reason: transaction_error_to_not_included_reason(
                         transaction_error,
+                        all_or_nothing,
                     ),
                     cost_units: 0,
                     fee_payer_balance: 0,
@@ -1484,6 +1489,7 @@ pub(crate) mod external {
                     ),
                 ],
                 &bank,
+                false,
             )
             .collect::<Vec<_>>();
 
@@ -1516,6 +1522,40 @@ pub(crate) mod external {
                     }
                 ]
             )
+        }
+
+        #[test]
+        fn test_commit_cancelled_response_reason_uses_batch_mode() {
+            let simple_tx = wincode::serialize(&transfer(
+                &solana_keypair::Keypair::new(),
+                &solana_pubkey::Pubkey::new_unique(),
+                1,
+                solana_hash::Hash::default(),
+            ))
+            .unwrap();
+            let bank = Bank::default_for_tests();
+            let tx = translate_to_runtime_view(
+                &simple_tx[..],
+                &bank,
+                bank.get_transaction_account_lock_limit(),
+                &sanitize_config(),
+            )
+            .ok()
+            .unwrap()
+            .0;
+            let commit_details =
+                CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled);
+
+            assert_eq!(
+                ExternalWorker::response_from_commit_details(&tx, &commit_details, &bank, true)
+                    .not_included_reason,
+                not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE
+            );
+            assert_eq!(
+                ExternalWorker::response_from_commit_details(&tx, &commit_details, &bank, false)
+                    .not_included_reason,
+                not_included_reasons::PARTIAL_BATCH_CANCELLED
+            );
         }
 
         #[test]

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1528,8 +1528,20 @@ pub(crate) mod external {
             )
         }
 
-        #[test]
-        fn test_commit_cancelled_response_reason_uses_batch_mode() {
+        #[test_case(
+            true,
+            not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE;
+            "all_or_nothing"
+        )]
+        #[test_case(
+            false,
+            not_included_reasons::PARTIAL_BATCH_CANCELLED;
+            "partial_batch"
+        )]
+        fn test_commit_cancelled_response_reason_uses_batch_mode(
+            all_or_nothing: bool,
+            expected_not_included_reason: u8,
+        ) {
             let simple_tx = wincode::serialize(&transfer(
                 &solana_keypair::Keypair::new(),
                 &solana_pubkey::Pubkey::new_unique(),
@@ -1549,13 +1561,9 @@ pub(crate) mod external {
             .0;
             let commit_details =
                 CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled);
-            let all_or_nothing_flags = ExecutionFlags {
+            let execution_flags = ExecutionFlags {
                 drop_on_failure: false,
-                all_or_nothing: true,
-            };
-            let partial_batch_flags = ExecutionFlags {
-                drop_on_failure: false,
-                all_or_nothing: false,
+                all_or_nothing,
             };
 
             assert_eq!(
@@ -1563,20 +1571,10 @@ pub(crate) mod external {
                     &tx,
                     &commit_details,
                     &bank,
-                    &all_or_nothing_flags,
+                    &execution_flags,
                 )
                 .not_included_reason,
-                not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE
-            );
-            assert_eq!(
-                ExternalWorker::response_from_commit_details(
-                    &tx,
-                    &commit_details,
-                    &bank,
-                    &partial_batch_flags,
-                )
-                .not_included_reason,
-                not_included_reasons::PARTIAL_BATCH_CANCELLED
+                expected_not_included_reason
             );
         }
 

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -1462,7 +1462,10 @@ pub(crate) mod external {
                     .0
                 })
                 .collect::<Vec<_>>();
-            let execution_flags = ExecutionFlags::default();
+            let execution_flags = ExecutionFlags {
+                drop_on_failure: false,
+                all_or_nothing: false,
+            };
 
             let responses = ExternalWorker::consume_response_iterator(
                 &[

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -40,7 +40,7 @@ pub(crate) const ENTRY_OVERHEAD_BYTES: u64 = 48;
 
 const SERIALIZED_ENTRIES_OVERHEAD: u64 = ENTRY_OVERHEAD_BYTES + 8; // Vec<Entry> length
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ExecutionFlags {
     /// Should failing transactions within the batch be dropped (no fee charged
     /// & not committed).
@@ -162,7 +162,7 @@ impl Consumer {
             bank,
             txs,
             check_results,
-            ExecutionFlags {
+            &ExecutionFlags {
                 drop_on_failure: false,
                 all_or_nothing: false,
             },
@@ -181,7 +181,7 @@ impl Consumer {
         bank: &Bank,
         txs: &[impl TransactionWithMeta],
         max_ages: &[MaxAge],
-        flags: ExecutionFlags,
+        flags: &ExecutionFlags,
     ) -> ProcessTransactionBatchOutput {
         // Need to filter out transactions since they were sanitized earlier.
         // This means that the transaction may cross and epoch boundary (not allowed),
@@ -201,7 +201,7 @@ impl Consumer {
         bank: &Bank,
         txs: &[impl TransactionWithMeta],
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
-        flags: ExecutionFlags,
+        flags: &ExecutionFlags,
     ) -> ProcessTransactionBatchOutput {
         // Only lock accounts for transactions that passed pre-lock checks;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
@@ -235,7 +235,7 @@ impl Consumer {
         &self,
         bank: &Bank,
         batch: &TransactionBatch<impl TransactionWithMeta>,
-        flags: ExecutionFlags,
+        flags: &ExecutionFlags,
     ) -> ExecuteAndCommitTransactionsOutput {
         let transaction_status_sender_enabled = self.committer.transaction_status_sender_enabled();
         let mut execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -40,7 +40,7 @@ pub(crate) const ENTRY_OVERHEAD_BYTES: u64 = 48;
 
 const SERIALIZED_ENTRIES_OVERHEAD: u64 = ENTRY_OVERHEAD_BYTES + 8; // Vec<Entry> length
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ExecutionFlags {
     /// Should failing transactions within the batch be dropped (no fee charged
     /// & not committed).

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1500,7 +1500,7 @@ mod tests {
                 &bank,
                 &transactions,
                 std::iter::repeat(Ok(())),
-                ExecutionFlags {
+                &ExecutionFlags {
                     drop_on_failure: false,
                     all_or_nothing: true,
                 },

--- a/scheduler-bindings/src/lib.rs
+++ b/scheduler-bindings/src/lib.rs
@@ -352,9 +352,11 @@ pub mod worker_message_types {
         /// The transaction could not attempt processing because the
         /// working bank was unavailable.
         pub const BANK_NOT_AVAILABLE: u8 = 1;
+        /// Transaction was cancelled by a partial batch failure.
+        pub const PARTIAL_BATCH_CANCELLED: u8 = 2;
 
         /// Transaction dropped because the batch was marked as
-        /// all_or_nothing and a different transacation failed.
+        /// all_or_nothing and a different transaction failed.
         pub const ALL_OR_NOTHING_BATCH_FAILURE: u8 = 3;
 
         // Remaining errors are translations from SDK.
@@ -441,7 +443,7 @@ pub mod worker_message_types {
         pub const PROGRAM_CACHE_HIT_MAX_LIMIT: u8 = 101;
 
         // This error in agave is only internal, and to avoid updating the sdk
-        // it is reused for mapping into `ALL_OR_NOTHING_BATCH_FAILURE`.
+        // it is mapped into a scheduler-specific reason above.
         // /// Commit cancelled internally.
         // pub const COMMIT_CANCELLED: u8 = 102;
     }

--- a/scheduling-utils/src/error.rs
+++ b/scheduling-utils/src/error.rs
@@ -3,15 +3,21 @@ use {
     solana_transaction_error::TransactionError,
 };
 
-/// Translate
-pub fn transaction_result_to_not_included_reason(result: &Result<(), TransactionError>) -> u8 {
+/// Translate a transaction result into an external scheduler response reason.
+pub fn transaction_result_to_not_included_reason(
+    result: &Result<(), TransactionError>,
+    all_or_nothing: bool,
+) -> u8 {
     match result {
         Ok(()) => not_included_reasons::NONE,
-        Err(err) => transaction_error_to_not_included_reason(err),
+        Err(err) => transaction_error_to_not_included_reason(err, all_or_nothing),
     }
 }
 
-pub fn transaction_error_to_not_included_reason(error: &TransactionError) -> u8 {
+pub fn transaction_error_to_not_included_reason(
+    error: &TransactionError,
+    all_or_nothing: bool,
+) -> u8 {
     match error {
         TransactionError::AccountInUse => not_included_reasons::ACCOUNT_IN_USE,
         TransactionError::AccountLoadedTwice => not_included_reasons::ACCOUNT_LOADED_TWICE,
@@ -89,6 +95,29 @@ pub fn transaction_error_to_not_included_reason(error: &TransactionError) -> u8 
         }
 
         // SPECIAL CASE - CommitCancelled is an internal error reused to avoid breaking sdk
-        TransactionError::CommitCancelled => not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE,
+        TransactionError::CommitCancelled => {
+            if all_or_nothing {
+                not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE
+            } else {
+                not_included_reasons::PARTIAL_BATCH_CANCELLED
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, agave_scheduler_bindings::worker_message_types::not_included_reasons};
+
+    #[test]
+    fn test_commit_cancelled_maps_by_batch_mode() {
+        assert_eq!(
+            transaction_error_to_not_included_reason(&TransactionError::CommitCancelled, true),
+            not_included_reasons::ALL_OR_NOTHING_BATCH_FAILURE
+        );
+        assert_eq!(
+            transaction_error_to_not_included_reason(&TransactionError::CommitCancelled, false),
+            not_included_reasons::PARTIAL_BATCH_CANCELLED
+        );
     }
 }


### PR DESCRIPTION
#### Problem

`consumer` returns `CommitCancelled` error in two possible scenarios:
- all-on-nothing batch has failed tx, entire batch is cancelled.
- non-all-or-nothing batch has failed tx, the remaining batch is cancelled.

The error code should be mapped differently so external schedulers are better informed.

#### Summary of Changes
- added `PARTIAL_BATCH_CANCELLED` error code
- map `CommitCancelled` to new code is all-or-nothing flag is not on; otherwise same behavior.

#### Testing
CI

Fixes #
