### PR TITLE
accounts-db: Unref and mark accounts obsolete during clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -47,7 +47,7 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, AccountsIndexScanResult, IndexKey,
-            ReclaimsSlotList, ReclaimsWithNewSlot, RefCount, ScanFilter, SlotList, Startup,
+            ReclaimsSlotList, ReclaimsWithNewestSlot, RefCount, ScanFilter, SlotList, Startup,
             UpsertReclaim, in_mem_accounts_index::StartupStats,
         },
         accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult, ScanTracker},
@@ -1185,9 +1185,9 @@ impl AccountsDb {
         &self,
         pubkey: &Pubkey,
         max_clean_root_inclusive: Option<Slot>,
-    ) -> ReclaimsWithNewSlot<AccountInfo> {
+    ) -> ReclaimsWithNewestSlot<AccountInfo> {
         let mut clean_rooted = Measure::start("clean_old_root-ms");
-        let mut reclaims = ReclaimsWithNewSlot::new();
+        let mut reclaims = ReclaimsWithNewestSlot::new();
         let removed_from_index = self.accounts_index.clean_rooted_entries(
             pubkey,
             &mut reclaims,
@@ -1203,12 +1203,12 @@ impl AccountsDb {
         reclaims
     }
 
-    /// Brings a clean candidate snapshotted during the index scan up date based on
-    /// reclaims
+    /// Brings clean candidate information cached during the index scan up date based on
+    /// slots reclaimed 
     fn update_candidate_after_reclaims(
         &self,
         candidate_info: &mut CleaningInfo,
-        reclaims: &ReclaimsWithNewSlot<AccountInfo>,
+        reclaims: &ReclaimsWithNewestSlot<AccountInfo>,
     ) {
         if candidate_info.slot_list.is_empty() {
             return;
@@ -1219,10 +1219,10 @@ impl AccountsDb {
             .expect("candidate ref count covers every reclaimed entry");
         // The reclaimed entries are exactly those below the newest
         // remaining slot at or below the clean root
-        let new_slot = reclaims[0].1;
+        let newest_slot = reclaims[0].1;
         candidate_info
             .slot_list
-            .retain(|(slot, _)| *slot >= new_slot);
+            .retain(|(slot, _)| *slot >= newest_slot);
 
         // Mark any ZLSRs
         if candidate_info.ref_count == 1
@@ -1237,27 +1237,27 @@ impl AccountsDb {
     ///
     /// The reclaimed accounts were already unref'd and removed from the slot list when the
     /// reclaims were collected
-    fn clean_accounts_older_than_root(&self, reclaims: &ReclaimsWithNewSlot<AccountInfo>) {
+    fn clean_accounts_older_than_root(&self, reclaims: &ReclaimsWithNewestSlot<AccountInfo>) {
         if reclaims.is_empty() {
             return;
         }
         let (_, reclaim_us) = measure_us!({
-            // Sort the reclaims by new_slot so that we can mark them obsolete in batches.
-            let mut reclaims_by_obsolete_slot: IntMap<_, ReclaimsSlotList<_>> = IntMap::default();
-            for (reclaimed_item, new_slot) in reclaims {
-                reclaims_by_obsolete_slot
-                    .entry(*new_slot)
+            // Group the reclaims by newest_slot so that we can mark them obsolete in batches.
+            let mut reclaims_by_newest_slot: IntMap<_, ReclaimsSlotList<_>> = IntMap::default();
+            for (reclaimed_item, newest_slot) in reclaims {
+                reclaims_by_newest_slot
+                    .entry(*newest_slot)
                     .or_default()
                     .push(*reclaimed_item);
             }
 
-            for (new_slot, reclaims) in reclaims_by_obsolete_slot {
+            for (newest_slot, reclaims) in reclaims_by_newest_slot {
                 let (purged_account_slots, _reclaimed_offsets) = self.handle_reclaims(
                     reclaims.iter(),
                     None,
                     &HashSet::new(),
                     &self.clean_accounts_stats.purge_stats,
-                    MarkAccountsObsolete::Yes(new_slot),
+                    MarkAccountsObsolete::Yes(newest_slot),
                 );
                 // Marking the reclaims obsolete skips dead-slot handling in
                 // handle_reclaims, so no whole slots are purged here.
@@ -1948,7 +1948,7 @@ impl AccountsDb {
         let not_found_on_fork_accum = AtomicU64::new(0);
         let missing_accum = AtomicU64::new(0);
         let useful_accum = AtomicU64::new(0);
-        let reclaims = ReclaimsWithNewSlot::with_capacity(num_candidates as usize);
+        let reclaims = ReclaimsWithNewestSlot::with_capacity(num_candidates as usize);
         let reclaims = Mutex::new(reclaims);
         // parallel scan the index.
         let do_clean_scan = || {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1242,27 +1242,24 @@ impl AccountsDb {
             return;
         }
         let (_, reclaim_us) = measure_us!({
-            // Group the reclaims by newest_slot so that we can mark them obsolete in batches.
-            let mut reclaims_by_newest_slot: IntMap<_, ReclaimsSlotList<_>> = IntMap::default();
-            for (reclaimed_item, newest_slot) in reclaims {
-                reclaims_by_newest_slot
-                    .entry(*newest_slot)
-                    .or_default()
-                    .push(*reclaimed_item);
-            }
-
-            for (newest_slot, reclaims) in reclaims_by_newest_slot {
-                let (purged_account_slots, _reclaimed_offsets) = self.handle_reclaims(
-                    reclaims.iter(),
-                    None,
-                    &HashSet::new(),
-                    &self.clean_accounts_stats.purge_stats,
-                    MarkAccountsObsolete::Yes(newest_slot),
-                );
-                // Marking the reclaims obsolete skips dead-slot handling in
-                // handle_reclaims, so no whole slots are purged here.
-                assert!(purged_account_slots.is_empty());
-            }
+            // Each reclaim is marked obsolete at the slot of its account's newest
+            // surviving entry
+            self.thread_pool_background.install(|| {
+                reclaims
+                    .par_iter()
+                    .for_each(|(reclaimed_item, newest_slot)| {
+                        let (purged_account_slots, _reclaimed_offsets) = self.handle_reclaims(
+                            iter::once(reclaimed_item),
+                            None,
+                            &HashSet::new(),
+                            &self.clean_accounts_stats.purge_stats,
+                            MarkAccountsObsolete::Yes(*newest_slot),
+                        );
+                        // Marking the reclaims obsolete skips dead-slot handling in
+                        // handle_reclaims, so no whole slots are purged here.
+                        assert!(purged_account_slots.is_empty());
+                    });
+            });
         });
         self.clean_accounts_stats
             .clean_old_root_reclaim_us

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1204,7 +1204,7 @@ impl AccountsDb {
     }
 
     /// Brings clean candidate information cached during the index scan up date based on
-    /// slots reclaimed 
+    /// slots reclaimed
     fn update_candidate_after_reclaims(
         &self,
         candidate_info: &mut CleaningInfo,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -47,8 +47,8 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, AccountsIndexScanResult, IndexKey,
-            ReclaimsSlotList, RefCount, ScanFilter, SlotList, Startup, UpsertReclaim,
-            in_mem_accounts_index::StartupStats,
+            ReclaimsSlotList, ReclaimsWithNewSlot, RefCount, ScanFilter, SlotList, Startup,
+            UpsertReclaim, in_mem_accounts_index::StartupStats,
         },
         accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult, ScanTracker},
         accounts_update_notifier_interface::{AccountForGeyser, AccountsUpdateNotifier},
@@ -1185,9 +1185,9 @@ impl AccountsDb {
         &self,
         pubkey: &Pubkey,
         max_clean_root_inclusive: Option<Slot>,
-    ) -> ReclaimsSlotList<AccountInfo> {
+    ) -> ReclaimsWithNewSlot<AccountInfo> {
         let mut clean_rooted = Measure::start("clean_old_root-ms");
-        let mut reclaims = ReclaimsSlotList::new();
+        let mut reclaims = ReclaimsWithNewSlot::new();
         let removed_from_index = self.accounts_index.clean_rooted_entries(
             pubkey,
             &mut reclaims,
@@ -1203,22 +1203,70 @@ impl AccountsDb {
         reclaims
     }
 
-    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
-    fn clean_accounts_older_than_root(&self, reclaims: &SlotList<AccountInfo>) -> ReclaimResult {
-        if reclaims.is_empty() {
-            return ReclaimResult::default();
+    /// Brings a clean candidate snapshotted during the index scan up date based on
+    /// reclaims
+    fn update_candidate_after_reclaims(
+        &self,
+        candidate_info: &mut CleaningInfo,
+        reclaims: &ReclaimsWithNewSlot<AccountInfo>,
+    ) {
+        if candidate_info.slot_list.is_empty() {
+            return;
         }
-        let (reclaim_result, reclaim_us) = measure_us!(self.handle_reclaims(
-            reclaims.iter(),
-            None,
-            &HashSet::new(),
-            &self.clean_accounts_stats.purge_stats,
-            MarkAccountsObsolete::No,
-        ));
+        candidate_info.ref_count = candidate_info
+            .ref_count
+            .checked_sub(reclaims.len() as RefCount)
+            .expect("candidate ref count covers every reclaimed entry");
+        // The reclaimed entries are exactly those below the newest
+        // remaining slot at or below the clean root
+        let new_slot = reclaims[0].1;
+        candidate_info
+            .slot_list
+            .retain(|(slot, _)| *slot >= new_slot);
+
+        // Mark any ZLSRs
+        if candidate_info.ref_count == 1
+            && let Some((slot, account_info)) = candidate_info.slot_list.first()
+            && account_info.is_zero_lamport()
+        {
+            self.zero_lamport_single_ref_found(*slot, account_info.offset());
+        }
+    }
+
+    /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
+    ///
+    /// The reclaimed accounts were already unref'd and removed from the slot list when the
+    /// reclaims were collected
+    fn clean_accounts_older_than_root(&self, reclaims: &ReclaimsWithNewSlot<AccountInfo>) {
+        if reclaims.is_empty() {
+            return;
+        }
+        let (_, reclaim_us) = measure_us!({
+            // Sort the reclaims by new_slot so that we can mark them obsolete in batches.
+            let mut reclaims_by_obsolete_slot: IntMap<_, ReclaimsSlotList<_>> = IntMap::default();
+            for (reclaimed_item, new_slot) in reclaims {
+                reclaims_by_obsolete_slot
+                    .entry(*new_slot)
+                    .or_default()
+                    .push(*reclaimed_item);
+            }
+
+            for (new_slot, reclaims) in reclaims_by_obsolete_slot {
+                let (purged_account_slots, _reclaimed_offsets) = self.handle_reclaims(
+                    reclaims.iter(),
+                    None,
+                    &HashSet::new(),
+                    &self.clean_accounts_stats.purge_stats,
+                    MarkAccountsObsolete::Yes(new_slot),
+                );
+                // Marking the reclaims obsolete skips dead-slot handling in
+                // handle_reclaims, so no whole slots are purged here.
+                assert!(purged_account_slots.is_empty());
+            }
+        });
         self.clean_accounts_stats
             .clean_old_root_reclaim_us
             .fetch_add(reclaim_us, Ordering::Relaxed);
-        reclaim_result
     }
 
     /// increment store_counts to non-zero for all stores that can not be deleted.
@@ -1900,7 +1948,7 @@ impl AccountsDb {
         let not_found_on_fork_accum = AtomicU64::new(0);
         let missing_accum = AtomicU64::new(0);
         let useful_accum = AtomicU64::new(0);
-        let reclaims: SlotList<AccountInfo> = SlotList::with_capacity(num_candidates as usize);
+        let reclaims = ReclaimsWithNewSlot::with_capacity(num_candidates as usize);
         let reclaims = Mutex::new(reclaims);
         // parallel scan the index.
         let do_clean_scan = || {
@@ -1991,6 +2039,7 @@ impl AccountsDb {
                         let reclaims_new =
                             self.collect_reclaims(candidate_pubkey, max_clean_root_inclusive);
                         if !reclaims_new.is_empty() {
+                            self.update_candidate_after_reclaims(candidate_info, &reclaims_new);
                             reclaims.lock().unwrap().extend(reclaims_new);
                         }
                     }
@@ -2026,8 +2075,7 @@ impl AccountsDb {
 
         let active_guard = self.active_stats.activate(ActiveStatItem::CleanOldAccounts);
         let mut clean_old_rooted = Measure::start("clean_old_roots");
-        let (purged_account_slots, removed_accounts) =
-            self.clean_accounts_older_than_root(&reclaims);
+        self.clean_accounts_older_than_root(&reclaims);
         clean_old_rooted.stop();
         drop(active_guard);
 
@@ -2038,33 +2086,11 @@ impl AccountsDb {
             .activate(ActiveStatItem::CleanCollectStoreCounts);
         let mut store_counts_time = Measure::start("store_counts");
         let mut store_counts: HashMap<Slot, (usize, HashSet<Pubkey>)> = HashMap::new();
-        for candidates_bin in candidates.iter_mut() {
-            for (pubkey, cleaning_info) in candidates_bin.iter_mut() {
-                let slot_list = &mut cleaning_info.slot_list;
-                let ref_count = &mut cleaning_info.ref_count;
+        for candidates_bin in candidates.iter() {
+            for (pubkey, cleaning_info) in candidates_bin.iter() {
+                let slot_list = &cleaning_info.slot_list;
                 debug_assert!(!slot_list.is_empty(), "candidate slot_list can't be empty");
-                if purged_account_slots.contains_key(pubkey) {
-                    *ref_count = self.accounts_index.ref_count_from_storage(pubkey);
-                }
-                slot_list.retain(|(slot, account_info)| {
-                    let was_slot_purged = purged_account_slots
-                        .get(pubkey)
-                        .map(|slots_removed| slots_removed.contains(slot))
-                        .unwrap_or(false);
-                    if was_slot_purged {
-                        // No need to look up the slot storage below if the entire
-                        // slot was purged
-                        return false;
-                    }
-                    // Check if this update in `slot` to the account with `key` was reclaimed earlier by
-                    // `clean_accounts_older_than_root()`
-                    let was_reclaimed = removed_accounts
-                        .get(slot)
-                        .map(|store_removed| store_removed.contains(&account_info.offset()))
-                        .unwrap_or(false);
-                    if was_reclaimed {
-                        return false;
-                    }
+                for (slot, account_info) in slot_list.iter() {
                     if let Some(store_count) = store_counts.get_mut(slot) {
                         store_count.0 -= 1;
                         store_count.1.insert(*pubkey);
@@ -2085,8 +2111,7 @@ impl AccountsDb {
                         );
                         store_counts.insert(*slot, (count, key_set));
                     }
-                    true
-                });
+                }
             }
         }
         store_counts_time.stop();

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1046,6 +1046,88 @@ fn test_clean_dead_slot_unrefs_reclaimed_pubkeys() {
 }
 
 #[test]
+fn test_clean_marks_reclaims_obsolete_at_new_slot() {
+    let accounts = AccountsDb::default_for_tests();
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let pubkey3 = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // Store all three pubkeys in slot 10; pubkey1 is superseded in slot 11 and pubkey2
+    // in slot 12, while pubkey3 keeps slot 10's storage alive.
+    accounts.store_for_tests((
+        10,
+        [
+            (&pubkey1, &account),
+            (&pubkey2, &account),
+            (&pubkey3, &account),
+        ]
+        .as_slice(),
+    ));
+    accounts.add_root(10);
+    accounts.store_for_tests((11, [(&pubkey1, &account)].as_slice()));
+    accounts.add_root(11);
+    accounts.store_for_tests((12, [(&pubkey2, &account)].as_slice()));
+    accounts.add_root(12);
+
+    // Flush without cleaning, so slot 10's superseded versions survive for clean to reclaim.
+    accounts.flush_rooted_accounts_cache_without_clean();
+
+    accounts.clean_accounts_for_tests();
+
+    // Each reclaimed account is marked obsolete at the slot of the entry that superseded
+    // it, not the clean root: pubkey1's slot 10 version at slot 11, pubkey2's at slot 12.
+    let storage = accounts.storage.get_slot_storage_entry(10).unwrap();
+    let obsolete_accounts = storage.obsolete_accounts_read_lock();
+    assert_eq!(
+        obsolete_accounts.filter_obsolete_accounts(Some(10)).count(),
+        0
+    );
+    assert_eq!(
+        obsolete_accounts.filter_obsolete_accounts(Some(11)).count(),
+        1
+    );
+    assert_eq!(
+        obsolete_accounts.filter_obsolete_accounts(Some(12)).count(),
+        2
+    );
+}
+
+#[test]
+fn test_clean_reclaim_marks_zero_lamport_single_ref() {
+    let accounts = AccountsDb::default_for_tests();
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+    let zero_lamport_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+    // pubkey1's newest version is zero-lamport in slot 11, whose storage is kept alive by
+    // pubkey2, so clean cannot purge pubkey1 outright.
+    accounts.store_for_tests((10, [(&pubkey1, &account)].as_slice()));
+    accounts.add_root(10);
+    accounts.store_for_tests((
+        11,
+        [(&pubkey1, &zero_lamport_account), (&pubkey2, &account)].as_slice(),
+    ));
+    accounts.add_root(11);
+
+    // Flush without cleaning, so slot 10's superseded version survives for clean to reclaim.
+    accounts.flush_rooted_accounts_cache_without_clean();
+
+    accounts.clean_accounts_for_tests();
+
+    // Reclaiming the slot 10 version made pubkey1 a zero-lamport single-ref account, and
+    // slot 10's storage is dead
+    assert!(accounts.storage.get_slot_storage_entry(10).is_none());
+    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+
+    // The surviving zero-lamport account is marked single-ref in slot 11's storage, so its
+    // bytes count as dead for shrink and the post-snapshot sweep
+    let storage = accounts.storage.get_slot_storage_entry(11).unwrap();
+    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 1);
+}
+
+#[test]
 fn test_clean_dead_slot_with_obsolete_accounts() {
     // This test is triggering a scenario in reclaim_accounts where the entire slot is reclaimed
     // When an entire slot is reclaimed, it normally unrefs the pubkeys, while when individual
@@ -4851,72 +4933,87 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     assert!(db.shrink_candidate_slots.lock().unwrap().contains(&1));
 }
 
-/// Tests that shrink correctly marks newly single ref zero lamport accounts and sends them to clean
+/// Tests that clean purges a zero lamport single ref account in the same pass that
+/// reclaims its older entries, and that a snapshot-gated one is instead marked in its
+/// storage and picked back up once the full snapshot advances.
 /// This test can be removed if RPC scan is removed since RPC scan is the only path which leads
 /// single ref zero lamport accounts not being marked immediately in flush_write_cache
 #[test]
-fn test_shrink_unref_handle_zero_lamport_single_ref_accounts() {
+fn test_clean_purges_zero_lamport_single_ref_at_reclaim() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let epoch_schedule = EpochSchedule::default();
     let account_key1 = Pubkey::new_unique();
     let account_key2 = Pubkey::new_unique();
+    let account_key3 = Pubkey::new_unique();
     let account1 = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     let account0 = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
 
     // Store into slot 0
     db.store_for_tests((0, [(&account_key1, &account1)].as_slice()));
     db.store_for_tests((0, [(&account_key2, &account1)].as_slice()));
+    db.store_for_tests((0, [(&account_key3, &account1)].as_slice()));
     db.add_root_and_flush_write_cache(0);
 
-    // Make account_key1 in slot 0 outdated by updating in rooted slot 1 with a zero lamport account
+    // Make account_key1 and account_key3 in slot 0 outdated by updating in rooted slots 1
+    // and 3 with zero lamport accounts
     db.store_for_tests((1, &[(&account_key1, &account0)][..]));
     db.add_root(1);
+    db.store_for_tests((3, &[(&account_key3, &account0)][..]));
+    db.add_root(3);
     // Flushes all roots without clean
     db.flush_rooted_accounts_cache_without_clean();
 
-    // Clean to remove outdated entry from slot 0
-    db.clean_accounts(Some(1), false);
+    // Gate zero-lamport purging above slot 1: account_key1's zero-lamport update is
+    // covered by the full snapshot, account_key3's is not.
+    db.set_latest_full_snapshot_slot(1);
 
-    // Shrink Slot 0
-    {
-        let mut shrink_candidate_slots = db.shrink_candidate_slots.lock().unwrap();
-        shrink_candidate_slots.insert(0);
-    }
-    db.shrink_candidate_slots(&epoch_schedule);
+    // Clean reclaims the outdated slot 0 entries, unreffing them at reclaim. That leaves
+    // each zero-lamport update as its account's only ref.
+    db.clean_accounts(Some(3), false);
 
-    // After shrink slot 0, check that the zero_lamport account on slot 1
-    // should be marked since it become singe_ref.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
+    // account_key1's purge is not gated, so the same clean pass purges the account: the
+    // pubkey is removed from the index and slot 1's storage, left with no live accounts,
+    // is dropped.
+    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 0);
+    assert!(!db.accounts_index.contains(&account_key1));
+    assert_no_storages_at_slot(&db, 1);
+
+    // account_key3's purge is gated behind the full snapshot, so it is instead marked
+    // zero-lamport single-ref in slot 3's storage, which now holds only such accounts and
+    // is queued for clean via dirty_stores rather than shrink.
+    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key3), 1);
     assert_eq!(
-        db.get_and_assert_single_storage(1)
+        db.get_and_assert_single_storage(3)
             .num_zero_lamport_single_ref_accounts(),
         1
     );
-    // And now, slot 1 should be marked complete dead, which will be added
-    // to uncleaned slots, which handle dropping dead storage. And it WON'T
-    // be participating shrinking in the next round.
-    assert!(db.dirty_stores.contains_key(&1));
-    assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&1));
+    assert!(db.dirty_stores.contains_key(&3));
+    assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&3));
+
+    // Once the full snapshot advances past slot 3, clean purges account_key3 and drops
+    // slot 3's storage.
+    db.set_latest_full_snapshot_slot(3);
+    db.clean_accounts(Some(3), false);
+    assert!(!db.accounts_index.contains(&account_key3));
+    assert_no_storages_at_slot(&db, 3);
+
+    // Slot 0 still holds the live account_key2; the other records there are obsolete.
+    db.get_and_assert_single_storage(0);
 
     // Now, make slot 0 dead by updating the remaining key
-    db.store_for_tests((2, &[(&account_key2, &account1)][..]));
-    db.add_root(2);
+    db.store_for_tests((4, &[(&account_key2, &account1)][..]));
+    db.add_root(4);
 
     // Flushes all roots
     db.flush_accounts_cache(true, None);
 
-    // Should be one store before clean for slot 1
-    db.get_and_assert_single_storage(1);
-    db.clean_accounts(Some(2), false);
+    db.clean_accounts(Some(4), false);
 
     // No stores should exist for slot 0. Slot 0 stores are cleaned when
-    // slot 2 is flushed; the older accounts are marked obsolete.
+    // slot 4 is flushed; the older accounts are marked obsolete.
     assert_no_storages_at_slot(&db, 0);
-    // No store should exit for slot 1 too as it has only a zero lamport single ref account.
-    assert_no_storages_at_slot(&db, 1);
-    // Store 2 should have a single account.
+    // Store 4 should have a single account.
     assert_eq!(db.accounts_index.ref_count_from_storage(&account_key2), 1);
-    db.get_and_assert_single_storage(2);
+    db.get_and_assert_single_storage(4);
 }
 
 #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -70,6 +70,8 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
 };
 pub type SlotList<T> = SmallVec<[SlotListItem<T>; 1]>;
 pub type ReclaimsSlotList<T> = Vec<SlotListItem<T>>;
+/// Reclaimed slot-list items, each with the slot of the newest surviving entry for that account
+pub type ReclaimsWithNewSlot<T> = Vec<(SlotListItem<T>, Slot)>;
 pub type SlotListItem<T> = (Slot, T);
 
 // The ref count cannot be higher than the total number of storages, and we should never have more
@@ -939,11 +941,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         }
     }
 
+    /// Reclaims every entry older than the newest entry at or below the clean root.
+    /// Each reclaim carries the slot of that newest entry.
     /// Returns true if the slot list was completely purged (is empty at the end).
     fn purge_older_root_entries(
         &self,
         slot_list: &mut SlotListWriteGuard<T>,
-        reclaims: &mut ReclaimsSlotList<T>,
+        reclaims: &mut ReclaimsWithNewSlot<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
         if slot_list.len() <= 1 {
@@ -961,7 +965,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         slot_list.retain_and_count(|(slot, value)| {
             let should_purge = *slot < newest_slot;
             if should_purge {
-                reclaims.push((*slot, *value));
+                reclaims.push(((*slot, *value), newest_slot));
             }
             !should_purge
         }) == 0
@@ -973,11 +977,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     pub fn clean_rooted_entries(
         &self,
         pubkey: &Pubkey,
-        reclaims: &mut ReclaimsSlotList<T>,
+        reclaims: &mut ReclaimsWithNewSlot<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
-        self.slot_list_mut(pubkey, |mut slot_list| {
+        let map = self.get_bin(pubkey);
+        map.slot_list_mut_with_entry(pubkey, |mut slot_list, entry| {
+            let reclaims_start = reclaims.len();
             self.purge_older_root_entries(&mut slot_list, reclaims, max_clean_root_inclusive);
+            // Unref each reclaimed entry. This must happen inside the closure so the
+            // updated ref count is visible to the write-through check.
+            entry.unref_by_count((reclaims.len() - reclaims_start) as RefCount);
         })
         .is_none()
     }
@@ -2135,22 +2144,25 @@ mod tests {
             AccountMapEntryMeta::default(),
         );
         let mut slot_list = entry.slot_list_write_lock();
-        let mut reclaims = ReclaimsSlotList::new();
+        let mut reclaims = ReclaimsWithNewSlot::new();
 
         // No max clean root: keep the newest slot (9), reclaim everything older.
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
         assert_eq!(
             reclaims,
-            ReclaimsSlotList::from([(1, true), (2, true), (5, true)])
+            ReclaimsWithNewSlot::from([((1, true), 9), ((2, true), 9), ((5, true), 9)])
         );
         assert_eq!(slot_list.clone_list(), SlotList::from_iter([(9, true)]));
 
         // Pass a max root >= than any root in the slot list, should not affect
         // outcome
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsSlotList::new();
+        reclaims = ReclaimsWithNewSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6)));
-        assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
+        assert_eq!(
+            reclaims,
+            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+        );
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -2158,9 +2170,12 @@ mod tests {
 
         // Pass a max root, earlier slots should be reclaimed
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsSlotList::new();
+        reclaims = ReclaimsWithNewSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5)));
-        assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
+        assert_eq!(
+            reclaims,
+            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+        );
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -2168,9 +2183,9 @@ mod tests {
 
         // Max clean root 2: newest slot <= 2 is 2, so only slot 1 is older and reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsSlotList::new();
+        reclaims = ReclaimsWithNewSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2)));
-        assert_eq!(reclaims, ReclaimsSlotList::from([(1, true)]));
+        assert_eq!(reclaims, ReclaimsWithNewSlot::from([((1, true), 2)]));
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(2, true), (5, true), (9, true)])
@@ -2179,7 +2194,7 @@ mod tests {
         // Max clean root 1: newest slot <= 1 is 1 and nothing is older, so nothing
         // is reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsSlotList::new();
+        reclaims = ReclaimsWithNewSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1)));
         assert!(reclaims.is_empty());
         assert_eq!(
@@ -2190,9 +2205,12 @@ mod tests {
         // Pass a max root that doesn't exist in the list but is greater than
         // some of the roots in the list, shouldn't return those smaller roots
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsSlotList::new();
+        reclaims = ReclaimsWithNewSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7)));
-        assert_eq!(reclaims, ReclaimsSlotList::from([(1, true), (2, true)]));
+        assert_eq!(
+            reclaims,
+            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+        );
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(5, true), (9, true)])
@@ -2491,9 +2509,7 @@ mod tests {
         // If we set a root at `later_slot`, and clean, then even though the account with secondary_key1
         // was outdated by the update in the later slot, the primary account key is still alive,
         // so both secondary keys will still be kept alive.
-        index.slot_list_mut(&account_key, |mut slot_list| {
-            index.purge_older_root_entries(&mut slot_list, &mut ReclaimsSlotList::new(), None)
-        });
+        let _ = index.clean_rooted_entries(&account_key, &mut ReclaimsWithNewSlot::new(), None);
 
         check_secondary_index_mapping_correct(
             secondary_index,
@@ -2627,7 +2643,7 @@ mod tests {
         let slot1 = 1;
         let slot2 = 2;
 
-        let mut gc = ReclaimsSlotList::new();
+        let mut gc = ReclaimsWithNewSlot::new();
         // return true if we don't know anything about 'key_unknown'
         // the item did not exist in the accounts index at all, so index is up to date
         assert!(index.clean_rooted_entries(&key_unknown, &mut gc, None));
@@ -2655,7 +2671,13 @@ mod tests {
 
         assert!(gc.is_empty());
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
-        assert_eq!(gc, ReclaimsSlotList::from([(slot1, value)]));
+        // The slot1 entry was reclaimed, updated by the surviving slot2 entry
+        assert_eq!(gc, ReclaimsWithNewSlot::from([((slot1, value), slot2)]));
+        // The reclaimed slot1 entry was unref'd at reclaim, leaving one ref for slot2
+        assert_eq!(
+            index.get_and_then(&key, |entry| (false, entry.unwrap().ref_count())),
+            1
+        );
     }
 
     #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -71,7 +71,7 @@ pub const ACCOUNTS_INDEX_CONFIG_FOR_BENCHMARKS: AccountsIndexConfig = AccountsIn
 pub type SlotList<T> = SmallVec<[SlotListItem<T>; 1]>;
 pub type ReclaimsSlotList<T> = Vec<SlotListItem<T>>;
 /// Reclaimed slot-list items, each with the slot of the newest surviving entry for that account
-pub type ReclaimsWithNewSlot<T> = Vec<(SlotListItem<T>, Slot)>;
+pub type ReclaimsWithNewestSlot<T> = Vec<(SlotListItem<T>, Slot)>;
 pub type SlotListItem<T> = (Slot, T);
 
 // The ref count cannot be higher than the total number of storages, and we should never have more
@@ -947,7 +947,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     fn purge_older_root_entries(
         &self,
         slot_list: &mut SlotListWriteGuard<T>,
-        reclaims: &mut ReclaimsWithNewSlot<T>,
+        reclaims: &mut ReclaimsWithNewestSlot<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
         if slot_list.len() <= 1 {
@@ -977,7 +977,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     pub fn clean_rooted_entries(
         &self,
         pubkey: &Pubkey,
-        reclaims: &mut ReclaimsWithNewSlot<T>,
+        reclaims: &mut ReclaimsWithNewestSlot<T>,
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
         let map = self.get_bin(pubkey);
@@ -2144,24 +2144,24 @@ mod tests {
             AccountMapEntryMeta::default(),
         );
         let mut slot_list = entry.slot_list_write_lock();
-        let mut reclaims = ReclaimsWithNewSlot::new();
+        let mut reclaims = ReclaimsWithNewestSlot::new();
 
         // No max clean root: keep the newest slot (9), reclaim everything older.
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, None));
         assert_eq!(
             reclaims,
-            ReclaimsWithNewSlot::from([((1, true), 9), ((2, true), 9), ((5, true), 9)])
+            ReclaimsWithNewestSlot::from([((1, true), 9), ((2, true), 9), ((5, true), 9)])
         );
         assert_eq!(slot_list.clone_list(), SlotList::from_iter([(9, true)]));
 
         // Pass a max root >= than any root in the slot list, should not affect
         // outcome
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsWithNewSlot::new();
+        reclaims = ReclaimsWithNewestSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(6)));
         assert_eq!(
             reclaims,
-            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+            ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
         );
         assert_eq!(
             slot_list.clone_list(),
@@ -2170,11 +2170,11 @@ mod tests {
 
         // Pass a max root, earlier slots should be reclaimed
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsWithNewSlot::new();
+        reclaims = ReclaimsWithNewestSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(5)));
         assert_eq!(
             reclaims,
-            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+            ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
         );
         assert_eq!(
             slot_list.clone_list(),
@@ -2183,9 +2183,9 @@ mod tests {
 
         // Max clean root 2: newest slot <= 2 is 2, so only slot 1 is older and reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsWithNewSlot::new();
+        reclaims = ReclaimsWithNewestSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(2)));
-        assert_eq!(reclaims, ReclaimsWithNewSlot::from([((1, true), 2)]));
+        assert_eq!(reclaims, ReclaimsWithNewestSlot::from([((1, true), 2)]));
         assert_eq!(
             slot_list.clone_list(),
             SlotList::from_iter([(2, true), (5, true), (9, true)])
@@ -2194,7 +2194,7 @@ mod tests {
         // Max clean root 1: newest slot <= 1 is 1 and nothing is older, so nothing
         // is reclaimed.
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsWithNewSlot::new();
+        reclaims = ReclaimsWithNewestSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(1)));
         assert!(reclaims.is_empty());
         assert_eq!(
@@ -2205,11 +2205,11 @@ mod tests {
         // Pass a max root that doesn't exist in the list but is greater than
         // some of the roots in the list, shouldn't return those smaller roots
         slot_list.assign([(1, true), (2, true), (5, true), (9, true)]);
-        reclaims = ReclaimsWithNewSlot::new();
+        reclaims = ReclaimsWithNewestSlot::new();
         assert!(!index.purge_older_root_entries(&mut slot_list, &mut reclaims, Some(7)));
         assert_eq!(
             reclaims,
-            ReclaimsWithNewSlot::from([((1, true), 5), ((2, true), 5)])
+            ReclaimsWithNewestSlot::from([((1, true), 5), ((2, true), 5)])
         );
         assert_eq!(
             slot_list.clone_list(),
@@ -2509,7 +2509,7 @@ mod tests {
         // If we set a root at `later_slot`, and clean, then even though the account with secondary_key1
         // was outdated by the update in the later slot, the primary account key is still alive,
         // so both secondary keys will still be kept alive.
-        let _ = index.clean_rooted_entries(&account_key, &mut ReclaimsWithNewSlot::new(), None);
+        let _ = index.clean_rooted_entries(&account_key, &mut ReclaimsWithNewestSlot::new(), None);
 
         check_secondary_index_mapping_correct(
             secondary_index,
@@ -2643,7 +2643,7 @@ mod tests {
         let slot1 = 1;
         let slot2 = 2;
 
-        let mut gc = ReclaimsWithNewSlot::new();
+        let mut gc = ReclaimsWithNewestSlot::new();
         // return true if we don't know anything about 'key_unknown'
         // the item did not exist in the accounts index at all, so index is up to date
         assert!(index.clean_rooted_entries(&key_unknown, &mut gc, None));
@@ -2672,7 +2672,7 @@ mod tests {
         assert!(gc.is_empty());
         assert!(!index.clean_rooted_entries(&key, &mut gc, Some(slot2)));
         // The slot1 entry was reclaimed, updated by the surviving slot2 entry
-        assert_eq!(gc, ReclaimsWithNewSlot::from([((slot1, value), slot2)]));
+        assert_eq!(gc, ReclaimsWithNewestSlot::from([((slot1, value), slot2)]));
         // The reclaimed slot1 entry was unref'd at reclaim, leaving one ref for slot2
         assert_eq!(
             index.get_and_then(&key, |entry| (false, entry.unwrap().ref_count())),


### PR DESCRIPTION
#### Problem
RefCount is still needed because clean removes items from the slot list, but shrink unrefs them. This also causes problems when deleting accounts during flush (https://github.com/anza-xyz/agave/pull/13715), which leads to possible account revivals.

#### Summary of Changes
- Instead Mark accounts obsolete and unref them during clean. 
- Then shrink will no longer unref them as they are obsolete. 
- I believe this makes ref_count non load bearing, but i will still need to verify 

#### Testing
- Introduced some new tests to validate the flow (2 in this PR)
Ran a validator that periodically injected scans for varying durations (up to 250 slots)to ensure clean paths ran.
<img width="959" height="323" alt="image" src="https://github.com/user-attachments/assets/49d1f449-c98a-487f-bfa7-a1f34e0da0b5" />
Can see RoryP has intermittent length cleans due to scan locking slot lists

Also, the accounts_db size spikes
<img width="959" height="323" alt="image" src="https://github.com/user-attachments/assets/e20be84f-e20c-4454-ae89-fed4282d0e8b" />

RoryPpbo6f9tYF4e8Y9twGBwkDCpjQXYsnWGYj5cTE2 is running this code with random scan injection right now if there is any other data you are interested in. 

Fixes #
