### PR TITLE
ci(xtask): add CI_QUEUE override for pipeline steps

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -73,10 +73,7 @@ fn generate_private_pipeline() -> Result<buildkite::Pipeline> {
     pipeline.add_step(buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("sanity"),
         command: String::from("ci/test-sanity.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(5),
         ..Default::default()
     }));
@@ -373,14 +370,16 @@ fn generate_full_pipeline() -> Result<buildkite::Pipeline> {
     Ok(pipeline)
 }
 
+fn queue_agents() -> HashMap<String, String> {
+    let queue = env::var("CI_QUEUE").unwrap_or_else(|_| String::from("default"));
+    HashMap::from([(String::from("queue"), queue)])
+}
+
 fn default_sanity_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("sanity"),
         command: String::from("ci/docker-run-default-image.sh ci/test-sanity.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(5),
         ..Default::default()
     })
@@ -390,10 +389,7 @@ fn default_channel_info_divergence_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("channel-info-divergence"),
         command: String::from("ci/docker-run-default-image.sh ci/test-channel-info-divergence.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(10),
         soft_fail: Some(true),
         ..Default::default()
@@ -404,10 +400,7 @@ fn default_shellcheck_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("shellcheck"),
         command: String::from("ci/shellcheck.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(5),
         ..Default::default()
     })
@@ -417,10 +410,7 @@ fn default_checks_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("check"),
         command: String::from("ci/docker-run-default-image.sh ci/test-checks.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(20),
         ..Default::default()
     })
@@ -441,10 +431,7 @@ fn default_feature_check_step(parallel: u64) -> buildkite::Step {
                     "ci/docker-run-default-image.sh ci/feature-check/test-feature.sh \
                      {i}/{parallel}"
                 ),
-                agents: Some(HashMap::from([(
-                    String::from("queue"),
-                    String::from("default"),
-                )])),
+                agents: Some(queue_agents()),
                 timeout_in_minutes: Some(20),
                 ..Default::default()
             }));
@@ -457,10 +444,7 @@ fn default_feature_check_step(parallel: u64) -> buildkite::Step {
             command: String::from(
                 "ci/docker-run-default-image.sh ci/feature-check/test-feature-dev-bins.sh",
             ),
-            agents: Some(HashMap::from([(
-                String::from("queue"),
-                String::from("default"),
-            )])),
+            agents: Some(queue_agents()),
             timeout_in_minutes: Some(20),
             ..Default::default()
         }));
@@ -472,10 +456,7 @@ fn default_miri_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("miri"),
         command: String::from("ci/docker-run-default-image.sh ci/test-miri.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(5),
         ..Default::default()
     })
@@ -485,10 +466,7 @@ fn default_frozen_abi_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("frozen-abi"),
         command: String::from("ci/docker-run-default-image.sh ci/test-frozen-abi.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(30),
         ..Default::default()
     })
@@ -508,10 +486,7 @@ fn default_stable_step(parallel: u64) -> buildkite::Step {
                 command: format!(
                     "ci/docker-run-default-image.sh ci/stable/run-partition.sh {i} {parallel}"
                 ),
-                agents: Some(HashMap::from([(
-                    String::from("queue"),
-                    String::from("default"),
-                )])),
+                agents: Some(queue_agents()),
                 timeout_in_minutes: Some(25),
                 retry: Some(HashMap::from([(
                     String::from("automatic"),
@@ -529,10 +504,7 @@ fn default_stable_step(parallel: u64) -> buildkite::Step {
                 "ci/docker-run-default-image.sh cargo nextest run --profile ci --manifest-path \
                  ./dev-bins/Cargo.toml",
             ),
-            agents: Some(HashMap::from([(
-                String::from("queue"),
-                String::from("default"),
-            )])),
+            agents: Some(queue_agents()),
             timeout_in_minutes: Some(35),
             ..Default::default()
         }));
@@ -554,10 +526,7 @@ fn default_local_cluster_step(parallel: u64) -> buildkite::Step {
                     "ci/docker-run-default-image.sh ci/stable/run-local-cluster-partially.sh {i} \
                      {parallel}"
                 ),
-                agents: Some(HashMap::from([(
-                    String::from("queue"),
-                    String::from("default"),
-                )])),
+                agents: Some(queue_agents()),
                 timeout_in_minutes: Some(15),
                 retry: Some(HashMap::from([(
                     String::from("automatic"),
@@ -573,10 +542,7 @@ fn default_docs_check_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("doctest"),
         command: String::from("ci/docker-run-default-image.sh ci/test-docs.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(15),
         ..Default::default()
     })
@@ -586,10 +552,7 @@ fn default_localnet_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("localnet"),
         command: String::from("ci/docker-run-default-image.sh ci/stable/run-localnet.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(30),
         ..Default::default()
     })
@@ -599,10 +562,7 @@ fn default_xdp_test_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("xdp-test"),
         command: String::from("ci/docker-run-default-image.sh ci/test-xdp.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(25),
         env: Some(HashMap::from([
             (
@@ -625,10 +585,7 @@ fn default_stable_sbf_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("stable-sbf"),
         command: String::from("ci/docker-run-default-image.sh ci/test-stable-sbf.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(35),
         ..Default::default()
     })
@@ -638,10 +595,7 @@ fn default_shuttle_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("shuttle"),
         command: String::from("ci/docker-run-default-image.sh ci/test-shuttle.sh"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(10),
         ..Default::default()
     })
@@ -659,10 +613,7 @@ fn default_coverage_step(parallel: u64) -> buildkite::Step {
             .push(buildkite::Step::Command(buildkite::CommandStep {
                 name: format!("coverage-{i}"),
                 command: format!("ci/docker-run-default-image.sh ci/coverage/part-{i}.sh"),
-                agents: Some(HashMap::from([(
-                    String::from("queue"),
-                    String::from("default"),
-                )])),
+                agents: Some(queue_agents()),
                 timeout_in_minutes: Some(60),
                 env: Some(HashMap::from([(
                     String::from("FETCH_CODECOV_ENVS"),
@@ -679,10 +630,7 @@ fn default_crate_publish_test_step() -> buildkite::Step {
     buildkite::Step::Command(buildkite::CommandStep {
         name: String::from("crate-publish-test"),
         command: String::from("cargo xtask publish test"),
-        agents: Some(HashMap::from([(
-            String::from("queue"),
-            String::from("default"),
-        )])),
+        agents: Some(queue_agents()),
         timeout_in_minutes: Some(45),
         ..Default::default()
     })


### PR DESCRIPTION
#### Problem
Every generated pipeline step hard-codes `queue: default`, pinning an
entire agave build to the default host group.

#### Change
Add a `CI_QUEUE` env override, read at pipeline-generation time, that
routes all steps to another queue. Unset keeps `default`, so there is
no behaviour change until a build opts in.

Enables the multi-job-per-host work (#13899) to drive an isolated
canary queue without diverting real PR CI.