### PR TITLE
Do not panic if async deleter doesn't find file

### DIFF
--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -123,7 +123,10 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path>) {
             trace!("background deleting {}...", path_delete.display());
             let (result, measure_delete) = measure_time!(dirs::remove_dir_all(&path_delete));
             if let Err(err) = result {
-                panic!("Failed to async delete '{}': {err}", path_delete.display());
+                match err.kind() {
+                    io::ErrorKind::NotFound => (),
+                    _ => panic!("Failed to async delete '{}': {err}", path_delete.display()),
+                }
             }
             trace!(
                 "background deleting {}... Done, and{measure_delete}",


### PR DESCRIPTION
#### Problem

From [discord](https://discord.com/channels/428295358100013066/838890116386521088/1527519987965890651):

> I hit this on v4.2 @ 1f7f4fba3b5c127c04f44ddf5ce82ffb811508e3:
> 
> ```
> thread 'solDeletePath' (340420) panicked at accounts-db/src/utils.rs:126:17:
> Failed to async delete '/home/sol/ledger/accounts/snapshot_to_be_deleted': No such file or directory (os error 2)
> ```


#### Summary of Changes

If the async deleter doesn't find the file to delete, do not panic.


#### Testing

Nothing additional.