### PR TITLE
v4.1: chore(dep): backport RUSTSEC-2026-0204 crossbeam-epoch fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "crossbeam-epoch"
 version = "0.9.5"
-source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"
+source = "git+https://github.com/anza-xyz/crossbeam?rev=153b426198d4ef7b56c2705db764994877bd2bab#153b426198d4ef7b56c2705db764994877bd2bab"
 dependencies = [
  "cfg-if 1.0.4",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -618,5 +618,5 @@ lto = "fat"
 codegen-units = 1
 
 [patch.crates-io]
-# for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
-crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
+# for details, see https://github.com/anza-xyz/crossbeam/commit/153b426198d4ef7b56c2705db764994877bd2bab
+crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "153b426198d4ef7b56c2705db764994877bd2bab" }

--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -66,6 +66,16 @@ default_cargo_audit_extra_args=(
   # Solution:  Upgrade to >=0.11.15
   # AGAVE OK:  we read 1 stream at a time, bounded to tx size, for up to 2s
   --ignore RUSTSEC-2026-0185
+
+  # Crate:     crossbeam-epoch
+  # Version:   0.9.5
+  # Title:     Invalid pointer dereference in fmt::Pointer impl for Atomic and Shared
+  # Date:      2026-07-06
+  # ID:        RUSTSEC-2026-0204
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0204
+  # Solution:  Upgrade to >=0.9.20
+  # AGAVE OK:  patched via vendored anza-xyz/crossbeam fork (rev 153b4261), which reports 0.9.5
+  --ignore RUSTSEC-2026-0204
 )
 
 xtask_cargo_audit_extra_args=(


### PR DESCRIPTION
Backport of the RUSTSEC-2026-0204 crossbeam-epoch `fmt::Pointer` fix to v4.1. Repoints the vendored `[patch.crates-io]` crossbeam-epoch at anza-xyz/crossbeam@153b4261 (`anza-crossbeam-epoch-0.9.5`): the 0.9.5 base + the fix + our PINNINGS patch.

#13747
