### PR TITLE
[feature-set] Update big mod exp syscall feature id description with proper SIMD number

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2024,7 +2024,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             enable_big_mod_exp_syscall::id(),
-            "add big_mod_exp syscall #28503",
+            "SIMD-0529: big_integer mod_exp syscall",
         ),
         (
             disable_builtin_loader_ownership_chains::id(),


### PR DESCRIPTION
#### Problem

The big mod exponentiation syscall description references the solana-labs issue number and we forgot to update this in https://github.com/anza-xyz/agave/pull/12321.

#### Summary of Changes

Update the description with a proper SIMD number.

Addresses https://github.com/anza-xyz/agave/pull/12321#issuecomment-5012526082.