### PR TITLE
rust: Bump nightly to 2026-05-23

### DIFF
--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-05-22
+  nightly_version=2026-05-23
 fi
 
 


### PR DESCRIPTION
#### Problem

As outlined in #14010, we need to bump the nightly version used by the repo so that the version is greater than 1.97.0. However, as discussed in #14013, we should aim to keep the nightly version close to the stable version.

#### Summary of changes

Just bump the nightly version to 2026-05-23 so that the version reported is 1.98.0. No other changes are necessary.

#### Testing

Run clippy and rustfmt.

Note: this will need another new docker image for CI