### PR TITLE
bench(vote-program): fix panics in process_vote and vote_instructions benchmarks

### DIFF
--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -75,7 +75,6 @@ fn create_accounts() -> (
     };
 
     let transaction_accounts = vec![
-        (solana_vote_program::id(), AccountSharedData::default()),
         (vote_pubkey, AccountSharedData::from(vote_account)),
         (
             sysvar::slot_hashes::id(),
@@ -89,7 +88,7 @@ fn create_accounts() -> (
     ];
     let mut instruction_account_metas = (0..4)
         .map(|index_in_callee| AccountMeta {
-            pubkey: transaction_accounts[1usize.saturating_add(index_in_callee)].0,
+            pubkey: transaction_accounts[index_in_callee].0,
             is_signer: false,
             is_writable: false,
         })

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -86,7 +86,6 @@ fn create_accounts() -> (
     };
 
     let transaction_accounts = vec![
-        (solana_vote_program::id(), AccountSharedData::default()),
         (vote_pubkey, AccountSharedData::from(vote_account)),
         (
             sysvar::slot_hashes::id(),

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -23,7 +23,8 @@ use {
         vote_state::{
             MAX_LOCKOUT_HISTORY, TowerSync, Vote, VoteAuthorize, VoteAuthorizeCheckedWithSeedArgs,
             VoteAuthorizeWithSeedArgs, VoteInit, VoteInitV2, VoteStateUpdate, VoteStateV3,
-            VoteStateV4, VoteStateVersions, create_v4_account_with_authorized,
+            VoteStateV4, VoteStateVersions, VoterWithBLSArgs,
+            create_bls_pubkey_and_proof_of_possession, create_v4_account_with_authorized,
             handler::VoteStateHandler,
         },
     },
@@ -177,6 +178,21 @@ fn create_test_account_with_authorized() -> (Pubkey, Pubkey, Pubkey, AccountShar
     )
 }
 
+/// Build the `VoterWithBLS` voter-authorization form for `vote_pubkey`.
+///
+/// Once `bls_pubkey_management_in_vote_account` is enabled (as it is under the
+/// mock harness' all-features-enabled set), the legacy `VoteAuthorize::Voter`
+/// form is rejected for accounts that have a BLS key, so a fresh BLS pubkey and
+/// proof-of-possession must be supplied.
+fn voter_with_bls(vote_pubkey: &Pubkey) -> VoteAuthorize {
+    let (bls_pubkey, bls_proof_of_possession) =
+        create_bls_pubkey_and_proof_of_possession(vote_pubkey);
+    VoteAuthorize::VoterWithBLS(VoterWithBLSArgs {
+        bls_pubkey,
+        bls_proof_of_possession,
+    })
+}
+
 fn process_instruction(
     instruction_data: &[u8],
     transaction_accounts: Vec<(Pubkey, AccountSharedData)>,
@@ -234,7 +250,7 @@ impl BenchAuthorize {
         let clock_account = account::create_account_shared_data_for_test(&clock);
         let instruction_data = serialize(&VoteInstruction::Authorize(
             authorized_voter_pubkey,
-            VoteAuthorize::Voter,
+            voter_with_bls(&vote_pubkey),
         ))
         .unwrap();
         let transaction_accounts = vec![
@@ -598,10 +614,23 @@ impl BenchAuthorizeChecked {
     fn new() -> Self {
         let vote_pubkey = Pubkey::new_unique();
         let new_authorized_pubkey = Pubkey::new_unique();
-        let vote_account = AccountSharedData::new(100, VoteStateV3::size_of(), &id());
+        let default_authorized_pubkey = Pubkey::default();
+        let node_pubkey = solana_pubkey::new_rand();
+        // Initialized V4 vote account whose current voter/withdrawer authority is
+        // `default_authorized_pubkey` (the signer below).
+        let vote_account = create_v4_account_with_authorized(
+            &node_pubkey,
+            &default_authorized_pubkey,
+            [0u8; BLS_PUBLIC_KEY_COMPRESSED_SIZE],
+            &default_authorized_pubkey,
+            0,
+            &default_authorized_pubkey,
+            0,
+            &node_pubkey,
+            100,
+        );
         let clock_address = sysvar::clock::id();
         let clock_account = account::create_account_shared_data_for_test(&Clock::default());
-        let default_authorized_pubkey = Pubkey::default();
         let authorized_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let new_authorized_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let transaction_accounts = vec![
@@ -633,8 +662,10 @@ impl BenchAuthorizeChecked {
             },
         ];
 
-        let instruction_data =
-            serialize(&VoteInstruction::AuthorizeChecked(VoteAuthorize::Voter)).unwrap();
+        let instruction_data = serialize(&VoteInstruction::AuthorizeChecked(voter_with_bls(
+            &vote_pubkey,
+        )))
+        .unwrap();
         Self {
             instruction_data,
             transaction_accounts,
@@ -774,7 +805,7 @@ impl BenchAuthorizeWithSeed {
             },
         ];
 
-        let authorization_type = VoteAuthorize::Voter;
+        let authorization_type = voter_with_bls(&vote_pubkey);
         let instruction_data = serialize(&VoteInstruction::AuthorizeWithSeed(
             VoteAuthorizeWithSeedArgs {
                 authorization_type,
@@ -808,8 +839,8 @@ struct BenchAuthorizeCheckedWithSeed {
 
 impl BenchAuthorizeCheckedWithSeed {
     fn new() -> Self {
-        let authorization_type: VoteAuthorize = VoteAuthorize::Voter;
         let vote_pubkey = Pubkey::new_unique();
+        let authorization_type = voter_with_bls(&vote_pubkey);
         let current_authority_base_key = Pubkey::new_unique();
         let current_authority_owner = Pubkey::new_unique();
         let current_authority_seed = String::from("VOTER_SEED");


### PR DESCRIPTION
#### Problem
The `solana-vote-program` benchmarks panic at runtime and cannot be run:

- **`process_vote` and 4 of the `vote_instructions` benches** panic with
  `assertion left == right failed: left: Err(UnsupportedProgramId), right: Ok(())`
  inside `mock_process_instruction_with_feature_set`.
- **4 voter-authorization benches** (`vote_instruction_authorize`, `vote_authorize_with_seed`,
  `vote_authorize_checked_with_seed`, `vote_authorize_checked`) panic with
  `InvalidInstructionData` / `InvalidAccountData`.

#### Summary of Changes

**1. Fix `UnsupportedProgramId` (`create_accounts`)**

Drop the dummy `(solana_vote_program::id(), AccountSharedData::default())` entry from
`create_accounts()` in the vote benches, so the mock harness synthesizes the program
account itself instead of picking up a non-executable, zero-owner account. Without this
the benches panic with `UnsupportedProgramId` and cannot run.

Regressed by #11106 (`mock_process_instruction` role-assignment refactor), which changed
the harness to derive the program account from the caller-supplied accounts rather than
constructing it internally.

**2. Fix voter-authorize benches (`VoterWithBLS`)**

The four voter-authorization benches built their instructions with the legacy
`VoteAuthorize::Voter` form, which is rejected once `bls_pubkey_management_in_vote_account`
is enabled (as it is under the mock harness' all-features-enabled set) for accounts that
have a BLS key. Switch them to the `VoterWithBLS` form via a shared `voter_with_bls` helper
that generates a BLS pubkey and proof-of-possession. `vote_authorize_checked` additionally
used an uninitialized `VoteStateV3`-sized account; give it a proper initialized V4 account
whose authority matches the signer.

#### Testing

`process_vote` (nightly libtest harness):

```
cargo +nightly-2026-05-22 bench -p solana-vote-program --bench process_vote

running 3 tests
test bench_process_tower_sync        ... bench:       4,822.85 ns/iter (+/- 72.31)
test bench_process_vote              ... bench:       4,114.84 ns/iter (+/- 489.05)
test bench_process_vote_state_update ... bench:       5,264.01 ns/iter (+/- 344.90)

test result: ok. 3 measured; 0 filtered out
```

`vote_instructions` (criterion; `--test` runs each bench once and fails on panic):

```
cargo bench -p solana-vote-program --bench vote_instructions -- --test

# all 16 benches report "Success"