### PR TITLE
runtime: exclude nonce txns from status cache

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5126,7 +5126,10 @@ impl ReplayStage {
             } in tracked_vote_transactions.iter()
             {
                 if new_root_bank
-                    .get_committed_transaction_status_and_slot(message_hash, transaction_blockhash)
+                    .get_transaction_status_and_slot_from_status_cache(
+                        message_hash,
+                        transaction_blockhash,
+                    )
                     .is_some()
                 {
                     *has_new_vote_been_rooted = true;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3521,14 +3521,19 @@ impl Bank {
         assert_eq!(sanitized_txs.len(), processing_results.len());
         for (tx, processing_result) in sanitized_txs.iter().zip(processing_results) {
             if let Ok(processed_tx) = &processing_result {
-                // Add the message hash to the status cache to ensure that this message
-                // won't be processed again with a different signature.
-                status_cache.insert(
-                    tx.recent_blockhash(),
-                    tx.message_hash(),
-                    self.slot(),
-                    processed_tx.status(),
-                );
+                // If this is a blockhash transaction, add the message hash to the status cache
+                // to ensure that this message won't be processed again with a different signature.
+                // Nonce transactions are protected from replay via the durable nonce mechanic.
+                // This exclusion is necessary to support SIMD-0297 (nonce relaxation).
+                if processed_tx.nonce_address().is_none() {
+                    status_cache.insert(
+                        tx.recent_blockhash(),
+                        tx.message_hash(),
+                        self.slot(),
+                        processed_tx.status(),
+                    );
+                }
+
                 if self.store_transaction_signatures_in_status_cache {
                     // Add the transaction signature to the status cache so that transaction
                     // status can be queried by transaction signature over RPC.
@@ -5314,7 +5319,7 @@ impl Bank {
             .map(|v| v.1)
     }
 
-    pub fn get_committed_transaction_status_and_slot(
+    pub fn get_transaction_status_and_slot_from_status_cache(
         &self,
         message_hash: &Hash,
         transaction_blockhash: &Hash,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -124,13 +124,15 @@ use {
         state::{Authorized, Delegation, Lockup, Stake, StakeStateV2},
     },
     solana_svm::{
-        account_loader::{FeesOnlyTransaction, LoadedTransaction, TRANSACTION_ACCOUNT_BASE_SIZE},
+        account_loader::{
+            FeesOnlyTransaction, LoadedTransaction, NoOpTransaction, TRANSACTION_ACCOUNT_BASE_SIZE,
+        },
         rollback_accounts::RollbackAccounts,
         transaction_commit_result::TransactionCommitResultExtensions,
         transaction_execution_result::{AccountsDeltas, ExecutedTransaction},
     },
     solana_svm_timings::ExecuteTimings,
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::svm_message::{SVMMessage, SVMStaticMessage},
     solana_system_interface::{
         MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION, MAX_PERMITTED_DATA_LENGTH,
         error::SystemError,
@@ -170,7 +172,7 @@ use {
         thread::Builder,
         time::{Duration, Instant},
     },
-    test_case::test_case,
+    test_case::{test_case, test_matrix},
 };
 
 fn create_genesis_config_no_tx_fee_no_rent(lamports: u64) -> (GenesisConfig, Keypair) {
@@ -251,6 +253,7 @@ fn test_race_register_tick_freeze() {
 fn new_executed_processing_result(
     status: Result<()>,
     fee_details: FeeDetails,
+    rollback_accounts: RollbackAccounts,
 ) -> TransactionProcessingResult {
     let accounts_deltas = status.as_ref().is_ok().then_some(AccountsDeltas {
         accounts_resize_delta: 0,
@@ -259,6 +262,9 @@ fn new_executed_processing_result(
     Ok(ProcessedTransaction::Executed(Box::new(
         ExecutedTransaction {
             loaded_transaction: LoadedTransaction {
+                accounts: vec![KeyedAccountSharedData::default()],
+                touched_flags: Box::new([false]),
+                rollback_accounts,
                 fee_details,
                 ..LoadedTransaction::default()
             },
@@ -2235,6 +2241,88 @@ fn test_tx_already_processed() {
         bank.process_transaction(&tx),
         Err(TransactionError::AlreadyProcessed)
     );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NonceTestCase {
+    Success,
+    Failed,
+    FeesOnly,
+    NoOp,
+    Blockhash,
+}
+
+#[test_matrix(
+    [NonceTestCase::Success, NonceTestCase::Failed, NonceTestCase::FeesOnly, NonceTestCase::NoOp, NonceTestCase::Blockhash],
+    [false, true]
+)]
+fn test_status_cache_ignores_nonce(case: NonceTestCase, separate_nonce: bool) {
+    let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+
+    let is_blockhash_transaction = case == NonceTestCase::Blockhash;
+    let fee_details = FeeDetails::new(5000, 0);
+    let rollback_accounts = match (is_blockhash_transaction, separate_nonce) {
+        (true, _) => RollbackAccounts::default(),
+        (false, true) => RollbackAccounts::SeparateNonceAndFeePayer {
+            nonce: KeyedAccountSharedData::default(),
+            fee_payer: KeyedAccountSharedData::default(),
+        },
+        (false, false) => RollbackAccounts::SameNonceAndFeePayer {
+            nonce: KeyedAccountSharedData::default(),
+        },
+    };
+
+    let result = match case {
+        NonceTestCase::Success | NonceTestCase::Blockhash => {
+            new_executed_processing_result(Ok(()), fee_details, rollback_accounts)
+        }
+        NonceTestCase::Failed => new_executed_processing_result(
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::Custom(0),
+            )),
+            fee_details,
+            rollback_accounts,
+        ),
+        NonceTestCase::FeesOnly => Ok(ProcessedTransaction::FeesOnly(Box::new(
+            FeesOnlyTransaction {
+                load_error: TransactionError::InvalidProgramForExecution,
+                rollback_accounts,
+                fee_details,
+                loaded_accounts_data_size: 0,
+            },
+        ))),
+        NonceTestCase::NoOp => Ok(ProcessedTransaction::NoOp(Box::new(NoOpTransaction {
+            validation_error: TransactionError::AccountNotFound,
+            fee_payer_balance: None,
+            compute_unit_limit: 0,
+            loaded_accounts_bytes_limit: 0,
+            nonce_address: Some(Pubkey::default()),
+        }))),
+    };
+
+    let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        &mint_keypair,
+        &Pubkey::new_unique(),
+        1,
+        bank.last_blockhash(),
+    ));
+
+    bank.commit_transactions(
+        std::slice::from_ref(&tx),
+        vec![result],
+        &ProcessedTransactionCounts::default(),
+        &mut ExecuteTimings::default(),
+    );
+
+    let is_message_hash_in_status_cache = bank
+        .get_transaction_status_and_slot_from_status_cache(tx.message_hash(), tx.recent_blockhash())
+        .is_some();
+    assert_eq!(is_message_hash_in_status_cache, is_blockhash_transaction);
+
+    let is_signature_in_status_cache = bank.get_signature_status(tx.signature()).is_some();
+    assert!(is_signature_in_status_cache);
 }
 
 #[test]
@@ -12051,8 +12139,9 @@ fn test_filter_program_errors_and_collect_fee_details() {
                 SystemError::ResultWithNegativeLamports.into(),
             )),
             fee_details,
+            RollbackAccounts::default(),
         ),
-        new_executed_processing_result(Ok(()), fee_details),
+        new_executed_processing_result(Ok(()), fee_details, RollbackAccounts::default()),
     ];
 
     bank.filter_program_errors_and_collect_fee_details(&results);

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -837,6 +837,7 @@ mod tests {
                 fee_payer_balance: Some(42),
                 compute_unit_limit: COMPUTE_UNIT_LIMIT,
                 loaded_accounts_bytes_limit: LOADED_ACCOUNTS_BYTES_LIMIT,
+                nonce_address: None,
             },
         )));
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -392,7 +392,7 @@ impl SendTransactionService {
                 stats.nonced_transactions.fetch_add(1, Ordering::Relaxed);
             }
             if root_bank
-                .get_committed_transaction_status_and_slot(
+                .get_transaction_status_and_slot_from_status_cache(
                     &transaction_info.message_hash,
                     &transaction_info.blockhash,
                 )
@@ -403,7 +403,7 @@ impl SendTransactionService {
                 stats.rooted_transactions.fetch_add(1, Ordering::Relaxed);
                 return false;
             }
-            let signature_status = working_bank.get_committed_transaction_status_and_slot(
+            let signature_status = working_bank.get_transaction_status_and_slot_from_status_cache(
                 &transaction_info.message_hash,
                 &transaction_info.blockhash,
             );

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -174,6 +174,7 @@ pub struct NoOpTransaction {
     pub fee_payer_balance: Option<u64>,
     pub compute_unit_limit: u64,
     pub loaded_accounts_bytes_limit: u32,
+    pub nonce_address: Option<Pubkey>,
 }
 
 // This is an internal SVM type that tracks account changes throughout a

--- a/svm/src/transaction_processing_result.rs
+++ b/svm/src/transaction_processing_result.rs
@@ -1,9 +1,11 @@
 use {
     crate::{
         account_loader::{FeesOnlyTransaction, NoOpTransaction},
+        rollback_accounts::RollbackAccounts,
         transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
     },
     solana_fee_structure::FeeDetails,
+    solana_pubkey::Pubkey,
     solana_transaction_error::{TransactionError, TransactionResult},
 };
 
@@ -64,6 +66,20 @@ impl ProcessedTransaction {
             Self::Executed(executed_tx) => executed_tx.execution_details.status.clone(),
             Self::FeesOnly(details) => Err(TransactionError::clone(&details.load_error)),
             Self::NoOp(details) => Err(TransactionError::clone(&details.validation_error)),
+        }
+    }
+
+    pub fn nonce_address(&self) -> Option<Pubkey> {
+        let rollback_accounts = match self {
+            Self::Executed(executed_tx) => &executed_tx.loaded_transaction.rollback_accounts,
+            Self::FeesOnly(details) => &details.rollback_accounts,
+            Self::NoOp(details) => return details.nonce_address,
+        };
+
+        match rollback_accounts {
+            RollbackAccounts::FeePayerOnly { .. } => None,
+            RollbackAccounts::SameNonceAndFeePayer { nonce }
+            | RollbackAccounts::SeparateNonceAndFeePayer { nonce, .. } => Some(nonce.0),
         }
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -764,6 +764,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                     compute_unit_limit: compute_budget_and_limits.budget.compute_unit_limit,
                     loaded_accounts_bytes_limit: compute_budget_and_limits
                         .loaded_accounts_data_size_limit,
+                    nonce_address,
                 })
             }
             Err(e) => TransactionValidationResult::Unprocessable(e),
@@ -2293,6 +2294,7 @@ mod tests {
                 fee_payer_balance: None,
                 compute_unit_limit: fee_and_limits.budget.compute_unit_limit,
                 loaded_accounts_bytes_limit: fee_and_limits.loaded_accounts_data_size_limit,
+                nonce_address: None,
             })
         } else {
             TransactionValidationResult::Unprocessable(expected_error)
@@ -2345,6 +2347,7 @@ mod tests {
                 fee_payer_balance: Some(fee_payer_balance),
                 compute_unit_limit: fee_and_limits.budget.compute_unit_limit,
                 loaded_accounts_bytes_limit: fee_and_limits.loaded_accounts_data_size_limit,
+                nonce_address: None,
             })
         } else {
             TransactionValidationResult::Unprocessable(expected_error)
@@ -2400,6 +2403,7 @@ mod tests {
                 fee_payer_balance: Some(starting_balance),
                 compute_unit_limit: fee_and_limits.budget.compute_unit_limit,
                 loaded_accounts_bytes_limit: fee_and_limits.loaded_accounts_data_size_limit,
+                nonce_address: None,
             })
         } else {
             TransactionValidationResult::Unprocessable(expected_error)
@@ -2451,6 +2455,7 @@ mod tests {
                 fee_payer_balance: Some(fee_payer_balance),
                 compute_unit_limit: fee_and_limits.budget.compute_unit_limit,
                 loaded_accounts_bytes_limit: fee_and_limits.loaded_accounts_data_size_limit,
+                nonce_address: None,
             })
         } else {
             TransactionValidationResult::Unprocessable(expected_error)


### PR DESCRIPTION
#### Problem
to support SIMD-0297, nonce transaction message hashes must not be allowed into the status cache. otherwise, the 300-block window would come under consensus, and would need to be replicated by firedancer. firedancer presently excludes nonces from their status cache, so this brings us into alignment

more concretely if we impled 297 and let nonce transactions into status cache you could break consensus by getting firedancer to commit a nonce transaction that agave considered to be `AlreadyProcessed`

status cache also buckets by transaction lifetime specifier. we only ever have 300 blockhash buckets but can have an unbounded number of durable nonce buckets, many of which will only contain a single transaction

#### Summary of Changes
exclude nonce transaction message hashes from status cache. we keep nonce transaction signatures because several rpc calls (confirmTransaction, signatureSubscribe, default getSignatureStatuses) are cache-only, and redesigning them is out of scope here. rpc nodes will continue making nonce buckets for signatures, but we eliminate this for real validators

~however we _must not_ store noop signatures. im going to have to make a simd discussion for the 297 amendments but the biggest weird issue is how to handle duplicates in bigtable/rpc. my current idea is we just dont serve nonce noops at all, which solves a lot of headaches with cases where noops would shadow or clobber a past success. in any event, nonce noops cannot exist yet so `(self.store_transaction_signatures_in_status_cache && !is_nonce_noop) == self.store_transaction_signatures_in_status_cache` invariably~

(edit: i decided the above is premature and we keep signature storage as it exists, the only change is message hash storage)

i also renamed `get_committed_transaction_status_and_slot()` to `get_transaction_status_and_slot_from_status_cache()`, the current name is technically wrong (it returns `None` for old committed transactions) and becomes even more wrong with this pr (also doesnt return nonce transactions)

this pr does _not_ impact consensus. committed nonce transactions never needed to go into status cache to prevent replay, and discarded nonce transactions do not go into status cache, so this pr entails no behavior change. we do it because it makes our status cache more like firedancer, which is nice now, but absolutely necessary for SIMD-0297

#### Testing
`test_status_cache_ignores_nonce()` asserts the expected behavior from status cache
