### PR TITLE
perf: update SlotMeta.next_slots to use SmallVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9140,6 +9140,7 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
+ "smallvec",
  "solana-account 4.3.1",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7194,6 +7194,7 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
+ "smallvec",
  "solana-account 4.3.1",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -60,6 +60,7 @@ rayon = { workspace = true }
 reed-solomon-erasure = { workspace = true, features = ["simd-accel"] }
 scopeguard = { workspace = true }
 serde = { workspace = true }
+smallvec = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true, features = ["wincode"] }
@@ -120,7 +121,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 trees = { workspace = true }
-wincode = { workspace = true, features = ["bytes"] }
+wincode = { workspace = true, features = ["bytes", "smallvec"] }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1391,11 +1391,11 @@ impl Blockstore {
             return true;
         }
 
-        let mut next_slots: VecDeque<_> = match self.meta(starting_slot) {
-            Ok(Some(starting_slot_meta)) => starting_slot_meta.next_slots.into(),
+        let mut next_slots = match self.meta(starting_slot) {
+            Ok(Some(starting_slot_meta)) => starting_slot_meta.next_slots,
             _ => return false,
         };
-        while let Some(slot) = next_slots.pop_front() {
+        while let Some(slot) = next_slots.pop() {
             if let Ok(Some(slot_meta)) = self.meta(slot)
                 && slot_meta.is_full()
             {
@@ -5155,11 +5155,11 @@ impl Blockstore {
 
     /// Returns a mapping from each elements of `slots` to a list of the
     /// element's children slots.
-    pub fn get_slots_since(&self, slots: &[Slot]) -> Result<HashMap<Slot, Vec<Slot>>> {
+    pub fn get_slots_since(&self, slots: &[Slot]) -> Result<HashMap<Slot, NextSlots>> {
         let keys = self.meta_cf.multi_get_keys(slots.iter().copied());
         let slot_metas = self.meta_cf.multi_get(&keys);
 
-        let mut slots_since: HashMap<Slot, Vec<Slot>> = HashMap::with_capacity(slots.len());
+        let mut slots_since: HashMap<Slot, _> = HashMap::with_capacity(slots.len());
         for meta in slot_metas.into_iter() {
             let meta = meta?;
             if let Some(meta) = meta {
@@ -5550,15 +5550,14 @@ impl Blockstore {
         self.meta_cf
             .put_in_batch(&mut write_batch, root_meta.slot, &root_meta)?;
 
-        let mut next_slots = VecDeque::from(root_meta.next_slots);
-        while !next_slots.is_empty() {
-            let slot = next_slots.pop_front().unwrap();
+        let mut next_slots = root_meta.next_slots;
+        while let Some(slot) = next_slots.pop() {
             let mut meta = self.meta(slot)?.unwrap_or_else(|| {
                 panic!("Slot {slot} is a child but has no SlotMeta in blockstore")
             });
 
             if meta.set_parent_connected() {
-                next_slots.extend(meta.next_slots.iter());
+                next_slots.extend(meta.next_slots.iter().copied());
             }
             self.meta_cf
                 .put_in_batch(&mut write_batch, meta.slot, &meta)?;
@@ -5792,7 +5791,7 @@ impl Blockstore {
             self.find_slot_meta_else_create(working_set, new_chained_slots, old_parent_slot)?
                 .borrow_mut()
                 .next_slots
-                .retain(|&s| s != slot);
+                .retain(|s| *s != slot);
 
             // Add slot to new parent's next_slots.
             let new_parent_meta =

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -153,7 +153,7 @@ impl Blockstore {
                 // only contain several elements so this isn't so bad
                 parent_slot_meta
                     .next_slots
-                    .retain(|&next_slot| next_slot != slot);
+                    .retain(|next_slot| *next_slot != slot);
                 self.meta_cf
                     .put_in_batch(&mut write_batch, parent_slot, &parent_slot_meta)?;
             } else {
@@ -409,7 +409,7 @@ impl Blockstore {
                 }
             }
 
-            meta.next_slots.retain(|&next_slot| next_slot > to_slot);
+            meta.next_slots.retain(|next_slot| *next_slot > to_slot);
             if !meta.next_slots.is_empty() {
                 let mut new_meta = SlotMeta::new_orphan(slot);
                 new_meta.next_slots = meta.next_slots;
@@ -1206,13 +1206,13 @@ pub mod tests {
         let expected_slot_meta = SlotMeta {
             slot: 5,
             // Only the next_slots should be preserved
-            next_slots: vec![6, 12],
+            next_slots: smallvec::smallvec![6, 12],
             ..SlotMeta::default()
         };
         assert_eq!(slot_meta, expected_slot_meta);
 
         let parent_slot_meta = blockstore.meta(4).unwrap().unwrap();
-        assert_eq!(parent_slot_meta.next_slots, vec![11]);
+        assert_eq!(parent_slot_meta.next_slots.as_slice(), &[11]);
 
         let child_slot_meta = blockstore.meta(6).unwrap().unwrap();
         assert_eq!(child_slot_meta.parent_slot.unwrap(), 5);

--- a/ledger/src/blockstore/column.rs
+++ b/ledger/src/blockstore/column.rs
@@ -887,6 +887,7 @@ mod tests {
     use {
         super::*,
         crate::blockstore_meta::{CompletedDataIndexes, ConnectedFlags},
+        smallvec::smallvec,
         solana_hash::Hash,
         wincode,
     };
@@ -900,7 +901,7 @@ mod tests {
             first_shred_timestamp: 1234567890,
             last_index: Some(14),
             parent_slot: Some(41),
-            next_slots: vec![43, 44],
+            next_slots: smallvec![43, 44],
             connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
             completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
             parent_block_id: Hash::new_unique(),
@@ -921,7 +922,7 @@ mod tests {
             first_shred_timestamp: 1234567890,
             last_index: Some(14),
             parent_slot: Some(41),
-            next_slots: vec![43, 44],
+            next_slots: smallvec![43, 44],
             connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
             completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
         };
@@ -935,7 +936,7 @@ mod tests {
             first_shred_timestamp: 1234567890,
             last_index: Some(14),
             parent_slot: Some(41),
-            next_slots: vec![43, 44],
+            next_slots: smallvec![43, 44],
             connected_flags: ConnectedFlags::CONNECTED | ConnectedFlags::PARENT_CONNECTED,
             completed_data_indexes: [0u32, 5, 10].into_iter().collect(),
             ..Default::default()
@@ -952,7 +953,7 @@ mod tests {
             first_shred_timestamp: 0,
             last_index: None,
             parent_slot: Some(0),
-            next_slots: vec![],
+            next_slots: smallvec![],
             connected_flags: ConnectedFlags::empty(),
             completed_data_indexes: CompletedDataIndexes::default(),
         };
@@ -968,7 +969,7 @@ mod tests {
             first_shred_timestamp: 0,
             last_index: None,
             parent_slot: Some(0),
-            next_slots: vec![],
+            next_slots: smallvec![],
             connected_flags: ConnectedFlags::empty(),
             completed_data_indexes: CompletedDataIndexes::default(),
             parent_block_id: Hash::new_unique(),

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -137,7 +137,8 @@ fn verify_next_slots(blockstore: &Blockstore, parent_slot: Slot, expected: &[Slo
 
     match (actual, expected.is_empty()) {
         (Some(actual), _) => assert_eq!(
-            actual, expected,
+            actual.as_slice(),
+            expected.as_slice(),
             "Parent slot {parent_slot} next_slots mismatch",
         ),
         (None, false) => panic!("Slot {parent_slot} meta doesn't exist"),
@@ -288,7 +289,7 @@ fn test_write_entries() {
         if i == num_slots - 1 {
             assert!(meta.next_slots.is_empty());
         } else {
-            assert_eq!(meta.next_slots, vec![i + 1]);
+            assert_eq!(meta.next_slots.as_slice(), &[i + 1]);
         }
         if i == 0 {
             assert_eq!(meta.parent_slot, Some(0));
@@ -900,7 +901,7 @@ fn test_handle_chaining_basic() {
     // Check the first slot again, it should chain to the second slot,
     // but still isn't connected.
     let meta1 = blockstore.meta(1).unwrap().unwrap();
-    assert_eq!(meta1.next_slots, vec![2]);
+    assert_eq!(meta1.next_slots.as_slice(), &[2]);
     assert!(!meta1.is_connected());
     assert_eq!(meta1.parent_slot, Some(0));
     assert_eq!(meta1.last_index, Some(shreds_per_slot as u64 - 1));
@@ -912,7 +913,7 @@ fn test_handle_chaining_basic() {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         // The last slot will not chain to any other slots
         if slot != 2 {
-            assert_eq!(meta.next_slots, vec![slot + 1]);
+            assert_eq!(meta.next_slots.as_slice(), &[slot + 1]);
         }
         if slot == 0 {
             assert_eq!(meta.parent_slot, Some(0));
@@ -951,7 +952,7 @@ fn test_handle_chaining_missing_slots() {
         // - Have an unknown parent since no shreds to indicate
         let meta = blockstore.meta(slot).unwrap().unwrap();
         if slot % 2 == 0 {
-            assert_eq!(meta.next_slots, vec![slot + 1]);
+            assert_eq!(meta.next_slots.as_slice(), &[slot + 1]);
             assert_eq!(meta.parent_slot, None);
         } else {
             assert!(meta.next_slots.is_empty());
@@ -971,7 +972,7 @@ fn test_handle_chaining_missing_slots() {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         // All slots except the last one should have a slot in next_slots
         if slot != num_slots - 1 {
-            assert_eq!(meta.next_slots, vec![slot + 1]);
+            assert_eq!(meta.next_slots.as_slice(), &[slot + 1]);
         } else {
             assert!(meta.next_slots.is_empty());
         }
@@ -1020,7 +1021,7 @@ pub fn test_forward_chaining_is_connected() {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         // The last slot will not chain to any other slots
         if slot != num_slots - 1 {
-            assert_eq!(meta.next_slots, vec![slot + 1]);
+            assert_eq!(meta.next_slots.as_slice(), &[slot + 1]);
         } else {
             assert!(meta.next_slots.is_empty());
         }
@@ -1049,7 +1050,7 @@ pub fn test_forward_chaining_is_connected() {
                 let meta = blockstore.meta(slot).unwrap().unwrap();
 
                 if slot != num_slots - 1 {
-                    assert_eq!(meta.next_slots, vec![slot + 1]);
+                    assert_eq!(meta.next_slots.as_slice(), &[slot + 1]);
                 } else {
                     assert!(meta.next_slots.is_empty());
                 }
@@ -1302,6 +1303,7 @@ fn test_slot_range_connected_starting_slot_not_full() {
 
 #[test]
 fn test_get_slots_since() {
+    use smallvec::{SmallVec, smallvec};
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
 
@@ -1312,22 +1314,24 @@ fn test_get_slots_since() {
     blockstore.meta_cf.put(0, &meta0).unwrap();
 
     // Slot exists, chains to nothing
-    let expected: HashMap<u64, Vec<u64>> = vec![(0, vec![])].into_iter().collect();
+    let expected: HashMap<u64, SmallVec<[Slot; 2]>> = vec![(0, smallvec![])].into_iter().collect();
     assert_eq!(blockstore.get_slots_since(&[0]).unwrap(), expected);
-    meta0.next_slots = vec![1, 2];
+    meta0.next_slots = smallvec![1, 2];
     blockstore.meta_cf.put(0, &meta0).unwrap();
 
     // Slot exists, chains to some other slots
-    let expected: HashMap<u64, Vec<u64>> = vec![(0, vec![1, 2])].into_iter().collect();
+    let expected: HashMap<u64, SmallVec<[Slot; 2]>> =
+        vec![(0, smallvec![1, 2])].into_iter().collect();
     assert_eq!(blockstore.get_slots_since(&[0]).unwrap(), expected);
     assert_eq!(blockstore.get_slots_since(&[0, 1]).unwrap(), expected);
 
     let mut meta3 = SlotMeta::new(3, Some(1));
-    meta3.next_slots = vec![10, 5];
+    meta3.next_slots = smallvec![10, 5];
     blockstore.meta_cf.put(3, &meta3).unwrap();
-    let expected: HashMap<u64, Vec<u64>> = vec![(0, vec![1, 2]), (3, vec![10, 5])]
-        .into_iter()
-        .collect();
+    let expected: HashMap<u64, SmallVec<[Slot; 2]>> =
+        vec![(0, smallvec![1, 2]), (3, smallvec![10, 5])]
+            .into_iter()
+            .collect();
     assert_eq!(blockstore.get_slots_since(&[0, 1, 3]).unwrap(), expected);
 }
 
@@ -2614,10 +2618,10 @@ fn test_no_insert_but_modify_slot_meta() {
     shreds3.insert(0, shreds0[1].clone());
     blockstore.insert_shreds(shreds2, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
-    assert_eq!(slot_meta.next_slots, vec![2]);
+    assert_eq!(slot_meta.next_slots.as_slice(), &[2]);
     blockstore.insert_shreds(shreds3, false).unwrap();
     let slot_meta = blockstore.meta(0).unwrap().unwrap();
-    assert_eq!(slot_meta.next_slots, vec![2, 3]);
+    assert_eq!(slot_meta.next_slots.as_slice(), &[2, 3]);
 }
 
 #[test]
@@ -5146,8 +5150,9 @@ fn test_clear_unconfirmed_slot() {
             .meta(unconfirmed_slot)
             .unwrap()
             .unwrap()
-            .next_slots,
-        vec![unconfirmed_child_slot]
+            .next_slots
+            .as_slice(),
+        &[unconfirmed_child_slot]
     );
     assert!(
         blockstore
@@ -5195,8 +5200,13 @@ fn test_clear_unconfirmed_slot_and_insert_again() {
         .insert_shreds(unconfirmed_slot_shreds, false)
         .unwrap();
     assert_eq!(
-        blockstore.meta(confirmed_slot).unwrap().unwrap().next_slots,
-        vec![unconfirmed_slot]
+        blockstore
+            .meta(confirmed_slot)
+            .unwrap()
+            .unwrap()
+            .next_slots
+            .as_slice(),
+        &[unconfirmed_slot]
     );
 }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -8,6 +8,7 @@ use {
         },
     },
     bitflags::bitflags,
+    smallvec::SmallVec,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::{HASH_BYTES, Hash},
     std::{
@@ -123,6 +124,17 @@ impl Debug for CompletedDataIndexes {
     }
 }
 
+/// Inline storage for [`SlotMeta::next_slots`].
+///
+/// On a chain with little forking, [`SlotMeta::next_slots`] usually contains
+/// one child (occasionally two), but its size is not strictly bounded.
+///
+/// On 64-bit targets, inline capacities 1 and 2 produce the same `SmallVec` size,
+/// so consume that space with an extra inline `Slot` which would otherwise be
+/// padding bytes. This also avoids a heap spill for intermittent cases where
+/// [`SlotMeta::next_slots`] contains two children.
+pub type NextSlots = SmallVec<[Slot; 2]>;
+
 #[derive(Clone, Debug, Default, SchemaRead, SchemaWrite, Eq, PartialEq)]
 /// The Meta column family
 pub struct SlotMetaBase<T> {
@@ -149,7 +161,7 @@ pub struct SlotMetaBase<T> {
     pub parent_slot: Option<Slot>,
     /// The list of slots, each of which contains a block that derives
     /// from this one.
-    pub next_slots: Vec<Slot>,
+    pub next_slots: NextSlots,
     /// Connected status flags of this slot
     #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
@@ -176,7 +188,7 @@ pub struct SlotMetaV3 {
     pub last_index: Option<u64>,
     #[wincode(with = "wincode_compat::OptionCompat")]
     pub parent_slot: Option<Slot>,
-    pub next_slots: Vec<Slot>,
+    pub next_slots: NextSlots,
     #[wincode(with = "PodConnectedFlags")]
     pub connected_flags: ConnectedFlags,
     pub completed_data_indexes: CompletedDataIndexes,
@@ -212,7 +224,7 @@ pub struct SlotMetaRepair {
     pub last_index: Option<u64>,
     #[wincode(with = "wincode_compat::OptionCompat")]
     pub parent_slot: Option<Slot>,
-    pub next_slots: Vec<Slot>,
+    pub next_slots: NextSlots,
 }
 
 // Wincode implementation of serialize and deserialize for Option<u64>
@@ -1118,7 +1130,7 @@ mod test {
                     first_shred_timestamp,
                     last_index,
                     parent_slot,
-                    next_slots,
+                    next_slots: next_slots.into(),
                     connected_flags: ConnectedFlags::from_bits_truncate(connected_flags),
                     completed_data_indexes: completed_data_indexes.into_iter().collect(),
                     parent_block_id: Hash::new_from_array(parent_block_id),
@@ -1361,11 +1373,11 @@ mod test {
         let mut slot_meta = SlotMeta::new_orphan(5);
         slot_meta.consumed = 5;
         slot_meta.received = 5;
-        slot_meta.next_slots = vec![6, 7];
+        slot_meta.next_slots = smallvec::smallvec![6, 7];
         slot_meta.clear_unconfirmed_slot();
 
         let mut expected = SlotMeta::new_orphan(5);
-        expected.next_slots = vec![6, 7];
+        expected.next_slots = smallvec::smallvec![6, 7];
         assert_eq!(slot_meta, expected);
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5731,7 +5731,7 @@ pub mod tests {
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank0);
 
         let mut genesis_meta = SlotMeta::new(0, None);
-        genesis_meta.next_slots = vec![1, 2];
+        genesis_meta.next_slots = smallvec::smallvec![1, 2];
         blockstore.put_meta(0, &genesis_meta).unwrap();
 
         for slot in [1, 2] {
@@ -5814,7 +5814,7 @@ pub mod tests {
 
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&parent_bank);
         let mut parent_meta = SlotMeta::new(1, Some(0));
-        parent_meta.next_slots = vec![2, 3];
+        parent_meta.next_slots = smallvec::smallvec![2, 3];
 
         for (slot, block_id) in [(2, Hash::new_unique()), (3, parent_block_id)] {
             let mut meta = SlotMeta::new(slot, Some(1));

--- a/ledger/src/rooted_slot_iterator.rs
+++ b/ledger/src/rooted_slot_iterator.rs
@@ -1,11 +1,15 @@
 use {
-    crate::{blockstore::*, blockstore_meta::SlotMeta},
+    crate::{
+        blockstore::*,
+        blockstore_meta::{NextSlots, SlotMeta},
+    },
     log::*,
+    smallvec::smallvec,
     solana_clock::Slot,
 };
 
 pub struct RootedSlotIterator<'a> {
-    next_slots: Vec<Slot>,
+    next_slots: NextSlots,
     prev_root: Slot,
     blockstore: &'a Blockstore,
 }
@@ -14,7 +18,7 @@ impl<'a> RootedSlotIterator<'a> {
     pub fn new(start_slot: Slot, blockstore: &'a Blockstore) -> Result<Self> {
         if blockstore.is_root(start_slot) {
             Ok(Self {
-                next_slots: vec![start_slot],
+                next_slots: smallvec![start_slot],
                 prev_root: start_slot,
                 blockstore,
             })

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7385,6 +7385,7 @@ dependencies = [
  "rocksdb",
  "scopeguard",
  "serde",
+ "smallvec",
  "solana-account 4.3.1",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",


### PR DESCRIPTION
#### Problem
`SlotMeta.next_slots` is declared as a `Vec<u64>`. Most of the time, the length of the `Vec` is `1`.

<img width="983" height="481" alt="image" src="https://github.com/user-attachments/assets/81df12f8-af6e-4761-887f-3935cf9a5862" />

`SlotMeta` and/or `SlotMetaRepair` is deserialized high-10s of thousands (more even?) of times per second, which is a significant amount of needless small heap allocations.


#### Summary of Changes

This updates `next_slots` to use `SmallVec<[Slot; 2]>` . I picked `2` because it's not uncommon, and the size of `SmallVec<[Slot; 1]>` and `SmallVec<[Slot; 2]>` requires the same amount of storage (with the `union` feature enabled), and the extra space would otherwise be used as padding bytes, so might as well use it to avoid spillage in the `len = 2` case.
