### PR TITLE
solana-genesis: require the bls pubkey be supplied

### DIFF
--- a/genesis/README.md
+++ b/genesis/README.md
@@ -4,22 +4,27 @@
 ### 1) Through bootstrap validator cli args:
 ```
 --bootstrap-validator <IDENTITY_PUBKEY> <VOTE_PUBKEY> <STAKE_PUBKEY>
+--bootstrap-validator-bls-pubkey <BLS_PUBKEY>
 --bootstrap-validator-lamports <LAMPORTS>
 --bootstrap-validator-stake-lamports <LAMPORTS>
 ```
-Note: you can pass in `--bootstrap-validator ...` multiple times, but the lamports associated with `--bootstrap-validator-lamports` and `--bootstrap-validator-stake-lamports` will apply to all `--bootstrap-validator` arguments.
+Note: you can pass in `--bootstrap-validator ...` multiple times. Each bootstrap validator requires one corresponding `--bootstrap-validator-bls-pubkey`, specified in the same order. The lamports associated with `--bootstrap-validator-lamports` and `--bootstrap-validator-stake-lamports` will apply to all `--bootstrap-validator` arguments.
 For example:
 ```
 cargo run --bin solana-genesis --
     --bootstrap-validator <IDENTITY_PUBKEY_0> <VOTE_PUBKEY_0> <STAKE_PUBKEY_0>
+    --bootstrap-validator-bls-pubkey <BLS_PUBKEY_0>
     --bootstrap-validator <IDENTITY_PUBKEY_1> <VOTE_PUBKEY_1> <STAKE_PUBKEY_1>
+    --bootstrap-validator-bls-pubkey <BLS_PUBKEY_1>
     ...
     --bootstrap-validator <IDENTITY_PUBKEY_N> <VOTE_PUBKEY_N> <STAKE_PUBKEY_N>
+    --bootstrap-validator-bls-pubkey <BLS_PUBKEY_N>
     --bootstrap-validator-stake-lamports 10000000000
     --bootstrap-validator-lamports 100000000000
 ```
 All validator accounts will receive the same number of stake and account lamports
 
+To find the corresponding bls pubkey for a validator identity, run `solana-keygen bls_pubkey <IDENTITY_KEYPAIR>`
 ### 2) Through the primordial accounts file flag:
 The primordial accounts file can be used to add accounts of any type to genesis. A user can define all account data and metadata. `data` field must be BASE64 encoded.
 ```

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -390,7 +390,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("BLS_PUBKEY")
                 .multiple(true)
                 .takes_value(true)
-                .required(false)
+                .required(true)
                 .help("The bootstrap validator's bls pubkey"),
         )
         .arg(

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -71,6 +71,7 @@ fi
 if [[ -e "$ledgerDir"/genesis.bin || -e "$ledgerDir"/genesis.tar.bz2 ]]; then
   echo "Use existing genesis"
 else
+  validator_bls_pubkey=$(solana-keygen bls_pubkey "$validator_identity")
   ./fetch-core-bpf.sh
   if [[ -r core-bpf-genesis-args.sh ]]; then
     CORE_BPF_GENESIS_ARGS=$(cat core-bpf-genesis-args.sh)
@@ -89,6 +90,7 @@ else
       "$validator_identity" \
       "$validator_vote_account" \
       "$validator_stake_account" \
+    --bootstrap-validator-bls-pubkey "$validator_bls_pubkey" \
     --ledger "$ledgerDir" \
     --cluster-type "$SOLANA_RUN_SH_CLUSTER_TYPE" \
     $CORE_BPF_GENESIS_ARGS \


### PR DESCRIPTION
#### Problem
Now that the VAT has been activated on all clusters, it's required that all genesis validators have the BLS pubkey set otherwise they cannot vote.

#### Summary of Changes
Make it a required argument for `solana-genesis` and update documentation