### PR TITLE
chore(deps): remove unwrap_none crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11678,7 +11678,6 @@ dependencies = [
  "solana-transaction",
  "static_assertions",
  "test-case",
- "unwrap_none",
 ]
 
 [[package]]
@@ -11714,7 +11713,6 @@ dependencies = [
  "solana-unified-scheduler-pool",
  "static_assertions",
  "test-case",
- "unwrap_none",
 ]
 
 [[package]]
@@ -13127,12 +13125,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unwrap_none"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461d0c5956fcc728ecc03a3a961e4adc9a7975d86f6f8371389a289517c02ca9"
 
 [[package]]
 name = "ur-parse-lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -567,7 +567,6 @@ trait-set = "0.3.0"
 trees = "0.4.2"
 trezor-client = { version = "0.1.5", default-features = false, features = ["solana"] }
 tungstenite = "0.28.0"
-unwrap_none = "0.1.2"
 ur-parse-lib = { version = "1.0.3", default-features = false, features = ["std"] }
 ur-registry = { version = "1.0.3", default-features = false, features = ["std"] }
 uriparse = "0.6.4"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -9049,7 +9049,6 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
- "unwrap_none",
 ]
 
 [[package]]
@@ -9078,7 +9077,6 @@ dependencies = [
  "solana-transaction-error",
  "solana-unified-scheduler-logic",
  "static_assertions",
- "unwrap_none",
 ]
 
 [[package]]
@@ -10251,12 +10249,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unwrap_none"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461d0c5956fcc728ecc03a3a961e4adc9a7975d86f6f8371389a289517c02ca9"
 
 [[package]]
 name = "uriparse"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -10134,7 +10134,6 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-transaction",
  "static_assertions",
- "unwrap_none",
 ]
 
 [[package]]
@@ -10163,7 +10162,6 @@ dependencies = [
  "solana-transaction-error",
  "solana-unified-scheduler-logic",
  "static_assertions",
- "unwrap_none",
 ]
 
 [[package]]
@@ -11446,12 +11444,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unwrap_none"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461d0c5956fcc728ecc03a3a961e4adc9a7975d86f6f8371389a289517c02ca9"
 
 [[package]]
 name = "uriparse"

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -25,7 +25,6 @@ solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-transaction = { workspace = true }
 static_assertions = { workspace = true }
-unwrap_none = { workspace = true }
 
 [dev-dependencies]
 solana-instruction = { workspace = true }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -111,7 +111,6 @@ use {
         mem,
         sync::Arc,
     },
-    unwrap_none::UnwrapNone,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -678,8 +677,10 @@ trait PriorityUsageQueueExt: Sized {
 
 impl PriorityUsageQueueExt for PriorityUsageQueue {
     fn insert_usage_from_task(&mut self, usage_from_task: UsageFromTask) {
-        self.insert(usage_from_task.1.task_id(), usage_from_task)
-            .unwrap_none();
+        assert!(
+            self.insert(usage_from_task.1.task_id(), usage_from_task)
+                .is_none()
+        );
     }
 
     fn pop_first_usage_from_task(&mut self) -> Option<UsageFromTask> {
@@ -764,9 +765,7 @@ impl UsageQueueInner {
             Self::Priority { current_usage, .. } => match current_usage {
                 Some(PriorityUsage::Readonly(tasks)) => match requested_usage {
                     RequestedUsage::Readonly => {
-                        tasks
-                            .insert(new_task.task_id(), new_task.clone())
-                            .unwrap_none();
+                        assert!(tasks.insert(new_task.task_id(), new_task.clone()).is_none());
                         Ok(())
                     }
                     RequestedUsage::Writable => Err(()),
@@ -1144,7 +1143,7 @@ impl SchedulingStateMachine {
     ///
     /// Note that this function takes ownership of the task to allow for future optimizations.
     pub fn buffer_task(&mut self, task: Task) {
-        self.schedule_or_buffer_task(task, true).unwrap_none();
+        assert!(self.schedule_or_buffer_task(task, true).is_none());
     }
 
     /// Schedules or buffers given `task`, returning successful one unless buffering is forced.

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -41,7 +41,6 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }
 static_assertions = { workspace = true }
-unwrap_none = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -55,7 +55,6 @@ use {
         thread::{self, JoinHandle, sleep},
         time::{Duration, Instant},
     },
-    unwrap_none::UnwrapNone,
 };
 
 mod sleepless_testing;
@@ -1133,9 +1132,11 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
     }
 
     fn put_session_result_with_timings(&mut self, result_with_timings: ResultWithTimings) {
-        self.session_result_with_timings
-            .replace(result_with_timings)
-            .unwrap_none();
+        assert!(
+            self.session_result_with_timings
+                .replace(result_with_timings)
+                .is_none()
+        );
     }
 
     // This method must take same set of session-related arguments as start_session() to avoid
@@ -1447,9 +1448,11 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                             }
                             Ok(NewTaskPayload::OpenSubchannel(context_and_result_with_timings)) => {
                                 let new_context = context_and_result_with_timings.0;
-                                new_result_with_timings
-                                    .replace(context_and_result_with_timings.1)
-                                    .unwrap_none();
+                                assert!(
+                                    new_result_with_timings
+                                        .replace(context_and_result_with_timings.1)
+                                        .is_none()
+                                );
                                 // We just received subsequent (= not initial) session and about to
                                 // enter into the preceding `while(!is_finished) {...}` loop again.
                                 // Before that, propagate new SchedulingContext to handler threads


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/devops/issues/1140 we are working to audit and reduce existing deps. `unwrap_none` is a single-purpose crate providing `Option::unwrap_none()`, used at 5 sites in the unified scheduler.

#### Summary of Changes

Replace each with std `assert!(x.is_none())` (already the norm, ~400 uses in-tree) and drop the dependency. Near-full parity with `unwrap_none()`: same panic condition, same panic location, and it stays always-on in release. The only difference is a violated invariant no longer prints the offending `Some` value in the panic message (the panic location and asserted expression are still shown).

#### Testing

`cargo test` for `solana-unified-scheduler-{logic,pool}` (`--features agave-unstable-api`) pass; `cargo sort` and `cargo metadata --locked` clean.

Fixes anza-xyz/devops#1140
