### PR TITLE
perf: reuse retransmit slot lookup storage

### DIFF
--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -124,7 +124,56 @@ struct RetransmitState {
     stats: RetransmitStats,
     addr_cache: AddrCache,
     shred_buf: Vec<Vec<shred::Payload>>,
+    slot_cache: SortedSlotCache<(Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
     pending_first_shred_event: Option<VotorEvent>,
+}
+
+/// Reusable sorted lookup for the small number of slots in one retransmit batch.
+struct SortedSlotCache<T> {
+    slots: Vec<Slot>,
+    entries: Vec<(Slot, T)>,
+}
+
+impl<T> Default for SortedSlotCache<T> {
+    fn default() -> Self {
+        Self {
+            slots: Vec::new(),
+            entries: Vec::new(),
+        }
+    }
+}
+
+impl<T> SortedSlotCache<T> {
+    fn populate(
+        &mut self,
+        slots: impl IntoIterator<Item = Slot>,
+        mut make_entry: impl FnMut(Slot) -> Option<T>,
+    ) {
+        self.entries.clear();
+        self.slots.clear();
+        self.slots.extend(slots);
+        self.slots.sort_unstable();
+        self.slots.dedup();
+        self.entries.extend(
+            self.slots
+                .iter()
+                .filter_map(|&slot| make_entry(slot).map(|entry| (slot, entry))),
+        );
+    }
+
+    #[inline]
+    fn get(&self, slot: Slot) -> Option<&T> {
+        let index = self
+            .entries
+            .binary_search_by_key(&slot, |&(slot, _)| slot)
+            .ok()?;
+        Some(&self.entries[index].1)
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.slots.clear();
+    }
 }
 
 struct RetransmitNotifiers {
@@ -154,6 +203,7 @@ impl RetransmitState {
             stats: RetransmitStats::new(now),
             addr_cache: AddrCache::with_capacity(/*capacity:*/ 4),
             shred_buf: Vec::with_capacity(RETRANSMIT_BATCH_SIZE),
+            slot_cache: SortedSlotCache::default(),
             pending_first_shred_event: None,
         }
     }
@@ -334,6 +384,7 @@ fn retransmit(context: &RetransmitContext, state: &mut RetransmitState) -> Resul
         stats,
         addr_cache,
         shred_buf,
+        slot_cache,
         pending_first_shred_event,
     } = state;
 
@@ -400,13 +451,12 @@ fn retransmit(context: &RetransmitContext, state: &mut RetransmitState) -> Resul
     epoch_cache_update.stop();
     stats.epoch_cache_update += epoch_cache_update.as_us();
     // Lookup slot leader and cluster nodes for each slot.
-    let cache: HashMap<Slot, _> = shred_buf
-        .iter()
-        .flatten()
-        .filter_map(|shred| shred::layout::get_slot(shred))
-        .collect::<HashSet<Slot>>()
-        .into_iter()
-        .filter_map(|slot: Slot| {
+    slot_cache.populate(
+        shred_buf
+            .iter()
+            .flatten()
+            .filter_map(|shred| shred::layout::get_slot(shred)),
+        |slot| {
             max_slots.retransmit.fetch_max(slot, Ordering::Relaxed);
             // TODO: consider using root-bank here for leader lookup!
             // Shreds' signatures should be verified before they reach here,
@@ -420,9 +470,9 @@ fn retransmit(context: &RetransmitContext, state: &mut RetransmitState) -> Resul
             };
             let cluster_nodes =
                 cluster_nodes_cache.get(slot, &root_bank, &working_bank, cluster_info);
-            Some((slot, (slot_leader.id, cluster_nodes)))
-        })
-        .collect();
+            Some((slot_leader.id, cluster_nodes))
+        },
+    );
     let socket_addr_space = cluster_info.socket_addr_space();
     let record = |mut stats: HashMap<Slot, RetransmitSlotStats>, out: RetransmitShredOutput| {
         let now = timestamp();
@@ -435,7 +485,7 @@ fn retransmit(context: &RetransmitContext, state: &mut RetransmitState) -> Resul
             shred,
             &root_bank,
             shred_deduper,
-            &cache,
+            slot_cache,
             addr_cache,
             socket_addr_space,
             socket,
@@ -478,6 +528,8 @@ fn retransmit(context: &RetransmitContext, state: &mut RetransmitState) -> Resul
         &context.notifiers,
         pending_first_shred_event,
     );
+    // Retain only vector allocations between batches, not ClusterNodes Arcs.
+    slot_cache.clear();
     timer_start.stop();
     stats.total_time += timer_start.as_us();
     stats.maybe_submit(
@@ -495,7 +547,7 @@ fn retransmit_shred(
     shred: shred::Payload,
     root_bank: &Bank,
     shred_deduper: &ShredDeduper,
-    cache: &HashMap<Slot, (/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
+    cache: &SortedSlotCache<(/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
     addr_cache: &AddrCache,
     socket_addr_space: &SocketAddrSpace,
     socket: RetransmitSocket<'_>,
@@ -570,7 +622,7 @@ fn retransmit_shred(
 
 fn get_retransmit_addrs<'a>(
     shred: &ShredId,
-    cache: &HashMap<Slot, (/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
+    cache: &SortedSlotCache<(/*leader:*/ Pubkey, Arc<ClusterNodes<RetransmitStage>>)>,
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
     stats: &RetransmitStats,
@@ -579,7 +631,7 @@ fn get_retransmit_addrs<'a>(
         stats.addr_cache_hit.fetch_add(1, Ordering::Relaxed);
         return Some((root_distance, Cow::Borrowed(addrs)));
     }
-    let (slot_leader, cluster_nodes) = cache.get(&shred.slot())?;
+    let (slot_leader, cluster_nodes) = cache.get(shred.slot())?;
     let (root_distance, addrs) = cluster_nodes
         .get_retransmit_addrs(slot_leader, shred, DATA_PLANE_FANOUT, socket_addr_space)
         .inspect_err(|err| match err {
@@ -966,6 +1018,31 @@ mod tests {
             .map(Keypair::try_from)
             .unwrap()
             .unwrap()
+    }
+
+    #[test]
+    fn test_sorted_slot_cache() {
+        let mut visited = Vec::new();
+        let mut cache = SortedSlotCache::default();
+        cache.populate([3, 1, 2, 3, 1], |slot| {
+            visited.push(slot);
+            (slot != 2).then_some(slot * 10)
+        });
+
+        assert_eq!(visited, [1, 2, 3]);
+        assert_eq!(cache.get(1), Some(&10));
+        assert_eq!(cache.get(2), None);
+        assert_eq!(cache.get(3), Some(&30));
+        assert_eq!(cache.get(4), None);
+
+        let slots_capacity = cache.slots.capacity();
+        let entries_capacity = cache.entries.capacity();
+        cache.clear();
+        cache.populate([4, 4], |slot| Some(slot * 10));
+        assert_eq!(cache.get(1), None);
+        assert_eq!(cache.get(4), Some(&40));
+        assert_eq!(cache.slots.capacity(), slots_capacity);
+        assert_eq!(cache.entries.capacity(), entries_capacity);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace per-batch `HashSet<Slot>` and `HashMap` construction with reusable sorted slot and entry vectors
- sort and deduplicate once per retransmit batch, then use binary search for exact slot lookup
- clear cached values after dispatch to release `ClusterNodes` handles while retaining vector capacity

Retransmit batches normally cover few slots. Reusing contiguous storage removes steady-state allocation and hashing costs without changing peer selection or payload ownership.

## Benchmark harness

The last-round harness is preserved here without adding benchmark-only dependencies or targets to the repository:

```rust
#![allow(clippy::arithmetic_side_effects)]

use {
    bencher::{Bencher, benchmark_group, benchmark_main},
    jemallocator::Jemalloc,
    solana_clock::Slot,
    solana_turbine::retransmit_stage::SortedSlotCache,
    std::{
        alloc::{GlobalAlloc, Layout},
        collections::{HashMap, HashSet},
        hint::black_box,
        sync::{
            Once,
            atomic::{AtomicUsize, Ordering},
        },
    },
};

// Production observations show 10--34 accepted shreds per channel message. Use
// the midpoint when flattening the receiver's maximum 4,096-message backlog.
const ACCEPTED_SHREDS_PER_MESSAGE: usize = 22;
const OBSERVED_BATCH_SIZE: usize = 34;

struct CountingAllocator;

static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);

// SAFETY: Allocation operations are forwarded unchanged to the validator's
// allocator; the atomics only observe successful allocation requests.
unsafe impl GlobalAlloc for CountingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        // SAFETY: The caller supplies the `GlobalAlloc` layout contract.
        let ptr = unsafe { Jemalloc.alloc(layout) };
        if !ptr.is_null() {
            ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
            ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
        }
        ptr
    }

    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
        // SAFETY: The caller supplies the `GlobalAlloc` layout contract.
        let ptr = unsafe { Jemalloc.alloc_zeroed(layout) };
        if !ptr.is_null() {
            ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
            ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
        }
        ptr
    }

    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
        // SAFETY: The caller guarantees this pointer/layout came from this allocator.
        unsafe { Jemalloc.dealloc(ptr, layout) };
    }

    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
        // SAFETY: The caller supplies the `GlobalAlloc` reallocation contract.
        let ptr = unsafe { Jemalloc.realloc(ptr, layout, new_size) };
        if !ptr.is_null() {
            ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
            ALLOC_BYTES.fetch_add(new_size, Ordering::Relaxed);
        }
        ptr
    }
}

#[global_allocator]
static GLOBAL: CountingAllocator = CountingAllocator;

#[derive(Clone, Copy)]
enum SlotDistribution {
    One,
    Adjacent8,
    AdversarialUnique,
}

fn make_observed_batch(num_slots: usize) -> Vec<Slot> {
    assert!(num_slots <= OBSERVED_BATCH_SIZE);
    (0..OBSERVED_BATCH_SIZE)
        // Deliberately scramble adjacent slots so the sorted representation
        // benchmarks its real ordering work rather than pre-sorted input.
        .map(|index| ((index * 5 + 3) % num_slots) as Slot)
        .collect()
}

fn make_backlog(messages: usize, distribution: SlotDistribution) -> Vec<Slot> {
    let shreds = messages.saturating_mul(ACCEPTED_SHREDS_PER_MESSAGE);
    (0..shreds)
        .map(|index| match distribution {
            SlotDistribution::One => 250_000_000,
            SlotDistribution::Adjacent8 => 250_000_000 + ((index * 5 + 3) % 8) as Slot,
            // Five is coprime to every benchmark length (22 * a power of two),
            // yielding a unique, deliberately scrambled permutation.
            SlotDistribution::AdversarialUnique => 250_000_000 + ((index * 5 + 3) % shreds) as Slot,
        })
        .collect()
}

fn legacy_once(batch: &[Slot]) {
    let cache: HashMap<Slot, Slot> = black_box(batch)
        .iter()
        // Match shred-layout extraction, whose filter_map has a zero lower size
        // hint even when every production shred is valid.
        .filter_map(|&slot| black_box(Some(slot)))
        .collect::<HashSet<_>>()
        .into_iter()
        .map(|slot| (slot, slot))
        .collect();
    for slot in black_box(batch) {
        black_box(cache.get(slot));
    }
    black_box(cache);
}

fn sorted_once(cache: &mut SortedSlotCache<Slot>, batch: &[Slot]) {
    cache.populate(black_box(batch).iter().copied(), Some);
    for &slot in black_box(batch) {
        black_box(cache.get(slot));
    }
}

fn assert_equivalent(batch: &[Slot]) {
    let legacy: HashMap<_, _> = batch.iter().copied().map(|slot| (slot, slot)).collect();
    let mut sorted = SortedSlotCache::default();
    sorted.populate(batch.iter().copied(), Some);
    for (&slot, expected) in &legacy {
        assert_eq!(sorted.get(slot), Some(expected));
    }
    assert_eq!(sorted.get(Slot::MAX), legacy.get(&Slot::MAX));
}

fn allocation_probe(mut run: impl FnMut()) -> (usize, usize) {
    run(); // Warm allocator-local state before resetting the counters.
    (0..8)
        .map(|_| {
            ALLOC_CALLS.store(0, Ordering::Relaxed);
            ALLOC_BYTES.store(0, Ordering::Relaxed);
            run();
            (
                ALLOC_CALLS.load(Ordering::Relaxed),
                ALLOC_BYTES.load(Ordering::Relaxed),
            )
        })
        .min()
        .unwrap()
}

fn bench_legacy(bencher: &mut Bencher, batch: Vec<Slot>, report: &'static Once) {
    assert_equivalent(&batch);
    report.call_once(|| {
        let allocations = allocation_probe(|| legacy_once(&batch));
        eprintln!(
            "retransmit-slot-cache legacy shreds={} allocations={}/{}B",
            batch.len(),
            allocations.0,
            allocations.1,
        );
    });
    bencher.iter(|| legacy_once(&batch));
}

fn bench_sorted_reused(bencher: &mut Bencher, batch: Vec<Slot>, report: &'static Once) {
    assert_equivalent(&batch);
    let mut cache = SortedSlotCache::<Slot>::default();
    sorted_once(&mut cache, &batch); // Warm both reusable allocations.
    report.call_once(|| {
        let allocations = allocation_probe(|| sorted_once(&mut cache, &batch));
        eprintln!(
            "retransmit-slot-cache sorted-reused shreds={} allocations={}/{}B",
            batch.len(),
            allocations.0,
            allocations.1,
        );
    });
    bencher.iter(|| sorted_once(&mut cache, &batch));
}

macro_rules! observed_slot_benchmarks {
    ($legacy:ident, $sorted:ident, $num_slots:expr) => {
        fn $legacy(bencher: &mut Bencher) {
            static REPORT: Once = Once::new();
            bench_legacy(bencher, make_observed_batch($num_slots), &REPORT);
        }

        fn $sorted(bencher: &mut Bencher) {
            static REPORT: Once = Once::new();
            bench_sorted_reused(bencher, make_observed_batch($num_slots), &REPORT);
        }
    };
}

macro_rules! backlog_benchmarks {
    ($legacy:ident, $sorted:ident, $messages:expr, $distribution:expr) => {
        fn $legacy(bencher: &mut Bencher) {
            static REPORT: Once = Once::new();
            bench_legacy(bencher, make_backlog($messages, $distribution), &REPORT);
        }

        fn $sorted(bencher: &mut Bencher) {
            static REPORT: Once = Once::new();
            bench_sorted_reused(bencher, make_backlog($messages, $distribution), &REPORT);
        }
    };
}

observed_slot_benchmarks!(bench_legacy_1_slot, bench_sorted_reused_1_slot, 1);
observed_slot_benchmarks!(bench_legacy_2_slots, bench_sorted_reused_2_slots, 2);
observed_slot_benchmarks!(bench_legacy_4_slots, bench_sorted_reused_4_slots, 4);
observed_slot_benchmarks!(bench_legacy_8_slots, bench_sorted_reused_8_slots, 8);

backlog_benchmarks!(
    bench_backlog_one_1_legacy,
    bench_backlog_one_1_sorted,
    1,
    SlotDistribution::One
);
backlog_benchmarks!(
    bench_backlog_one_8_legacy,
    bench_backlog_one_8_sorted,
    8,
    SlotDistribution::One
);
backlog_benchmarks!(
    bench_backlog_one_64_legacy,
    bench_backlog_one_64_sorted,
    64,
    SlotDistribution::One
);
backlog_benchmarks!(
    bench_backlog_one_4096_legacy,
    bench_backlog_one_4096_sorted,
    4096,
    SlotDistribution::One
);
backlog_benchmarks!(
    bench_backlog_adjacent_1_legacy,
    bench_backlog_adjacent_1_sorted,
    1,
    SlotDistribution::Adjacent8
);
backlog_benchmarks!(
    bench_backlog_adjacent_8_legacy,
    bench_backlog_adjacent_8_sorted,
    8,
    SlotDistribution::Adjacent8
);
backlog_benchmarks!(
    bench_backlog_adjacent_64_legacy,
    bench_backlog_adjacent_64_sorted,
    64,
    SlotDistribution::Adjacent8
);
backlog_benchmarks!(
    bench_backlog_adjacent_4096_legacy,
    bench_backlog_adjacent_4096_sorted,
    4096,
    SlotDistribution::Adjacent8
);
backlog_benchmarks!(
    bench_backlog_unique_1_legacy,
    bench_backlog_unique_1_sorted,
    1,
    SlotDistribution::AdversarialUnique
);
backlog_benchmarks!(
    bench_backlog_unique_8_legacy,
    bench_backlog_unique_8_sorted,
    8,
    SlotDistribution::AdversarialUnique
);
backlog_benchmarks!(
    bench_backlog_unique_64_legacy,
    bench_backlog_unique_64_sorted,
    64,
    SlotDistribution::AdversarialUnique
);
backlog_benchmarks!(
    bench_backlog_unique_4096_legacy,
    bench_backlog_unique_4096_sorted,
    4096,
    SlotDistribution::AdversarialUnique
);

benchmark_group!(
    benches,
    bench_legacy_1_slot,
    bench_sorted_reused_1_slot,
    bench_legacy_2_slots,
    bench_sorted_reused_2_slots,
    bench_legacy_4_slots,
    bench_sorted_reused_4_slots,
    bench_legacy_8_slots,
    bench_sorted_reused_8_slots,
    bench_backlog_one_1_legacy,
    bench_backlog_one_1_sorted,
    bench_backlog_one_8_legacy,
    bench_backlog_one_8_sorted,
    bench_backlog_one_64_legacy,
    bench_backlog_one_64_sorted,
    bench_backlog_one_4096_legacy,
    bench_backlog_one_4096_sorted,
    bench_backlog_adjacent_1_legacy,
    bench_backlog_adjacent_1_sorted,
    bench_backlog_adjacent_8_legacy,
    bench_backlog_adjacent_8_sorted,
    bench_backlog_adjacent_64_legacy,
    bench_backlog_adjacent_64_sorted,
    bench_backlog_adjacent_4096_legacy,
    bench_backlog_adjacent_4096_sorted,
    bench_backlog_unique_1_legacy,
    bench_backlog_unique_1_sorted,
    bench_backlog_unique_8_legacy,
    bench_backlog_unique_8_sorted,
    bench_backlog_unique_64_legacy,
    bench_backlog_unique_64_sorted,
    bench_backlog_unique_4096_legacy,
    bench_backlog_unique_4096_sorted,
);
benchmark_main!(benches);
```

## Last benchmark round

Production-shaped batches used 34 shreds:

| Slots | Previous | Reused | Improvement |
| ---: | ---: | ---: | ---: |
| 1 | 946 ns | 43 ns | 22.0x |
| 2 | 965 ns | 94 ns | 10.3x |
| 4 | 1,056 ns | 136 ns | 7.76x |
| 8 | 1,263 ns | 161 ns | 7.84x |

One-slot backlog results:

| Messages | Previous | Reused |
| ---: | ---: | ---: |
| 1 | 625 ns | 30 ns |
| 8 | 4,648 ns | 190 ns |
| 64 | 36,767 ns | 1,571 ns |
| 4,096 | 2.351232 ms | 108.391 us |

The maximum adjacent-slot backlog improved from 2.354463 ms to 383.788 us. The maximum unique-slot backlog improved from 6.406204 ms to 2.194278 ms. Every warmed reuse shape recorded zero allocations.

