### PR TITLE
fix(runtime): set rewards len exactly to provided value

### DIFF
--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -836,10 +836,10 @@ impl Bank {
             total_stake_rewards_lamports,
         } = rewards_accumulator;
         // SAFETY: We initialized all the `stake_rewards` elements up to
-        // `num_stake_rewards`.
-        debug_assert!(num_stake_rewards <= stake_delegations_len);
+        // `stake_delegations_len` (one cell per delegation, `Some` or `None`).
+        // `num_stake_rewards` is the count of the `Some` cells.
         unsafe {
-            stake_rewards.assume_init(num_stake_rewards);
+            stake_rewards.assume_init(num_stake_rewards, stake_delegations_len);
         }
         measure_redeem_rewards.stop();
         metrics.redeem_rewards_us = measure_redeem_rewards.as_us();

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -96,9 +96,12 @@ impl PartitionedStakeRewards {
         self.rewards.spare_capacity_mut()
     }
 
-    unsafe fn assume_init(&mut self, num_stake_rewards: usize) {
+    /// Safety: all `total_len` elements must be initialized in `self.rewards`.
+    /// `num_stake_rewards` is the number of those elements that are `Some`.
+    unsafe fn assume_init(&mut self, num_stake_rewards: usize, total_len: usize) {
+        debug_assert!(num_stake_rewards <= total_len);
         unsafe {
-            self.rewards.set_len(self.rewards.capacity());
+            self.rewards.set_len(total_len);
         }
         self.num_rewards = num_stake_rewards;
     }


### PR DESCRIPTION
#### Problem
The vector has its len set using unsafe setter to its capacity, which is allocated prior to expected len, but Rust is allowed to overallocate and makes it incorrect.

#### Summary of Changes
Set vector len to the actual count of items that were initialized (that is a new parameter to `assume_init`, since the passed `num_stake_rewards` is the filtered count of `Some` items).

#### Testing
CI