### PR TITLE
cost-model: merge would_fit and add_transaction_cost into a single pass try_add

### DIFF
--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -22,10 +22,6 @@ use {
 
 const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 4096;
 
-// Capacity of `try_add`'s rollback bitmap.
-// For crafted transactions beyond this bound, possible using tooling paths like ledger-tool, rollback stays panic free.
-const ROLLBACK_BITMAP_ACCOUNTS: usize = 256;
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CostTrackerError {
     /// would exceed block max limit
@@ -169,8 +165,8 @@ impl CostTracker {
     /// Checks the block and account limits and, if the transaction fits,
     /// adds its cost to the tracker.
     ///
-    /// A failed call leaves the tracker unchanged on all validated paths:
-    /// account costs applied before the failing account are rolled back,
+    /// A failed call leaves the tracker equivalent to the pre-call state.
+    /// Account costs applied before the failing account are rolled back,
     /// and the block-level state (including the lock free shared `block_cost`)
     /// is only published after every check has passed.
     pub fn try_add(
@@ -197,11 +193,8 @@ impl CostTracker {
         }
 
         // Check each account against account_cost_limit and apply the cost in
-        // the same lookup. On failure, undo the applied prefix. `inserted`
-        // records which of those lookups created a new entry (a pre-existing
-        // entry may hold 0, so the value alone cannot distinguish them).
+        // the same lookup. On failure, undo the applied prefix.
         let mut updated_costliest_account_cost = 0;
-        let mut inserted = [0u64; ROLLBACK_BITMAP_ACCOUNTS / u64::BITS as usize];
         for (index, account_key) in tx_cost.writable_accounts().enumerate() {
             let new_account_cost = match self.cost_by_writable_accounts.entry(*account_key) {
                 Entry::Occupied(mut entry) => {
@@ -217,15 +210,12 @@ impl CostTracker {
                     // `cost <= limits.account_cost` was checked above, so an
                     // account without chained cost always fits
                     entry.insert(cost);
-                    if let Some(word) = inserted.get_mut(index / u64::BITS as usize) {
-                        *word |= 1 << (index % u64::BITS as usize);
-                    }
                     Some(cost)
                 }
             };
             let Some(new_account_cost) = new_account_cost else {
                 // the first `index` accounts were applied before this failure
-                self.roll_back_applied_costs(tx_cost, cost, index, &inserted);
+                self.roll_back_applied_costs(tx_cost, cost, index);
                 return Err(CostTrackerError::WouldExceedAccountMaxLimit);
             };
             updated_costliest_account_cost = updated_costliest_account_cost.max(new_account_cost);
@@ -249,30 +239,22 @@ impl CostTracker {
     }
 
     /// Undoes the first `num_applied` per account cost applications of a
-    /// partially applied transaction. Entries newly created by this call
-    /// (per the `inserted` bitmap) are removed, pre existing ones are decremented.
-    ///
-    /// Tolerates precondition violating inputs from unvalidated (non consensus) callers.
-    /// With duplicate keys, only the first occurrence is marked.
-    /// Its removal makes the later occurrences undo a no-op.
-    /// The net effect (entry absent) still matches the pre-call state.
-    ///
-    /// Keys past the bitmap capacity are decremented rather than removed, possibly leaving a zero-cost entry.
+    /// partially applied transaction by subtracting the cost each one added.
+    /// Entries left with zero cost are removed.
     fn roll_back_applied_costs(
         &mut self,
         tx_cost: &TransactionCost<impl TransactionWithMeta>,
         cost: u64,
         num_applied: usize,
-        inserted: &[u64],
     ) {
-        for (index, account_key) in tx_cost.writable_accounts().take(num_applied).enumerate() {
-            let was_inserted = inserted
-                .get(index / u64::BITS as usize)
-                .is_some_and(|word| word & (1 << (index % u64::BITS as usize)) != 0);
-            if was_inserted {
-                self.cost_by_writable_accounts.remove(account_key);
-            } else if let Some(account_cost) = self.cost_by_writable_accounts.get_mut(account_key) {
-                *account_cost = account_cost.saturating_sub(cost);
+        for account_key in tx_cost.writable_accounts().take(num_applied) {
+            if let Entry::Occupied(mut entry) = self.cost_by_writable_accounts.entry(*account_key) {
+                let new_account_cost = entry.get().saturating_sub(cost);
+                if new_account_cost == 0 {
+                    entry.remove();
+                } else {
+                    *entry.get_mut() = new_account_cost;
+                }
             }
         }
     }
@@ -842,7 +824,7 @@ mod tests {
     }
 
     #[test]
-    fn test_try_add_rollback_across_bitmap_words() {
+    fn test_try_add_rollback_many_accounts() {
         let cost = 100;
         let hot_account = Pubkey::new_unique();
         let mut testee = CostTracker::new(cost * 2, cost * 1000);
@@ -855,7 +837,7 @@ mod tests {
         let block_cost_before = testee.block_cost();
 
         // 100 fresh accounts followed by hot_account, all 100 fresh entries
-        // (bitmap words 0 and 1) are inserted before the failure at index 100
+        // are inserted before the failure at index 100
         let mut keys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
         keys.push(hot_account);
         let transaction = WritableKeysTransaction::new(keys);
@@ -873,8 +855,8 @@ mod tests {
         assert_eq!(block_cost_before, testee.block_cost());
     }
 
-    // Duplicate writable keys are tolerated by the rollback.
-    // Check if only the first occurrence is bitmap marked so rollback must net out to the pre-call state
+    // Duplicate writable keys net out.
+    // Each occurrence's undo subtracts what it added, and the entry is removed when it reaches zero
     #[test]
     fn test_try_add_rollback_with_duplicate_keys() {
         let cost = 100;
@@ -890,7 +872,7 @@ mod tests {
         }
         let block_cost_before = testee.block_cost();
 
-        // fresh dup - rollback removes the single entry on the first occurrence, the second undo is a no-op
+        // fresh dup - each undo subtracts what that occurrence added; the entry reaches zero on the second undo and is removed
         let transaction = WritableKeysTransaction::new(vec![dup, dup, hot_account]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
         assert!(matches!(
@@ -913,6 +895,41 @@ mod tests {
             Err(CostTrackerError::WouldExceedAccountMaxLimit)
         ));
         assert_eq!(Some(&cost), testee.cost_by_writable_accounts.get(&dup));
+        assert_eq!(block_cost_before, testee.block_cost());
+    }
+
+    #[test]
+    fn test_try_add_rollback_removes_zeroed_entries() {
+        let cost = 100;
+        let zeroed = Pubkey::new_unique();
+        let hot_account = Pubkey::new_unique();
+        let mut testee = CostTracker::new(cost * 2, cost * 1000);
+
+        // leave `zeroed` in the map with zero cost
+        let transaction = WritableKeysTransaction::new(vec![zeroed]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
+        testee.remove(&tx_cost);
+        assert_eq!(Some(&0), testee.cost_by_writable_accounts.get(&zeroed));
+
+        // drive hot_account to the limit so the next charge fails
+        let transaction = WritableKeysTransaction::new(vec![hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&tx_cost).is_ok());
+        let block_cost_before = testee.block_cost();
+
+        let transaction = WritableKeysTransaction::new(vec![zeroed, hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(matches!(
+            testee.try_add(&tx_cost),
+            Err(CostTrackerError::WouldExceedAccountMaxLimit)
+        ));
+        assert!(!testee.cost_by_writable_accounts.contains_key(&zeroed));
+        assert_eq!(
+            Some(&(cost * 2)),
+            testee.cost_by_writable_accounts.get(&hot_account)
+        );
         assert_eq!(block_cost_before, testee.block_cost());
     }
 

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -1,8 +1,6 @@
 //! `cost_tracker` keeps tracking transaction cost per chained accounts as well as for entire block
-//! The main functions are:
-//! - would_fit(&tx_cost), immutable function to test if tx with tx_cost would fit into current block
-//! - add_transaction_cost(&tx_cost), mutable function to accumulate tx_cost to tracker.
-//!
+//! The main function is:
+//! - try_add, checks the configured limits and records the transaction's cost when it fits.
 use {
     crate::{
         block_cost_limits::*, cost_tracker_post_analysis::CostTrackerPostAnalysis,
@@ -13,7 +11,7 @@ use {
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_transaction_error::TransactionError,
     std::{
-        collections::HashMap,
+        collections::{HashMap, hash_map::Entry},
         num::Saturating,
         sync::{
             Arc,
@@ -23,6 +21,10 @@ use {
 };
 
 const WRITABLE_ACCOUNTS_PER_BLOCK: usize = 4096;
+
+// Capacity of `try_add`'s rollback bitmap.
+// For crafted transactions beyond this bound, possible using tooling paths like ledger-tool, rollback stays panic free.
+const ROLLBACK_BITMAP_ACCOUNTS: usize = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CostTrackerError {
@@ -164,16 +166,115 @@ impl CostTracker {
         self.set_limits(CostTrackerLimits::MAX);
     }
 
+    /// Checks the block and account limits and, if the transaction fits,
+    /// adds its cost to the tracker.
+    ///
+    /// A failed call leaves the tracker unchanged on all validated paths:
+    /// account costs applied before the failing account are rolled back,
+    /// and the block-level state (including the lock free shared `block_cost`)
+    /// is only published after every check has passed.
     pub fn try_add(
         &mut self,
         tx_cost: &TransactionCost<impl TransactionWithMeta>,
     ) -> Result<UpdatedCosts, CostTrackerError> {
-        self.would_fit(tx_cost)?;
-        let updated_costliest_account_cost = self.add_transaction_cost(tx_cost);
+        let cost = tx_cost.sum();
+
+        if self.block_cost().saturating_add(cost) > self.limits.block_cost {
+            // check against the total package cost
+            return Err(CostTrackerError::WouldExceedBlockMaxLimit);
+        }
+
+        // check if the transaction itself is more costly than the account_cost_limit
+        if cost > self.limits.account_cost {
+            return Err(CostTrackerError::WouldExceedAccountMaxLimit);
+        }
+
+        let allocated_accounts_data_size =
+            self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
+
+        if allocated_accounts_data_size.0 > self.limits.allocated_data_size {
+            return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
+        }
+
+        // Check each account against account_cost_limit and apply the cost in
+        // the same lookup. On failure, undo the applied prefix. `inserted`
+        // records which of those lookups created a new entry (a pre-existing
+        // entry may hold 0, so the value alone cannot distinguish them).
+        let mut updated_costliest_account_cost = 0;
+        let mut inserted = [0u64; ROLLBACK_BITMAP_ACCOUNTS / u64::BITS as usize];
+        for (index, account_key) in tx_cost.writable_accounts().enumerate() {
+            let new_account_cost = match self.cost_by_writable_accounts.entry(*account_key) {
+                Entry::Occupied(mut entry) => {
+                    let new_account_cost = entry.get().saturating_add(cost);
+                    if new_account_cost > self.limits.account_cost {
+                        None
+                    } else {
+                        *entry.get_mut() = new_account_cost;
+                        Some(new_account_cost)
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    // `cost <= limits.account_cost` was checked above, so an
+                    // account without chained cost always fits
+                    entry.insert(cost);
+                    if let Some(word) = inserted.get_mut(index / u64::BITS as usize) {
+                        *word |= 1 << (index % u64::BITS as usize);
+                    }
+                    Some(cost)
+                }
+            };
+            let Some(new_account_cost) = new_account_cost else {
+                // the first `index` accounts were applied before this failure
+                self.roll_back_applied_costs(tx_cost, cost, index, &inserted);
+                return Err(CostTrackerError::WouldExceedAccountMaxLimit);
+            };
+            updated_costliest_account_cost = updated_costliest_account_cost.max(new_account_cost);
+        }
+
+        // every check passed: publish the block-level state
+        self.allocated_accounts_data_size = allocated_accounts_data_size;
+        self.transaction_count += 1;
+        self.transaction_signature_count += tx_cost.num_transaction_signatures();
+        self.secp256k1_instruction_signature_count +=
+            tx_cost.num_secp256k1_instruction_signatures();
+        self.ed25519_instruction_signature_count += tx_cost.num_ed25519_instruction_signatures();
+        self.secp256r1_instruction_signature_count +=
+            tx_cost.num_secp256r1_instruction_signatures();
+        self.block_cost.fetch_add(cost);
+
         Ok(UpdatedCosts {
             updated_block_cost: self.block_cost(),
             updated_costliest_account_cost,
         })
+    }
+
+    /// Undoes the first `num_applied` per account cost applications of a
+    /// partially applied transaction. Entries newly created by this call
+    /// (per the `inserted` bitmap) are removed, pre existing ones are decremented.
+    ///
+    /// Tolerates precondition violating inputs from unvalidated (non consensus) callers.
+    /// With duplicate keys, only the first occurrence is marked.
+    /// Its removal makes the later occurrences undo a no-op.
+    /// The net effect (entry absent) still matches the pre-call state.
+    ///
+    /// Keys past the bitmap capacity are decremented rather than removed, possibly leaving a zero-cost entry.
+    fn roll_back_applied_costs(
+        &mut self,
+        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        cost: u64,
+        num_applied: usize,
+        inserted: &[u64],
+    ) {
+        for (index, account_key) in tx_cost.writable_accounts().take(num_applied).enumerate() {
+            let was_inserted = inserted
+                .get(index / u64::BITS as usize)
+                .is_some_and(|word| word & (1 << (index % u64::BITS as usize)) != 0);
+            if was_inserted {
+                self.cost_by_writable_accounts.remove(account_key);
+            } else if let Some(account_cost) = self.cost_by_writable_accounts.get_mut(account_key) {
+                *account_cost = account_cost.saturating_sub(cost);
+            }
+        }
     }
 
     pub fn remove(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
@@ -269,59 +370,6 @@ impl CostTracker {
             .count()
     }
 
-    fn would_fit(
-        &self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
-    ) -> Result<(), CostTrackerError> {
-        let cost: u64 = tx_cost.sum();
-
-        if self.block_cost().saturating_add(cost) > self.limits.block_cost {
-            // check against the total package cost
-            return Err(CostTrackerError::WouldExceedBlockMaxLimit);
-        }
-
-        // check if the transaction itself is more costly than the account_cost_limit
-        if cost > self.limits.account_cost {
-            return Err(CostTrackerError::WouldExceedAccountMaxLimit);
-        }
-
-        let allocated_accounts_data_size =
-            self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
-
-        if allocated_accounts_data_size.0 > self.limits.allocated_data_size {
-            return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
-        }
-
-        // check each account against account_cost_limit,
-        for account_key in tx_cost.writable_accounts() {
-            match self.cost_by_writable_accounts.get(account_key) {
-                Some(chained_cost) => {
-                    if chained_cost.saturating_add(cost) > self.limits.account_cost {
-                        return Err(CostTrackerError::WouldExceedAccountMaxLimit);
-                    } else {
-                        continue;
-                    }
-                }
-                None => continue,
-            }
-        }
-
-        Ok(())
-    }
-
-    // Returns the highest account cost for all write-lock accounts `TransactionCost` updated
-    fn add_transaction_cost(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) -> u64 {
-        self.allocated_accounts_data_size += tx_cost.allocated_accounts_data_size();
-        self.transaction_count += 1;
-        self.transaction_signature_count += tx_cost.num_transaction_signatures();
-        self.secp256k1_instruction_signature_count +=
-            tx_cost.num_secp256k1_instruction_signatures();
-        self.ed25519_instruction_signature_count += tx_cost.num_ed25519_instruction_signatures();
-        self.secp256r1_instruction_signature_count +=
-            tx_cost.num_secp256r1_instruction_signatures();
-        self.add_transaction_execution_cost(tx_cost, tx_cost.sum())
-    }
-
     fn remove_transaction_cost(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
         let cost = tx_cost.sum();
         self.sub_transaction_execution_cost(tx_cost, cost);
@@ -333,27 +381,6 @@ impl CostTracker {
         self.ed25519_instruction_signature_count -= tx_cost.num_ed25519_instruction_signatures();
         self.secp256r1_instruction_signature_count -=
             tx_cost.num_secp256r1_instruction_signatures();
-    }
-
-    /// Apply additional actual execution units to cost_tracker
-    /// Return the costliest account cost that were updated by `TransactionCost`
-    fn add_transaction_execution_cost(
-        &mut self,
-        tx_cost: &TransactionCost<impl TransactionWithMeta>,
-        adjustment: u64,
-    ) -> u64 {
-        let mut costliest_account_cost = 0;
-        for account_key in tx_cost.writable_accounts() {
-            let account_cost = self
-                .cost_by_writable_accounts
-                .entry(*account_key)
-                .or_insert(0);
-            *account_cost = account_cost.saturating_add(adjustment);
-            costliest_account_cost = costliest_account_cost.max(*account_cost);
-        }
-        self.block_cost.fetch_add(adjustment);
-
-        costliest_account_cost
     }
 
     /// Subtract extra execution units from cost_tracker
@@ -499,8 +526,7 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
-        testee.add_transaction_cost(&tx_cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
         assert_eq!(cost, testee.block_cost());
         let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost, costliest_account_cost);
@@ -515,8 +541,7 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
-        testee.add_transaction_cost(&tx_cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
         assert_eq!(cost, testee.block_cost());
         let (_costliest_account, costliest_account_cost) = testee.find_costliest_account();
         assert_eq!(cost, costliest_account_cost);
@@ -532,9 +557,8 @@ mod tests {
 
         // build testee to have capacity for one simple transaction
         let mut testee = CostTracker::new(cost, cost);
-        assert!(testee.would_fit(&tx_cost).is_ok());
         let old = testee.allocated_accounts_data_size;
-        testee.add_transaction_cost(&tx_cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
         assert_eq!(old.0 + 1, testee.allocated_accounts_data_size.0);
     }
 
@@ -552,12 +576,10 @@ mod tests {
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cost1 + cost2, cost1 + cost2);
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
-            testee.add_transaction_cost(&tx_cost1);
+            assert!(testee.try_add(&tx_cost1).is_ok());
         }
         {
-            assert!(testee.would_fit(&tx_cost2).is_ok());
-            testee.add_transaction_cost(&tx_cost2);
+            assert!(testee.try_add(&tx_cost2).is_ok());
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
         assert_eq!(1, testee.cost_by_writable_accounts.len());
@@ -581,12 +603,10 @@ mod tests {
         // build testee to have capacity for two simple transactions, with same accounts
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
-            testee.add_transaction_cost(&tx_cost1);
+            assert!(testee.try_add(&tx_cost1).is_ok());
         }
         {
-            assert!(testee.would_fit(&tx_cost2).is_ok());
-            testee.add_transaction_cost(&tx_cost2);
+            assert!(testee.try_add(&tx_cost2).is_ok());
         }
         assert_eq!(cost1 + cost2, testee.block_cost());
         assert_eq!(2, testee.cost_by_writable_accounts.len());
@@ -609,12 +629,11 @@ mod tests {
         let mut testee = CostTracker::new(cmp::min(cost1, cost2), cost1 + cost2);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
-            testee.add_transaction_cost(&tx_cost1);
+            assert!(testee.try_add(&tx_cost1).is_ok());
         }
         // but no more sapce on the same chain (same signer account)
         {
-            assert!(testee.would_fit(&tx_cost2).is_err());
+            assert!(testee.try_add(&tx_cost2).is_err());
         }
     }
 
@@ -634,12 +653,11 @@ mod tests {
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1);
         // should have room for first transaction
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
-            testee.add_transaction_cost(&tx_cost1);
+            assert!(testee.try_add(&tx_cost1).is_ok());
         }
         // but no more room for package as whole
         {
-            assert!(testee.would_fit(&tx_cost2).is_err());
+            assert!(testee.try_add(&tx_cost2).is_err());
         }
     }
 
@@ -659,10 +677,9 @@ mod tests {
         let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
         // should have room for first vote
         {
-            assert!(testee.would_fit(&tx_cost1).is_ok());
-            testee.add_transaction_cost(&tx_cost1);
+            assert!(testee.try_add(&tx_cost1).is_ok());
         }
-        assert!(testee.would_fit(&tx_cost2).is_ok());
+        assert!(testee.try_add(&tx_cost2).is_ok());
     }
 
     #[test]
@@ -680,13 +697,13 @@ mod tests {
         let cost2 = tx_cost2.sum();
 
         // build testee that passes
-        let testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2 - 1);
-        assert!(testee.would_fit(&tx_cost1).is_ok());
+        let mut testee = CostTracker::new(cmp::max(cost1, cost2), cost1 + cost2);
+        assert!(testee.try_add(&tx_cost1).is_ok());
         // data is too big
-        assert_eq!(
-            testee.would_fit(&tx_cost2),
+        assert!(matches!(
+            testee.try_add(&tx_cost2),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
-        );
+        ));
     }
 
     #[test]
@@ -699,17 +716,17 @@ mod tests {
 
         // Transaction fits with default limit.
         let mut testee = CostTracker::new(u64::MAX, u64::MAX);
-        assert_eq!(testee.would_fit(&tx_cost), Ok(()),);
+        assert!(testee.try_add(&tx_cost).is_ok());
 
         // Transaction does not fit with 1B limit.
         testee.set_limits(CostTrackerLimits {
             allocated_data_size: 1,
             ..testee.get_limits()
         });
-        assert_eq!(
-            testee.would_fit(&tx_cost),
+        assert!(matches!(
+            testee.try_add(&tx_cost),
             Err(CostTrackerError::WouldExceedAccountDataBlockLimit),
-        );
+        ));
     }
 
     #[test]
@@ -800,7 +817,103 @@ mod tests {
             assert_eq!(3, testee.cost_by_writable_accounts.len());
             assert_eq!(cost * 2, costliest_account_cost);
             assert_eq!(acct2, costliest_account);
+            // the pre-existing acct1 entry was decremented back, not removed
+            assert_eq!(Some(&cost), testee.cost_by_writable_accounts.get(&acct1));
         }
+
+        // case 4: add tx writes to [acct4 (unseen), acct2], acct2 exceeds limit;
+        // the entry freshly inserted for acct4 must be removed by the rollback,
+        // leaving the tracker exactly as after case 2
+        {
+            let acct4 = Pubkey::new_unique();
+            let transaction = WritableKeysTransaction::new(vec![acct4, acct2]);
+            let tx_cost = simple_transaction_cost(&transaction, cost);
+            assert!(matches!(
+                testee.try_add(&tx_cost),
+                Err(CostTrackerError::WouldExceedAccountMaxLimit)
+            ));
+            let (costliest_account, costliest_account_cost) = testee.find_costliest_account();
+            assert_eq!(cost * 2, testee.block_cost());
+            assert_eq!(3, testee.cost_by_writable_accounts.len());
+            assert!(!testee.cost_by_writable_accounts.contains_key(&acct4));
+            assert_eq!(cost * 2, costliest_account_cost);
+            assert_eq!(acct2, costliest_account);
+        }
+    }
+
+    #[test]
+    fn test_try_add_rollback_across_bitmap_words() {
+        let cost = 100;
+        let hot_account = Pubkey::new_unique();
+        let mut testee = CostTracker::new(cost * 2, cost * 1000);
+
+        // drive hot_account to the limit so the next charge fails
+        let transaction = WritableKeysTransaction::new(vec![hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
+        assert!(testee.try_add(&tx_cost).is_ok());
+        let block_cost_before = testee.block_cost();
+
+        // 100 fresh accounts followed by hot_account, all 100 fresh entries
+        // (bitmap words 0 and 1) are inserted before the failure at index 100
+        let mut keys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
+        keys.push(hot_account);
+        let transaction = WritableKeysTransaction::new(keys);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(matches!(
+            testee.try_add(&tx_cost),
+            Err(CostTrackerError::WouldExceedAccountMaxLimit)
+        ));
+
+        assert_eq!(1, testee.cost_by_writable_accounts.len());
+        assert_eq!(
+            Some(&(cost * 2)),
+            testee.cost_by_writable_accounts.get(&hot_account)
+        );
+        assert_eq!(block_cost_before, testee.block_cost());
+    }
+
+    // Duplicate writable keys are tolerated by the rollback.
+    // Check if only the first occurrence is bitmap marked so rollback must net out to the pre-call state
+    #[test]
+    fn test_try_add_rollback_with_duplicate_keys() {
+        let cost = 100;
+        let dup = Pubkey::new_unique();
+        let hot_account = Pubkey::new_unique();
+        let mut testee = CostTracker::new(cost * 4, cost * 1000);
+
+        // drive hot_account to the limit so any further charge fails
+        let transaction = WritableKeysTransaction::new(vec![hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        for _ in 0..4 {
+            assert!(testee.try_add(&tx_cost).is_ok());
+        }
+        let block_cost_before = testee.block_cost();
+
+        // fresh dup - rollback removes the single entry on the first occurrence, the second undo is a no-op
+        let transaction = WritableKeysTransaction::new(vec![dup, dup, hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(matches!(
+            testee.try_add(&tx_cost),
+            Err(CostTrackerError::WouldExceedAccountMaxLimit)
+        ));
+        assert!(!testee.cost_by_writable_accounts.contains_key(&dup));
+        assert_eq!(block_cost_before, testee.block_cost());
+
+        // pre-existing dup
+        let transaction = WritableKeysTransaction::new(vec![dup]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(testee.try_add(&tx_cost).is_ok());
+        let block_cost_before = testee.block_cost();
+
+        let transaction = WritableKeysTransaction::new(vec![dup, dup, hot_account]);
+        let tx_cost = simple_transaction_cost(&transaction, cost);
+        assert!(matches!(
+            testee.try_add(&tx_cost),
+            Err(CostTrackerError::WouldExceedAccountMaxLimit)
+        ));
+        assert_eq!(Some(&cost), testee.cost_by_writable_accounts.get(&dup));
+        assert_eq!(block_cost_before, testee.block_cost());
     }
 
     #[test]
@@ -827,21 +940,6 @@ mod tests {
                 assert_eq!(expected_block_cost, *units);
             });
 
-        // adjust up
-        {
-            let adjustment = 50u64;
-            testee.add_transaction_execution_cost(&tx_cost, adjustment);
-            expected_block_cost += 50;
-            assert_eq!(expected_block_cost, testee.block_cost());
-            assert_eq!(expected_tx_count, testee.transaction_count());
-            testee
-                .cost_by_writable_accounts
-                .iter()
-                .for_each(|(_key, units)| {
-                    assert_eq!(expected_block_cost, *units);
-                });
-        }
-
         // adjust down
         {
             let adjustment = 50u64;
@@ -865,7 +963,7 @@ mod tests {
         let cost = 100u64;
         let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
-        cost_tracker.add_transaction_cost(&tx_cost);
+        cost_tracker.try_add(&tx_cost).unwrap();
         // assert cost_tracker is reverted to default
         assert_eq!(1, cost_tracker.transaction_count.0);
         assert_eq!(1, cost_tracker.number_of_accounts());
@@ -886,7 +984,7 @@ mod tests {
         let cost = 100u64;
         let transaction = WritableKeysTransaction::new(vec![Pubkey::new_unique()]);
         let tx_cost = simple_transaction_cost(&transaction, cost);
-        cost_tracker.add_transaction_cost(&tx_cost);
+        cost_tracker.try_add(&tx_cost).unwrap();
         let cost_by_writable_accounts = cost_tracker.get_cost_by_writable_accounts();
         assert_eq!(1, cost_by_writable_accounts.len());
         assert_eq!(cost, *cost_by_writable_accounts.values().next().unwrap());


### PR DESCRIPTION
#### Problem

`CostTracker::try_add()` walks every writable account twice while holding the cost-tracker lock. Read only in `would_fit()` to check account limits, then again in `add_transaction_cost()` to apply them. Two hash lookups per account on the leader/replay hot path.

#### Summary of Changes

Merge check and apply into one pass using the `Entry` API: each account's limit check and cost application share one lookup. On failure, the applied prefix is rolled back by subtracting the cost each application added. Entries left at zero cost are removed. Block level state, including the lock-free shared `block_cost`, publishes only after every check passes, so a failed `try_add` leaves the tracker unchanged.

Error variants and check order are unchanged.

`would_fit()` and `add_transaction_cost()` are folded into `try_add()`.

#### Testing

- Existing cost-tracker tests migrated from `would_fit` + `add_transaction_cost` to `try_add`; new tests pin the rollback paths. Fresh entry removal, pre-existing-entry decrement, duplicate writable keys, a 100 account failure, and removal of entries already sitting at zero cost.
- Mainnet A/B testing (ledger-tool verify over a captured ~7.2k slots / ~9.6M txs): `CheckBlockLimitsUs` −5.22% median with complete range separation across all runs (exact p ~0.002); control `ExecuteUs` flat; total replay wall time unchanged.
- Microbench (the cost_tracker bench removed in #13291, run locally): −21.6% on 128-writable-account contentious transactions.

#### Consensus note

This change is equivalent to the old `would_fit()` + `add_transaction_cost()` on every input reachable from consensus paths. Same limit checks in the same order, same error variants, same final tracker state on success, and an unchanged tracker on failure. Both consumers (banking stage QoS and replay's check_block_cost_limits) cost-track only transactions that already passed `validate_account_locks`, which rejects duplicate writable keys (`AccountLoadedTwice`).

Blocks that fit before still fit; blocks that failed still fail with the identical error. No feature gate is needed. Inputs that violate the lock validation invariants (duplicate writable keys) are reachable only via tooling paths; the subtraction-based rollback nets each occurrence out on its own, at any account count. The only representational difference on failure is that an entry whose cost returns to zero is removed rather than left in the map. Indistinguishable to every limit decision.