### PR TITLE
bigtable: Consolidate read metrics

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -916,25 +916,13 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         table_name: &str,
         request: ReadRowsRequest,
     ) -> Result<tonic::Response<tonic::Streaming<ReadRowsResponse>>> {
-        let datapoint_bigtable = if table_name == "blocks" {
-            "bigtable_blocks"
-        } else if table_name == "tx" {
-            "bigtable_tx"
-        } else if table_name == "tx-by-addr" {
-            "bigtable_tx-by-addr"
-        } else if table_name == "entries" {
-            "bigtable_entries"
-        } else {
-            "bigtable_unknown"
-        };
-        datapoint_info!(datapoint_bigtable, ("read_rows", 1, i64));
         tokio::time::timeout(
             self.timeout.unwrap_or(Duration::from_secs(30)),
             self.client.read_rows(request),
         )
         .await
         .map_err(|_| {
-            datapoint_error!(datapoint_bigtable, ("timeout", 1, i64));
+            datapoint_error!("storage-bigtable-timeout", ("table", table_name, String));
             Error::Timeout
         })?
         .map_err(Error::from)

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -29,7 +29,7 @@ use {
         fmt::Debug,
         sync::{
             Arc,
-            atomic::{AtomicUsize, Ordering},
+            atomic::{AtomicI64, Ordering},
         },
         time::Duration,
     },
@@ -470,25 +470,59 @@ const METRICS_REPORT_INTERVAL_MS: u64 = 10_000;
 
 #[derive(Default)]
 struct LedgerStorageStats {
-    num_queries: AtomicUsize,
+    num_blocks_table_reads: AtomicI64,
+    num_entries_table_reads: AtomicI64,
+    num_tx_table_reads: AtomicI64,
+    num_tx_by_addr_table_reads: AtomicI64,
     last_report: AtomicInterval,
 }
 
 impl LedgerStorageStats {
-    fn increment_num_queries(&self) {
-        self.num_queries.fetch_add(1, Ordering::Relaxed);
+    fn increment_num_blocks_table_reads(&self) {
+        self.num_blocks_table_reads.fetch_add(1, Ordering::Relaxed);
+        self.maybe_report();
+    }
+
+    fn increment_num_entries_table_reads(&self) {
+        self.num_entries_table_reads.fetch_add(1, Ordering::Relaxed);
+        self.maybe_report();
+    }
+
+    fn increment_num_tx_table_reads(&self) {
+        self.num_tx_table_reads.fetch_add(1, Ordering::Relaxed);
+        self.maybe_report();
+    }
+
+    fn increment_num_tx_by_addr_table_reads(&self) {
+        self.num_tx_by_addr_table_reads
+            .fetch_add(1, Ordering::Relaxed);
         self.maybe_report();
     }
 
     fn maybe_report(&self) {
         if self.last_report.should_update(METRICS_REPORT_INTERVAL_MS) {
-            datapoint_debug!(
-                "storage-bigtable-query",
+            datapoint_info!(
+                "storage-bigtable-reads",
                 (
-                    "num_queries",
-                    self.num_queries.swap(0, Ordering::Relaxed) as i64,
+                    "num_blocks_table_reads",
+                    self.num_blocks_table_reads.swap(0, Ordering::Relaxed),
                     i64
-                )
+                ),
+                (
+                    "num_entries_table_reads",
+                    self.num_entries_table_reads.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_tx_table_reads",
+                    self.num_tx_table_reads.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "num_tx_by_addr_table_reads",
+                    self.num_tx_by_addr_table_reads.swap(0, Ordering::Relaxed),
+                    i64
+                ),
             );
         }
     }
@@ -567,8 +601,9 @@ impl LedgerStorage {
     /// Return the available slot that contains a block
     pub async fn get_first_available_block(&self) -> Result<Option<Slot>> {
         trace!("LedgerStorage::get_first_available_block request received");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_blocks_table_reads();
         let mut bigtable = self.connection.client();
+
         let blocks = bigtable.get_row_keys("blocks", None, None, 1).await?;
         if blocks.is_empty() {
             return Ok(None);
@@ -582,8 +617,9 @@ impl LedgerStorage {
     /// limit: stop after this many slots have been found
     pub async fn get_confirmed_blocks(&self, start_slot: Slot, limit: usize) -> Result<Vec<Slot>> {
         trace!("LedgerStorage::get_confirmed_blocks request received: {start_slot:?} {limit:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_blocks_table_reads();
         let mut bigtable = self.connection.client();
+
         let blocks = bigtable
             .get_row_keys(
                 "blocks",
@@ -601,8 +637,9 @@ impl LedgerStorage {
         slots: impl IntoIterator<Item = Slot> + Debug,
     ) -> Result<impl Iterator<Item = (Slot, ConfirmedBlock)>> {
         trace!("LedgerStorage::get_confirmed_blocks_with_data request received: {slots:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_blocks_table_reads();
         let mut bigtable = self.connection.client();
+
         let row_keys = slots.into_iter().map(slot_to_blocks_key);
         let data = bigtable
             .get_protobuf_or_bincode_cells("blocks", row_keys)
@@ -625,8 +662,9 @@ impl LedgerStorage {
     /// Fetch the confirmed block from the desired slot
     pub async fn get_confirmed_block(&self, slot: Slot) -> Result<ConfirmedBlock> {
         trace!("LedgerStorage::get_confirmed_block request received: {slot:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_blocks_table_reads();
         let mut bigtable = self.connection.client();
+
         let block_cell_data = bigtable
             .get_protobuf_or_bincode_cell::<StoredConfirmedBlock, generated::ConfirmedBlock>(
                 "blocks",
@@ -648,7 +686,7 @@ impl LedgerStorage {
     /// Does the confirmed block exist in the Bigtable
     pub async fn confirmed_block_exists(&self, slot: Slot) -> Result<bool> {
         trace!("LedgerStorage::confirmed_block_exists request received: {slot:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_blocks_table_reads();
         let mut bigtable = self.connection.client();
 
         let block_exists = bigtable
@@ -664,8 +702,9 @@ impl LedgerStorage {
         slot: Slot,
     ) -> Result<impl Iterator<Item = EntrySummary> + use<>> {
         trace!("LedgerStorage::get_block_entries request received: {slot:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_entries_table_reads();
         let mut bigtable = self.connection.client();
+
         let entry_cell_data = bigtable
             .get_protobuf_cell::<entries::Entries>("entries", slot_to_entries_key(slot))
             .await
@@ -679,8 +718,9 @@ impl LedgerStorage {
 
     pub async fn get_signature_status(&self, signature: &Signature) -> Result<TransactionStatus> {
         trace!("LedgerStorage::get_signature_status request received: {signature:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_tx_table_reads();
         let mut bigtable = self.connection.client();
+
         let transaction_info = bigtable
             .get_bincode_cell::<TransactionInfo>("tx", signature.to_string())
             .await
@@ -697,7 +737,7 @@ impl LedgerStorage {
         signatures: &[Signature],
     ) -> Result<Vec<ConfirmedTransactionWithStatusMeta>> {
         trace!("LedgerStorage::get_confirmed_transactions request received: {signatures:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_tx_table_reads();
         let mut bigtable = self.connection.client();
 
         // Fetch transactions info
@@ -757,7 +797,7 @@ impl LedgerStorage {
         signature: &Signature,
     ) -> Result<Option<ConfirmedTransactionWithStatusMeta>> {
         trace!("LedgerStorage::get_confirmed_transaction request received: {signature:?}");
-        self.stats.increment_num_queries();
+        self.stats.increment_num_tx_table_reads();
         let mut bigtable = self.connection.client();
 
         // Figure out which block the transaction is located in
@@ -812,14 +852,14 @@ impl LedgerStorage {
         )>,
     > {
         trace!("LedgerStorage::get_confirmed_signatures_for_address request received: {address:?}");
-        self.stats.increment_num_queries();
         let mut bigtable = self.connection.client();
-        let address_prefix = format!("{address}/");
 
+        let address_prefix = format!("{address}/");
         // Figure out where to start listing from based on `before_signature`
         let (first_slot, before_transaction_index) = match before_signature {
             None => (Slot::MAX, 0),
             Some(before_signature) => {
+                self.stats.increment_num_tx_table_reads();
                 let TransactionInfo { slot, index, .. } = bigtable
                     .get_bincode_cell("tx", before_signature.to_string())
                     .await
@@ -836,6 +876,7 @@ impl LedgerStorage {
         let (last_slot, until_transaction_index) = match until_signature {
             None => (0, u32::MAX),
             Some(until_signature) => {
+                self.stats.increment_num_tx_table_reads();
                 let TransactionInfo { slot, index, .. } = bigtable
                     .get_bincode_cell("tx", until_signature.to_string())
                     .await
@@ -850,6 +891,7 @@ impl LedgerStorage {
 
         let mut infos = vec![];
 
+        self.stats.increment_num_tx_by_addr_table_reads();
         let starting_slot_tx_len = bigtable
             .get_protobuf_or_bincode_cell::<Vec<LegacyTransactionByAddrInfo>, tx_by_addr::TransactionByAddr>(
                 "tx-by-addr",
@@ -864,6 +906,7 @@ impl LedgerStorage {
             })
             .unwrap_or(0);
 
+        self.stats.increment_num_tx_by_addr_table_reads();
         // Return the next tx-by-addr data of amount `limit` plus extra to account for the largest
         // number that might be filtered out
         let tx_by_addr_data = bigtable
@@ -947,6 +990,7 @@ impl LedgerStorage {
         confirmed_block: VersionedConfirmedBlock,
     ) -> Result<()> {
         trace!("LedgerStorage::upload_confirmed_block request received: {slot:?}");
+
         self.upload_confirmed_block_with_entries(
             slot,
             VersionedConfirmedBlockWithEntries {
@@ -963,6 +1007,7 @@ impl LedgerStorage {
         confirmed_block: VersionedConfirmedBlockWithEntries,
     ) -> Result<()> {
         trace!("LedgerStorage::upload_confirmed_block_with_entries request received: {slot:?}");
+
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
         let VersionedConfirmedBlockWithEntries {
             block: confirmed_block,
@@ -1034,28 +1079,31 @@ impl LedgerStorage {
         let mut tasks = vec![];
 
         if !tx_cells.is_empty() {
-            let conn = self.connection.clone();
+            let bigtable = self.connection.clone();
             tasks.push(tokio::spawn(async move {
-                conn.put_bincode_cells_with_retry::<TransactionInfo>("tx", &tx_cells)
+                bigtable
+                    .put_bincode_cells_with_retry::<TransactionInfo>("tx", &tx_cells)
                     .await
             }));
         }
 
         if !tx_by_addr_cells.is_empty() {
-            let conn = self.connection.clone();
+            let bigtable = self.connection.clone();
             tasks.push(tokio::spawn(async move {
-                conn.put_protobuf_cells_with_retry::<tx_by_addr::TransactionByAddr>(
-                    "tx-by-addr",
-                    &tx_by_addr_cells,
-                )
-                .await
+                bigtable
+                    .put_protobuf_cells_with_retry::<tx_by_addr::TransactionByAddr>(
+                        "tx-by-addr",
+                        &tx_by_addr_cells,
+                    )
+                    .await
             }));
         }
 
         if num_entries > 0 {
-            let conn = self.connection.clone();
+            let bigtable = self.connection.clone();
             tasks.push(tokio::spawn(async move {
-                conn.put_protobuf_cells_with_retry::<entries::Entries>("entries", &[entry_cell])
+                bigtable
+                    .put_protobuf_cells_with_retry::<entries::Entries>("entries", &[entry_cell])
                     .await
             }));
         }


### PR DESCRIPTION
#### Problem
Currently, a datapoint is emitted for every single row read. This ends up being incredibly noisy for any node that is actually servicing read requests. 

#### Summary of Changes
To reduce noise, adapt the existing datapoint that is reported on a regular cadence and remove the per-read datapoint

There is technically a little bit of unrelated cleanup where I create white space consistency and rename "conn" to "bigtable" for consistency; these seemed minor enough to lump in

#### Testing
Compiles