### PR TITLE
bucket-map: Removes unused fs-err dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7594,7 +7594,6 @@ dependencies = [
  "bv",
  "bytemuck",
  "bytemuck_derive",
- "fs_extra",
  "memmap2 0.9.11",
  "modular-bitfield",
  "num_enum",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -37,7 +37,6 @@ solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }


### PR DESCRIPTION
#### Problem

bucket-map has a dev dependency on fs-err, but it isn't used.


#### Summary of Changes

Remove it.


#### Testing

Nothing additional.