### PR TITLE
gossip: price pull-request scan budget by actual shard occupancy

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -17,7 +17,7 @@ use {
     crate::{
         cluster_info_metrics::{Counter, GossipStats, ScopedTimer, TimedGuard},
         contact_info::{self, ContactInfo, ContactInfoQuery, Error as ContactInfoError},
-        crds::{CRDS_SHARDS_BITS, Crds, Cursor, GossipRoute},
+        crds::{Crds, Cursor, GossipRoute},
         crds_data::{self, CrdsData, EpochSlotsIndex, LowestSlot, MAX_VOTES, SnapshotHashes, Vote},
         crds_filter::{GossipFilterDirection, should_retain_crds_value},
         crds_gossip::CrdsGossip,
@@ -133,13 +133,9 @@ const GOSSIP_PULL_SCAN_BUDGET_REFILL_PER_SEC: u64 =
     4 * crds_gossip_pull::MIN_NUM_BLOOM_ITEMS as u64;
 const GOSSIP_PULL_SCAN_BUDGET_SHARD_COUNT: usize = 64;
 
-/// Estimated CRDS shard scan work for a pull request filter.
 #[inline]
-fn pull_request_scan_cost(crds_len: usize, mask_bits: u32, bloom_hash_count: usize) -> u64 {
-    // Extra mask bits still require one full shard scan.
-    let shift = mask_bits.min(CRDS_SHARDS_BITS);
-    let scan_entries = (crds_len >> shift).max(1) as u64;
-
+fn pull_request_scan_cost(scan_entries: usize, bloom_hash_count: usize) -> u64 {
+    let scan_entries = u64::try_from(scan_entries).unwrap_or(u64::MAX).max(1);
     let bloom_hash_count = u64::try_from(bloom_hash_count)
         .unwrap_or(u64::MAX)
         .max(crds_gossip_pull::KEYS as u64);
@@ -1700,12 +1696,12 @@ impl ClusterInfo {
         }
     }
 
-    fn try_consume_pull_request_scan_budget(&self, request: &PullRequest, crds_len: usize) -> bool {
-        let cost = pull_request_scan_cost(
-            crds_len,
-            request.filter.get_mask_bits(),
-            request.filter.bloom_hash_count(),
-        );
+    fn try_consume_pull_request_scan_budget(
+        &self,
+        request: &PullRequest,
+        scan_entries: usize,
+    ) -> bool {
+        let cost = pull_request_scan_cost(scan_entries, request.filter.bloom_hash_count());
         if self
             .pull_request_budget
             .consume_tokens(request.addr.ip(), cost)
@@ -1753,7 +1749,9 @@ impl ClusterInfo {
                         is_full_alpenglow_epoch,
                     )
                 },
-                |request, crds_len| self.try_consume_pull_request_scan_budget(request, crds_len),
+                |request, scan_entries| {
+                    self.try_consume_pull_request_scan_budget(request, scan_entries)
+                },
                 &self.stats,
             )
         };
@@ -2705,14 +2703,10 @@ mod tests {
 
     #[test]
     fn test_pull_request_scan_cost() {
-        assert_eq!(pull_request_scan_cost(0, 0, 0), 8);
-        assert_eq!(pull_request_scan_cost(1_024, 6, 8), 128);
-        assert_eq!(pull_request_scan_cost(1_024, 6, 12), 192);
-        let crds_len = 1usize << (CRDS_SHARDS_BITS + 1);
-        assert_eq!(
-            pull_request_scan_cost(crds_len, CRDS_SHARDS_BITS + 1, 8),
-            16,
-        );
+        assert_eq!(pull_request_scan_cost(0, 0), 8);
+        assert_eq!(pull_request_scan_cost(16, 8), 128);
+        assert_eq!(pull_request_scan_cost(16, 12), 192);
+        assert_eq!(pull_request_scan_cost(2, 8), 16);
     }
 
     #[test]
@@ -2754,11 +2748,7 @@ mod tests {
         };
         request.filter.sanitize().unwrap();
         let crds_len = crds_gossip_pull::MIN_NUM_BLOOM_ITEMS;
-        let cost = pull_request_scan_cost(
-            crds_len,
-            request.filter.get_mask_bits(),
-            request.filter.bloom_hash_count(),
-        );
+        let cost = pull_request_scan_cost(crds_len, request.filter.bloom_hash_count());
         let successful_requests = GOSSIP_PULL_SCAN_BUDGET_CAPACITY / cost;
 
         assert!(cost <= GOSSIP_PULL_SCAN_BUDGET_CAPACITY);

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -515,6 +515,10 @@ impl Crds {
             .filter(move |VersionedCrdsValue { value, .. }| !value.data().is_deprecated())
     }
 
+    pub(crate) fn filter_bitmask_scan_count(&self, mask: u64, mask_bits: u32) -> usize {
+        self.shards.find_count(mask, mask_bits)
+    }
+
     /// Update the timestamp's of all the labels that are associated with Pubkey
     pub(crate) fn update_record_timestamp(&mut self, pubkey: &Pubkey, now: u64) {
         // It suffices to only overwrite the origin's timestamp since that is

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -510,7 +510,6 @@ impl CrdsGossipPull {
         let mut dropped_requests = 0usize;
         let mut total_skipped = 0usize;
         let crds = crds.read().unwrap();
-        let crds_len = crds.len();
         let apply_filter = |request: &PullRequest| {
             if output_size_limit == 0 {
                 return Vec::default();
@@ -521,8 +520,9 @@ impl CrdsGossipPull {
                 dropped_requests += 1;
                 return Vec::default();
             }
+            let scan_len = crds.filter_bitmask_scan_count(filter.mask, filter.mask_bits);
             // Charge only requests that passed cheaper pre-scan checks.
-            if !try_consume_scan_budget(request, crds_len) {
+            if !try_consume_scan_budget(request, scan_len) {
                 return Vec::default();
             }
             let caller_wallclock = caller_wallclock.checked_add(jitter).unwrap_or(0);

--- a/gossip/src/crds_shards.rs
+++ b/gossip/src/crds_shards.rs
@@ -63,6 +63,21 @@ impl CrdsShards {
         }
     }
 
+    pub(crate) fn find_count(&self, mask: u64, mask_bits: u32) -> usize {
+        let mask = CrdsFilter::canonical_mask(mask, mask_bits);
+        match self.shard_bits.cmp(&mask_bits) {
+            Ordering::Less | Ordering::Equal => self.shard(mask).len(),
+            Ordering::Greater => {
+                let count = 1 << (self.shard_bits - mask_bits);
+                let end = self.shard_index(mask) + 1;
+                self.shards[end - count..end]
+                    .iter()
+                    .map(IndexMap::len)
+                    .sum()
+            }
+        }
+    }
+
     #[inline]
     fn shard_index(&self, hash: u64) -> usize {
         hash.checked_shr(64 - self.shard_bits).unwrap_or(0) as usize
@@ -203,11 +218,17 @@ mod test {
             }
             shards.check(&values);
         }
-        // Random masks.
+        const SHARD_BITS: u32 = 5;
         for _ in 0..10 {
             let mask = rng.random();
             for mask_bits in 0..12 {
                 let mut set = filter_crds_values(&values, mask, mask_bits);
+                let visited = filter_crds_values(&values, mask, mask_bits.min(SHARD_BITS)).len();
+                assert_eq!(
+                    shards.find_count(mask, mask_bits),
+                    visited,
+                    "find_count should equal visited entries for mask_bits={mask_bits}"
+                );
                 for index in shards.find(mask, mask_bits) {
                     assert!(set.remove(&index));
                 }
@@ -234,5 +255,82 @@ mod test {
                 shards.check(&values);
             }
         }
+    }
+
+    #[test]
+    fn test_find_count_reflects_prefix_skew() {
+        const SHARD_BITS: u32 = 4;
+        const HOT: usize = 100;
+        const COLD: usize = 40;
+        let mut rng = rng();
+        let mut shards = CrdsShards::new(SHARD_BITS);
+        let mut values: Vec<VersionedCrdsValue> = Vec::new();
+        let prefix = |v: &VersionedCrdsValue| {
+            CrdsFilter::hash_as_u64(v.value.hash())
+                .checked_shr(64 - SHARD_BITS)
+                .unwrap_or(0)
+        };
+        while values.iter().filter(|v| prefix(v) == 0).count() < HOT {
+            let v = new_test_crds_value(&mut rng);
+            if prefix(&v) == 0 {
+                let index = values.len();
+                assert!(shards.insert(index, &v));
+                values.push(v);
+            }
+        }
+        let mut cold = 0;
+        while cold < COLD {
+            let v = new_test_crds_value(&mut rng);
+            if prefix(&v) != 0 {
+                let index = values.len();
+                assert!(shards.insert(index, &v));
+                values.push(v);
+                cold += 1;
+            }
+        }
+        let crds_len = values.len();
+        let scanned = shards.find_count(0, SHARD_BITS);
+        assert_eq!(scanned, HOT, "hot prefix must scan all its entries");
+        assert_eq!(scanned, shards.find(0, SHARD_BITS).count());
+        let average_estimate = (crds_len >> SHARD_BITS).max(1);
+        assert!(
+            scanned > average_estimate * 8,
+            "find_count={scanned} should dwarf average estimate={average_estimate}",
+        );
+    }
+
+    #[test]
+    fn test_find_count_charges_full_shard_for_fine_mask() {
+        const SHARD_BITS: u32 = 4;
+        const HOT: usize = 100;
+        let mut rng = rng();
+        let mut shards = CrdsShards::new(SHARD_BITS);
+        let mut values: Vec<VersionedCrdsValue> = Vec::new();
+        let prefix = |v: &VersionedCrdsValue| {
+            CrdsFilter::hash_as_u64(v.value.hash())
+                .checked_shr(64 - SHARD_BITS)
+                .unwrap_or(0)
+        };
+        while values.iter().filter(|v| prefix(v) == 0).count() < HOT {
+            let v = new_test_crds_value(&mut rng);
+            if prefix(&v) == 0 {
+                let index = values.len();
+                assert!(shards.insert(index, &v));
+                values.push(v);
+            }
+        }
+        let absent = (!0u64).checked_shr(SHARD_BITS).unwrap_or(0);
+        assert!(
+            !values
+                .iter()
+                .any(|v| CrdsFilter::hash_as_u64(v.value.hash()) == absent),
+            "sentinel hash must be absent",
+        );
+        assert_eq!(shards.find(absent, 64).count(), 0, "filter matches nothing");
+        assert_eq!(
+            shards.find_count(absent, 64),
+            HOT,
+            "must charge for the full physical shard scanned, not the zero matches",
+        );
     }
 }


### PR DESCRIPTION
#### Problem

Scan budget is unnecessarily an approximation, so can potentially be inaccurate.

#### Summary of Changes

Price the pull-request scan budget by the true number of CRDS entries a filter will scan, instead of a table-wide average

#### Testing

Verified that we do not see limits unexpectedly hit on mainnet.
