### PR TITLE
bcl: fix reward aggregate signature identity issue

### DIFF
--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -81,7 +81,7 @@ impl Entry {
     ) -> Result<RewardRespSucc, BuildRewardCertsRespError> {
         let notar = self.notar.build_cert(reward_slot)?;
         let skip = match self.skip.build_sig_bitmap() {
-            BuildResult::Empty => None,
+            BuildResult::Empty | BuildResult::Identity => None,
             BuildResult::EncodingError(e) => return Err(BuildRewardCertsRespError::Encoding(e)),
             BuildResult::Success {
                 signature,
@@ -119,10 +119,14 @@ mod tests {
     use {
         super::*,
         agave_votor_messages::{
-            consensus_message::Block, vote::Vote, wire::get_vote_payload_to_sign,
+            consensus_message::Block,
+            vote::Vote,
+            wire::{VotePayloadToSign, get_vote_payload_to_sign},
         },
         rand::Rng,
-        solana_bls_signatures::{Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed},
+        solana_bls_signatures::{
+            Keypair as BlsKeypair, PubkeyCompressed as BlsPubkeyCompressed, SignatureProjective,
+        },
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
         solana_pubkey::Pubkey,
@@ -165,6 +169,31 @@ mod tests {
         };
         let aggregate = VoteAggregate::new_from_verified_vote(keypairs.len(), vote_msg);
         (aggregate, vec![Pubkey::new_unique()])
+    }
+
+    pub(crate) fn new_identity_reward_vote_aggregate(
+        vote: Vote,
+        max_validators: usize,
+        ranks_and_stakes: &[(u16, u64)],
+        shred_version: u16,
+    ) -> (VoteAggregate, Vec<Pubkey>) {
+        // This models the aggregate produced by individually valid votes whose signatures cancel.
+        let aggregate = VoteAggregate::new_from_verified_votes(
+            max_validators,
+            VotePayloadToSign::new_from_vote(vote, shred_version),
+            ranks_and_stakes.iter().map(|(rank, stake)| {
+                (
+                    *rank,
+                    NonZero::new(*stake).expect("test stake must be nonzero"),
+                )
+            }),
+            SignatureProjective::identity(),
+        );
+        let validators = ranks_and_stakes
+            .iter()
+            .map(|_| Pubkey::new_unique())
+            .collect();
+        (aggregate, validators)
     }
 
     pub(crate) fn get_keypairs(max_validators: usize, slot: Slot) -> Vec<BlsKeypair> {
@@ -279,5 +308,71 @@ mod tests {
         assert_eq!(notar.slot, slot);
         assert_eq!(notar.block_id, blockid1);
         validate_bitmap(notar.bitmap(), 3, 5);
+    }
+
+    #[test]
+    fn identity_skip_cert_is_omitted_without_dropping_notar_cert() {
+        let slot = 123;
+        let max_validators = 3;
+        let shred_version = rand::rng().random();
+        let keypairs = (0..max_validators)
+            .map(|_| BlsKeypair::new())
+            .collect::<Vec<_>>();
+        let mut entry = Entry::new(max_validators);
+
+        let skip = Vote::new_skip_vote(slot);
+        let (aggregate, skip_validators) = new_identity_reward_vote_aggregate(
+            skip,
+            max_validators,
+            &[(0, 100), (1, 100)],
+            shred_version,
+        );
+        entry.add_aggregate(aggregate, skip_validators).unwrap();
+
+        let block_id = Hash::new_unique();
+        let notar = Vote::new_notarization_vote(Block { slot, block_id });
+        let (aggregate, notar_validators) =
+            new_reward_vote_aggregate(notar, 2, &keypairs, None, shred_version);
+        entry
+            .add_aggregate(aggregate, notar_validators.clone())
+            .unwrap();
+
+        let resp = entry.build_certs(slot).unwrap();
+        assert!(resp.skip.is_none());
+        assert_eq!(resp.notar.unwrap().block_id, block_id);
+        assert_eq!(resp.validators, notar_validators);
+    }
+
+    #[test]
+    fn identity_notar_cert_is_omitted_without_dropping_skip_cert() {
+        let slot = 123;
+        let max_validators = 3;
+        let shred_version = rand::rng().random();
+        let keypairs = (0..max_validators)
+            .map(|_| BlsKeypair::new())
+            .collect::<Vec<_>>();
+        let mut entry = Entry::new(max_validators);
+
+        let block_id = Hash::new_unique();
+        let notar = Vote::new_notarization_vote(Block { slot, block_id });
+        let (aggregate, notar_validators) = new_identity_reward_vote_aggregate(
+            notar,
+            max_validators,
+            &[(0, 100), (1, 100)],
+            shred_version,
+        );
+        entry.add_aggregate(aggregate, notar_validators).unwrap();
+
+        let skip = Vote::new_skip_vote(slot);
+        let (aggregate, skip_validators) =
+            new_reward_vote_aggregate(skip, 2, &keypairs, None, shred_version);
+        entry
+            .add_aggregate(aggregate, skip_validators.clone())
+            .unwrap();
+
+        let resp = entry.build_certs(slot).unwrap();
+        assert!(resp.notar.is_none());
+        assert_eq!(resp.skip.unwrap().slot, slot);
+        assert_eq!(resp.validators, skip_validators);
     }
 }

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -13,7 +13,7 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    std::collections::HashMap,
+    std::{cmp::Reverse, collections::HashMap},
 };
 
 #[derive(Clone)]
@@ -69,27 +69,26 @@ impl NotarEntry {
         reward_slot: Slot,
     ) -> Result<Option<(NotarRewardCertificate, Vec<Pubkey>)>, BuildRewardCertsRespError> {
         // We can only submit one notar rewards certificate, but different validators may vote for
-        // different block ids. Pick the block id with the most stake to maximize leader rewards.
-        let selected = self
-            .partials
-            .into_iter()
-            .max_by_key(|(_block_id, partial)| partial.stake());
-        let Some((block_id, partial)) = selected else {
-            return Ok(None);
-        };
-        match partial.build_sig_bitmap() {
-            BuildResult::Empty => Ok(None),
-            BuildResult::EncodingError(e) => Err(BuildRewardCertsRespError::Encoding(e)),
-            BuildResult::Success {
-                signature,
-                bitmap,
-                validators,
-            } => {
-                let cert =
-                    NotarRewardCertificate::try_new(reward_slot, block_id, signature, bitmap)?;
-                Ok(Some((cert, validators)))
-            }
+        // different block ids. Try them in descending stake order to maximize leader rewards,
+        // skipping empty candidates and aggregates with an identity signature.
+        let mut candidates = self.partials.into_iter().collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|(_block_id, partial)| Reverse(partial.stake()));
+        for (block_id, partial) in candidates {
+            let (signature, bitmap, validators) = match partial.build_sig_bitmap() {
+                BuildResult::Empty | BuildResult::Identity => continue,
+                BuildResult::EncodingError(e) => {
+                    return Err(BuildRewardCertsRespError::Encoding(e));
+                }
+                BuildResult::Success {
+                    signature,
+                    bitmap,
+                    validators,
+                } => (signature, bitmap, validators),
+            };
+            let cert = NotarRewardCertificate::try_new(reward_slot, block_id, signature, bitmap)?;
+            return Ok(Some((cert, validators)));
         }
+        Ok(None)
     }
 }
 
@@ -98,7 +97,8 @@ mod tests {
     use {
         super::*,
         crate::block_creation_loop::rewards::certs_builder::entry::tests::{
-            get_keypair_with_stakes, get_keypairs, new_reward_vote_aggregate, validate_bitmap,
+            get_keypair_with_stakes, get_keypairs, new_identity_reward_vote_aggregate,
+            new_reward_vote_aggregate, validate_bitmap,
         },
         agave_votor_messages::{consensus_message::Block, vote::Vote},
         rand::Rng,
@@ -169,5 +169,61 @@ mod tests {
         // We should pick the block id with the most stake (not the most votes)
         assert_eq!(notar_cert.block_id, blockid0);
         validate_bitmap(notar_cert.bitmap(), 2, 5);
+    }
+
+    #[test]
+    fn build_cert_falls_back_to_buildable_candidate() {
+        let slot = 123;
+        let max_validators = 5;
+        let shred_version = rand::rng().random();
+        let keypairs = get_keypairs(max_validators, slot);
+        let mut entry = NotarEntry::new();
+
+        let blockid0 = Hash::new_unique();
+        let notar = Vote::new_notarization_vote(Block {
+            slot,
+            block_id: blockid0,
+        });
+        let (aggregate, vote_account_pubkeys) = new_identity_reward_vote_aggregate(
+            notar,
+            max_validators,
+            &[(0, 200), (1, 200)],
+            shred_version,
+        );
+        entry
+            .add_aggregate(aggregate, vote_account_pubkeys, blockid0, max_validators)
+            .unwrap();
+
+        let blockid1 = Hash::new_unique();
+        let notar = Vote::new_notarization_vote(Block {
+            slot,
+            block_id: blockid1,
+        });
+        let (aggregate, vote_account_pubkeys) = new_identity_reward_vote_aggregate(
+            notar,
+            max_validators,
+            &[(2, 150), (3, 150)],
+            shred_version,
+        );
+        entry
+            .add_aggregate(aggregate, vote_account_pubkeys, blockid1, max_validators)
+            .unwrap();
+
+        let blockid2 = Hash::new_unique();
+        let notar = Vote::new_notarization_vote(Block {
+            slot,
+            block_id: blockid2,
+        });
+        let (aggregate, vote_account_pubkeys) =
+            new_reward_vote_aggregate(notar, 4, &keypairs, None, shred_version);
+        let expected_validators = vote_account_pubkeys.clone();
+        entry
+            .add_aggregate(aggregate, vote_account_pubkeys, blockid2, max_validators)
+            .unwrap();
+
+        let (notar_cert, validators) = entry.build_cert(slot).unwrap().unwrap();
+        assert_eq!(notar_cert.block_id, blockid2);
+        assert_eq!(validators, expected_validators);
+        validate_bitmap(notar_cert.bitmap(), 1, max_validators);
     }
 }

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -1,13 +1,15 @@
 use {
     agave_votor::aggregate_accumulator::{AggregateAccumulator, AggregateAccumulatorError},
     agave_votor_messages::{consensus_message::VoteMessage, sig_verified_messages::VoteAggregate},
-    solana_bls_signatures::SignatureCompressed as BLSSignatureCompressed,
+    solana_bls_signatures::{SignatureCompressed as BLSSignatureCompressed, SignatureProjective},
     solana_pubkey::Pubkey,
     solana_signer_store::EncodeError,
+    std::sync::LazyLock,
 };
 
 pub(super) enum BuildResult {
     Empty,
+    Identity,
     EncodingError(EncodeError),
     Success {
         signature: BLSSignatureCompressed,
@@ -15,6 +17,9 @@ pub(super) enum BuildResult {
         validators: Vec<Pubkey>,
     },
 }
+
+static IDENTITY_SIGNATURE: LazyLock<BLSSignatureCompressed> =
+    LazyLock::new(|| SignatureProjective::identity().into());
 
 #[derive(Clone)]
 /// Struct to hold state for building a single reward cert.
@@ -65,6 +70,18 @@ impl PartialCert {
             Ok(res) => res,
             Err(e) => return BuildResult::EncodingError(e),
         };
+
+        // In case of a aggregate with low participation, malicious validators can collude
+        // such that the aggregate signature ends up being the identity signature.
+        // The individual votes would be valid, but their aggregate would be invalid.
+        // To protect against this, we do not pack such rewards aggregates.
+        //
+        // Note: this does not affect normal certificate construction, as that requires at least
+        // 60% stake participation. For such a certificate to aggregate to the identity signature,
+        // all 60% must be malicious.
+        if signature == *IDENTITY_SIGNATURE {
+            return BuildResult::Identity;
+        }
         BuildResult::Success {
             signature,
             bitmap,


### PR DESCRIPTION
Credits to @mixy1-osec for finding this bug

#### Problem
There could be a slot where the rewards certificates are lopsided (100% notarize, or 100% skip).
2 Malicious validators could submit votes for the opposite side (e.g. submit 2 skip votes when the remaining cluster submitted notarize).

These individual votes themselves are valid, but when taken together they aggregate to the identity key & signature:
```
x   = random scalar in [1, r-1]
sk_a = x
sk_b = -x mod r

pk_a = x * g1
pk_b = -x * g1  = -pk_a

s_a  = x * h
s_b  = -x * h  = -s_a

#  e(pk_a, h) == e(g1, s_a)  verifies
#  e(pk_b, h) == e(g1, s_b)  verifies

agg_pk = pk_a + pk_b = x*g1 + (-x*g1) = O  # identity in G1
agg_sig = s_a + s_b  = x*h + (-x*h) = O  # identity in G2
```

This causes signature verification to fail. However the leader is unaware, so these malicious validators could force the leader's block to be invalid and skip their slot.

#### Summary of Changes
When packing the notarize and skip rewards aggregate, reject them if they correspond to the identity

#### Testing
Unit tests