### PR TITLE
bucket-map: Removes agave_logger from tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7590,7 +7590,6 @@ dependencies = [
 name = "solana-bucket-map"
 version = "4.3.0-alpha.1"
 dependencies = [
- "agave-logger",
  "ahash 0.8.12",
  "bv",
  "bytemuck",

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -37,7 +37,6 @@ solana-pubkey = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
-agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 fs_extra = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -1530,7 +1530,6 @@ mod tests {
     #[test]
     #[should_panic(expected = "index asked to insert the same data twice")]
     fn test_occupy_if_matches_panic() {
-        agave_logger::setup();
         let random = 1;
         let k = Pubkey::from([1u8; 32]);
         let v = 12u64;
@@ -1564,8 +1563,6 @@ mod tests {
     #[should_panic(expected = "batch insertion can only occur prior to any deletes")]
     #[test]
     fn batch_insert_after_delete() {
-        agave_logger::setup();
-
         let tmpdir = tempdir().unwrap();
         let paths: Vec<PathBuf> = vec![tmpdir.path().to_path_buf()];
         assert!(!paths.is_empty());

--- a/bucket_map/src/bucket_map.rs
+++ b/bucket_map/src/bucket_map.rs
@@ -275,7 +275,6 @@ mod tests {
 
     #[test]
     fn bucket_map_test_update_to_0_len() {
-        agave_logger::setup();
         let key = Pubkey::new_unique();
         let config = BucketMapConfig::new(1 << 1);
         let index = BucketMap::new(config);
@@ -390,7 +389,6 @@ mod tests {
     #[test]
     fn hashmap_compare() {
         use std::sync::Mutex;
-        agave_logger::setup();
         for mut use_batch_insert in [true, false] {
             let maps = (0..2)
                 .map(|max_buckets_pow2| {

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -621,7 +621,6 @@ mod test {
             )
             .is_none()
         );
-        agave_logger::setup();
         for len in [0, 1, 47, 48, 49, 4097] {
             // create a zero len file. That will fail to load since it is too small.
             let path = tmpdir.path().join("small");


### PR DESCRIPTION
Logging in unit tests is an anti-pattern. Remove 'em.

(And also remove the dev-dependency on the logger.)