### PR TITLE
Refactor handle reclaims

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -623,7 +623,6 @@ pub type AccountsFileId = u32;
 
 type AccountSlots = HashMap<Pubkey, IntSet<Slot>>;
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
-type ReclaimResult = (AccountSlots, SlotOffsets);
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;
 
@@ -2344,10 +2343,8 @@ impl AccountsDb {
     ) where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
-        let mut reclaim_result = ReclaimResult::default();
-        let (dead_slots, reclaimed_offsets) =
+        let dead_slots =
             self.remove_dead_accounts(reclaims, expected_single_dead_slot, mark_accounts_obsolete);
-        reclaim_result.1 = reclaimed_offsets;
         if let Some(expected_single_dead_slot) = expected_single_dead_slot {
             assert!(dead_slots.len() <= 1);
             if dead_slots.len() == 1 {
@@ -5301,13 +5298,13 @@ impl AccountsDb {
         }
     }
 
-    /// returns (dead slots, reclaimed_offsets)
+    /// returns the dead slots
     fn remove_dead_accounts<'a, I>(
         &'a self,
         reclaims: I,
         expected_slot: Option<Slot>,
         mark_accounts_obsolete: MarkAccountsObsolete,
-    ) -> (IntSet<Slot>, SlotOffsets)
+    ) -> IntSet<Slot>
     where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
@@ -5333,15 +5330,15 @@ impl AccountsDb {
             .slots_cleaned
             .fetch_add(reclaimed_offsets.len() as u64, Ordering::Relaxed);
 
-        reclaimed_offsets.iter().for_each(|(slot, offsets)| {
-            if let Some(store) = self.storage.get_slot_storage_entry(*slot) {
+        reclaimed_offsets.into_iter().for_each(|(slot, offsets)| {
+            if let Some(store) = self.storage.get_slot_storage_entry(slot) {
                 assert_eq!(
-                    *slot,
+                    slot,
                     store.slot(),
                     "AccountsDB::accounts_index corrupted. Storage pointed to: {}, expected: {}, \
                      should only point to one slot",
                     store.slot(),
-                    *slot
+                    slot
                 );
 
                 let remaining_accounts = if offsets.len() == store.count() {
@@ -5384,8 +5381,8 @@ impl AccountsDb {
                 // This may be different from the check above as this
                 // can be multithreaded
                 if remaining_accounts == 0 {
-                    self.dirty_stores.insert(*slot, store);
-                    dead_slots.insert(*slot);
+                    self.dirty_stores.insert(slot, store);
+                    dead_slots.insert(slot);
                 } else if self.is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
                 {
@@ -5393,7 +5390,7 @@ impl AccountsDb {
                     // should be a sufficient indication that the slot is ready to be shrunk
                     // because slots should only have one storage entry, namely the one that was
                     // created by `flush_slot_cache()`.
-                    new_shrink_candidates.insert(*slot);
+                    new_shrink_candidates.insert(slot);
                 };
             }
         });
@@ -5422,7 +5419,7 @@ impl AccountsDb {
             true
         });
 
-        (dead_slots, reclaimed_offsets)
+        dead_slots
     }
 
     /// lookup each pubkey in 'pubkeys' and unref it in the accounts index

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -621,7 +621,6 @@ impl IsZeroLamport for Account {
 pub type AtomicAccountsFileId = AtomicU32;
 pub type AccountsFileId = u32;
 
-type AccountSlots = HashMap<Pubkey, IntSet<Slot>>;
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
 type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;
@@ -2464,15 +2463,10 @@ impl AccountsDb {
         if dead_slots.is_empty() {
             return;
         }
-        let purged_account_slots = Some(&mut AccountSlots::new());
         let mut clean_dead_slots = Measure::start("reclaims::clean_dead_slots");
 
         if clean_stored_dead_slots {
-            self.clean_stored_dead_slots(
-                dead_slots,
-                purged_account_slots,
-                pubkeys_removed_from_accounts_index,
-            );
+            self.clean_stored_dead_slots(dead_slots, pubkeys_removed_from_accounts_index);
         }
 
         clean_dead_slots.stop();
@@ -5466,13 +5460,11 @@ impl AccountsDb {
     }
 
     /// lookup each pubkey in 'purged_slot_pubkeys' and unref it in the accounts index
-    /// populate 'purged_stored_account_slots' by grouping 'purged_slot_pubkeys' by pubkey
     /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
     ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
     fn unref_accounts(
         &self,
         purged_slot_pubkeys: HashSet<(Slot, Pubkey)>,
-        purged_stored_account_slots: &mut AccountSlots,
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
     ) {
         self.unref_pubkeys(
@@ -5480,12 +5472,6 @@ impl AccountsDb {
             purged_slot_pubkeys.len(),
             pubkeys_removed_from_accounts_index,
         );
-        for (slot, pubkey) in purged_slot_pubkeys {
-            purged_stored_account_slots
-                .entry(pubkey)
-                .or_default()
-                .insert(slot);
-        }
     }
 
     /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
@@ -5493,7 +5479,6 @@ impl AccountsDb {
     fn clean_stored_dead_slots(
         &self,
         dead_slots: &IntSet<Slot>,
-        purged_account_slots: Option<&mut AccountSlots>,
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
     ) {
         let mut measure = Measure::start("clean_stored_dead_slots-ms");
@@ -5541,13 +5526,7 @@ impl AccountsDb {
         //Unref the accounts from storage
         let mut measure_unref = Measure::start("unref_from_storage");
 
-        if let Some(purged_account_slots) = purged_account_slots {
-            self.unref_accounts(
-                purged_slot_pubkeys,
-                purged_account_slots,
-                pubkeys_removed_from_accounts_index,
-            );
-        }
+        self.unref_accounts(purged_slot_pubkeys, pubkeys_removed_from_accounts_index);
         measure_unref.stop();
         self.clean_accounts_stats
             .clean_unref_from_storage_us

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2360,7 +2360,6 @@ impl AccountsDb {
 
         self.process_dead_slots(
             &dead_slots,
-            Some(&mut reclaim_result.0),
             purge_stats,
             pubkeys_removed_from_accounts_index,
             clean_stored_dead_slots,
@@ -2461,7 +2460,6 @@ impl AccountsDb {
     fn process_dead_slots(
         &self,
         dead_slots: &IntSet<Slot>,
-        purged_account_slots: Option<&mut AccountSlots>,
         purge_stats: &PurgeStats,
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         clean_stored_dead_slots: bool,
@@ -2469,6 +2467,7 @@ impl AccountsDb {
         if dead_slots.is_empty() {
             return;
         }
+        let purged_account_slots = Some(&mut AccountSlots::new());
         let mut clean_dead_slots = Measure::start("reclaims::clean_dead_slots");
 
         if clean_stored_dead_slots {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1248,16 +1248,13 @@ impl AccountsDb {
                 reclaims
                     .par_iter()
                     .for_each(|(reclaimed_item, newest_slot)| {
-                        let (purged_account_slots, _reclaimed_offsets) = self.handle_reclaims(
+                        self.handle_reclaims(
                             iter::once(reclaimed_item),
                             None,
                             &HashSet::new(),
                             &self.clean_accounts_stats.purge_stats,
                             MarkAccountsObsolete::Yes(*newest_slot),
                         );
-                        // Marking the reclaims obsolete skips dead-slot handling in
-                        // handle_reclaims, so no whole slots are purged here.
-                        assert!(purged_account_slots.is_empty());
                     });
             });
         });
@@ -2344,8 +2341,7 @@ impl AccountsDb {
         pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         purge_stats: &PurgeStats,
         mark_accounts_obsolete: MarkAccountsObsolete,
-    ) -> ReclaimResult
-    where
+    ) where
         I: Iterator<Item = &'a (Slot, AccountInfo)>,
     {
         let mut reclaim_result = ReclaimResult::default();
@@ -2369,7 +2365,6 @@ impl AccountsDb {
             pubkeys_removed_from_accounts_index,
             clean_stored_dead_slots,
         );
-        reclaim_result
     }
 
     /// During clean, some zero-lamport accounts that are marked for purge should *not* actually

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -2822,7 +2822,7 @@ fn test_clean_stored_dead_slots_empty() {
     let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let mut dead_slots = IntSet::default();
     dead_slots.insert(10);
-    accounts.clean_stored_dead_slots(&dead_slots, None, &HashSet::default());
+    accounts.clean_stored_dead_slots(&dead_slots, &HashSet::default());
 }
 
 #[test]
@@ -5954,16 +5954,7 @@ fn test_unref_pubkeys_removed_from_accounts_index() {
             UpsertReclaim::IgnoreReclaims,
         );
 
-        let mut purged_stored_account_slots = AccountSlots::default();
-        db.unref_accounts(
-            purged_slot_pubkeys,
-            &mut purged_stored_account_slots,
-            &pubkeys_removed_from_accounts_index,
-        );
-        assert_eq!(
-            vec![(pk1, vec![slot1].into_iter().collect::<IntSet<_>>())],
-            purged_stored_account_slots.into_iter().collect::<Vec<_>>()
-        );
+        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
         let expected = RefCount::from(already_removed);
         assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), expected);
     }
@@ -5975,14 +5966,8 @@ fn test_unref_accounts() {
 
     {
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-        let mut purged_stored_account_slots = AccountSlots::default();
 
-        db.unref_accounts(
-            HashSet::default(),
-            &mut purged_stored_account_slots,
-            &pubkeys_removed_from_accounts_index,
-        );
-        assert!(purged_stored_account_slots.is_empty());
+        db.unref_accounts(HashSet::default(), &pubkeys_removed_from_accounts_index);
     }
 
     let slot1 = 1;
@@ -6004,21 +5989,11 @@ fn test_unref_accounts() {
             UpsertReclaim::IgnoreReclaims,
         );
 
-        let mut purged_stored_account_slots = AccountSlots::default();
-        db.unref_accounts(
-            purged_slot_pubkeys,
-            &mut purged_stored_account_slots,
-            &pubkeys_removed_from_accounts_index,
-        );
-        assert_eq!(
-            vec![(pk1, vec![slot1].into_iter().collect::<IntSet<_>>())],
-            purged_stored_account_slots.into_iter().collect::<Vec<_>>()
-        );
+        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
         assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
     }
     {
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-        let mut purged_stored_account_slots = AccountSlots::default();
         let mut purged_slot_pubkeys = HashSet::default();
         let mut reclaims = ReclaimsSlotList::default();
         // pk1 and pk2 both in slot1 and slot2, so each has refcount of 2
@@ -6039,16 +6014,7 @@ fn test_unref_accounts() {
         purges.into_iter().for_each(|(slot, pk)| {
             purged_slot_pubkeys.insert((slot, pk));
         });
-        db.unref_accounts(
-            purged_slot_pubkeys,
-            &mut purged_stored_account_slots,
-            &pubkeys_removed_from_accounts_index,
-        );
-        for (pk, slots) in [(pk1, vec![slot1, slot2]), (pk2, vec![slot1])] {
-            let result = purged_stored_account_slots.remove(&pk).unwrap();
-            assert_eq!(result, slots.into_iter().collect::<IntSet<_>>());
-        }
-        assert!(purged_stored_account_slots.is_empty());
+        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
         assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
         assert_eq!(db.accounts_index.ref_count_from_storage(&pk2), 1);
     }
@@ -6057,7 +6023,6 @@ fn test_unref_accounts() {
 #[test]
 fn test_many_unrefs() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let mut purged_stored_account_slots = AccountSlots::default();
     let mut reclaims = ReclaimsSlotList::default();
     let pk1 = Pubkey::from([1; 32]);
     // make sure we have > 1 batch. Bigger numbers cost more in test time here.
@@ -6082,11 +6047,7 @@ fn test_many_unrefs() {
         n as RefCount,
     );
     // unref all 'n' slots
-    db.unref_accounts(
-        purged_slot_pubkeys,
-        &mut purged_stored_account_slots,
-        &HashSet::default(),
-    );
+    db.unref_accounts(purged_slot_pubkeys, &HashSet::default());
     assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
 }
 


### PR DESCRIPTION
#### Problem
handle_reclaims return value is effectively unused. 

#### Summary of Changes
Remove it. Easier to look at commit by commit

List of commits
1. Removed the return value from handle_reclaims. 
- It is only used in one location, and in that location it is guaranteed.
The call site passes in MarkAccountsObsolete::Yes. This results in clean_stored_dead_slots = false which ensures purged_account_slots is never populated. So it is asserting that a data structure that is not touched on the flow, is still empty. 
2. Since purged_account_slots is no longer returned, it can be moved to process_dead_slots instead
3. Since ReclaimResults is just used to store a value that is never used, remove it as well. This also modifies the return value from remove_dead_accounts, and changes it into an into_iter internally (as reclaimed_offsets is no longer returned).
4. Remove purged_account_slots since it is unused
 
#### Testing
CI 

Fixes #
