### PR TITLE
chore: create `agave-test-utilities` crate and kill rpc -> unified-scheduler dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-test-utilities"
+version = "4.3.0-alpha.2"
+dependencies = [
+ "crossbeam-channel",
+ "solana-entry",
+ "solana-ledger",
+ "solana-rpc",
+ "solana-runtime",
+ "solana-unified-scheduler-pool",
+]
+
+[[package]]
 name = "agave-transaction-view"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7896,6 +7908,7 @@ name = "solana-client-test"
 version = "4.3.0-alpha.2"
 dependencies = [
  "agave-logger",
+ "agave-test-utilities",
  "async-trait",
  "futures-util",
  "log",
@@ -8105,6 +8118,7 @@ dependencies = [
  "agave-scheduler-bindings",
  "agave-scheduling-utils",
  "agave-snapshots",
+ "agave-test-utilities",
  "agave-transaction-view",
  "agave-votor",
  "agave-votor-messages",
@@ -10044,6 +10058,7 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-test-utilities",
  "agave-votor-messages",
  "base64 0.22.1",
  "bs58",
@@ -10124,7 +10139,6 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
- "solana-unified-scheduler-pool",
  "solana-validator-exit",
  "solana-version",
  "solana-vote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ members = [
     "svm-type-overrides",
     "syscalls",
     "syscalls/gen-syscall-list",
+    "test-utilities",
     "test-validator",
     "tls-utils",
     "tokens",
@@ -183,6 +184,7 @@ agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.3.
 agave-scheduler-bindings = { path = "scheduler-bindings", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
+agave-test-utilities = { path = "test-utilities" }
 agave-transaction-view = "5.1.0"
 agave-votor = { path = "votor", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 agave-votor-messages = { path = "votor-messages", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -43,6 +43,7 @@ tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
+agave-test-utilities = { workspace = true, features = ["dev-context-only-utils"] }
 async-trait = { workspace = true }
 log = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -1,4 +1,5 @@
 use {
+    agave_test_utilities::populate_blockstore_for_tests,
     futures_util::StreamExt,
     serde_json::{Value, json},
     solana_clock::Slot,
@@ -11,7 +12,7 @@ use {
     solana_pubsub_client::{nonblocking, pubsub_client::PubsubClient},
     solana_rpc::{
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-        rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
+        rpc::create_test_transaction_entries,
         rpc_pubsub_service::{PubSubConfig, PubSubService},
         rpc_subscriptions::RpcSubscriptions,
     },

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -192,6 +192,7 @@ sysctl = { workspace = true }
 [dev-dependencies]
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 agave-scheduler-bindings = { path = "../scheduler-bindings", features = ["agave-unstable-api"] }
+agave-test-utilities = { workspace = true, features = ["dev-context-only-utils"] }
 bencher = { workspace = true }
 bitvec = { workspace = true }
 criterion = { workspace = true }

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -11,6 +11,7 @@ use {
         replay_stage::ReplayStage,
         vote_simulator::{self, VoteSimulator},
     },
+    agave_test_utilities::populate_blockstore_for_tests,
     agave_votor_messages::{
         certificate::{CertSignature, GenesisCert},
         consensus_message::Block,
@@ -53,8 +54,7 @@ use {
     solana_poh_config::PohConfig,
     solana_rpc::{
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
-        rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
-        slot_status_notifier::SlotStatusNotifierInterface,
+        rpc::create_test_transaction_entries, slot_status_notifier::SlotStatusNotifierInterface,
     },
     solana_runtime::{
         bank::BankTestConfig,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7858,7 +7858,6 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-transaction-status",
- "solana-unified-scheduler-pool",
  "solana-validator-exit",
  "solana-version",
  "solana-vote",

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,10 +22,8 @@ name = "solana_rpc"
 agave-unstable-api = []
 dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
-    "dep:solana-unified-scheduler-pool",
     "solana-ledger/dev-context-only-utils",
     "solana-rpc/dev-context-only-utils",
-    "solana-unified-scheduler-pool/dev-context-only-utils",
 ]
 
 [dependencies]
@@ -93,7 +91,6 @@ solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, optional = true }
 solana-validator-exit = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
@@ -109,6 +106,7 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-test-utilities = { workspace = true, features = ["dev-context-only-utils"] }
 serial_test = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-client = { workspace = true }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1,8 +1,4 @@
 //! The `rpc` module implements the Solana RPC interface.
-#[cfg(feature = "dev-context-only-utils")]
-use solana_runtime::installed_scheduler_pool::{
-    BankWithScheduler, InstalledSchedulerPool, SchedulingContext,
-};
 use {
     crate::{
         filter::filter_allows, max_slots::MaxSlots,
@@ -4526,63 +4522,6 @@ pub fn create_test_transaction_entries(
     (vec![entry_1, entry_2], signatures)
 }
 
-#[cfg(feature = "dev-context-only-utils")]
-pub fn populate_blockstore_for_tests(
-    entries: Vec<Entry>,
-    bank: Arc<Bank>,
-    blockstore: Arc<Blockstore>,
-    max_complete_transaction_status_slot: Arc<AtomicU64>,
-) {
-    use crossbeam_channel::bounded;
-
-    let slot = bank.slot();
-    let parent_slot = bank.parent_slot();
-    let shreds =
-        solana_ledger::blockstore::entries_to_test_shreds(&entries, slot, parent_slot, true, 0);
-    blockstore.insert_shreds(shreds, false).unwrap();
-    blockstore.set_roots(std::iter::once(&slot)).unwrap();
-
-    let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
-    let tss_exit = Arc::new(AtomicBool::new(false));
-    let transaction_status_service =
-        crate::transaction_status_service::TransactionStatusService::new(
-            transaction_status_receiver,
-            max_complete_transaction_status_slot,
-            true,
-            None,
-            blockstore,
-            false,
-            None,
-            tss_exit.clone(),
-        );
-
-    let transaction_status_sender =
-        solana_runtime::transaction_execution::TransactionStatusSender {
-            sender: transaction_status_sender,
-            dependency_tracker: None,
-        };
-    let pool = solana_unified_scheduler_pool::DefaultSchedulerPool::new_for_verification(
-        None,
-        None,
-        Some(transaction_status_sender),
-        None,
-        None,
-    );
-
-    let context = SchedulingContext::new(bank.clone());
-    let scheduler = pool.take_scheduler(context).unwrap();
-    let bank = BankWithScheduler::new(bank, Some(scheduler));
-
-    // Check that process_entries successfully writes can_commit transactions statuses, and
-    // that they are matched properly by get_rooted_block
-    assert_eq!(
-        solana_ledger::blockstore_processor::process_entries_for_tests(&bank, entries),
-        Ok(())
-    );
-
-    transaction_status_service.quiesce_and_join_for_tests(tss_exit);
-}
-
 #[cfg(test)]
 pub mod tests {
     use {
@@ -4597,6 +4536,7 @@ pub mod tests {
             rpc_subscriptions::RpcSubscriptions,
         },
         agave_reserved_account_keys::ReservedAccountKeys,
+        agave_test_utilities::populate_blockstore_for_tests,
         jsonrpc_core::{ErrorCode, MetaIoHandler, Output, Response, Value, futures},
         jsonrpc_core_client::transports::local,
         serde::de::DeserializeOwned,

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1211,10 +1211,11 @@ pub(crate) mod tests {
             optimistically_confirmed_bank_tracker::{
                 BankNotification, OptimisticallyConfirmedBank, OptimisticallyConfirmedBankTracker,
             },
-            rpc::{create_test_transaction_entries, populate_blockstore_for_tests},
+            rpc::create_test_transaction_entries,
             rpc_pubsub::RpcSolPubSubInternal,
             rpc_pubsub_service,
         },
+        agave_test_utilities::populate_blockstore_for_tests,
         serial_test::serial,
         solana_commitment_config::CommitmentConfig,
         solana_hash::Hash,

--- a/test-utilities/Cargo.toml
+++ b/test-utilities/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "agave-test-utilities"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[features]
+dev-context-only-utils = [
+    "solana-ledger/dev-context-only-utils",
+    "solana-rpc/dev-context-only-utils",
+    "solana-runtime/dev-context-only-utils",
+    "solana-unified-scheduler-pool/dev-context-only-utils",
+]
+
+[dependencies]
+crossbeam-channel = { workspace = true }
+solana-entry = { workspace = true }
+solana-ledger = { workspace = true }
+solana-rpc = { workspace = true }
+solana-runtime = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true }
+
+[lints]
+workspace = true

--- a/test-utilities/src/lib.rs
+++ b/test-utilities/src/lib.rs
@@ -1,0 +1,73 @@
+//! Shared test helpers for Agave crates.
+//!
+//! The whole crate is gated behind the `dev-context-only-utils` feature; it
+//! is intended to be used as a dev-dependency only.
+#![cfg(feature = "dev-context-only-utils")]
+
+use {
+    crossbeam_channel::bounded,
+    solana_entry::entry::Entry,
+    solana_ledger::{
+        blockstore::{Blockstore, entries_to_test_shreds},
+        blockstore_processor::process_entries_for_tests,
+    },
+    solana_rpc::transaction_status_service::TransactionStatusService,
+    solana_runtime::{
+        bank::Bank,
+        installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerPool, SchedulingContext},
+        transaction_execution::TransactionStatusSender,
+    },
+    solana_unified_scheduler_pool::DefaultSchedulerPool,
+    std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64},
+    },
+};
+
+pub fn populate_blockstore_for_tests(
+    entries: Vec<Entry>,
+    bank: Arc<Bank>,
+    blockstore: Arc<Blockstore>,
+    max_complete_transaction_status_slot: Arc<AtomicU64>,
+) {
+    let slot = bank.slot();
+    let parent_slot = bank.parent_slot();
+    let shreds = entries_to_test_shreds(&entries, slot, parent_slot, true, 0);
+    blockstore.insert_shreds(shreds, false).unwrap();
+    blockstore.set_roots(std::iter::once(&slot)).unwrap();
+
+    let (transaction_status_sender, transaction_status_receiver) = bounded(1024);
+    let tss_exit = Arc::new(AtomicBool::new(false));
+    let transaction_status_service = TransactionStatusService::new(
+        transaction_status_receiver,
+        max_complete_transaction_status_slot,
+        true,
+        None,
+        blockstore,
+        false,
+        None,
+        tss_exit.clone(),
+    );
+
+    let transaction_status_sender = TransactionStatusSender {
+        sender: transaction_status_sender,
+        dependency_tracker: None,
+    };
+    let pool = DefaultSchedulerPool::new_for_verification(
+        None,
+        None,
+        Some(transaction_status_sender),
+        None,
+        None,
+    );
+
+    let context = SchedulingContext::new(bank.clone());
+    let scheduler = pool.take_scheduler(context).unwrap();
+    let bank = BankWithScheduler::new(bank, Some(scheduler));
+
+    // Check that process_entries successfully writes can_commit transactions statuses, and
+    // that they are matched properly by get_rooted_block
+    assert_eq!(process_entries_for_tests(&bank, entries), Ok(()));
+
+    transaction_status_service.quiesce_and_join_for_tests(tss_exit);
+}


### PR DESCRIPTION
#### Problem
From #13895
>solana-unified-scheduler-pool is used in populate_blockstore_for_tests, which is config gated with the feature dev-context-only-utils, which is why it's an optional dependency. So we can't really make it a pure dev-dep since other crates depend on populate_blockstore_for_tests for their own tests.

The above problem is a symptom of another problem; we have public functions that are test helpers defined in production source code with feature flag `dev-context-only-utils` that other crates then depend on. This leads to some helpers being shoehorned into a crate that is the least bad fit, and then have other crates depend on that crate with the feature activated to access the test helper. It might make more sense to have these kinds of test utility functions, that are shared across crates, in a dedicated crate that is a test target only instead of cross dependencies.

#### Summary of Changes
- introduce a new crate `agave-test-utilities` where cross crate test helpers can live.
- move `populate_blockstore_for_tests` from `rpc` crate to `agave-test-utilities`
- remove solana-unified-scheduler-pool dependency from rpc crate

#### Testing
This is a refactor with all previous tests kept intact.

Fixes https://github.com/anza-xyz/agave/issues/13895 
