### PR TITLE
xdp: add transmitter smoke w/ 2 queues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ name = "agave-xdp"
 version = "4.3.0-alpha.2"
 dependencies = [
  "agave-cpu-utils",
+ "agave-xdp",
  "agave-xdp-ebpf",
  "arc-swap",
  "arrayvec",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1532,31 +1532,4 @@ mod xdp_tests {
             "XDP core overlapping PoH core must produce an error"
         );
     }
-
-    #[test]
-    fn test_two_explicit_xdp_cores_configure_two_copy_mode_queues() {
-        let cpus = [1, 2];
-        let cpu_list = format!("{},{}", cpus[0], cpus[1]);
-        let default_args = DefaultArgs::default();
-        let app = add_args(clap::App::new("agave-validator"), &default_args);
-        let matches = app.get_matches_from(vec!["agave-validator", "--xdp-cpu-cores", &cpu_list]);
-
-        let config = build_xdp_config(&matches, &Operation::Run, &single_ip_bind())
-            .unwrap()
-            .expect("two explicit XDP cores enable XDP");
-        assert_eq!(
-            config.queues,
-            vec![
-                QueueCpuBinding {
-                    queue: 0,
-                    cpu: cpus[0],
-                },
-                QueueCpuBinding {
-                    queue: 1,
-                    cpu: cpus[1],
-                },
-            ]
-        );
-        assert!(!config.zero_copy);
-    }
 }

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1532,4 +1532,31 @@ mod xdp_tests {
             "XDP core overlapping PoH core must produce an error"
         );
     }
+
+    #[test]
+    fn test_two_explicit_xdp_cores_configure_two_copy_mode_queues() {
+        let cpus = [1, 2];
+        let cpu_list = format!("{},{}", cpus[0], cpus[1]);
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator", "--xdp-cpu-cores", &cpu_list]);
+
+        let config = build_xdp_config(&matches, &Operation::Run, &single_ip_bind())
+            .unwrap()
+            .expect("two explicit XDP cores enable XDP");
+        assert_eq!(
+            config.queues,
+            vec![
+                QueueCpuBinding {
+                    queue: 0,
+                    cpu: cpus[0],
+                },
+                QueueCpuBinding {
+                    queue: 1,
+                    cpu: cpus[1],
+                },
+            ]
+        );
+        assert!(!config.zero_copy);
+    }
 }

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -15,6 +15,7 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [features]
 agave-unstable-api = []
+dev-context-only-utils = []
 
 [dependencies]
 agave-cpu-utils = { workspace = true }
@@ -30,6 +31,9 @@ arrayvec = { workspace = true }
 aya = { workspace = true }
 caps = { workspace = true }
 crossbeam-queue = { workspace = true }
+
+[dev-dependencies]
+agave-xdp = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 aya = { workspace = true, features = ["test-helpers"] }

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -90,6 +90,21 @@ impl XdpConfig {
             tx_channel_cap: XdpConfig::DEFAULT_TX_CHANNEL_CAP,
         }
     }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn with_tx_channel_cap(
+        interface: Option<impl Into<String>>,
+        queues: Vec<QueueCpuBinding>,
+        zero_copy: bool,
+        tx_channel_cap: usize,
+    ) -> Self {
+        Self {
+            interface: interface.map(|s| s.into()),
+            queues,
+            zero_copy,
+            tx_channel_cap,
+        }
+    }
 }
 
 /// [`BytesTxPacket`] encapsulates the information needed to transmit a packet via XDP. Besides

--- a/xdp/tests/common/mod.rs
+++ b/xdp/tests/common/mod.rs
@@ -6,7 +6,6 @@ use {
     agave_xdp::netlink::MacAddress,
     std::{
         ffi::{CString, OsString},
-        num::NonZeroU32,
         os::unix::ffi::OsStringExt,
         path::{Path, PathBuf},
         process::{Command, Output},
@@ -40,15 +39,7 @@ pub struct TestGreTunnel {
     pub overlay_ip: std::net::Ipv4Addr,
 }
 
-pub fn setup_veth_pair() -> TestLinks {
-    setup_veth_pair_with_tx_queue_count(NonZeroU32::MIN)
-}
-
-pub fn setup_two_queue_veth_pair() -> TestLinks {
-    setup_veth_pair_with_tx_queue_count(NonZeroU32::new(2).unwrap())
-}
-
-fn setup_veth_pair_with_tx_queue_count(tx_queue_count: NonZeroU32) -> TestLinks {
+pub fn setup_veth_pair_with_tx_queue_count(tx_queue_count: u32) -> TestLinks {
     let left_ip = std::net::Ipv4Addr::new(10, 0, 0, 1);
     let right_ip = std::net::Ipv4Addr::new(10, 0, 0, 2);
     let left_mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);

--- a/xdp/tests/common/mod.rs
+++ b/xdp/tests/common/mod.rs
@@ -6,6 +6,7 @@ use {
     agave_xdp::netlink::MacAddress,
     std::{
         ffi::{CString, OsString},
+        num::NonZeroU32,
         os::unix::ffi::OsStringExt,
         path::{Path, PathBuf},
         process::{Command, Output},
@@ -40,20 +41,33 @@ pub struct TestGreTunnel {
 }
 
 pub fn setup_veth_pair() -> TestLinks {
+    setup_veth_pair_with_tx_queue_count(NonZeroU32::MIN)
+}
+
+pub fn setup_two_queue_veth_pair() -> TestLinks {
+    setup_veth_pair_with_tx_queue_count(NonZeroU32::new(2).unwrap())
+}
+
+fn setup_veth_pair_with_tx_queue_count(tx_queue_count: NonZeroU32) -> TestLinks {
     let left_ip = std::net::Ipv4Addr::new(10, 0, 0, 1);
     let right_ip = std::net::Ipv4Addr::new(10, 0, 0, 2);
     let left_mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x01]);
     let right_mac = MacAddress([0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0x02]);
+    let tx_queue_count = tx_queue_count.to_string();
 
     run_ip(&[
         "link",
         "add",
         LEFT_IFACE,
+        "numtxqueues",
+        &tx_queue_count,
         "type",
         "veth",
         "peer",
         "name",
         RIGHT_IFACE,
+        "numtxqueues",
+        &tx_queue_count,
     ]);
     set_link_mac(LEFT_IFACE, &left_mac.to_string());
     set_link_mac(RIGHT_IFACE, &right_mac.to_string());

--- a/xdp/tests/netlink_snapshot.rs
+++ b/xdp/tests/netlink_snapshot.rs
@@ -15,7 +15,7 @@ use {
 #[ignore = "requires root and network namespace privileges"]
 fn netlink_snapshot_reads_the_prepared_namespace() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     let routed_prefix = "203.0.113.0/24";
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
@@ -56,7 +56,7 @@ fn netlink_snapshot_reads_the_prepared_namespace() {
 #[ignore = "requires root and network namespace privileges"]
 fn netlink_snapshot_reads_gre_tunnel_metadata() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
     let gre = common::setup_gre_tunnel(&links);
 
     let interfaces = netlink_get_interfaces(AF_INET as u8).expect("read interfaces from netlink");

--- a/xdp/tests/route_monitor.rs
+++ b/xdp/tests/route_monitor.rs
@@ -64,7 +64,7 @@ fn start_route_monitor() -> RouteMonitorGuard {
 #[ignore = "requires root and network namespace privileges"]
 fn route_monitor_publishes_live_route_updates() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     let monitor = start_route_monitor();
 
@@ -113,7 +113,7 @@ fn route_monitor_publishes_live_route_updates() {
 #[ignore = "requires root and network namespace privileges"]
 fn route_monitor_publishes_live_neighbor_updates() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     let monitor = start_route_monitor();
     let routed_destination = Ipv4Addr::new(203, 0, 113, 7);
@@ -179,7 +179,7 @@ fn route_monitor_publishes_live_neighbor_updates() {
 #[ignore = "requires root and network namespace privileges"]
 fn route_monitor_publishes_link_removals() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
     common::add_route("203.0.113.0/24", links.right_ip, common::LEFT_IFACE);
@@ -221,7 +221,7 @@ fn route_monitor_publishes_link_removals() {
 #[ignore = "requires root and network namespace privileges"]
 fn route_monitor_publishes_live_gre_route_updates() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     let monitor = start_route_monitor();
     let overlay_destination = Ipv4Addr::new(192, 0, 2, 99);

--- a/xdp/tests/router_snapshot.rs
+++ b/xdp/tests/router_snapshot.rs
@@ -11,7 +11,7 @@ use {
 #[ignore = "requires root and network namespace privileges"]
 fn router_snapshot_resolves_gre_routes_from_netlink() {
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
 
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
     common::add_route_to_dev(&format!("{}/32", links.right_ip), common::LEFT_IFACE);

--- a/xdp/tests/transmitter_smoke.rs
+++ b/xdp/tests/transmitter_smoke.rs
@@ -34,14 +34,19 @@ use {
     },
 };
 
-fn transmitter_cpu() -> usize {
+fn transmitter_cpus<const COUNT: usize>() -> [usize; COUNT] {
     let cores = cpu_affinity(None).expect("linux provides affine cores");
     assert!(
-        cores.len() >= 2,
-        "transmitter smoke test requires at least 2 affine CPU cores, found {}",
+        cores.len() > COUNT,
+        "transmitter smoke test requires at least {} affine CPU cores, found {}",
+        COUNT.saturating_add(1),
         cores.len(),
     );
-    **cores.first().expect("at least two affine cores")
+    std::array::from_fn(|index| *cores[index])
+}
+fn transmitter_cpu() -> usize {
+    let [cpu_id] = transmitter_cpus();
+    cpu_id
 }
 
 struct PacketSocket {
@@ -393,6 +398,83 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
         )
         .expect("receive UDP frame from AF_XDP transmitter");
     assert_eq!(received, payload.as_ref());
+}
+
+#[test]
+#[ignore = "requires root and network namespace privileges"]
+fn transmitter_sends_udp_payload_over_two_queues_in_copy_mode() {
+    let [first_cpu, second_cpu] = transmitter_cpus();
+
+    let _netns = common::NetNsGuard::new().expect("create network namespace");
+    let links = common::setup_two_queue_veth_pair();
+    common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
+
+    let receiver = PacketSocket::bind(links.right_if_index).expect("bind raw packet receiver");
+    let src_port = 12_347;
+
+    let exit = Arc::new(AtomicBool::new(false));
+    let mut config = XdpConfig::new(
+        Some(common::LEFT_IFACE.to_string()),
+        vec![
+            QueueCpuBinding {
+                queue: 0,
+                cpu: first_cpu,
+            },
+            QueueCpuBinding {
+                queue: 1,
+                cpu: second_cpu,
+            },
+        ],
+        false,
+    );
+    config.tx_channel_cap = 16;
+
+    let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
+        .expect("build two-queue copy-mode transmitter")
+        .build();
+    let transmitter = TransmitterGuard::new(transmitter, sender, exit);
+    assert_eq!(transmitter.sender().len(), 2);
+
+    for (sender_index, dst_port, payload) in [
+        (
+            0,
+            45_680,
+            Bytes::from_static(b"agave-xdp-transmitter-queue-0"),
+        ),
+        (
+            1,
+            45_681,
+            Bytes::from_static(b"agave-xdp-transmitter-queue-1"),
+        ),
+    ] {
+        let destination = SocketAddr::V4(SocketAddrV4::new(links.right_ip, dst_port));
+        let packet = BytesTxPacket::new(
+            SocketAddrV4::new(links.left_ip, src_port),
+            destination,
+            None,
+            payload.clone(),
+        );
+        transmitter
+            .sender()
+            .try_send(sender_index, packet)
+            .unwrap_or_else(|err| panic!("queue packet through sender {sender_index}: {err}"));
+
+        let received = receiver
+            .recv_matching_udp(
+                &ExpectedUdpPacket {
+                    src_mac: links.left_mac,
+                    dst_mac: links.right_mac,
+                    src_ip: links.left_ip,
+                    dst_ip: links.right_ip,
+                    src_port,
+                    dst_port,
+                    payload: payload.as_ref(),
+                },
+                Duration::from_secs(3),
+            )
+            .unwrap_or_else(|err| panic!("receive UDP frame from sender {sender_index}: {err}"));
+        assert_eq!(received, payload.as_ref());
+    }
 }
 
 #[test]

--- a/xdp/tests/transmitter_smoke.rs
+++ b/xdp/tests/transmitter_smoke.rs
@@ -34,6 +34,8 @@ use {
     },
 };
 
+const TEST_TX_CHANNEL_CAP: usize = 16;
+
 fn transmitter_cpus<const COUNT: usize>() -> [usize; COUNT] {
     let cores = cpu_affinity(None).expect("linux provides affine cores");
     assert!(
@@ -44,6 +46,7 @@ fn transmitter_cpus<const COUNT: usize>() -> [usize; COUNT] {
     );
     std::array::from_fn(|index| *cores[index])
 }
+
 fn transmitter_cpu() -> usize {
     let [cpu_id] = transmitter_cpus();
     cpu_id
@@ -345,7 +348,7 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
     let cpu_id = transmitter_cpu();
 
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
 
     let receiver = PacketSocket::bind(links.right_if_index).expect("bind raw packet receiver");
@@ -355,15 +358,15 @@ fn transmitter_sends_udp_payload_over_veth_in_copy_mode() {
     let payload = Bytes::from_static(b"agave-xdp-transmitter-smoke");
 
     let exit = Arc::new(AtomicBool::new(false));
-    let mut config = XdpConfig::new(
+    let config = XdpConfig::with_tx_channel_cap(
         Some(common::LEFT_IFACE.to_string()),
         vec![QueueCpuBinding {
             queue: 0,
             cpu: cpu_id,
         }],
         false,
+        TEST_TX_CHANNEL_CAP,
     );
-    config.tx_channel_cap = 16;
 
     let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
         .expect("build copy-mode transmitter")
@@ -406,14 +409,14 @@ fn transmitter_sends_udp_payload_over_two_queues_in_copy_mode() {
     let [first_cpu, second_cpu] = transmitter_cpus();
 
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_two_queue_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(2);
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
 
     let receiver = PacketSocket::bind(links.right_if_index).expect("bind raw packet receiver");
     let src_port = 12_347;
 
     let exit = Arc::new(AtomicBool::new(false));
-    let mut config = XdpConfig::new(
+    let config = XdpConfig::with_tx_channel_cap(
         Some(common::LEFT_IFACE.to_string()),
         vec![
             QueueCpuBinding {
@@ -426,8 +429,8 @@ fn transmitter_sends_udp_payload_over_two_queues_in_copy_mode() {
             },
         ],
         false,
+        TEST_TX_CHANNEL_CAP,
     );
-    config.tx_channel_cap = 16;
 
     let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
         .expect("build two-queue copy-mode transmitter")
@@ -435,6 +438,7 @@ fn transmitter_sends_udp_payload_over_two_queues_in_copy_mode() {
     let transmitter = TransmitterGuard::new(transmitter, sender, exit);
     assert_eq!(transmitter.sender().len(), 2);
 
+    let mut buf = [0u8; 2048];
     for (sender_index, dst_port, payload) in [
         (
             0,
@@ -461,6 +465,7 @@ fn transmitter_sends_udp_payload_over_two_queues_in_copy_mode() {
 
         let received = receiver
             .recv_matching_udp(
+                &mut buf,
                 &ExpectedUdpPacket {
                     src_mac: links.left_mac,
                     dst_mac: links.right_mac,
@@ -483,7 +488,7 @@ fn transmitter_sends_udp_payload_over_gre_tunnel_in_copy_mode() {
     let cpu_id = transmitter_cpu();
 
     let _netns = common::NetNsGuard::new().expect("create network namespace");
-    let links = common::setup_veth_pair();
+    let links = common::setup_veth_pair_with_tx_queue_count(1);
     common::replace_neighbor(links.right_ip, links.right_mac, common::LEFT_IFACE);
     common::add_route_to_dev(&format!("{}/32", links.right_ip), common::LEFT_IFACE);
     let gre = common::setup_gre_tunnel(&links);
@@ -499,15 +504,15 @@ fn transmitter_sends_udp_payload_over_gre_tunnel_in_copy_mode() {
     let payload = Bytes::from_static(b"agave-xdp-transmitter-gre-smoke");
 
     let exit = Arc::new(AtomicBool::new(false));
-    let mut config = XdpConfig::new(
+    let config = XdpConfig::with_tx_channel_cap(
         Some(common::LEFT_IFACE.to_string()),
         vec![QueueCpuBinding {
             queue: 0,
             cpu: cpu_id,
         }],
         false,
+        TEST_TX_CHANNEL_CAP,
     );
-    config.tx_channel_cap = 16;
 
     let (transmitter, sender) = TransmitterBuilder::new(config, Arc::clone(&exit))
         .expect("build copy-mode transmitter")


### PR DESCRIPTION
#### Problem
No coverage of two queue xdp transmission in our xdp test harness

#### Summary of Changes
Add transmitter test that runs xdp w/o zc but with 2 queues. 

#### Testing
ci
