### PR TITLE
Rename flush cache account stats

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4701,12 +4701,12 @@ impl AccountsDb {
             .filter_map(|iter_item| {
                 let key = iter_item.key();
                 let account = &iter_item.value().account;
-                let mut should_flush = match pubkeys_to_flush {
+                let mut should_store = match pubkeys_to_flush {
                     PubkeysToFlush::All => true,
                     PubkeysToFlush::Only(flush_keys) => flush_keys.contains(key),
                 };
                 // `true` keeps a disk-loaded entry in-mem for the index upsert below
-                if should_flush
+                if should_store
                     && account.is_zero_lamport()
                     && !self
                         .accounts_index
@@ -4718,9 +4718,9 @@ impl AccountsDb {
                     if !self.account_indexes.is_empty() {
                         skipped_zero_lamport_pubkeys.push(*key);
                     }
-                    should_flush = false;
+                    should_store = false;
                 }
-                if should_flush {
+                if should_store {
                     flush_stats.num_bytes_stored +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
                     flush_stats.num_accounts_stored += 1;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4503,18 +4503,22 @@ impl AccountsDb {
             ("total_new_excess_roots", total_new_excess_roots, i64),
             ("num_excess_roots_flushed", num_excess_roots_flushed, i64),
             ("flush_roots_elapsed", flush_roots_elapsed.as_us(), i64),
+            ("account_bytes_stored", flush_stats.num_bytes_stored.0, i64),
             (
-                "account_bytes_flushed",
-                flush_stats.num_bytes_flushed.0,
+                "num_accounts_stored",
+                flush_stats.num_accounts_stored.0,
                 i64
             ),
             (
-                "num_accounts_flushed",
-                flush_stats.num_accounts_flushed.0,
+                "account_bytes_skipped",
+                flush_stats.num_bytes_skipped.0,
                 i64
             ),
-            ("account_bytes_skipped", flush_stats.num_bytes_skipped.0, i64),
-            ("num_accounts_skipped", flush_stats.num_accounts_skipped.0, i64),
+            (
+                "num_accounts_skipped",
+                flush_stats.num_accounts_skipped.0,
+                i64
+            ),
             (
                 "num_zero_lamport_accounts_skipped",
                 flush_stats.num_zero_lamport_accounts_skipped.0,
@@ -4717,9 +4721,9 @@ impl AccountsDb {
                     should_flush = false;
                 }
                 if should_flush {
-                    flush_stats.num_bytes_flushed +=
+                    flush_stats.num_bytes_stored +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
-                    flush_stats.num_accounts_flushed += 1;
+                    flush_stats.num_accounts_stored += 1;
                     Some((key, account))
                 } else {
                     // Skip writing this account. Either superseded or zero lamport
@@ -4745,7 +4749,7 @@ impl AccountsDb {
             // This ensures that all updates are written to an AppendVec, before any
             // updates to the index happen, so anybody that sees a real entry in the index,
             // will be able to find the account in storage
-            let flushed_store = Arc::new(self.create_store(slot, flush_stats.num_bytes_flushed.0));
+            let flushed_store = Arc::new(self.create_store(slot, flush_stats.num_bytes_stored.0));
             self.storage.insert(Arc::clone(&flushed_store));
 
             let (store_accounts_for_flush_stats, store_accounts_for_flush_us) =

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4513,8 +4513,8 @@ impl AccountsDb {
                 flush_stats.num_accounts_flushed.0,
                 i64
             ),
-            ("account_bytes_saved", flush_stats.num_bytes_purged.0, i64),
-            ("num_accounts_saved", flush_stats.num_accounts_purged.0, i64),
+            ("account_bytes_skipped", flush_stats.num_bytes_skipped.0, i64),
+            ("num_accounts_skipped", flush_stats.num_accounts_skipped.0, i64),
             (
                 "num_zero_lamport_accounts_skipped",
                 flush_stats.num_zero_lamport_accounts_skipped.0,
@@ -4722,10 +4722,10 @@ impl AccountsDb {
                     flush_stats.num_accounts_flushed += 1;
                     Some((key, account))
                 } else {
-                    // No need to write this account. Either superseded or zero lamport
-                    flush_stats.num_bytes_purged +=
+                    // Skip writing this account. Either superseded or zero lamport
+                    flush_stats.num_bytes_skipped +=
                         AppendVec::calculate_stored_size(account.data().len()) as u64;
-                    flush_stats.num_accounts_purged += 1;
+                    flush_stats.num_accounts_skipped += 1;
                     None
                 }
             })

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4613,7 +4613,7 @@ impl AccountsDb {
             FlushShouldClean::No => (
                 flushed_roots
                     .iter()
-                    .map(|&root| (root, PubkeysToFlush::All))
+                    .map(|&root| (root, PubkeysToStore::All))
                     .collect(),
                 0,
             ),
@@ -4650,7 +4650,7 @@ impl AccountsDb {
         &self,
         flushed_roots: &BTreeSet<Slot>,
         max_clean_root: Option<Slot>,
-    ) -> IntMap<Slot, PubkeysToFlush> {
+    ) -> IntMap<Slot, PubkeysToStore> {
         let mut pubkeys_to_flush = IntMap::with_capacity(flushed_roots.len());
 
         // Presize the dedup set from the newest root (flushed first), doubled to leave room
@@ -4666,7 +4666,7 @@ impl AccountsDb {
         for &root in flushed_roots.iter().rev() {
             let cleaned = max_clean_root.is_none_or(|max_clean_root| root <= max_clean_root);
             let to_flush = if !cleaned {
-                PubkeysToFlush::All
+                PubkeysToStore::All
             } else {
                 let mut flush_keys = HashSet::default();
                 if let Some(slot_cache) = self.accounts_cache.slot_cache(root) {
@@ -4678,7 +4678,7 @@ impl AccountsDb {
                         }
                     }
                 }
-                PubkeysToFlush::Only(flush_keys)
+                PubkeysToStore::Only(flush_keys)
             };
             pubkeys_to_flush.insert(root, to_flush);
         }
@@ -4689,7 +4689,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         slot_cache: &SlotCache,
-        pubkeys_to_store: &PubkeysToFlush,
+        pubkeys_to_store: &PubkeysToStore,
     ) -> FlushStats {
         debug_assert!(self.accounts_cache.contains_unflushed_root(slot));
         let mut flush_stats = FlushStats::default();
@@ -4702,8 +4702,8 @@ impl AccountsDb {
                 let key = iter_item.key();
                 let account = &iter_item.value().account;
                 let mut should_store = match pubkeys_to_store {
-                    PubkeysToFlush::All => true,
-                    PubkeysToFlush::Only(flush_keys) => flush_keys.contains(key),
+                    PubkeysToStore::All => true,
+                    PubkeysToStore::Only(store_keys) => store_keys.contains(key),
                 };
                 // `true` keeps a disk-loaded entry in-mem for the index upsert below
                 if should_store
@@ -4736,13 +4736,13 @@ impl AccountsDb {
             .collect();
 
         // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning.
-        // Cleaning is enabled if pubkeys_to_store is PubkeysToFlush::Only
-        // pubkeys_to_store is PubkeysToFlush::All when
+        // Cleaning is enabled if pubkeys_to_store is PubkeysToStore::Only
+        // pubkeys_to_store is PubkeysToStore::All when
         // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
         // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
         let reclaim_method = match pubkeys_to_store {
-            PubkeysToFlush::Only(_) => UpsertReclaim::ReclaimOldSlots,
-            PubkeysToFlush::All => UpsertReclaim::IgnoreReclaims,
+            PubkeysToStore::Only(_) => UpsertReclaim::ReclaimOldSlots,
+            PubkeysToStore::All => UpsertReclaim::IgnoreReclaims,
         };
 
         if !accounts.is_empty() {
@@ -4813,12 +4813,12 @@ impl AccountsDb {
     fn flush_slot_cache(
         &self,
         slot: Slot,
-        pubkeys_to_flush: &PubkeysToFlush,
+        pubkeys_to_store: &PubkeysToStore,
     ) -> Option<FlushStats> {
         // If a slot cache exists for this slot, flush it.
         self.accounts_cache
             .slot_cache(slot)
-            .map(|slot_cache| self.do_flush_slot_cache(slot, &slot_cache, pubkeys_to_flush))
+            .map(|slot_cache| self.do_flush_slot_cache(slot, &slot_cache, pubkeys_to_store))
     }
 
     fn report_store_stats(&self) {
@@ -6790,12 +6790,12 @@ enum FlushShouldClean {
 
 /// Which of a slot's cached accounts to write to storage when flushing it.
 #[derive(Debug, PartialEq, Eq)]
-enum PubkeysToFlush {
-    /// Flush every account in the slot, reclaiming nothing. Used for roots above
+enum PubkeysToStore {
+    /// Store every account in the slot, reclaiming nothing. Used for roots above
     /// `max_clean_root` and when not cleaning, since an in-flight scan may still need
     /// those versions.
     All,
-    /// Flush only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
+    /// Store only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
     /// purging the rest from the index and reclaiming older versions.
     Only(HashSet<Pubkey, PubkeyHasherBuilder>),
 }
@@ -6857,7 +6857,7 @@ impl AccountsDb {
 
     pub fn flush_accounts_cache_slot_for_tests(&self, slot: Slot) {
         assert!(self.accounts_cache.contains_unflushed_root(slot));
-        self.flush_slot_cache(slot, &PubkeysToFlush::All);
+        self.flush_slot_cache(slot, &PubkeysToStore::All);
     }
 
     /// useful to adapt tests written prior to introduction of the write cache

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4689,7 +4689,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         slot_cache: &SlotCache,
-        pubkeys_to_flush: &PubkeysToFlush,
+        pubkeys_to_store: &PubkeysToFlush,
     ) -> FlushStats {
         debug_assert!(self.accounts_cache.contains_unflushed_root(slot));
         let mut flush_stats = FlushStats::default();
@@ -4701,7 +4701,7 @@ impl AccountsDb {
             .filter_map(|iter_item| {
                 let key = iter_item.key();
                 let account = &iter_item.value().account;
-                let mut should_store = match pubkeys_to_flush {
+                let mut should_store = match pubkeys_to_store {
                     PubkeysToFlush::All => true,
                     PubkeysToFlush::Only(flush_keys) => flush_keys.contains(key),
                 };
@@ -4736,11 +4736,11 @@ impl AccountsDb {
             .collect();
 
         // Use ReclaimOldSlots to reclaim old slots if marking obsolete accounts and cleaning.
-        // Cleaning is enabled if pubkeys_to_flush is PubkeysToFlush::Only
-        // pubkeys_to_flush is PubkeysToFlush::All when
+        // Cleaning is enabled if pubkeys_to_store is PubkeysToFlush::Only
+        // pubkeys_to_store is PubkeysToFlush::All when
         // 1) There's an ongoing scan to avoid reclaiming accounts being scanned.
         // 2) The slot is > max_clean_root to prevent unrooted slots from reclaiming rooted versions.
-        let reclaim_method = match pubkeys_to_flush {
+        let reclaim_method = match pubkeys_to_store {
             PubkeysToFlush::Only(_) => UpsertReclaim::ReclaimOldSlots,
             PubkeysToFlush::All => UpsertReclaim::IgnoreReclaims,
         };

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4605,9 +4605,9 @@ impl AccountsDb {
         let num_new_roots = flushed_roots.len();
 
         // For each root being flushed, which of its cached accounts to write to storage.
-        let (pubkeys_to_flush, select_pubkeys_us) = match should_clean {
+        let (pubkeys_to_store, select_pubkeys_us) = match should_clean {
             FlushShouldClean::Yes { max_clean_root } => {
-                measure_us!(self.select_pubkeys_to_flush(&flushed_roots, max_clean_root))
+                measure_us!(self.select_pubkeys_to_store(&flushed_roots, max_clean_root))
             }
             // Not cleaning: every root writes all of its accounts.
             FlushShouldClean::No => (
@@ -4625,7 +4625,7 @@ impl AccountsDb {
             ..FlushStats::default()
         };
         for root in flushed_roots {
-            if let Some(stats) = self.flush_slot_cache(root, &pubkeys_to_flush[&root]) {
+            if let Some(stats) = self.flush_slot_cache(root, &pubkeys_to_store[&root]) {
                 num_roots_flushed += 1;
                 flush_stats.accumulate(&stats);
             } else {
@@ -4646,12 +4646,12 @@ impl AccountsDb {
     /// root keeps `Only` the newest version of each account, deduped newest-first. A root above
     /// `max_clean_root` instead flushes `All`, since an in-flight scan may still need those
     /// versions; `None` means there is no bound and every flushed root is cleaned.
-    fn select_pubkeys_to_flush(
+    fn select_pubkeys_to_store(
         &self,
         flushed_roots: &BTreeSet<Slot>,
         max_clean_root: Option<Slot>,
     ) -> IntMap<Slot, PubkeysToStore> {
-        let mut pubkeys_to_flush = IntMap::with_capacity(flushed_roots.len());
+        let mut pubkeys_to_store = IntMap::with_capacity(flushed_roots.len());
 
         // Presize the dedup set from the newest root (flushed first), doubled to leave room
         // for unique accounts contributed by older roots.
@@ -4680,9 +4680,9 @@ impl AccountsDb {
                 }
                 PubkeysToStore::Only(flush_keys)
             };
-            pubkeys_to_flush.insert(root, to_flush);
+            pubkeys_to_store.insert(root, to_flush);
         }
-        pubkeys_to_flush
+        pubkeys_to_store
     }
 
     fn do_flush_slot_cache(
@@ -4807,8 +4807,8 @@ impl AccountsDb {
         flush_stats
     }
 
-    /// `pubkeys_to_flush` selects which accounts are written to storage: `Only(set)` flushes
-    /// just the pubkeys in the set, dropping the rest with the cache, while `All` flushes every
+    /// `pubkeys_to_store` selects which accounts are written to storage: `Only(set)` stores
+    /// just the pubkeys in the set, dropping the rest with the cache, while `All` stores every
     /// account in the slot.
     fn flush_slot_cache(
         &self,
@@ -6795,7 +6795,7 @@ enum PubkeysToStore {
     /// `max_clean_root` and when not cleaning, since an in-flight scan may still need
     /// those versions.
     All,
-    /// Store only these pubkeys (the newest version of each, per `select_pubkeys_to_flush`),
+    /// Store only these pubkeys (the newest version of each, per `select_pubkeys_to_store`),
     /// purging the rest from the index and reclaiming older versions.
     Only(HashSet<Pubkey, PubkeyHasherBuilder>),
 }

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -232,8 +232,8 @@ impl PurgeStats {
 
 #[derive(Debug, Default)]
 pub struct FlushStats {
-    pub num_accounts_flushed: Saturating<usize>,
-    pub num_bytes_flushed: Saturating<u64>,
+    pub num_accounts_stored: Saturating<usize>,
+    pub num_bytes_stored: Saturating<u64>,
     pub num_accounts_skipped: Saturating<usize>,
     pub num_bytes_skipped: Saturating<u64>,
     pub num_zero_lamport_accounts_skipped: Saturating<usize>,
@@ -270,8 +270,8 @@ impl FlushStats {
     }
 
     pub fn accumulate(&mut self, other: &Self) {
-        self.num_accounts_flushed += other.num_accounts_flushed;
-        self.num_bytes_flushed += other.num_bytes_flushed;
+        self.num_accounts_stored += other.num_accounts_stored;
+        self.num_bytes_stored += other.num_bytes_stored;
         self.num_accounts_skipped += other.num_accounts_skipped;
         self.num_bytes_skipped += other.num_bytes_skipped;
         self.num_zero_lamport_accounts_skipped += other.num_zero_lamport_accounts_skipped;

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -234,8 +234,8 @@ impl PurgeStats {
 pub struct FlushStats {
     pub num_accounts_flushed: Saturating<usize>,
     pub num_bytes_flushed: Saturating<u64>,
-    pub num_accounts_purged: Saturating<usize>,
-    pub num_bytes_purged: Saturating<u64>,
+    pub num_accounts_skipped: Saturating<usize>,
+    pub num_bytes_skipped: Saturating<u64>,
     pub num_zero_lamport_accounts_skipped: Saturating<usize>,
     pub store_accounts_total_us: Saturating<u64>,
     pub write_accounts_us: Saturating<u64>,
@@ -272,8 +272,8 @@ impl FlushStats {
     pub fn accumulate(&mut self, other: &Self) {
         self.num_accounts_flushed += other.num_accounts_flushed;
         self.num_bytes_flushed += other.num_bytes_flushed;
-        self.num_accounts_purged += other.num_accounts_purged;
-        self.num_bytes_purged += other.num_bytes_purged;
+        self.num_accounts_skipped += other.num_accounts_skipped;
+        self.num_bytes_skipped += other.num_bytes_skipped;
         self.num_zero_lamport_accounts_skipped += other.num_zero_lamport_accounts_skipped;
         self.store_accounts_total_us += other.store_accounts_total_us;
         self.write_accounts_us += other.write_accounts_us;

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1996,7 +1996,7 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
     // Slot 0: a rooted non-zero version so the tombstone below reaches storage and the index
     store_rooted_nonzero_accounts(&accounts, 0, [&pubkey]);
 
-    // Slot 1: a rooted zero-lamport tombstone. Flush with `PubkeysToFlush::All` so it is not
+    // Slot 1: a rooted zero-lamport tombstone. Store with `PubkeysToStore::All` so it is not
     // reclaimed
     accounts.store_for_tests((index_slot, [(&pubkey, &zero_account)].as_slice()));
     accounts.add_root(index_slot);
@@ -3800,8 +3800,8 @@ fn test_select_pubkeys_to_flush() {
         db.accounts_cache.store(slot, &shared, account.clone());
     }
 
-    let shared_only = PubkeysToFlush::Only([shared].into_iter().collect());
-    let deduped = PubkeysToFlush::Only(HashSet::default());
+    let shared_only = PubkeysToStore::Only([shared].into_iter().collect());
+    let deduped = PubkeysToStore::Only(HashSet::default());
 
     // No bound: every flushed root is cleaned, so `shared` is written only at its newest root
     // (15), deduped from 5 and 10.
@@ -3819,7 +3819,7 @@ fn test_select_pubkeys_to_flush() {
     // max_clean_root = 10: root 15 is above the boundary and flushes `All` (no dedup), so
     // `shared` is not dropped from root 10 — a scan at root 10 may still need that version.
     let plans = db.select_pubkeys_to_flush(&roots, Some(10));
-    assert_eq!(plans[&15], PubkeysToFlush::All);
+    assert_eq!(plans[&15], PubkeysToStore::All);
     assert_eq!(plans[&10], shared_only);
     assert_eq!(plans[&5], deduped);
 }

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -3786,10 +3786,10 @@ fn test_load_with_read_only_accounts_cache() {
     assert_eq!(slot, 2);
 }
 
-/// `select_pubkeys_to_flush` keeps only the newest version of each account across the
-/// cleaned roots and flushes roots above `max_clean_root` in full.
+/// `select_pubkeys_to_store` stores only the newest version of each account across the
+/// cleaned roots and stores roots above `max_clean_root` in full.
 #[test]
-fn test_select_pubkeys_to_flush() {
+fn test_select_pubkeys_to_store() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let account = AccountSharedData::new(1, 0, &Pubkey::default());
 
@@ -3805,20 +3805,20 @@ fn test_select_pubkeys_to_flush() {
 
     // No bound: every flushed root is cleaned, so `shared` is written only at its newest root
     // (15), deduped from 5 and 10.
-    let plans = db.select_pubkeys_to_flush(&roots, None);
+    let plans = db.select_pubkeys_to_store(&roots, None);
     assert_eq!(plans[&15], shared_only);
     assert_eq!(plans[&10], deduped);
     assert_eq!(plans[&5], deduped);
 
     // max_clean_root = 15 (== newest root): same result, every root is at or below the bound.
-    let plans = db.select_pubkeys_to_flush(&roots, Some(15));
+    let plans = db.select_pubkeys_to_store(&roots, Some(15));
     assert_eq!(plans[&15], shared_only);
     assert_eq!(plans[&10], deduped);
     assert_eq!(plans[&5], deduped);
 
     // max_clean_root = 10: root 15 is above the boundary and flushes `All` (no dedup), so
     // `shared` is not dropped from root 10 — a scan at root 10 may still need that version.
-    let plans = db.select_pubkeys_to_flush(&roots, Some(10));
+    let plans = db.select_pubkeys_to_store(&roots, Some(10));
     assert_eq!(plans[&15], PubkeysToStore::All);
     assert_eq!(plans[&10], shared_only);
     assert_eq!(plans[&5], deduped);


### PR DESCRIPTION
#### Problem
Account stats in flush stats are extremely confusing. "Saved and Purged" refers to accounts that are not written (ie not stored). Flushed refers to accounts that are stored.

#### Summary of Changes
- Leave slot language alone
- Update all instances of saved/purged to skipped
- Update all instances of flushed to stored

#### Testing
CI

Fixes #
