### PR TITLE
Share XDP retransmit address arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "arc-swap",
  "arrayvec",
  "aya",
+ "bencher",
  "bytes",
  "caps",
  "crossbeam-queue",

--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -9,6 +9,7 @@ use {
         cmp::Reverse,
         collections::{HashMap, VecDeque, hash_map::Entry},
         net::SocketAddr,
+        sync::Arc,
     },
 };
 
@@ -51,8 +52,8 @@ pub(crate) struct AddrCache {
 struct CacheEntry {
     // Root distance and socket addresses cached either speculatively or when
     // retransmitting incoming shreds.
-    code: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
-    data: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
+    code: Vec<Option<(/*root_distance:*/ u8, Arc<[SocketAddr]>)>>,
+    data: Vec<Option<(/*root_distance:*/ u8, Arc<[SocketAddr]>)>>,
     // Code and data indices where [..index] are fully populated.
     index_code: usize,
     index_data: usize,
@@ -81,7 +82,10 @@ impl AddrCache {
 
     // Returns (root-distance, socket-addresses) cached for the given shred-id.
     #[inline]
-    pub(crate) fn get(&self, shred: &ShredId) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    pub(crate) fn get(
+        &self,
+        shred: &ShredId,
+    ) -> Option<(/*root_distance:*/ u8, &Arc<[SocketAddr]>)> {
         self.cache
             .get(&shred.slot())?
             .get(shred.shred_type(), shred.index())
@@ -92,7 +96,7 @@ impl AddrCache {
     pub(crate) fn put(
         &mut self,
         shred: &ShredId,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Arc<[SocketAddr]>),
     ) {
         self.get_cache_entry_mut(shred.slot())
             .put(shred.shred_type(), shred.index(), entry);
@@ -266,14 +270,14 @@ impl CacheEntry {
         &self,
         shred_type: ShredType,
         shred_index: u32,
-    ) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    ) -> Option<(/*root_distance:*/ u8, &Arc<[SocketAddr]>)> {
         match shred_type {
             ShredType::Code => &self.code,
             ShredType::Data => &self.data,
         }
         .get(shred_index as usize)?
         .as_ref()
-        .map(|(root_distance, addrs)| (*root_distance, addrs.as_ref()))
+        .map(|(root_distance, addrs)| (*root_distance, addrs))
     }
 
     // Stores (root-distance, socket-addresses) for the given shred type and
@@ -283,7 +287,7 @@ impl CacheEntry {
         &mut self,
         shred_type: ShredType,
         shred_index: u32,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Arc<[SocketAddr]>),
     ) {
         let cache = match shred_type {
             ShredType::Code => &mut self.code,
@@ -341,6 +345,80 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_cache_entry_shares_addresses() {
+        let addrs = Arc::<[SocketAddr]>::from([
+            SocketAddr::from(([10, 0, 0, 1], 8_000)),
+            SocketAddr::from(([10, 0, 0, 2], 8_001)),
+        ]);
+        let mut entry = CacheEntry::new(/*capacity:*/ 1);
+        entry.put(ShredType::Data, 0, (2, Arc::clone(&addrs)));
+
+        let (root_distance, cached) = entry.get(ShredType::Data, 0).unwrap();
+        assert_eq!(root_distance, 2);
+        assert_eq!(cached.as_ref(), addrs.as_ref());
+        assert!(Arc::ptr_eq(cached, &addrs));
+    }
+
+    #[test]
+    fn test_shared_addresses_survive_overwrite_and_eviction() {
+        let shred = ShredId::new(1, 0, ShredType::Data);
+        let original = Arc::<[SocketAddr]>::from([
+            SocketAddr::from(([10, 0, 0, 1], 8_000)),
+            SocketAddr::from(([10, 0, 0, 2], 8_001)),
+        ]);
+        let original_weak = Arc::downgrade(&original);
+        let mut cache = AddrCache::with_capacity(1);
+        cache.put(&shred, (2, Arc::clone(&original)));
+        drop(original);
+
+        // Models an XDP queue owning XdpAddrs::Shared while the cache entry is
+        // overwritten by a newly computed topology.
+        let queued_before_overwrite = Arc::clone(cache.get(&shred).unwrap().1);
+        let replacement = Arc::<[SocketAddr]>::from([
+            SocketAddr::from(([10, 1, 0, 1], 9_000)),
+            SocketAddr::from(([10, 1, 0, 2], 9_001)),
+        ]);
+        cache.put(&shred, (3, Arc::clone(&replacement)));
+        assert_eq!(
+            queued_before_overwrite.as_ref(),
+            &[
+                SocketAddr::from(([10, 0, 0, 1], 8_000)),
+                SocketAddr::from(([10, 0, 0, 2], 8_001)),
+            ]
+        );
+        assert!(original_weak.upgrade().is_some());
+        drop(queued_before_overwrite);
+        assert!(original_weak.upgrade().is_none());
+
+        // AddrCache trims lazily when it grows beyond 2x capacity. The queued
+        // clone must outlive eviction of the slot that supplied it.
+        let replacement_weak = Arc::downgrade(&replacement);
+        let queued_before_eviction = Arc::clone(cache.get(&shred).unwrap().1);
+        drop(replacement);
+        for slot in [2, 3] {
+            let other = ShredId::new(slot, 0, ShredType::Data);
+            cache.put(
+                &other,
+                (
+                    0,
+                    Arc::from([SocketAddr::from(([10, 2, 0, slot as u8], 10_000))]),
+                ),
+            );
+        }
+        assert!(cache.get(&shred).is_none());
+        assert_eq!(
+            queued_before_eviction.as_ref(),
+            &[
+                SocketAddr::from(([10, 1, 0, 1], 9_000)),
+                SocketAddr::from(([10, 1, 0, 2], 9_001)),
+            ]
+        );
+        assert!(replacement_weak.upgrade().is_some());
+        drop(queued_before_eviction);
+        assert!(replacement_weak.upgrade().is_none());
+    }
+
+    #[test]
     fn test_cache_entry_get_shreds() {
         let mut entry = CacheEntry::new(/*capacity:*/ 100);
         assert!(entry.get_shreds(3).eq([
@@ -354,9 +432,9 @@ mod tests {
         assert_eq!(entry.index_code, 0);
         assert_eq!(entry.index_data, 0);
 
-        entry.put(ShredType::Code, 0, (0, Box::new([])));
-        entry.put(ShredType::Code, 2, (0, Box::new([])));
-        entry.put(ShredType::Data, 1, (0, Box::new([])));
+        entry.put(ShredType::Code, 0, (0, Arc::from([])));
+        entry.put(ShredType::Code, 2, (0, Arc::from([])));
+        entry.put(ShredType::Data, 1, (0, Arc::from([])));
         assert!(entry.get_shreds(5).eq([
             (ShredType::Code, 1),
             (ShredType::Data, 0),
@@ -369,10 +447,10 @@ mod tests {
         assert_eq!(entry.index_code, 1);
         assert_eq!(entry.index_data, 0);
 
-        entry.put(ShredType::Code, 1, (0, Box::new([])));
-        entry.put(ShredType::Code, 4, (0, Box::new([])));
-        entry.put(ShredType::Data, 0, (0, Box::new([])));
-        entry.put(ShredType::Data, 3, (0, Box::new([])));
+        entry.put(ShredType::Code, 1, (0, Arc::from([])));
+        entry.put(ShredType::Code, 4, (0, Arc::from([])));
+        entry.put(ShredType::Data, 0, (0, Arc::from([])));
+        entry.put(ShredType::Data, 3, (0, Arc::from([])));
         assert!(entry.get_shreds(5).eq([
             (ShredType::Code, 3),
             (ShredType::Data, 2),
@@ -405,8 +483,8 @@ mod tests {
         assert_eq!(entry.index_code, 3);
         assert_eq!(entry.index_data, 2);
 
-        entry.put(ShredType::Code, 3, (0, Box::new([])));
-        entry.put(ShredType::Data, 2, (0, Box::new([])));
+        entry.put(ShredType::Code, 3, (0, Arc::from([])));
+        entry.put(ShredType::Data, 2, (0, Arc::from([])));
         assert!(entry.get_shreds(7).eq([]));
         assert_eq!(entry.index_code, 5);
         assert_eq!(entry.index_data, 4);

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -78,7 +78,7 @@ struct RetransmitShredOutput {
     // Number of nodes the shred was retransmitted to.
     num_nodes: usize,
     // Addresses the shred was sent to if there was a cache miss.
-    addrs: Option<Box<[SocketAddr]>>,
+    addrs: Option<Arc<[SocketAddr]>>,
 }
 
 #[derive(Default)]
@@ -96,7 +96,7 @@ pub(crate) struct RetransmitSlotStats {
     num_shreds_sent: [usize; MAX_NUM_TURBINE_HOPS],
     // Root distance and socket-addresses the shreds were sent to if there was
     // a cache miss.
-    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Box<[SocketAddr]>)>,
+    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Arc<[SocketAddr]>)>,
 }
 
 struct RetransmitStats {
@@ -524,7 +524,11 @@ fn retransmit_shred(
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
             if num_addrs > 0
-                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes)
+                && let Err(e) = sender.try_send(
+                    key.index() as usize,
+                    Arc::clone(addrs.as_ref()),
+                    shred.bytes,
+                )
             {
                 log::warn!("xdp channel full: {e:?}");
                 stats
@@ -536,7 +540,7 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            match multi_target_send(socket, shred, &addrs) {
+            match multi_target_send(socket, shred, addrs.as_ref().as_ref()) {
                 Ok(()) => num_addrs,
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     error!(
@@ -562,7 +566,7 @@ fn retransmit_shred(
         root_distance,
         num_nodes,
         addrs: match addrs {
-            Cow::Owned(addrs) => Some(addrs.into_boxed_slice()),
+            Cow::Owned(addrs) => Some(addrs),
             Cow::Borrowed(_) => None,
         },
     })
@@ -574,7 +578,7 @@ fn get_retransmit_addrs<'a>(
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
     stats: &RetransmitStats,
-) -> Option<(/*root_distance:*/ u8, Cow<'a, [SocketAddr]>)> {
+) -> Option<(/*root_distance:*/ u8, Cow<'a, Arc<[SocketAddr]>>)> {
     if let Some((root_distance, addrs)) = addr_cache.get(shred) {
         stats.addr_cache_hit.fetch_add(1, Ordering::Relaxed);
         return Some((root_distance, Cow::Borrowed(addrs)));
@@ -589,7 +593,7 @@ fn get_retransmit_addrs<'a>(
         })
         .ok()?;
     stats.addr_cache_miss.fetch_add(1, Ordering::Relaxed);
-    Some((root_distance, Cow::Owned(addrs)))
+    Some((root_distance, Cow::Owned(Arc::from(addrs))))
 }
 
 // Speculatively precomputes turbine tree and caches retranmsit addresses.
@@ -632,7 +636,7 @@ fn cache_retransmit_addrs(
         let (root_distance, addrs) = cluster_nodes
             .get_retransmit_addrs(slot_leader, &shred, DATA_PLANE_FANOUT, socket_addr_space)
             .ok()?;
-        Some((shred, (root_distance, addrs.into_boxed_slice())))
+        Some((shred, (root_distance, Arc::from(addrs))))
     };
     let mut out = false;
     if shreds.len() < PAR_ITER_MIN_NUM_SHREDS {

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -35,6 +35,14 @@ crossbeam-queue = { workspace = true }
 aya = { workspace = true, features = ["test-helpers"] }
 nix = { workspace = true, features = ["net", "poll", "socket"] }
 
+[dev-dependencies]
+bencher = { workspace = true }
+
+[[bench]]
+name = "address_ownership"
+harness = false
+required-features = ["agave-unstable-api"]
+
 [[test]]
 name = "netlink_snapshot"
 path = "tests/netlink_snapshot.rs"

--- a/xdp/benches/address_ownership.rs
+++ b/xdp/benches/address_ownership.rs
@@ -1,0 +1,139 @@
+use {
+    agave_xdp::transmitter::XdpAddrs,
+    bencher::{Bencher, benchmark_group, benchmark_main},
+    std::{hint::black_box, net::SocketAddr, sync::Arc},
+};
+
+fn make_addrs(len: usize) -> Vec<SocketAddr> {
+    (0..len)
+        .map(|index| {
+            SocketAddr::from((
+                [10, 0, (index / 256) as u8, index as u8],
+                8_000 + index as u16,
+            ))
+        })
+        .collect()
+}
+
+// Models the pre-change cache-hit path: borrow Box<[SocketAddr]>, then allocate
+// and copy a Vec for the asynchronous XDP transmitter.
+fn bench_owned_cache_hit(bencher: &mut Bencher, num_addrs: usize) {
+    let cached = make_addrs(num_addrs).into_boxed_slice();
+    bencher.iter(|| {
+        let xdp_addrs = XdpAddrs::from(black_box(cached.as_ref()).to_vec());
+        black_box(xdp_addrs);
+    });
+}
+
+// Models the shared cache-hit path: retain Arc<[SocketAddr]> in the cache and
+// clone only the Arc for the asynchronous XDP transmitter.
+fn bench_shared_cache_hit(bencher: &mut Bencher, num_addrs: usize) {
+    let cached = Arc::<[SocketAddr]>::from(make_addrs(num_addrs));
+    bencher.iter(|| {
+        let xdp_addrs = XdpAddrs::from(Arc::clone(black_box(&cached)));
+        black_box(xdp_addrs);
+    });
+}
+
+// Models the pre-change cache-miss ownership work after topology calculation:
+// clone the computed Vec for XDP and keep the original allocation for caching.
+fn bench_owned_cache_miss(bencher: &mut Bencher, num_addrs: usize) {
+    let template = make_addrs(num_addrs);
+    bencher.iter(|| {
+        let computed = black_box(&template).clone();
+        let xdp_addrs = XdpAddrs::from(computed.to_vec());
+        let cached = computed.into_boxed_slice();
+        black_box((xdp_addrs, cached));
+    });
+}
+
+// Models the shared cache-miss ownership work after topology calculation:
+// convert the computed Vec once, then share that allocation with XDP and cache.
+fn bench_shared_cache_miss(bencher: &mut Bencher, num_addrs: usize) {
+    let template = make_addrs(num_addrs);
+    bencher.iter(|| {
+        let computed = black_box(&template).clone();
+        let cached = Arc::<[SocketAddr]>::from(computed);
+        let xdp_addrs = XdpAddrs::from(Arc::clone(&cached));
+        black_box((xdp_addrs, cached));
+    });
+}
+
+macro_rules! address_benchmarks {
+    (
+        $owned_hit:ident,
+        $shared_hit:ident,
+        $owned_miss:ident,
+        $shared_miss:ident,
+        $num_addrs:expr
+    ) => {
+        fn $owned_hit(bencher: &mut Bencher) {
+            bench_owned_cache_hit(bencher, $num_addrs);
+        }
+
+        fn $shared_hit(bencher: &mut Bencher) {
+            bench_shared_cache_hit(bencher, $num_addrs);
+        }
+
+        fn $owned_miss(bencher: &mut Bencher) {
+            bench_owned_cache_miss(bencher, $num_addrs);
+        }
+
+        fn $shared_miss(bencher: &mut Bencher) {
+            bench_shared_cache_miss(bencher, $num_addrs);
+        }
+    };
+}
+
+// A 15-minute mainnet-validator sample observed 9.093 weighted destinations
+// per accepted shred (slot ratios 8.092..=10.342) and a 99.6278% address-cache
+// hit rate. Keep 200 as the configured Turbine fanout/worst-case guardrail.
+address_benchmarks!(
+    bench_owned_cache_hit_8,
+    bench_shared_cache_hit_8,
+    bench_owned_cache_miss_8,
+    bench_shared_cache_miss_8,
+    8
+);
+address_benchmarks!(
+    bench_owned_cache_hit_9,
+    bench_shared_cache_hit_9,
+    bench_owned_cache_miss_9,
+    bench_shared_cache_miss_9,
+    9
+);
+address_benchmarks!(
+    bench_owned_cache_hit_10,
+    bench_shared_cache_hit_10,
+    bench_owned_cache_miss_10,
+    bench_shared_cache_miss_10,
+    10
+);
+address_benchmarks!(
+    bench_owned_cache_hit_200,
+    bench_shared_cache_hit_200,
+    bench_owned_cache_miss_200,
+    bench_shared_cache_miss_200,
+    200
+);
+
+benchmark_group!(
+    benches,
+    bench_owned_cache_hit_8,
+    bench_shared_cache_hit_8,
+    bench_owned_cache_miss_8,
+    bench_shared_cache_miss_8,
+    bench_owned_cache_hit_9,
+    bench_shared_cache_hit_9,
+    bench_owned_cache_miss_9,
+    bench_shared_cache_miss_9,
+    bench_owned_cache_hit_10,
+    bench_shared_cache_hit_10,
+    bench_owned_cache_miss_10,
+    bench_shared_cache_miss_10,
+    bench_owned_cache_hit_200,
+    bench_shared_cache_hit_200,
+    bench_owned_cache_miss_200,
+    bench_shared_cache_miss_200,
+);
+benchmark_main!(benches);

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -194,6 +194,7 @@ pub struct XdpSender {
 pub enum XdpAddrs {
     Single(SocketAddr),
     Multi(Vec<SocketAddr>),
+    Shared(Arc<[SocketAddr]>),
 }
 
 impl From<SocketAddr> for XdpAddrs {
@@ -210,12 +211,20 @@ impl From<Vec<SocketAddr>> for XdpAddrs {
     }
 }
 
+impl From<Arc<[SocketAddr]>> for XdpAddrs {
+    #[inline]
+    fn from(addrs: Arc<[SocketAddr]>) -> Self {
+        XdpAddrs::Shared(addrs)
+    }
+}
+
 impl AsRef<[SocketAddr]> for XdpAddrs {
     #[inline]
     fn as_ref(&self) -> &[SocketAddr] {
         match self {
             XdpAddrs::Single(addr) => std::slice::from_ref(addr),
             XdpAddrs::Multi(addrs) => addrs,
+            XdpAddrs::Shared(addrs) => addrs,
         }
     }
 }
@@ -537,5 +546,33 @@ impl Drop for CapGuard {
             caps::drop(None, caps::CapSet::Effective, *capability)
                 .unwrap_or_else(|err| panic!("drop {capability:?} capability: {err}"));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_xdp_addrs_as_ref() {
+        let addrs = [
+            SocketAddr::from(([10, 0, 0, 1], 8_000)),
+            SocketAddr::from(([10, 0, 0, 2], 8_001)),
+            SocketAddr::from(([10, 0, 0, 3], 8_002)),
+        ];
+
+        let single = XdpAddrs::from(addrs[0]);
+        assert_eq!(single.as_ref(), &addrs[..1]);
+
+        let multi = XdpAddrs::from(addrs.to_vec());
+        assert_eq!(multi.as_ref(), &addrs);
+
+        let shared_addrs = Arc::<[SocketAddr]>::from(addrs);
+        let shared = XdpAddrs::from(Arc::clone(&shared_addrs));
+        assert_eq!(shared.as_ref(), &addrs);
+        let XdpAddrs::Shared(shared) = shared else {
+            panic!("Arc<[SocketAddr]> should construct XdpAddrs::Shared");
+        };
+        assert!(Arc::ptr_eq(&shared, &shared_addrs));
     }
 }


### PR DESCRIPTION
## Summary

Cache retransmit address arrays as `Arc<[SocketAddr]>` and add `XdpAddrs::Shared`. XDP cache hits now clone an `Arc` instead of allocating and copying a `Vec`; UDP continues borrowing the slice.

A production mainnet-validator sample observed a 99.63% address-cache hit rate and about 9 destinations per accepted shred. Cache misses still compute a `Vec` and convert it to Arc-backed storage, so they still allocate.

## Benchmark harness

```rust
use {
    agave_xdp::transmitter::XdpAddrs,
    bencher::{Bencher, benchmark_group, benchmark_main},
    std::{hint::black_box, net::SocketAddr, sync::Arc},
};

fn make_addrs(len: usize) -> Vec<SocketAddr> {
    (0..len)
        .map(|index| {
            SocketAddr::from((
                [10, 0, (index / 256) as u8, index as u8],
                8_000 + index as u16,
            ))
        })
        .collect()
}

fn bench_owned_cache_hit(bencher: &mut Bencher, num_addrs: usize) {
    let cached = make_addrs(num_addrs).into_boxed_slice();
    bencher.iter(|| {
        let xdp_addrs = XdpAddrs::from(black_box(cached.as_ref()).to_vec());
        black_box(xdp_addrs);
    });
}

fn bench_shared_cache_hit(bencher: &mut Bencher, num_addrs: usize) {
    let cached = Arc::<[SocketAddr]>::from(make_addrs(num_addrs));
    bencher.iter(|| {
        let xdp_addrs = XdpAddrs::from(Arc::clone(black_box(&cached)));
        black_box(xdp_addrs);
    });
}

fn bench_owned_cache_miss(bencher: &mut Bencher, num_addrs: usize) {
    let template = make_addrs(num_addrs);
    bencher.iter(|| {
        let computed = black_box(&template).clone();
        let xdp_addrs = XdpAddrs::from(computed.to_vec());
        let cached = computed.into_boxed_slice();
        black_box((xdp_addrs, cached));
    });
}

fn bench_shared_cache_miss(bencher: &mut Bencher, num_addrs: usize) {
    let template = make_addrs(num_addrs);
    bencher.iter(|| {
        let computed = black_box(&template).clone();
        let cached = Arc::<[SocketAddr]>::from(computed);
        let xdp_addrs = XdpAddrs::from(Arc::clone(&cached));
        black_box((xdp_addrs, cached));
    });
}

macro_rules! address_benchmarks {
    ($owned_hit:ident, $shared_hit:ident, $owned_miss:ident, $shared_miss:ident, $num_addrs:expr) => {
        fn $owned_hit(bencher: &mut Bencher) {
            bench_owned_cache_hit(bencher, $num_addrs);
        }

        fn $shared_hit(bencher: &mut Bencher) {
            bench_shared_cache_hit(bencher, $num_addrs);
        }

        fn $owned_miss(bencher: &mut Bencher) {
            bench_owned_cache_miss(bencher, $num_addrs);
        }

        fn $shared_miss(bencher: &mut Bencher) {
            bench_shared_cache_miss(bencher, $num_addrs);
        }
    };
}

address_benchmarks!(owned_hit_8, shared_hit_8, owned_miss_8, shared_miss_8, 8);
address_benchmarks!(owned_hit_9, shared_hit_9, owned_miss_9, shared_miss_9, 9);
address_benchmarks!(owned_hit_10, shared_hit_10, owned_miss_10, shared_miss_10, 10);
address_benchmarks!(owned_hit_200, shared_hit_200, owned_miss_200, shared_miss_200, 200);

benchmark_group!(
    benches,
    owned_hit_8,
    shared_hit_8,
    owned_miss_8,
    shared_miss_8,
    owned_hit_9,
    shared_hit_9,
    owned_miss_9,
    shared_miss_9,
    owned_hit_10,
    shared_hit_10,
    owned_miss_10,
    shared_miss_10,
    owned_hit_200,
    shared_hit_200,
    owned_miss_200,
    shared_miss_200,
);
benchmark_main!(benches);
```

## Last benchmark round

| Fanout | Cache hit owned | Cache hit shared | Cache hit improvement | Cache miss owned | Cache miss shared | Shared miss elapsed-time change |
|---:|---:|---:|---:|---:|---:|---:|
| 8 | 7 ns | 2 ns | 71.4% faster | 14 ns | 21 ns | +50.0% |
| 9 | 8 ns | 2 ns | 75.0% faster | 16 ns | 19 ns | +18.8% |
| 10 | 7 ns | 2 ns | 71.4% faster | 15 ns | 19 ns | +26.7% |
| 200 | 54 ns | 2 ns | 96.3% faster | 111 ns | 110 ns | -0.9% |

Positive cache-miss changes mean the shared path took longer; negative means it took less time.

