### PR TITLE
rust: Bump nightly version to 2026-07-20

### DIFF
--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -397,7 +397,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     // is perhaps being flushed by another thread already.
     pub fn next_bucket_to_flush(&self) -> usize {
         self.next_bucket_to_flush
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
                 Some((bucket + 1) % self.bins)
             })
             .unwrap()

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -269,7 +269,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         &self,
         pubkey: &Pubkey,
         // return true if item should be added to in_mem cache
-        callback: impl for<'a> FnOnce(Option<&AccountMapEntry<T>>) -> (bool, RT),
+        callback: impl FnOnce(Option<&AccountMapEntry<T>>) -> (bool, RT),
     ) -> RT {
         // SAFETY: The entry Arc is not passed to `callback`, so
         // it cannot live beyond this function call.

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-05-22
+  nightly_version=2026-07-20
 fi
 
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3686,7 +3686,7 @@ impl Blockstore {
         entries: Vec<Entry>,
         version: u16,
     ) -> Result<usize /*num of data shreds*/> {
-        let mut parent_slot = parent.map_or(start_slot.saturating_sub(1), |v| v);
+        let mut parent_slot = parent.unwrap_or(start_slot.saturating_sub(1));
         let num_slots = (start_slot - parent_slot).max(1); // Note: slot 0 has parent slot 0
         assert!(num_ticks_in_start_slot < num_slots * ticks_per_slot);
         let mut remaining_ticks_in_slot = num_slots * ticks_per_slot - num_ticks_in_start_slot;

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -164,42 +164,42 @@ macro_rules! create_datapoint {
 macro_rules! datapoint {
     ($level:expr, $name:expr, $($fields:tt)+) => {
         if log::log_enabled!($level) {
-            $crate::submit($crate::create_datapoint!(@point $name, $($fields)+), $level);
+            $crate::submit($crate::create_datapoint!(@point $name, $($fields)+), $level)
         }
     };
 }
 #[macro_export]
 macro_rules! datapoint_error {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Error, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Error, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_warn {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Warn, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Warn, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_info {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Info, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Info, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_debug {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Debug, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Debug, $name, $($fields)+)
     };
 }
 
 #[macro_export]
 macro_rules! datapoint_trace {
     ($name:expr, $($fields:tt)+) => {
-        $crate::datapoint!(log::Level::Trace, $name, $($fields)+);
+        $crate::datapoint!(log::Level::Trace, $name, $($fields)+)
     };
 }
 

--- a/net-utils/src/token_bucket.rs
+++ b/net-utils/src/token_bucket.rs
@@ -77,7 +77,7 @@ impl TokenBucket {
     pub fn consume_tokens(&self, request_size: u64) -> Result<u64, u64> {
         let now = self.time_us();
         self.update_state(now);
-        match self.tokens.fetch_update(
+        match self.tokens.try_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
             |tokens| {
@@ -105,7 +105,7 @@ impl TokenBucket {
         let now = self.time_us();
         self.update_state(now);
         let mut consumed = 0u64;
-        let _ = self.tokens.fetch_update(
+        let _ = self.tokens.try_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
             |tokens| {
@@ -119,7 +119,7 @@ impl TokenBucket {
     /// Adds given amount of tokens, up to a maximum of self.max_tokens.
     #[inline]
     pub fn add_tokens(&self, new_tokens: u64) {
-        let _ = self.tokens.fetch_update(
+        let _ = self.tokens.try_update(
             Ordering::AcqRel,  // writer publishes new amount
             Ordering::Acquire, //we fetch the correct amount
             |tokens| Some(tokens.saturating_add(new_tokens).min(self.max_tokens)),
@@ -318,7 +318,7 @@ where
         if entry_added {
             if let Ok(count) =
                 self.countdown_to_shrink
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    .try_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
                         if v == 0 {
                             // reset the countup to starting position
                             // thus preventing other threads from racing for locks

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -43,7 +43,7 @@ impl ProgramStatistics {
     fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
         let duration_ema = duration_us.saturating_mul(EMA_SCALE);
         counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
                 // Exponential moving average iteratively is computed as $ema' = alpha *
                 // observation + (1 - alpha) * ema$. This works great for floating point, but we
                 // want integers. For purposes of convenience we also want to really think in terms

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -446,6 +446,7 @@ impl QuicClient {
         Err(last_error.expect("QuicClient::_send_buffer last_error.expect"))
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn send_buffer<T>(
         &self,
         data: T,
@@ -461,6 +462,7 @@ impl QuicClient {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn send_batch<T>(
         &self,
         buffers: &[T],

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1062,6 +1062,7 @@ impl JsonRpcRequestProcessor {
         largest_accounts_cache.set_largest_accounts(filter, slot, accounts)
     }
 
+    #[allow(clippy::result_large_err)]
     async fn get_largest_accounts(
         &self,
         config: Option<RpcLargestAccountsConfig>,
@@ -1116,6 +1117,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     async fn get_supply(
         &self,
         config: Option<RpcSupplyConfig>,
@@ -2306,6 +2308,7 @@ impl JsonRpcRequestProcessor {
     }
 
     /// Get an iterator of spl-token accounts by owner address
+    #[allow(clippy::result_large_err)]
     async fn get_filtered_spl_token_accounts_by_owner(
         &self,
         bank: Arc<Bank>,
@@ -2355,6 +2358,7 @@ impl JsonRpcRequestProcessor {
     }
 
     /// Get an iterator of spl-token accounts by mint address
+    #[allow(clippy::result_large_err)]
     async fn get_filtered_spl_token_accounts_by_mint(
         &self,
         bank: Arc<Bank>,
@@ -5240,8 +5244,8 @@ pub mod tests {
             "tpuForwardsQuic": "127.0.0.1:8010",
             "tpuVote": "127.0.0.1:8005",
             "serveRepair": "127.0.0.1:8008",
-            "rpc": format!("127.0.0.1:8899"),
-            "pubsub": format!("127.0.0.1:8900"),
+            "rpc": "127.0.0.1:8899".to_string(),
+            "pubsub": "127.0.0.1:8900".to_string(),
             "version": format!("{version}"),
             "featureSet": version.feature_set(),
             "clientId": "Agave",
@@ -5256,8 +5260,8 @@ pub mod tests {
             "tpuForwardsQuic": "127.0.0.1:1245",
             "tpuVote": "127.0.0.1:1241",
             "serveRepair": "127.0.0.1:1242",
-            "rpc": format!("127.0.0.1:8899"),
-            "pubsub": format!("127.0.0.1:8900"),
+            "rpc": "127.0.0.1:8899".to_string(),
+            "pubsub": "127.0.0.1:8900".to_string(),
             "version": format!("{version}"),
             "featureSet": version.feature_set(),
             "clientId": "Agave",

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -602,7 +602,7 @@ impl SubscriberCountGuard {
         let max = control.max_active_subscriptions;
         control
             .subscriber_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 (current < max).then_some(current + 1)
             })
             .ok()?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4281,7 +4281,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_on_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
                 Some(accounts_data_size_delta_on_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`
@@ -4296,7 +4296,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_off_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
                 Some(accounts_data_size_delta_off_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -468,11 +468,11 @@ impl TestValidatorGenesis {
                             return Err(format!("Invalid alt account data length for {address}"));
                         }
 
-                        for address_slice in
-                            raw_addresses_data.chunks_exact(std::mem::size_of::<Pubkey>())
+                        for address_array in raw_addresses_data
+                            .as_chunks::<{ std::mem::size_of::<Pubkey>() }>()
+                            .0
                         {
-                            // safe because size was checked earlier
-                            let address = Pubkey::try_from(address_slice).unwrap();
+                            let address = Pubkey::from(*address_array);
                             alt_entries.push(address);
                         }
                         self.add_account(*address, AccountSharedData::from(account));

--- a/transaction-context/src/instruction_accounts.rs
+++ b/transaction-context/src/instruction_accounts.rs
@@ -373,11 +373,10 @@ impl BorrowedInstructionAccount<'_, '_> {
 fn is_zeroed(buf: &[u8]) -> bool {
     const ZEROS_LEN: usize = 1024;
     const ZEROS: [u8; ZEROS_LEN] = [0; ZEROS_LEN];
-    let mut chunks = buf.chunks_exact(ZEROS_LEN);
+    let (chunks, remainder) = buf.as_chunks::<ZEROS_LEN>();
 
     #[expect(clippy::indexing_slicing)]
     {
-        chunks.all(|chunk| chunk == &ZEROS[..])
-            && chunks.remainder() == &ZEROS[..chunks.remainder().len()]
+        chunks.iter().all(|chunk| chunk == &ZEROS[..]) && remainder == &ZEROS[..remainder.len()]
     }
 }


### PR DESCRIPTION
#### Problem

As noticed in #14010, the nightly Rust version is still on 1.97.0, and we should probably bump nightly at a similar cadence to stable.

#### Summary of changes

Bump the nightly version, re-run formatting, and fix issues. Those issues are:

* Change `fetch_update` -> `try_update`
* Add `allow(clippy::result_large_err)` where needed
* Remove unnecessary `for<'a>` annotation
* Use `unwrap_or` over `map_or`
* Remove semi-colons from `datapoint!` macros (more info at https://github.com/rust-lang/rust/issues/79813)
* Use `as_chunks::<N>` instead of `chunks_exact`
* Use `str::to_string()` instead of `format!`

#### Testing

Clippy, rustfmt, and existing tests.