### PR TITLE
sigverify: drop fully discarded batches early

### DIFF
--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -272,11 +272,12 @@ impl SigVerifyWorkerPool {
         sharable_banks: &SharableBanks,
         state: &SigVerifyWorkerState,
     ) -> bool {
+        let batch_len = batch.len();
         state.stats.total_batches.fetch_add(1, Ordering::Relaxed);
         state
             .stats
             .total_packets
-            .fetch_add(batch.len(), Ordering::Relaxed);
+            .fetch_add(batch_len, Ordering::Relaxed);
 
         let (discard_or_dedup_fail, dedup_time_us) =
             measure_us!(deduper::dedup_packets_and_count_discards(
@@ -291,6 +292,10 @@ impl SigVerifyWorkerPool {
             .stats
             .total_dedup_time_us
             .fetch_add(dedup_time_us as usize, Ordering::Relaxed);
+
+        if discard_or_dedup_fail as usize == batch_len {
+            return true;
+        }
 
         let working_bank = sharable_banks.working();
 
@@ -333,6 +338,10 @@ impl SigVerifyWorkerPool {
             .stats
             .total_verify_time_us
             .fetch_add(verify_time_us as usize, Ordering::Relaxed);
+
+        if num_valid_packets == 0 {
+            return true;
+        }
 
         let banking_packet_batch = BankingPacketBatch::new(batch);
         // Sample backlog before the push: measures consumer health without

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -1,8 +1,7 @@
 //! The `sigverify_stage` implements the signature verification stage of the TPU. It
-//! receives a list of lists of packets and outputs the same list, but tags each
-//! top-level list with a list of booleans, telling the next stage whether the
-//! signature in that packet is valid. It assumes each packet contains one
-//! transaction. All processing is done on the CPU by default.
+//! receives packet batches, marks rejected packets as discarded, and forwards
+//! only batches containing at least one valid packet. It assumes each packet
+//! contains one transaction. All processing is done on the CPU by default.
 
 use {
     crate::{
@@ -472,7 +471,7 @@ mod tests {
 
     #[test_case(false, false; "tx_v1_disabled")]
     #[test_case(true, true; "tx_v1_enabled")]
-    fn test_sigverify_stage_tx_v1_feature_gate(enable_tx_v1: bool, expected_valid: bool) {
+    fn test_sigverify_stage_tx_v1_feature_gate(enable_tx_v1: bool, expect_v1_output: bool) {
         let genesis_config = create_genesis_config(1).genesis_config;
         let mut bank = Bank::new_for_tests(&genesis_config);
         if enable_tx_v1 {
@@ -499,18 +498,30 @@ mod tests {
             None,
         );
 
+        let tx_v1_bytes = wincode::serialize(&test_tx_v1()).unwrap();
         let mut bytes_batch = BytesPacketBatch::with_capacity(1);
-        bytes_batch.push(BytesPacket::from_bytes(
-            None,
-            wincode::serialize(&test_tx_v1()).unwrap(),
-        ));
+        bytes_batch.push(BytesPacket::from_bytes(None, tx_v1_bytes.clone()));
         packet_s.send(PacketBatch::from(bytes_batch)).unwrap();
+        let sentinel_batch = to_packet_batches(&[test_tx()], 1).pop().unwrap();
+        let sentinel_bytes = sentinel_batch.get(0).unwrap().data(..).unwrap().to_vec();
+        packet_s.send(sentinel_batch).unwrap();
 
+        if expect_v1_output {
+            let verified_batch = verified_r.recv_timeout(Duration::from_secs(30)).unwrap();
+            assert_eq!(verified_batch.len(), 1);
+            assert!(!verified_batch.get(0).unwrap().meta().discard());
+            assert_eq!(
+                verified_batch.get(0).unwrap().data(..).unwrap(),
+                tx_v1_bytes
+            );
+        }
+        // Receiving the sentinel proves that the preceding v1 packet was processed.
         let verified_batch = verified_r.recv_timeout(Duration::from_secs(30)).unwrap();
         assert_eq!(verified_batch.len(), 1);
+        assert!(!verified_batch.get(0).unwrap().meta().discard());
         assert_eq!(
-            !verified_batch.get(0).unwrap().meta().discard(),
-            expected_valid
+            verified_batch.get(0).unwrap().data(..).unwrap(),
+            sentinel_bytes
         );
 
         drop(packet_s);


### PR DESCRIPTION
#### Problem
Batches containing no valid packets after dedup and signature verification are sent to the scheduler, consuming channel capacity and scheduler resources despite having no usable transactions.

As far as I can tell, there is no reason for fully discarded batches to reach the scheduler only to be filtered out. Moreover, we already return early in the scheduler-priority-floor path when every packet in a batch falls below the floor. So, let's do this in all cases.

#### Summary of Changes
- Return early when dedup leaves no usable packets.
- Do not send batches with no valid signatures to the scheduler.
- Update the sigverify stage documentation.
- Update the v1 feature-gate test.

#### Testing
```
cargo test -p solana-core --lib sigverify_stage::tests::test_sigverify_stage_tx_v1_feature_gate
```

Fixes #
