### PR TITLE
Introduces RewardVoteMessage

### DIFF
--- a/bls-sigverify/benches/bls_vote_sigverify.rs
+++ b/bls-sigverify/benches/bls_vote_sigverify.rs
@@ -17,7 +17,7 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_signer::Signer,
-    std::hint::black_box,
+    std::{hint::black_box, num::NonZero},
 };
 
 static BATCH_SIZES: &[usize] = &[8, 16, 32, 64, 128];
@@ -58,6 +58,7 @@ fn generate_test_data(
                     sender_bls_pubkey: bls_keypair.public,
                     sender_vote_account_pubkey: Keypair::new().pubkey(),
                     sender_identity_pubkey: Keypair::new().pubkey(),
+                    stake: NonZero::new(123).unwrap(),
                 }
             })
             .collect(),

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -6,7 +6,7 @@ use {
         bls_vote_sigverify::{UnverifiedVotePayload, verify_and_send_votes},
         errors::SigVerifyError,
         generated_cert_types::GeneratedCertTypes,
-        rewards::rewards_wants_vote,
+        rewards::{RewardVoteMessage, rewards_wants_unverified_vote_msg},
         stats::SigVerifierStats,
     },
     agave_votor_messages::{
@@ -14,7 +14,6 @@ use {
         certificate::CertificateType,
         metric_types::ConsensusMetricsEventSender,
         migration::MigrationStatus,
-        reward_certificate::AddVoteMessage,
         sig_verified_messages::SigVerifiedBatch,
         unverified_vote_message::{
             DecodedWireConsensusMessage, UnverifiedCertificate, UnverifiedVoteMessage,
@@ -73,7 +72,7 @@ pub struct SigVerifierChannels {
     pub packet_receiver: Receiver<PacketBatch>,
     pub certificate_receiver: Receiver<(Slot, UnverifiedCertificate)>,
     pub channel_to_repair: VerifiedVoterSlotsSender,
-    pub channel_to_reward: Sender<AddVoteMessage>,
+    pub channel_to_reward: Sender<Vec<RewardVoteMessage>>,
     pub channel_to_pool: Sender<SigVerifiedBatch>,
     pub channel_to_metrics: ConsensusMetricsEventSender,
 }
@@ -378,11 +377,11 @@ impl SigVerifier {
             return None;
         }
         if vote_slot <= root_slot
-            && !rewards_wants_vote(
+            && !rewards_wants_unverified_vote_msg(
                 &self.cluster_info,
                 &self.leader_schedule,
                 root_slot,
-                &msg.vote,
+                &msg,
             )
         {
             self.stats.num_old_votes_received += 1;
@@ -419,6 +418,7 @@ impl SigVerifier {
             sender_bls_pubkey: entry.bls_pubkey,
             sender_vote_account_pubkey: entry.vote_account_pubkey,
             sender_identity_pubkey,
+            stake: entry.stake,
         })
     }
 }
@@ -500,7 +500,7 @@ mod tests {
 
         _packet_sender: Sender<PacketBatch>,
         repair_receiver: VerifiedVoterSlotsReceiver,
-        _reward_receiver: Receiver<AddVoteMessage>,
+        _reward_receiver: Receiver<Vec<RewardVoteMessage>>,
         pool_receiver: Receiver<SigVerifiedBatch>,
         _metrics_receiver: ConsensusMetricsEventReceiver,
         generated_cert_types: Arc<GeneratedCertTypes>,

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -4,7 +4,7 @@ use {
     crate::{
         bls_sigverifier::{BAN_TIMEOUT, NUM_SLOTS_FOR_VERIFY, SigVerifierChannels},
         errors::SigVerifyVoteError,
-        rewards::rewards_wants_vote,
+        rewards::RewardVoteMessage,
         stats::SigVerifyVoteStats,
         utils::{
             send_votes_to_metrics, send_votes_to_pool, send_votes_to_repair, send_votes_to_rewards,
@@ -13,7 +13,6 @@ use {
     agave_votor_messages::{
         consensus_message::VoteMessage,
         metric_types::ConsensusMetricsEvent,
-        reward_certificate::AddVoteMessage,
         sig_verified_messages::SigVerifiedBatch,
         unverified_vote_message::UnverifiedVoteMessage,
         vote::Vote,
@@ -35,7 +34,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::nonblocking::simple_qos::SimpleQosBanlist,
-    std::collections::HashMap,
+    std::{collections::HashMap, num::NonZero},
 };
 
 fn into_vote_msg(msg: UnverifiedVoteMessage) -> VoteMessage {
@@ -50,6 +49,7 @@ fn into_vote_msg(msg: UnverifiedVoteMessage) -> VoteMessage {
 struct VerifiedVotePayload {
     vote_message: VoteMessage,
     sender_vote_account_pubkey: Pubkey,
+    stake: NonZero<u64>,
 }
 
 /// [`VoteMessage`] along with other information needed to sig verify it.
@@ -60,6 +60,7 @@ pub(super) struct UnverifiedVotePayload {
     pub sender_bls_pubkey: PopVerified<BlsPubkeyAffine>,
     pub sender_vote_account_pubkey: Pubkey,
     pub sender_identity_pubkey: Pubkey,
+    pub stake: NonZero<u64>,
 }
 
 impl UnverifiedVotePayload {
@@ -71,6 +72,7 @@ impl UnverifiedVotePayload {
             .map(|()| VerifiedVotePayload {
                 vote_message: into_vote_msg(self.vote_message),
                 sender_vote_account_pubkey: self.sender_vote_account_pubkey,
+                stake: self.stake,
             })
     }
 }
@@ -155,7 +157,7 @@ fn process_verified_votes(
 ) -> (
     SigVerifiedBatch,
     HashMap<Pubkey, Vec<Slot>>,
-    AddVoteMessage,
+    Vec<RewardVoteMessage>,
     Vec<ConsensusMetricsEvent>,
 ) {
     let mut votes_for_reward = Vec::with_capacity(verified_votes.len());
@@ -163,13 +165,15 @@ fn process_verified_votes(
     let mut votes_for_pool = Vec::with_capacity(verified_votes.len());
     let mut votes_for_metrics = Vec::with_capacity(verified_votes.len());
     for payload in verified_votes {
-        if rewards_wants_vote(
+        if let Some(reward_vote_msg) = RewardVoteMessage::try_new(
             cluster_info,
             leader_schedule,
             root_bank.slot(),
-            &payload.vote_message.vote,
+            &payload.vote_message,
+            payload.stake,
+            payload.sender_vote_account_pubkey,
         ) {
-            votes_for_reward.push(payload.vote_message.clone());
+            votes_for_reward.push(reward_vote_msg);
         }
 
         inspect_for_repair(&payload, &mut msgs_for_repair);
@@ -192,9 +196,7 @@ fn process_verified_votes(
     (
         votes_for_pool,
         msgs_for_repair,
-        AddVoteMessage {
-            votes: votes_for_reward,
-        },
+        votes_for_reward,
         votes_for_metrics,
     )
 }

--- a/bls-sigverify/src/rewards.rs
+++ b/bls-sigverify/src/rewards.rs
@@ -1,26 +1,124 @@
 use {
-    agave_votor_messages::{reward_certificate::NUM_SLOTS_FOR_REWARD, vote::Vote},
+    agave_votor_messages::{
+        consensus_message::VoteMessage,
+        reward_certificate::NUM_SLOTS_FOR_REWARD,
+        unverified_vote_message::UnverifiedVoteMessage,
+        vote::{NotarizationVote, SkipVote, Vote},
+    },
+    solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::leader_schedule_cache::LeaderScheduleCache,
+    solana_pubkey::Pubkey,
+    std::num::NonZero,
 };
 
-/// Returns [`false`] if the rewards container is not interested in the [`VoteMessage`].
-/// Returns [`true`] if the rewards container might be interested in the [`VoteMessage`].
-pub fn rewards_wants_vote(
+#[derive(Debug, Clone)]
+/// Different types of reward votes.
+pub enum RewardVote {
+    /// Notar type reward vote.
+    Notar(NotarizationVote),
+    /// Skip type reward vote.
+    Skip(SkipVote),
+}
+
+impl RewardVote {
+    /// Returns the slot on the vote
+    pub fn slot(&self) -> Slot {
+        match self {
+            Self::Notar(v) => v.block.slot,
+            Self::Skip(v) => v.slot,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+/// A reward vote message.
+pub struct RewardVoteMessage {
+    /// The type of reward vote.
+    pub vote: RewardVote,
+    /// The signature on the vote.
+    pub signature: BLSSignature,
+    /// The rank of the validator.
+    pub rank: u16,
+    pub stake: NonZero<u64>,
+    pub vote_account_pubkey: Pubkey,
+}
+
+impl RewardVoteMessage {
+    /// Returns a new RewardVoteMesage if the `msg` is needed for rewards to this node and the
+    /// `msg.vote` is needed for rewards.
+    pub fn try_new(
+        cluster_info: &ClusterInfo,
+        leader_schedule: &LeaderScheduleCache,
+        root_slot: Slot,
+        msg: &VoteMessage,
+        stake: NonZero<u64>,
+        vote_account_pubkey: Pubkey,
+    ) -> Option<Self> {
+        let vote_slot = msg.vote.slot();
+        let vote = match &msg.vote {
+            Vote::Notarize(notar) => RewardVote::Notar(*notar),
+            Vote::Skip(skip) => RewardVote::Skip(*skip),
+            Vote::Finalize(_)
+            | Vote::NotarizeFallback(_)
+            | Vote::SkipFallback(_)
+            | Vote::Genesis(_) => return None,
+        };
+        if !is_relevant(vote_slot, root_slot, cluster_info, leader_schedule) {
+            return None;
+        }
+        Some(Self {
+            vote,
+            signature: msg.signature,
+            rank: msg.rank,
+            stake,
+            vote_account_pubkey,
+        })
+    }
+}
+
+impl From<RewardVoteMessage> for VoteMessage {
+    fn from(msg: RewardVoteMessage) -> Self {
+        let vote = match msg.vote {
+            RewardVote::Notar(notar) => Vote::new_notarization_vote(notar.block),
+            RewardVote::Skip(skip) => Vote::new_skip_vote(skip.slot),
+        };
+        Self {
+            vote,
+            signature: msg.signature,
+            rank: msg.rank,
+        }
+    }
+}
+
+#[must_use]
+/// Returns true if the given `msg` is needed for rewards.
+pub(crate) fn rewards_wants_unverified_vote_msg(
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
     root_slot: Slot,
-    vote: &Vote,
+    msg: &UnverifiedVoteMessage,
 ) -> bool {
-    match vote {
-        Vote::Notarize(_) | Vote::Skip(_) => (),
+    match &msg.vote {
         Vote::Finalize(_)
         | Vote::NotarizeFallback(_)
         | Vote::SkipFallback(_)
         | Vote::Genesis(_) => return false,
+        Vote::Notarize(_) | Vote::Skip(_) => (),
     }
-    let vote_slot = vote.slot();
+    let vote_slot = msg.vote.slot();
+    is_relevant(vote_slot, root_slot, cluster_info, leader_schedule)
+}
+
+#[must_use]
+/// Returns true if a reward vote at the `vote_slot` is needed by this node for rewards.
+fn is_relevant(
+    vote_slot: Slot,
+    root_slot: Slot,
+    cluster_info: &ClusterInfo,
+    leader_schedule: &LeaderScheduleCache,
+) -> bool {
     if vote_slot.saturating_add(NUM_SLOTS_FOR_REWARD) <= root_slot {
         return false;
     }

--- a/bls-sigverify/src/utils.rs
+++ b/bls-sigverify/src/utils.rs
@@ -1,12 +1,12 @@
 use {
     crate::{
         errors::{SigVerifyCertError, SigVerifyVoteError},
+        rewards::RewardVoteMessage,
         stats::{SigVerifyCertStats, SigVerifyVoteStats},
     },
     agave_votor_messages::{
         VerifiedVoterSlotsSender,
         metric_types::{ConsensusMetricsEvent, ConsensusMetricsEventSender},
-        reward_certificate::AddVoteMessage,
         sig_verified_messages::SigVerifiedBatch,
     },
     crossbeam_channel::{Sender, TrySendError},
@@ -37,11 +37,11 @@ pub(super) fn send_votes_to_metrics(
 }
 
 pub(super) fn send_votes_to_rewards(
-    msg: AddVoteMessage,
-    channel: &Sender<AddVoteMessage>,
+    msg: Vec<RewardVoteMessage>,
+    channel: &Sender<Vec<RewardVoteMessage>>,
     stats: &mut SigVerifyVoteStats,
 ) -> Result<(), SigVerifyVoteError> {
-    let len = msg.votes.len();
+    let len = msg.len();
     match channel.try_send(msg) {
         Ok(()) => {
             stats.rewards_sent += len as u64;

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -13,10 +13,11 @@ use {
         },
         replay_stage::{Finalizer, ReplayStage},
     },
+    agave_bls_sigverify::rewards::RewardVoteMessage,
     agave_votor::event::LeaderWindowInfo,
     agave_votor_messages::{
         consensus_message::Block,
-        reward_certificate::{AddVoteMessage, NotarRewardCertificate, SkipRewardCertificate},
+        reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
     },
     crossbeam_channel::{Receiver, Sender, select_biased},
     solana_clock::Slot,
@@ -85,10 +86,9 @@ pub struct BlockCreationLoop {
 }
 
 impl BlockCreationLoop {
-    pub fn new(config: BlockCreationLoopConfig) -> (Self, Sender<AddVoteMessage>) {
+    pub fn new(config: BlockCreationLoopConfig) -> (Self, Sender<Vec<RewardVoteMessage>>) {
         let (reward_certs_service, certs_requestor, votes_sender) = RewardCertsService::new(
             config.cluster_info.clone(),
-            config.leader_schedule_cache.clone(),
             config.sharable_banks.clone(),
             config.exit.clone(),
         );

--- a/core/src/block_creation_loop/rewards/certs_builder.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder.rs
@@ -2,16 +2,12 @@ use {
     crate::block_creation_loop::rewards::msg_types::{
         RewardRequest, RewardRespSucc, RewardResponse,
     },
-    agave_bls_sigverify::rewards::rewards_wants_vote,
-    agave_votor_messages::{
-        consensus_message::VoteMessage,
-        reward_certificate::{BuildRewardCertsRespError, NUM_SLOTS_FOR_REWARD},
-    },
+    agave_bls_sigverify::rewards::RewardVoteMessage,
+    agave_votor_messages::reward_certificate::{BuildRewardCertsRespError, NUM_SLOTS_FOR_REWARD},
     crossbeam_channel::RecvError,
     entry::Entry,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_runtime::bank::Bank,
     std::{collections::BTreeMap, sync::Arc},
 };
@@ -24,20 +20,14 @@ pub(super) struct CertsBuilder {
     votes: BTreeMap<Slot, Entry>,
     /// Stores the latest pubkey for the current node.
     cluster_info: Arc<ClusterInfo>,
-    /// Stores the leader schedules.
-    leader_schedule: Arc<LeaderScheduleCache>,
 }
 
 impl CertsBuilder {
     /// Constructs a new instance of [`CertsBuilder`].
-    pub(super) fn new(
-        cluster_info: Arc<ClusterInfo>,
-        leader_schedule: Arc<LeaderScheduleCache>,
-    ) -> Self {
+    pub(super) fn new(cluster_info: Arc<ClusterInfo>) -> Self {
         Self {
             votes: BTreeMap::default(),
             cluster_info,
-            leader_schedule,
         }
     }
 
@@ -86,24 +76,16 @@ impl CertsBuilder {
     }
 
     /// Returns [`true`] if the rewards container is interested in this vote else [`false`].
-    fn wants_vote(&self, root_slot: Slot, vote: &VoteMessage) -> bool {
-        if !rewards_wants_vote(
-            &self.cluster_info,
-            &self.leader_schedule,
-            root_slot,
-            &vote.vote,
-        ) {
-            return false;
-        }
-        let Some(entry) = self.votes.get(&vote.vote.slot()) else {
+    fn wants_vote(&self, msg: &RewardVoteMessage) -> bool {
+        let Some(entry) = self.votes.get(&msg.vote.slot()) else {
             return true;
         };
-        entry.wants_vote(vote)
+        entry.wants_vote(msg)
     }
 
     /// Adds received [`VoteMessage`] from other validators.
-    pub(super) fn add_vote(&mut self, root_bank: &Bank, vote: &VoteMessage) {
-        let slot = vote.vote.slot();
+    pub(super) fn add_vote(&mut self, root_bank: &Bank, msg: RewardVoteMessage) {
+        let slot = msg.vote.slot();
         let Some(rank_map) = root_bank.get_rank_map(slot) else {
             warn!(
                 "failed to look up rank_map for slot {slot} using bank for slot {}",
@@ -120,18 +102,18 @@ impl CertsBuilder {
             .votes
             .split_off(&root_slot.saturating_sub(NUM_SLOTS_FOR_REWARD));
 
-        if !self.wants_vote(root_slot, vote) {
+        if !self.wants_vote(&msg) {
             return;
         }
         match self
             .votes
-            .entry(vote.vote.slot())
+            .entry(msg.vote.slot())
             .or_insert(Entry::new(max_validators))
-            .add_vote(rank_map, vote)
+            .add_vote(&msg)
         {
             Ok(()) => (),
             Err(e) => {
-                warn!("Adding vote {vote:?} failed with {e}");
+                warn!("Adding vote {msg:?} failed with {e}");
             }
         }
     }

--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -1,14 +1,12 @@
 use {
     super::BuildRewardCertsRespError,
     crate::block_creation_loop::rewards::msg_types::RewardRespSucc,
-    agave_votor_messages::{
-        consensus_message::VoteMessage, reward_certificate::SkipRewardCertificate, vote::Vote,
-    },
+    agave_bls_sigverify::rewards::{RewardVote, RewardVoteMessage},
+    agave_votor_messages::reward_certificate::SkipRewardCertificate,
     notar_entry::NotarEntry,
     partial_cert::{BuildSigBitmapError, PartialCert},
     solana_bls_signatures::BlsError,
     solana_clock::Slot,
-    solana_runtime::epoch_stakes::BLSPubkeyToRankMap,
     thiserror::Error,
 };
 
@@ -48,33 +46,21 @@ impl Entry {
     }
 
     /// Returns true if the [`Entry`] needs the vote else false.
-    pub(super) fn wants_vote(&self, vote: &VoteMessage) -> bool {
-        match vote.vote {
-            Vote::Skip(_) => self.skip.wants_vote(vote.rank),
-            Vote::Notarize(_) => self.notar.wants_vote(vote.rank),
-            Vote::Finalize(_)
-            | Vote::NotarizeFallback(_)
-            | Vote::SkipFallback(_)
-            | Vote::Genesis(_) => false,
+    pub(super) fn wants_vote(&self, msg: &RewardVoteMessage) -> bool {
+        match msg.vote {
+            RewardVote::Skip(_) => self.skip.wants_vote(msg.rank),
+            RewardVote::Notar(_) => self.notar.wants_vote(msg.rank),
         }
     }
 
     /// Adds the given [`VoteMessage`] to the aggregate.
-    pub(super) fn add_vote(
-        &mut self,
-        rank_map: &BLSPubkeyToRankMap,
-        vote: &VoteMessage,
-    ) -> Result<(), AddVoteError> {
-        match vote.vote {
-            Vote::Notarize(notar) => self.notar.add_vote(
-                rank_map,
-                vote.rank,
-                &vote.signature,
-                notar.block.block_id,
-                self.max_validators,
-            ),
-            Vote::Skip(_) => self.skip.add_vote(rank_map, vote.rank, &vote.signature),
-            _ => Ok(()),
+    pub(super) fn add_vote(&mut self, msg: &RewardVoteMessage) -> Result<(), AddVoteError> {
+        match &msg.vote {
+            RewardVote::Notar(notar) => {
+                self.notar
+                    .add_vote(msg, notar.block.block_id, self.max_validators)
+            }
+            RewardVote::Skip(_) => self.skip.add_vote(msg),
         }
     }
 
@@ -120,11 +106,14 @@ impl Entry {
 mod tests {
     use {
         super::*,
-        agave_votor_messages::{consensus_message::Block, wire::get_vote_payload_to_sign},
+        agave_votor_messages::{
+            consensus_message::Block, vote::Vote, wire::get_vote_payload_to_sign,
+        },
         rand::Rng,
         solana_bls_signatures::{Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed},
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
+        solana_pubkey::Pubkey,
         solana_runtime::{
             bank::{Bank, SlotLeader},
             genesis_utils::{
@@ -132,7 +121,7 @@ mod tests {
             },
         },
         solana_signer_store::{Decoded, decode},
-        std::{collections::HashMap, sync::Arc},
+        std::{collections::HashMap, num::NonZero},
     };
 
     pub(crate) fn validate_bitmap(bitmap: &[u8], num_set: usize, max_len: usize) {
@@ -143,32 +132,38 @@ mod tests {
         }
     }
 
-    pub(crate) fn new_vote(
+    pub(crate) fn new_reward_vote_msg(
         vote: Vote,
         rank: usize,
         keypairs: &[BlsKeypair],
+        stakes: Option<&[u64]>,
         shred_version: u16,
-    ) -> VoteMessage {
+    ) -> RewardVoteMessage {
         let serialized = get_vote_payload_to_sign(vote, shred_version);
         let signature = keypairs[rank].sign(&serialized).into();
-        VoteMessage {
+        let vote = match vote {
+            Vote::Notarize(notar) => RewardVote::Notar(notar),
+            Vote::Skip(skip) => RewardVote::Skip(skip),
+            rest => panic!("unexpect vote: {rest:?}"),
+        };
+        let stake = match stakes {
+            None => NonZero::new(123).unwrap(),
+            Some(stakes) => NonZero::new(stakes[rank]).unwrap(),
+        };
+        RewardVoteMessage {
             vote,
             signature,
             rank: rank.try_into().unwrap(),
+            stake,
+            vote_account_pubkey: Pubkey::new_unique(),
         }
     }
 
-    pub(crate) fn get_rank_map_keypairs(
-        max_validators: usize,
-        slot: Slot,
-    ) -> (Arc<BLSPubkeyToRankMap>, Vec<BlsKeypair>) {
-        get_rank_map_keypairs_with_stakes(vec![100; max_validators], slot)
+    pub(crate) fn get_keypairs(max_validators: usize, slot: Slot) -> Vec<BlsKeypair> {
+        get_keypair_with_stakes(vec![100; max_validators], slot)
     }
 
-    pub(crate) fn get_rank_map_keypairs_with_stakes(
-        stakes: Vec<u64>,
-        slot: Slot,
-    ) -> (Arc<BLSPubkeyToRankMap>, Vec<BlsKeypair>) {
+    pub(crate) fn get_keypair_with_stakes(stakes: Vec<u64>, slot: Slot) -> Vec<BlsKeypair> {
         let max_validators = stakes.len();
         let validator_keypairs = (0..max_validators)
             .map(|_| ValidatorVoteKeypairs::new_rand())
@@ -198,7 +193,7 @@ mod tests {
             slot,
         );
         let rank_map = bank.get_rank_map(slot).unwrap().clone();
-        let signing_keys = (0..max_validators)
+        (0..max_validators)
             .map(|index| {
                 let pubkey_affine = rank_map.get_pubkey_stake_entry(index).unwrap().bls_pubkey;
                 keypair_map
@@ -206,15 +201,14 @@ mod tests {
                     .unwrap()
                     .clone()
             })
-            .collect::<Vec<_>>();
-        (rank_map, signing_keys)
+            .collect()
     }
 
     #[test]
     fn validate_build_skip_cert() {
         let slot = 123;
         let max_validators = 5;
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
         let shred_version = rand::rng().random();
         let mut entry = Entry::new(max_validators);
         let resp = entry.clone().build_certs(slot).unwrap();
@@ -222,8 +216,8 @@ mod tests {
         assert_eq!(resp.notar, None);
 
         let skip = Vote::new_skip_vote(7);
-        let vote = new_vote(skip, 0, &keypairs, shred_version);
-        entry.add_vote(&rank_map, &vote).unwrap();
+        let vote = new_reward_vote_msg(skip, 0, &keypairs, None, shred_version);
+        entry.add_vote(&vote).unwrap();
         let resp = entry.build_certs(slot).unwrap();
         assert_eq!(resp.notar, None);
         let skip = resp.skip.unwrap();
@@ -236,7 +230,7 @@ mod tests {
         let slot = 123;
         let max_validators = 5;
         let shred_version = rand::rng().random();
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
 
         let mut entry = Entry::new(max_validators);
         let resp = entry.clone().build_certs(slot).unwrap();
@@ -251,16 +245,16 @@ mod tests {
                 slot,
                 block_id: blockid0,
             });
-            let vote = new_vote(notar, rank, &keypairs, shred_version);
-            entry.add_vote(&rank_map, &vote).unwrap();
+            let vote = new_reward_vote_msg(notar, rank, &keypairs, None, shred_version);
+            entry.add_vote(&vote).unwrap();
         }
         for rank in 2..5 {
             let notar = Vote::new_notarization_vote(Block {
                 slot,
                 block_id: blockid1,
             });
-            let vote = new_vote(notar, rank, &keypairs, shred_version);
-            entry.add_vote(&rank_map, &vote).unwrap();
+            let vote = new_reward_vote_msg(notar, rank, &keypairs, None, shred_version);
+            entry.add_vote(&vote).unwrap();
         }
         let resp = entry.build_certs(slot).unwrap();
         assert_eq!(resp.skip, None);

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -3,12 +3,11 @@
 
 use {
     super::{AddVoteError, BuildSigBitmapError, partial_cert::PartialCert},
+    agave_bls_sigverify::rewards::RewardVoteMessage,
     agave_votor_messages::reward_certificate::{BuildRewardCertsRespError, NotarRewardCertificate},
-    solana_bls_signatures::Signature as BLSSignature,
     solana_clock::Slot,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::BLSPubkeyToRankMap,
     std::collections::{HashMap, HashSet},
 };
 
@@ -40,22 +39,20 @@ impl NotarEntry {
     /// Adds a new observed vote to the aggregate.
     pub(super) fn add_vote(
         &mut self,
-        rank_map: &BLSPubkeyToRankMap,
-        rank: u16,
-        signature: &BLSSignature,
+        msg: &RewardVoteMessage,
         block_id: Hash,
         max_validators: usize,
     ) -> Result<(), AddVoteError> {
-        if !self.voted.insert(rank) {
+        if !self.voted.insert(msg.rank) {
             return Err(AddVoteError::Duplicate);
         }
         let partial = self
             .partials
             .entry(block_id)
             .or_insert(PartialCert::new(max_validators));
-        let res = partial.add_vote(rank_map, rank, signature);
+        let res = partial.add_vote(msg);
         if res.is_err() {
-            self.voted.remove(&rank);
+            self.voted.remove(&msg.rank);
         }
         res
     }
@@ -93,15 +90,17 @@ mod tests {
     use {
         super::*,
         crate::block_creation_loop::rewards::certs_builder::entry::tests::{
-            get_rank_map_keypairs, get_rank_map_keypairs_with_stakes, new_vote, validate_bitmap,
+            get_keypair_with_stakes, get_keypairs, new_reward_vote_msg, validate_bitmap,
         },
+        agave_bls_sigverify::rewards::RewardVote,
         agave_votor_messages::{
-            consensus_message::{Block, VoteMessage},
-            vote::Vote,
+            consensus_message::Block,
+            vote::{NotarizationVote, Vote},
         },
         rand::Rng,
-        solana_bls_signatures::signature::BLS_SIGNATURE_AFFINE_SIZE,
+        solana_bls_signatures::{Signature as BLSSignature, signature::BLS_SIGNATURE_AFFINE_SIZE},
         solana_hash::Hash,
+        std::num::NonZero,
     };
 
     #[test]
@@ -109,48 +108,40 @@ mod tests {
         let slot = 123;
         let max_validators = 5;
         let shred_version = rand::rng().random();
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
         let rank = 0;
         let mut entry = NotarEntry::new(max_validators);
 
         let blockid0 = Hash::new_unique();
-        let notar = Vote::new_notarization_vote(Block {
+        let block = Block {
             slot,
             block_id: blockid0,
+        };
+        let notar_vote = Vote::new_notarization_vote(block);
+        let notar_reward_vote = RewardVote::Notar(NotarizationVote {
+            block: Block {
+                slot,
+                block_id: blockid0,
+            },
         });
-        let invalid_vote = VoteMessage {
-            vote: notar,
+        let invalid_reward_vote_msg = RewardVoteMessage {
+            vote: notar_reward_vote,
             signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
             rank,
+            stake: NonZero::new(1234).unwrap(),
+            vote_account_pubkey: Pubkey::new_unique(),
         };
         entry
-            .add_vote(
-                &rank_map,
-                invalid_vote.rank,
-                &invalid_vote.signature,
-                blockid0,
-                max_validators,
-            )
+            .add_vote(&invalid_reward_vote_msg, blockid0, max_validators)
             .unwrap_err();
 
-        let vote = new_vote(notar, rank as usize, &keypairs, shred_version);
+        let reward_vote_msg =
+            new_reward_vote_msg(notar_vote, rank as usize, &keypairs, None, shred_version);
         entry
-            .add_vote(
-                &rank_map,
-                vote.rank,
-                &vote.signature,
-                blockid0,
-                max_validators,
-            )
+            .add_vote(&reward_vote_msg, blockid0, max_validators)
             .unwrap();
         let err = entry
-            .add_vote(
-                &rank_map,
-                vote.rank,
-                &vote.signature,
-                blockid0,
-                max_validators,
-            )
+            .add_vote(&reward_vote_msg, blockid0, max_validators)
             .unwrap_err();
         assert!(matches!(err, AddVoteError::Duplicate));
     }
@@ -159,8 +150,8 @@ mod tests {
     fn validate_build_cert() {
         let slot = 123;
         let max_validators = 5;
-        let (rank_map, keypairs) =
-            get_rank_map_keypairs_with_stakes(vec![1_000, 900, 10, 10, 10], slot);
+        let stakes = vec![1_000, 900, 10, 10, 10];
+        let keypairs = get_keypair_with_stakes(stakes.clone(), slot);
         let shred_version = rand::rng().random();
 
         let mut entry = NotarEntry::new(max_validators);
@@ -174,15 +165,10 @@ mod tests {
                 slot,
                 block_id: blockid0,
             });
-            let vote = new_vote(notar, rank, &keypairs, shred_version);
+            let reward_vote_msg =
+                new_reward_vote_msg(notar, rank, &keypairs, Some(&stakes), shred_version);
             entry
-                .add_vote(
-                    &rank_map,
-                    vote.rank,
-                    &vote.signature,
-                    blockid0,
-                    max_validators,
-                )
+                .add_vote(&reward_vote_msg, blockid0, max_validators)
                 .unwrap();
         }
         for rank in 2..5 {
@@ -190,15 +176,10 @@ mod tests {
                 slot,
                 block_id: blockid1,
             });
-            let vote = new_vote(notar, rank, &keypairs, shred_version);
+            let reward_vote_msg =
+                new_reward_vote_msg(notar, rank, &keypairs, Some(&stakes), shred_version);
             entry
-                .add_vote(
-                    &rank_map,
-                    vote.rank,
-                    &vote.signature,
-                    blockid1,
-                    max_validators,
-                )
+                .add_vote(&reward_vote_msg, blockid1, max_validators)
                 .unwrap();
         }
         let (notar_cert, _) = entry.build_cert(slot).unwrap().unwrap();

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -1,12 +1,12 @@
 use {
     super::AddVoteError,
+    agave_bls_sigverify::rewards::RewardVoteMessage,
     bitvec::{order::Lsb0, vec::BitVec},
     solana_bls_signatures::{
         Signature as BLSSignature, SignatureCompressed as BLSSignatureCompressed,
         SignatureProjective,
     },
     solana_pubkey::Pubkey,
-    solana_runtime::epoch_stakes::BLSPubkeyToRankMap,
     solana_signer_store::{EncodeError, encode_base2},
     thiserror::Error,
 };
@@ -52,24 +52,17 @@ impl PartialCert {
     }
 
     /// Adds a new observed vote to the aggregate.
-    pub(super) fn add_vote(
-        &mut self,
-        rank_map: &BLSPubkeyToRankMap,
-        rank: u16,
-        signature: &BLSSignature,
-    ) -> Result<(), AddVoteError> {
-        match self.bitvec.get_mut(rank as usize) {
+    pub(super) fn add_vote(&mut self, msg: &RewardVoteMessage) -> Result<(), AddVoteError> {
+        match self.bitvec.get_mut(msg.rank as usize) {
             None => return Err(AddVoteError::InvalidRank),
             Some(mut ind) => {
                 if *ind {
                     return Err(AddVoteError::Duplicate);
                 }
-                let entry = rank_map
-                    .get_pubkey_stake_entry(rank.into())
-                    .ok_or(AddVoteError::InvalidRank)?;
-                self.signature.aggregate_with(std::iter::once(signature))?;
-                self.validators.push(entry.vote_account_pubkey);
-                self.stake = self.stake.saturating_add(entry.stake.get());
+                self.signature
+                    .aggregate_with(std::iter::once(&msg.signature))?;
+                self.validators.push(msg.vote_account_pubkey);
+                self.stake = self.stake.saturating_add(msg.stake.get());
                 *ind = true;
             }
         }
@@ -104,13 +97,17 @@ mod tests {
     use {
         super::*,
         crate::block_creation_loop::rewards::certs_builder::entry::tests::{
-            get_rank_map_keypairs, new_vote, validate_bitmap,
+            get_keypairs, new_reward_vote_msg, validate_bitmap,
         },
+        agave_bls_sigverify::rewards::RewardVote,
         agave_votor_messages::{
-            consensus_message::VoteMessage, vote::Vote, wire::get_vote_payload_to_sign,
+            consensus_message::VoteMessage,
+            vote::{SkipVote, Vote},
+            wire::get_vote_payload_to_sign,
         },
         rand::Rng,
-        solana_bls_signatures::Keypair as BlsKeypair,
+        solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Keypair as BlsKeypair},
+        std::num::NonZero,
     };
 
     fn new_invalid_vote(vote: Vote, rank: usize) -> VoteMessage {
@@ -129,7 +126,7 @@ mod tests {
         let slot = 123;
         let max_validators = 2;
         let shred_version = rand::rng().random();
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
         let mut partial_cert = PartialCert::new(max_validators);
         assert!(matches!(
             partial_cert.clone().build_sig_bitmap(),
@@ -137,10 +134,8 @@ mod tests {
         ));
         let skip = Vote::new_skip_vote(slot);
         for rank in 0..max_validators {
-            let vote = new_vote(skip, rank, &keypairs, shred_version);
-            partial_cert
-                .add_vote(&rank_map, vote.rank, &vote.signature)
-                .unwrap();
+            let reward_vote_msg = new_reward_vote_msg(skip, rank, &keypairs, None, shred_version);
+            partial_cert.add_vote(&reward_vote_msg).unwrap();
             let (_signature, bitmap, _) = partial_cert.clone().build_sig_bitmap().unwrap();
             validate_bitmap(&bitmap, rank + 1, max_validators);
         }
@@ -151,29 +146,32 @@ mod tests {
         let slot = 123;
         let max_validators = 2;
         let shred_version = rand::rng().random();
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
         let mut partial_cert = PartialCert::new(max_validators);
+        let reward_vote = RewardVote::Skip(SkipVote { slot });
+        let invalid_reward_vote_msg = RewardVoteMessage {
+            vote: reward_vote,
+            signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            rank: 2,
+            stake: NonZero::new(1234).unwrap(),
+            vote_account_pubkey: Pubkey::new_unique(),
+        };
         let skip = Vote::new_skip_vote(slot);
-        let vote = new_invalid_vote(skip, 2);
         assert!(matches!(
-            partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
+            partial_cert.add_vote(&invalid_reward_vote_msg),
             Err(AddVoteError::InvalidRank)
         ));
-        let vote = new_vote(skip, 0, &keypairs, shred_version);
-        partial_cert
-            .add_vote(&rank_map, vote.rank, &vote.signature)
-            .unwrap();
+        let reward_vote_msg = new_reward_vote_msg(skip, 0, &keypairs, None, shred_version);
+        partial_cert.add_vote(&reward_vote_msg).unwrap();
         assert!(matches!(
-            partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
+            partial_cert.add_vote(&reward_vote_msg),
             Err(AddVoteError::Duplicate)
         ));
-        let vote = new_vote(skip, 1, &keypairs, shred_version);
-        partial_cert
-            .add_vote(&rank_map, vote.rank, &vote.signature)
-            .unwrap();
-        let vote = new_vote(skip, 0, &keypairs, shred_version);
+        let reward_vote_msg = new_reward_vote_msg(skip, 1, &keypairs, None, shred_version);
+        partial_cert.add_vote(&reward_vote_msg).unwrap();
+        let reward_vote_msg = new_reward_vote_msg(skip, 0, &keypairs, None, shred_version);
         assert!(matches!(
-            partial_cert.add_vote(&rank_map, vote.rank, &vote.signature),
+            partial_cert.add_vote(&reward_vote_msg),
             Err(AddVoteError::Duplicate)
         ));
     }
@@ -183,21 +181,17 @@ mod tests {
         let slot = 123;
         let max_validators = 2;
         let shred_version = rand::rng().random();
-        let (rank_map, keypairs) = get_rank_map_keypairs(max_validators, slot);
+        let keypairs = get_keypairs(max_validators, slot);
         let skip = Vote::new_skip_vote(slot);
         let mut partial_cert = PartialCert::new(max_validators);
         let vote = new_invalid_vote(skip, 2);
         assert!(!partial_cert.wants_vote(vote.rank));
-        let vote = new_vote(skip, 0, &keypairs, shred_version);
-        assert!(partial_cert.wants_vote(vote.rank));
-        partial_cert
-            .add_vote(&rank_map, vote.rank, &vote.signature)
-            .unwrap();
-        assert!(!partial_cert.wants_vote(vote.rank));
-        let vote = new_vote(skip, 1, &keypairs, shred_version);
-        partial_cert
-            .add_vote(&rank_map, vote.rank, &vote.signature)
-            .unwrap();
-        assert!(!partial_cert.wants_vote(vote.rank));
+        let reward_vote_msg = new_reward_vote_msg(skip, 0, &keypairs, None, shred_version);
+        assert!(partial_cert.wants_vote(reward_vote_msg.rank));
+        partial_cert.add_vote(&reward_vote_msg).unwrap();
+        assert!(!partial_cert.wants_vote(reward_vote_msg.rank));
+        let reward_vote_msg = new_reward_vote_msg(skip, 1, &keypairs, None, shred_version);
+        partial_cert.add_vote(&reward_vote_msg).unwrap();
+        assert!(!partial_cert.wants_vote(reward_vote_msg.rank));
     }
 }

--- a/core/src/block_creation_loop/rewards/reward_certs_service.rs
+++ b/core/src/block_creation_loop/rewards/reward_certs_service.rs
@@ -5,10 +5,9 @@ use {
         },
         tvu::MAX_ALPENGLOW_PACKET_NUM,
     },
-    agave_votor_messages::reward_certificate::AddVoteMessage,
+    agave_bls_sigverify::rewards::RewardVoteMessage,
     crossbeam_channel::{Receiver, Sender, bounded, select_biased},
     solana_gossip::cluster_info::ClusterInfo,
-    solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_runtime::bank_forks::SharableBanks,
     std::{
         sync::{
@@ -27,13 +26,12 @@ pub(crate) struct RewardCertsService {
 impl RewardCertsService {
     pub(crate) fn new(
         cluster_info: Arc<ClusterInfo>,
-        leader_schedule: Arc<LeaderScheduleCache>,
         sharable_banks: SharableBanks,
         exit: Arc<AtomicBool>,
-    ) -> (Self, CertsRequestor, Sender<AddVoteMessage>) {
+    ) -> (Self, CertsRequestor, Sender<Vec<RewardVoteMessage>>) {
         let (votes_sender, votes_receiver) = bounded(MAX_ALPENGLOW_PACKET_NUM);
         let (certs_requestor, req_receiver) = CertsRequestor::new();
-        let builder = CertsBuilder::new(cluster_info.clone(), leader_schedule);
+        let builder = CertsBuilder::new(cluster_info.clone());
         let ctx = Context::new(
             exit,
             cluster_info,
@@ -59,7 +57,7 @@ impl RewardCertsService {
 struct Context {
     exit: Arc<AtomicBool>,
     cluster_info: Arc<ClusterInfo>,
-    votes_receiver: Receiver<AddVoteMessage>,
+    votes_receiver: Receiver<Vec<RewardVoteMessage>>,
     req_receiver: Receiver<RewardRequest>,
     sharable_banks: SharableBanks,
     builder: CertsBuilder,
@@ -69,7 +67,7 @@ impl Context {
     fn new(
         exit: Arc<AtomicBool>,
         cluster_info: Arc<ClusterInfo>,
-        votes_receiver: Receiver<AddVoteMessage>,
+        votes_receiver: Receiver<Vec<RewardVoteMessage>>,
         req_receiver: Receiver<RewardRequest>,
         sharable_banks: SharableBanks,
         builder: CertsBuilder,
@@ -98,8 +96,8 @@ impl Context {
                     match msg {
                         Ok(msg) => {
                             let bank = self.sharable_banks.root();
-                            for vote in msg.votes {
-                                self.builder.add_vote(&bank, &vote);
+                            for vote in msg {
+                                self.builder.add_vote(&bank, vote);
                             }
                         }
                         Err(_) => {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1782,7 +1782,7 @@ impl ReplayStage {
             None,
             &mut HashMap::new(),
         ) {
-            GenerateVoteTxResult::Vote(vote_msg) => {
+            GenerateVoteTxResult::Vote(vote_msg, _, _) => {
                 // Send vote to ConsensusPool and rest of cluster
                 warn!(
                     "{} Alpenglow migration: Casting genesis vote for ({block:?})",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -29,6 +29,7 @@ use {
     agave_bls_sigverify::{
         bls_sigverifier::{self, SigVerifierChannels, SigVerifierContext},
         generated_cert_types::GeneratedCertTypes,
+        rewards::RewardVoteMessage,
     },
     agave_votor::{
         event::{LatestSwitchRequest, LeaderWindowInfo, VotorEventReceiver, VotorEventSender},
@@ -41,7 +42,7 @@ use {
     },
     agave_votor_messages::{
         VerifiedVoterSlotsReceiver, VerifiedVoterSlotsSender, consensus_message::Block,
-        metric_types::MAX_IN_FLIGHT_CONSENSUS_EVENTS, reward_certificate::AddVoteMessage,
+        metric_types::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
     },
     crossbeam_channel::{Receiver, Sender, bounded, unbounded},
     solana_client::connection_cache::ConnectionCache,
@@ -252,7 +253,7 @@ impl Tvu {
         slot_status_notifier: Option<SlotStatusNotifier>,
         vote_connection_cache: Arc<ConnectionCache>,
         votor_init: AlpenglowInitializationState,
-        reward_votes_sender: Sender<AddVoteMessage>,
+        reward_votes_sender: Sender<Vec<RewardVoteMessage>>,
     ) -> Result<Self, String> {
         let migration_status = bank_forks.read().unwrap().migration_status();
 

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -1,7 +1,6 @@
 //! Defines aggregates used for vote rewards.
 
 use {
-    crate::consensus_message::VoteMessage,
     solana_bls_signatures::SignatureCompressed as BLSSignatureCompressed,
     solana_clock::Slot,
     solana_hash::Hash,
@@ -125,11 +124,4 @@ pub enum BuildRewardCertsRespError {
     /// Experienced failure with encoding.
     #[error("encode error {0:?}")]
     Encode(EncodeError),
-}
-
-/// Message to add votes to the rewards container.
-#[derive(Debug)]
-pub struct AddVoteMessage {
-    /// List of [`VoteMessage`]s.
-    pub votes: Vec<VoteMessage>,
 }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -969,10 +969,10 @@ mod tests {
             },
             voting_service::BLSOp,
         },
+        agave_bls_sigverify::rewards::RewardVoteMessage,
         agave_votor_messages::{
             consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
             metric_types::ConsensusMetricsEventReceiver,
-            reward_certificate::AddVoteMessage,
             sig_verified_messages::SigVerifiedBatch,
             vote::Vote,
             wire::get_vote_payload_to_sign,
@@ -1013,7 +1013,7 @@ mod tests {
         commitment_receiver: Receiver<CommitmentAggregationData>,
         own_vote_receiver: Receiver<SigVerifiedBatch>,
         #[allow(dead_code)] // Keep receiver alive to prevent SenderDisconnected errors
-        reward_votes_receiver: Receiver<AddVoteMessage>,
+        reward_votes_receiver: Receiver<Vec<RewardVoteMessage>>,
         bank_forks: Arc<RwLock<BankForks>>,
         my_bls_keypair: BLSKeypair,
         timer_manager: Arc<PlRwLock<TimerManager>>,
@@ -1138,7 +1138,7 @@ mod tests {
             my_pubkey: my_node_keypair.pubkey(),
             bank_forks: bank_forks.clone(),
             blockstore: blockstore.clone(),
-            leader_schedule_cache,
+            leader_schedule_cache: leader_schedule_cache.clone(),
             drop_bank_sender: drop_bank_sender.clone(),
         });
         let highest_parent_ready = Arc::new(RwLock::default());
@@ -1174,6 +1174,7 @@ mod tests {
             own_vote_sender,
             reward_votes_sender,
             consensus_metrics_sender,
+            leader_schedule: leader_schedule_cache,
         };
 
         let root_context = RootContext {

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -5,10 +5,10 @@ use {
         vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions, VoteHistoryStorage},
         voting_service::BLSOp,
     },
+    agave_bls_sigverify::rewards::RewardVoteMessage,
     agave_votor_messages::{
         consensus_message::{BLS_KEYPAIR_DERIVE_SEED, VoteMessage},
         metric_types::ConsensusMetricsEventSender,
-        reward_certificate::AddVoteMessage,
         sig_verified_messages::SigVerifiedBatch,
         vote::Vote,
         wire::get_vote_payload_to_sign,
@@ -18,12 +18,14 @@ use {
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
+    solana_ledger::leader_schedule_cache::LeaderScheduleCache,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, bank_forks::SharableBanks, epoch_stakes::BLSPubkeyStakeEntry},
     solana_signer::Signer,
     solana_transaction::Transaction,
     std::{
         collections::{HashMap, hash_map::Entry},
+        num::NonZero,
         sync::{Arc, RwLock},
     },
     thiserror::Error,
@@ -58,7 +60,7 @@ pub enum GenerateVoteTxResult {
     // Generated a vote transaction
     Tx(Transaction),
     // Generated a VoteMessage
-    Vote(VoteMessage),
+    Vote(VoteMessage, NonZero<u64>, Pubkey),
 }
 
 impl GenerateVoteTxResult {
@@ -78,7 +80,7 @@ impl GenerateVoteTxResult {
             | Self::WaitForStartupVerification
             | Self::WaitToVoteSlot(_)
             | Self::NoRankFound => false,
-            Self::Tx(_) | Self::Vote(_) => false,
+            Self::Tx(_) | Self::Vote(_, _, _) => false,
         }
     }
 
@@ -90,7 +92,7 @@ impl GenerateVoteTxResult {
             | Self::WaitForStartupVerification
             | Self::WaitToVoteSlot(_)
             | Self::NoRankFound => true,
-            Self::Tx(_) | Self::Vote(_) => false,
+            Self::Tx(_) | Self::Vote(_, _, _) => false,
         }
     }
 }
@@ -119,6 +121,7 @@ pub enum VoteError {
 /// Context required to construct vote transactions
 pub struct VotingContext {
     pub cluster_info: Arc<ClusterInfo>,
+    pub leader_schedule: Arc<LeaderScheduleCache>,
     pub vote_history: VoteHistory,
     pub vote_account_pubkey: Pubkey,
     pub identity_keypair: Arc<Keypair>,
@@ -127,7 +130,7 @@ pub struct VotingContext {
     // The BLS keypair should always change with authorized_voter_keypairs.
     pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
     pub own_vote_sender: Sender<SigVerifiedBatch>,
-    pub reward_votes_sender: Sender<AddVoteMessage>,
+    pub reward_votes_sender: Sender<Vec<RewardVoteMessage>>,
     pub bls_sender: Sender<BLSOp>,
     pub commitment_sender: Sender<CommitmentAggregationData>,
     pub wait_to_vote_slot: Option<u64>,
@@ -186,7 +189,7 @@ pub fn generate_vote_tx(
         vote_account_pubkey: expected_vote_pubkey,
         node_pubkey: expected_node_pubkey,
         bls_pubkey: expected_bls_pubkey,
-        stake: _,
+        stake,
     } = rank_map
         .get_pubkey_stake_entry(my_rank as usize)
         .expect("rank-map index should be valid");
@@ -227,11 +230,15 @@ pub fn generate_vote_tx(
     };
 
     let vote_payload_to_sign = get_vote_payload_to_sign(vote, shred_version);
-    GenerateVoteTxResult::Vote(VoteMessage {
-        vote,
-        signature: bls_keypair.sign(&vote_payload_to_sign).into(),
-        rank: my_rank,
-    })
+    GenerateVoteTxResult::Vote(
+        VoteMessage {
+            vote,
+            signature: bls_keypair.sign(&vote_payload_to_sign).into(),
+            rank: my_rank,
+        },
+        *stake,
+        *expected_vote_pubkey,
+    )
 }
 
 /// Creates a vote message from `vote`, respecting `context.wait_to_vote_slot` only if `respect_wait_to_vote` is true
@@ -239,7 +246,7 @@ fn create_vote_message(
     vote: Vote,
     context: &mut VotingContext,
     respect_wait_to_vote: bool,
-) -> Result<VoteMessage, VoteError> {
+) -> Result<(VoteMessage, NonZero<u64>, Pubkey), VoteError> {
     let bank = context.sharable_banks.root();
     let wait_to_vote_slot = if respect_wait_to_vote {
         context.wait_to_vote_slot
@@ -256,7 +263,9 @@ fn create_vote_message(
         wait_to_vote_slot,
         &mut context.derived_bls_keypairs,
     ) {
-        GenerateVoteTxResult::Vote(vote) => Ok(vote),
+        GenerateVoteTxResult::Vote(vote, stake, vote_account_pubkey) => {
+            Ok((vote, stake, vote_account_pubkey))
+        }
         e => {
             if e.is_transient_error() {
                 Err(VoteError::TransientError(Box::new(e)))
@@ -318,28 +327,37 @@ pub(crate) fn create_and_send_own_vote_message(
     context: &mut VotingContext,
     respect_wait_to_vote: bool,
 ) -> Result<Option<VoteMessage>, VoteError> {
-    let vote_msg = match create_vote_message(vote, context, respect_wait_to_vote) {
-        Ok(vote_msg) => vote_msg,
-        Err(e) => {
-            handle_skippable_vote_error(e, "generate vote message")?;
-            return Ok(None);
-        }
-    };
+    let (vote_msg, stake, vote_account_pubkey) =
+        match create_vote_message(vote, context, respect_wait_to_vote) {
+            Ok(vote_msg) => vote_msg,
+            Err(e) => {
+                handle_skippable_vote_error(e, "generate vote message")?;
+                return Ok(None);
+            }
+        };
 
     context
         .own_vote_sender
         .send(SigVerifiedBatch::Votes(vec![vote_msg.clone()]))
         .map_err(|_| SendError(()))?;
 
-    match context.reward_votes_sender.try_send(AddVoteMessage {
-        votes: vec![vote_msg.clone()],
-    }) {
-        Ok(()) => (),
-        Err(TrySendError::Full(_)) => {
-            warn!("Reward votes channel is full, dropping own vote {vote:?}");
-        }
-        Err(TrySendError::Disconnected(_)) => {
-            return Err(VoteError::RewardsChannelDisconnected);
+    let root_slot = context.sharable_banks.root().slot();
+    if let Some(reward_vote_msg) = RewardVoteMessage::try_new(
+        &context.cluster_info,
+        &context.leader_schedule,
+        root_slot,
+        &vote_msg,
+        stake,
+        vote_account_pubkey,
+    ) {
+        match context.reward_votes_sender.try_send(vec![reward_vote_msg]) {
+            Ok(()) => (),
+            Err(TrySendError::Full(_)) => {
+                warn!("Reward votes channel is full, dropping own vote {vote:?}");
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                return Err(VoteError::RewardsChannelDisconnected);
+            }
         }
     }
 
@@ -351,7 +369,7 @@ pub fn generate_refresh_vote_message(
     vctx: &mut VotingContext,
 ) -> Result<Option<VoteMessage>, VoteError> {
     match create_vote_message(vote, vctx, /* respect_wait_to_vote */ true) {
-        Ok(vote_msg) => Ok(Some(vote_msg)),
+        Ok((vote_msg, _, _)) => Ok(Some(vote_msg)),
         Err(e) => {
             handle_skippable_vote_error(e, "generate refresh vote message")?;
             Ok(None)
@@ -398,7 +416,7 @@ mod tests {
         own_vote_sender: Sender<SigVerifiedBatch>,
         validator_keypairs: &[ValidatorVoteKeypairs],
         my_index: usize,
-    ) -> (VotingContext, Receiver<AddVoteMessage>) {
+    ) -> (VotingContext, Receiver<Vec<RewardVoteMessage>>) {
         let (voting_context, _, reward_votes_receiver) =
             setup_voting_context_and_bank_forks_with_forks(
                 own_vote_sender,
@@ -415,7 +433,7 @@ mod tests {
     ) -> (
         VotingContext,
         Arc<RwLock<BankForks>>,
-        Receiver<AddVoteMessage>,
+        Receiver<Vec<RewardVoteMessage>>,
     ) {
         // Can't have stake of 0, so start at 1 and go to 10. In descending order, so 0 has largest stake.
         let stakes: Vec<u64> = (1u64..=10).rev().map(|x| x.saturating_mul(100)).collect();
@@ -435,6 +453,7 @@ mod tests {
             SocketAddrSpace::Unspecified,
         ));
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+        let leader_schedule = Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
         let bls_sender = bounded(1024).0;
         let commitment_sender = bounded(1024).0;
         let consensus_metrics_sender = bounded(1024).0;
@@ -456,6 +475,7 @@ mod tests {
             wait_to_vote_slot: None,
             sharable_banks,
             consensus_metrics_sender,
+            leader_schedule,
         };
         (voting_context, bank_forks, reward_votes_receiver)
     }
@@ -504,10 +524,10 @@ mod tests {
         );
 
         // Check that the reward service receives the vote.
-        assert_eq!(
-            reward_votes_receiver.recv().unwrap().votes,
-            vec![expected_message.clone()]
-        );
+        let reward_votes = reward_votes_receiver.recv().unwrap();
+        assert_eq!(reward_votes.len(), 1);
+        let received_vote_msg = VoteMessage::from(reward_votes[0].clone());
+        assert_eq!(received_vote_msg, expected_message);
 
         let refresh_vote = Vote::new_notarization_vote(Block {
             slot: vote_slot,

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -60,11 +60,10 @@ use {
         voting_service::BLSOp,
         voting_utils::VotingContext,
     },
-    agave_bls_sigverify::generated_cert_types::GeneratedCertTypes,
+    agave_bls_sigverify::{generated_cert_types::GeneratedCertTypes, rewards::RewardVoteMessage},
     agave_votor_messages::{
         consensus_message::Block,
         metric_types::{ConsensusMetricsEventReceiver, ConsensusMetricsEventSender},
-        reward_certificate::AddVoteMessage,
         sig_verified_messages::SigVerifiedBatch,
     },
     crossbeam_channel::{Receiver, Sender},
@@ -115,7 +114,7 @@ pub struct VotorConfig {
     pub highest_parent_ready: Arc<RwLock<(Slot, Block)>>,
     pub event_sender: VotorEventSender,
     pub own_vote_sender: Sender<SigVerifiedBatch>,
-    pub reward_votes_sender: Sender<AddVoteMessage>,
+    pub reward_votes_sender: Sender<Vec<RewardVoteMessage>>,
     pub repair_event_sender: RepairEventSender,
     pub latest_switch_request: LatestSwitchRequest,
 
@@ -198,6 +197,7 @@ impl Votor {
 
         let voting_context = VotingContext {
             cluster_info: cluster_info.clone(),
+            leader_schedule: leader_schedule_cache.clone(),
             vote_history,
             vote_account_pubkey: vote_account,
             identity_keypair,


### PR DESCRIPTION
#### Problem

We are sending the "generic" `VoteMessage` to the rewards container.  This is causing the rewards container to look up a bunch of information that was already inspected and validated when the `VoteMessage` was verified.  The additional look ups are adding complexity to the rewards container and also causing it to redo work that was already done before.  If instead, we could send a more specific struct to the rewards container, then we will simplify the code and we will avoid redoing work.

This cleanup will also help in landing #13381 


#### Summary of Changes
- Introduces `RewardVoteMessage` that contains all the relevant info that the reward container needs
- it can only store notar and skip votes; it contains the sender's vote account pubkey; stake; etc.  All this information makes the code in the rewards container simpler and avoids us having to look it up again.


#### Testing

Just CI
