### PR TITLE
clippy: Update fetch_update -> try_update

### DIFF
--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -397,7 +397,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     // is perhaps being flushed by another thread already.
     pub fn next_bucket_to_flush(&self) -> usize {
         self.next_bucket_to_flush
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |bucket| {
                 Some((bucket + 1) % self.bins)
             })
             .unwrap()

--- a/net-utils/src/token_bucket.rs
+++ b/net-utils/src/token_bucket.rs
@@ -77,7 +77,7 @@ impl TokenBucket {
     pub fn consume_tokens(&self, request_size: u64) -> Result<u64, u64> {
         let now = self.time_us();
         self.update_state(now);
-        match self.tokens.fetch_update(
+        match self.tokens.try_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
             |tokens| {
@@ -105,7 +105,7 @@ impl TokenBucket {
         let now = self.time_us();
         self.update_state(now);
         let mut consumed = 0u64;
-        let _ = self.tokens.fetch_update(
+        let _ = self.tokens.try_update(
             Ordering::AcqRel,  // winner publishes new amount
             Ordering::Acquire, // everyone observed correct number
             |tokens| {
@@ -119,7 +119,7 @@ impl TokenBucket {
     /// Adds given amount of tokens, up to a maximum of self.max_tokens.
     #[inline]
     pub fn add_tokens(&self, new_tokens: u64) {
-        let _ = self.tokens.fetch_update(
+        let _ = self.tokens.try_update(
             Ordering::AcqRel,  // writer publishes new amount
             Ordering::Acquire, //we fetch the correct amount
             |tokens| Some(tokens.saturating_add(new_tokens).min(self.max_tokens)),
@@ -318,7 +318,7 @@ where
         if entry_added {
             if let Ok(count) =
                 self.countdown_to_shrink
-                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                    .try_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
                         if v == 0 {
                             // reset the countup to starting position
                             // thus preventing other threads from racing for locks

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -43,7 +43,7 @@ impl ProgramStatistics {
     fn observe_ema<const WINDOW_SIZE: u64>(counter: &AtomicU64, duration_us: u64) {
         let duration_ema = duration_us.saturating_mul(EMA_SCALE);
         counter
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |ema| {
                 // Exponential moving average iteratively is computed as $ema' = alpha *
                 // observation + (1 - alpha) * ema$. This works great for floating point, but we
                 // want integers. For purposes of convenience we also want to really think in terms

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -602,7 +602,7 @@ impl SubscriberCountGuard {
         let max = control.max_active_subscriptions;
         control
             .subscriber_count
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            .try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 (current < max).then_some(current + 1)
             })
             .ok()?;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4265,7 +4265,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_on_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_on_chain| {
                 Some(accounts_data_size_delta_on_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`
@@ -4280,7 +4280,7 @@ impl Bank {
         }
 
         self.accounts_data_size_delta_off_chain
-            .fetch_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
+            .try_update(AcqRel, Acquire, |accounts_data_size_delta_off_chain| {
                 Some(accounts_data_size_delta_off_chain.saturating_add(amount))
             })
             // SAFETY: unwrap() is safe since our update fn always returns `Some`


### PR DESCRIPTION
#### Problem

The `fetch_update` function has been deprecated in favor of `try_update`. More info at
[`fetch_update`](https://doc.rust-lang.org/std/sync/atomic/struct.Atomic.html#method.fetch_update-6).

#### Summary of changes

Use `try_update` instead.

#### Testing

Run clippy and rustfmt.