### PR TITLE
validator: expose wait-to-vote-slot and update slahsable panic msg

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -946,7 +946,13 @@ impl ClusterInfo {
             // to push an old vote. This could be a slashable offense so better to panic here.
             let (_, vote, hash, _) = vote_parser::parse_vote_transaction(&vote).unwrap();
             panic!(
-                "Submitting old vote, switch: {}, vote slots: {:?}, tower: {:?}",
+                "Submitting old vote, switch: {}, vote slots: {:?}, tower: {:?}. The local \
+                 tower.bin was out of date or missing, and we are attempting to submit slashable \
+                 votes. Another possibility is that the node was not correctly started with wait \
+                 for supermajority during a cluster restart, and then later started with wait for \
+                 supermajority, causing the tower.bin to be pruned. To progress, either download \
+                 a newer snapshot or set --wait-to-vote-slot higher than the last vote present in \
+                 gossip",
                 hash.is_some(),
                 vote.slots(),
                 tower

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -604,6 +604,17 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             ),
     )
     .arg(
+        Arg::with_name("wait_to_vote_slot")
+            .long("wait-to-vote-slot")
+            .value_name("SLOT")
+            .takes_value(true)
+            .validator(is_slot)
+            .help(
+                "Do not vote until reaching this slot. This can be used to avoid submitting \
+                 slashable votes after restoring a stale/missing Tower / VoteHistory",
+            ),
+    )
+    .arg(
         Arg::with_name("no_wait_for_vote_to_start_leader")
             .hidden(hidden_unless_forced())
             .long("no-wait-for-vote-to-start-leader")

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -841,7 +841,7 @@ pub fn execute(
         accounts_db_force_initial_clean: matches.is_present("no_skip_initial_accounts_db_clean"),
         snapshot_config,
         no_wait_for_vote_to_start_leader: matches.is_present("no_wait_for_vote_to_start_leader"),
-        wait_to_vote_slot: None,
+        wait_to_vote_slot: value_t!(matches, "wait_to_vote_slot", Slot).ok(),
         staked_nodes_overrides: staked_nodes_overrides.clone(),
         use_snapshot_archives_at_startup,
         ip_echo_server_threads,


### PR DESCRIPTION
#### Problem
Many validtors mess up and delete their tower.bin or restart without WFSM during a cluster restart.

They end up reaching the slashable vote protection panic in gossip.

#### Summary of Changes
Expose a `--wait-to-vote-slot` to allow them to progress and update the panic message

#### Testing
CI