### PR TITLE
bls-sigverify : check banlist before BLS verification to skip redunda…

### DIFF
--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -22,7 +22,10 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_streamer::nonblocking::simple_qos::SimpleQosBanlist,
-    std::collections::{HashMap, HashSet},
+    std::{
+        collections::{HashMap, HashSet},
+        time::Instant,
+    },
     thiserror::Error,
 };
 
@@ -41,7 +44,9 @@ enum CertVerifyError {
 
 struct CertVerifyOutcome {
     verified_cert: Option<Certificate>,
-    failures: Vec<(CertVerifyError, Pubkey)>,
+    local_stats: SigVerifyCertStats,
+    num_attempted: usize,
+    newly_banned: Vec<Pubkey>,
 }
 
 /// Verifies certificates and sends the verified certificates to the consensus pool.
@@ -58,8 +63,9 @@ pub(super) fn verify_and_send_certificates(
     root_bank: &Bank,
     channel_to_pool: &Sender<SigVerifiedBatch>,
     banlist: &SimpleQosBanlist,
+    locally_banned: &HashMap<Pubkey, Instant>,
     thread_pool: &ThreadPool,
-) -> Result<SigVerifyCertStats, SigVerifyCertError> {
+) -> Result<(SigVerifyCertStats, Vec<Pubkey>), SigVerifyCertError> {
     for cert_type in cert_groups.keys() {
         debug_assert!(!verified_certs_set.contains(cert_type));
     }
@@ -67,15 +73,16 @@ pub(super) fn verify_and_send_certificates(
     let mut stats = SigVerifyCertStats::default();
 
     if cert_groups.is_empty() {
-        return Ok(stats);
+        return Ok((stats, vec![]));
     }
 
-    let messages = verify_certs(
+    let (messages, newly_banned) = verify_certs(
         cert_groups,
         root_bank,
         verified_certs_set,
         &mut stats,
         banlist,
+        locally_banned,
         thread_pool,
     );
     stats.sig_verified_certs += messages.len() as u64;
@@ -85,7 +92,7 @@ pub(super) fn verify_and_send_certificates(
     stats
         .fn_verify_and_send_certs_stats
         .add_sample(measure.as_us());
-    Ok(stats)
+    Ok((stats, newly_banned))
 }
 
 /// Verifies certificates in `cert_groups`, stores a local copy, and prepares them for forwarding.
@@ -99,31 +106,27 @@ fn verify_certs(
     verified_certs_set: &mut HashSet<CertificateType>,
     stats: &mut SigVerifyCertStats,
     banlist: &SimpleQosBanlist,
+    locally_banned: &HashMap<Pubkey, Instant>,
     thread_pool: &ThreadPool,
-) -> SigVerifiedBatch {
+) -> (SigVerifiedBatch, Vec<Pubkey>) {
     let verified = thread_pool.install(|| {
         cert_groups
             .into_par_iter()
             .map(|(_, certs)| {
                 let num_certs = certs.len();
-                (num_certs, verify_cert_group(certs, root_bank))
+                (num_certs, verify_cert_group(certs, root_bank, locally_banned, banlist))
             })
             .collect::<Vec<_>>()
     });
 
     let mut certs = Vec::new();
+    let mut newly_banned = Vec::new();
     for (num_certs, outcome) in verified {
-        let num_certs_attempted = if outcome.verified_cert.is_some() {
-            outcome.failures.len().saturating_add(1)
-        } else {
-            outcome.failures.len()
-        };
-        stats.certs_to_sig_verify += num_certs_attempted as u64;
-        stats.redundant_certs_skipped += num_certs.saturating_sub(num_certs_attempted) as u64;
-
-        for (err, sender_identity_pubkey) in outcome.failures {
-            handle_cert_verify_error(err, sender_identity_pubkey, stats, banlist);
-        }
+        stats.certs_to_sig_verify += outcome.num_attempted as u64;
+        stats.redundant_certs_skipped +=
+            num_certs.saturating_sub(outcome.num_attempted) as u64;
+        stats.merge(outcome.local_stats);
+        newly_banned.extend(outcome.newly_banned);
 
         if let Some(cert) = outcome.verified_cert {
             if verified_certs_set.insert(cert.cert_type) {
@@ -134,27 +137,55 @@ fn verify_certs(
         }
     }
 
-    SigVerifiedBatch::Certificates(certs)
+    (SigVerifiedBatch::Certificates(certs), newly_banned)
 }
 
-fn verify_cert_group(certs: Vec<CertPayload>, root_bank: &Bank) -> CertVerifyOutcome {
-    let mut failures = Vec::new();
+fn verify_cert_group(
+    certs: Vec<CertPayload>,
+    root_bank: &Bank,
+    locally_banned: &HashMap<Pubkey, Instant>,
+    banlist: &SimpleQosBanlist,
+) -> CertVerifyOutcome {
+    let mut local_stats = SigVerifyCertStats::default();
+    let mut num_attempted = 0;
+    let mut newly_banned = Vec::new();
+    // Tracks senders that failed earlier in this same group so we skip their duplicates.
+    let mut intra_group_banned = HashSet::new();
 
     for cert_payload in certs {
+        if locally_banned.contains_key(&cert_payload.sender_identity_pubkey)
+            || intra_group_banned.contains(&cert_payload.sender_identity_pubkey)
+        {
+            continue;
+        }
+        num_attempted += 1;
         match verify_cert(cert_payload.cert, root_bank) {
             Ok(cert) => {
                 return CertVerifyOutcome {
                     verified_cert: Some(cert),
-                    failures,
+                    local_stats,
+                    num_attempted,
+                    newly_banned,
                 };
             }
-            Err(err) => failures.push((err, cert_payload.sender_identity_pubkey)),
+            Err(err) => {
+                intra_group_banned.insert(cert_payload.sender_identity_pubkey);
+                newly_banned.push(cert_payload.sender_identity_pubkey);
+                handle_cert_verify_error(
+                    err,
+                    cert_payload.sender_identity_pubkey,
+                    &mut local_stats,
+                    banlist,
+                );
+            }
         }
     }
 
     CertVerifyOutcome {
         verified_cert: None,
-        failures,
+        local_stats,
+        num_attempted,
+        newly_banned,
     }
 }
 

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -39,7 +39,7 @@ use {
             atomic::{AtomicBool, Ordering},
         },
         thread::{self, Builder},
-        time::Duration,
+        time::{Duration, Instant},
     },
 };
 
@@ -116,6 +116,8 @@ struct SigVerifier {
     generated_cert_types: Arc<GeneratedCertTypes>,
     vote_pool: VotePool,
     rank_map_cache: HashMap<Epoch, Arc<BLSPubkeyToRankMap>>,
+    /// Senders banned locally due to invalid certs/votes, replacing banlist.is_banned() reads.
+    locally_banned: HashMap<Pubkey, Instant>,
 }
 
 impl SigVerifier {
@@ -150,6 +152,7 @@ impl SigVerifier {
             thread_pool,
             generated_cert_types,
             rank_map_cache: HashMap::new(),
+            locally_banned: HashMap::new(),
         }
     }
 
@@ -224,13 +227,19 @@ impl SigVerifier {
                     &root_bank,
                     &self.channels.channel_to_pool,
                     &self.banlist,
+                    &self.locally_banned,
                     &self.thread_pool,
                 )
             },
         );
 
-        let vote_stats = votes_result?;
-        let cert_stats = certs_result?;
+        let (vote_stats, newly_banned_votes) = votes_result?;
+        let (cert_stats, newly_banned_certs) = certs_result?;
+
+        let now = Instant::now();
+        for pubkey in newly_banned_votes.into_iter().chain(newly_banned_certs) {
+            self.locally_banned.insert(pubkey, now);
+        }
 
         self.stats.vote_stats.merge(vote_stats);
         self.stats.cert_stats.merge(cert_stats);
@@ -244,6 +253,8 @@ impl SigVerifier {
             self.last_checked_root_slot = root_slot;
             self.verified_certs.retain(|cert| cert.slot() >= root_slot);
             self.vote_pool.prune(root_slot);
+            self.locally_banned
+                .retain(|_, banned_at| banned_at.elapsed() < BAN_TIMEOUT);
         }
         if self.last_checked_root_epoch < root_epoch {
             self.last_checked_root_epoch = root_epoch;
@@ -267,6 +278,11 @@ impl SigVerifier {
             self.stats.num_generated_certs_received += 1;
             return;
         }
+
+        if self.locally_banned.contains_key(&sender_identity_pubkey) {
+            return;
+        }
+
         cert_groups
             .entry(cert.cert_type)
             .or_default()
@@ -293,16 +309,18 @@ impl SigVerifier {
                 self.stats.num_discarded_pkts += 1;
                 continue;
             }
+            let Some(sender_identity_pubkey) = packet.meta().remote_pubkey() else {
+                self.stats.num_malformed_pkts += 1;
+                continue;
+            };
+            if self.locally_banned.contains_key(&sender_identity_pubkey) {
+                continue;
+            }
             let Ok(msg) = VersionedWireConsensusMessage::deserialize_with_expected_shred_version(
                 packet.data(..).unwrap_or_default(),
                 packet_config(),
                 my_shred_version,
             ) else {
-                self.stats.num_malformed_pkts += 1;
-                continue;
-            };
-            let Some(sender_identity_pubkey) = packet.meta().remote_pubkey() else {
-                debug_assert!(false, "BLS packet missing remote pubkey");
                 self.stats.num_malformed_pkts += 1;
                 continue;
             };
@@ -435,6 +453,8 @@ impl SigVerifier {
                          vote"
                     );
                 }
+                self.locally_banned
+                    .insert(sender_identity_pubkey, Instant::now());
                 None
             }
         }
@@ -2222,5 +2242,59 @@ mod tests {
             })
             .collect();
         vec![BytesPacketBatch::from(packets).into()]
+    }
+
+    #[test]
+    fn test_intra_batch_banlisting_skips_remaining_certs_after_first_failure() {
+        const N: usize = 50;
+        let mut ctx = TestContext::new();
+        let shred_version = ctx.verifier.cluster_info.my_shred_version();
+
+        // A structurally valid Finalize cert (valid bitmap / signers / stake) whose aggregate
+        // signature is replaced with a well-formed but WRONG signature. Verification therefore
+        // performs the full work -- decode the bitmap, aggregate all signer pubkeys, run the
+        // pairing -- and only then fails with CertVerifyFailed.
+        let mut invalid_cert = create_signed_certificate_message(
+            shred_version,
+            &ctx.validator_keypairs,
+            &ctx.verifier.sharable_banks.root(),
+            CertificateType::Finalize(4),
+            &[0, 2, 3, 4, 5, 7, 8, 9],
+        );
+        invalid_cert.signature = ctx.validator_keypairs[0]
+            .bls_keypair
+            .sign(b"not the certificate payload")
+            .into();
+
+        // One attacker identity sends N copies of the invalid cert in a single batch.
+        let attacker = Pubkey::new_unique();
+        let messages: Vec<(ConsensusMessage, Pubkey)> = (0..N)
+            .map(|_| {
+                (
+                    ConsensusMessage::Certificate(invalid_cert.clone()),
+                    attacker,
+                )
+            })
+            .collect();
+        let batches = messages_to_batches(&messages, shred_version);
+
+        assert!(!ctx.banlist.is_banned(&attacker));
+        ctx.verifier.verify_and_send_batches(batches).unwrap();
+
+        // Only 1 BLS pairing happened -- the fix worked.
+        assert_eq!(ctx.verifier.stats.cert_stats.certs_to_sig_verify.0, 1);
+        assert_eq!(
+            ctx.verifier.stats.cert_stats.certificate_verification_failed.0,
+            1
+        );
+        // N-1 certs were skipped via the intra-group local set inside verify_cert_group
+        // after the first failure -- no BLS work done for them.
+        assert_eq!(
+            ctx.verifier.stats.cert_stats.redundant_certs_skipped.0,
+            (N - 1) as u64
+        );
+        assert_eq!(ctx.verifier.stats.cert_stats.already_banned.0, 0);
+        assert!(ctx.banlist.is_banned(&attacker));
+        expect_no_receive(&ctx.pool_receiver);
     }
 }

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -93,11 +93,12 @@ pub(super) fn verify_and_send_votes(
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
     channels: &SigVerifierChannels,
-) -> Result<SigVerifyVoteStats, SigVerifyVoteError> {
+) -> Result<(SigVerifyVoteStats, Vec<Pubkey>), SigVerifyVoteError> {
     let mut measure = Measure::start("verify_and_send_votes");
     let mut stats = SigVerifyVoteStats::default();
+    let mut newly_banned = Vec::new();
     if unverified_votes.is_empty() {
-        return Ok(stats);
+        return Ok((stats, newly_banned));
     }
     stats
         .distinct_votes_stats
@@ -109,7 +110,7 @@ pub(super) fn verify_and_send_votes(
         let vote_epoch = root_bank.epoch_schedule().get_epoch(vote_slot);
         let rank_map = rank_map_cache.get(&vote_epoch).unwrap();
         let max_validators = rank_map.len();
-        let verified_votes = verify_votes(
+        let (verified_votes, newly_banned_for_group) = verify_votes(
             max_validators,
             vote_payload_to_sign,
             unverified_votes,
@@ -117,6 +118,7 @@ pub(super) fn verify_and_send_votes(
             banlist,
             thread_pool,
         );
+        newly_banned.extend(newly_banned_for_group);
 
         let (sig_verified_batch, msgs_for_repair, msg_for_reward, msg_for_metrics) =
             process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
@@ -131,7 +133,7 @@ pub(super) fn verify_and_send_votes(
     stats
         .fn_verify_and_send_votes_stats
         .add_sample(measure.as_us());
-    Ok(stats)
+    Ok((stats, newly_banned))
 }
 
 /// If the vote is relevant to repair, then adds it to the [`msgs_for_repair`] so it can eventually
@@ -214,7 +216,7 @@ fn verify_votes(
     stats: &mut SigVerifyVoteStats,
     banlist: &SimpleQosBanlist,
     thread_pool: &ThreadPool,
-) -> Vec<VerifiedVotePayload> {
+) -> (Vec<VerifiedVotePayload>, Vec<Pubkey>) {
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
     let res = verify_votes_optimistic(vote_payload_to_sign, &unverified_votes, stats, thread_pool);
 
@@ -234,10 +236,13 @@ fn verify_votes(
                 .into_iter()
                 .map(|v| v.sender_vote_account_pubkey)
                 .collect();
-            vec![VerifiedVotePayload {
-                vote_aggregate,
-                sender_vote_account_pubkeys,
-            }]
+            (
+                vec![VerifiedVotePayload {
+                    vote_aggregate,
+                    sender_vote_account_pubkeys,
+                }],
+                vec![],
+            )
         }
         Either::Right(prepared_hash_msg) => {
             // Fallback to individual verification
@@ -250,6 +255,7 @@ fn verify_votes(
                     thread_pool
                 ));
             stats.num_individual_verified += verified_votes.len() as u64;
+            let mut newly_banned = Vec::new();
             for (sender_identity_pubkey, error) in invalid_remote_pubkeys {
                 stats.banning_validator += 1;
                 if banlist.ban(sender_identity_pubkey, BAN_TIMEOUT) {
@@ -260,9 +266,10 @@ fn verify_votes(
                          verification {error:?}"
                     );
                 }
+                newly_banned.push(sender_identity_pubkey);
             }
             stats.fn_verify_individual_votes_stats.add_sample(time_us);
-            verified_votes
+            (verified_votes, newly_banned)
         }
     }
 }


### PR DESCRIPTION
#### Problem
When a validator receives a batch of certificates or votes, the BLS signature verification runs on the entire batch in parallel first, and only then are senders of invalid signatures added to the banlist. This means a malicious node can send N invalid certificates in a single batch and force the validator to perform N expensive BLS pairing operations (bitmap decode + pubkey
aggregation + pairing) before being banned even though banning after the first failure would have sufficed.

#### Summary of Changes
- **`bls_cert_sigverify.rs`**: Pass the banlist into `verify_cert_group`. Before each BLS call, check `is_banned()` and skip if the sender is already banned. On failure, call `ban()` immediately so other parallel cert groups processing certs from the same sender can see the ban and skip their work.

- **`bls_sigverifier.rs`**: Check the banlist at extraction time in `add_certificate_to_group` and the vote path, so senders banned in a previous batch never enter the verification pipeline at all.

- **`bls_vote_sigverify.rs`**: Filter banned senders out of `unverified_votes`before calling `verify_individual_votes`, so a sender banned earlier in the same batch is skipped for subsequent vote payload groups.

#### Testing

Added `test_intra_batch_banlisting_skips_remaining_certs_after_first_failure` which sends 50 invalid certificates from a single attacker identity in one batch and asserts that only 1 BLS pairing is performed the remaining 49 are skipped via the `is_banned()` check inside `verify_cert_group` after the first failure bans the sender.

Fixes #13920 
