### PR TITLE
feat: use bytes for banking_stage's transaction-view

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -23,7 +23,7 @@ use {
     futures::{StreamExt, stream::FuturesUnordered},
     histogram::Histogram,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfoQuery},
-    solana_perf::packet::PACKETS_PER_BATCH,
+    solana_perf::packet::{PACKETS_PER_BATCH, PacketRef, bytes::Bytes},
     solana_poh::{
         poh_controller::PohController, poh_recorder::PohRecorder,
         transaction_recorder::TransactionRecorder,
@@ -82,6 +82,13 @@ const DEFAULT_NUM_WORKERS: NonZeroUsize = NonZeroUsize::new(4).unwrap();
 
 const TOTAL_BUFFERED_PACKETS: usize = 100_000;
 const SLOT_BOUNDARY_CHECK_PERIOD: Duration = Duration::from_millis(10);
+
+fn packet_bytes(packet: PacketRef<'_>, packet_data: &[u8]) -> Bytes {
+    match packet {
+        PacketRef::Bytes(packet) => packet.buffer().clone(),
+        PacketRef::Packet(_) => Bytes::copy_from_slice(packet_data),
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct BankingStageStats {

--- a/core/src/banking_stage/latest_validator_vote_packet.rs
+++ b/core/src/banking_stage/latest_validator_vote_packet.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
-use solana_perf::packet::PacketRef;
+use {crate::banking_stage::packet_bytes, solana_perf::packet::PacketRef};
 use {
-    crate::banking_stage::transaction_scheduler::transaction_state_container::SharedBytes,
     agave_transaction_view::transaction_view::SanitizedTransactionView,
     solana_bincode::limited_deserialize,
     solana_clock::{Slot, UnixTimestamp},
     solana_hash::Hash,
     solana_packet::PACKET_DATA_SIZE,
+    solana_perf::packet::bytes::Bytes,
     solana_pubkey::Pubkey,
     solana_vote_program::vote_instruction::VoteInstruction,
     thiserror::Error,
@@ -24,7 +24,7 @@ pub struct LatestValidatorVote {
     vote_source: VoteSource,
     vote_pubkey: Pubkey,
     authorized_voter_pubkey: Pubkey,
-    vote: Option<SanitizedTransactionView<SharedBytes>>,
+    vote: Option<SanitizedTransactionView<Bytes>>,
     slot: Slot,
     hash: Hash,
     timestamp: Option<UnixTimestamp>,
@@ -32,7 +32,7 @@ pub struct LatestValidatorVote {
 
 impl LatestValidatorVote {
     pub fn new_from_view(
-        vote: SanitizedTransactionView<SharedBytes>,
+        vote: SanitizedTransactionView<Bytes>,
         vote_source: VoteSource,
         deprecate_legacy_vote_ixs: bool,
     ) -> Result<Self, DeserializedPacketError> {
@@ -106,8 +106,9 @@ impl LatestValidatorVote {
             return Err(DeserializedPacketError::VoteTransaction);
         }
 
+        let packet_data = packet.data(..).unwrap();
         let vote = SanitizedTransactionView::try_new_sanitized(
-            std::sync::Arc::new(packet.data(..).unwrap().to_vec()),
+            packet_bytes(packet, packet_data),
             &solana_runtime_transaction::sanitize_config::sanitize_config(),
         )
         .unwrap();
@@ -143,7 +144,7 @@ impl LatestValidatorVote {
         self.vote.is_none()
     }
 
-    pub fn take_vote(&mut self) -> Option<SanitizedTransactionView<SharedBytes>> {
+    pub fn take_vote(&mut self) -> Option<SanitizedTransactionView<Bytes>> {
         self.vote.take()
     }
 }

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -3,12 +3,13 @@ use {
         transaction_priority_id::TransactionPriorityId,
         transaction_state::TransactionState,
         transaction_state_container::{
-            SharedBytes, StateContainer, TransactionViewState, TransactionViewStateContainer,
+            StateContainer, TransactionViewState, TransactionViewStateContainer,
         },
     },
     crate::{
         banking_stage::{
-            consumer::Consumer, decision_maker::BufferedPacketsDecision, scheduler_messages::MaxAge,
+            consumer::Consumer, decision_maker::BufferedPacketsDecision, packet_bytes,
+            scheduler_messages::MaxAge,
         },
         transaction_priority::calculate_priority_and_cost,
     },
@@ -24,6 +25,7 @@ use {
     solana_address_lookup_table_interface::state::estimate_last_valid_slot,
     solana_clock::{Epoch, Slot},
     solana_message::v0::LoadedAddresses,
+    solana_perf::packet::bytes::Bytes,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
@@ -140,7 +142,7 @@ pub(crate) struct TransactionViewReceiveAndBuffer {
 }
 
 impl ReceiveAndBuffer for TransactionViewReceiveAndBuffer {
-    type Transaction = RuntimeTransaction<ResolvedTransactionView<SharedBytes>>;
+    type Transaction = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
     type Container = TransactionViewStateContainer;
 
     fn receive_and_buffer_packets(
@@ -268,27 +270,25 @@ impl TransactionViewReceiveAndBuffer {
                 continue;
             }
 
-            // Reserve free-space to copy packet into, run sanitization checks, and insert.
-            if let Some(transaction_id) =
-                container.try_insert_map_only_with_data(packet_data, |bytes| {
-                    match Self::try_handle_packet(
-                        bytes,
-                        root_bank,
-                        working_bank,
-                        transaction_account_lock_limit,
-                        &sanitize_config,
-                        &self.filter_keys,
-                    ) {
-                        // Parent giving us state means successful parse, ALTs resolved, no obvious static issues.
-                        Ok(state) => Ok(state),
+            let bytes = packet_bytes(packet, packet_data);
+            let state = match Self::try_handle_packet(
+                bytes,
+                root_bank,
+                working_bank,
+                transaction_account_lock_limit,
+                &sanitize_config,
+                &self.filter_keys,
+            ) {
+                // Successful parse, ALTs resolved, and no obvious static issues.
+                Ok(state) => state,
 
-                        // Parsing or some other static checks failed.
-                        Err(ref err) => {
-                            receiving_stats.add_packet_handling_error(err);
-                            Err(())
-                        }
-                    }
-                })
+                // Parsing or some other static checks failed.
+                Err(ref err) => {
+                    receiving_stats.add_packet_handling_error(err);
+                    continue;
+                }
+            };
+            let transaction_id = container.insert_map_only(state);
             {
                 let (priority, raw_nonce_address) = container
                     .get_mut_transaction_state(transaction_id)
@@ -383,7 +383,7 @@ impl TransactionViewReceiveAndBuffer {
     }
 
     fn try_handle_packet(
-        bytes: SharedBytes,
+        bytes: Bytes,
         root_bank: &Bank,
         working_bank: &Bank,
         transaction_account_lock_limit: usize,
@@ -1052,6 +1052,32 @@ mod tests {
         assert_eq!(num_buffered, 1);
         assert_eq!(num_evicted_on_nonce_dedup, 0);
 
+        verify_container(&mut container, 1);
+    }
+
+    #[test]
+    fn test_receive_and_buffer_pinned_packet() {
+        let (sender, receiver) = bounded(1024);
+        let (bank_forks, mint_keypair) = test_bank_forks();
+        let (mut receive_and_buffer, mut container) =
+            setup_transaction_view_receive_and_buffer(receiver, bank_forks.clone());
+
+        let transaction = transfer(
+            &mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            bank_forks.read().unwrap().root_bank().last_blockhash(),
+        );
+        let packet = Packet::from_data(None, transaction).unwrap();
+        sender
+            .send(Arc::new(PacketBatch::from(RecycledPacketBatch::new(vec![
+                packet,
+            ]))))
+            .unwrap();
+
+        let stats = receive(&mut receive_and_buffer, &mut container);
+        assert_eq!(stats.num_received, 1);
+        assert_eq!(stats.num_buffered, 1);
         verify_container(&mut container, 1);
     }
 

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -3,7 +3,7 @@ use {
     crate::banking_stage::scheduler_messages::TransactionId,
     agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
     slab::{Slab, VacantEntry},
-    solana_packet::PACKET_DATA_SIZE,
+    solana_perf::packet::bytes::Bytes,
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
@@ -12,7 +12,6 @@ use {
         collections::{BTreeSet, HashMap, hash_map::Entry},
         iter::Rev,
         ops::Bound,
-        sync::Arc,
     },
 };
 
@@ -264,6 +263,15 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
 }
 
 impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
+    /// Insert into the map, but NOT into the priority queue.
+    /// Returns the id of the inserted transaction.
+    pub(crate) fn insert_map_only(&mut self, state: TransactionState<Tx>) -> TransactionId {
+        let entry = self.get_vacant_map_entry();
+        let transaction_id = entry.key();
+        entry.insert(state);
+        transaction_id
+    }
+
     /// Insert a new transaction into the container's queues and maps.
     /// Returns `true` if a packet was dropped due to capacity limits.
     #[cfg(test)]
@@ -274,12 +282,9 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
         priority: u64,
         cost: u64,
     ) -> bool {
-        let priority_id = {
-            let entry = self.get_vacant_map_entry();
-            let transaction_id = entry.key();
-            entry.insert(TransactionState::new(transaction, max_age, priority, cost));
-            TransactionPriorityId::new(priority, transaction_id)
-        };
+        let transaction_id =
+            self.insert_map_only(TransactionState::new(transaction, max_age, priority, cost));
+        let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
         self.push_ids_into_queue(std::iter::once(priority_id)) > 0
     }
@@ -304,165 +309,9 @@ impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
     }
 }
 
-pub type SharedBytes = Arc<Vec<u8>>;
-pub(crate) type RuntimeTransactionView = RuntimeTransaction<ResolvedTransactionView<SharedBytes>>;
+pub(crate) type RuntimeTransactionView = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
 pub(crate) type TransactionViewState = TransactionState<RuntimeTransactionView>;
-
-/// A wrapper around `TransactionStateContainer` that allows reuse of
-/// pre-allocated `Bytes` to copy packet data into and use for serialization.
-/// This is used to avoid allocations in parsing transactions.
-pub struct TransactionViewStateContainer {
-    inner: TransactionStateContainer<RuntimeTransactionView>,
-    bytes_buffer: Box<[SharedBytes]>,
-}
-
-impl TransactionViewStateContainer {
-    /// Insert into the map, but NOT into the priority queue.
-    /// Returns the id of the transaction if it was inserted.
-    pub(crate) fn try_insert_map_only_with_data(
-        &mut self,
-        data: &[u8],
-        f: impl FnOnce(SharedBytes) -> Result<TransactionState<RuntimeTransactionView>, ()>,
-    ) -> Option<usize> {
-        // Get a vacant entry in the slab.
-        let vacant_entry = self.inner.get_vacant_map_entry();
-        let transaction_id = vacant_entry.key();
-
-        // Get the vacant space in the bytes buffer.
-        let bytes_entry = &mut self.bytes_buffer[transaction_id];
-        // Assert the entry is unique, then copy the packet data.
-        {
-            // The strong count must be 1 here. These are only cloned into the
-            // inner container below, wrapped by a `ResolveTransactionView`,
-            // which does not expose the backing memory (the `Arc`), or
-            // implement `Clone`.
-            // This could only fail if there is a bug in the container that the
-            // entry in the slab was not cleared. However, since we share
-            // indexing between the slab and our `bytes_buffer`, we know that
-            // `vacant_entry` is not occupied.
-            assert_eq!(Arc::strong_count(bytes_entry), 1, "entry must be unique");
-            let bytes = Arc::make_mut(bytes_entry);
-
-            // Clear and copy the packet data into the bytes buffer.
-            bytes.clear();
-            bytes.extend_from_slice(data);
-        }
-
-        // Attempt to insert the transaction.
-        if let Ok(state) = f(Arc::clone(bytes_entry)) {
-            vacant_entry.insert(state);
-            Some(transaction_id)
-        } else {
-            None
-        }
-    }
-}
-
-impl StateContainer<RuntimeTransactionView> for TransactionViewStateContainer {
-    fn with_capacity(capacity: usize) -> Self {
-        let inner = TransactionStateContainer::with_capacity(capacity);
-        let bytes_buffer = (0..inner.id_to_transaction_state.capacity())
-            .map(|_| Arc::new(Vec::with_capacity(PACKET_DATA_SIZE)))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-        Self {
-            inner,
-            bytes_buffer,
-        }
-    }
-
-    #[inline]
-    fn queue_size(&self) -> usize {
-        self.inner.queue_size()
-    }
-
-    #[inline]
-    fn buffer_size(&self) -> usize {
-        self.inner.buffer_size()
-    }
-
-    #[inline]
-    fn is_empty(&self) -> bool {
-        self.inner.is_empty()
-    }
-
-    #[inline]
-    fn pop(&mut self) -> Option<TransactionPriorityId> {
-        self.inner.pop()
-    }
-
-    #[inline]
-    fn get_mut_transaction_state(
-        &mut self,
-        id: TransactionId,
-    ) -> Option<&mut TransactionViewState> {
-        self.inner.get_mut_transaction_state(id)
-    }
-
-    #[inline]
-    fn get_transaction(&self, id: TransactionId) -> Option<&RuntimeTransactionView> {
-        self.inner.get_transaction(id)
-    }
-
-    #[inline]
-    fn push_ids_into_queue(
-        &mut self,
-        priority_ids: impl Iterator<Item = TransactionPriorityId>,
-    ) -> usize {
-        self.inner.push_ids_into_queue(priority_ids)
-    }
-
-    #[inline]
-    fn hold_transaction(&mut self, priority_id: TransactionPriorityId) {
-        self.inner.hold_transaction(priority_id);
-    }
-
-    #[inline]
-    fn remove_by_id(&mut self, id: TransactionId) {
-        self.inner.remove_by_id(id);
-    }
-
-    #[inline]
-    fn flush_held_transactions(&mut self) {
-        self.inner.flush_held_transactions();
-    }
-
-    #[inline]
-    fn get_min_max_priority(&self) -> Option<(u64, u64)> {
-        self.inner.get_min_max_priority()
-    }
-
-    #[inline]
-    fn recheck_iter(
-        &self,
-        cursor: Option<&TransactionPriorityId>,
-    ) -> Rev<std::collections::btree_set::Range<'_, TransactionPriorityId>> {
-        self.inner.recheck_iter(cursor)
-    }
-
-    #[inline]
-    fn is_queued(&self, id: &TransactionPriorityId) -> bool {
-        self.inner.is_queued(id)
-    }
-
-    #[inline]
-    fn get_nonce_transaction_priority_id(
-        &self,
-        nonce_address: &Pubkey,
-    ) -> Option<&TransactionPriorityId> {
-        self.inner.get_nonce_transaction_priority_id(nonce_address)
-    }
-
-    #[inline]
-    fn set_nonce_transaction_priority_id(
-        &mut self,
-        nonce_address: &Pubkey,
-        priority_id: TransactionPriorityId,
-    ) {
-        self.inner
-            .set_nonce_transaction_priority_id(nonce_address, priority_id);
-    }
-}
+pub(crate) type TransactionViewStateContainer = TransactionStateContainer<RuntimeTransactionView>;
 
 #[cfg(test)]
 mod tests {
@@ -580,18 +429,15 @@ mod tests {
             )
             .unwrap();
 
-            Ok(TransactionState::new(view, MaxAge::MAX, priority, cost))
+            TransactionState::new(view, MaxAge::MAX, priority, cost)
         };
 
         // Push 2 transactions into the queue so buffer is full.
         for priority in [4, 5] {
             let (transaction, _max_age, priority, cost) = test_transaction(priority);
             let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
-            let id = container
-                .try_insert_map_only_with_data(packet.data(..).unwrap(), |data| {
-                    packet_parser(data, priority, cost)
-                })
-                .unwrap();
+            let data = Bytes::copy_from_slice(packet.data(..).unwrap());
+            let id = container.insert_map_only(packet_parser(data, priority, cost));
             let priority_id = TransactionPriorityId::new(priority, id);
             assert_eq!(
                 container.push_ids_into_queue(std::iter::once(priority_id)),
@@ -603,11 +449,8 @@ mod tests {
         for priority in [10, 11, 12, 1, 2] {
             let (transaction, _max_age, priority, cost) = test_transaction(priority);
             let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
-            let id = container
-                .try_insert_map_only_with_data(packet.data(..).unwrap(), |data| {
-                    packet_parser(data, priority, cost)
-                })
-                .unwrap();
+            let data = Bytes::copy_from_slice(packet.data(..).unwrap());
+            let id = container.insert_map_only(packet_parser(data, priority, cost));
             let priority_id = TransactionPriorityId::new(priority, id);
             assert_eq!(
                 container.push_ids_into_queue(std::iter::once(priority_id)),
@@ -624,11 +467,8 @@ mod tests {
         let priority = u64::MAX;
         let (transaction, _max_age, priority, cost) = test_transaction(priority);
         let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
-        let id = container
-            .try_insert_map_only_with_data(packet.data(..).unwrap(), |data| {
-                packet_parser(data, priority, cost)
-            })
-            .unwrap();
+        let data = Bytes::copy_from_slice(packet.data(..).unwrap());
+        let id = container.insert_map_only(packet_parser(data, priority, cost));
         let priority_id = TransactionPriorityId::new(priority, id);
         assert_eq!(
             container.push_ids_into_queue(std::iter::once(priority_id)),

--- a/core/src/banking_stage/vote_packet_receiver.rs
+++ b/core/src/banking_stage/vote_packet_receiver.rs
@@ -1,9 +1,8 @@
 use {
     super::{
         BankingStageStats, latest_validator_vote_packet::VoteSource,
-        leader_slot_metrics::LeaderSlotMetricsTracker, vote_storage::VoteStorage,
+        leader_slot_metrics::LeaderSlotMetricsTracker, packet_bytes, vote_storage::VoteStorage,
     },
-    crate::banking_stage::transaction_scheduler::transaction_state_container::SharedBytes,
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     agave_transaction_view::{
         result::TransactionViewError, sanitize::SanitizeConfig,
@@ -11,6 +10,7 @@ use {
     },
     crossbeam_channel::RecvTimeoutError,
     solana_measure::{measure::Measure, measure_us},
+    solana_perf::packet::bytes::Bytes,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::sanitize_config::sanitize_config,
     std::{
@@ -139,7 +139,7 @@ impl VotePacketReceiver {
             };
 
             match SanitizedTransactionView::try_new_sanitized(
-                Arc::new(packet_data.to_vec()),
+                packet_bytes(packet, packet_data),
                 sanitize_config,
             ) {
                 Ok(packet) => {
@@ -219,7 +219,7 @@ impl VotePacketReceiver {
         slot_metrics_tracker.increment_received_packet_counts(stats.packet_stats);
     }
 
-    fn should_filter_packet(&self, packet: &SanitizedTransactionView<SharedBytes>) -> bool {
+    fn should_filter_packet(&self, packet: &SanitizedTransactionView<Bytes>) -> bool {
         // Vote transactions do not use address lookup tables, so static keys cover this path.
         !self.filter_keys.is_empty()
             && packet

--- a/core/src/banking_stage/vote_storage.rs
+++ b/core/src/banking_stage/vote_storage.rs
@@ -1,12 +1,12 @@
 use {
     super::latest_validator_vote_packet::{LatestValidatorVote, VoteSource},
-    crate::banking_stage::transaction_scheduler::transaction_state_container::SharedBytes,
     agave_transaction_view::transaction_view::SanitizedTransactionView,
     ahash::HashMap,
     itertools::Itertools,
     rand::{Rng, rng},
     solana_account::ReadableAccount as _,
     solana_clock::Epoch,
+    solana_perf::packet::bytes::Bytes,
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
@@ -108,7 +108,7 @@ impl VoteStorage {
     pub(crate) fn insert_packet(
         &mut self,
         vote_source: VoteSource,
-        packet: SanitizedTransactionView<SharedBytes>,
+        packet: SanitizedTransactionView<Bytes>,
     ) -> VoteInsertionMetrics {
         let Ok(vote) =
             LatestValidatorVote::new_from_view(packet, vote_source, self.deprecate_legacy_vote_ixs)
@@ -122,7 +122,7 @@ impl VoteStorage {
     // Re-insert re-tryable packets.
     pub(crate) fn reinsert_packets(
         &mut self,
-        packets: impl Iterator<Item = SanitizedTransactionView<SharedBytes>>,
+        packets: impl Iterator<Item = SanitizedTransactionView<Bytes>>,
     ) {
         let should_deprecate_legacy_vote_ixs = self.deprecate_legacy_vote_ixs;
         for vote in packets.filter_map(|packet| {
@@ -137,7 +137,7 @@ impl VoteStorage {
         }
     }
 
-    pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<SanitizedTransactionView<SharedBytes>> {
+    pub fn drain_unprocessed(&mut self, bank: &Bank) -> Vec<SanitizedTransactionView<Bytes>> {
         let slot_hashes = bank
             .get_account(&sysvar::slot_hashes::id())
             .and_then(|account| wincode::deserialize::<SlotHashes>(account.data()).ok());
@@ -387,7 +387,6 @@ pub(crate) mod tests {
         solana_signer::Signer,
         solana_vote::vote_transaction::new_tower_sync_transaction,
         solana_vote_program::vote_state::TowerSync,
-        std::sync::Arc,
     };
 
     /// Create a VoteAccount with a specific authorized voter for the given epoch
@@ -511,18 +510,15 @@ pub(crate) mod tests {
         packet
     }
 
-    fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<SharedBytes> {
-        SanitizedTransactionView::try_new_sanitized(
-            Arc::new(packet.buffer().to_vec()),
-            &sanitize_config(),
-        )
-        .unwrap()
+    fn to_sanitized_view(packet: BytesPacket) -> SanitizedTransactionView<Bytes> {
+        SanitizedTransactionView::try_new_sanitized(packet.buffer().clone(), &sanitize_config())
+            .unwrap()
     }
 
     fn insert_packets(
         vote_storage: &mut VoteStorage,
         vote_source: VoteSource,
-        packets: impl IntoIterator<Item = SanitizedTransactionView<SharedBytes>>,
+        packets: impl IntoIterator<Item = SanitizedTransactionView<Bytes>>,
     ) {
         for packet in packets {
             vote_storage.insert_packet(vote_source, packet);

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -12,7 +12,7 @@ use {
     },
     crate::banking_stage::{
         consumer::{ExecuteAndCommitTransactionsOutput, ProcessTransactionBatchOutput},
-        transaction_scheduler::transaction_state_container::{RuntimeTransactionView, SharedBytes},
+        transaction_scheduler::transaction_state_container::RuntimeTransactionView,
     },
     agave_transaction_view::{
         transaction_version::TransactionVersion, transaction_view::SanitizedTransactionView,
@@ -21,6 +21,7 @@ use {
     solana_accounts_db::account_locks::validate_account_locks,
     solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
     solana_measure::{measure::Measure, measure_us},
+    solana_perf::packet::bytes::Bytes,
     solana_poh::poh_recorder::PohRecorderError,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_runtime_transaction::{
@@ -443,7 +444,7 @@ impl VoteWorker {
 
 fn consume_scan_should_process_packet(
     bank: &Bank,
-    packet: SanitizedTransactionView<SharedBytes>,
+    packet: SanitizedTransactionView<Bytes>,
     error_counters: &mut TransactionErrorMetrics,
 ) -> Option<RuntimeTransactionView> {
     // Construct the RuntimeTransaction.


### PR DESCRIPTION
#### Problem
- Working on parallelization of ingress checks, similar to how we planning for external scheduler
- We currently use an Arc<Vec<u8>> which we store in our container, which would make us re-parse after copying
- We can just take the Bytes out of the packet (non-vote guaranteed bytes, albeit not type-guaranteed)

#### Summary of Changes
- Remove `SharedBytes` container stuff
	- Directly use `Bytes` for non-votes
	- Copy into a Bytes instead of Arc<Vec<>> for votes

#### Testing
- CI

Fixes #
