### PR TITLE
core: delay insert of txn state into container

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -288,17 +288,9 @@ impl TransactionViewReceiveAndBuffer {
                     continue;
                 }
             };
-            let transaction_id = container.insert_map_only(state);
-            let (priority, raw_nonce_address) = container
-                .get_mut_transaction_state(transaction_id)
-                .map(|state| {
-                    (
-                        state.priority(),
-                        state.transaction().get_durable_nonce().cloned(),
-                    )
-                })
-                .expect("transaction must exist");
-            let priority_id = TransactionPriorityId::new(priority, transaction_id);
+
+            let priority = state.priority();
+            let raw_nonce_address = state.transaction().get_durable_nonce().cloned();
 
             // When we first receive a transaction, we drop it if a) it looks nonce-like, AND
             // b) there is a higher-priority nonce transaction using the same nonce in the queue
@@ -314,18 +306,13 @@ impl TransactionViewReceiveAndBuffer {
 
             if drop_incoming_nonce_tx {
                 receiving_stats.num_dropped_on_nonce_dedup += 1;
-                container.remove_by_id(transaction_id);
                 continue;
             }
-
-            let transaction = container
-                .get_transaction(transaction_id)
-                .expect("transaction must exist");
 
             // Check blockhash transaction age is ok, or nonce transaction has a valid nonce.
             // Only a fully validated nonce address can be used for priority queue eviction.
             let validated_nonce_address = match working_bank.check_transaction_without_status_cache(
-                transaction,
+                state.transaction(),
                 working_bank.max_processing_age(),
                 &mut error_counters,
             ) {
@@ -338,19 +325,22 @@ impl TransactionViewReceiveAndBuffer {
                 // Invalid
                 Err(ref err) => {
                     receiving_stats.add_transaction_error(err);
-                    container.remove_by_id(transaction_id);
                     continue;
                 }
             };
 
             // Check the transaction's fee-payer validates.
-            if let Err(_err) =
-                Consumer::check_fee_payer_unlocked(working_bank, transaction, &mut error_counters)
-            {
+            if let Err(_err) = Consumer::check_fee_payer_unlocked(
+                working_bank,
+                state.transaction(),
+                &mut error_counters,
+            ) {
                 receiving_stats.num_dropped_on_fee_payer += 1;
-                container.remove_by_id(transaction_id);
                 continue;
             };
+
+            let transaction_id = container.insert_map_only(state);
+            let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
             // Now, if this is a nonce transaction, we know it is validated and higher-priority than any
             // which may exist in the priority queue. If one is queued, evict it. Regardless, record the

--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -289,92 +289,87 @@ impl TransactionViewReceiveAndBuffer {
                 }
             };
             let transaction_id = container.insert_map_only(state);
-            {
-                let (priority, raw_nonce_address) = container
-                    .get_mut_transaction_state(transaction_id)
-                    .map(|state| {
-                        (
-                            state.priority(),
-                            state.transaction().get_durable_nonce().cloned(),
-                        )
-                    })
-                    .expect("transaction must exist");
-                let priority_id = TransactionPriorityId::new(priority, transaction_id);
+            let (priority, raw_nonce_address) = container
+                .get_mut_transaction_state(transaction_id)
+                .map(|state| {
+                    (
+                        state.priority(),
+                        state.transaction().get_durable_nonce().cloned(),
+                    )
+                })
+                .expect("transaction must exist");
+            let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
-                // When we first receive a transaction, we drop it if a) it looks nonce-like, AND
-                // b) there is a higher-priority nonce transaction using the same nonce in the queue
-                // or any in-flight nonce transaction using the same nonce. This means we discard
-                // blockhash transactions structured like nonce transactions; this is acceptable because
-                // they would fail after the earlier nonce transaction is processed, and it allows us to
-                // prefilter without loading from accounts-db.
-                let drop_incoming_nonce_tx = raw_nonce_address
-                    .and_then(|address| container.get_nonce_transaction_priority_id(&address))
-                    .is_some_and(|existing| {
-                        existing.priority >= priority || !container.is_queued(existing)
-                    });
+            // When we first receive a transaction, we drop it if a) it looks nonce-like, AND
+            // b) there is a higher-priority nonce transaction using the same nonce in the queue
+            // or any in-flight nonce transaction using the same nonce. This means we discard
+            // blockhash transactions structured like nonce transactions; this is acceptable because
+            // they would fail after the earlier nonce transaction is processed, and it allows us to
+            // prefilter without loading from accounts-db.
+            let drop_incoming_nonce_tx = raw_nonce_address
+                .and_then(|address| container.get_nonce_transaction_priority_id(&address))
+                .is_some_and(|existing| {
+                    existing.priority >= priority || !container.is_queued(existing)
+                });
 
-                if drop_incoming_nonce_tx {
-                    receiving_stats.num_dropped_on_nonce_dedup += 1;
-                    container.remove_by_id(transaction_id);
-                    continue;
-                }
-
-                let transaction = container
-                    .get_transaction(transaction_id)
-                    .expect("transaction must exist");
-
-                // Check blockhash transaction age is ok, or nonce transaction has a valid nonce.
-                // Only a fully validated nonce address can be used for priority queue eviction.
-                let validated_nonce_address = match working_bank
-                    .check_transaction_without_status_cache(
-                        transaction,
-                        working_bank.max_processing_age(),
-                        &mut error_counters,
-                    ) {
-                    // Valid nonce transaction
-                    Ok(Some(nonce_address)) => Some(nonce_address),
-
-                    // Valid blockhash transaction
-                    Ok(None) => None,
-
-                    // Invalid
-                    Err(ref err) => {
-                        receiving_stats.add_transaction_error(err);
-                        container.remove_by_id(transaction_id);
-                        continue;
-                    }
-                };
-
-                // Check the transaction's fee-payer validates.
-                if let Err(_err) = Consumer::check_fee_payer_unlocked(
-                    working_bank,
-                    transaction,
-                    &mut error_counters,
-                ) {
-                    receiving_stats.num_dropped_on_fee_payer += 1;
-                    container.remove_by_id(transaction_id);
-                    continue;
-                };
-
-                // Now, if this is a nonce transaction, we know it is validated and higher-priority than any
-                // which may exist in the priority queue. If one is queued, evict it. Regardless, record the
-                // incoming nonce transaction's nonce as in-use.
-                if let Some(nonce_address) = validated_nonce_address {
-                    if let Some(existing_nonce_priority_id) =
-                        container.get_nonce_transaction_priority_id(&nonce_address)
-                    {
-                        receiving_stats.num_evicted_on_nonce_dedup += 1;
-                        container.remove_by_id(existing_nonce_priority_id.id);
-                    }
-                    container.set_nonce_transaction_priority_id(&nonce_address, priority_id);
-                }
-
-                // Transaction is already fully validated and can be inserted into priority queue.
-                receiving_stats.num_dropped_on_capacity +=
-                    container.push_ids_into_queue(std::iter::once(priority_id));
-
-                receiving_stats.num_buffered += 1;
+            if drop_incoming_nonce_tx {
+                receiving_stats.num_dropped_on_nonce_dedup += 1;
+                container.remove_by_id(transaction_id);
+                continue;
             }
+
+            let transaction = container
+                .get_transaction(transaction_id)
+                .expect("transaction must exist");
+
+            // Check blockhash transaction age is ok, or nonce transaction has a valid nonce.
+            // Only a fully validated nonce address can be used for priority queue eviction.
+            let validated_nonce_address = match working_bank.check_transaction_without_status_cache(
+                transaction,
+                working_bank.max_processing_age(),
+                &mut error_counters,
+            ) {
+                // Valid nonce transaction
+                Ok(Some(nonce_address)) => Some(nonce_address),
+
+                // Valid blockhash transaction
+                Ok(None) => None,
+
+                // Invalid
+                Err(ref err) => {
+                    receiving_stats.add_transaction_error(err);
+                    container.remove_by_id(transaction_id);
+                    continue;
+                }
+            };
+
+            // Check the transaction's fee-payer validates.
+            if let Err(_err) =
+                Consumer::check_fee_payer_unlocked(working_bank, transaction, &mut error_counters)
+            {
+                receiving_stats.num_dropped_on_fee_payer += 1;
+                container.remove_by_id(transaction_id);
+                continue;
+            };
+
+            // Now, if this is a nonce transaction, we know it is validated and higher-priority than any
+            // which may exist in the priority queue. If one is queued, evict it. Regardless, record the
+            // incoming nonce transaction's nonce as in-use.
+            if let Some(nonce_address) = validated_nonce_address {
+                if let Some(existing_nonce_priority_id) =
+                    container.get_nonce_transaction_priority_id(&nonce_address)
+                {
+                    receiving_stats.num_evicted_on_nonce_dedup += 1;
+                    container.remove_by_id(existing_nonce_priority_id.id);
+                }
+                container.set_nonce_transaction_priority_id(&nonce_address, priority_id);
+            }
+
+            // Transaction is already fully validated and can be inserted into priority queue.
+            receiving_stats.num_dropped_on_capacity +=
+                container.push_ids_into_queue(std::iter::once(priority_id));
+
+            receiving_stats.num_buffered += 1;
         }
 
         // `receive_time_us` is set outside this function


### PR DESCRIPTION
#### Problem
thanks to https://github.com/anza-xyz/agave/pull/14079 getting rid of the callback-insert flow, we dont need to insert a txn into the slab until we are sure we will also insert into the priority queue. this lets us get rid of all the cases where we need to _remove_ from the slab, which is nice. it also lets up remove a couple unwraps

#### Summary of Changes
* [9b6209b](https://github.com/anza-xyz/agave/pull/14117/commits/9b6209be3e3c2e3aa99403c1923819573c6aa718) is a `cargo fmt` after removing some braces with no non-indent changes
* [73ed52e](https://github.com/anza-xyz/agave/pull/14117/commits/73ed52eca8e6bc0600197fd8c0886b337563fa00) is the full actual change

i split them up to make reviewing the real changes easier (and set their commit messages so that when they squash it will look right)

im not sure exactly what youre planning with "Working on parallelization of ingress checks" but plausibly this will help with that