### PR TITLE
chore(deps): remove percentage crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,7 +847,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.1",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -866,7 +866,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -887,7 +887,7 @@ dependencies = [
  "digest 0.10.7",
  "educe 0.6.0",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -919,7 +919,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -932,7 +932,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -976,7 +976,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -989,7 +989,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2839,7 +2839,7 @@ version = "3.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -4547,7 +4547,7 @@ checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -4559,7 +4559,7 @@ checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -4884,47 +4884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -4951,29 +4916,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -5296,15 +5238,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "percentage"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
-dependencies = [
- "num",
-]
 
 [[package]]
 name = "pest"
@@ -7396,7 +7329,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "solana-define-syscall 3.0.0",
 ]
@@ -7407,7 +7340,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "solana-define-syscall 5.1.0",
 ]
 
@@ -9782,7 +9715,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "openssl",
- "percentage",
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
@@ -10339,7 +10271,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "percentage",
  "proptest",
  "prost 0.11.9",
  "protosol",
@@ -10970,7 +10901,6 @@ dependencies = [
  "libsecp256k1",
  "log",
  "openssl",
- "percentage",
  "prost 0.11.9",
  "protosol",
  "qualifier_attr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -304,7 +304,6 @@ openssl = "0.10"
 pairing = "0.23.0"
 parking_lot = "0.12"
 pem = "1.1.1"
-percentage = "0.1.0"
 pickledb = { version = "0.5.1", default-features = false }
 predicates = "3.1"
 pretty-hex = "0.4.2"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -671,7 +671,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -690,7 +690,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version",
@@ -711,7 +711,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -743,7 +743,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -756,7 +756,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -800,7 +800,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -813,7 +813,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -3791,7 +3791,7 @@ checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -3803,7 +3803,7 @@ checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -4084,47 +4084,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -4151,29 +4116,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -4415,15 +4357,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "percentage"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
-dependencies = [
- "num",
-]
 
 [[package]]
 name = "petgraph"
@@ -5997,7 +5930,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "solana-define-syscall 5.1.0",
 ]
 
@@ -7632,7 +7565,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "itertools 0.14.0",
  "log",
- "percentage",
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
@@ -8001,7 +7933,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "percentage",
  "qualifier_attr",
  "rand 0.9.4",
  "rayon",
@@ -8536,7 +8467,6 @@ dependencies = [
  "ahash 0.8.12",
  "bincode",
  "log",
- "percentage",
  "qualifier_attr",
  "serde",
  "solana-account 4.3.1",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -35,7 +35,6 @@ bincode = { workspace = true }
 cfg-if = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
-percentage = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -8,7 +8,6 @@ use {
         program_metrics::{EMA_SCALE, ProgramCacheStats},
     },
     log::error,
-    percentage::PercentageInteger,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_sbpf::program::BuiltinProgram,
@@ -115,6 +114,15 @@ pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
 }
 
 pub const MAX_LOADED_ENTRY_COUNT: usize = 512;
+
+/// The given percentage of [`MAX_LOADED_ENTRY_COUNT`], as an entry count.
+/// Equivalent to the former `percentage` crate's
+/// `Percentage::from(percent).apply_to(MAX_LOADED_ENTRY_COUNT)`,
+/// i.e. floor(MAX_LOADED_ENTRY_COUNT * percent / 100).
+fn percent_of_max_entries(percent: u8) -> usize {
+    debug_assert!(percent <= 100, "percent must be <= 100");
+    MAX_LOADED_ENTRY_COUNT.saturating_mul(percent as usize) / 100
+}
 
 /// Relationship between two fork IDs
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -809,14 +817,14 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 
     /// Unloads programs which were used infrequently
-    pub fn sort_and_unload(&mut self, shrink_to: PercentageInteger) {
+    pub fn sort_and_unload(&mut self, shrink_to_percent: u8) {
         let mut sorted_candidates = self.get_flattened_entries();
         sorted_candidates.sort_by_cached_key(|(_id, _last_modification_slot, program)| {
             program.stats.uses.load(Ordering::Relaxed)
         });
         let num_to_unload = sorted_candidates
             .len()
-            .saturating_sub(shrink_to.apply_to(MAX_LOADED_ENTRY_COUNT));
+            .saturating_sub(percent_of_max_entries(shrink_to_percent));
         for (program, last_modification_slot, entry) in sorted_candidates.iter().take(num_to_unload)
         {
             self.unload_program_entry(*program, *last_modification_slot, entry);
@@ -828,7 +836,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     ///
     /// The eviction is performed enough number of times to reduce the cache usage to the given
     /// percentage.
-    pub fn evict_using_random_selection(&mut self, shrink_to: PercentageInteger, now: Slot) {
+    pub fn evict_using_random_selection(&mut self, shrink_to_percent: u8, now: Slot) {
         let mut candidates = self.get_flattened_entries();
         let mut rng = rng();
         self.stats
@@ -836,7 +844,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             .store(candidates.len() as u64, Ordering::Relaxed);
         let num_to_unload = candidates
             .len()
-            .saturating_sub(shrink_to.apply_to(MAX_LOADED_ENTRY_COUNT));
+            .saturating_sub(percent_of_max_entries(shrink_to_percent));
         let mut sample_entry = |candidates: &Vec<(Pubkey, u64, Arc<ProgramCacheEntry>)>| {
             // gen_range is deprecated in favor of random_range in rand>=0.9, but we also get
             // rnd() from shuttle, which doesn't yet support rand 0.9 APIs
@@ -971,7 +979,6 @@ pub(crate) mod tests {
             program_metrics::ProgramStatistics,
         },
         assert_matches::assert_matches,
-        percentage::Percentage,
         solana_clock::Slot,
         solana_pubkey::Pubkey,
         solana_sbpf::{elf::Executable, program::BuiltinProgram},
@@ -1190,12 +1197,11 @@ pub(crate) mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct = 1;
+        let eviction_pct: u8 = 1;
 
-        let num_loaded_expected =
-            Percentage::from(eviction_pct).apply_to(crate::loaded_programs::MAX_LOADED_ENTRY_COUNT);
+        let num_loaded_expected = crate::loaded_programs::percent_of_max_entries(eviction_pct);
         let num_unloaded_expected = num_unloaded_expected + num_loaded - num_loaded_expected;
-        cache.evict_using_random_selection(Percentage::from(eviction_pct), 21);
+        cache.evict_using_random_selection(eviction_pct, 21);
 
         // Count the number of loaded, unloaded and tombstone entries.
         let num_loaded = num_matching_entries(&cache, |program_type| {
@@ -1273,13 +1279,12 @@ pub(crate) mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct = 1;
+        let eviction_pct: u8 = 1;
 
-        let num_loaded_expected =
-            Percentage::from(eviction_pct).apply_to(crate::loaded_programs::MAX_LOADED_ENTRY_COUNT);
+        let num_loaded_expected = crate::loaded_programs::percent_of_max_entries(eviction_pct);
         let num_unloaded_expected = num_unloaded_expected + num_loaded - num_loaded_expected;
 
-        cache.sort_and_unload(Percentage::from(eviction_pct));
+        cache.sort_and_unload(eviction_pct);
 
         // Check that every program is still in the cache.
         let entries = cache.get_flattened_entries_for_tests();
@@ -1330,9 +1335,9 @@ pub(crate) mod tests {
         let env = get_mock_program_runtime_environment();
 
         let program = Pubkey::new_unique();
-        let evict_to_pct = 2;
+        let evict_to_pct: u8 = 2;
         let cache_capacity_after_shrink =
-            Percentage::from(evict_to_pct).apply_to(crate::loaded_programs::MAX_LOADED_ENTRY_COUNT);
+            crate::loaded_programs::percent_of_max_entries(evict_to_pct);
         // Add enough programs to the cache to trigger 1 eviction after shrinking.
         let num_total_programs = (cache_capacity_after_shrink + 1) as u64;
         (0..num_total_programs).for_each(|i| {
@@ -1344,7 +1349,7 @@ pub(crate) mod tests {
             cache.assign_program(&env, program, i, entry);
         });
 
-        cache.sort_and_unload(Percentage::from(evict_to_pct));
+        cache.sort_and_unload(evict_to_pct);
 
         let num_unloaded = num_matching_entries(&cache, |program_type| {
             matches!(program_type, ProgramCacheEntryType::Unloaded(_))

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -122,7 +122,7 @@ pub type Percent = u8;
 /// Equivalent to the former `percentage` crate's
 /// `Percentage::from(percent).apply_to(MAX_LOADED_ENTRY_COUNT)`,
 /// i.e. floor(MAX_LOADED_ENTRY_COUNT * percent / 100).
-fn percent_of_max_entries(percent: u8) -> usize {
+fn percent_of_max_entries(percent: Percent) -> usize {
     debug_assert!(percent <= 100, "percent must be <= 100");
     MAX_LOADED_ENTRY_COUNT.saturating_mul(percent as usize) / 100
 }
@@ -971,7 +971,7 @@ pub(crate) mod tests {
     use {
         crate::{
             loaded_programs::{
-                BlockRelation, ForkGraph, ProgramCache, ProgramCacheForTxBatch,
+                BlockRelation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
                 ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramToLoad,
                 get_mock_program_runtime_environment,
             },
@@ -1200,7 +1200,7 @@ pub(crate) mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct: u8 = 1;
+        let eviction_pct: Percent = 1;
 
         let num_loaded_expected = crate::loaded_programs::percent_of_max_entries(eviction_pct);
         let num_unloaded_expected = num_unloaded_expected + num_loaded - num_loaded_expected;
@@ -1282,7 +1282,7 @@ pub(crate) mod tests {
         assert_eq!(num_tombstones, num_tombstones_expected);
 
         // Evict entries from the cache
-        let eviction_pct: u8 = 1;
+        let eviction_pct: Percent = 1;
 
         let num_loaded_expected = crate::loaded_programs::percent_of_max_entries(eviction_pct);
         let num_unloaded_expected = num_unloaded_expected + num_loaded - num_loaded_expected;
@@ -1338,7 +1338,7 @@ pub(crate) mod tests {
         let env = get_mock_program_runtime_environment();
 
         let program = Pubkey::new_unique();
-        let evict_to_pct: u8 = 2;
+        let evict_to_pct: Percent = 2;
         let cache_capacity_after_shrink =
             crate::loaded_programs::percent_of_max_entries(evict_to_pct);
         // Add enough programs to the cache to trigger 1 eviction after shrinking.

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -115,6 +115,9 @@ pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
 
 pub const MAX_LOADED_ENTRY_COUNT: usize = 512;
 
+/// A percentage, expected to be in the range `0..=100`.
+pub type Percent = u8;
+
 /// The given percentage of [`MAX_LOADED_ENTRY_COUNT`], as an entry count.
 /// Equivalent to the former `percentage` crate's
 /// `Percentage::from(percent).apply_to(MAX_LOADED_ENTRY_COUNT)`,
@@ -817,7 +820,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     }
 
     /// Unloads programs which were used infrequently
-    pub fn sort_and_unload(&mut self, shrink_to_percent: u8) {
+    pub fn sort_and_unload(&mut self, shrink_to_percent: Percent) {
         let mut sorted_candidates = self.get_flattened_entries();
         sorted_candidates.sort_by_cached_key(|(_id, _last_modification_slot, program)| {
             program.stats.uses.load(Ordering::Relaxed)
@@ -836,7 +839,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     ///
     /// The eviction is performed enough number of times to reduce the cache usage to the given
     /// percentage.
-    pub fn evict_using_random_selection(&mut self, shrink_to_percent: u8, now: Slot) {
+    pub fn evict_using_random_selection(&mut self, shrink_to_percent: Percent, now: Slot) {
         let mut candidates = self.get_flattened_entries();
         let mut rng = rng();
         self.stats

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.1",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -686,7 +686,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version",
@@ -707,7 +707,7 @@ dependencies = [
  "digest 0.10.7",
  "educe 0.6.0",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -739,7 +739,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -752,7 +752,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -796,7 +796,7 @@ dependencies = [
  "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -809,7 +809,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1978,7 +1978,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2311,7 +2311,7 @@ version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -3810,7 +3810,7 @@ checksum = "3c9a85a9752c549ceb7578064b4ed891179d20acd85f27318573b64d2d7ee7ee"
 dependencies = [
  "ark-bn254 0.4.0",
  "ark-ff 0.4.2",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -3822,7 +3822,7 @@ checksum = "47a1ccadd0bb5a32c196da536fd72c59183de24a055f6bf0513bf845fefab862"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "thiserror 1.0.69",
 ]
 
@@ -4104,47 +4104,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -4171,29 +4136,6 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
  "num-traits",
 ]
 
@@ -4468,15 +4410,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "percentage"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
-dependencies = [
- "num",
-]
 
 [[package]]
 name = "petgraph"
@@ -6142,7 +6075,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "solana-define-syscall 3.0.0",
 ]
@@ -6153,7 +6086,7 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "solana-define-syscall 5.1.0",
 ]
 
@@ -7872,7 +7805,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "itertools 0.14.0",
  "log",
- "percentage",
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
@@ -8302,7 +8234,6 @@ dependencies = [
  "mockall",
  "num-derive",
  "num-traits",
- "percentage",
  "qualifier_attr",
  "rand 0.9.4",
  "rayon",
@@ -9563,7 +9494,6 @@ dependencies = [
  "ahash 0.8.12",
  "bincode",
  "log",
- "percentage",
  "qualifier_attr",
  "serde",
  "solana-account 4.3.1",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -86,7 +86,6 @@ log = { workspace = true }
 mockall = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-percentage = { workspace = true }
 prost = { version = "0.11", optional = true }
 protosol = { workspace = true, optional = true }
 qualifier_attr = { workspace = true }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10995,7 +10995,7 @@ fn test_feature_activation_loaded_programs_epoch_transition() {
         );
 
         // Unload all (which is only the entry with the new environment)
-        program_cache.sort_and_unload(percentage::Percentage::from(0));
+        program_cache.sort_and_unload(0);
     }
 
     // Reload the unloaded program with the new environment.

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -72,7 +72,6 @@ agave-precompiles = { workspace = true, optional = true }
 ahash = { workspace = true }
 bincode = { workspace = true }
 log = { workspace = true }
-percentage = { workspace = true }
 prost = { version = "0.11", optional = true }
 protosol = { workspace = true, optional = true }
 qualifier_attr = { workspace = true, optional = true }

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -21,7 +21,6 @@ use {
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
     },
     log::debug,
-    percentage::Percentage,
     solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
@@ -663,14 +662,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // still at least one other batch, which will evict the program cache, even after the
         // occurrences of cooperative loading.
         if program_cache_for_tx_batch.loaded_missing || program_cache_for_tx_batch.merged_modified {
+            // NOTE: this is a percentage; do not set above 100.
             const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
             self.global_program_cache
                 .write()
                 .unwrap()
-                .evict_using_random_selection(
-                    Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE),
-                    self.slot,
-                );
+                .evict_using_random_selection(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE, self.slot);
         }
 
         debug!(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -41,7 +41,7 @@ use {
         },
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
-            EpochBoundaryPreparation, ForkGraph, ProgramCache, ProgramCacheForTxBatch,
+            EpochBoundaryPreparation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
             ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
             ProgramToLoad,
         },
@@ -663,7 +663,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         // occurrences of cooperative loading.
         if program_cache_for_tx_batch.loaded_missing || program_cache_for_tx_batch.merged_modified {
             // NOTE: this is a percentage; do not set above 100.
-            const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: u8 = 90;
+            const SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE: Percent = 90;
             self.global_program_cache
                 .write()
                 .unwrap()


### PR DESCRIPTION
#### Problem
The `percentage` crate only provided `Percentage::from(pct).apply_to(value)`, which is floor(value * pct / 100). It was used solely on the program cache eviction path, yet pulled the entire `num` meta-crate into the tree.


#### Summary of Changes
Replace the two usages with a small in-tree helper in `loaded_programs`:

```rust
    fn percent_of_max_entries(percent: u8) -> usize {
        MAX_LOADED_ENTRY_COUNT.saturating_mul(percent as usize) / 100
    }
```

The public `ProgramCache::sort_and_unload` and
`ProgramCache::evict_using_random_selection` signatures change from `PercentageInteger` to a plain `u8` percent; `svm` is the only in-tree caller.

MAX_LOADED_ENTRY_COUNT is 512 and the percent is <= 100, so the multiplication cannot overflow and the result is bit-identical to the crate's `apply_to`.

Drops `percentage`, `num`, `num-bigint`, `num-complex`, `num-iter`, and `num-rational` from Cargo.lock.

note: 
"num-bigint 0.4.6" → "num-bigint" is automatic cargo output, not a hand edit. The suffix only existed with two versions. Removing percentage deleted the old 0.2.6 copy (percentage → num → num-bigint 0.2); 0.4.6 (from ark/light-poseidon) is now the only version, so cargo drops the redundant tag.

#### Testing
No behavior change: `percent_of_max_entries` computes the same `floor(MAX_LOADED_ENTRY_COUNT * pct / 100)` the`percentage` crate did, and`Cargo.lock` drops only `percentage` + the now-orphaned `num` family. 

Verified locally:

- `cargo clippy -p solana-program-runtime -p solana-svm --all-targets` — clean
- `cargo test -p solana-program-runtime --lib loaded_programs` — 42 pass (covers
  both eviction paths)
- `cargo check -p solana-runtime --tests` — compiles
- `cargo sort --workspace --check` and `cargo metadata --locked` — pass

Fixes #
Partially fixes anza-xyz/devops#1140