### PR TITLE
Remove expected dead slot

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2154,13 +2154,16 @@ impl AccountsDb {
             self.purge_keys_exact(pubkey_to_slot_set);
 
         if !reclaims.is_empty() {
-            self.handle_reclaims(
+            let expected_dead_slots: IntSet<_> = reclaims.iter().map(|(slot, _)| *slot).collect();
+            let dead_slots = self.handle_reclaims(
                 reclaims.iter(),
                 None,
                 &pubkeys_removed_from_accounts_index,
                 &self.clean_accounts_stats.purge_stats,
                 MarkAccountsObsolete::No,
             );
+            // Every slot with accounts reclaimed should be marked dead
+            assert_eq!(expected_dead_slots, dead_slots);
         }
 
         reclaims_time.stop();
@@ -2339,7 +2342,8 @@ impl AccountsDb {
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         purge_stats: &PurgeStats,
         mark_accounts_obsolete: MarkAccountsObsolete,
-    ) where
+    ) -> IntSet<Slot>
+    where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
         let dead_slots =
@@ -2360,6 +2364,7 @@ impl AccountsDb {
             pubkeys_removed_from_accounts_index,
             clean_stored_dead_slots,
         );
+        dead_slots
     }
 
     /// During clean, some zero-lamport accounts that are marked for purge should *not* actually
@@ -4298,13 +4303,15 @@ impl AccountsDb {
         // There is no reason to mark accounts obsolete as the slot storage is being purged
         let expected_dead_slot = Some(remove_slot);
         if !reclaims.is_empty() {
-            self.handle_reclaims(
+            let dead_slots = self.handle_reclaims(
                 reclaims.iter(),
                 expected_dead_slot,
                 &pubkeys_removed_from_accounts_index,
                 purge_stats,
                 MarkAccountsObsolete::No,
             );
+            // Ensure the expected slot is marked dead
+            assert_eq!(dead_slots, IntSet::from_iter(std::iter::once(remove_slot)));
         }
         handle_reclaims_elapsed.stop();
         purge_stats

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1248,7 +1248,6 @@ impl AccountsDb {
                     .for_each(|(reclaimed_item, newest_slot)| {
                         self.handle_reclaims(
                             iter::once(reclaimed_item),
-                            None,
                             &HashSet::new(),
                             &self.clean_accounts_stats.purge_stats,
                             MarkAccountsObsolete::Yes(*newest_slot),
@@ -2157,7 +2156,6 @@ impl AccountsDb {
             let expected_dead_slots: IntSet<_> = reclaims.iter().map(|(slot, _)| *slot).collect();
             let dead_slots = self.handle_reclaims(
                 reclaims.iter(),
-                None,
                 &pubkeys_removed_from_accounts_index,
                 &self.clean_accounts_stats.purge_stats,
                 MarkAccountsObsolete::No,
@@ -2315,11 +2313,6 @@ impl AccountsDb {
     /// * `reclaims` - The accounts to remove from storage entries' "count". Note here
     ///   that we should not remove cache entries, only entries for accounts actually
     ///   stored in a storage entry.
-    /// * `expected_single_dead_slot` - A correctness assertion. If this is equal to `Some(S)`,
-    ///   then the function will check that the only slot being cleaned up in `reclaims`
-    ///   is the slot == `S`. This is true for instance when `handle_reclaims` is called
-    ///   from store or slot shrinking, as those should only touch the slot they are
-    ///   currently storing to or shrinking.
     /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the
     ///   accounts index and should not be unref'd. If they exist in the accounts index,
     ///   they are NEW.
@@ -2338,7 +2331,6 @@ impl AccountsDb {
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: I,
-        expected_single_dead_slot: Option<Slot>,
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         purge_stats: &PurgeStats,
         mark_accounts_obsolete: MarkAccountsObsolete,
@@ -2346,14 +2338,8 @@ impl AccountsDb {
     where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
-        let dead_slots =
-            self.remove_dead_accounts(reclaims, expected_single_dead_slot, mark_accounts_obsolete);
-        if let Some(expected_single_dead_slot) = expected_single_dead_slot {
-            assert!(dead_slots.len() <= 1);
-            if dead_slots.len() == 1 {
-                assert!(dead_slots.contains(&expected_single_dead_slot));
-            }
-        }
+        let dead_slots = self.remove_dead_accounts(reclaims, mark_accounts_obsolete);
+
         // if we are marking accounts obsolete, then any dead slots have already been cleaned
         let clean_stored_dead_slots =
             !matches!(mark_accounts_obsolete, MarkAccountsObsolete::Yes(_));
@@ -4299,13 +4285,10 @@ impl AccountsDb {
         // `handle_reclaims()` should remove all the account index entries and
         // storage entries
         let mut handle_reclaims_elapsed = Measure::start("handle_reclaims_elapsed");
-        // Slot should be dead after removing all its account entries
         // There is no reason to mark accounts obsolete as the slot storage is being purged
-        let expected_dead_slot = Some(remove_slot);
         if !reclaims.is_empty() {
             let dead_slots = self.handle_reclaims(
                 reclaims.iter(),
-                expected_dead_slot,
                 &pubkeys_removed_from_accounts_index,
                 purge_stats,
                 MarkAccountsObsolete::No,
@@ -5303,7 +5286,6 @@ impl AccountsDb {
     fn remove_dead_accounts<'a, I>(
         &'a self,
         reclaims: I,
-        expected_slot: Option<Slot>,
         mark_accounts_obsolete: MarkAccountsObsolete,
     ) -> IntSet<Slot>
     where
@@ -5321,10 +5303,6 @@ impl AccountsDb {
                 .entry(*slot)
                 .or_default()
                 .insert(account_info.offset());
-        }
-        if let Some(expected_slot) = expected_slot {
-            assert_eq!(reclaimed_offsets.len(), 1);
-            assert!(reclaimed_offsets.contains_key(&expected_slot));
         }
 
         self.clean_accounts_stats
@@ -5736,7 +5714,6 @@ impl AccountsDb {
             let purge_stats = PurgeStats::default();
             self.handle_reclaims(
                 reclaims.iter().flatten(),
-                None,
                 &HashSet::default(),
                 &purge_stats,
                 MarkAccountsObsolete::Yes(slot),
@@ -6594,7 +6571,6 @@ impl AccountsDb {
                 if !reclaims.is_empty() {
                     self.handle_reclaims(
                         reclaims.iter(),
-                        None,
                         &HashSet::new(),
                         &stats,
                         MarkAccountsObsolete::Yes(slot_marked_obsolete),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2328,6 +2328,8 @@ impl AccountsDb {
     ///   determine the state of the account at a specified slot. This should only be done if the
     ///   account is already unrefed and removed from the accounts index
     ///   It must be unrefed and removed to avoid double counting or missed counting in shrink
+    ///
+    /// Returns the set of dead slots that were removed from storage as a result of this call.
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: I,
@@ -4294,7 +4296,7 @@ impl AccountsDb {
                 MarkAccountsObsolete::No,
             );
             // Ensure the expected slot is marked dead
-            assert_eq!(dead_slots, IntSet::from_iter(std::iter::once(remove_slot)));
+            assert_eq!(dead_slots, IntSet::from_iter(iter::once(remove_slot)));
         }
         handle_reclaims_elapsed.stop();
         purge_stats

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1558,11 +1558,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
             .accounts_index
             .get_with_and_then(&pubkey, &ancestors, false, |account_info| account_info)
             .unwrap();
-        accounts_db.remove_dead_accounts(
-            [account_info].iter(),
-            None,
-            MarkAccountsObsolete::Yes(slot1),
-        );
+        accounts_db.remove_dead_accounts([account_info].iter(), MarkAccountsObsolete::Yes(slot1));
     }
 
     accounts_db.shrink_slot_forced(slot1);
@@ -4291,11 +4287,7 @@ fn test_alive_bytes() {
             assert_eq!(account_info.0, slot);
             let reclaims = [account_info];
             num_obsolete_accounts += reclaims.len();
-            accounts_db.remove_dead_accounts(
-                reclaims.iter(),
-                None,
-                MarkAccountsObsolete::Yes(slot),
-            );
+            accounts_db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot));
             let after_size = storage0.alive_bytes();
             if storage0.count() == 0 {
                 // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
@@ -6610,11 +6602,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
             // Lookup the pubkey in the database and find the AccountInfo
             db.accounts_index
                 .get_with_and_then(pubkey, &ancestors, false, |account_info| {
-                    db.remove_dead_accounts(
-                        [account_info].iter(),
-                        None,
-                        MarkAccountsObsolete::Yes(slot),
-                    );
+                    db.remove_dead_accounts([account_info].iter(), MarkAccountsObsolete::Yes(slot));
                 });
 
             obsolete_pubkeys.push(*pubkey);


### PR DESCRIPTION
#### Problem
Expected dead slot is currently only used on devtooling, and similar asserts can be done on the caller side. 

#### Summary of Changes
- Modify handle_reclaims to return dead_slots and assert on caller side that dead_slots has the expected data
- Remove expected dead_slots and internal asserts. 

#### Testing


Fixes #
