### PR TITLE
tpu-client-next: remove skip_check_transaction_age

### DIFF
--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -539,7 +539,6 @@ impl TpuClientNextClient {
             // Cache size of 128 covers all nodes above the P90 slot count threshold,
             // which together account for ~75% of total slots in the epoch.
             num_connections: NonZeroUsize::new(128).unwrap(),
-            skip_check_transaction_age: true,
             worker_channel_size: 2,
             max_reconnect_attempts: 4,
             // Send to the next leader only, but verify that connections exist

--- a/tpu-client-next/src/client_builder.rs
+++ b/tpu-client-next/src/client_builder.rs
@@ -81,7 +81,6 @@ pub struct ClientBuilder {
     identity: Option<StakeIdentity>,
     num_connections: NonZeroUsize,
     leader_send_fanout: usize,
-    skip_check_transaction_age: bool,
     sender_channel_size: usize,
     worker_channel_size: usize,
     max_reconnect_attempts: usize,
@@ -101,7 +100,6 @@ impl ClientBuilder {
             identity: None,
             num_connections: NonZeroUsize::new(64).unwrap(),
             leader_send_fanout: 2,
-            skip_check_transaction_age: true,
             worker_channel_size: 2,
             sender_channel_size: 64,
             max_reconnect_attempts: 2,
@@ -215,7 +213,6 @@ impl ClientBuilder {
             bind,
             stake_identity: self.identity,
             num_connections: self.num_connections,
-            skip_check_transaction_age: self.skip_check_transaction_age,
             worker_channel_size: self.worker_channel_size,
             max_reconnect_attempts: self.max_reconnect_attempts,
             // We open connection to one more leader in advance, which time-wise means ~1.6s

--- a/tpu-client-next/src/connection_worker.rs
+++ b/tpu-client-next/src/connection_worker.rs
@@ -11,10 +11,9 @@ use {
         transaction_batch::TransactionBatch,
     },
     quinn::{ConnectError, Connection, ConnectionError, Endpoint},
-    solana_clock::{DEFAULT_MS_PER_SLOT, MAX_PROCESSING_AGE},
+    solana_clock::DEFAULT_MS_PER_SLOT,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_measure::measure::Measure,
-    solana_time_utils::timestamp,
     solana_tls_utils::socket_addr_to_quic_server_name,
     std::{
         net::SocketAddr,
@@ -36,10 +35,6 @@ pub(crate) const DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::
 /// a best-effort estimate, based on current network conditions.
 const RETRY_SLEEP_INTERVAL: Duration =
     Duration::from_millis(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64 * DEFAULT_MS_PER_SLOT);
-
-/// Maximum age (in milliseconds) of a blockhash, beyond which transaction
-/// batches are dropped.
-const MAX_PROCESSING_AGE_MS: u64 = MAX_PROCESSING_AGE as u64 * DEFAULT_MS_PER_SLOT;
 
 /// [`ConnectionState`] represents the current state of a quic connection.
 ///
@@ -84,7 +79,6 @@ pub(crate) struct ConnectionWorker {
     transactions_receiver: mpsc::Receiver<TransactionBatch>,
     connection: ConnectionState,
     last_congestion_events: u64,
-    skip_check_transaction_age: bool,
     max_reconnect_attempts: usize,
     send_txs_stats: Arc<SendTransactionStats>,
     cancel: CancellationToken,
@@ -95,9 +89,7 @@ impl ConnectionWorker {
     /// Constructs a [`ConnectionWorker`].
     ///
     /// [`ConnectionWorker`] maintains a connection to a `peer` and processes
-    /// transactions from `transactions_receiver`. If
-    /// `skip_check_transaction_age` is set to `true`, the worker skips checking
-    /// for transaction blockhash expiration. The `max_reconnect_attempts`
+    /// transactions from `transactions_receiver`. The `max_reconnect_attempts`
     /// parameter controls how many times the worker will attempt to reconnect
     /// in case of connection failure. Returns the created `ConnectionWorker`
     /// along with a cancellation token that can be used by the caller to stop
@@ -106,7 +98,6 @@ impl ConnectionWorker {
         endpoint: Endpoint,
         peer: SocketAddr,
         transactions_receiver: mpsc::Receiver<TransactionBatch>,
-        skip_check_transaction_age: bool,
         max_reconnect_attempts: usize,
         send_txs_stats: Arc<SendTransactionStats>,
         handshake_timeout: Duration,
@@ -117,7 +108,6 @@ impl ConnectionWorker {
             peer,
             transactions_receiver,
             connection: ConnectionState::NotSetup,
-            skip_check_transaction_age,
             max_reconnect_attempts,
             send_txs_stats,
             cancel: cancel.clone(),
@@ -262,22 +252,12 @@ impl ConnectionWorker {
     ///
     /// Each transaction in the batch is sent over the QUIC streams one at the
     /// time, which prevents traffic fragmentation and shows better TPS in
-    /// comparison with multistream send. If the batch is determined to be
-    /// outdated and flag `skip_check_transaction_age` is unset, it will be
-    /// dropped without being sent.
+    /// comparison with multistream send.
     ///
     /// The method checks connection health before sending each transaction to
     /// avoid operations on a closed connection. In case of error, it doesn't
     /// retry to send the same transactions again but transitions to retry state.
     async fn send_transactions(&mut self, connection: Connection, transactions: TransactionBatch) {
-        let now = timestamp();
-        if !self.skip_check_transaction_age
-            && now.saturating_sub(transactions.timestamp()) > MAX_PROCESSING_AGE_MS
-        {
-            debug!("Drop outdated transaction batch for peer: {}", self.peer);
-            return;
-        }
-
         let mut measure_send = Measure::start("send transaction batch");
         for data in transactions.into_iter() {
             // Check connection health before each send

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -88,9 +88,6 @@ pub struct ConnectionWorkersSchedulerConfig {
     /// The number of connections to be maintained by the scheduler.
     pub num_connections: NonZeroUsize,
 
-    /// Whether to skip checking the transaction blockhash expiration.
-    pub skip_check_transaction_age: bool,
-
     /// The size of the channel used to transmit transaction batches to the
     /// worker tasks.
     pub worker_channel_size: usize,
@@ -215,7 +212,6 @@ impl ConnectionWorkersScheduler {
             bind,
             stake_identity,
             num_connections,
-            skip_check_transaction_age,
             worker_channel_size,
             max_reconnect_attempts,
             leaders_fanout,
@@ -282,7 +278,6 @@ impl ConnectionWorkersScheduler {
                     peer,
                     &endpoint,
                     worker_channel_size,
-                    skip_check_transaction_age,
                     max_reconnect_attempts,
                     DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
                     stats.clone(),

--- a/tpu-client-next/src/transaction_batch.rs
+++ b/tpu-client-next/src/transaction_batch.rs
@@ -1,14 +1,11 @@
 //! This module holds [`TransactionBatch`] structure.
 
-use {solana_time_utils::timestamp, tokio_util::bytes::Bytes};
+use tokio_util::bytes::Bytes;
 
-/// Batch of generated transactions timestamp is used to discard batches which
-/// are too old to have valid blockhash.
+/// Batch of generated transactions.
 #[derive(Clone, PartialEq)]
 pub struct TransactionBatch {
     wired_transactions: Vec<WiredTransaction>,
-    // Time of creation of this batch, used for batch timeouts
-    timestamp: u64,
 }
 
 type WiredTransaction = Bytes;
@@ -31,12 +28,6 @@ impl TransactionBatch {
             .map(|v| Bytes::from_owner(v))
             .collect();
 
-        Self {
-            wired_transactions,
-            timestamp: timestamp(),
-        }
-    }
-    pub fn timestamp(&self) -> u64 {
-        self.timestamp
+        Self { wired_transactions }
     }
 }

--- a/tpu-client-next/src/workers_cache.rs
+++ b/tpu-client-next/src/workers_cache.rs
@@ -83,7 +83,6 @@ pub fn spawn_worker(
     endpoint: &Endpoint,
     peer: &SocketAddr,
     worker_channel_size: usize,
-    skip_check_transaction_age: bool,
     max_reconnect_attempts: usize,
     handshake_timeout: Duration,
     stats: Arc<SendTransactionStats>,
@@ -96,7 +95,6 @@ pub fn spawn_worker(
         endpoint,
         peer,
         txs_receiver,
-        skip_check_transaction_age,
         max_reconnect_attempts,
         stats,
         handshake_timeout,
@@ -179,7 +177,6 @@ impl WorkersCache {
         peer: SocketAddr,
         endpoint: &Endpoint,
         worker_channel_size: usize,
-        skip_check_transaction_age: bool,
         max_reconnect_attempts: usize,
         handshake_timeout: Duration,
         stats: Arc<SendTransactionStats>,
@@ -197,7 +194,6 @@ impl WorkersCache {
             endpoint,
             &peer,
             worker_channel_size,
-            skip_check_transaction_age,
             max_reconnect_attempts,
             handshake_timeout,
             stats,
@@ -396,14 +392,12 @@ mod tests {
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
 
         let worker_channel_size = 1;
-        let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;
         let stats = Arc::new(SendTransactionStats::default());
         let worker_info = spawn_worker(
             &endpoint,
             &peer,
             worker_channel_size,
-            skip_check_transaction_age,
             max_reconnect_attempts,
             DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
             stats.clone(),
@@ -430,14 +424,12 @@ mod tests {
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
 
         let worker_channel_size = 1;
-        let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;
         let stats = Arc::new(SendTransactionStats::default());
         let worker_info = spawn_worker(
             &endpoint,
             &peer,
             worker_channel_size,
-            skip_check_transaction_age,
             max_reconnect_attempts,
             DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
             stats.clone(),
@@ -462,14 +454,12 @@ mod tests {
         let port_range = unique_port_range_for_tests(2);
         let peer: SocketAddr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port_range.start);
         let worker_channel_size = 1;
-        let skip_check_transaction_age = true;
         let max_reconnect_attempts = 0;
         let stats = Arc::new(SendTransactionStats::default());
         let worker = spawn_worker(
             &endpoint,
             &peer,
             worker_channel_size,
-            skip_check_transaction_age,
             max_reconnect_attempts,
             DEFAULT_MAX_CONNECTION_HANDSHAKE_TIMEOUT,
             stats.clone(),

--- a/tpu-client-next/tests/connection_workers_scheduler_test.rs
+++ b/tpu-client-next/tests/connection_workers_scheduler_test.rs
@@ -56,7 +56,6 @@ fn test_config(stake_identity: Option<Keypair>) -> ConnectionWorkersSchedulerCon
         bind: BindTarget::Address(address),
         stake_identity: stake_identity.map(|identity| StakeIdentity::new(&identity)),
         num_connections: NonZeroUsize::new(1).unwrap(),
-        skip_check_transaction_age: false,
         // At the moment we have only one strategy to send transactions: we try
         // to put to worker channel transaction batch and in case of failure
         // just drop it. This requires to use large channels here. In the


### PR DESCRIPTION
#### Problem

This flag along with the checks on the transaction batch age based on time is not useful.

#### Summary of Changes

We just delete age checks.