### PR TITLE
Share XDP retransmit addresses

### DIFF
--- a/turbine/src/addr_cache.rs
+++ b/turbine/src/addr_cache.rs
@@ -9,6 +9,7 @@ use {
         cmp::Reverse,
         collections::{HashMap, VecDeque, hash_map::Entry},
         net::SocketAddr,
+        sync::Arc,
     },
 };
 
@@ -51,8 +52,8 @@ pub(crate) struct AddrCache {
 struct CacheEntry {
     // Root distance and socket addresses cached either speculatively or when
     // retransmitting incoming shreds.
-    code: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
-    data: Vec<Option<(/*root_distance:*/ u8, Box<[SocketAddr]>)>>,
+    code: Vec<Option<(/*root_distance:*/ u8, Arc<[SocketAddr]>)>>,
+    data: Vec<Option<(/*root_distance:*/ u8, Arc<[SocketAddr]>)>>,
     // Code and data indices where [..index] are fully populated.
     index_code: usize,
     index_data: usize,
@@ -81,7 +82,10 @@ impl AddrCache {
 
     // Returns (root-distance, socket-addresses) cached for the given shred-id.
     #[inline]
-    pub(crate) fn get(&self, shred: &ShredId) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    pub(crate) fn get(
+        &self,
+        shred: &ShredId,
+    ) -> Option<(/*root_distance:*/ u8, &Arc<[SocketAddr]>)> {
         self.cache
             .get(&shred.slot())?
             .get(shred.shred_type(), shred.index())
@@ -92,7 +96,7 @@ impl AddrCache {
     pub(crate) fn put(
         &mut self,
         shred: &ShredId,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Arc<[SocketAddr]>),
     ) {
         self.get_cache_entry_mut(shred.slot())
             .put(shred.shred_type(), shred.index(), entry);
@@ -266,14 +270,14 @@ impl CacheEntry {
         &self,
         shred_type: ShredType,
         shred_index: u32,
-    ) -> Option<(/*root_distance:*/ u8, &[SocketAddr])> {
+    ) -> Option<(/*root_distance:*/ u8, &Arc<[SocketAddr]>)> {
         match shred_type {
             ShredType::Code => &self.code,
             ShredType::Data => &self.data,
         }
         .get(shred_index as usize)?
         .as_ref()
-        .map(|(root_distance, addrs)| (*root_distance, addrs.as_ref()))
+        .map(|(root_distance, addrs)| (*root_distance, addrs))
     }
 
     // Stores (root-distance, socket-addresses) for the given shred type and
@@ -283,7 +287,7 @@ impl CacheEntry {
         &mut self,
         shred_type: ShredType,
         shred_index: u32,
-        entry: (/*root_distance:*/ u8, Box<[SocketAddr]>),
+        entry: (/*root_distance:*/ u8, Arc<[SocketAddr]>),
     ) {
         let cache = match shred_type {
             ShredType::Code => &mut self.code,
@@ -354,9 +358,9 @@ mod tests {
         assert_eq!(entry.index_code, 0);
         assert_eq!(entry.index_data, 0);
 
-        entry.put(ShredType::Code, 0, (0, Box::new([])));
-        entry.put(ShredType::Code, 2, (0, Box::new([])));
-        entry.put(ShredType::Data, 1, (0, Box::new([])));
+        entry.put(ShredType::Code, 0, (0, Arc::from([])));
+        entry.put(ShredType::Code, 2, (0, Arc::from([])));
+        entry.put(ShredType::Data, 1, (0, Arc::from([])));
         assert!(entry.get_shreds(5).eq([
             (ShredType::Code, 1),
             (ShredType::Data, 0),
@@ -369,10 +373,10 @@ mod tests {
         assert_eq!(entry.index_code, 1);
         assert_eq!(entry.index_data, 0);
 
-        entry.put(ShredType::Code, 1, (0, Box::new([])));
-        entry.put(ShredType::Code, 4, (0, Box::new([])));
-        entry.put(ShredType::Data, 0, (0, Box::new([])));
-        entry.put(ShredType::Data, 3, (0, Box::new([])));
+        entry.put(ShredType::Code, 1, (0, Arc::from([])));
+        entry.put(ShredType::Code, 4, (0, Arc::from([])));
+        entry.put(ShredType::Data, 0, (0, Arc::from([])));
+        entry.put(ShredType::Data, 3, (0, Arc::from([])));
         assert!(entry.get_shreds(5).eq([
             (ShredType::Code, 3),
             (ShredType::Data, 2),
@@ -405,8 +409,8 @@ mod tests {
         assert_eq!(entry.index_code, 3);
         assert_eq!(entry.index_data, 2);
 
-        entry.put(ShredType::Code, 3, (0, Box::new([])));
-        entry.put(ShredType::Data, 2, (0, Box::new([])));
+        entry.put(ShredType::Code, 3, (0, Arc::from([])));
+        entry.put(ShredType::Data, 2, (0, Arc::from([])));
         assert!(entry.get_shreds(7).eq([]));
         assert_eq!(entry.index_code, 5);
         assert_eq!(entry.index_data, 4);

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -78,7 +78,7 @@ struct RetransmitShredOutput {
     // Number of nodes the shred was retransmitted to.
     num_nodes: usize,
     // Addresses the shred was sent to if there was a cache miss.
-    addrs: Option<Box<[SocketAddr]>>,
+    addrs: Option<Arc<[SocketAddr]>>,
 }
 
 #[derive(Default)]
@@ -96,7 +96,7 @@ pub(crate) struct RetransmitSlotStats {
     num_shreds_sent: [usize; MAX_NUM_TURBINE_HOPS],
     // Root distance and socket-addresses the shreds were sent to if there was
     // a cache miss.
-    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Box<[SocketAddr]>)>,
+    pub(crate) addrs: Vec<(ShredId, /*root_distance:*/ u8, Arc<[SocketAddr]>)>,
 }
 
 struct RetransmitStats {
@@ -524,7 +524,8 @@ fn retransmit_shred(
         RetransmitSocket::Xdp(sender) => {
             let mut sent = num_addrs;
             if num_addrs > 0
-                && let Err(e) = sender.try_send(key.index() as usize, addrs.to_vec(), shred.bytes)
+                && let Err(e) =
+                    sender.try_send(key.index() as usize, Arc::clone(&addrs), shred.bytes)
             {
                 log::warn!("xdp channel full: {e:?}");
                 stats
@@ -536,7 +537,7 @@ fn retransmit_shred(
         }
         RetransmitSocket::Socket(_) | RetransmitSocket::Multihomed { .. } => {
             let socket = socket.get_socket();
-            match multi_target_send(socket, shred, &addrs) {
+            match multi_target_send(socket, shred, addrs.as_ref()) {
                 Ok(()) => num_addrs,
                 Err(SendPktsError::IoError(ioerr, num_failed)) => {
                     error!(
@@ -562,7 +563,7 @@ fn retransmit_shred(
         root_distance,
         num_nodes,
         addrs: match addrs {
-            Cow::Owned(addrs) => Some(addrs.into_boxed_slice()),
+            Cow::Owned(addrs) => Some(addrs),
             Cow::Borrowed(_) => None,
         },
     })
@@ -574,7 +575,7 @@ fn get_retransmit_addrs<'a>(
     addr_cache: &'a AddrCache,
     socket_addr_space: &SocketAddrSpace,
     stats: &RetransmitStats,
-) -> Option<(/*root_distance:*/ u8, Cow<'a, [SocketAddr]>)> {
+) -> Option<(/*root_distance:*/ u8, Cow<'a, Arc<[SocketAddr]>>)> {
     if let Some((root_distance, addrs)) = addr_cache.get(shred) {
         stats.addr_cache_hit.fetch_add(1, Ordering::Relaxed);
         return Some((root_distance, Cow::Borrowed(addrs)));
@@ -589,7 +590,7 @@ fn get_retransmit_addrs<'a>(
         })
         .ok()?;
     stats.addr_cache_miss.fetch_add(1, Ordering::Relaxed);
-    Some((root_distance, Cow::Owned(addrs)))
+    Some((root_distance, Cow::Owned(Arc::from(addrs))))
 }
 
 // Speculatively precomputes turbine tree and caches retranmsit addresses.
@@ -632,7 +633,7 @@ fn cache_retransmit_addrs(
         let (root_distance, addrs) = cluster_nodes
             .get_retransmit_addrs(slot_leader, &shred, DATA_PLANE_FANOUT, socket_addr_space)
             .ok()?;
-        Some((shred, (root_distance, addrs.into_boxed_slice())))
+        Some((shred, (root_distance, Arc::from(addrs))))
     };
     let mut out = false;
     if shreds.len() < PAR_ITER_MIN_NUM_SHREDS {

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -193,7 +193,7 @@ pub struct XdpSender {
 
 pub enum XdpAddrs {
     Single(SocketAddr),
-    Multi(Vec<SocketAddr>),
+    Multi(Arc<[SocketAddr]>),
 }
 
 impl From<SocketAddr> for XdpAddrs {
@@ -206,6 +206,13 @@ impl From<SocketAddr> for XdpAddrs {
 impl From<Vec<SocketAddr>> for XdpAddrs {
     #[inline]
     fn from(addrs: Vec<SocketAddr>) -> Self {
+        XdpAddrs::Multi(addrs.into())
+    }
+}
+
+impl From<Arc<[SocketAddr]>> for XdpAddrs {
+    #[inline]
+    fn from(addrs: Arc<[SocketAddr]>) -> Self {
         XdpAddrs::Multi(addrs)
     }
 }


### PR DESCRIPTION
## Summary

Cache retransmit destination arrays as `Arc<[SocketAddr]>` so XDP can share them without copying.

- `AddrCache` now stores `Arc<[SocketAddr]>`
- `XdpAddrs::Multi` now owns `Arc<[SocketAddr]>`, XDP cache hits clone the `Arc` instead of allocating and copying a `Vec`.
- Cache misses convert the computed `Vec` to `Arc` once and share it with XDP.
- UDP continues to borrow the cached slice.

## Production motivation

One 2-second `retransmit-stage` datapoint at `2026-07-19T14:59:59.088Z` had:

```text
num_nodes=96056
num_shreds=26096
num_shreds_skipped=15604
addr_cache_hit=10453
addr_cache_miss=39
num_addrs_failed=0
num_shreds_dropped_xdp_full=0
```

- Accepted shreds: `10453 + 39 = 10492`, matching `26096 - 15604`.
- Cache-hit rate: `10453 / 10492 = 99.6283%`.
- Destinations per accepted shred: `96056 / 10492 = 9.155`.
- At that hit rate and fanout, sharing avoids roughly 48,000 `SocketAddr` element copies per second in the sampled workload.

## Benchmark
- **Before (`owned`)**: a hit copies the cached boxed slice into a `Vec`; a miss copies the computed `Vec` for XDP and boxes the original for the cache.
- **After (`shared`)**: a hit clones the cached `Arc`; a miss converts the computed `Vec` to `Arc` once and clones it for XDP.

Command:
The benchmark binary uses `tikv-jemallocator` 0.6.0 as its global allocator. Values are medians from three serial runs.

| Fanout | Before hit | After hit | Change | Before miss | After miss | Change |
|---:|---:|---:|---:|---:|---:|---:|
| 8 | 5 ns | 2 ns | 60.0% faster | 10 ns | 13 ns | 30.0% slower |
| 9 | 7 ns | 2 ns | 71.4% faster | 14 ns | 21 ns | 50.0% slower |
| 10 | 7 ns | 2 ns | 71.4% faster | 14 ns | 18 ns | 28.6% slower |
| 200 | 52 ns | 2 ns | 96.2% faster | 104 ns | 108 ns | 3.8% slower |

With the observed 99.6283% cache-hit rate, the hit path dominates.
