### PR TITLE
chore(dep): update vendored crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2218,14 +2218,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
-source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"
+version = "0.9.20"
+source = "git+https://github.com/anza-xyz/crossbeam?rev=5ee1c6ec671d94db14ed9238eb99e59a84555aad#5ee1c6ec671d94db14ed9238eb99e59a84555aad"
 dependencies = [
- "cfg-if 1.0.4",
  "crossbeam-utils",
- "lazy_static",
- "memoffset 0.6.4",
- "scopeguard",
 ]
 
 [[package]]
@@ -4688,15 +4684,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -4867,7 +4854,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -7204,7 +7191,7 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "log",
- "memoffset 0.9.1",
+ "memoffset",
  "modular-bitfield",
  "num_cpus",
  "qualifier_attr",
@@ -9672,7 +9659,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778f08fb0eaf52c9a3bef2978247f7fab0ccfddc44cfddb936d5ad9f98ede886"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -10336,7 +10323,7 @@ dependencies = [
  "libc",
  "libsecp256k1",
  "log",
- "memoffset 0.9.1",
+ "memoffset",
  "mockall",
  "num-derive",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,5 +617,5 @@ lto = "fat"
 codegen-units = 1
 
 [patch.crates-io]
-# for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
-crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+# for details, see https://github.com/anza-xyz/crossbeam/commit/5ee1c6ec671d94db14ed9238eb99e59a84555aad
+crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "5ee1c6ec671d94db14ed9238eb99e59a84555aad" }


### PR DESCRIPTION
#### Problem

Agave vendors `crossbeam-epoch` via a `[patch.crates-io]` git dependency, so it was not covered by #13686, which bumped `crossbeam-epoch` to 0.9.20 across the other workspaces. The vendored patch still pinned the old 0.9.5-based rev (`fd279d7`), which predates the RUSTSEC-2026-0204 `fmt::Pointer` soundness fix.

For transparency: this advisory is not reachable from Agave in practice. `crossbeam-epoch` is used only via rayon (`crossbeam-deque`), which holds an epoch `Atomic` internally but never formats it with `{:p}` (the only vulnerable path) and implements no `fmt::Pointer`. Agave references `crossbeam-epoch` in zero lines of Rust. So this is dependency hygiene / closing the vendoring gap left by #13686, not a fix for an exploitable path.

#### Summary of Changes

Repoint the `[patch.crates-io]` `crossbeam-epoch` at [anza-xyz/crossbeam@5ee1c6ec](https://github.com/anza-xyz/crossbeam/tree/anza-crossbeam-epoch-0.9.20) (branch `anza-crossbeam-epoch-0.9.20`): `crossbeam-epoch` 0.9.20 plus our `PINNINGS_BETWEEN_COLLECT` patch. `Cargo.lock` regenerated (`crossbeam-epoch` 0.9.5 -> 0.9.20; drops the now-unused `memoffset` 0.6.4).

#13747