### PR TITLE
clippy: Use `as_chunks` instead of `chunks_exact`

### DIFF
--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -468,11 +468,11 @@ impl TestValidatorGenesis {
                             return Err(format!("Invalid alt account data length for {address}"));
                         }
 
-                        for address_slice in
-                            raw_addresses_data.chunks_exact(std::mem::size_of::<Pubkey>())
+                        for address_array in raw_addresses_data
+                            .as_chunks::<{ std::mem::size_of::<Pubkey>() }>()
+                            .0
                         {
-                            // safe because size was checked earlier
-                            let address = Pubkey::try_from(address_slice).unwrap();
+                            let address = Pubkey::from(*address_array);
                             alt_entries.push(address);
                         }
                         self.add_account(*address, AccountSharedData::from(account));

--- a/transaction-context/src/instruction_accounts.rs
+++ b/transaction-context/src/instruction_accounts.rs
@@ -373,11 +373,10 @@ impl BorrowedInstructionAccount<'_, '_> {
 fn is_zeroed(buf: &[u8]) -> bool {
     const ZEROS_LEN: usize = 1024;
     const ZEROS: [u8; ZEROS_LEN] = [0; ZEROS_LEN];
-    let mut chunks = buf.chunks_exact(ZEROS_LEN);
+    let (chunks, remainder) = buf.as_chunks::<ZEROS_LEN>();
 
     #[expect(clippy::indexing_slicing)]
     {
-        chunks.all(|chunk| chunk == &ZEROS[..])
-            && chunks.remainder() == &ZEROS[..chunks.remainder().len()]
+        chunks.iter().all(|chunk| chunk == &ZEROS[..]) && remainder == &ZEROS[..remainder.len()]
     }
 }


### PR DESCRIPTION
#### Problem

In two places, we use `chunks_exact` with a const parameter, but a future clippy lint will report an error and encourage using `as_chunks` instead.

#### Summary of changes

Use `as_chunks` where future clippy reported an error.

#### Testing

Clippy / rustfmt / check.