### PR TITLE
votor: add option to supply a separate bls keypair

### DIFF
--- a/clap-utils/src/input_parsers.rs
+++ b/clap-utils/src/input_parsers.rs
@@ -7,7 +7,7 @@ use {
     clap::ArgMatches,
     solana_bls_signatures::{
         BLS_PUBLIC_KEY_COMPRESSED_SIZE, Pubkey as BLSPubkey,
-        PubkeyCompressed as BLSPubkeyCompressed,
+        PubkeyCompressed as BLSPubkeyCompressed, keypair::Keypair as BLSKeypair,
     },
     solana_clock::UnixTimestamp,
     solana_cluster_type::ClusterType,
@@ -106,6 +106,12 @@ pub fn pubkeys_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Pubkey>> {
             })
             .collect()
     })
+}
+
+pub fn bls_keypair_of(matches: &ArgMatches<'_>, name: &str) -> Option<BLSKeypair> {
+    matches
+        .value_of(name)
+        .and_then(|path| BLSKeypair::read_json_file(path).ok())
 }
 
 fn bls_pubkey_compressed_from_base58(value: &str) -> Result<BLSPubkeyCompressed, String> {
@@ -301,7 +307,7 @@ mod tests {
     use {
         super::*,
         clap::{App, Arg},
-        solana_bls_signatures::{Pubkey as BLSPubkey, keypair::Keypair as BLSKeypair},
+        solana_bls_signatures::Pubkey as BLSPubkey,
         solana_keypair::write_keypair_file,
         std::fs,
     };
@@ -463,6 +469,23 @@ mod tests {
         assert_ne!(lamports_of_sol(&matches, "single"), Some(15_700_000));
         let matches = app().get_matches_from(vec!["test", "--single", "0.5025"]);
         assert_ne!(lamports_of_sol(&matches, "single"), Some(502_500_000));
+    }
+
+    #[test]
+    fn test_bls_keypair_of() {
+        let bls_keypair = BLSKeypair::new();
+        let outfile = tmp_file_path("test_bls_keypair_of.json", &Pubkey::new_unique());
+        bls_keypair.write_json_file(&outfile).unwrap();
+
+        let matches = app().get_matches_from(vec!["test", "--single", &outfile]);
+        let parsed = bls_keypair_of(&matches, "single").unwrap();
+        assert_eq!(parsed.public, bls_keypair.public);
+        assert!(bls_keypair_of(&matches, "multiple").is_none());
+
+        let matches = app().get_matches_from(vec!["test", "--single", "missing-keypair.json"]);
+        assert!(bls_keypair_of(&matches, "single").is_none());
+
+        fs::remove_file(&outfile).unwrap();
     }
 
     #[test]

--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -4,6 +4,7 @@ use {
         keypair::{ASK_KEYWORD, SignerSourceKind, parse_signer_source},
     },
     chrono::DateTime,
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
     solana_keypair::read_keypair_file,
@@ -77,6 +78,16 @@ where
     T: AsRef<str> + Display,
 {
     read_keypair_file(string.as_ref())
+        .map(|_| ())
+        .map_err(|err| format!("{err}"))
+}
+
+/// Return an error if a BLS keypair file cannot be parsed.
+pub fn is_bls_keypair<T>(string: T) -> Result<(), String>
+where
+    T: AsRef<str> + Display,
+{
+    BLSKeypair::read_json_file(string.as_ref())
         .map(|_| ())
         .map_err(|err| format!("{err}"))
 }
@@ -478,7 +489,7 @@ pub fn is_non_zero(value: impl AsRef<str>) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {super::*, tempfile::NamedTempFile};
 
     #[test]
     fn test_is_derivation() {
@@ -491,6 +502,20 @@ mod tests {
         assert!(is_derivation("4294967296").is_err());
         assert!(is_derivation("a/b").is_err());
         assert!(is_derivation("0/4294967296").is_err());
+    }
+
+    #[test]
+    fn test_is_bls_keypair() {
+        assert!(is_bls_keypair("nonexistent_file.json").is_err());
+
+        let invalid_file = NamedTempFile::new().unwrap();
+        std::fs::write(invalid_file.path(), "invalid content").unwrap();
+        assert!(is_bls_keypair(invalid_file.path().to_str().unwrap()).is_err());
+
+        let bls_keypair = BLSKeypair::new();
+        let valid_file = NamedTempFile::new().unwrap();
+        bls_keypair.write_json_file(valid_file.path()).unwrap();
+        assert!(is_bls_keypair(valid_file.path().to_str().unwrap()).is_ok());
     }
 
     #[test]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -51,6 +51,7 @@ use {
     itertools::Itertools,
     rayon::{ThreadPool, prelude::*},
     solana_accounts_db::contains::Contains,
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clock::{BankId, Slot},
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::cluster_info::ClusterInfo,
@@ -418,6 +419,7 @@ impl PartitionInfo {
 pub struct ReplayStageConfig {
     pub vote_account: Pubkey,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+    pub bls_keypair: Option<Arc<BLSKeypair>>,
     pub exit: Arc<AtomicBool>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
@@ -739,6 +741,7 @@ impl ReplayStage {
         let ReplayStageConfig {
             vote_account,
             authorized_voter_keypairs,
+            bls_keypair,
             exit,
             leader_schedule_cache,
             block_commitment_cache,
@@ -1227,6 +1230,7 @@ impl ReplayStage {
                             vote_account,
                             &identity_keypair,
                             &authorized_voter_keypairs,
+                            bls_keypair.as_ref(),
                             &own_message_sender,
                             &bls_sender,
                         )
@@ -1754,6 +1758,7 @@ impl ReplayStage {
         vote_account: Pubkey,
         identity_keypair: &Arc<Keypair>,
         authorized_voter_keypairs: &Arc<std::sync::RwLock<Vec<Arc<Keypair>>>>,
+        bls_keypair: Option<&Arc<BLSKeypair>>,
         own_message_sender: &Sender<SigVerifiedBatch>,
         bls_sender: &Sender<BLSOp>,
     ) -> bool {
@@ -1770,6 +1775,7 @@ impl ReplayStage {
             my_shred_version,
             identity_keypair,
             authorized_voter_keypairs,
+            bls_keypair,
             None,
             &mut HashMap::new(),
         ) {

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -45,6 +45,7 @@ use {
         metric_types::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
     },
     crossbeam_channel::{Receiver, Sender, bounded, unbounded},
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_client::connection_cache::ConnectionCache,
     solana_clock::Slot,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
@@ -211,6 +212,7 @@ impl Tvu {
     pub fn new(
         vote_account: &Pubkey,
         authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+        bls_keypair: Option<Arc<BLSKeypair>>,
         bank_forks: Arc<RwLock<BankForks>>,
         cluster_info: &Arc<ClusterInfo>,
         sockets: TvuSockets,
@@ -508,6 +510,7 @@ impl Tvu {
             vote_history_storage: vote_history_storage.clone(),
             generated_cert_types,
             authorized_voter_keypairs: authorized_voter_keypairs.clone(),
+            bls_keypair: bls_keypair.clone(),
             blockstore: blockstore.clone(),
             bank_forks: bank_forks.clone(),
             cluster_info: cluster_info.clone(),
@@ -570,6 +573,7 @@ impl Tvu {
         let replay_stage_config = ReplayStageConfig {
             vote_account: *vote_account,
             authorized_voter_keypairs,
+            bls_keypair,
             exit: exit.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
             block_commitment_cache,
@@ -846,6 +850,7 @@ pub mod tests {
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
+            None,
             bank_forks.clone(),
             &cref1,
             TvuSockets {

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -49,6 +49,7 @@ use {
         accounts_update_notifier_interface::AccountsUpdateNotifier,
         utils::validate_account_paths_for_direct_io,
     },
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_client::connection_cache::{ConnectionCache, Protocol},
     solana_clock::Slot,
     solana_entry::poh::compute_hash_time,
@@ -324,6 +325,9 @@ pub struct ValidatorConfig {
     pub expected_bank_hash: Option<Hash>,
     pub expected_shred_version: Option<u16>,
     pub voting_disabled: bool,
+    /// Advanced override for the BLS signing keypair. Normally unset, in which case BLS keypairs
+    /// are derived from the authorized voter keypairs.
+    pub bls_keypair: Option<Arc<BLSKeypair>>,
     pub account_paths: Vec<PathBuf>,
     pub account_snapshot_paths: Vec<PathBuf>,
     pub rpc_config: JsonRpcConfig,
@@ -409,6 +413,7 @@ impl ValidatorConfig {
             expected_bank_hash: None,
             expected_shred_version: None,
             voting_disabled: false,
+            bls_keypair: None,
             max_ledger_shreds: None,
             blockstore_options: BlockstoreOptions::default_for_tests(),
             account_paths: Vec::new(),
@@ -1624,6 +1629,7 @@ impl Validator {
         let tvu = Tvu::new(
             vote_account,
             authorized_voter_keypairs,
+            config.bls_keypair.clone(),
             bank_forks.clone(),
             &cluster_info,
             TvuSockets {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -394,20 +394,39 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
         )
         .subcommand(
             Command::new("bls_pubkey")
-                .about("Display the compressed BLS pubkey derived from given ed25519 keypair file")
+                .about(
+                    "Display the compressed BLS pubkey derived from an ed25519 keypair or read \
+                     from a BLS keypair file",
+                )
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("keypair")
                         .index(1)
                         .value_name("KEYPAIR")
                         .takes_value(true)
-                        .required(true)
+                        .required_unless_present("bls_keypair")
+                        .conflicts_with("bls_keypair")
                         .value_parser(SignerSourceParserBuilder::default().allow_all().build())
-                        .help("Filepath or URL to a keypair"),
+                        .help(
+                            "Filepath or URL to an ed25519 keypair to derive the BLS pubkey from",
+                        ),
+                )
+                .arg(
+                    Arg::new("bls_keypair")
+                        .long("bls-keypair")
+                        .value_name("BLS_KEYPAIR_FILE")
+                        .takes_value(true)
+                        .help(
+                            "Read the pubkey from a custom BLS keypair file. This advanced option \
+                             is only for power users who maintain their own BLS keypair file; \
+                             normally, the BLS keypair is derived from the authorized voter \
+                             keypair",
+                        ),
                 )
                 .arg(
                     Arg::new(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
                         .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
+                        .requires("keypair")
                         .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
                 )
                 .arg(
@@ -540,8 +559,13 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             }
         }
         ("bls_pubkey", matches) => {
-            let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
-            let bls_keypair = BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?;
+            let bls_keypair =
+                if let Some(bls_keypair_file) = matches.try_get_one::<String>("bls_keypair")? {
+                    BLSKeypair::read_json_file(bls_keypair_file)?
+                } else {
+                    let keypair = get_keypair_from_matches(matches, config, &mut wallet_manager)?;
+                    BLSKeypair::derive_from_signer(&keypair, BLS_KEYPAIR_DERIVE_SEED)?
+                };
             let bls_pubkey_compressed = bls_keypair.public.to_bytes_compressed();
 
             if matches.try_contains_id("outfile")? {
@@ -1323,6 +1347,65 @@ mod tests {
             BLSKeypair::derive_from_signer(&my_keypair, BLS_KEYPAIR_DERIVE_SEED).unwrap();
         let read_bls_pubkey = read_bls_pubkey_file(&outfile_path).unwrap();
         assert_eq!(read_bls_pubkey, bls_keypair.public.to_bytes_compressed());
+    }
+
+    #[test]
+    fn test_generate_bls_pubkey_from_bls_keypair_file() {
+        let keypair_dir = tempdir().unwrap();
+        let bls_keypair_path = tmp_outfile_path(&keypair_dir, "bls-keypair.json");
+        let bls_keypair = BLSKeypair::new();
+        bls_keypair.write_json_file(&bls_keypair_path).unwrap();
+
+        let outfile_dir = tempdir().unwrap();
+        let outfile_path = tmp_outfile_path(&outfile_dir, "bls-pubkey.json");
+        process_test_command(&[
+            "solana-keygen",
+            "bls_pubkey",
+            "--bls-keypair",
+            &bls_keypair_path,
+            "--outfile",
+            &outfile_path,
+        ])
+        .unwrap();
+
+        assert_eq!(
+            read_bls_pubkey_file(&outfile_path).unwrap(),
+            bls_keypair.public.to_bytes_compressed()
+        );
+    }
+
+    #[test]
+    fn test_bls_pubkey_requires_exactly_one_keypair_source() {
+        let default_num_threads = num_cpus::get().to_string();
+        let solana_version = solana_version::version!();
+        let missing_source = app(&default_num_threads, solana_version)
+            .try_get_matches_from(["solana-keygen", "bls_pubkey"])
+            .unwrap_err();
+        assert_eq!(
+            missing_source.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let keypair_dir = tempdir().unwrap();
+        let (_, ed25519_keypair_path, _) =
+            create_tmp_keypair_and_config_file(&keypair_dir, &tempdir().unwrap());
+        let bls_keypair_path = tmp_outfile_path(&keypair_dir, "bls-keypair.json");
+        BLSKeypair::new()
+            .write_json_file(&bls_keypair_path)
+            .unwrap();
+        let conflicting_sources = app(&default_num_threads, solana_version)
+            .try_get_matches_from([
+                "solana-keygen",
+                "bls_pubkey",
+                &ed25519_keypair_path,
+                "--bls-keypair",
+                &bls_keypair_path,
+            ])
+            .unwrap_err();
+        assert_eq!(
+            conflicting_sources.kind(),
+            clap::error::ErrorKind::ArgumentConflict
+        );
     }
 
     #[test]

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -11,6 +11,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         expected_bank_hash: config.expected_bank_hash,
         expected_shred_version: config.expected_shred_version,
         voting_disabled: config.voting_disabled,
+        bls_keypair: config.bls_keypair.clone(),
         account_paths: config.account_paths.clone(),
         account_snapshot_paths: config.account_snapshot_paths.clone(),
         rpc_config: config.rpc_config.clone(),

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -12,8 +12,8 @@ use {
         hidden_unless_forced,
         input_parsers::keypair_of,
         input_validators::{
-            is_keypair_or_ask_keyword, is_non_zero, is_parsable, is_pow2, is_pubkey,
-            is_pubkey_or_keypair, is_slot, is_within_range, validate_cpu_ranges,
+            is_bls_keypair, is_keypair_or_ask_keyword, is_non_zero, is_parsable, is_pow2,
+            is_pubkey, is_pubkey_or_keypair, is_slot, is_within_range, validate_cpu_ranges,
             validate_maximum_full_snapshot_archives_to_retain,
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
@@ -169,6 +169,21 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help(
                 "Include an additional authorized voter keypair. May be specified multiple times. \
                  [default: the --identity keypair]",
+            ),
+    )
+    .arg(
+        Arg::with_name("bls_keypair")
+            .long("bls-keypair")
+            .value_name("KEYPAIR")
+            .takes_value(true)
+            .hidden(true)
+            .validator(is_bls_keypair)
+            .requires("vote_account")
+            .help(
+                "Use a separate BLS keypair file for Alpenglow voting. This advanced option is \
+                 normally omitted; by default, BLS keypairs are derived from the authorized voter \
+                 keypairs. Use this only if you intend to securely maintain a separate BLS \
+                 keypair file",
             ),
     )
     .arg(
@@ -1841,5 +1856,15 @@ mod tests {
             vec!["--allow-private-addr", "--no-xdp"],
             expected_args,
         );
+    }
+
+    #[test]
+    fn verify_bls_keypair_option_is_hidden() {
+        let default_args = DefaultArgs::default();
+        let mut app = add_args(App::new("run_command"), &default_args);
+        let mut help = Vec::new();
+        app.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+        assert!(!help.contains("--bls-keypair"));
     }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -30,7 +30,9 @@ use {
             create_and_canonicalize_directory,
         },
     },
-    solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of, values_of},
+    solana_clap_utils::input_parsers::{
+        bls_keypair_of, keypair_of, keypairs_of, pubkey_of, value_of, values_of,
+    },
     solana_clock::{DEFAULT_SLOTS_PER_EPOCH, Slot},
     solana_core::{
         banking_stage::transaction_scheduler::scheduler_controller::SchedulerConfig,
@@ -768,9 +770,18 @@ pub fn execute(
              snapshot generation are disabled"
         );
     }
+    let bls_keypair = matches
+        .value_of("bls_keypair")
+        .map(|path| {
+            bls_keypair_of(matches, "bls_keypair")
+                .ok_or_else(|| format!("failed to read BLS keypair file: {path}"))
+        })
+        .transpose()?
+        .map(Arc::new);
 
     let mut validator_config = ValidatorConfig {
         log_config,
+        bls_keypair,
         require_tower: matches.is_present("require_tower"),
         require_vote_history: !matches.is_present("do_not_require_vote_history"),
         tower_storage,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1170,6 +1170,7 @@ mod tests {
             wait_to_vote_slot: None,
             authorized_voter_keypairs: Arc::new(RwLock::new(vec![Arc::new(my_vote_keypair)])),
             vote_history_storage: vote_history_storage.clone(),
+            bls_keypair: None,
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             reward_votes_sender,

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -127,6 +127,8 @@ pub struct VotingContext {
     pub identity_keypair: Arc<Keypair>,
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
     pub vote_history_storage: Arc<dyn VoteHistoryStorage>,
+    /// Explicit BLS signing keypair. When unset, keypairs are derived from the authorized voters.
+    pub bls_keypair: Option<Arc<BLSKeypair>>,
     // The BLS keypair should always change with authorized_voter_keypairs.
     pub derived_bls_keypairs: HashMap<Pubkey, Arc<BLSKeypair>>,
     pub own_vote_sender: Sender<SigVerifiedBatch>,
@@ -163,6 +165,7 @@ pub fn generate_vote_tx(
     shred_version: u16,
     identity_keypair: &Keypair,
     authorized_voter_keypairs: &RwLock<Vec<Arc<Keypair>>>,
+    supplied_bls_keypair: Option<&Arc<BLSKeypair>>,
     wait_to_vote_slot: Option<u64>,
     derived_bls_keypairs: &mut HashMap<Pubkey, Arc<BLSKeypair>>,
 ) -> GenerateVoteTxResult {
@@ -210,7 +213,9 @@ pub fn generate_vote_tx(
         return GenerateVoteTxResult::HotSpare;
     }
 
-    let Some(bls_keypair) =
+    let selected_bls_keypair = if let Some(bls_keypair) = supplied_bls_keypair {
+        (&bls_keypair.public == expected_bls_pubkey).then(|| bls_keypair.clone())
+    } else {
         authorized_voter_keypairs
             .read()
             .unwrap()
@@ -221,11 +226,19 @@ pub fn generate_vote_tx(
                         .unwrap_or_else(|e| panic!("Failed to derive my own BLS keypair: {e}"));
                 (&bls_keypair.public == expected_bls_pubkey).then_some(bls_keypair)
             })
-    else {
-        warn!(
-            "No authorized voter keypair matches rank-map BLS key for vote account \
-             {vote_account_pubkey}. Unable to vote"
-        );
+    };
+    let Some(bls_keypair) = selected_bls_keypair else {
+        if supplied_bls_keypair.is_some() {
+            warn!(
+                "Supplied BLS keypair does not match rank-map BLS key for vote account \
+                 {vote_account_pubkey}. Unable to vote"
+            );
+        } else {
+            warn!(
+                "No authorized voter keypair matches rank-map BLS key for vote account \
+                 {vote_account_pubkey}. Unable to vote"
+            );
+        }
         return GenerateVoteTxResult::NonVoting;
     };
 
@@ -260,6 +273,7 @@ fn create_vote_message(
         context.cluster_info.my_shred_version(),
         &context.identity_keypair,
         &context.authorized_voter_keypairs,
+        context.bls_keypair.as_ref(),
         wait_to_vote_slot,
         &mut context.derived_bls_keypairs,
     ) {
@@ -467,6 +481,7 @@ mod tests {
                 my_keys.vote_keypair.insecure_clone(),
             )])),
             vote_history_storage: Arc::new(NullVoteHistoryStorage::default()),
+            bls_keypair: None,
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             reward_votes_sender,
@@ -594,6 +609,7 @@ mod tests {
                 voting_context.cluster_info.my_shred_version(),
                 &voting_context.identity_keypair,
                 &voting_context.authorized_voter_keypairs,
+                voting_context.bls_keypair.as_ref(),
                 voting_context.wait_to_vote_slot,
                 &mut voting_context.derived_bls_keypairs,
             ),
@@ -636,6 +652,7 @@ mod tests {
                 voting_context.cluster_info.my_shred_version(),
                 &wrong_identity_keypair,
                 &voting_context.authorized_voter_keypairs,
+                voting_context.bls_keypair.as_ref(),
                 voting_context.wait_to_vote_slot,
                 &mut voting_context.derived_bls_keypairs,
             ),

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -68,6 +68,7 @@ use {
     },
     crossbeam_channel::{Receiver, Sender},
     parking_lot::RwLock as PlRwLock,
+    solana_bls_signatures::keypair::Keypair as BLSKeypair,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -98,6 +99,7 @@ pub struct VotorConfig {
 
     // Shared state
     pub authorized_voter_keypairs: Arc<RwLock<Vec<Arc<Keypair>>>>,
+    pub bls_keypair: Option<Arc<BLSKeypair>>,
     pub blockstore: Arc<Blockstore>,
     pub bank_forks: Arc<RwLock<BankForks>>,
     pub cluster_info: Arc<ClusterInfo>,
@@ -153,6 +155,7 @@ impl Votor {
             vote_history,
             vote_history_storage,
             authorized_voter_keypairs,
+            bls_keypair,
             blockstore,
             bank_forks,
             cluster_info,
@@ -203,6 +206,7 @@ impl Votor {
             identity_keypair,
             authorized_voter_keypairs,
             vote_history_storage,
+            bls_keypair,
             derived_bls_keypairs: HashMap::new(),
             own_vote_sender,
             reward_votes_sender,


### PR DESCRIPTION
#### Problem
Currently the bls keypair is derived from the authorized voter keypair.

Some validators have asked if the can grind vanity BLS keys instead.

If so they'll need to the ability to specify their own bls keypair instead of deriving it for `agave-validator`.

#### Summary of Changes
Add the ability to specify a `--bls-keypair` as a hidden cli flag. When specified this overrides the normally derived keypair.

#### Testing