### PR TITLE
Limit consensus pool message batch draining

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -67,6 +67,15 @@ pub(crate) enum PoolMessage {
     Certificates(Vec<Certificate>),
 }
 
+/// Maximum number of messages to process from a selected message channel before
+/// returning to channel selection. This keeps a continuously busy channel from
+/// starving the other consensus pool input channel.
+const TOTAL_MESSAGES_PER_RECEIVE: usize = 128;
+
+/// Number of additional messages to drain from the selected message channel
+/// after receiving the first message.
+const ADDITIONAL_MESSAGES_PER_RECEIVE: usize = TOTAL_MESSAGES_PER_RECEIVE - 1;
+
 /// Inputs for the consensus pool and consensus pool service
 pub(crate) struct ConsensusPoolContext {
     pub(crate) exit: Arc<AtomicBool>,
@@ -568,7 +577,13 @@ impl ConsensusPoolService {
             return Err(());
         };
 
-        for msg in std::iter::once(first).chain(ctx.own_message_receiver.try_iter()) {
+        let mut received_messages = 0;
+        for msg in std::iter::once(first).chain(
+            ctx.own_message_receiver
+                .try_iter()
+                .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
+        ) {
+            received_messages += 1;
             let pool_msg = match msg {
                 OwnMessage::Vote(vote_msg) => {
                     stats.received_vote_aggregates += 1;
@@ -597,6 +612,10 @@ impl ConsensusPoolService {
                 stats,
             )?;
         }
+        stats.received_own_messages += received_messages;
+        if received_messages == TOTAL_MESSAGES_PER_RECEIVE {
+            stats.receive_msgs_limit_reached += 1;
+        }
         Ok(())
     }
 
@@ -613,7 +632,13 @@ impl ConsensusPoolService {
             return Err(());
         };
 
-        for batch in std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()) {
+        let mut received_batches = 0;
+        for batch in std::iter::once(first).chain(
+            ctx.consensus_message_receiver
+                .try_iter()
+                .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
+        ) {
+            received_batches += 1;
             let msg = match batch {
                 SigVerifiedBatch::Votes(votes) => {
                     stats.received_vote_aggregates += votes.len();
@@ -641,6 +666,10 @@ impl ConsensusPoolService {
                 standstill_timer,
                 stats,
             )?;
+        }
+        stats.received_consensus_message_batches += received_batches;
+        if received_batches == TOTAL_MESSAGES_PER_RECEIVE {
+            stats.receive_msgs_limit_reached += 1;
         }
         Ok(())
     }
@@ -697,7 +726,8 @@ mod tests {
         consensus_pool: ConsensusPool,
         ctx: ConsensusPoolContext,
         bls_receiver: Receiver<BLSOp>,
-        _consensus_message_sender: Sender<SigVerifiedBatch>,
+        consensus_message_sender: Sender<SigVerifiedBatch>,
+        _own_message_sender: Sender<OwnMessage>,
         event_receiver: Receiver<VotorEvent>,
         _repair_event_receiver: Receiver<RepairEvent>,
         validator_keypairs: Vec<ValidatorVoteKeypairs>,
@@ -747,7 +777,7 @@ mod tests {
                 initial_parent_ready,
             );
             let (consensus_message_sender, consensus_message_receiver) = unbounded();
-            let (_own_message_sender, own_message_receiver) = unbounded();
+            let (own_message_sender, own_message_receiver) = unbounded();
             let (event_sender, event_receiver) = unbounded();
             let (repair_event_sender, repair_event_receiver) = unbounded();
 
@@ -772,7 +802,8 @@ mod tests {
                 consensus_pool,
                 ctx,
                 bls_receiver,
-                _consensus_message_sender: consensus_message_sender,
+                consensus_message_sender,
+                _own_message_sender: own_message_sender,
                 event_receiver,
                 _repair_event_receiver: repair_event_receiver,
                 validator_keypairs,
@@ -920,6 +951,39 @@ mod tests {
             }
         }
         assert!(found_skip, "Should have received the skip certificate");
+    }
+
+    #[test]
+    fn test_receive_msgs_limits_batches_per_call() {
+        let mut ctx = TestContext::default();
+
+        for _ in 0..TOTAL_MESSAGES_PER_RECEIVE + 1 {
+            ctx.consensus_message_sender
+                .send(SigVerifiedBatch::Votes(vec![]))
+                .unwrap();
+        }
+
+        let mut events = vec![];
+        let mut standstill_timer = Instant::now();
+        let mut stats = ConsensusPoolServiceStats::new();
+
+        ConsensusPoolService::receive_msgs(
+            &mut ctx.ctx,
+            &mut ctx.consensus_pool,
+            &mut events,
+            &mut standstill_timer,
+            &mut stats,
+            Duration::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(ctx.ctx.consensus_message_receiver.len(), 1);
+        assert_eq!(stats.received_own_messages.0, 0);
+        assert_eq!(
+            stats.received_consensus_message_batches.0,
+            TOTAL_MESSAGES_PER_RECEIVE
+        );
+        assert_eq!(stats.receive_msgs_limit_reached.0, 1);
     }
 
     #[test]

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -577,13 +577,13 @@ impl ConsensusPoolService {
             return Err(());
         };
 
-        let mut received_messages = 0;
+        let mut received_messages: usize = 0;
         for msg in std::iter::once(first).chain(
             ctx.own_message_receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
         ) {
-            received_messages += 1;
+            received_messages = received_messages.saturating_add(1);
             let pool_msg = match msg {
                 OwnMessage::Vote(vote_msg) => {
                     stats.received_vote_aggregates += 1;
@@ -614,7 +614,7 @@ impl ConsensusPoolService {
         }
         stats.received_own_messages += received_messages;
         if received_messages == MAX_MESSAGES_PER_RECEIVE {
-            stats.receive_msgs_limit_reached += 1;
+            stats.own_message_receive_limit_reached += 1;
         }
         Ok(())
     }
@@ -632,13 +632,13 @@ impl ConsensusPoolService {
             return Err(());
         };
 
-        let mut received_batches = 0;
+        let mut received_batches: usize = 0;
         for batch in std::iter::once(first).chain(
             ctx.consensus_message_receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
         ) {
-            received_batches += 1;
+            received_batches = received_batches.saturating_add(1);
             let msg = match batch {
                 SigVerifiedBatch::Votes(votes) => {
                     stats.received_vote_aggregates += votes.len();
@@ -669,7 +669,7 @@ impl ConsensusPoolService {
         }
         stats.received_consensus_message_batches += received_batches;
         if received_batches == MAX_MESSAGES_PER_RECEIVE {
-            stats.receive_msgs_limit_reached += 1;
+            stats.consensus_message_batch_receive_limit_reached += 1;
         }
         Ok(())
     }
@@ -727,7 +727,7 @@ mod tests {
         ctx: ConsensusPoolContext,
         bls_receiver: Receiver<BLSOp>,
         consensus_message_sender: Sender<SigVerifiedBatch>,
-        _own_message_sender: Sender<OwnMessage>,
+        own_message_sender: Sender<OwnMessage>,
         event_receiver: Receiver<VotorEvent>,
         _repair_event_receiver: Receiver<RepairEvent>,
         validator_keypairs: Vec<ValidatorVoteKeypairs>,
@@ -803,7 +803,7 @@ mod tests {
                 ctx,
                 bls_receiver,
                 consensus_message_sender,
-                _own_message_sender: own_message_sender,
+                own_message_sender,
                 event_receiver,
                 _repair_event_receiver: repair_event_receiver,
                 validator_keypairs,
@@ -954,7 +954,7 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_msgs_limits_batches_per_call() {
+    fn test_receive_msgs_limits_consensus_batches_per_call() {
         let mut ctx = TestContext::default();
 
         for _ in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
@@ -983,7 +983,43 @@ mod tests {
             stats.received_consensus_message_batches.0,
             MAX_MESSAGES_PER_RECEIVE
         );
-        assert_eq!(stats.receive_msgs_limit_reached.0, 1);
+        assert_eq!(stats.own_message_receive_limit_reached.0, 0);
+        assert_eq!(stats.consensus_message_batch_receive_limit_reached.0, 1);
+    }
+
+    #[test]
+    fn test_receive_msgs_limits_own_messages_per_call() {
+        let mut ctx = TestContext::default();
+
+        for slot in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
+            ctx.own_message_sender
+                .send(OwnMessage::Certificate(Certificate {
+                    cert_type: CertificateType::Skip(slot.try_into().unwrap()),
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                    bitmap: vec![],
+                }))
+                .unwrap();
+        }
+
+        let mut events = vec![];
+        let mut standstill_timer = Instant::now();
+        let mut stats = ConsensusPoolServiceStats::new();
+
+        ConsensusPoolService::receive_msgs(
+            &mut ctx.ctx,
+            &mut ctx.consensus_pool,
+            &mut events,
+            &mut standstill_timer,
+            &mut stats,
+            Duration::ZERO,
+        )
+        .unwrap();
+
+        assert_eq!(ctx.ctx.own_message_receiver.len(), 1);
+        assert_eq!(stats.received_own_messages.0, MAX_MESSAGES_PER_RECEIVE);
+        assert_eq!(stats.received_consensus_message_batches.0, 0);
+        assert_eq!(stats.own_message_receive_limit_reached.0, 1);
+        assert_eq!(stats.consensus_message_batch_receive_limit_reached.0, 0);
     }
 
     #[test]

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -70,11 +70,11 @@ pub(crate) enum PoolMessage {
 /// Maximum number of messages to process from a selected message channel before
 /// returning to channel selection. This keeps a continuously busy channel from
 /// starving the other consensus pool input channel.
-const TOTAL_MESSAGES_PER_RECEIVE: usize = 128;
+const MAX_MESSAGES_PER_RECEIVE: usize = 128;
 
 /// Number of additional messages to drain from the selected message channel
 /// after receiving the first message.
-const ADDITIONAL_MESSAGES_PER_RECEIVE: usize = TOTAL_MESSAGES_PER_RECEIVE - 1;
+const ADDITIONAL_MESSAGES_PER_RECEIVE: usize = MAX_MESSAGES_PER_RECEIVE - 1;
 
 /// Inputs for the consensus pool and consensus pool service
 pub(crate) struct ConsensusPoolContext {
@@ -613,7 +613,7 @@ impl ConsensusPoolService {
             )?;
         }
         stats.received_own_messages += received_messages;
-        if received_messages == TOTAL_MESSAGES_PER_RECEIVE {
+        if received_messages == MAX_MESSAGES_PER_RECEIVE {
             stats.receive_msgs_limit_reached += 1;
         }
         Ok(())
@@ -668,7 +668,7 @@ impl ConsensusPoolService {
             )?;
         }
         stats.received_consensus_message_batches += received_batches;
-        if received_batches == TOTAL_MESSAGES_PER_RECEIVE {
+        if received_batches == MAX_MESSAGES_PER_RECEIVE {
             stats.receive_msgs_limit_reached += 1;
         }
         Ok(())
@@ -957,7 +957,7 @@ mod tests {
     fn test_receive_msgs_limits_batches_per_call() {
         let mut ctx = TestContext::default();
 
-        for _ in 0..TOTAL_MESSAGES_PER_RECEIVE + 1 {
+        for _ in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
             ctx.consensus_message_sender
                 .send(SigVerifiedBatch::Votes(vec![]))
                 .unwrap();
@@ -981,7 +981,7 @@ mod tests {
         assert_eq!(stats.received_own_messages.0, 0);
         assert_eq!(
             stats.received_consensus_message_batches.0,
-            TOTAL_MESSAGES_PER_RECEIVE
+            MAX_MESSAGES_PER_RECEIVE
         );
         assert_eq!(stats.receive_msgs_limit_reached.0, 1);
     }

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -20,7 +20,8 @@ pub(super) struct ConsensusPoolServiceStats {
     pub(super) received_vote_aggregates: Saturating<usize>,
     pub(super) received_own_messages: Saturating<usize>,
     pub(super) received_consensus_message_batches: Saturating<usize>,
-    pub(super) receive_msgs_limit_reached: Saturating<usize>,
+    pub(super) own_message_receive_limit_reached: Saturating<usize>,
+    pub(super) consensus_message_batch_receive_limit_reached: Saturating<usize>,
     pub(super) received_certificates: Saturating<usize>,
     pub(super) standstill: bool,
     pub(super) prune_old_state_called: Saturating<usize>,
@@ -42,7 +43,8 @@ impl ConsensusPoolServiceStats {
             received_vote_aggregates: Saturating(0),
             received_own_messages: Saturating(0),
             received_consensus_message_batches: Saturating(0),
-            receive_msgs_limit_reached: Saturating(0),
+            own_message_receive_limit_reached: Saturating(0),
+            consensus_message_batch_receive_limit_reached: Saturating(0),
             received_certificates: Saturating(0),
             standstill: false,
             prune_old_state_called: Saturating(0),
@@ -64,7 +66,9 @@ impl ConsensusPoolServiceStats {
             received_vote_aggregates: Saturating(received_vote_aggregates),
             received_own_messages: Saturating(received_own_messages),
             received_consensus_message_batches: Saturating(received_consensus_message_batches),
-            receive_msgs_limit_reached: Saturating(receive_msgs_limit_reached),
+            own_message_receive_limit_reached: Saturating(own_message_receive_limit_reached),
+            consensus_message_batch_receive_limit_reached:
+                Saturating(consensus_message_batch_receive_limit_reached),
             received_certificates: Saturating(received_certificates),
             standstill,
             prune_old_state_called: Saturating(prune_old_state_called),
@@ -101,8 +105,13 @@ impl ConsensusPoolServiceStats {
                 i64
             ),
             (
-                "receive_msgs_limit_reached",
-                receive_msgs_limit_reached,
+                "own_message_receive_limit_reached",
+                own_message_receive_limit_reached,
+                i64
+            ),
+            (
+                "consensus_message_batch_receive_limit_reached",
+                consensus_message_batch_receive_limit_reached,
                 i64
             ),
             ("received_certificates", received_certificates, i64),

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -18,6 +18,9 @@ pub(super) struct ConsensusPoolServiceStats {
     pub(super) parent_ready_missed_window: Saturating<usize>,
     pub(super) parent_ready_produce_window: Saturating<usize>,
     pub(super) received_vote_aggregates: Saturating<usize>,
+    pub(super) received_own_messages: Saturating<usize>,
+    pub(super) received_consensus_message_batches: Saturating<usize>,
+    pub(super) receive_msgs_limit_reached: Saturating<usize>,
     pub(super) received_certificates: Saturating<usize>,
     pub(super) standstill: bool,
     pub(super) prune_old_state_called: Saturating<usize>,
@@ -37,6 +40,9 @@ impl ConsensusPoolServiceStats {
             parent_ready_missed_window: Saturating(0),
             parent_ready_produce_window: Saturating(0),
             received_vote_aggregates: Saturating(0),
+            received_own_messages: Saturating(0),
+            received_consensus_message_batches: Saturating(0),
+            receive_msgs_limit_reached: Saturating(0),
             received_certificates: Saturating(0),
             standstill: false,
             prune_old_state_called: Saturating(0),
@@ -56,6 +62,9 @@ impl ConsensusPoolServiceStats {
             parent_ready_missed_window: Saturating(parent_ready_missed_window),
             parent_ready_produce_window: Saturating(parent_ready_produce_window),
             received_vote_aggregates: Saturating(received_vote_aggregates),
+            received_own_messages: Saturating(received_own_messages),
+            received_consensus_message_batches: Saturating(received_consensus_message_batches),
+            receive_msgs_limit_reached: Saturating(receive_msgs_limit_reached),
             received_certificates: Saturating(received_certificates),
             standstill,
             prune_old_state_called: Saturating(prune_old_state_called),
@@ -85,6 +94,17 @@ impl ConsensusPoolServiceStats {
                 i64
             ),
             ("received_vote_aggregates", received_vote_aggregates, i64),
+            ("received_own_messages", received_own_messages, i64),
+            (
+                "received_consensus_message_batches",
+                received_consensus_message_batches,
+                i64
+            ),
+            (
+                "receive_msgs_limit_reached",
+                receive_msgs_limit_reached,
+                i64
+            ),
             ("received_certificates", received_certificates, i64),
             ("in_standstill_bool", standstill, bool),
             ("prune_old_state_called", prune_old_state_called, i64),


### PR DESCRIPTION
#### Problem
`ConsensusPoolService::receive_msgs()` receives one sig-verified batch from either the local/own message channel or the peer consensus message channel, then drains the selected channel with `try_iter()`. If the selected channel is continuously busy, the service can spend an unbounded amount of time processing that channel before returning to `select_biased!`, delaying the other input channel.


#### Summary of Changes
- Limit additional batches drained from the selected channel to `MAX_MESSAGES_PER_RECEIVE`.
- Add batch-level consensus pool service stats for own-channel batches, peer consensus-channel batches, and cap-hit count.
- Add a focused unit test covering the receive batch cap and stats updates.


#### Testing
- `cargo test -p agave-votor test_receive_msgs_limits_batches_per_call`

Fixes #13268

#### Additional Notes
chose `128` arbitrarily for now, waiting on some input from you guys
```rust
const TOTAL_SIG_VERIFIED_BATCHES_PER_RECEIVE: usize = 128;
```
