### PR TITLE
monitor: move VAT status line to top of progress bar

### DIFF
--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -190,9 +190,10 @@ impl Dashboard {
                         let vat_status_formatted = format_vat_status(vat_status.as_ref());
 
                         progress_bar.set_message(format!(
-                            "{}{}| Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: {} | \
-                             Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
-                             Transactions: {} | {}\n{}",
+                            "{}\n{}{}| Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: \
+                             {} | Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
+                             Transactions: {} | {}",
+                            vat_status_formatted,
                             uptime,
                             if health == "ok" {
                                 "".to_string()
@@ -214,7 +215,6 @@ impl Dashboard {
                                 .unwrap_or_else(|| '-'.to_string()),
                             transaction_count,
                             identity_balance,
-                            vat_status_formatted,
                         ));
                         thread::sleep(refresh_interval);
                     }


### PR DESCRIPTION
#### Problem
It was asked to move the VAT status line of the progress bar above slot info for readability

#### Summary of Changes

The new monitor progress bar looks like:
```
VAT: epoch 3 in (stake: 0.000000042 SOL), epoch 5: eligible if staked
00:00:01 | Processed Slot: 10 | Confirmed Slot: 9 | Finalized Slot: 8 | Full Snapshot Slot: 7 | Incremental Snapshot Slot: 6 | Transactions: 5 | 0.000000004 SOL
```