### PR TITLE
gesyser: add notification for the block footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Release channels have their own copy of this changelog:
   `notify_block_metadata_for_bank` replaces `notify_block_metadata`.
 * Added `update_bank_status` for bank-scoped slot status updates with `bank_id`;
   `update_slot_status` remains for non-bank slot statuses.
+* Added `GeyserPlugin::notify_block_footer` and
+  `GeyserPlugin::block_footer_notifications_enabled`; plugins can opt in to receive the complete
+  versioned Alpenglow block footer, slot, and bank ID in entry order independently of entry
+  notifications.
 ### SDK
 #### Breaking
 * solana-program-test: syscall getters (e.g. `Rent::get()`, `Clock::get()`) and `solana_sysvar::get_sysvar()` now return

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ version = "4.3.0-alpha.2"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-message",
  "solana-signature",

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,7 +1,9 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
     solana_clock::BankId,
-    solana_entry::{entry::EntrySummary, entry_or_marker::EntryOrMarker},
+    solana_entry::{
+        block_component::VersionedBlockMarker, entry::EntrySummary, entry_or_marker::EntryOrMarker,
+    },
     solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
     solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     std::{
@@ -77,27 +79,44 @@ impl TpuEntryNotifier {
         };
         let index = *current_index;
 
-        if let EntryOrMarker::Entry(ref entry) = entry_or_marker {
-            let entry_summary = EntrySummary {
-                num_hashes: entry.num_hashes,
-                hash: entry.hash,
-                num_transactions: entry.transactions.len() as u64,
-            };
-            if let Err(err) = entry_notification_sender.send(EntryNotification {
-                slot,
-                bank_id,
-                index,
-                entry: entry_summary,
-                starting_transaction_index: *current_transaction_index,
-            }) {
-                warn!(
-                    "Failed to send slot {slot:?} entry {index:?} from Tpu to \
-                     EntryNotifierService, error {err:?}",
-                );
+        match &entry_or_marker {
+            EntryOrMarker::Entry(entry) => {
+                let entry_summary = EntrySummary {
+                    num_hashes: entry.num_hashes,
+                    hash: entry.hash,
+                    num_transactions: entry.transactions.len() as u64,
+                };
+                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
+                    slot,
+                    bank_id,
+                    index,
+                    entry: entry_summary,
+                    starting_transaction_index: *current_transaction_index,
+                }) {
+                    warn!(
+                        "Failed to send slot {slot:?} entry {index:?} from Tpu to \
+                         EntryNotifierService, error {err:?}",
+                    );
+                }
+                *current_index += 1;
+                *current_transaction_index += entry.transactions.len();
             }
-            *current_index += 1;
-            *current_transaction_index += entry.transactions.len();
-        };
+            EntryOrMarker::Marker(VersionedBlockMarker::V1(marker)) => {
+                if let Some(block_footer) = marker.as_block_footer()
+                    && let Err(err) =
+                        entry_notification_sender.send(EntryNotification::BlockFooter {
+                            slot,
+                            bank_id,
+                            block_footer: Box::new(block_footer.clone()),
+                        })
+                {
+                    warn!(
+                        "Failed to send slot {slot:?} block footer from Tpu to \
+                         EntryNotifierService, error {err:?}",
+                    );
+                }
+            }
+        }
 
         if let Err(err) = broadcast_entry_sender.send((bank, (entry_or_marker, tick_height))) {
             warn!(
@@ -113,5 +132,87 @@ impl TpuEntryNotifier {
 
     pub(crate) fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crossbeam_channel::unbounded,
+        solana_entry::block_component::{
+            BlockFooterV1, VersionedBlockFooter, VersionedBlockMarker,
+        },
+        solana_genesis_config::GenesisConfig,
+        solana_hash::Hash,
+        solana_runtime::bank::{Bank, SlotLeader},
+    };
+
+    #[test]
+    fn test_block_footer_notification_and_forwarding() {
+        let (parent, _bank_forks) = Bank::new_with_bank_forks_for_tests(&GenesisConfig::default());
+        let bank = Arc::new(Bank::new_from_parent(parent, SlotLeader::default(), 42));
+        let slot = bank.slot();
+        let bank_id = bank.bank_id();
+        let block_footer = BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 1_234_567_890,
+            block_user_agent: b"test-validator/1.0".to_vec(),
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        };
+        let expected_block_footer = VersionedBlockFooter::V1(block_footer.clone());
+        let marker = VersionedBlockMarker::from_block_footer(block_footer);
+        let tick_height = 123;
+
+        let (entry_sender, entry_receiver) = unbounded();
+        let (entry_notification_sender, entry_notification_receiver) = unbounded();
+        let (broadcast_entry_sender, broadcast_entry_receiver) = unbounded();
+        entry_sender
+            .send((
+                bank.clone(),
+                (EntryOrMarker::Marker(marker.clone()), tick_height),
+            ))
+            .unwrap();
+
+        let mut current_slot = 0;
+        let mut current_bank_id = BankId::default();
+        let mut current_index = 0;
+        let mut current_transaction_index = 0;
+        TpuEntryNotifier::send_entry_notification(
+            Arc::new(AtomicBool::new(false)),
+            &entry_receiver,
+            &entry_notification_sender,
+            &broadcast_entry_sender,
+            &mut current_slot,
+            &mut current_bank_id,
+            &mut current_index,
+            &mut current_transaction_index,
+        )
+        .unwrap();
+
+        let EntryNotification::BlockFooter {
+            slot: notified_slot,
+            bank_id: notified_bank_id,
+            block_footer: notified_block_footer,
+        } = entry_notification_receiver.try_recv().unwrap()
+        else {
+            panic!("expected block footer notification");
+        };
+        assert_eq!(notified_slot, slot);
+        assert_eq!(notified_bank_id, bank_id);
+        assert_eq!(*notified_block_footer, expected_block_footer);
+        assert!(entry_notification_receiver.try_recv().is_err());
+
+        let (forwarded_bank, (forwarded_entry_or_marker, forwarded_tick_height)) =
+            broadcast_entry_receiver.try_recv().unwrap();
+        assert!(Arc::ptr_eq(&forwarded_bank, &bank));
+        assert_eq!(forwarded_tick_height, tick_height);
+        let EntryOrMarker::Marker(forwarded_marker) = forwarded_entry_or_marker else {
+            panic!("expected forwarded block footer marker");
+        };
+        assert_eq!(forwarded_marker, marker);
+        assert!(broadcast_entry_receiver.try_recv().is_err());
     }
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -148,6 +148,7 @@ version = "4.3.0-alpha.2"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-message",
  "solana-signature",

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -20,6 +20,7 @@ agave-unstable-api = []
 [dependencies]
 log = { workspace = true, features = ["std"] }
 solana-clock = { workspace = true }
+solana-entry = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
 solana-signature = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -4,6 +4,7 @@
 //! creates the implementation of the plugin.
 use {
     solana_clock::{BankId, Slot, UnixTimestamp},
+    solana_entry::block_component::VersionedBlockFooter,
     solana_hash::Hash,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
@@ -294,6 +295,22 @@ pub struct ReplicaEntryInfoV2<'a> {
 pub enum ReplicaEntryInfoVersions<'a> {
     V0_0_1(&'a ReplicaEntryInfo<'a>),
     V0_0_2(&'a ReplicaEntryInfoV2<'a>),
+}
+
+/// Information about an Alpenglow block footer.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockFooterInfo<'a> {
+    /// The slot containing the block footer.
+    pub slot: Slot,
+    /// The versioned block footer.
+    pub block_footer: &'a VersionedBlockFooter,
+}
+
+/// A wrapper to future-proof ReplicaBlockFooterInfo handling.
+#[repr(u32)]
+pub enum ReplicaBlockFooterInfoVersions<'a> {
+    V0_0_1(&'a ReplicaBlockFooterInfo<'a>),
 }
 
 #[derive(Clone, Debug)]
@@ -712,6 +729,20 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         self.notify_entry(entry)
     }
 
+    /// Called when an Alpenglow block footer is processed.
+    ///
+    /// `bank_id` identifies the concrete bank instance associated with the
+    /// footer. This callback is ordered with entry notifications and is only
+    /// called when `block_footer_notifications_enabled()` returns true.
+    #[allow(unused_variables)]
+    fn notify_block_footer(
+        &self,
+        block_footer: ReplicaBlockFooterInfoVersions,
+        bank_id: BankId,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Called when block's metadata is updated.
     #[deprecated(
         since = "4.3.0",
@@ -807,6 +838,13 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// Default is false -- if the plugin is interested in
     /// entry data, return true.
     fn entry_notifications_enabled(&self) -> bool {
+        false
+    }
+
+    /// Check if the plugin is interested in Alpenglow block footer data.
+    /// Default is false -- if the plugin is interested in
+    /// Alpenglow block footer data, return true.
+    fn block_footer_notifications_enabled(&self) -> bool {
         false
     }
 

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -2,12 +2,13 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaEntryInfoV2, ReplicaEntryInfoVersions,
+        ReplicaBlockFooterInfo, ReplicaBlockFooterInfoVersions, ReplicaEntryInfoV2,
+        ReplicaEntryInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::{BankId, Slot},
-    solana_entry::entry::EntrySummary,
+    solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
     solana_ledger::entry_notifier_interface::EntryNotifier,
     std::sync::Arc,
 };
@@ -53,6 +54,39 @@ impl EntryNotifier for EntryNotifierImpl {
             }
         }
     }
+
+    fn notify_block_footer(
+        &self,
+        slot: Slot,
+        bank_id: BankId,
+        block_footer: &VersionedBlockFooter,
+    ) {
+        let plugin_manager = self.plugin_manager.load();
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let block_footer_info = ReplicaBlockFooterInfo { slot, block_footer };
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.block_footer_notifications_enabled() {
+                continue;
+            }
+            match plugin.notify_block_footer(
+                ReplicaBlockFooterInfoVersions::V0_0_1(&block_footer_info),
+                bank_id,
+            ) {
+                Err(err) => error!(
+                    "Failed to notify block footer, error: ({}) to plugin {}",
+                    err,
+                    plugin.name()
+                ),
+                Ok(_) => trace!(
+                    "Successfully notified block footer to plugin {}",
+                    plugin.name()
+                ),
+            }
+        }
+    }
 }
 
 impl EntryNotifierImpl {
@@ -85,16 +119,20 @@ mod tests {
         agave_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin, Result},
         arc_swap::ArcSwap,
         libloading::Library,
+        solana_entry::block_component::BlockFooterV1,
         solana_hash::Hash,
         std::sync::{Arc, Mutex},
     };
 
     type EntryUpdate = (Slot, BankId, usize, usize);
+    type BlockFooterUpdate = (Slot, BankId, VersionedBlockFooter);
 
     #[derive(Debug)]
     struct TestEntryPlugin {
         entry_notifications_enabled: bool,
-        updates: Arc<Mutex<Vec<EntryUpdate>>>,
+        block_footer_notifications_enabled: bool,
+        entry_updates: Arc<Mutex<Vec<EntryUpdate>>>,
+        block_footer_updates: Arc<Mutex<Vec<BlockFooterUpdate>>>,
     }
 
     impl GeyserPlugin for TestEntryPlugin {
@@ -110,7 +148,7 @@ mod tests {
             let ReplicaEntryInfoVersions::V0_0_2(entry) = entry else {
                 panic!("expected V0_0_2 entry info");
             };
-            self.updates.lock().unwrap().push((
+            self.entry_updates.lock().unwrap().push((
                 entry.slot,
                 bank_id,
                 entry.index,
@@ -119,8 +157,26 @@ mod tests {
             Ok(())
         }
 
+        fn notify_block_footer(
+            &self,
+            block_footer: ReplicaBlockFooterInfoVersions,
+            bank_id: BankId,
+        ) -> Result<()> {
+            let ReplicaBlockFooterInfoVersions::V0_0_1(block_footer) = block_footer;
+            self.block_footer_updates.lock().unwrap().push((
+                block_footer.slot,
+                bank_id,
+                block_footer.block_footer.clone(),
+            ));
+            Ok(())
+        }
+
         fn entry_notifications_enabled(&self) -> bool {
             self.entry_notifications_enabled
+        }
+
+        fn block_footer_notifications_enabled(&self) -> bool {
+            self.block_footer_notifications_enabled
         }
     }
 
@@ -138,18 +194,24 @@ mod tests {
     }
 
     #[test]
-    fn test_notify_entry_includes_bank_id() {
-        let enabled_updates = Arc::new(Mutex::new(Vec::new()));
-        let disabled_updates = Arc::new(Mutex::new(Vec::new()));
+    fn test_notify_entry_and_block_footer_independently() {
+        let entry_plugin_entry_updates = Arc::new(Mutex::new(Vec::new()));
+        let entry_plugin_block_footer_updates = Arc::new(Mutex::new(Vec::new()));
+        let block_footer_plugin_entry_updates = Arc::new(Mutex::new(Vec::new()));
+        let block_footer_plugin_block_footer_updates = Arc::new(Mutex::new(Vec::new()));
         let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
             plugins: vec![
                 loaded_test_plugin(TestEntryPlugin {
                     entry_notifications_enabled: true,
-                    updates: enabled_updates.clone(),
+                    block_footer_notifications_enabled: false,
+                    entry_updates: entry_plugin_entry_updates.clone(),
+                    block_footer_updates: entry_plugin_block_footer_updates.clone(),
                 }),
                 loaded_test_plugin(TestEntryPlugin {
                     entry_notifications_enabled: false,
-                    updates: disabled_updates.clone(),
+                    block_footer_notifications_enabled: true,
+                    entry_updates: block_footer_plugin_entry_updates.clone(),
+                    block_footer_updates: block_footer_plugin_block_footer_updates.clone(),
                 }),
             ],
         })));
@@ -159,10 +221,27 @@ mod tests {
             hash: Hash::new_unique(),
             num_transactions: 2,
         };
+        let block_footer = VersionedBlockFooter::V1(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 123,
+            block_user_agent: b"test-validator".to_vec(),
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
 
         notifier.notify_entry(42, 9, 3, &entry, 7);
+        notifier.notify_block_footer(42, 9, &block_footer);
 
-        assert_eq!(*enabled_updates.lock().unwrap(), vec![(42, 9, 3, 7)]);
-        assert!(disabled_updates.lock().unwrap().is_empty());
+        assert_eq!(
+            *entry_plugin_entry_updates.lock().unwrap(),
+            vec![(42, 9, 3, 7)]
+        );
+        assert!(entry_plugin_block_footer_updates.lock().unwrap().is_empty());
+        assert!(block_footer_plugin_entry_updates.lock().unwrap().is_empty());
+        assert_eq!(
+            *block_footer_plugin_block_footer_updates.lock().unwrap(),
+            vec![(42, 9, block_footer)]
+        );
     }
 }

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -113,6 +113,16 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if there is any plugin interested in Alpenglow block footer data
+    pub fn block_footer_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.block_footer_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Check if there is any plugin interested in deshred transaction data
     pub fn deshred_transaction_notifications_enabled(&self) -> bool {
         for plugin in &self.plugins {

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -109,8 +109,10 @@ impl GeyserPluginService {
             .load()
             .deshred_transaction_notifications_enabled()
             || geyser_plugin_always_enabled;
-        let entry_notifications_enabled =
-            plugin_manager.load().entry_notifications_enabled() || geyser_plugin_always_enabled;
+        let entry_or_block_footer_notifications_enabled =
+            plugin_manager.load().entry_notifications_enabled()
+                || plugin_manager.load().block_footer_notifications_enabled()
+                || geyser_plugin_always_enabled;
 
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
             if account_data_notifications_enabled {
@@ -140,12 +142,13 @@ impl GeyserPluginService {
                 None
             };
 
-        let entry_notifier: Option<EntryNotifierArc> = if entry_notifications_enabled {
-            let entry_notifier = EntryNotifierImpl::new(plugin_manager.clone());
-            Some(Arc::new(entry_notifier))
-        } else {
-            None
-        };
+        let entry_notifier: Option<EntryNotifierArc> =
+            if entry_or_block_footer_notifications_enabled {
+                let entry_notifier = EntryNotifierImpl::new(plugin_manager.clone());
+                Some(Arc::new(entry_notifier))
+            } else {
+                None
+            };
 
         let (slot_status_observer, block_metadata_notifier, slot_status_notifier): (
             Option<SlotStatusObserver>,
@@ -154,7 +157,7 @@ impl GeyserPluginService {
         ) = if account_data_notifications_enabled
             || transaction_notifications_enabled
             || deshred_transaction_notifications_enabled
-            || entry_notifications_enabled
+            || entry_or_block_footer_notifications_enabled
         {
             let slot_status_notifier = SlotStatusNotifierImpl::new(plugin_manager.clone());
             let slot_status_notifier = Arc::new(RwLock::new(slot_status_notifier));

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -20,7 +20,7 @@ use {
     },
     solana_clock::{BankId, Slot},
     solana_entry::{
-        block_component::BlockComponent,
+        block_component::{BlockComponent, VersionedBlockMarker},
         entry::{self, Entry, EntrySlice, EntryType, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
@@ -1320,7 +1320,10 @@ pub fn confirm_slot(
                 )?;
             }
             BlockComponent::BlockMarker(marker) => {
-                if marker.is_footer() {
+                let block_footer = match &marker {
+                    VersionedBlockMarker::V1(marker) => marker.as_block_footer().cloned(),
+                };
+                if block_footer.is_some() {
                     // The footer path mutates vote accounts directly to pay rewards.
                     // All prior transactions must finish first so vote account view is deterministic.
                     if let Some((result, execute_time)) = bank.wait_for_completed_scheduler() {
@@ -1349,6 +1352,20 @@ pub fn confirm_slot(
                                 );
                             }
                         })?;
+                    if let Some(block_footer) = block_footer
+                        && let Some(entry_notification_sender) = entry_notification_sender
+                        && let Err(err) =
+                            entry_notification_sender.send(EntryNotification::BlockFooter {
+                                slot,
+                                bank_id: bank.bank_id(),
+                                block_footer: Box::new(block_footer),
+                            })
+                    {
+                        warn!(
+                            "Slot {slot} block footer entry_notification_sender send failed: \
+                             {err:?}"
+                        );
+                    }
                 }
                 progress.num_shreds += num_shreds as u64;
             }
@@ -1402,7 +1419,7 @@ fn confirm_slot_entries(
         .map(|(i, entry)| {
             if let Some(entry_notification_sender) = entry_notification_sender {
                 let entry_index = progress.num_entries.saturating_add(i);
-                if let Err(err) = entry_notification_sender.send(EntryNotification {
+                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
                     slot,
                     bank_id,
                     index: entry_index,
@@ -2362,7 +2379,10 @@ pub mod tests {
         solana_account::{AccountSharedData, WritableAccount},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{
-            block_component::{BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockMarker},
+            block_component::{
+                BlockComponent, BlockFooterV1, BlockHeaderV1, VersionedBlockFooter,
+                VersionedBlockMarker,
+            },
             entry::{create_ticks, next_entry, next_entry_mut},
         },
         solana_epoch_schedule::EpochSchedule,
@@ -5411,7 +5431,7 @@ pub mod tests {
         )
         .unwrap();
         let footer = VersionedBlockMarker::from_block_footer(BlockFooterV1 {
-            bank_hash: Hash::new_unique(),
+            bank_hash: Hash::new_from_array([42; 32]),
             block_producer_time_nanos,
             block_user_agent: b"test".to_vec(),
             block_final_cert: None,
@@ -5564,6 +5584,8 @@ pub mod tests {
                 .is_active(&agave_feature_set::alpenglow::id())
         );
         let bank1 = bank_forks.write().unwrap().insert(bank1);
+        let (entry_notification_sender, entry_notification_receiver) =
+            bounded::<EntryNotification>(2);
 
         confirm_slot(
             &blockstore,
@@ -5573,13 +5595,57 @@ pub mod tests {
             &mut ConfirmationTiming::default(),
             &mut ConfirmationProgress::new(bank0.last_blockhash()),
             true,
-            None,
+            Some(&entry_notification_sender),
             None,
             None,
             false,
             &MigrationStatus::post_migration_status(),
         )
         .unwrap();
+
+        let EntryNotification::BlockFooter {
+            slot,
+            bank_id,
+            block_footer,
+        } = entry_notification_receiver.try_recv().unwrap()
+        else {
+            panic!("expected block footer notification before the alpentick entry");
+        };
+        assert_eq!(slot, bank1.slot());
+        assert_eq!(bank_id, bank1.bank_id());
+        let VersionedBlockFooter::V1(block_footer) = *block_footer;
+        assert_eq!(block_footer.bank_hash, Hash::new_from_array([42; 32]));
+        assert_eq!(
+            block_footer.block_producer_time_nanos,
+            u64::try_from(
+                genesis_config
+                    .creation_time
+                    .saturating_mul(1_000_000_000)
+                    .saturating_add(1),
+            )
+            .unwrap()
+        );
+        assert_eq!(block_footer.block_user_agent, b"test");
+        assert!(block_footer.block_final_cert.is_none());
+        assert!(block_footer.skip_reward_cert.is_none());
+        assert!(block_footer.notar_reward_cert.is_none());
+
+        let EntryNotification::Entry {
+            slot,
+            bank_id,
+            index,
+            entry,
+            starting_transaction_index,
+        } = entry_notification_receiver.try_recv().unwrap()
+        else {
+            panic!("expected alpentick entry notification after the block footer");
+        };
+        assert_eq!(slot, bank1.slot());
+        assert_eq!(bank_id, bank1.bank_id());
+        assert_eq!(index, 0);
+        assert_eq!(entry.num_transactions, 0);
+        assert_eq!(starting_transaction_index, 0);
+        assert!(entry_notification_receiver.try_recv().is_err());
     }
 
     #[test]

--- a/ledger/src/entry_notifier_interface.rs
+++ b/ledger/src/entry_notifier_interface.rs
@@ -1,6 +1,6 @@
 use {
     solana_clock::{BankId, Slot},
-    solana_entry::entry::EntrySummary,
+    solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
     std::sync::Arc,
 };
 
@@ -13,6 +13,18 @@ pub trait EntryNotifier {
         entry: &EntrySummary,
         starting_transaction_index: usize,
     );
+
+    /// Notify an Alpenglow block footer.
+    ///
+    /// This callback is delivered on the same channel as entry notifications,
+    /// preserving the order of entries and the footer within the block.
+    fn notify_block_footer(
+        &self,
+        _slot: Slot,
+        _bank_id: BankId,
+        _block_footer: &VersionedBlockFooter,
+    ) {
+    }
 }
 
 pub type EntryNotifierArc = Arc<dyn EntryNotifier + Sync + Send>;

--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -2,7 +2,7 @@ use {
     crate::entry_notifier_interface::EntryNotifierArc,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
     solana_clock::{BankId, Slot},
-    solana_entry::entry::EntrySummary,
+    solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
     std::{
         sync::{
             Arc,
@@ -13,12 +13,19 @@ use {
     },
 };
 
-pub struct EntryNotification {
-    pub slot: Slot,
-    pub bank_id: BankId,
-    pub index: usize,
-    pub entry: EntrySummary,
-    pub starting_transaction_index: usize,
+pub enum EntryNotification {
+    Entry {
+        slot: Slot,
+        bank_id: BankId,
+        index: usize,
+        entry: EntrySummary,
+        starting_transaction_index: usize,
+    },
+    BlockFooter {
+        slot: Slot,
+        bank_id: BankId,
+        block_footer: Box<VersionedBlockFooter>,
+    },
 }
 
 pub type EntryNotifierSender = Sender<EntryNotification>;
@@ -41,7 +48,7 @@ impl EntryNotifierService {
                     }
 
                     if let Err(RecvTimeoutError::Disconnected) =
-                        Self::notify_entry(&entry_notification_receiver, entry_notifier.clone())
+                        Self::notify(&entry_notification_receiver, entry_notifier.clone())
                     {
                         break;
                     }
@@ -54,18 +61,32 @@ impl EntryNotifierService {
         }
     }
 
-    fn notify_entry(
+    fn notify(
         entry_notification_receiver: &EntryNotifierReceiver,
         entry_notifier: EntryNotifierArc,
     ) -> Result<(), RecvTimeoutError> {
-        let EntryNotification {
-            slot,
-            bank_id,
-            index,
-            entry,
-            starting_transaction_index,
-        } = entry_notification_receiver.recv_timeout(Duration::from_secs(1))?;
-        entry_notifier.notify_entry(slot, bank_id, index, &entry, starting_transaction_index);
+        match entry_notification_receiver.recv_timeout(Duration::from_secs(1))? {
+            EntryNotification::Entry {
+                slot,
+                bank_id,
+                index,
+                entry,
+                starting_transaction_index,
+            } => {
+                entry_notifier.notify_entry(
+                    slot,
+                    bank_id,
+                    index,
+                    &entry,
+                    starting_transaction_index,
+                );
+            }
+            EntryNotification::BlockFooter {
+                slot,
+                bank_id,
+                block_footer,
+            } => entry_notifier.notify_block_footer(slot, bank_id, block_footer.as_ref()),
+        }
         Ok(())
     }
 
@@ -79,5 +100,119 @@ impl EntryNotifierService {
 
     pub fn join(self) -> thread::Result<()> {
         self.thread_hdl.join()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::entry_notifier_interface::EntryNotifier,
+        solana_entry::block_component::BlockFooterV1, solana_hash::Hash, std::sync::Mutex,
+    };
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum TestEvent {
+        Entry {
+            slot: Slot,
+            bank_id: BankId,
+            index: usize,
+            starting_transaction_index: usize,
+        },
+        BlockFooter {
+            slot: Slot,
+            bank_id: BankId,
+            block_footer: Box<VersionedBlockFooter>,
+        },
+    }
+
+    #[derive(Default)]
+    struct TestEntryNotifier {
+        events: Mutex<Vec<TestEvent>>,
+    }
+
+    impl EntryNotifier for TestEntryNotifier {
+        fn notify_entry(
+            &self,
+            slot: Slot,
+            bank_id: BankId,
+            index: usize,
+            _entry: &EntrySummary,
+            starting_transaction_index: usize,
+        ) {
+            self.events.lock().unwrap().push(TestEvent::Entry {
+                slot,
+                bank_id,
+                index,
+                starting_transaction_index,
+            });
+        }
+
+        fn notify_block_footer(
+            &self,
+            slot: Slot,
+            bank_id: BankId,
+            block_footer: &VersionedBlockFooter,
+        ) {
+            self.events.lock().unwrap().push(TestEvent::BlockFooter {
+                slot,
+                bank_id,
+                block_footer: Box::new(block_footer.clone()),
+            });
+        }
+    }
+
+    #[test]
+    fn test_forwards_entry_and_block_footer_in_order() {
+        let (sender, receiver) = unbounded();
+        let notifier = Arc::new(TestEntryNotifier::default());
+        let block_footer = VersionedBlockFooter::V1(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 123,
+            block_user_agent: b"test-validator".to_vec(),
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        });
+
+        sender
+            .send(EntryNotification::Entry {
+                slot: 42,
+                bank_id: 9,
+                index: 3,
+                entry: EntrySummary {
+                    num_hashes: 1,
+                    hash: Hash::new_unique(),
+                    num_transactions: 2,
+                },
+                starting_transaction_index: 7,
+            })
+            .unwrap();
+        sender
+            .send(EntryNotification::BlockFooter {
+                slot: 42,
+                bank_id: 9,
+                block_footer: Box::new(block_footer.clone()),
+            })
+            .unwrap();
+
+        EntryNotifierService::notify(&receiver, notifier.clone()).unwrap();
+        EntryNotifierService::notify(&receiver, notifier.clone()).unwrap();
+
+        assert_eq!(
+            *notifier.events.lock().unwrap(),
+            vec![
+                TestEvent::Entry {
+                    slot: 42,
+                    bank_id: 9,
+                    index: 3,
+                    starting_transaction_index: 7,
+                },
+                TestEvent::BlockFooter {
+                    slot: 42,
+                    bank_id: 9,
+                    block_footer: Box::new(block_footer),
+                },
+            ]
+        );
     }
 }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -148,6 +148,7 @@ version = "4.3.0-alpha.2"
 dependencies = [
  "log",
  "solana-clock",
+ "solana-entry",
  "solana-hash 4.5.0",
  "solana-message",
  "solana-signature",


### PR DESCRIPTION
#### Problem
The read layer is interested in the block footer for Alpenglow blocks in order to parse finalization certificates and rewards info

This is currently not exposed anywhere.

#### Summary of Changes
Add a geyser notification for the block footer

#### Testing
CI