### PR TITLE
feat(snapshot): deserialize bank snapshots with wincode

### DIFF
--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -598,7 +598,9 @@ where
 pub(crate) mod tests {
     use {
         super::*,
-        crate::{stake_account::StakeAccount, stakes::Stakes},
+        crate::{
+            serde_snapshot::deserialize_wincode_from, stake_account::StakeAccount, stakes::Stakes,
+        },
         solana_account::AccountSharedData,
         solana_bls_signatures::keypair::Keypair as BLSKeypair,
         solana_rent::Rent,
@@ -1116,9 +1118,11 @@ pub(crate) mod tests {
         }
 
         let deserialized_epoch_stakes: VersionedEpochStakes =
-            bincode::deserialize::<DeserializableVersionedEpochStakes>(&serialized_bytes)
-                .unwrap()
-                .into();
+            deserialize_wincode_from::<_, DeserializableVersionedEpochStakes>(
+                std::io::Cursor::new(&serialized_bytes),
+            )
+            .unwrap()
+            .into();
         assert_eq!(
             deserialized_epoch_stakes
                 .stakes()

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -20,7 +20,7 @@ use {
     agave_snapshots::error::SnapshotError,
     bincode::{self, Error, config::Options},
     log::*,
-    serde::{Deserialize, Serialize, de::DeserializeOwned},
+    serde::{Deserialize, Serialize},
     smallvec::{SmallVec, smallvec},
     solana_accounts_db::{
         ObsoleteAccounts,
@@ -467,26 +467,6 @@ where
     wincode::config::deserialize_from(reader, MaxStreamSizeConfig::new())
 }
 
-pub(crate) fn deserialize_from<R, T>(reader: R) -> bincode::Result<T>
-where
-    R: Read,
-    T: DeserializeOwned,
-{
-    bincode::options()
-        .with_limit(MAX_STREAM_SIZE as u64)
-        .with_fixint_encoding()
-        .allow_trailing_bytes()
-        .deserialize_from::<R, T>(reader)
-}
-
-#[cfg(test)]
-fn deserialize_accounts_db_fields<R>(stream: &mut BufReader<R>) -> Result<AccountsDbFields, Error>
-where
-    R: Read,
-{
-    deserialize_from::<_, _>(stream)
-}
-
 /// Extra fields that are deserialized from the end of snapshots.
 ///
 /// Note that this struct's fields should stay synced with the fields in
@@ -557,21 +537,21 @@ pub struct ExtraFieldsToSerialize {
     pub block_id: Option<Hash>,
 }
 
-/// Deserializable counterpart of [`SerializableBankSnapshot`], read as one struct (bincode reads
+/// Deserializable counterpart of [`SerializableBankSnapshot`], read as one struct (wincode reads
 /// the parts sequentially, matching separate reads).
 ///
 /// Its frozen-abi digest must equal [`SerializableBankSnapshotForAbi`]'s, so the read and write
 /// wire formats can't diverge.
 #[cfg_attr(
     feature = "frozen-abi",
-    derive(Serialize, SchemaWrite, StableAbi, StableAbiSample),
+    derive(Deserialize, Serialize, SchemaWrite, StableAbi, StableAbiSample),
     frozen_abi(
         abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "wire_only"
     )
 )]
-#[derive(Deserialize, SchemaRead)]
+#[derive(SchemaRead)]
 struct DeserializableBankSnapshot {
     bank: DeserializableVersionedBank,
     accounts_db: AccountsDbFields,
@@ -580,16 +560,16 @@ struct DeserializableBankSnapshot {
 
 impl DeserializableBankSnapshot {
     /// Folds the extra fields into the bank fields; errors if `unused_epoch_stakes` is non-empty.
-    fn into_fields(self) -> Result<(BankFieldsToDeserialize, AccountsDbFields), Error> {
+    fn into_fields(self) -> wincode::ReadResult<(BankFieldsToDeserialize, AccountsDbFields)> {
         let Self {
             bank,
             accounts_db,
             extra_fields,
         } = self;
         if !bank.unused_epoch_stakes.is_empty() {
-            return Err(Box::new(bincode::ErrorKind::Custom(
-                "Expected deserialized bank's unused_epoch_stakes field to be empty".to_string(),
-            )));
+            return Err(wincode::ReadError::InvalidValue(
+                "Expected deserialized bank's unused_epoch_stakes field to be empty",
+            ));
         }
         let mut bank_fields = BankFieldsToDeserialize::from(bank);
         let ExtraFieldsToDeserialize {
@@ -614,25 +594,16 @@ impl DeserializableBankSnapshot {
     }
 }
 
-fn deserialize_bank_fields<R>(
-    stream: &mut BufReader<R>,
-) -> Result<(BankFieldsToDeserialize, AccountsDbFields), Error>
-where
-    R: Read,
-{
-    deserialize_from::<_, DeserializableBankSnapshot>(stream)?.into_fields()
-}
-
 pub(crate) fn fields_from_stream<R: Read>(
     snapshot_stream: &mut BufReader<R>,
-) -> std::result::Result<(BankFieldsToDeserialize, AccountsDbFields), Error> {
-    deserialize_bank_fields(snapshot_stream)
+) -> wincode::ReadResult<(BankFieldsToDeserialize, AccountsDbFields)> {
+    deserialize_wincode_from::<_, DeserializableBankSnapshot>(snapshot_stream)?.into_fields()
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 pub(crate) fn fields_from_streams(
     snapshot_streams: &mut SnapshotStreams<impl Read>,
-) -> std::result::Result<(SnapshotBankFields, SnapshotAccountsDbFields), Error> {
+) -> wincode::ReadResult<(SnapshotBankFields, SnapshotAccountsDbFields)> {
     let (full_snapshot_bank_fields, full_snapshot_accounts_db_fields) =
         fields_from_stream(snapshot_streams.full_snapshot_stream)?;
     let (incremental_snapshot_bank_fields, incremental_snapshot_accounts_db_fields) =
@@ -676,7 +647,7 @@ pub(crate) fn bank_from_streams<R>(
     accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> std::result::Result<(Bank, BankFromStreamsInfo), Error>
+) -> std::result::Result<(Bank, BankFromStreamsInfo), SnapshotError>
 where
     R: Read,
 {
@@ -972,7 +943,7 @@ pub(crate) fn reconstruct_bank_from_fields(
     accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> Result<(Bank, ReconstructedBankInfo), Error> {
+) -> Result<(Bank, ReconstructedBankInfo), SnapshotError> {
     let mut bank_fields = bank_fields.collapse_into();
     // Epoch stakes take several seconds to reconstruct, do it in parallel with loading accountsdb
     let deserializable_epoch_stakes = std::mem::take(&mut bank_fields.versioned_epoch_stakes);
@@ -1182,7 +1153,7 @@ fn reconstruct_accountsdb_from_fields(
     accounts_db_config: AccountsDbConfig,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     exit: Arc<AtomicBool>,
-) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), Error> {
+) -> Result<(AccountsDb, ReconstructedAccountsDbInfo), SnapshotError> {
     let mut accounts_db = AccountsDb::new_with_config(
         account_paths.to_vec(),
         accounts_db_config,

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -4,13 +4,13 @@ mod serde_snapshot_tests {
         crate::{
             bank::BankHashStats,
             serde_snapshot::{
-                SerializableAccountsDb, SnapshotAccountsDbFields, deserialize_accounts_db_fields,
-                reconstruct_accountsdb_from_fields, remap_append_vec_file, serialize_into,
+                AccountsDbFields, SerializableAccountsDb, SnapshotAccountsDbFields,
+                deserialize_wincode_from, reconstruct_accountsdb_from_fields,
+                remap_append_vec_file, serialize_into,
             },
             snapshot_utils::StorageAndNextAccountsFileId,
         },
         agave_fs::{FileInfo, buffered_reader::FileBufRead as _, io_setup::IoSetupState},
-        bincode::Error,
         log::info,
         rand::{Rng, rng},
         solana_account::{AccountSharedData, ReadableAccount},
@@ -55,17 +55,17 @@ mod serde_snapshot_tests {
         account_paths: &[PathBuf],
         storage_and_next_append_vec_id: StorageAndNextAccountsFileId,
         accounts_db_config: AccountsDbConfig,
-    ) -> Result<AccountsDb, Error>
+    ) -> agave_snapshots::Result<AccountsDb>
     where
         R: Read,
     {
         // read and deserialise the accounts database directly from the stream
-        let accounts_db_fields = deserialize_accounts_db_fields(stream)?;
+        let accounts_db_fields: AccountsDbFields = deserialize_wincode_from(&mut *stream)?;
         let snapshot_accounts_db_fields = SnapshotAccountsDbFields {
             full_snapshot_accounts_db_fields: accounts_db_fields,
             incremental_snapshot_accounts_db_fields: None,
         };
-        reconstruct_accountsdb_from_fields(
+        let (accounts_db, _) = reconstruct_accountsdb_from_fields(
             snapshot_accounts_db_fields,
             account_paths,
             storage_and_next_append_vec_id,
@@ -74,8 +74,8 @@ mod serde_snapshot_tests {
             accounts_db_config,
             None,
             Arc::default(),
-        )
-        .map(|(accounts_db, _)| accounts_db)
+        )?;
+        Ok(accounts_db)
     }
 
     fn accountsdb_from_stream<R>(
@@ -83,7 +83,7 @@ mod serde_snapshot_tests {
         account_paths: &[PathBuf],
         storage_and_next_append_vec_id: StorageAndNextAccountsFileId,
         accounts_db_config: AccountsDbConfig,
-    ) -> Result<AccountsDb, Error>
+    ) -> agave_snapshots::Result<AccountsDb>
     where
         R: Read,
     {

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -223,7 +223,7 @@ fn stable_abi_sample_stake_delegations(
 mod tests {
     use {
         super::*,
-        crate::{stake_utils, stakes::StakesCache},
+        crate::{serde_snapshot::deserialize_wincode_from, stake_utils, stakes::StakesCache},
         rand::Rng,
         serde::Deserialize,
         solana_rent::Rent,
@@ -241,7 +241,7 @@ mod tests {
             tail: String,
         }
 
-        #[derive(Debug, Deserialize)]
+        #[derive(Debug, Deserialize, SchemaRead)]
         struct DeserializableDummy {
             head: String,
             stakes: DeserializableDelegationStakes,
@@ -294,7 +294,8 @@ mod tests {
         };
         assert!(dummy.stakes.vote_accounts().as_ref().len() >= 5);
         let data = bincode::serialize(&dummy).unwrap();
-        let other: DeserializableDummy = bincode::deserialize(&data).unwrap();
+        let other: DeserializableDummy =
+            deserialize_wincode_from(std::io::Cursor::new(&data)).unwrap();
         assert_eq!(other.head, dummy.head);
         assert_eq!(other.tail, dummy.tail);
 


### PR DESCRIPTION
#### Problem
bincode deserialization is slow

#### Summary of Changes
Read the bank fields, accounts-db fields, and extra fields from the snapshot stream with wincode instead of bincode, through the single `DeserializableBankSnapshot` root type (schemas added in the previous commit); reading goes through `deserialize_wincode_from`, and the read-path error types move from `bincode::Error` to `wincode::ReadError / SnapshotError`. Removes the now-unused bincode `deserialize_from` / `deserialize_bank_fields / deserialize_accounts_db_fields` helpers.

#### Testing
* Switches the serde_snapshot tests and the epoch-stakes / stakes deserialize roundtrip tests to read with wincode (still serializing the bytes with bincode, so the bincode serialize path stays exercised).
* `ledger-tool verify` passes
* switching mnb validator to this PR and back passes

##### Performance impact
* master (409ms)
<img width="2286" height="1644" alt="master-deser" src="https://github.com/user-attachments/assets/68f69115-9f0d-49f9-b91b-6010ece3f32d" />

* Pr (155ms)
<img width="2286" height="1644" alt="pr-deser" src="https://github.com/user-attachments/assets/233953e7-bc6f-479c-8207-1f026c44492d" />
