### PR TITLE
bench(programs/vote): migrate process_vote to criterion

### DIFF
--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -79,5 +79,9 @@ test-case = { workspace = true }
 name = "vote_instructions"
 harness = false
 
+[[bench]]
+name = "process_vote"
+harness = false
+
 [lints]
 workspace = true

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -1,9 +1,6 @@
-#![feature(test)]
-
-extern crate test;
-
 use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
+    criterion::{BatchSize, Criterion, criterion_group, criterion_main},
     solana_account::{Account, AccountSharedData, create_account_for_test},
     solana_clock::{Clock, Slot},
     solana_hash::Hash,
@@ -23,7 +20,7 @@ use {
             VoteStateVersions, handler::VoteStateHandler,
         },
     },
-    test::Bencher,
+    std::time::Duration,
 };
 
 fn create_accounts() -> (
@@ -105,50 +102,80 @@ fn create_accounts() -> (
 }
 
 fn bench_process_deprecated_vote_instruction(
-    bencher: &mut Bencher,
+    c: &mut Criterion,
+    name: &str,
     transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {
     let mut deprecated_feature_set = FeatureSet::all_enabled();
     deprecated_feature_set.deactivate(&deprecate_legacy_vote_ixs::id());
-    bencher.iter(|| {
-        mock_process_instruction_with_feature_set(
-            &solana_vote_program::id(),
-            &instruction_data,
-            transaction_accounts.clone(),
-            instruction_account_metas.clone(),
-            Ok(()),
-            solana_vote_program::vote_processor::Entrypoint::register,
-            |_invoke_context| {},
-            |_invoke_context| {},
-            &deprecated_feature_set.runtime_features(),
-        );
+    let feature_set = deprecated_feature_set.runtime_features();
+    c.bench_function(name, |bencher| {
+        // Processing a vote mutates the vote-account state, so hand each
+        // iteration a fresh clone of the accounts/metas via the (untimed)
+        // batched setup closure.
+        bencher.iter_batched(
+            || {
+                (
+                    transaction_accounts.clone(),
+                    instruction_account_metas.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_account_metas)| {
+                mock_process_instruction_with_feature_set(
+                    &solana_vote_program::id(),
+                    &instruction_data,
+                    transaction_accounts,
+                    instruction_account_metas,
+                    Ok(()),
+                    solana_vote_program::vote_processor::Entrypoint::register,
+                    |_invoke_context| {},
+                    |_invoke_context| {},
+                    &feature_set,
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
 fn bench_process_vote_instruction(
-    bencher: &mut Bencher,
+    c: &mut Criterion,
+    name: &str,
     transaction_accounts: Vec<KeyedAccountSharedData>,
     instruction_account_metas: Vec<AccountMeta>,
     instruction_data: Vec<u8>,
 ) {
-    bencher.iter(|| {
-        mock_process_instruction(
-            &solana_vote_program::id(),
-            &instruction_data,
-            transaction_accounts.clone(),
-            instruction_account_metas.clone(),
-            Ok(()),
-            solana_vote_program::vote_processor::Entrypoint::register,
-            |_invoke_context| {},
-            |_invoke_context| {},
-        );
+    c.bench_function(name, |bencher| {
+        // Processing a vote mutates the vote-account state, so hand each
+        // iteration a fresh clone of the accounts/metas via the (untimed)
+        // batched setup closure.
+        bencher.iter_batched(
+            || {
+                (
+                    transaction_accounts.clone(),
+                    instruction_account_metas.clone(),
+                )
+            },
+            |(transaction_accounts, instruction_account_metas)| {
+                mock_process_instruction(
+                    &solana_vote_program::id(),
+                    &instruction_data,
+                    transaction_accounts,
+                    instruction_account_metas,
+                    Ok(()),
+                    solana_vote_program::vote_processor::Entrypoint::register,
+                    |_invoke_context| {},
+                    |_invoke_context| {},
+                );
+            },
+            BatchSize::SmallInput,
+        )
     });
 }
 
-#[bench]
-fn bench_process_vote(bencher: &mut Bencher) {
+fn bench_process_vote(c: &mut Criterion) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
 
@@ -168,15 +195,15 @@ fn bench_process_vote(bencher: &mut Bencher) {
     let instruction_data = bincode::serialize(&VoteInstruction::Vote(vote)).unwrap();
 
     bench_process_deprecated_vote_instruction(
-        bencher,
+        c,
+        "process_vote",
         transaction_accounts,
         instruction_account_metas,
         instruction_data,
     );
 }
 
-#[bench]
-fn bench_process_vote_state_update(bencher: &mut Bencher) {
+fn bench_process_vote_state_update(c: &mut Criterion) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
 
@@ -198,15 +225,15 @@ fn bench_process_vote_state_update(bencher: &mut Bencher) {
         bincode::serialize(&VoteInstruction::UpdateVoteState(vote_state_update)).unwrap();
 
     bench_process_deprecated_vote_instruction(
-        bencher,
+        c,
+        "process_vote_state_update",
         transaction_accounts,
         instruction_account_metas,
         instruction_data,
     );
 }
 
-#[bench]
-fn bench_process_tower_sync(bencher: &mut Bencher) {
+fn bench_process_tower_sync(c: &mut Criterion) {
     let (num_initial_votes, slot_hashes, transaction_accounts, instruction_account_metas) =
         create_accounts();
 
@@ -228,9 +255,24 @@ fn bench_process_tower_sync(bencher: &mut Bencher) {
     let instruction_data = bincode::serialize(&VoteInstruction::TowerSync(tower_sync)).unwrap();
 
     bench_process_vote_instruction(
-        bencher,
+        c,
+        "process_tower_sync",
         transaction_accounts,
         instruction_account_metas,
         instruction_data,
     );
 }
+
+criterion_group! {
+    name = benches;
+    // Trim criterion's defaults so the suite runs in a couple of seconds.
+    // These are cheap, low-variance CPU-bound benchmarks, so short windows and
+    // few samples already give tight confidence intervals.
+    config = Criterion::default()
+        .warm_up_time(Duration::from_millis(250))
+        .measurement_time(Duration::from_millis(400))
+        .sample_size(10)
+        .without_plots();
+    targets = bench_process_vote, bench_process_vote_state_update, bench_process_tower_sync,
+}
+criterion_main!(benches);


### PR DESCRIPTION
#### Problem
We want to reduce exposure to nightly-only testing, i.e. built-in benchmarks and migrate to tools available on stable.

#### Summary of Changes
Convert the three `process_vote` benchmarks from the nightly `#[bench]` (libtest) harness to criterion so they build and run on stable. Each iteration gets a fresh clone of the accounts via `iter_batched`, since processing a vote mutates vote-account state.

Tune the criterion config to keep the suite fast:
    warm_up_time      250ms
    measurement_time  400ms
    sample_size       10
    without_plots()

Criterion's defaults (3s warm-up + 5s measurement + per-bench plot generation) run the 3-bench suite in ~33s, with plot generation alone costing ~1.3s/bench. With plots off, wall clock is ~(warm_up + measurement) x 3, so the trimmed windows land at ~2.5s -- comparable to the ~2s libtest baseline -- while keeping tighter measured accuracy (CI +/-1-2% vs libtest's +/-5-9%). Shorter windows start inflating the estimates, so this is roughly the accuracy floor.

#### Testing
```
$ cargo bench -p solana-vote-program --bench process_vote
```
