### PR TITLE
Tighten Alpenglow block limits

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -68,7 +68,7 @@ use {
 type OutstandingBlockIdRepairs = OutstandingRequests<BlockIdRepairType>;
 
 const MAX_REPAIR_REQUESTS_PER_ITERATION: usize = 200;
-const MAX_ALTERNATE_BLOCKS_PER_SLOT: usize = 11;
+const MAX_ALTERNATE_BLOCKS_PER_SLOT: usize = 6;
 const MAX_PENDING_REPAIR_EVENTS: usize = 10_000;
 
 /// Idle wake-up cadence for `run_repair_iteration`'s `select!`. Bounds the worst-case

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -3,7 +3,7 @@ use {agave_votor_messages::fraction::Fraction, std::time::Duration};
 // Core consensus types and constants
 pub(crate) type Stake = u64;
 
-pub(crate) const MAX_NOTAR_FALLBACK_BLOCKS: usize = 7;
+pub(crate) const MAX_NOTAR_FALLBACK_BLOCKS: usize = 4;
 
 pub(crate) const SAFE_TO_NOTAR_MIN_NOTARIZE_ONLY: Fraction = Fraction::from_percentage(40);
 pub(crate) const SAFE_TO_NOTAR_MIN_NOTARIZE_FOR_NOTARIZE_OR_SKIP: Fraction =

--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -317,6 +317,26 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(
+        expected = "assertion failed: status.notar_fallbacks.len() <= MAX_NOTAR_FALLBACK_BLOCKS"
+    )]
+    fn test_too_many_notar_fallback_blocks() {
+        let cluster_info = get_cluster_info(Keypair::new());
+        let mut tracker = new_tracker(cluster_info, Block::default());
+        let mut events = vec![];
+
+        for _ in 0..=MAX_NOTAR_FALLBACK_BLOCKS {
+            tracker.add_new_notar_fallback_or_stronger(
+                Block {
+                    slot: 1,
+                    block_id: Hash::new_unique(),
+                },
+                &mut events,
+            );
+        }
+    }
+
+    #[test]
     fn skips() {
         let cluster_info = get_cluster_info(Keypair::new());
         let genesis = Block::default();


### PR DESCRIPTION
## Summary

Tightens the Alpenglow block limits based on the updated bounds described in #14039.

- Reduces `MAX_NOTAR_FALLBACK_BLOCKS` from 7 to 4.
- Reduces `MAX_ALTERNATE_BLOCKS_PER_SLOT` from 11 to 6.
- Adds coverage for exceeding the `MAX_NOTAR_FALLBACK_BLOCKS` bound.

The existing Block-ID repair tests use `MAX_ALTERNATE_BLOCKS_PER_SLOT` symbolically and continue to cover the limit and `MAX + 1` behavior.


## Testing

- `cargo test -p solana-core alternate_blocks -- --nocapture`
- `cargo test -p agave-votor --features agave-unstable-api parent_ready_tracker -- --nocapture`
- `cargo test -p agave-votor --features agave-unstable-api test_too_many_notar_fallback_blocks -- --nocapture`


Fixes #14039