### PR TITLE
Adds a manager thread for the async accounts lt hash updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10285,6 +10285,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "crossbeam-channel",
+ "crossbeam-queue",
  "crossbeam-utils",
  "dashmap",
  "imbl",

--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -364,6 +364,7 @@ pub(super) fn mark_replay_dead_slot(
     progress: &mut ProgressMap,
     dead_slot_context: &mut DeadSlotContext<'_>,
 ) {
+    bank.clear_accounts_lt_hash_async_progress_is_at_end();
     if let Some(reason) = soft_dead_reason(
         dead_slot_context.notifications.blockstore.as_ref(),
         bank,

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -346,6 +346,7 @@ pub(super) fn handle_abandoned_bank(
     purge_repair_slot_counter: &mut PurgeRepairSlotCounter,
     tbft_structs: Option<&mut TowerBFTStructures>,
 ) {
+    bank.clear_accounts_lt_hash_async_progress_is_at_end();
     // Handle UpdateParent marker during fast leader handover. The leader
     // built on an optimistic parent that didn't match the ParentReady event.
     //

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8033,6 +8033,7 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
  "crossbeam-utils",
  "dashmap",
  "imbl",

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1534,6 +1534,9 @@ fn confirm_slot_entries(
     let slot = bank.slot();
     let bank_id = bank.bank_id();
     let (entries, num_shreds, slot_full) = slot_entries_load_result;
+    if slot_full {
+        bank.set_accounts_lt_hash_async_progress_is_at_end();
+    }
     let num_entries = entries.len();
     let mut entry_tx_starting_indexes = Vec::with_capacity(num_entries);
     let mut entry_tx_starting_index = progress.num_txs;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8262,6 +8262,7 @@ dependencies = [
  "bitvec",
  "bytemuck",
  "crossbeam-channel",
+ "crossbeam-queue",
  "crossbeam-utils",
  "dashmap",
  "imbl",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -76,6 +76,7 @@ bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
 crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
 crossbeam-utils = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1043,7 +1043,7 @@ pub struct Bank {
     accounts_lt_hash: Mutex<AccountsLtHash>,
 
     /// Track progress of the asynchronous accounts lt hashing for this Bank.
-    accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress,
+    accounts_lt_hash_async_progress: Arc<AccountsLtHashAsyncProgress>,
 
     /// The unique identifier for the corresponding block for this bank.
     /// None for banks that have not yet completed replay or for leader banks as we cannot populate block_id
@@ -1268,7 +1268,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(AccountsLtHash(LtHash::identity())),
-            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
+            accounts_lt_hash_async_progress: Arc::new(AccountsLtHashAsyncProgress::new()),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -1535,7 +1535,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: parent.hash_overrides.clone(),
             accounts_lt_hash: Mutex::new(parent.accounts_lt_hash.lock().unwrap().clone()),
-            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
+            accounts_lt_hash_async_progress: Arc::new(AccountsLtHashAsyncProgress::new()),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
@@ -2191,7 +2191,7 @@ impl Bank {
             #[cfg(feature = "dev-context-only-utils")]
             hash_overrides: Arc::new(Mutex::new(HashOverrides::default())),
             accounts_lt_hash: Mutex::new(fields.accounts_lt_hash),
-            accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
+            accounts_lt_hash_async_progress: Arc::new(AccountsLtHashAsyncProgress::new()),
             block_id: RwLock::new(fields.block_id),
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
@@ -6702,6 +6702,20 @@ impl Bank {
         let genesis_cert = self.get_alpenglow_genesis_certificate()?;
         Some(genesis_cert.block.slot)
     }
+
+    /// Signals to the accounts lt hash manager that this bank has reached the end
+    /// of its slot and needs all of its account updates as soon as possible.
+    pub fn set_accounts_lt_hash_async_progress_is_at_end(&self) {
+        self.accounts_lt_hash_async_progress.set_is_at_end_of_slot();
+    }
+
+    /// Clears the bank-is-at-end-of-slot from `set_accounts_lt_hash_async_progress_is_at_end()`.
+    ///
+    /// To be called when a bank is EOL. Either during Bank::freeze(), or being discarded.
+    pub fn clear_accounts_lt_hash_async_progress_is_at_end(&self) {
+        self.accounts_lt_hash_async_progress
+            .clear_is_at_end_of_slot();
+    }
 }
 
 impl InvokeContextCallback for Bank {
@@ -7202,6 +7216,7 @@ fn calculate_data_size_delta(old_data_size: usize, new_data_size: usize) -> i64 
 
 impl Drop for Bank {
     fn drop(&mut self) {
+        self.clear_accounts_lt_hash_async_progress_is_at_end();
         if let Some(drop_callback) = self.drop_callback.read().unwrap().0.as_ref() {
             drop_callback.callback(self);
         } else {

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -1,6 +1,10 @@
 use {
     super::Bank,
-    crossbeam_utils::CachePadded,
+    crossbeam_queue::SegQueue,
+    crossbeam_utils::{
+        CachePadded,
+        sync::{Parker, Unparker},
+    },
     rayon::{
         ThreadPool, ThreadPoolBuilder,
         iter::{IntoParallelIterator, ParallelIterator},
@@ -10,13 +14,16 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_pubkey::Pubkey,
     std::{
-        array, hint,
+        array,
+        collections::hash_map::Entry,
+        hint,
         mem::size_of,
         sync::{
             Arc, LazyLock, Mutex,
-            atomic::{AtomicU64, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         },
-        time::Instant,
+        thread,
+        time::{Duration, Instant},
     },
 };
 
@@ -27,7 +34,7 @@ const NUM_ACCOUNTS_HASHER_THREADS: usize = 4;
 const MAX_BYTES_SEEN_ACCOUNTS_FREELIST: usize = 10_000_000;
 
 impl Bank {
-    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher thread pool.
+    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher threads.
     ///
     /// This fn is meant to be called by on-chain events, e.g. transaction processing.
     /// This fn deduplicates from `accounts`, keeping only the latest version of each account.
@@ -43,16 +50,24 @@ impl Bank {
             return;
         }
 
+        let manager = accounts_lt_hash_manager();
         let seen_accounts_freelist = seen_accounts_freelist();
         let mut seen_accounts = seen_accounts_freelist.try_pop().unwrap_or_default();
-        let async_progress = &self.accounts_lt_hash_async_progress;
-        let thread_pool = accounts_hasher_thread_pool();
+
+        // The number of pending jobs ensures a bank during freeze()
+        // waits for all the account updates to complete.
+        self.accounts_lt_hash_async_progress
+            .num_jobs_pending
+            .fetch_add(accounts.len(), Ordering::Relaxed);
 
         // process accounts in reverse because we must only count the latest version of each account
+        let mut num_enqueued = 0;
+        let mut num_skipped = 0;
         for index in (0..accounts.len()).rev() {
             let address = accounts.pubkey(index);
             if !seen_accounts.insert(*address) {
                 // we've already enqueued a newer update for the same account; skip this one
+                num_skipped += 1;
                 continue;
             }
             let prev_account = self
@@ -65,24 +80,41 @@ impl Bank {
             });
             if prev_account.is_none() && curr_account.is_none() {
                 // the account was ephemeral; skip it
+                num_skipped += 1;
             } else {
                 // the account was modified; enqueue this update
-                async_progress.spawn(
-                    thread_pool,
-                    AccountsLtHashUpdate {
+                let async_progress = Arc::clone(&self.accounts_lt_hash_async_progress);
+                manager.queue.push(QueuedAccountsLtHashUpdate {
+                    async_progress,
+                    num_updates: 1,
+                    inner: AccountsLtHashUpdate {
                         address: *address,
                         prev_account,
                         curr_account,
                     },
-                );
+                });
+                num_enqueued += 1;
             }
+        }
+        debug_assert_eq!(num_enqueued + num_skipped, accounts.len());
+
+        // If any accounts were skipped, then we need to correct the number of pending jobs.
+        if num_skipped > 0 {
+            self.accounts_lt_hash_async_progress
+                .num_jobs_pending
+                .fetch_sub(num_skipped, Ordering::Relaxed);
+        }
+
+        // Wake up the manager in case updates were enqueued and banks are waiting.
+        if num_enqueued > 0 && manager.num_banks_waiting.load(Ordering::Relaxed) > 0 {
+            manager.unparker.unpark();
         }
 
         // reclaim the seen accounts hashset
         seen_accounts_freelist.try_push(seen_accounts);
     }
 
-    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher thread pool.
+    /// Enqueues the accounts lt hash updates for `accounts` to the accounts hasher threads.
     ///
     /// This fn is meant to be called by off-chain events, meaning we know/control `accounts`.
     /// Contrasting with `enqueue_on_chain_accounts_lt_hash_updates()`, this fn:
@@ -90,7 +122,7 @@ impl Bank {
     /// - Does not assume loading the previous version of accounts is fast,
     ///   e.g. when storing stake accounts as part of partitioned epoch rewards.
     ///
-    /// If Some, `thread_pool_for_hashing_accounts` will be used
+    /// If Some, `thread_pool_for_loading_accounts` will be used
     /// to load the previous version of accounts in parallel.
     pub fn enqueue_off_chain_accounts_lt_hash_updates<'a>(
         &self,
@@ -126,12 +158,11 @@ impl Bank {
             }
         }
 
-        let async_progress = &self.accounts_lt_hash_async_progress;
         let thread_pool_for_hashing_accounts = accounts_hasher_thread_pool();
 
-        // A closure that does the loading and enqueueing, so code is shared
+        // A closure that does the loading and spawning, so code is shared
         // whether using the thread_pool_for_loading_accounts or not.
-        let load_then_enqueue = |index| {
+        let load_then_spawn = |index| {
             let address = accounts.pubkey(index);
             let prev_account = self
                 .rc
@@ -141,20 +172,23 @@ impl Bank {
             let curr_account = accounts.account(index, |account| {
                 (account.lamports() != 0).then(|| account.take_account())
             });
-            if prev_account.is_none() && curr_account.is_none() {
-                // the account was ephemeral; skip it
-            } else {
-                // the account was modified; enqueue this update
-                async_progress.spawn(
-                    thread_pool_for_hashing_accounts,
-                    AccountsLtHashUpdate {
-                        address: *address,
-                        prev_account,
-                        curr_account,
-                    },
-                );
-            }
+            let async_progress = Arc::clone(&self.accounts_lt_hash_async_progress);
+            async_progress.spawn(
+                thread_pool_for_hashing_accounts,
+                AccountsLtHashUpdate {
+                    address: *address,
+                    prev_account,
+                    curr_account,
+                },
+                1,
+            );
         };
+
+        // The number of pending jobs ensures a bank during freeze()
+        // waits for all the account updates to complete.
+        self.accounts_lt_hash_async_progress
+            .num_jobs_pending
+            .fetch_add(accounts.len(), Ordering::Relaxed);
 
         if let Some(thread_pool_for_loading_accounts) = thread_pool_for_loading_accounts {
             // The previous version of accounts must be loaded before subsequent account
@@ -162,10 +196,10 @@ impl Bank {
             thread_pool_for_loading_accounts.install(|| {
                 (0..accounts.len())
                     .into_par_iter()
-                    .for_each(load_then_enqueue);
+                    .for_each(load_then_spawn);
             });
         } else {
-            (0..accounts.len()).for_each(load_then_enqueue);
+            (0..accounts.len()).for_each(load_then_spawn);
         }
     }
 
@@ -176,15 +210,18 @@ impl Bank {
     /// - mix out its previous state, and
     /// - mix in its current state
     ///
-    /// This function waits for any in-flight jobs on the accounts hasher threads,
+    /// This function waits for any queued or in-flight jobs on the accounts hasher threads,
     /// computes their combined delta lt hash, then mixes it into the bank.
     pub fn finish_accounts_lt_hash_updates(&self) {
         let timer = Instant::now();
+        self.accounts_lt_hash_async_progress.set_is_at_end_of_slot();
         let num_jobs_total = {
             let mut accounts_lt_hash = self.accounts_lt_hash.lock().unwrap();
             self.accounts_lt_hash_async_progress
                 .finish(&mut accounts_lt_hash.0)
         };
+        self.accounts_lt_hash_async_progress
+            .clear_is_at_end_of_slot();
         let finish_time = timer.elapsed();
 
         let seen_accounts_freelist_stats = seen_accounts_freelist().stats();
@@ -206,6 +243,13 @@ impl Bank {
             (
                 "seen_accounts_freelist_capacity_bytes",
                 seen_accounts_freelist_stats.capacity_bytes,
+                i64
+            ),
+            (
+                "num_banks_waiting",
+                accounts_lt_hash_manager()
+                    .num_banks_waiting
+                    .load(Ordering::Relaxed),
                 i64
             ),
         );
@@ -240,45 +284,52 @@ pub struct AccountsLtHashAsyncProgress {
     //  │       │                │         │       │                │         │
     //  │0      │6 <-- unaligned │2054     │2176   │2182            │4230     │4352
     //
-    accumulators: Arc<[Mutex<CachePadded<LtHash>>; NUM_ACCOUNTS_HASHER_THREADS]>,
-    num_jobs_pending: Arc<AtomicUsize>,
+    accumulators: [Mutex<CachePadded<LtHash>>; NUM_ACCOUNTS_HASHER_THREADS],
+    num_jobs_pending: AtomicUsize,
     num_jobs_total: AtomicU64,
+    /// Flag to indicate if the bank has reached the end of the slot.
+    /// When true, this causes the manager to send account updates to
+    /// the thread pool for processing as quickly as possible.
+    /// See AccountsLtHashManager::num_banks_waiting for more info.
+    is_at_end_of_slot: AtomicBool,
 }
 
 impl AccountsLtHashAsyncProgress {
-    /// Creates a new AccountsLtHashAsyncProgress variable, which is suitable for a new Bank.
+    /// Creates a new AccountsLtHashAsyncProgress instance that is suitable for a new Bank.
     pub fn new() -> Self {
         Self {
-            accumulators: Arc::new(array::from_fn(|_| {
-                Mutex::new(CachePadded::new(LtHash::identity()))
-            })),
-            num_jobs_pending: Arc::new(AtomicUsize::new(0)),
+            accumulators: array::from_fn(|_| Mutex::new(CachePadded::new(LtHash::identity()))),
+            num_jobs_pending: AtomicUsize::new(0),
             num_jobs_total: AtomicU64::new(0),
+            is_at_end_of_slot: AtomicBool::new(false),
         }
     }
 
     /// Enqueues `update` into `thread_pool` for asynchronous processing.
-    fn spawn(&self, thread_pool: &'static ThreadPool, update: AccountsLtHashUpdate) {
-        self.num_jobs_pending.fetch_add(1, Ordering::Relaxed);
+    fn spawn(
+        self: Arc<Self>,
+        thread_pool: &'static ThreadPool,
+        update: AccountsLtHashUpdate,
+        num_updates: usize,
+    ) {
         self.num_jobs_total.fetch_add(1, Ordering::Relaxed);
         thread_pool.spawn({
-            let accumulators = Arc::clone(&self.accumulators);
-            let num_jobs_pending = Arc::clone(&self.num_jobs_pending);
             move || {
                 // SAFETY: We always call from the same/correct Rayon thread pool.
                 let worker_index = thread_pool.current_thread_index().unwrap();
 
                 // SAFETY: There are num_threads accumulators, and each
                 // thread's index shall always be in range 0..num_threads.
-                debug_assert!(worker_index < accumulators.len());
-                let accumulator = unsafe { accumulators.get_unchecked(worker_index) };
+                debug_assert!(worker_index < self.accumulators.len());
+                let accumulator = unsafe { self.accumulators.get_unchecked(worker_index) };
 
                 Self::process(&mut accumulator.lock().unwrap(), update);
 
                 // Decrementing the number of pending jobs MUST happen *after*
                 // accumulating the result.  This ensures `finish()` cannot
                 // observe zero pending jobs until all workers are done.
-                num_jobs_pending.fetch_sub(1, Ordering::Relaxed);
+                self.num_jobs_pending
+                    .fetch_sub(num_updates, Ordering::Relaxed);
             }
         });
     }
@@ -320,6 +371,177 @@ impl AccountsLtHashAsyncProgress {
             accum_lt_hash.mix_in(&curr_lt_hash.0);
         }
     }
+
+    /// Signals to the accounts lt hash manager that this bank has reached the end
+    /// of its slot and needs all of its account updates as soon as possible.
+    pub fn set_is_at_end_of_slot(&self) {
+        if !self.is_at_end_of_slot.swap(true, Ordering::Relaxed) {
+            let manager = accounts_lt_hash_manager();
+            manager.num_banks_waiting.fetch_add(1, Ordering::Relaxed);
+            manager.unparker.unpark();
+        }
+    }
+
+    /// Clears the bank-is-at-end-of-slot signal from `set_is_at_end_of_slot()`.
+    ///
+    /// To be called when a bank is EOL. Either during Bank::freeze(), or being discarded.
+    pub fn clear_is_at_end_of_slot(&self) {
+        if self.is_at_end_of_slot.swap(false, Ordering::Relaxed) {
+            accounts_lt_hash_manager()
+                .num_banks_waiting
+                .fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Returns the global accounts lt hash manager.
+///
+/// Note, the manager instance will be created on first call.
+fn accounts_lt_hash_manager() -> &'static AccountsLtHashManager {
+    static MANAGER: LazyLock<AccountsLtHashManager> = LazyLock::new(AccountsLtHashManager::new);
+    &MANAGER
+}
+
+/// Manages account updates.
+///
+/// Replay/etc threads push account updates into a queue owned by the manager.
+/// The manager handles deduplicating updates and spawning into the thread pool.
+/// This helps speed up the replay/etc threads since they don't need to wait
+/// for spawning into the thread pool to complete.
+struct AccountsLtHashManager {
+    /// the queue of account updates
+    queue: Arc<SegQueue<QueuedAccountsLtHashUpdate>>,
+    /// thread unparker, used to wake up early and break out of the dedup loop
+    unparker: Unparker,
+    /// A count used to signal when banks are waiting on updates.
+    /// When non-zero, updates are spawned immediately; the manager does not wait to dedup.
+    num_banks_waiting: Arc<AtomicUsize>,
+}
+
+impl AccountsLtHashManager {
+    /// How long to deduplicate queued updates before sending them for processing.
+    const DEDUP_INTERVAL: Duration = Duration::from_millis(2);
+    /// The maximum number of updates to pop off the queue before
+    /// we stop to check how long we have be deduplicating for.
+    const MAX_UPDATES_TO_POP: usize = 10_000;
+
+    fn new() -> Self {
+        let queue = Arc::new(SegQueue::<QueuedAccountsLtHashUpdate>::new());
+        let num_banks_waiting = Arc::new(AtomicUsize::new(0));
+        let parker = Parker::new();
+        let unparker = parker.unparker().clone();
+        thread::Builder::new()
+            .name("solAcctsHashMgr".into())
+            .spawn({
+                let queue = Arc::clone(&queue);
+                let num_banks_waiting = Arc::clone(&num_banks_waiting);
+                move || {
+                    let thread_pool = accounts_hasher_thread_pool();
+                    let mut deduplicated_updates = ahash::HashMap::default();
+                    loop {
+                        // poll the queue for up to DEDUP_INTERVAL
+                        let start_time = Instant::now();
+                        loop {
+                            // Pop updates off the queue and deduplicate them.
+                            // Break out of the loop if the queue is empty,
+                            // or if we've already popped MAX_UPDATES_TO_POP.
+                            // This ensures we don't loop infinitely, popping off
+                            // the queue and never processing the updates.
+                            let mut queue_was_empty = false;
+                            for _ in 0..Self::MAX_UPDATES_TO_POP {
+                                let Some(queued_update) = queue.pop() else {
+                                    queue_was_empty = true;
+                                    break;
+                                };
+                                Self::deduplicate_update(&mut deduplicated_updates, queued_update);
+                            }
+
+                            // If there are banks actively waiting (i.e. freezing), and updates
+                            // to process, then break immediately and spawn the updates we have.
+                            //
+                            // Do not check the remaining time until after this `if` block.
+                            // It lets us skip doing an unnecessary Instant::now().
+                            if !deduplicated_updates.is_empty()
+                                && num_banks_waiting.load(Ordering::Relaxed) > 0
+                            {
+                                break;
+                            }
+
+                            // Now, check if we've been polling the queue for longer than the
+                            // dedup interval, and either break the loop or park the thread.
+                            let remaining_time =
+                                Self::DEDUP_INTERVAL.saturating_sub(start_time.elapsed());
+                            if remaining_time == Duration::ZERO {
+                                break;
+                            }
+
+                            // If the queue was empty, park the thread to wait for more.
+                            // Because if the queue was _not_ empty, loop around to pop
+                            // and deduplicate more updates.
+                            if queue_was_empty {
+                                parker.park_timeout(remaining_time);
+                            }
+                        }
+
+                        // spawn updates into thread pool for processing
+                        for (_, queued_update) in deduplicated_updates.drain() {
+                            let QueuedAccountsLtHashUpdate {
+                                async_progress,
+                                num_updates,
+                                inner: account_update,
+                            } = queued_update;
+                            async_progress.spawn(thread_pool, account_update, num_updates);
+                        }
+                    }
+                }
+            })
+            .expect("new accounts hasher manager thread");
+        Self {
+            queue,
+            unparker,
+            num_banks_waiting,
+        }
+    }
+
+    /// Deduplicates account updates.
+    ///
+    /// Given an account update, `queued_updated`, check `deduplicated_updates`
+    /// if this account already has a pending update.
+    /// If yes, deduplicate the update by merging the two: retain the existing
+    /// update's 'previous' version, and use `queued_update`'s 'current' version.
+    /// If no, insert `queued_update` into `deduplicated_updates`.
+    fn deduplicate_update(
+        deduplicated_updates: &mut ahash::HashMap<(usize, Pubkey), QueuedAccountsLtHashUpdate>,
+        queued_update: QueuedAccountsLtHashUpdate,
+    ) {
+        // Include the AsyncProgress instance in the hashmap key as a proxy for the Bank.
+        // Since updates for the same address can apply to different banks/forks.
+        let key = (
+            Arc::as_ptr(&queued_update.async_progress) as usize,
+            queued_update.inner.address,
+        );
+        match deduplicated_updates.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(queued_update);
+            }
+            Entry::Occupied(mut entry) => {
+                let value = entry.get_mut();
+                value.num_updates += queued_update.num_updates;
+                value.inner.curr_account = queued_update.inner.curr_account;
+            }
+        }
+    }
+}
+
+/// An account update, queued to the manager.
+struct QueuedAccountsLtHashUpdate {
+    /// The async progress instance this account update should apply to.
+    async_progress: Arc<AccountsLtHashAsyncProgress>,
+    /// The number of total updates this instance represents.
+    /// When updates are deduplicated, this count is incremented.
+    num_updates: usize,
+    // The actual account update.
+    inner: AccountsLtHashUpdate,
 }
 
 /// A single accounts lt hash update to process.
@@ -1003,6 +1225,61 @@ mod tests {
         accounts.shuffle(&mut rand::rng());
 
         bank.store_accounts((bank.slot(), accounts.as_slice()), None);
+    }
+
+    #[test]
+    fn test_deduplicate_account_updates() {
+        let address = Pubkey::new_unique();
+        let async_progress1 = Arc::new(AccountsLtHashAsyncProgress::new());
+        let async_progress2 = Arc::new(AccountsLtHashAsyncProgress::new());
+        let mut deduplicated_updates = ahash::HashMap::default();
+
+        AccountsLtHashManager::deduplicate_update(
+            &mut deduplicated_updates,
+            QueuedAccountsLtHashUpdate {
+                async_progress: Arc::clone(&async_progress1),
+                num_updates: 1,
+                inner: AccountsLtHashUpdate {
+                    address,
+                    prev_account: Some(AccountSharedData::new(11, 0, &Pubkey::default())),
+                    curr_account: Some(AccountSharedData::new(12, 0, &Pubkey::default())),
+                },
+            },
+        );
+        // An update for the same account; should be deduplicated.
+        AccountsLtHashManager::deduplicate_update(
+            &mut deduplicated_updates,
+            QueuedAccountsLtHashUpdate {
+                async_progress: Arc::clone(&async_progress1),
+                num_updates: 1,
+                inner: AccountsLtHashUpdate {
+                    address,
+                    prev_account: Some(AccountSharedData::new(12, 0, &Pubkey::default())),
+                    curr_account: Some(AccountSharedData::new(13, 0, &Pubkey::default())),
+                },
+            },
+        );
+        // An update for the same account, but in a different slot/bank;
+        // should *NOT* be deduplicated.
+        AccountsLtHashManager::deduplicate_update(
+            &mut deduplicated_updates,
+            QueuedAccountsLtHashUpdate {
+                async_progress: Arc::clone(&async_progress2),
+                num_updates: 1,
+                inner: AccountsLtHashUpdate {
+                    address,
+                    prev_account: Some(AccountSharedData::new(21, 0, &Pubkey::default())),
+                    curr_account: Some(AccountSharedData::new(22, 0, &Pubkey::default())),
+                },
+            },
+        );
+
+        assert_eq!(deduplicated_updates.len(), 2);
+        let key = (Arc::as_ptr(&async_progress1) as usize, address);
+        let update = deduplicated_updates.get(&key).unwrap();
+        assert_eq!(update.num_updates, 2);
+        assert_eq!(update.inner.prev_account.as_ref().unwrap().lamports(), 11);
+        assert_eq!(update.inner.curr_account.as_ref().unwrap().lamports(), 13);
     }
 
     /// Ensure freelist respects max size.


### PR DESCRIPTION
#### Problem

Spawning account updates into the rayon thread pool for accounts lt hashing is too slow.

In Bank::commit_transactions(), 35% of the time is enqueue accounts lt hash updates:

<img width="2536" height="1739" alt="Screenshot 2026-08-04 at 9 46 47 AM" src="https://github.com/user-attachments/assets/3aea6ec5-253a-48ab-9300-08b25b077da7" />

And most of that is spawning into the rayon thread pool:

<img width="2536" height="1739" alt="Screenshot 2026-08-04 at 9 47 00 AM" src="https://github.com/user-attachments/assets/e77ea52f-1a79-4eb6-aa01-4c412fc88495" />


#### Summary of Changes

Add a new thread, the accounts lt hash manager, where replay/etc threads send account updates.

The manager then is responsible for spawning the updates into the rayon thread pool that does the account hashing. The manager also deduplicates updates to the same account.

When a bank is at the end of the slot, we break out of the deduplication loop and immediately spawn updates, to minimize latency when freezing.


#### Testing

I've been running a node (`3XU`) on mnb with this PR.

First, here's Bank::commit_transactions(). It no longer spawns into the rayon thread pool, and thus now enqueuing accounts lt hash updates drops to 13% of the time.

<img width="2536" height="1739" alt="Screenshot 2026-08-04 at 9 46 36 AM" src="https://github.com/user-attachments/assets/4bfc39b1-e69b-4fae-9665-0cf9ccc1247f" />


Here's some metrics comparing with `mce1`.

Mean and max time spent in Bank::freeze() looks comparable:

<img width="922" height="448" alt="Screenshot 2026-08-04 at 9 16 09 AM" src="https://github.com/user-attachments/assets/c916e0d2-eac1-47bc-aa66-c51083436e46" />

<img width="924" height="448" alt="Screenshot 2026-08-04 at 9 16 14 AM" src="https://github.com/user-attachments/assets/bbd67c07-8323-43e8-8590-af0fed8c8b95" />

And the deduplication is a few hundred per slot:

<img width="921" height="486" alt="Screenshot 2026-08-04 at 9 17 32 AM" src="https://github.com/user-attachments/assets/2fbda207-46f6-4903-baac-857b8e477dd2" />

<img width="922" height="479" alt="Screenshot 2026-08-04 at 9 17 47 AM" src="https://github.com/user-attachments/assets/febf1cfe-dbe4-4d5a-9ae5-9c0c803993e4" />