### PR TITLE
remove mermaid diagrams from code documentation comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,20 +756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,25 +3983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,27 +5552,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -10318,7 +10264,6 @@ dependencies = [
  "agave-transaction-view",
  "agave-votor-messages",
  "ahash 0.8.12",
- "aquamarine",
  "arc-swap",
  "arrayref",
  "assert_matches",
@@ -11687,7 +11632,6 @@ version = "4.3.0-alpha.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
  "agave-logger",
- "aquamarine",
  "assert_matches",
  "crossbeam-channel",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,6 @@ agave-xdp = { path = "xdp", version = "=4.3.0-alpha.2", features = ["agave-unsta
 agave-xdp-ebpf = { path = "xdp-ebpf", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 ahash = "0.8.12"
 anyhow = "1.0.103"
-aquamarine = "0.6.0"
 arbitrary = "1.4.2"
 arc-swap = "1.9.2"
 arrayref = "0.3.9"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -589,20 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3316,25 +3302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4600,27 +4567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -7983,7 +7929,6 @@ dependencies = [
  "agave-snapshots",
  "agave-votor-messages",
  "ahash 0.8.12",
- "aquamarine",
  "arc-swap",
  "arrayref",
  "assert_matches",
@@ -9057,7 +9002,6 @@ name = "solana-unified-scheduler-pool"
 version = "4.3.0-alpha.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
- "aquamarine",
  "assert_matches",
  "crossbeam-channel",
  "dashmap",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -585,20 +585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,25 +3316,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4637,27 +4604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -8284,7 +8230,6 @@ dependencies = [
  "agave-snapshots",
  "agave-votor-messages",
  "ahash 0.8.12",
- "aquamarine",
  "arc-swap",
  "arrayref",
  "assert_matches",
@@ -10142,7 +10087,6 @@ name = "solana-unified-scheduler-pool"
 version = "4.3.0-alpha.2"
 dependencies = [
  "agave-banking-stage-ingress-types",
- "aquamarine",
  "assert_matches",
  "crossbeam-channel",
  "dashmap",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,7 +68,6 @@ agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor-messages = { workspace = true }
 ahash = { workspace = true }
-aquamarine = { workspace = true }
 arc-swap = { workspace = true }
 arrayref = { workspace = true }
 assert_matches = { workspace = true }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -96,53 +96,7 @@ impl Debug for TimeoutListener {
     }
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// Schedules, executes, and commits transactions under encapsulated implementation
-///
-/// The following chart illustrates the ownership/reference interaction between inter-dependent
-/// objects across crates:
-///
-/// ```mermaid
-/// graph TD
-///     Bank["Arc#lt;Bank#gt;"]
-///
-///     subgraph solana-runtime[<span style="font-size: 70%">solana-runtime</span>]
-///         BankForks;
-///         BankWithScheduler;
-///         Bank;
-///         LoadExecuteAndCommitTransactions([<span style="font-size: 67%">load_execute_and_commit_transactions#lpar;#rpar;</span>]);
-///         SchedulingContext;
-///         InstalledSchedulerPool{{InstalledSchedulerPool}};
-///         InstalledScheduler{{InstalledScheduler}};
-///     end
-///
-///     subgraph solana-unified-scheduler-pool[<span style="font-size: 70%">solana-unified-scheduler-pool</span>]
-///         SchedulerPool;
-///         PooledScheduler;
-///         ScheduleExecution(["schedule_execution()"]);
-///     end
-///
-///     subgraph solana-ledger[<span style="font-size: 60%">solana-ledger</span>]
-///         ExecuteBatch(["execute_batch()"]);
-///     end
-///
-///     ScheduleExecution -. calls .-> ExecuteBatch;
-///     BankWithScheduler -. dyn-calls .-> ScheduleExecution;
-///     ExecuteBatch -. calls .-> LoadExecuteAndCommitTransactions;
-///     linkStyle 0,1,2 stroke:gray,color:gray;
-///
-///     BankForks -- owns --> BankWithScheduler;
-///     BankForks -- owns --> InstalledSchedulerPool;
-///     BankWithScheduler -- refs --> Bank;
-///     BankWithScheduler -- owns --> InstalledScheduler;
-///     SchedulingContext -- refs --> Bank;
-///     InstalledScheduler -- owns --> SchedulingContext;
-///
-///     SchedulerPool -- owns --> PooledScheduler;
-///     SchedulerPool -. impls .-> InstalledSchedulerPool;
-///     PooledScheduler -. impls .-> InstalledScheduler;
-///     PooledScheduler -- refs --> SchedulerPool;
-/// ```
 #[cfg_attr(feature = "dev-context-only-utils", automock)]
 // suppress false clippy complaints arising from mockall-derive:
 //   warning: `#[must_use]` has no effect when applied to a struct field

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -20,7 +20,6 @@ dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
-aquamarine = { workspace = true }
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -858,7 +858,6 @@ fn disconnected<T>() -> Receiver<T> {
     crossbeam_channel::unbounded().1
 }
 
-#[cfg_attr(doc, aquamarine::aquamarine)]
 /// The concrete scheduler instance along with 1 scheduler and N handler threads.
 ///
 /// This implements the dyn-compatible [`InstalledScheduler`] trait to be interacted by
@@ -900,31 +899,6 @@ fn disconnected<T>() -> Receiver<T> {
 /// reasons like [`UsageQueueLoader`] being overgrown or many idling schedulers in the pool, in
 /// addition to the obvious reason of aborted scheduler.
 ///
-/// ### Life cycle and ownership movement across crates of a particular scheduler
-///
-/// ```mermaid
-/// stateDiagram-v2
-///     [*] --> Active: Spawned (New bank by solReplayStage)
-///     state solana-runtime {
-///         state if_usable <<choice>>
-///         Active --> if_usable: Returned (Bank-freezing by solReplayStage)
-///         Active --> if_usable: Dropped (BankForks-pruning by solReplayStage)
-///         Aborted --> if_usable: Dropped (BankForks-pruning by solReplayStage)
-///         if_usable --> Pooled: IF !overgrown && !aborted
-///         Active --> Aborted: Errored on TX execution
-///         Aborted --> Stale: !Dropped after TIMEOUT_DURATION since taken
-///         Active --> Stale: No new TX after TIMEOUT_DURATION since taken
-///         Stale --> if_usable: Returned (Timeout-triggered by solScCleaner)
-///         Pooled --> Active: Taken (New bank by solReplayStage)
-///     }
-///     state solana-unified-scheduler-pool {
-///         Pooled --> Idle: !Taken after POOLING_DURATION
-///         if_usable --> Trashed: IF overgrown || aborted
-///         Idle --> Retired
-///         Trashed --> Retired
-///     }
-///     Retired --> [*]: Terminated (by solScCleaner)
-/// ```
 #[derive(Debug)]
 pub struct PooledScheduler<TH: TaskHandler> {
     inner: PooledSchedulerInner<Self, TH>,


### PR DESCRIPTION
#### Problem

we have two beautifully designed flowcharts written in mermaid that can be rendered on docs.rs
- https://docs.rs/solana-unified-scheduler-pool/4.3.0-alpha.2/solana_unified_scheduler_pool/struct.PooledScheduler.html
- https://docs.rs/solana-runtime/4.3.0-alpha.2/solana_runtime/installed_scheduler_pool/trait.InstalledScheduler.html

however, I'm considering whether we should remove them or move them elsewhere for the following reasons:

- `aquamarine` depends on `proc-macro-error2`, which is unmaintained
<img width="479" height="160" alt="Screenshot 2026-07-23 at 20 52 22" src="https://github.com/user-attachments/assets/7c653be1-471b-45e6-be2e-6be7823a554f" />

- prone to getting out of date

it looks good on docs.rs, but it's also easier for it to become outdated. also it's easy to forget to update it, and keeping it in sync can be cumbersome.

#### Summary of Changes

I would like to remove it from here. we can definitely add these charts to docs.anza.xyz instead if needed