### PR TITLE
ci: broaden clippy checks

### DIFF
--- a/ci/feature-check/test-feature-non-root-workspaces.sh
+++ b/ci/feature-check/test-feature-non-root-workspaces.sh
@@ -14,5 +14,18 @@ fi
 # shellcheck source=ci/rust-version.sh
 source "$here"/../rust-version.sh nightly
 
-cargo +"$rust_nightly" hack --manifest-path "$here/../../dev-bins/Cargo.toml" check --all-targets
-cargo +"$rust_nightly" hack --manifest-path "$here/../../dev-bins/Cargo.toml" check --all-targets --all-features
+export RUSTFLAGS="-D warnings"
+
+manifest_paths=(
+	"$here/../../dev-bins/Cargo.toml"
+	"$here/../../ci/xtask/Cargo.toml"
+	"$here/../../programs/sbf/Cargo.toml"
+)
+
+for manifest_path in "${manifest_paths[@]}"; do
+	cargo +"$rust_nightly" hack clippy \
+		--manifest-path "$manifest_path" \
+		--each-feature \
+		--exclude-all-features \
+		--all-targets
+done

--- a/ci/feature-check/test-feature.sh
+++ b/ci/feature-check/test-feature.sh
@@ -24,7 +24,7 @@ exclude_features=(
 
 export RUSTFLAGS="-D warnings"
 
-cargo +"$rust_nightly" hack check \
+cargo +"$rust_nightly" hack clippy \
 	--each-feature \
 	--exclude-features "$(IFS=,; echo "${exclude_features[*]}")" \
 	--exclude-all-features \

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -52,8 +52,6 @@ fi
 
 _ scripts/check-msrv.sh
 
-_ scripts/cargo-clippy.sh
-
 _ ci/do-audit.sh
 
 if [[ -n $CI ]] && [[ $CHANNEL = "stable" ]]; then

--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -439,9 +439,10 @@ fn default_feature_check_step(parallel: u64) -> buildkite::Step {
     group
         .steps
         .push(buildkite::Step::Command(buildkite::CommandStep {
-            name: String::from("feature-check-dev-bins"),
+            name: String::from("feature-check-non-root-workspaces"),
             command: String::from(
-                "ci/docker-run-default-image.sh ci/feature-check/test-feature-dev-bins.sh",
+                "ci/docker-run-default-image.sh \
+                 ci/feature-check/test-feature-non-root-workspaces.sh",
             ),
             agents: Some(queue_agents()),
             timeout_in_minutes: Some(20),


### PR DESCRIPTION
#### Problem

we've already been running `cargo check` across many different features. we could use `cargo clippy` instead, so we don't have to worry about adding new features to `dummy-for-ci-check` every time one is introduced.


#### Summary of Changes

update it