### PR TITLE
tpu-client-next: fix congestion events metric

### DIFF
--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -301,7 +301,7 @@ impl ConnectionWorker {
             } else {
                 let events = connection.stats().path.congestion_events;
                 self.send_txs_stats.transport_congestion_events.fetch_add(
-                    self.last_congestion_events.saturating_sub(events),
+                    events.saturating_sub(self.last_congestion_events),
                     Ordering::Relaxed,
                 );
                 self.last_congestion_events = events;
@@ -340,6 +340,7 @@ impl ConnectionWorker {
                 );
                 match res {
                     Ok(Ok(connection)) => {
+                        self.last_congestion_events = 0;
                         self.connection = ConnectionState::Active(connection);
                     }
                     Ok(Err(err)) => {


### PR DESCRIPTION
#### Problem

We used to have a bug in congestion events counting.

#### Summary of Changes

Fix it.