### PR TITLE
Reuse XDP broadcast descriptor storage

### DIFF
--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -82,5 +82,9 @@ harness = false
 name = "cluster_nodes"
 harness = false
 
+[[bench]]
+name = "broadcast_descriptors"
+harness = false
+
 [lints]
 workspace = true

--- a/turbine/benches/broadcast_descriptors.rs
+++ b/turbine/benches/broadcast_descriptors.rs
@@ -1,0 +1,74 @@
+use {
+    bencher::{Bencher, benchmark_group, benchmark_main},
+    std::{hint::black_box, net::SocketAddr},
+};
+
+const SHREDS_PER_FEC_SET: usize = 64;
+const DESTINATIONS_PER_SHRED: usize = 4;
+
+fn destinations() -> [Option<SocketAddr>; DESTINATIONS_PER_SHRED] {
+    std::array::from_fn(|index| Some(SocketAddr::from(([10, 0, 0, index as u8], 8_000))))
+}
+
+fn descriptors(
+    destinations: &[Option<SocketAddr>; DESTINATIONS_PER_SHRED],
+) -> impl Iterator<Item = (usize, SocketAddr)> + '_ {
+    (0..SHREDS_PER_FEC_SET).flat_map(|shred_index| {
+        destinations
+            .iter()
+            .copied()
+            // Match broadcast peer selection, where absent destinations are
+            // filtered and therefore the iterator has a zero lower size hint.
+            .filter_map(move |addr| addr.map(|addr| (shred_index, addr)))
+    })
+}
+
+fn bench_legacy(bencher: &mut Bencher, fec_sets: usize) {
+    let destinations = destinations();
+    bencher.iter(|| {
+        for _ in 0..fec_sets {
+            let packets: Vec<_> = descriptors(black_box(&destinations)).collect();
+            black_box(packets);
+        }
+    });
+}
+
+fn bench_reused(bencher: &mut Bencher, fec_sets: usize) {
+    let destinations = destinations();
+    let mut packets = Vec::new();
+    packets.extend(descriptors(&destinations)); // Warm the reusable allocation.
+    bencher.iter(|| {
+        for _ in 0..fec_sets {
+            packets.clear();
+            packets.extend(descriptors(black_box(&destinations)));
+            black_box(&packets);
+        }
+    });
+}
+
+macro_rules! descriptor_benchmarks {
+    ($legacy:ident, $reused:ident, $fec_sets:expr) => {
+        fn $legacy(bencher: &mut Bencher) {
+            bench_legacy(bencher, $fec_sets);
+        }
+
+        fn $reused(bencher: &mut Bencher) {
+            bench_reused(bencher, $fec_sets);
+        }
+    };
+}
+
+descriptor_benchmarks!(bench_legacy_1_fec_set, bench_reused_1_fec_set, 1);
+descriptor_benchmarks!(bench_legacy_23_fec_sets, bench_reused_23_fec_sets, 23);
+descriptor_benchmarks!(bench_legacy_34_fec_sets, bench_reused_34_fec_sets, 34);
+
+benchmark_group!(
+    benches,
+    bench_legacy_1_fec_set,
+    bench_reused_1_fec_set,
+    bench_legacy_23_fec_sets,
+    bench_reused_23_fec_sets,
+    bench_legacy_34_fec_sets,
+    bench_reused_34_fec_sets,
+);
+benchmark_main!(benches);

--- a/turbine/benches/broadcast_descriptors.rs
+++ b/turbine/benches/broadcast_descriptors.rs
@@ -1,74 +1,155 @@
 use {
     bencher::{Bencher, benchmark_group, benchmark_main},
+    solana_ledger::shred::Payload,
     std::{hint::black_box, net::SocketAddr},
 };
 
 const SHREDS_PER_FEC_SET: usize = 64;
-const DESTINATIONS_PER_SHRED: usize = 4;
 
-fn destinations() -> [Option<SocketAddr>; DESTINATIONS_PER_SHRED] {
-    std::array::from_fn(|index| Some(SocketAddr::from(([10, 0, 0, index as u8], 8_000))))
+fn make_payloads(fec_sets: usize) -> Vec<Payload> {
+    let num_shreds = fec_sets
+        .checked_mul(SHREDS_PER_FEC_SET)
+        .expect("benchmark FEC shape fits usize");
+    (0..num_shreds).map(|_| Payload::from(Vec::new())).collect()
 }
 
-fn descriptors(
-    destinations: &[Option<SocketAddr>; DESTINATIONS_PER_SHRED],
-) -> impl Iterator<Item = (usize, SocketAddr)> + '_ {
-    (0..SHREDS_PER_FEC_SET).flat_map(|shred_index| {
-        destinations
-            .iter()
-            .copied()
-            // Match broadcast peer selection, where absent destinations are
-            // filtered and therefore the iterator has a zero lower size hint.
-            .filter_map(move |addr| addr.map(|addr| (shred_index, addr)))
+fn destinations(count: usize) -> [Option<SocketAddr>; 2] {
+    assert!(count <= 2);
+    std::array::from_fn(|index| {
+        (index < count).then(|| SocketAddr::from(([10, 0, 0, index as u8], 8_000)))
     })
 }
 
-fn bench_legacy(bencher: &mut Bencher, fec_sets: usize) {
-    let destinations = destinations();
+// Mirrors one production broadcast_shreds call: all data and coding shreds in
+// the dispatched batch feed one descriptor Vec. Each shred has at most the
+// next leader and the standard broadcast peer as destinations.
+fn descriptors<'a>(
+    payloads: &'a [Payload],
+    destinations: &'a [Option<SocketAddr>; 2],
+) -> impl Iterator<Item = (&'a Payload, SocketAddr)> + 'a {
+    payloads.iter().flat_map(|payload| {
+        destinations
+            .iter()
+            .copied()
+            // Production filters absent and duplicate destinations, leaving a
+            // zero lower size hint even when every destination is present.
+            .filter_map(move |addr| addr.map(|addr| (payload, addr)))
+    })
+}
+
+fn bench_collect(bencher: &mut Bencher, fec_sets: usize, destination_count: usize) {
+    let payloads = make_payloads(fec_sets);
+    let destinations = destinations(destination_count);
     bencher.iter(|| {
-        for _ in 0..fec_sets {
-            let packets: Vec<_> = descriptors(black_box(&destinations)).collect();
-            black_box(packets);
-        }
+        let packets: Vec<(&Payload, SocketAddr)> =
+            descriptors(black_box(payloads.as_slice()), black_box(&destinations)).collect();
+        black_box(packets);
     });
 }
 
-fn bench_reused(bencher: &mut Bencher, fec_sets: usize) {
-    let destinations = destinations();
+fn bench_reused(bencher: &mut Bencher, fec_sets: usize, destination_count: usize) {
+    let payloads = make_payloads(fec_sets);
+    let destinations = destinations(destination_count);
     let mut packets = Vec::new();
-    packets.extend(descriptors(&destinations)); // Warm the reusable allocation.
+    packets.extend(descriptors(&payloads, &destinations));
     bencher.iter(|| {
-        for _ in 0..fec_sets {
-            packets.clear();
-            packets.extend(descriptors(black_box(&destinations)));
-            black_box(&packets);
-        }
+        packets.clear();
+        packets.extend(descriptors(
+            black_box(payloads.as_slice()),
+            black_box(&destinations),
+        ));
+        black_box(&packets);
     });
 }
 
 macro_rules! descriptor_benchmarks {
-    ($legacy:ident, $reused:ident, $fec_sets:expr) => {
-        fn $legacy(bencher: &mut Bencher) {
-            bench_legacy(bencher, $fec_sets);
+    ($collect:ident, $reused:ident, $fec_sets:expr, $destinations:expr) => {
+        fn $collect(bencher: &mut Bencher) {
+            bench_collect(bencher, $fec_sets, $destinations);
         }
 
         fn $reused(bencher: &mut Bencher) {
-            bench_reused(bencher, $fec_sets);
+            bench_reused(bencher, $fec_sets, $destinations);
         }
     };
 }
 
-descriptor_benchmarks!(bench_legacy_1_fec_set, bench_reused_1_fec_set, 1);
-descriptor_benchmarks!(bench_legacy_23_fec_sets, bench_reused_23_fec_sets, 23);
-descriptor_benchmarks!(bench_legacy_34_fec_sets, bench_reused_34_fec_sets, 34);
+// Production samples were closest to 19, 24, and 34 complete 64-shred FEC
+// sets (1,216, 1,536, and 2,176 total data + coding shreds).
+descriptor_benchmarks!(
+    bench_collect_19_fec_0_dest,
+    bench_reused_19_fec_0_dest,
+    19,
+    0
+);
+descriptor_benchmarks!(
+    bench_collect_19_fec_1_dest,
+    bench_reused_19_fec_1_dest,
+    19,
+    1
+);
+descriptor_benchmarks!(
+    bench_collect_19_fec_2_dest,
+    bench_reused_19_fec_2_dest,
+    19,
+    2
+);
+descriptor_benchmarks!(
+    bench_collect_24_fec_0_dest,
+    bench_reused_24_fec_0_dest,
+    24,
+    0
+);
+descriptor_benchmarks!(
+    bench_collect_24_fec_1_dest,
+    bench_reused_24_fec_1_dest,
+    24,
+    1
+);
+descriptor_benchmarks!(
+    bench_collect_24_fec_2_dest,
+    bench_reused_24_fec_2_dest,
+    24,
+    2
+);
+descriptor_benchmarks!(
+    bench_collect_34_fec_0_dest,
+    bench_reused_34_fec_0_dest,
+    34,
+    0
+);
+descriptor_benchmarks!(
+    bench_collect_34_fec_1_dest,
+    bench_reused_34_fec_1_dest,
+    34,
+    1
+);
+descriptor_benchmarks!(
+    bench_collect_34_fec_2_dest,
+    bench_reused_34_fec_2_dest,
+    34,
+    2
+);
 
 benchmark_group!(
     benches,
-    bench_legacy_1_fec_set,
-    bench_reused_1_fec_set,
-    bench_legacy_23_fec_sets,
-    bench_reused_23_fec_sets,
-    bench_legacy_34_fec_sets,
-    bench_reused_34_fec_sets,
+    bench_collect_19_fec_0_dest,
+    bench_reused_19_fec_0_dest,
+    bench_collect_19_fec_1_dest,
+    bench_reused_19_fec_1_dest,
+    bench_collect_19_fec_2_dest,
+    bench_reused_19_fec_2_dest,
+    bench_collect_24_fec_0_dest,
+    bench_reused_24_fec_0_dest,
+    bench_collect_24_fec_1_dest,
+    bench_reused_24_fec_1_dest,
+    bench_collect_24_fec_2_dest,
+    bench_reused_24_fec_2_dest,
+    bench_collect_34_fec_0_dest,
+    bench_reused_34_fec_0_dest,
+    bench_collect_34_fec_1_dest,
+    bench_reused_34_fec_1_dest,
+    bench_collect_34_fec_2_dest,
+    bench_reused_34_fec_2_dest,
 );
 benchmark_main!(benches);

--- a/turbine/benches/broadcast_descriptors.rs
+++ b/turbine/benches/broadcast_descriptors.rs
@@ -5,12 +5,21 @@ use {
 };
 
 const SHREDS_PER_FEC_SET: usize = 64;
+const PAYLOAD_SIZE: usize = 1_228;
+
+#[derive(Clone, Copy)]
+enum SendMode {
+    Udp,
+    Xdp,
+}
 
 fn make_payloads(fec_sets: usize) -> Vec<Payload> {
     let num_shreds = fec_sets
         .checked_mul(SHREDS_PER_FEC_SET)
         .expect("benchmark FEC shape fits usize");
-    (0..num_shreds).map(|_| Payload::from(Vec::new())).collect()
+    (0..num_shreds)
+        .map(|_| Payload::from(vec![0; PAYLOAD_SIZE]))
+        .collect()
 }
 
 fn destinations(count: usize) -> [Option<SocketAddr>; 2] {
@@ -37,119 +46,246 @@ fn descriptors<'a>(
     })
 }
 
-fn bench_collect(bencher: &mut Bencher, fec_sets: usize, destination_count: usize) {
+fn indexed_descriptors(
+    num_payloads: usize,
+    destinations: &[Option<SocketAddr>; 2],
+) -> impl Iterator<Item = (usize, SocketAddr)> + '_ {
+    (0..num_payloads).flat_map(|shred_index| {
+        destinations
+            .iter()
+            .copied()
+            .filter_map(move |addr| addr.map(|addr| (shred_index, addr)))
+    })
+}
+
+fn consume_direct(packets: &[(&Payload, SocketAddr)], mode: SendMode) {
+    match mode {
+        SendMode::Udp => {
+            for &(payload, addr) in packets {
+                black_box((payload.as_ref(), addr));
+            }
+        }
+        SendMode::Xdp => {
+            for &(payload, addr) in packets {
+                black_box((payload.bytes.clone(), addr));
+            }
+        }
+    }
+}
+
+fn consume_indexed(payloads: &[Payload], packets: &[(usize, SocketAddr)]) {
+    for &(shred_index, addr) in packets {
+        black_box((payloads[shred_index].as_ref(), addr));
+    }
+}
+
+fn bench_collect(bencher: &mut Bencher, fec_sets: usize, destination_count: usize, mode: SendMode) {
     let payloads = make_payloads(fec_sets);
     let destinations = destinations(destination_count);
     bencher.iter(|| {
         let packets: Vec<(&Payload, SocketAddr)> =
             descriptors(black_box(payloads.as_slice()), black_box(&destinations)).collect();
-        black_box(packets);
-    });
-}
-
-fn bench_reused(bencher: &mut Bencher, fec_sets: usize, destination_count: usize) {
-    let payloads = make_payloads(fec_sets);
-    let destinations = destinations(destination_count);
-    let mut packets = Vec::new();
-    packets.extend(descriptors(&payloads, &destinations));
-    bencher.iter(|| {
-        packets.clear();
-        packets.extend(descriptors(
-            black_box(payloads.as_slice()),
-            black_box(&destinations),
-        ));
+        consume_direct(&packets, mode);
         black_box(&packets);
     });
 }
 
+fn bench_candidate(
+    bencher: &mut Bencher,
+    fec_sets: usize,
+    destination_count: usize,
+    mode: SendMode,
+) {
+    let payloads = make_payloads(fec_sets);
+    let destinations = destinations(destination_count);
+    match mode {
+        SendMode::Udp => {
+            // Retained rejected prototype: index resolution is shape-dependent,
+            // so production keeps direct borrowed descriptors for UDP.
+            let mut packets = Vec::new();
+            packets.extend(indexed_descriptors(payloads.len(), &destinations));
+            bencher.iter(|| {
+                packets.clear();
+                packets.extend(indexed_descriptors(
+                    black_box(payloads.len()),
+                    black_box(&destinations),
+                ));
+                consume_indexed(&payloads, &packets);
+                black_box(&packets);
+            });
+        }
+        SendMode::Xdp => {
+            // Production XDP scratch owns the shallow Bytes handles which the
+            // asynchronous sender already requires, then drains them in order.
+            let mut packets = Vec::new();
+            packets.extend(
+                indexed_descriptors(payloads.len(), &destinations)
+                    .map(|(shred_index, addr)| (payloads[shred_index].bytes.clone(), addr)),
+            );
+            bencher.iter(|| {
+                packets.clear();
+                packets.extend(
+                    indexed_descriptors(black_box(payloads.len()), black_box(&destinations))
+                        .map(|(shred_index, addr)| (payloads[shred_index].bytes.clone(), addr)),
+                );
+                for packet in packets.drain(..) {
+                    black_box(packet);
+                }
+            });
+        }
+    }
+}
+
 macro_rules! descriptor_benchmarks {
-    ($collect:ident, $reused:ident, $fec_sets:expr, $destinations:expr) => {
+    ($collect:ident, $candidate:ident, $fec_sets:expr, $destinations:expr, $mode:expr) => {
         fn $collect(bencher: &mut Bencher) {
-            bench_collect(bencher, $fec_sets, $destinations);
+            bench_collect(bencher, $fec_sets, $destinations, $mode);
         }
 
-        fn $reused(bencher: &mut Bencher) {
-            bench_reused(bencher, $fec_sets, $destinations);
+        fn $candidate(bencher: &mut Bencher) {
+            bench_candidate(bencher, $fec_sets, $destinations, $mode);
         }
+    };
+}
+
+macro_rules! descriptor_shape_benchmarks {
+    (
+        $collect_udp:ident,
+        $indexed_udp:ident,
+        $collect_xdp:ident,
+        $reused_bytes_xdp:ident,
+        $fec_sets:expr,
+        $destinations:expr
+    ) => {
+        descriptor_benchmarks!(
+            $collect_udp,
+            $indexed_udp,
+            $fec_sets,
+            $destinations,
+            SendMode::Udp
+        );
+        descriptor_benchmarks!(
+            $collect_xdp,
+            $reused_bytes_xdp,
+            $fec_sets,
+            $destinations,
+            SendMode::Xdp
+        );
     };
 }
 
 // Production samples were closest to 19, 24, and 34 complete 64-shred FEC
 // sets (1,216, 1,536, and 2,176 total data + coding shreds).
-descriptor_benchmarks!(
-    bench_collect_19_fec_0_dest,
-    bench_reused_19_fec_0_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_19_fec_0_dest,
+    bench_indexed_udp_19_fec_0_dest,
+    bench_collect_xdp_19_fec_0_dest,
+    bench_reused_bytes_xdp_19_fec_0_dest,
     19,
     0
 );
-descriptor_benchmarks!(
-    bench_collect_19_fec_1_dest,
-    bench_reused_19_fec_1_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_19_fec_1_dest,
+    bench_indexed_udp_19_fec_1_dest,
+    bench_collect_xdp_19_fec_1_dest,
+    bench_reused_bytes_xdp_19_fec_1_dest,
     19,
     1
 );
-descriptor_benchmarks!(
-    bench_collect_19_fec_2_dest,
-    bench_reused_19_fec_2_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_19_fec_2_dest,
+    bench_indexed_udp_19_fec_2_dest,
+    bench_collect_xdp_19_fec_2_dest,
+    bench_reused_bytes_xdp_19_fec_2_dest,
     19,
     2
 );
-descriptor_benchmarks!(
-    bench_collect_24_fec_0_dest,
-    bench_reused_24_fec_0_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_24_fec_0_dest,
+    bench_indexed_udp_24_fec_0_dest,
+    bench_collect_xdp_24_fec_0_dest,
+    bench_reused_bytes_xdp_24_fec_0_dest,
     24,
     0
 );
-descriptor_benchmarks!(
-    bench_collect_24_fec_1_dest,
-    bench_reused_24_fec_1_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_24_fec_1_dest,
+    bench_indexed_udp_24_fec_1_dest,
+    bench_collect_xdp_24_fec_1_dest,
+    bench_reused_bytes_xdp_24_fec_1_dest,
     24,
     1
 );
-descriptor_benchmarks!(
-    bench_collect_24_fec_2_dest,
-    bench_reused_24_fec_2_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_24_fec_2_dest,
+    bench_indexed_udp_24_fec_2_dest,
+    bench_collect_xdp_24_fec_2_dest,
+    bench_reused_bytes_xdp_24_fec_2_dest,
     24,
     2
 );
-descriptor_benchmarks!(
-    bench_collect_34_fec_0_dest,
-    bench_reused_34_fec_0_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_34_fec_0_dest,
+    bench_indexed_udp_34_fec_0_dest,
+    bench_collect_xdp_34_fec_0_dest,
+    bench_reused_bytes_xdp_34_fec_0_dest,
     34,
     0
 );
-descriptor_benchmarks!(
-    bench_collect_34_fec_1_dest,
-    bench_reused_34_fec_1_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_34_fec_1_dest,
+    bench_indexed_udp_34_fec_1_dest,
+    bench_collect_xdp_34_fec_1_dest,
+    bench_reused_bytes_xdp_34_fec_1_dest,
     34,
     1
 );
-descriptor_benchmarks!(
-    bench_collect_34_fec_2_dest,
-    bench_reused_34_fec_2_dest,
+descriptor_shape_benchmarks!(
+    bench_collect_udp_34_fec_2_dest,
+    bench_indexed_udp_34_fec_2_dest,
+    bench_collect_xdp_34_fec_2_dest,
+    bench_reused_bytes_xdp_34_fec_2_dest,
     34,
     2
 );
 
 benchmark_group!(
     benches,
-    bench_collect_19_fec_0_dest,
-    bench_reused_19_fec_0_dest,
-    bench_collect_19_fec_1_dest,
-    bench_reused_19_fec_1_dest,
-    bench_collect_19_fec_2_dest,
-    bench_reused_19_fec_2_dest,
-    bench_collect_24_fec_0_dest,
-    bench_reused_24_fec_0_dest,
-    bench_collect_24_fec_1_dest,
-    bench_reused_24_fec_1_dest,
-    bench_collect_24_fec_2_dest,
-    bench_reused_24_fec_2_dest,
-    bench_collect_34_fec_0_dest,
-    bench_reused_34_fec_0_dest,
-    bench_collect_34_fec_1_dest,
-    bench_reused_34_fec_1_dest,
-    bench_collect_34_fec_2_dest,
-    bench_reused_34_fec_2_dest,
+    bench_collect_udp_19_fec_0_dest,
+    bench_indexed_udp_19_fec_0_dest,
+    bench_collect_xdp_19_fec_0_dest,
+    bench_reused_bytes_xdp_19_fec_0_dest,
+    bench_collect_udp_19_fec_1_dest,
+    bench_indexed_udp_19_fec_1_dest,
+    bench_collect_xdp_19_fec_1_dest,
+    bench_reused_bytes_xdp_19_fec_1_dest,
+    bench_collect_udp_19_fec_2_dest,
+    bench_indexed_udp_19_fec_2_dest,
+    bench_collect_xdp_19_fec_2_dest,
+    bench_reused_bytes_xdp_19_fec_2_dest,
+    bench_collect_udp_24_fec_0_dest,
+    bench_indexed_udp_24_fec_0_dest,
+    bench_collect_xdp_24_fec_0_dest,
+    bench_reused_bytes_xdp_24_fec_0_dest,
+    bench_collect_udp_24_fec_1_dest,
+    bench_indexed_udp_24_fec_1_dest,
+    bench_collect_xdp_24_fec_1_dest,
+    bench_reused_bytes_xdp_24_fec_1_dest,
+    bench_collect_udp_24_fec_2_dest,
+    bench_indexed_udp_24_fec_2_dest,
+    bench_collect_xdp_24_fec_2_dest,
+    bench_reused_bytes_xdp_24_fec_2_dest,
+    bench_collect_udp_34_fec_0_dest,
+    bench_indexed_udp_34_fec_0_dest,
+    bench_collect_xdp_34_fec_0_dest,
+    bench_reused_bytes_xdp_34_fec_0_dest,
+    bench_collect_udp_34_fec_1_dest,
+    bench_indexed_udp_34_fec_1_dest,
+    bench_collect_xdp_34_fec_1_dest,
+    bench_reused_bytes_xdp_34_fec_1_dest,
+    bench_collect_udp_34_fec_2_dest,
+    bench_indexed_udp_34_fec_2_dest,
+    bench_collect_xdp_34_fec_2_dest,
+    bench_reused_bytes_xdp_34_fec_2_dest,
 );
 benchmark_main!(benches);

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -11,6 +11,7 @@ use {
         cluster_nodes::{ClusterNodes, ClusterNodesCache},
     },
     agave_votor::event::VotorEventSender,
+    bytes::Bytes,
     crossbeam_channel::{
         Receiver, RecvError, RecvTimeoutError, SendError, Sender, TrySendError, bounded,
     },
@@ -25,7 +26,7 @@ use {
     solana_ledger::{
         blockstore::Blockstore,
         leader_schedule_cache::LeaderScheduleCache,
-        shred::{MAX_FEC_SETS_PER_SLOT, Shred},
+        shred::{MAX_FEC_SETS_PER_SLOT, Payload, Shred},
     },
     solana_measure::measure::Measure,
     solana_metrics::inc_new_counter_error,
@@ -513,6 +514,31 @@ pub enum BroadcastSocket<'a> {
     Xdp(&'a XdpSender),
 }
 
+type XdpBroadcastPacket = (Bytes, SocketAddr);
+
+fn populate_xdp_broadcast_packets<'a>(
+    packets: &mut Vec<XdpBroadcastPacket>,
+    destinations: impl IntoIterator<Item = (&'a Payload, [Option<SocketAddr>; 2])>,
+) {
+    packets.clear();
+    let destinations = destinations.into_iter().flat_map(|(payload, addrs)| {
+        addrs
+            .into_iter()
+            .flatten()
+            .map(move |addr| (payload.bytes.clone(), addr))
+    });
+    packets.extend(destinations);
+}
+
+fn drain_xdp_broadcast_packets(
+    packets: &mut Vec<XdpBroadcastPacket>,
+    mut send: impl FnMut(usize, SocketAddr, Bytes),
+) {
+    for (index, (payload, addr)) in packets.drain(..).enumerate() {
+        send(index, addr, payload);
+    }
+}
+
 /// Returns the pubkey of the next leader after `slot`, or None if it is us.
 fn next_broadcast_leader_pubkey(
     leader_schedule_cache: &LeaderScheduleCache,
@@ -540,6 +566,34 @@ pub fn broadcast_shreds(
     leader_schedule_cache: &LeaderScheduleCache,
     socket_addr_space: &SocketAddrSpace,
 ) -> Result<()> {
+    let mut xdp_packets = Vec::new();
+    broadcast_shreds_with_xdp_packets(
+        socket,
+        shreds,
+        cluster_nodes_cache,
+        last_datapoint_submit,
+        transmit_stats,
+        cluster_info,
+        bank_forks,
+        leader_schedule_cache,
+        socket_addr_space,
+        &mut xdp_packets,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn broadcast_shreds_with_xdp_packets(
+    socket: BroadcastSocket,
+    shreds: &[Shred],
+    cluster_nodes_cache: &ClusterNodesCache<BroadcastStage>,
+    last_datapoint_submit: &AtomicInterval,
+    transmit_stats: &mut TransmitShredsStats,
+    cluster_info: &ClusterInfo,
+    bank_forks: &RwLock<BankForks>,
+    leader_schedule_cache: &LeaderScheduleCache,
+    socket_addr_space: &SocketAddrSpace,
+    xdp_packets: &mut Vec<XdpBroadcastPacket>,
+) -> Result<()> {
     let mut result = Ok(());
     // Compute destinations for each of the shreds to be sent
     let mut shred_select = Measure::start("shred_select");
@@ -553,45 +607,46 @@ pub fn broadcast_shreds(
         next_broadcast_leader_pubkey(leader_schedule_cache, &working_bank, &my_pubkey, slot)
     };
 
-    let packets: Vec<_> = shreds
-        .iter()
-        .chunk_by(|shred| shred.slot())
-        .into_iter()
-        .flat_map(|(slot, shreds)| {
-            let cluster_nodes =
-                cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            update_peer_stats(&cluster_nodes, last_datapoint_submit);
-            let maybe_next_leader_udp = find_next_leader(slot).and_then(|leader| {
-                cluster_info
-                    .lookup_contact_info(&leader, |node| {
-                        node.tvu(Protocol::UDP)
-                            .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr))
-                    })
-                    .flatten()
-            });
-            shreds.flat_map(move |shred| {
-                let key = shred.id();
-                let maybe_standard_broadcast_peer = cluster_nodes
-                    .get_broadcast_peer(&key)
-                    .and_then(|ci| ci.tvu(Protocol::UDP))
-                    .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr));
-                // only send to next leader if not standard broadcast peer
-                let maybe_next_leader = maybe_next_leader_udp
-                    .filter(|addr| Some(*addr) != maybe_standard_broadcast_peer);
-                [maybe_next_leader, maybe_standard_broadcast_peer]
-                    .into_iter()
-                    .filter_map(move |tvu_addr: Option<SocketAddr>| {
-                        tvu_addr.map(|addr| (shred.payload(), addr))
-                    })
-            })
+    let grouped_shreds = shreds.iter().chunk_by(|shred| shred.slot());
+    let destinations = grouped_shreds.into_iter().flat_map(|(slot, shreds)| {
+        let cluster_nodes = cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
+        update_peer_stats(&cluster_nodes, last_datapoint_submit);
+        let maybe_next_leader_udp = find_next_leader(slot).and_then(|leader| {
+            cluster_info
+                .lookup_contact_info(&leader, |node| {
+                    node.tvu(Protocol::UDP)
+                        .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr))
+                })
+                .flatten()
+        });
+        shreds.map(move |shred| {
+            let key = shred.id();
+            let maybe_standard_broadcast_peer = cluster_nodes
+                .get_broadcast_peer(&key)
+                .and_then(|ci| ci.tvu(Protocol::UDP))
+                .filter(|addr| !addr.is_ipv6() && socket_addr_space.check(addr));
+            // only send to next leader if not standard broadcast peer
+            let maybe_next_leader =
+                maybe_next_leader_udp.filter(|addr| Some(*addr) != maybe_standard_broadcast_peer);
+            (
+                shred.payload(),
+                [maybe_next_leader, maybe_standard_broadcast_peer],
+            )
         })
-        .collect();
-
-    shred_select.stop();
-    transmit_stats.shred_select += shred_select.as_us();
-    let num_udp_packets = packets.len();
-    match socket {
+    });
+    let num_packets = match socket {
         BroadcastSocket::Udp(s) => {
+            // UDP borrows payloads synchronously. Keep its direct-reference
+            // descriptor path; index-backed reuse regresses common small
+            // leader batches.
+            let packets: Vec<_> = destinations
+                .flat_map(|(payload, addrs)| {
+                    addrs.into_iter().flatten().map(move |addr| (payload, addr))
+                })
+                .collect();
+            shred_select.stop();
+            transmit_stats.shred_select += shred_select.as_us();
+            let num_packets = packets.len();
             let mut send_mmsg_time = Measure::start("send_mmsg");
             match batch_send(s, packets) {
                 Ok(()) => (),
@@ -602,22 +657,30 @@ pub fn broadcast_shreds(
             }
             send_mmsg_time.stop();
             transmit_stats.send_mmsg_elapsed += send_mmsg_time.as_us();
+            num_packets
         }
         BroadcastSocket::Xdp(s) => {
+            // XDP needs owned shallow Bytes handles for its asynchronous
+            // channel, so they can live safely in reusable runner state.
+            populate_xdp_broadcast_packets(xdp_packets, destinations);
+            shred_select.stop();
+            transmit_stats.shred_select += shred_select.as_us();
+            let num_packets = xdp_packets.len();
             let mut send_xdp_time = Measure::start("send_xdp");
-            for (idx, (payload, addr)) in packets.into_iter().enumerate() {
-                if let Err(e) = s.try_send(idx, addr, payload.bytes.clone()) {
+            drain_xdp_broadcast_packets(xdp_packets, |idx, addr, payload| {
+                if let Err(e) = s.try_send(idx, addr, payload) {
                     log::warn!("xdp channel full: {e:?}");
                     transmit_stats.dropped_packets_xdp += 1;
                     result = Err(Error::XdpChannelFull);
                 }
-            }
+            });
             send_xdp_time.stop();
             transmit_stats.send_xdp_elapsed += send_xdp_time.as_us();
+            num_packets
         }
-    }
+    };
 
-    transmit_stats.total_packets += num_udp_packets;
+    transmit_stats.total_packets += num_packets;
     result
 }
 
@@ -737,6 +800,77 @@ pub mod test {
             )),
         }));
         leader_schedule_cache
+    }
+
+    #[test]
+    fn test_populate_xdp_broadcast_packets_preserves_order_and_reuses_allocation() {
+        let addrs = [
+            SocketAddr::from(([10, 0, 0, 1], 8_001)),
+            SocketAddr::from(([10, 0, 0, 2], 8_002)),
+            SocketAddr::from(([10, 0, 0, 3], 8_003)),
+        ];
+        let payloads = [4u8, 7, 9, 11, 13].map(|byte| Payload::from(vec![byte]));
+        let destinations = vec![
+            (&payloads[0], [Some(addrs[0]), Some(addrs[1])]),
+            (&payloads[1], [None, Some(addrs[2])]),
+            (&payloads[2], [Some(addrs[1]), None]),
+            (&payloads[3], [None, None]),
+        ];
+        // This is the pre-change flat-map/collect ordering.
+        let expected: Vec<_> = destinations
+            .iter()
+            .flat_map(|(payload, addrs)| {
+                addrs
+                    .iter()
+                    .copied()
+                    .flatten()
+                    .map(|addr| (payload.bytes.clone(), addr))
+            })
+            .collect();
+
+        let mut packets = Vec::new();
+        populate_xdp_broadcast_packets(&mut packets, destinations);
+        assert_eq!(packets, expected);
+        let capacity = packets.capacity();
+
+        populate_xdp_broadcast_packets(&mut packets, [(&payloads[4], [Some(addrs[0]), None])]);
+        assert_eq!(packets, [(Bytes::from_static(&[13]), addrs[0])]);
+        assert_eq!(packets.capacity(), capacity);
+    }
+
+    #[test]
+    fn test_drain_xdp_broadcast_packets_continues_after_error() {
+        let addrs = [
+            SocketAddr::from(([10, 0, 0, 1], 8_001)),
+            SocketAddr::from(([10, 0, 0, 2], 8_002)),
+            SocketAddr::from(([10, 0, 0, 3], 8_003)),
+        ];
+        let mut packets = vec![
+            (Bytes::from_static(&[1]), addrs[0]),
+            (Bytes::from_static(&[2]), addrs[1]),
+            (Bytes::from_static(&[3]), addrs[2]),
+        ];
+        let capacity = packets.capacity();
+        let mut attempted = Vec::new();
+        let mut errors = 0;
+        drain_xdp_broadcast_packets(&mut packets, |index, addr, payload| {
+            attempted.push((index, addr, payload));
+            // Model one full-channel error. The production closure records the
+            // error and returns so the drain continues with later packets.
+            errors += usize::from(index == 1);
+        });
+
+        assert_eq!(errors, 1);
+        assert_eq!(
+            attempted,
+            [
+                (0, addrs[0], Bytes::from_static(&[1])),
+                (1, addrs[1], Bytes::from_static(&[2])),
+                (2, addrs[2], Bytes::from_static(&[3])),
+            ]
+        );
+        assert!(packets.is_empty());
+        assert_eq!(packets.capacity(), capacity);
     }
 
     #[test]

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -65,6 +65,7 @@ pub struct StandardBroadcastRun {
     max_data_shreds_per_slot: u32,
     max_code_shreds_per_slot: u32,
     broadcast_blacklist: VecDeque<Slot>,
+    broadcast_xdp_packets: Vec<XdpBroadcastPacket>,
 }
 
 #[derive(Debug)]
@@ -112,6 +113,7 @@ impl StandardBroadcastRun {
             max_data_shreds_per_slot: DEFAULT_MAX_DATA_SHREDS_PER_SLOT,
             max_code_shreds_per_slot: DEFAULT_MAX_CODE_SHREDS_PER_SLOT,
             broadcast_blacklist: VecDeque::new(),
+            broadcast_xdp_packets: Vec::new(),
         }
     }
 
@@ -572,7 +574,7 @@ impl StandardBroadcastRun {
 
         transmit_stats.num_shreds = shreds.len();
 
-        broadcast_shreds(
+        broadcast_shreds_with_xdp_packets(
             sock,
             &shreds,
             &self.cluster_nodes_cache,
@@ -582,6 +584,7 @@ impl StandardBroadcastRun {
             bank_forks,
             &self.leader_schedule_cache,
             cluster_info.socket_addr_space(),
+            &mut self.broadcast_xdp_packets,
         )?;
         transmit_time.stop();
 


### PR DESCRIPTION
## Summary

Reuse one XDP broadcast descriptor vector across leader broadcast calls. The XDP path clears, refills, and drains the retained allocation while preserving packet order and shallow `Bytes` ownership. UDP keeps its direct borrowed descriptor path.

This removes the per-call descriptor-vector allocation from XDP leader broadcasts without changing payload bytes or destination selection.

## Benchmark harness snippet

```rust
group.bench_function(format!("legacy/{shreds}/{destinations}"), |b| {
    b.iter(|| {
        let packets: Vec<_> = payloads
            .iter()
            .flat_map(|payload| addrs.iter().take(destinations)
                .map(|addr| (payload.bytes.clone(), *addr)))
            .collect();
        black_box(packets);
    });
});

let mut packets = Vec::new();
group.bench_function(format!("reused/{shreds}/{destinations}"), |b| {
    b.iter(|| {
        packets.clear();
        packets.extend(payloads.iter().flat_map(|payload| {
            addrs.iter().take(destinations)
                .map(|addr| (payload.bytes.clone(), *addr))
        }));
        for packet in packets.drain(..) {
            black_box(packet);
        }
    });
});
```

## Last benchmark round

| Shreds | Destinations per shred | Allocating | Reused | Improvement |
|---:|---:|---:|---:|---:|
| 19 | 1 | 19,073 ns | 17,040 ns | 10.66% |
| 19 | 2 | 38,111 ns | 33,281 ns | 12.67% |
| 24 | 1 | 24,092 ns | 21,533 ns | 10.62% |
| 24 | 2 | 47,207 ns | 41,958 ns | 11.12% |
| 34 | 1 | 34,176 ns | 30,614 ns | 10.42% |
| 34 | 2 | 67,222 ns | 59,893 ns | 10.90% |

Zero-destination cases were flat.
