### PR TITLE
fix sbpf 0.22 upgrade

### DIFF
--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -24,18 +24,30 @@ pub fn modify_memory_region_of_account(
     account: &mut BorrowedInstructionAccount<'_, '_>,
     region: &mut MemoryRegion,
 ) {
+    let data_ptr = region.host_buffer().ptr() as *mut u8;
+    let new_buffer = std::ptr::slice_from_raw_parts_mut(data_ptr, account.get_data().len());
     if account.can_data_be_changed().is_ok() {
         unsafe {
             // SAFETY:
-            // Contract from `HostBuffer::mutable`: This host buffer must have been initially
-            // constructed with a mutable pointer.
-            // Evidence: this region must be pointing to a serialized data buffer which is known to
-            // be mutable.
-            region.redirect(region.host_buffer().mutable());
+            // Contract from `MemoryRegion::redirect`: The memory pointed to by the MemoryRegions
+            // must point to a valid object live for the duration of this MemoryMapping.
+            //
+            // TODO(nagisa): Local reasoning for this contract is infeasible. In particular for the
+            // `serialization.rs` code it is pretty easy to see that the regions passed in will
+            // always be larger than `account.get_data().len()`. However for `cpi.rs` callsite this
+            // is not as easy to prove and relies on careful coordination between any code that
+            // might increase the account data buffer length.
+            region.redirect(new_buffer);
         }
         region.access_violation_handler_payload = Some(account.get_index_in_transaction());
     } else {
-        region.make_immutable();
+        unsafe {
+            // SAFETY:
+            //
+            // Contract from `MemoryRegion::redirect`: same as for the call above.
+            // Evidence: same as for the call above.
+            region.redirect(new_buffer.cast_const());
+        }
         region.access_violation_handler_payload = None;
     }
 }

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -696,7 +696,7 @@ mod tests {
         solana_program_entrypoint::deserialize,
         solana_rent::Rent,
         solana_sbpf::{memory_region::MemoryMapping, program::SBPFVersion, vm::Config},
-        solana_sdk_ids::bpf_loader,
+        solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable},
         solana_system_interface::MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION,
         solana_transaction_context::{
             MAX_ACCOUNTS_PER_TRANSACTION, instruction_accounts::InstructionAccount,
@@ -1695,5 +1695,58 @@ mod tests {
                 .len(),
             remaining_allowed_growth,
         );
+    }
+
+    #[test]
+    fn test_regression_initial_serialized_account_region_does_not_include_resize_affordance() {
+        let program_id = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(0, 4, &program_id),
+            ),
+            (
+                solana_pubkey::new_rand(),
+                AccountSharedData::from(Account {
+                    lamports: 0,
+                    data: b"agave".into(),
+                    owner: bpf_loader_upgradeable::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                }),
+            ),
+        ];
+        with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
+        invoke_context
+            .transaction_context
+            .configure_top_level_instruction_for_tests(
+                0,
+                vec![InstructionAccount::new(1, false, true)],
+                vec![],
+            )
+            .unwrap();
+        invoke_context.push().unwrap();
+        let instruction_context = invoke_context
+            .transaction_context
+            .get_current_instruction_context()
+            .unwrap();
+        let (_serialized, regions, accounts_metadata, _instruction_data_offset) =
+            crate::serialization::serialize_parameters(
+                &instruction_context,
+                true,  // virtual_address_space_adjustments
+                false, // account_data_direct_mapping
+                false, // direct_account_pointers_in_program_input
+            )
+            .unwrap();
+        let config = Config {
+            aligned_memory_mapping: false,
+            ..Config::default()
+        };
+        let memory_mapping =
+            unsafe { MemoryMapping::new(regions, &config, SBPFVersion::V3).unwrap() };
+        let account_metadata = &accounts_metadata[0];
+        let vm_data_addr = account_metadata.vm_data_addr;
+        let (_region_index, region) = memory_mapping.find_region(vm_data_addr).unwrap();
+        assert_eq!(region.len(), 5);
     }
 }

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -566,8 +566,11 @@ impl<'ix_data> TransactionContext<'ix_data> {
                     {
                         return;
                     }
+
+                    account.resize(new_len, 0);
+                    let data_ptr = region.host_buffer().ptr() as *mut u8;
+                    let new_buffer = std::ptr::slice_from_raw_parts_mut(data_ptr, new_len);
                     unsafe {
-                        account.resize(new_len, 0);
                         // SAFETY:
                         //
                         // Contract from `MemoryRegion::redirect`: MemoryRegion must point to a
@@ -581,6 +584,11 @@ impl<'ix_data> TransactionContext<'ix_data> {
                         // * In the direct mapping case `account.resize` invalidates the buffer this
                         // region has been pointing at, but this is fixed up later in the "unshare"
                         // branch later.
+                        // * In the serialization case the section of serialized buffer has the
+                        // necessary padding after the account payload proper for resize. This
+                        // padding is a part of the originally constructed `MemoryRegion` and is
+                        // only later subsliced to not expose it before the first access to the
+                        // area (which invokes this handler.)
                         //
                         // Contract from `MemoryRegion::redirect`: For `MemoryRegion`s marked
                         // writable, the host buffer must accept arbitrary bytes being overwritten
@@ -591,12 +599,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
                         // writable (even though the HostBuffer might have been initially created as
                         // immutable.) In the direct mapping case we redirect the region to the
                         // buffer stored in the account later on.
-                        //
-                        // Contract from `HostBuffer::mutable`: This host buffer must have been
-                        // initially constructed with a mutable pointer.
-                        // Evidence: See `create_memory_region_of_account`. Direct mapping case
-                        // later reconstructs this buffer from scratch. See below.
-                        region.redirect(region.host_buffer().mutable());
+                        region.redirect(new_buffer);
                     }
                 }
 


### PR DESCRIPTION
#### Problem

A recent refactor in https://github.com/anza-xyz/agave/pull/13480 has omitted the two places where `len` of the region was being adjusted. This was purely an oversight as #13480 was meant to replicate the old code paths holistically without attempting any significant refactors at all. With these length adjustments missing the serialization code path would produce memory regions that allowed programs to read the padding zeroes in account payloads before a resize occurred. This is a significant change to the execution model.

#### Summary of Changes

The first commit introduces a regression test that was passing before the refactor and passes again after the fixes here. The 2nd commit restores the length adjustments to be exactly as they were before.

#### Testing

The newly added regression test verifies that the behaviour after this change matches the behaviour before #13480.