### PR TITLE
Remove unref accounts

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -620,7 +620,6 @@ pub type AtomicAccountsFileId = AtomicU32;
 pub type AccountsFileId = u32;
 
 type SlotOffsets = IntMap<Slot, IntSet<Offset>>;
-type PubkeysRemovedFromAccountsIndex = HashSet<Pubkey>;
 type ShrinkCandidates = IntSet<Slot>;
 
 // Some hints for applicability of additional sanity checks for the do_load fast-path;
@@ -1246,7 +1245,6 @@ impl AccountsDb {
                     .for_each(|(reclaimed_item, newest_slot)| {
                         self.handle_reclaims(
                             iter::once(reclaimed_item),
-                            &HashSet::new(),
                             &self.clean_accounts_stats.purge_stats,
                             MarkAccountsObsolete::Yes(*newest_slot),
                         );
@@ -1420,10 +1418,7 @@ impl AccountsDb {
     pub fn purge_keys_exact<C>(
         &self,
         pubkey_to_slot_set: impl IntoIterator<Item = (Pubkey, C)>,
-    ) -> (
-        ReclaimsSlotList<AccountInfo>,
-        PubkeysRemovedFromAccountsIndex,
-    )
+    ) -> ReclaimsSlotList<AccountInfo>
     where
         C: for<'a> Contains<'a, Slot>,
     {
@@ -1442,10 +1437,9 @@ impl AccountsDb {
                 }
             });
 
-        let (pubkeys_removed_from_accounts_index, handle_dead_keys_us) = measure_us!({
+        let (_, handle_dead_keys_us) = measure_us!({
             let removed_keys = self.accounts_index.handle_dead_keys(&dead_keys);
             self.purge_secondary_indexes_for_dead_keys(&removed_keys);
-            removed_keys
         });
 
         self.stats
@@ -1457,7 +1451,7 @@ impl AccountsDb {
         self.stats
             .purge_exact_us
             .fetch_add(purge_exact_us, Ordering::Relaxed);
-        (reclaims, pubkeys_removed_from_accounts_index)
+        reclaims
     }
 
     fn max_clean_root(&self, proposed_clean_root: Option<Slot>) -> Option<Slot> {
@@ -2147,14 +2141,12 @@ impl AccountsDb {
             pubkey_to_slot_set.append(&mut bin_set);
         }
 
-        let (reclaims, pubkeys_removed_from_accounts_index) =
-            self.purge_keys_exact(pubkey_to_slot_set);
+        let reclaims = self.purge_keys_exact(pubkey_to_slot_set);
 
         if !reclaims.is_empty() {
             let expected_dead_slots: IntSet<_> = reclaims.iter().map(|(slot, _)| *slot).collect();
             let dead_slots = self.handle_reclaims(
                 reclaims.iter(),
-                &pubkeys_removed_from_accounts_index,
                 &self.clean_accounts_stats.purge_stats,
                 MarkAccountsObsolete::No,
             );
@@ -2178,11 +2170,6 @@ impl AccountsDb {
                 i64
             ),
             ("oldest_dirty_slot", key_timings.oldest_dirty_slot, i64),
-            (
-                "pubkeys_removed_from_accounts_index",
-                pubkeys_removed_from_accounts_index.len(),
-                i64
-            ),
             (
                 "dirty_store_processing_us",
                 key_timings.dirty_store_processing_us,
@@ -2297,9 +2284,6 @@ impl AccountsDb {
     /// * `reclaims` - The accounts to remove from storage entries' "count". Note here
     ///   that we should not remove cache entries, only entries for accounts actually
     ///   stored in a storage entry.
-    /// * `pubkeys_removed_from_accounts_index` - These keys have already been removed from the
-    ///   accounts index and should not be unref'd. If they exist in the accounts index,
-    ///   they are NEW.
     /// * `handle_reclaims`. `purge_stats` are stats used to track performance of purging
     ///   dead slots if value is `ProcessDeadSlots`.
     ///   Otherwise, there can be no dead slots
@@ -2317,7 +2301,6 @@ impl AccountsDb {
     fn handle_reclaims<'a, I>(
         &'a self,
         reclaims: I,
-        pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
         purge_stats: &PurgeStats,
         mark_accounts_obsolete: MarkAccountsObsolete,
     ) -> IntSet<Slot>
@@ -2326,11 +2309,7 @@ impl AccountsDb {
     {
         let dead_slots = self.remove_dead_accounts(reclaims, mark_accounts_obsolete);
 
-        self.process_dead_slots(
-            &dead_slots,
-            purge_stats,
-            pubkeys_removed_from_accounts_index,
-        );
+        self.process_dead_slots(&dead_slots, purge_stats);
         dead_slots
     }
 
@@ -2419,14 +2398,7 @@ impl AccountsDb {
 
     // Must be kept private!, does sensitive cleanup that should only be called from
     // supported pipelines in AccountsDb
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    fn process_dead_slots(
-        &self,
-        dead_slots: &IntSet<Slot>,
-        purge_stats: &PurgeStats,
-        _pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
-    ) {
+    fn process_dead_slots(&self, dead_slots: &IntSet<Slot>, purge_stats: &PurgeStats) {
         if dead_slots.is_empty() {
             return;
         }
@@ -4224,7 +4196,7 @@ impl AccountsDb {
 
         let mut purge_accounts_index_elapsed = Measure::start("purge_accounts_index_elapsed");
         // Purge this slot from the accounts index
-        let (reclaims, pubkeys_removed_from_accounts_index) = self.purge_keys_exact(stored_keys);
+        let reclaims = self.purge_keys_exact(stored_keys);
         purge_accounts_index_elapsed.stop();
         purge_stats
             .purge_accounts_index_elapsed
@@ -4235,12 +4207,8 @@ impl AccountsDb {
         let mut handle_reclaims_elapsed = Measure::start("handle_reclaims_elapsed");
         // There is no reason to mark accounts obsolete as the slot storage is being purged
         if !reclaims.is_empty() {
-            let dead_slots = self.handle_reclaims(
-                reclaims.iter(),
-                &pubkeys_removed_from_accounts_index,
-                purge_stats,
-                MarkAccountsObsolete::No,
-            );
+            let dead_slots =
+                self.handle_reclaims(reclaims.iter(), purge_stats, MarkAccountsObsolete::No);
             // Ensure the expected slot is marked dead
             assert_eq!(dead_slots, IntSet::from_iter(iter::once(remove_slot)));
         }
@@ -5541,7 +5509,6 @@ impl AccountsDb {
             let purge_stats = PurgeStats::default();
             self.handle_reclaims(
                 reclaims.iter().flatten(),
-                &HashSet::default(),
                 &purge_stats,
                 MarkAccountsObsolete::Yes(slot),
             );
@@ -6398,7 +6365,6 @@ impl AccountsDb {
                 if !reclaims.is_empty() {
                     self.handle_reclaims(
                         reclaims.iter(),
-                        &HashSet::new(),
                         &stats,
                         MarkAccountsObsolete::Yes(slot_marked_obsolete),
                     );

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -103,8 +103,6 @@ use {
 const WRITE_CACHE_LIMIT_BYTES_DEFAULT: u64 = 15_000_000_000;
 const SCAN_SLOT_PAR_ITER_THRESHOLD: usize = 4000;
 
-const UNREF_ACCOUNTS_BATCH_SIZE: usize = 10_000;
-
 const DEFAULT_NUM_DIRS: u32 = 4;
 
 // This value reflects recommended memory lock limit documented in the validator's
@@ -2263,20 +2261,6 @@ impl AccountsDb {
                 i64
             ),
             (
-                "clean_stored_dead_slots_us",
-                self.clean_accounts_stats
-                    .clean_stored_dead_slots_us
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "clean_unref_from_storage_us",
-                self.clean_accounts_stats
-                    .clean_unref_from_storage_us
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "purge_older_root_entries_one_slot_list",
                 self.accounts_index
                     .purge_older_root_entries_one_slot_list
@@ -2342,15 +2326,10 @@ impl AccountsDb {
     {
         let dead_slots = self.remove_dead_accounts(reclaims, mark_accounts_obsolete);
 
-        // if we are marking accounts obsolete, then any dead slots have already been cleaned
-        let clean_stored_dead_slots =
-            !matches!(mark_accounts_obsolete, MarkAccountsObsolete::Yes(_));
-
         self.process_dead_slots(
             &dead_slots,
             purge_stats,
             pubkeys_removed_from_accounts_index,
-            clean_stored_dead_slots,
         );
         dead_slots
     }
@@ -2442,27 +2421,15 @@ impl AccountsDb {
     // supported pipelines in AccountsDb
     /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
     ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    /// clean_stored_dead_slots - clean_stored_dead_slots iterates through all the pubkeys in the dead
-    ///    slots and unrefs them in the accounts index if they are not present in
-    ///    pubkeys_removed_from_accounts_index. Skipping clean is the equivalent to
-    ///    pubkeys_removed_from_accounts_index containing all the pubkeys in the dead slots
     fn process_dead_slots(
         &self,
         dead_slots: &IntSet<Slot>,
         purge_stats: &PurgeStats,
-        pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
-        clean_stored_dead_slots: bool,
+        _pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
     ) {
         if dead_slots.is_empty() {
             return;
         }
-        let mut clean_dead_slots = Measure::start("reclaims::clean_dead_slots");
-
-        if clean_stored_dead_slots {
-            self.clean_stored_dead_slots(dead_slots, pubkeys_removed_from_accounts_index);
-        }
-
-        clean_dead_slots.stop();
 
         let mut purge_removed_slots = Measure::start("reclaims::purge_removed_slots");
         self.purge_dead_slots_from_storage(dead_slots.iter(), purge_stats);
@@ -2478,9 +2445,8 @@ impl AccountsDb {
         }
 
         debug!(
-            "process_dead_slots({}): {} {} {:?}",
+            "process_dead_slots({}): {} {:?}",
             dead_slots.len(),
-            clean_dead_slots,
             purge_removed_slots,
             dead_slots,
         );
@@ -2773,36 +2739,17 @@ impl AccountsDb {
     /// And also `slot` is <= the latest full snapshot slot, and can purge zero lamport accounts.
     /// Thus, we did NOT treat this as an alive account, so we did NOT copy the zero lamport account to the new
     /// storage. So, the account will no longer be alive or exist at `slot`.
-    /// So, first, remove the ref count since this newly shrunk storage will no longer access it.
-    /// Second, remove `slot` from the index entry's slot list. If the slot list is now empty, then the
+    /// Decrement the ref count and remove the `slot` from the index entry's slot list. If the slot list is now empty, then the
     /// pubkey can be removed completely from the index.
-    /// In parallel with this code (which is running in the bg), the same pubkey could be revived and written to
-    /// as part of tx processing. In that case, the slot list will contain a slot in the write cache and the
-    /// index entry will NOT be deleted.
     fn remove_zero_lamport_single_ref_accounts_after_shrink(
         &self,
         zero_lamport_single_ref_pubkeys: &[&Pubkey],
         slot: Slot,
         stats: &ShrinkStats,
-        do_assert: bool,
     ) {
         stats.purged_zero_lamports.fetch_add(
             zero_lamport_single_ref_pubkeys.len() as u64,
             Ordering::Relaxed,
-        );
-
-        // we have to unref before we `purge_keys_exact`. Otherwise, we could race with the foreground with tx processing
-        // reviving this index entry and then we'd unref the revived version, which is a refcount bug.
-
-        self.accounts_index.scan(
-            zero_lamport_single_ref_pubkeys.iter().cloned(),
-            |_pubkey, _slots_refs| AccountsIndexScanResult::Unref,
-            if do_assert {
-                Some(AccountsIndexScanResult::UnrefAssert0)
-            } else {
-                Some(AccountsIndexScanResult::UnrefLog0)
-            },
-            ScanFilter::All,
         );
 
         zero_lamport_single_ref_pubkeys.iter().for_each(|k| {
@@ -2828,7 +2775,6 @@ impl AccountsDb {
             &shrink_collect.zero_lamport_single_ref_pubkeys,
             shrink_collect.slot,
             stats,
-            false,
         );
 
         // Purge old, overwritten storage entries
@@ -4563,6 +4509,7 @@ impl AccountsDb {
     // Flush all rooted slots without cleaning. This is used when rooted accounts must be flushed
     // to storage but older versions of the accounts are still required. For example, the
     // older versions may be needed for snapshotting.
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn flush_rooted_accounts_cache_without_clean(&self) -> (usize, usize, FlushStats) {
         self.flush_rooted_accounts_cache(None, FlushShouldClean::No)
     }
@@ -5401,128 +5348,6 @@ impl AccountsDb {
         });
 
         dead_slots
-    }
-
-    /// lookup each pubkey in 'pubkeys' and unref it in the accounts index
-    /// skip pubkeys that are in 'pubkeys_removed_from_accounts_index'
-    fn unref_pubkeys<'a>(
-        &'a self,
-        pubkeys: impl Iterator<Item = &'a Pubkey> + Clone + Send + Sync,
-        num_pubkeys: usize,
-        pubkeys_removed_from_accounts_index: &'a PubkeysRemovedFromAccountsIndex,
-    ) {
-        let batches = 1 + (num_pubkeys / UNREF_ACCOUNTS_BATCH_SIZE);
-        self.thread_pool_background.install(|| {
-            (0..batches).into_par_iter().for_each(|batch| {
-                let skip = batch * UNREF_ACCOUNTS_BATCH_SIZE;
-                self.accounts_index.scan(
-                    pubkeys
-                        .clone()
-                        .skip(skip)
-                        .take(UNREF_ACCOUNTS_BATCH_SIZE)
-                        .filter(|pubkey| {
-                            // filter out pubkeys that have already been removed from the accounts index in a previous step
-                            let already_removed =
-                                pubkeys_removed_from_accounts_index.contains(pubkey);
-                            !already_removed
-                        }),
-                    |_pubkey, slots_refs| {
-                        if let Some((slot_list, ref_count)) = slots_refs {
-                            // Let's handle the special case - after unref, the result is a single ref zero lamport account.
-                            if slot_list.len() == 1
-                                && ref_count == 2
-                                && let Some((slot_alive, acct_info)) = slot_list.first()
-                                && acct_info.is_zero_lamport()
-                            {
-                                self.zero_lamport_single_ref_found(*slot_alive, acct_info.offset());
-                            }
-                        }
-                        AccountsIndexScanResult::Unref
-                    },
-                    None,
-                    ScanFilter::All,
-                )
-            });
-        });
-    }
-
-    /// lookup each pubkey in 'purged_slot_pubkeys' and unref it in the accounts index
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    fn unref_accounts(
-        &self,
-        purged_slot_pubkeys: HashSet<(Slot, Pubkey)>,
-        pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
-    ) {
-        self.unref_pubkeys(
-            purged_slot_pubkeys.iter().map(|(_slot, pubkey)| pubkey),
-            purged_slot_pubkeys.len(),
-            pubkeys_removed_from_accounts_index,
-        );
-    }
-
-    /// pubkeys_removed_from_accounts_index - These keys have already been removed from the accounts index
-    ///    and should not be unref'd. If they exist in the accounts index, they are NEW.
-    fn clean_stored_dead_slots(
-        &self,
-        dead_slots: &IntSet<Slot>,
-        pubkeys_removed_from_accounts_index: &PubkeysRemovedFromAccountsIndex,
-    ) {
-        let mut measure = Measure::start("clean_stored_dead_slots-ms");
-        let mut stores = vec![];
-        // get all stores in a vec so we can iterate in parallel
-        for slot in dead_slots.iter() {
-            if let Some(slot_storage) = self.storage.get_slot_storage_entry(*slot) {
-                stores.push(slot_storage);
-            }
-        }
-        // get all pubkeys in all dead slots
-        let purged_slot_pubkeys: HashSet<(Slot, Pubkey)> = {
-            self.thread_pool_background.install(|| {
-                stores
-                    .into_par_iter()
-                    .map(|store| {
-                        let slot = store.slot();
-                        let mut pubkeys = Vec::with_capacity(store.count());
-                        // Obsolete accounts are already unreffed before this point, so do not add
-                        // them to the pubkeys list.
-                        let obsolete_accounts: HashSet<_> = store
-                            .obsolete_accounts_read_lock()
-                            .filter_obsolete_accounts(None)
-                            .collect();
-                        // Tombstones have already been removed from the index, so they must not be
-                        // unref'd here (a revived pubkey could otherwise be wrongly unref'd).
-                        let tombstone_offsets = store.tombstone_offsets_read_lock();
-                        store
-                            .accounts
-                            .scan_accounts_without_data(|offset, account| {
-                                if !obsolete_accounts.contains(&(offset, account.data_len))
-                                    && !tombstone_offsets.contains(&offset)
-                                {
-                                    pubkeys.push((slot, *account.pubkey));
-                                }
-                            })
-                            .expect("must scan accounts storage");
-                        pubkeys
-                    })
-                    .flatten()
-                    .collect::<HashSet<_>>()
-            })
-        };
-
-        //Unref the accounts from storage
-        let mut measure_unref = Measure::start("unref_from_storage");
-
-        self.unref_accounts(purged_slot_pubkeys, pubkeys_removed_from_accounts_index);
-        measure_unref.stop();
-        self.clean_accounts_stats
-            .clean_unref_from_storage_us
-            .fetch_add(measure_unref.as_us(), Ordering::Relaxed);
-
-        measure.stop();
-        self.clean_accounts_stats
-            .clean_stored_dead_slots_us
-            .fetch_add(measure.as_us(), Ordering::Relaxed);
     }
 
     /// Stores accounts in the write cache and updates the index.

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -294,14 +294,12 @@ impl FlushStats {
 #[derive(Debug, Default)]
 pub struct CleanAccountsStats {
     pub purge_stats: PurgeStats,
-    pub clean_unref_from_storage_us: AtomicU64,
 
     // stats held here and reported by clean_accounts
     pub clean_old_root_us: AtomicU64,
     pub clean_old_root_reclaim_us: AtomicU64,
     pub remove_dead_accounts_remove_us: AtomicU64,
     pub remove_dead_accounts_shrink_us: AtomicU64,
-    pub clean_stored_dead_slots_us: AtomicU64,
     pub get_account_sizes_us: AtomicU64,
     pub slots_cleaned: AtomicU64,
 }

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1187,37 +1187,6 @@ fn test_clean_dead_slot_with_obsolete_accounts() {
 }
 
 #[test]
-#[should_panic(expected = "ref count expected to be zero")]
-fn test_remove_zero_lamport_multi_ref_accounts_panic() {
-    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let pubkey_zero = Pubkey::from([1; 32]);
-    let one_lamport_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
-
-    let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-    let slot = 1;
-
-    accounts.store_for_tests((slot, [(&pubkey_zero, &one_lamport_account)].as_slice()));
-
-    // Flush without cleaning to avoid reclaiming pubkey_zero early
-    accounts.add_root(1);
-    accounts.flush_rooted_accounts_cache_without_clean();
-
-    accounts.store_for_tests((slot + 1, [(&pubkey_zero, &zero_lamport_account)].as_slice()));
-
-    // Flush without cleaning to avoid reclaiming pubkey_zero early
-    accounts.add_root(2);
-    accounts.flush_rooted_accounts_cache_without_clean();
-
-    // This should panic because there are 2 refs for pubkey_zero.
-    accounts.remove_zero_lamport_single_ref_accounts_after_shrink(
-        &[&pubkey_zero],
-        slot,
-        &ShrinkStats::default(),
-        true,
-    );
-}
-
-#[test]
 fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
     for pass in 0..3 {
         let accounts =
@@ -1271,7 +1240,6 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
             &zero_lamport_single_ref_pubkeys,
             slot,
             &ShrinkStats::default(),
-            true,
         );
 
         accounts.accounts_index.get_and_then(&pubkey_zero, |entry| {
@@ -1321,6 +1289,32 @@ fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
             assert!(entry.is_some(), "{pass}");
             (false, ())
         });
+
+        if pass == 2 {
+            // Partially purge pubkey_zero: remove only the entry at `slot`, leaving the
+            // entry at `slot + 1` alive. The ref count must drop by exactly the number
+            // of removed slot list entries.
+            let reclaims = accounts.purge_keys_exact([(pubkey_zero, slot)]);
+            assert_eq!(
+                reclaims
+                    .iter()
+                    .map(|(reclaimed_slot, _)| *reclaimed_slot)
+                    .collect::<Vec<_>>(),
+                vec![slot]
+            );
+            accounts.accounts_index.get_and_then(&pubkey_zero, |entry| {
+                assert_eq!(entry.unwrap().ref_count(), 1);
+                let slots = entry
+                    .unwrap()
+                    .slot_list_read_lock()
+                    .iter()
+                    .map(|(s, _)| s)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                assert_eq!(slots, vec![slot + 1]);
+                (false, ())
+            });
+        }
     }
 }
 
@@ -2811,14 +2805,6 @@ fn test_exhaustively_verify_refcounts_small_dataset_detects_mismatch() {
     });
 
     accounts.exhaustively_verify_refcounts(Some(slot));
-}
-
-#[test]
-fn test_clean_stored_dead_slots_empty() {
-    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let mut dead_slots = IntSet::default();
-    dead_slots.insert(10);
-    accounts.clean_stored_dead_slots(&dead_slots, &HashSet::default());
 }
 
 #[test]
@@ -5920,127 +5906,6 @@ fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
             should_contain: false,
         });
     }
-}
-
-#[test]
-/// test 'unref' parameter 'pubkeys_removed_from_accounts_index'
-fn test_unref_pubkeys_removed_from_accounts_index() {
-    let slot1 = 1;
-    let pk1 = Pubkey::from([1; 32]);
-    for already_removed in [false, true] {
-        let mut pubkeys_removed_from_accounts_index = PubkeysRemovedFromAccountsIndex::default();
-        if already_removed {
-            pubkeys_removed_from_accounts_index.insert(pk1);
-        }
-        // pk1 in slot1, purge it
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-        let mut purged_slot_pubkeys = HashSet::default();
-        purged_slot_pubkeys.insert((slot1, pk1));
-        let mut reclaims = ReclaimsSlotList::default();
-        db.accounts_index.upsert(
-            slot1,
-            slot1,
-            &pk1,
-            AccountInfo::default(),
-            &mut reclaims,
-            UpsertReclaim::IgnoreReclaims,
-        );
-
-        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
-        let expected = RefCount::from(already_removed);
-        assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), expected);
-    }
-}
-
-#[test]
-fn test_unref_accounts() {
-    let pubkeys_removed_from_accounts_index = PubkeysRemovedFromAccountsIndex::default();
-
-    {
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-
-        db.unref_accounts(HashSet::default(), &pubkeys_removed_from_accounts_index);
-    }
-
-    let slot1 = 1;
-    let slot2 = 2;
-    let pk1 = Pubkey::from([1; 32]);
-    let pk2 = Pubkey::from([2; 32]);
-    {
-        // pk1 in slot1, purge it
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-        let mut purged_slot_pubkeys = HashSet::default();
-        purged_slot_pubkeys.insert((slot1, pk1));
-        let mut reclaims = ReclaimsSlotList::default();
-        db.accounts_index.upsert(
-            slot1,
-            slot1,
-            &pk1,
-            AccountInfo::default(),
-            &mut reclaims,
-            UpsertReclaim::IgnoreReclaims,
-        );
-
-        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
-        assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
-    }
-    {
-        let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-        let mut purged_slot_pubkeys = HashSet::default();
-        let mut reclaims = ReclaimsSlotList::default();
-        // pk1 and pk2 both in slot1 and slot2, so each has refcount of 2
-        for slot in [slot1, slot2] {
-            for pk in [pk1, pk2] {
-                db.accounts_index.upsert(
-                    slot,
-                    slot,
-                    &pk,
-                    AccountInfo::default(),
-                    &mut reclaims,
-                    UpsertReclaim::IgnoreReclaims,
-                );
-            }
-        }
-        // purge pk1 from both 1 and 2 and pk2 from slot 1
-        let purges = vec![(slot1, pk1), (slot1, pk2), (slot2, pk1)];
-        purges.into_iter().for_each(|(slot, pk)| {
-            purged_slot_pubkeys.insert((slot, pk));
-        });
-        db.unref_accounts(purged_slot_pubkeys, &pubkeys_removed_from_accounts_index);
-        assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
-        assert_eq!(db.accounts_index.ref_count_from_storage(&pk2), 1);
-    }
-}
-
-#[test]
-fn test_many_unrefs() {
-    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let mut reclaims = ReclaimsSlotList::default();
-    let pk1 = Pubkey::from([1; 32]);
-    // make sure we have > 1 batch. Bigger numbers cost more in test time here.
-    let n = (UNREF_ACCOUNTS_BATCH_SIZE + 1) as Slot;
-    // put the pubkey into the acct idx in 'n' slots
-    let purged_slot_pubkeys = (0..n)
-        .map(|slot| {
-            db.accounts_index.upsert(
-                slot,
-                slot,
-                &pk1,
-                AccountInfo::default(),
-                &mut reclaims,
-                UpsertReclaim::IgnoreReclaims,
-            );
-            (slot, pk1)
-        })
-        .collect::<HashSet<_>>();
-
-    assert_eq!(
-        db.accounts_index.ref_count_from_storage(&pk1),
-        n as RefCount,
-    );
-    // unref all 'n' slots
-    db.unref_accounts(purged_slot_pubkeys, &HashSet::default());
-    assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
 }
 
 #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -30,7 +30,6 @@ use {
     solana_pubkey::Pubkey,
     stats::Stats,
     std::{
-        collections::HashSet,
         fmt::Debug,
         num::NonZeroUsize,
         path::PathBuf,
@@ -338,20 +337,19 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     }
 
     /// Remove keys from the account index if the key's slot list is empty.
-    /// Returns the keys that were removed from the index. These keys should not be accessed again
-    /// in the current code path.
+    /// Returns the keys that were removed from the index.
     ///
     /// When secondary indexes are enabled, callers must pass the returned keys to
     /// `AccountsDb::purge_secondary_indexes_for_dead_keys`, otherwise their secondary index
     /// entries leak.
     #[must_use]
-    pub fn handle_dead_keys(&self, dead_keys: &[Pubkey]) -> HashSet<Pubkey> {
-        let mut pubkeys_removed_from_accounts_index = HashSet::default();
+    pub fn handle_dead_keys(&self, dead_keys: &[Pubkey]) -> Vec<Pubkey> {
+        let mut pubkeys_removed_from_accounts_index = Vec::default();
         if !dead_keys.is_empty() {
             for key in dead_keys.iter() {
                 let w_index = self.get_bin(key);
                 if w_index.remove_if_slot_list_empty(*key) {
-                    pubkeys_removed_from_accounts_index.insert(*key);
+                    pubkeys_removed_from_accounts_index.push(*key);
                 }
             }
         }
@@ -1071,6 +1069,7 @@ mod tests {
         solana_account::AccountSharedData,
         solana_pubkey::PUBKEY_BYTES,
         spl_generic_token::{spl_token_ids, token::SPL_TOKEN_ACCOUNT_OWNER_OFFSET},
+        std::collections::HashSet,
         test_case::test_matrix,
     };
 
@@ -2694,9 +2693,6 @@ mod tests {
         let key = solana_pubkey::new_rand();
         let index = AccountsIndex::<bool, bool>::default_for_tests();
 
-        assert_eq!(
-            index.handle_dead_keys(&[key]),
-            vec![key].into_iter().collect::<HashSet<_>>()
-        );
+        assert_eq!(index.handle_dead_keys(&[key]), vec![key]);
     }
 }

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -327,6 +327,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .is_some()
     }
 
+    #[cfg(test)]
     fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,
@@ -410,6 +411,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             .collect()
     }
 
+    /// Removes `slots_to_purge` from the slot list of `pubkey`, pushing removed entries into
+    /// `reclaims` and unreffing each removed entry under the same lock.
+    ///
     /// returns true if, after this fn call:
     /// accounts index entry for `pubkey` has an empty slot list
     /// or `pubkey` does not exist in accounts index
@@ -419,16 +423,21 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         slots_to_purge: impl for<'a> Contains<'a, Slot>,
         reclaims: &mut ReclaimsSlotList<T>,
     ) -> bool {
-        self.slot_list_mut(pubkey, |mut slot_list| {
-            slot_list.retain_and_count(|(slot, item)| {
+        let map = self.get_bin(pubkey);
+        map.slot_list_mut_with_entry(pubkey, |mut slot_list, entry| {
+            let mut removed_count = 0;
+            let count = slot_list.retain_and_count(|(slot, item)| {
                 let should_purge = slots_to_purge.contains(slot);
                 if should_purge {
                     reclaims.push((*slot, *item));
+                    removed_count += 1;
                     false
                 } else {
                     true
                 }
-            }) == 0
+            });
+            entry.unref_by_count(removed_count);
+            count == 0
         })
         .unwrap_or(true)
     }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -388,6 +388,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 
     /// Convenience wrapper for slot_list_mut_with_entry that ignores the entry
+    #[cfg(test)]
     pub(crate) fn slot_list_mut<RT>(
         &self,
         pubkey: &Pubkey,

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -581,6 +581,56 @@ mod tests {
         ); // snapshot slot is untouched, so still has all 300 accounts
     }
 
+    /// Purging an account from a filtered storage must decrement its ref count when the
+    /// account is still alive in a later slot.
+    #[test]
+    fn test_minimize_accounts_db_unrefs_multi_ref_accounts() {
+        let (genesis_config, _) = create_genesis_config(1_000_000);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let accounts = &bank.accounts().accounts_db;
+
+        let pubkey_keep = Pubkey::new_unique();
+        let pubkey_multi = Pubkey::new_unique();
+        let account = AccountSharedData::new(223, 0, &Pubkey::default());
+
+        // pubkey_multi is stored in both slot 1 and slot 2; pubkey_keep keeps slot 1's
+        // storage out of the dead slot set
+        accounts.store_for_tests((
+            1,
+            [(&pubkey_keep, &account), (&pubkey_multi, &account)].as_slice(),
+        ));
+        accounts.add_root(1);
+        accounts.store_for_tests((2, [(&pubkey_multi, &account)].as_slice()));
+        accounts.add_root(2);
+        // Flush without clean so pubkey_multi keeps both slot list entries
+        accounts.flush_rooted_accounts_cache_without_clean();
+
+        assert_eq!(
+            accounts
+                .accounts_index
+                .ref_count_from_storage(&pubkey_multi),
+            2
+        );
+
+        let minimized_account_set = DashSet::new();
+        minimized_account_set.insert(pubkey_keep);
+        let minimizer = SnapshotMinimizer {
+            bank: &bank,
+            starting_slot: 2,
+            minimized_account_set,
+        };
+        minimizer.minimize_accounts_db();
+
+        // filter_storage purged (pubkey_multi, slot 1) from the index, decrementing its
+        // ref count; the other entry keeps it alive
+        assert_eq!(
+            accounts
+                .accounts_index
+                .ref_count_from_storage(&pubkey_multi),
+            1
+        );
+    }
+
     /// Ensure that minimized snapshots are loadable with and without
     /// recalculating the accounts lt hash.
     #[test_case(false)]


### PR DESCRIPTION
#### Problem
unref_accounts nested in handle_reclaims that can be done in purge_keys_exact instead now that 
https://github.com/anza-xyz/agave/pull/14012 is merged (which removes any remaining edge case where it was not ok).

Another benefit is that this will make it *much* easier to analyze ref count removal. Still a few more PRs before that though!
It also helps with some of the tombstone work as well, which is why I'm pulling it in now. 

#### Logic
First a quick definition of what a reference is in our code base: A reference refers to a copy of an account stored in a rooted storage that is not marked obsolete and is not a tombstone

unref_accounts is called in handle_reclaims IFF mark_accounts_obsolete = MarkAccountsObsolete::No. There are two callers:
- clean_accounts as referenced in https://github.com/anza-xyz/agave/pull/14061#discussion_r3642195577
- purge_slot_storage

In both of these cases: 
A set of pubkeys is collected from a set of slots (or singular slot). It is then guaranteed afterwards that all the slots referenced by the purged set are removed (the ref is removed). Therefore, it is guaranteed that purge is also tied to an unref (as the storage is entirely removed).

The remaining callers of purge_keys_exact
- remove_zero_lamport_single_ref_accounts_after_shrink: After a storage is cleaned by shrink, purge and then decrement: unref is already done here anways. Saved to remove the scan/unref and fold it in.
- filter_storage: Used in the snapshot minimizer. purge_keys_exact and then rewrite the storage without those keys. Previous to this change it did not unref at all. This is a benign bug, but technically it is more correct to unref. So safe here to unref now.

#### Summary of Changes
- Unref in purge_keys_exact
- remove unref_accounts from handle_reclaims
- remove PubkeysRemovedFromAccountsIndex

#### Testing
- Ran a validator with the disk index enabled and periodic scanguards for several days
- New test above
- Proof above (and tested with adversarial testers with Fable) 


Fixes #
