### PR TITLE
feat: migrate solana-loader-v3-interface to 8.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8949,9 +8949,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "7.0.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
+checksum = "46255f7494fa739cb0c65ad43aaa12f49d1ed884d8632f0437b9c91ce48a936a"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -8959,7 +8959,9 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
+ "solana-serde",
  "solana-system-interface 3.3.0",
+ "wincode",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -423,7 +423,7 @@ solana-lattice-hash = { path = "lattice-hash", version = "=4.4.0-alpha.1", featu
 solana-leader-schedule = { path = "leader-schedule", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }
 solana-ledger = { path = "ledger", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }
 solana-loader-v2-interface = "3.0.0"
-solana-loader-v3-interface = "7.0.0"
+solana-loader-v3-interface = "8.1.1"
 solana-loader-v4-interface = "3.1.0"
 solana-local-cluster = { path = "local-cluster", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -70,7 +70,7 @@ solana-feature-gate-interface = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde", "wincode"] }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -1614,6 +1614,7 @@ async fn process_program_upgrade(
             &buffer_pubkey,
             &upgrade_authority_signer.pubkey(),
             &fee_payer_signer.pubkey(),
+            true,
         )],
         Some(&fee_payer_signer.pubkey()),
         &blockhash,
@@ -2239,6 +2240,7 @@ async fn close(
             recipient_pubkey,
             Some(&authority_signer.pubkey()),
             program_pubkey,
+            false,
         )],
         Some(&config.signers[0].pubkey()),
     ));
@@ -2639,6 +2641,7 @@ async fn do_process_program_deploy(
                 .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
                 .await?,
             program_data_max_len,
+            true,
         )?
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
@@ -2902,6 +2905,7 @@ async fn do_process_program_upgrade(
         buffer_pubkey,
         &upgrade_authority.pubkey(),
         &fee_payer_signer.pubkey(),
+        true,
     )]
     .with_compute_unit_config(&ComputeUnitConfig {
         compute_unit_price,

--- a/cli/tests/program.rs
+++ b/cli/tests/program.rs
@@ -2177,6 +2177,7 @@ async fn test_cli_program_write_buffer() {
             &keypair.pubkey(),
             Some(&keypair.pubkey()),
             None,
+            false,
         )],
         Some(&keypair.pubkey()),
     );

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -208,7 +208,7 @@ solana-cost-model = { path = "../cost-model", features = ["agave-unstable-api", 
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-loader-v3-interface = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["serde", "wincode"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-poh = { path = "../poh", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/core/tests/scheduler_cost_adjustment.rs
+++ b/core/tests/scheduler_cost_adjustment.rs
@@ -204,6 +204,7 @@ impl TestSetup {
             &upgrade_authority_address,
             /* program_lamports */ 0, // Doesn't matter here.
             /* max_data_len */ memo.data().len().saturating_mul(2),
+            true,
         )
         .unwrap()
         .pop()

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7057,9 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "7.0.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
+checksum = "46255f7494fa739cb0c65ad43aaa12f49d1ed884d8632f0437b9c91ce48a936a"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -7067,7 +7067,9 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
+ "solana-serde",
  "solana-system-interface 3.3.0",
+ "wincode",
 ]
 
 [[package]]

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -104,7 +104,7 @@ solana-instruction = "3.4.0"
 solana-instruction-error = "2.4.0"
 solana-keypair = "3.1.2"
 solana-ledger = { path = "../ledger", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }
-solana-loader-v3-interface = "7.0.0"
+solana-loader-v3-interface = "8.1.1"
 solana-loader-v4-interface = "3.1.0"
 solana-local-cluster = { path = "../local-cluster", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }
 solana-measure = { path = "../measure", version = "=4.4.0-alpha.1", features = ["agave-unstable-api"] }

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -54,7 +54,7 @@ solana-genesis-utils = { workspace = true }
 solana-inflation = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-loader-v3-interface = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
 solana-pubkey = { workspace = true }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -61,7 +61,7 @@ solana-inflation = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true, features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-loader-v3-interface = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }

--- a/program-binaries/Cargo.toml
+++ b/program-binaries/Cargo.toml
@@ -20,7 +20,7 @@ agave-unstable-api = []
 [dependencies]
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["bincode", "serde"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -45,7 +45,7 @@ solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-loader-v3-interface = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["wincode"] }
 solana-message = { workspace = true }
 solana-msg = { workspace = true }
 solana-native-token = { workspace = true }

--- a/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
+++ b/programs/bpf_loader/benches/bpf_loader_upgradeable.rs
@@ -150,7 +150,8 @@ mod bench {
             self.transaction_accounts
                 .push(self.transaction_accounts[1].clone());
             self.instruction_data =
-                bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+                bincode::serialize(&UpgradeableLoaderInstruction::Close { tombstone: false })
+                    .unwrap();
         }
 
         fn run(&self) {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -199,7 +199,10 @@ fn process_loader_upgradeable_instruction(
                 invoke_context,
             )?;
         }
-        UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
+        UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+            max_data_len,
+            close_buffer: _,
+        } => {
             instruction_context.check_number_of_instruction_accounts(4)?;
             let payer_key = *instruction_context.get_key_of_instruction_account(0)?;
             let programdata_key = *instruction_context.get_key_of_instruction_account(1)?;
@@ -364,7 +367,7 @@ fn process_loader_upgradeable_instruction(
 
             ic_logger_msg!(log_collector, "Deployed program {:?}", new_program_id);
         }
-        UpgradeableLoaderInstruction::Upgrade => {
+        UpgradeableLoaderInstruction::Upgrade { close_buffer: _ } => {
             instruction_context.check_number_of_instruction_accounts(3)?;
             let programdata_key = *instruction_context.get_key_of_instruction_account(0)?;
             let rent =
@@ -683,7 +686,7 @@ fn process_loader_upgradeable_instruction(
 
             ic_logger_msg!(log_collector, "New authority {:?}", new_authority_key);
         }
-        UpgradeableLoaderInstruction::Close => {
+        UpgradeableLoaderInstruction::Close { tombstone: _ } => {
             instruction_context.check_number_of_instruction_accounts(2)?;
             if instruction_context.get_index_of_instruction_account_in_transaction(0)?
                 == instruction_context.get_index_of_instruction_account_in_transaction(1)?
@@ -1845,7 +1848,8 @@ mod tests {
             expected_result: Result<(), InstructionError>,
         ) -> Vec<AccountSharedData> {
             let instruction_data =
-                bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
+                bincode::serialize(&UpgradeableLoaderInstruction::Upgrade { close_buffer: true })
+                    .unwrap();
             process_instruction_with_setup(
                 &bpf_loader_upgradeable::id(),
                 &instruction_data,
@@ -1995,7 +1999,9 @@ mod tests {
             &elf_new,
         );
         *instruction_accounts.get_mut(1).unwrap() = instruction_accounts.get(2).unwrap().clone();
-        let instruction_data = bincode::serialize(&UpgradeableLoaderInstruction::Upgrade).unwrap();
+        let instruction_data =
+            bincode::serialize(&UpgradeableLoaderInstruction::Upgrade { close_buffer: true })
+                .unwrap();
 
         process_instruction_with_setup(
             &bpf_loader_upgradeable::id(),
@@ -2470,6 +2476,7 @@ mod tests {
             let instruction_data =
                 bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                     max_data_len,
+                    close_buffer: true,
                 })
                 .unwrap();
             process_instruction_with_setup(
@@ -3710,7 +3717,8 @@ mod tests {
 
     #[test]
     fn test_bpf_loader_upgradeable_close() {
-        let instruction = bincode::serialize(&UpgradeableLoaderInstruction::Close).unwrap();
+        let instruction =
+            bincode::serialize(&UpgradeableLoaderInstruction::Close { tombstone: false }).unwrap();
         let loader_id = bpf_loader_upgradeable::id();
         let invalid_authority_address = Pubkey::new_unique();
         let authority_address = Pubkey::new_unique();
@@ -3934,6 +3942,7 @@ mod tests {
             &loader_id,
             &bincode::serialize(&UpgradeableLoaderInstruction::DeployWithMaxDataLen {
                 max_data_len: 0,
+                close_buffer: true,
             })
             .unwrap(),
             vec![

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7184,9 +7184,9 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v3-interface"
-version = "7.0.0"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68029ab11d9c891d4ce23ada75745e40f983c5674af366f447b672569634231b"
+checksum = "46255f7494fa739cb0c65ad43aaa12f49d1ed884d8632f0437b9c91ce48a936a"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -7194,7 +7194,9 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey 4.3.0",
  "solana-sdk-ids",
+ "solana-serde",
  "solana-system-interface 3.3.0",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -204,7 +204,7 @@ solana-fee-structure = "4.0.0"
 solana-hash = "4.3.0"
 solana-instruction = { workspace = true }
 solana-keypair = "3.1.2"
-solana-loader-v3-interface = "7.0.0"
+solana-loader-v3-interface = { version = "8.1.1", features = ["serde", "wincode"] }
 solana-message = "4.1.0"
 solana-program-binaries = { workspace = true, features = ["agave-unstable-api"] }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -503,6 +503,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
         &authority_pubkey,
         1,
         program_elf.len() * 2,
+        true,
     )
     .unwrap()
     .pop()
@@ -1934,6 +1935,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
         &buffer_keypair.pubkey(),
         &authority_keypair.pubkey(),
         &mint_keypair.pubkey(),
+        true,
     );
 
     // Redeployment causes programs to be unavailable to both top-level-instructions and CPI instructions
@@ -1970,6 +1972,7 @@ fn test_program_sbf_invoke_stable_genesis_and_bank() {
         &mint_keypair.pubkey(),
         Some(&authority_keypair.pubkey()),
         Some(&program_id),
+        false,
     );
 
     let invoke_instruction =
@@ -2061,6 +2064,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
                 .unwrap(),
         ),
         program.len() * 2,
+        true,
     )
     .unwrap();
 
@@ -2150,6 +2154,7 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
         &buffer_keypair.pubkey(),
         &authority_keypair.pubkey(),
         &mint_keypair.pubkey(),
+        true,
     );
 
     // Deploy indirect invocation program
@@ -2252,6 +2257,7 @@ fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
         &mint_keypair.pubkey(),
         Some(&authority_keypair.pubkey()),
         Some(&program_id),
+        false,
     );
 
     // Undeployment causes the program to become unavailable to both top-level
@@ -2560,6 +2566,7 @@ fn test_program_sbf_upgrade_via_cpi() {
         &buffer_keypair.pubkey(),
         &new_authority_keypair.pubkey(),
         &mint_keypair.pubkey(),
+        true,
     );
     upgrade_instruction.program_id = invoke_and_return;
     upgrade_instruction

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -32,6 +32,7 @@ dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
     "solana-accounts-db/dev-context-only-utils",
     "solana-entry/dev-context-only-utils",
+    "solana-loader-v3-interface/wincode",
     "solana-program-binaries",
     "solana-svm/dev-context-only-utils",
     "solana-runtime-transaction/dev-context-only-utils",
@@ -141,7 +142,7 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, features = ["seed-derivable"] }
 solana-lattice-hash = { workspace = true }
 solana-leader-schedule = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6604,6 +6604,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
             &upgrade_authority_keypair.pubkey(),
             min_program_balance,
             elf.len(),
+            true,
         )
         .unwrap(),
         Some(&payer_keypair.pubkey()),
@@ -12272,6 +12273,7 @@ fn test_deploy_last_epoch_slot() {
             &upgrade_authority_keypair.pubkey(),
             min_program_balance,
             program_len,
+            true,
         )
         .unwrap(),
         Some(&payer_keypair.pubkey()),
@@ -12756,7 +12758,10 @@ fn test_bpf_loader_upgradeable_deploy_with_more_than_255_accounts() {
             ),
             Instruction::new_with_bincode(
                 bpf_loader_upgradeable::id(),
-                &UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len },
+                &UpgradeableLoaderInstruction::DeployWithMaxDataLen {
+                    max_data_len,
+                    close_buffer: true,
+                },
                 deploy_ix_accounts,
             ),
         ])

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -158,6 +158,7 @@ pub fn load_upgradeable_program(
                     .unwrap(),
             ),
             program.len() * 2,
+            true,
         )
         .unwrap(),
         Some(&from_keypair.pubkey()),
@@ -237,6 +238,7 @@ pub fn upgrade_program<T: Client>(
             &buffer_keypair.pubkey(),
             &authority_keypair.pubkey(),
             &payer_keypair.pubkey(),
+            true,
         )],
         Some(&payer_keypair.pubkey()),
     );

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -102,7 +102,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instruction-error = { workspace = true, optional = true }
 solana-instructions-sysvar = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-loader-v4-interface = { workspace = true }
 solana-message = { workspace = true }
 solana-nonce = { workspace = true, features = ["wincode"] }
@@ -151,6 +151,7 @@ solana-compute-budget-program = { path = "../programs/compute-budget", features 
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["wincode"] }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -2896,6 +2896,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
             &buffer_address,
             &fee_payer,
             &Pubkey::new_unique(),
+            true,
         )
     } else {
         loaderv3_instruction::close_any(
@@ -2903,6 +2904,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
             &Pubkey::new_unique(),
             Some(&fee_payer),
             Some(&program_id),
+            false,
         )
     };
 
@@ -3014,8 +3016,13 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
     test_entry.drop_expected_account(deploy);
 
     // close the buffer
-    let close_instruction =
-        loaderv3_instruction::close_any(&target, &Pubkey::new_unique(), Some(&fee_payer), None);
+    let close_instruction = loaderv3_instruction::close_any(
+        &target,
+        &Pubkey::new_unique(),
+        Some(&fee_payer),
+        None,
+        false,
+    );
 
     // reopen as a program
     #[allow(deprecated)]
@@ -3026,6 +3033,7 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
         &fee_payer,
         LAMPORTS_PER_SOL,
         buffer_data.len(),
+        true,
     )
     .unwrap();
 
@@ -3271,6 +3279,7 @@ fn program_cache_stats() {
             &buffer_address,
             &fee_payer,
             &Pubkey::new_unique(),
+            true,
         )],
         Some(&fee_payer),
         &[&fee_payer_keypair],

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -51,7 +51,7 @@ solana-inflation = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
-solana-loader-v3-interface = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -34,7 +34,7 @@ solana-entry = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-loader-v2-interface = { workspace = true, features = ["bincode"] }
-solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
+solana-loader-v3-interface = { workspace = true, features = ["serde"] }
 solana-message = { workspace = true }
 solana-program-option = { workspace = true }
 solana-pubkey = { workspace = true }
@@ -60,6 +60,7 @@ wincode = { workspace = true }
 [dev-dependencies]
 bencher = { workspace = true }
 bytemuck = { workspace = true }
+solana-loader-v3-interface = { workspace = true, features = ["wincode"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-transaction-status = { path = ".", features = ["agave-unstable-api"] }
 spl-token-confidential-transfer-proof-extraction = { workspace = true }

--- a/transaction-status/src/parse_bpf_loader.rs
+++ b/transaction-status/src/parse_bpf_loader.rs
@@ -92,7 +92,7 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
-        UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len } => {
+        UpgradeableLoaderInstruction::DeployWithMaxDataLen { max_data_len, .. } => {
             check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 8)?;
             Ok(ParsedInstructionEnum {
                 instruction_type: "deployWithMaxDataLen".to_string(),
@@ -109,7 +109,7 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
-        UpgradeableLoaderInstruction::Upgrade => {
+        UpgradeableLoaderInstruction::Upgrade { .. } => {
             check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 7)?;
             Ok(ParsedInstructionEnum {
                 instruction_type: "upgrade".to_string(),
@@ -150,7 +150,7 @@ pub fn parse_bpf_upgradeable_loader(
                 }),
             })
         }
-        UpgradeableLoaderInstruction::Close => {
+        UpgradeableLoaderInstruction::Close { .. } => {
             check_num_bpf_upgradeable_loader_accounts(&instruction.accounts, 3)?;
             Ok(ParsedInstructionEnum {
                 instruction_type: "close".to_string(),
@@ -428,6 +428,7 @@ mod test {
             &upgrade_authority_address,
             55,
             max_data_len,
+            true,
         )
         .unwrap();
         let mut message = Message::new(&instructions, None);
@@ -483,6 +484,7 @@ mod test {
             &buffer_address,
             &authority_address,
             &spill_address,
+            true,
         );
         let mut message = Message::new(&[instruction], None);
         assert_eq!(
@@ -722,8 +724,12 @@ mod test {
         let close_address = Pubkey::new_unique();
         let recipient_address = Pubkey::new_unique();
         let authority_address = Pubkey::new_unique();
-        let instruction =
-            bpf_loader_upgradeable::close(&close_address, &recipient_address, &authority_address);
+        let instruction = bpf_loader_upgradeable::close(
+            &close_address,
+            &recipient_address,
+            &authority_address,
+            false,
+        );
         let mut message = Message::new(&[instruction], None);
         assert_eq!(
             parse_bpf_upgradeable_loader(
@@ -767,6 +773,7 @@ mod test {
             &recipient_address,
             Some(&authority_address),
             Some(&program_address),
+            false,
         );
         let mut message = Message::new(&[instruction], None);
         assert_eq!(


### PR DESCRIPTION
#### Problem
agave uses `solana-loader-v3-interface` at 7.0, which lacks wincode supported interfaces. 8.x added those, but has some breaking changes that affect callers. We should bump dependency keeping old-behavior defaults.

#### Summary of Changes
Bump to 8.1.1, which drops the `bincode` feature (now split into `serde` and `wincode`) and adds SIMD-0432 fields to the upgradeable loader instructions. Switch each crate's feature selection accordingly and ignore the new `close_buffer`/`tombstone` fields to preserve current behavior; SIMD-0432 semantics are intentionally left unimplemented.

#### Testing
CI
