### PR TITLE
fix(sbf): move solana-program-binaries to workspace.dependencies

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -136,6 +136,7 @@ solana-keccak-hasher = { version = "=3.1.0", features = ["sha3"] }
 solana-msg = "=3.1.0"
 solana-poseidon = "=4.0.0"
 solana-program = "=4.0.0"
+solana-program-binaries = { path = "../../program-binaries", version = "=4.3.0-alpha.1" }
 solana-program-entrypoint = "=3.1.1"
 solana-program-error = "=3.0.1"
 solana-program-memory = "=3.1.0"
@@ -203,7 +204,7 @@ solana-instruction = { workspace = true }
 solana-keypair = "3.1.2"
 solana-loader-v3-interface = "7.0.0"
 solana-message = "4.1.0"
-solana-program-binaries = { path = "../../program-binaries", version = "=4.3.0-alpha.1", features = ["agave-unstable-api"] }
+solana-program-binaries = { workspace = true, features = ["agave-unstable-api"] }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = "4.2.0"
 solana-rent = "4.1.0"


### PR DESCRIPTION
#### Problem

`programs/sbf/Cargo.toml` declares `solana-program-binaries` as a bare path dev-dependency, unlike the sibling `solana-program-runtime` which sits in `[workspace.dependencies]` with a path+version pin.

#### Summary of Changes

Move it to `[workspace.dependencies]`, reference via `workspace = true`. Matches local convention; version stays tracked by increment-cargo-version.sh.
