### PR TITLE
Reuse retransmit parent scratch storage

### DIFF
--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -42,6 +42,7 @@ thread_local! {
     static THREAD_LOCAL_WEIGHTED_SHUFFLE: RefCell<WeightedShuffle> = RefCell::new(
         WeightedShuffle::new::<[u64; 0]>("get_retransmit_addrs", []),
     );
+    static THREAD_LOCAL_PARENT_INDICES: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
 }
 
 pub(crate) const DATA_PLANE_FANOUT: usize = 200;
@@ -328,14 +329,16 @@ impl ClusterNodes<RetransmitStage> {
         }
 
         let mut rng = TurbineRng::new_seeded(leader, shred, self.use_cha_cha_8);
-        // Only need shuffled nodes until this node itself.
-        let nodes: Vec<_> = weighted_shuffle
-            .shuffle(&mut rng)
-            .map(|index| &self.nodes[index])
-            .take_while(|node| node.pubkey() != &self.pubkey)
-            .collect();
-        let parent = get_retransmit_parent(fanout, nodes.len(), &nodes);
-        Ok(parent.map(Node::pubkey).copied())
+        THREAD_LOCAL_PARENT_INDICES.with_borrow_mut(|indices| {
+            indices.clear();
+            indices.extend(
+                weighted_shuffle
+                    .shuffle(&mut rng)
+                    .take_while(|&index| self.nodes[index].pubkey() != &self.pubkey),
+            );
+            let parent = get_retransmit_parent(fanout, indices.len(), indices);
+            Ok(parent.map(|index| *self.nodes[index].pubkey()))
+        })
     }
 }
 
@@ -724,10 +727,68 @@ mod tests {
         itertools::Itertools,
         rand::prelude::IndexedRandom as _,
         solana_hash::Hash as SolanaHash,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::shred::{
+            ProcessShredsStats, ReedSolomonCache, ShredId, ShredType, Shredder,
+        },
         std::{collections::VecDeque, fmt::Debug, hash::Hash},
         test_case::test_case,
     };
+
+    fn legacy_get_retransmit_parent(
+        cluster_nodes: &ClusterNodes<RetransmitStage>,
+        leader: &Pubkey,
+        shred: &ShredId,
+        fanout: usize,
+    ) -> Option<Pubkey> {
+        let mut weighted_shuffle = cluster_nodes.weighted_shuffle.clone();
+        if let Some(index) = cluster_nodes.index.get(leader).copied() {
+            weighted_shuffle.remove_index(index);
+        }
+        let mut rng = TurbineRng::new_seeded(leader, shred, cluster_nodes.use_cha_cha_8);
+        let nodes: Vec<_> = weighted_shuffle
+            .shuffle(&mut rng)
+            .map(|index| &cluster_nodes.nodes[index])
+            .take_while(|node| node.pubkey() != &cluster_nodes.pubkey)
+            .collect();
+        get_retransmit_parent(fanout, nodes.len(), &nodes)
+            .map(Node::pubkey)
+            .copied()
+    }
+
+    #[test_case(true /* chacha8 */)]
+    #[test_case(false /* chacha20 */)]
+    fn test_retransmit_parent_scratch_matches_legacy(use_cha_cha_8: bool) {
+        let mut rng = ChaCha8Rng::seed_from_u64(0x5eed_cafe);
+        let (nodes, mut stakes, cluster_info) = make_test_cluster(&mut rng, 500, Some((4, 5)));
+        stakes.insert(cluster_info.id(), 1_000);
+        let cluster_nodes = new_cluster_nodes::<RetransmitStage>(
+            &cluster_info,
+            ClusterType::Development,
+            &stakes,
+            use_cha_cha_8,
+        );
+        for leader in nodes.iter().skip(1).take(4).map(GossipContactInfo::pubkey) {
+            for index in 0..256u32 {
+                let shred_type = if index % 2 == 0 {
+                    ShredType::Data
+                } else {
+                    ShredType::Code
+                };
+                let shred = ShredId::new(50_000 + u64::from(index), index, shred_type);
+                for fanout in [2, 32, DATA_PLANE_FANOUT] {
+                    let expected =
+                        legacy_get_retransmit_parent(&cluster_nodes, leader, &shred, fanout);
+                    let actual = cluster_nodes
+                        .get_retransmit_parent(leader, &shred, fanout)
+                        .unwrap();
+                    assert_eq!(
+                        actual, expected,
+                        "leader {leader}, shred {shred:?}, fanout {fanout}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test_case(true /* chacha8 */)]
     #[test_case(false /* chacha20 */)]


### PR DESCRIPTION
## Summary

Reuse a thread-local `Vec<usize>` when calculating a retransmit parent. The weighted-shuffle clone, seeded permutation, and parent selection remain unchanged; only the temporary index allocation is retained between calls. Deterministic equivalence coverage compares the legacy and scratch paths under ChaCha8 and ChaCha20 across multiple leaders, shred seeds and types, and fanouts.

## Benchmark harness

```rust
fn bench_shape(c: &mut Criterion, name: &str, fixture: Fixture) {
    let mut group = c.benchmark_group(format!("cluster_nodes/{name}/parent_warm"));
    group.throughput(Throughput::Elements(1));

    group.bench_function("before_legacy_clone_vec", |b| {
        let mut index = 0u32;
        b.iter(|| {
            let shred = ShredId::new(314_170_000, index, ShredType::Data);
            index = index.wrapping_add(1);
            black_box(fixture.cluster_nodes.legacy_get_retransmit_parent(
                &fixture.slot_leader,
                &shred,
                200,
            ));
        });
    });

    group.bench_function("after_thread_local_scratch", |b| {
        let mut index = 0u32;
        b.iter(|| {
            let shred = ShredId::new(314_170_000, index, ShredType::Data);
            index = index.wrapping_add(1);
            black_box(fixture.cluster_nodes.get_retransmit_parent(
                &fixture.slot_leader,
                &shred,
                200,
            ));
        });
    });

    group.finish();
}

fn bench_retransmit_parent(c: &mut Criterion) {
    bench_shape(
        c,
        "production_3928_721_staked",
        make_fixture(0x7a11_ce00, 3_830, (83, 100)),
    );
    bench_shape(
        c,
        "stress_5000",
        make_fixture(0x7a11_ce02, 4_900, (1, 2)),
    );
}
```

## Last benchmark round

| Fixture | Legacy | Scratch | Improvement |
| --- | ---: | ---: | ---: |
| Production: 3,928 nodes / 721 staked | 9.7550 µs | 9.4707 µs | 2.91% faster |
| Stress: 5,000 nodes | 32.129 µs | 31.478 µs | 2.03% faster |

