### PR TITLE
program-runtime: Add conditional `pub` qualifier to `process_instruction`

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -592,6 +592,7 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
     }
 
     /// Processes an instruction and returns how many compute units were used
+    #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn process_instruction(
         &mut self,
         compute_units_consumed: &mut u64,


### PR DESCRIPTION
#### Problem

PR #13618 refactored the `InvokeContext` API and made `process_instruction` not available externally, but developer tooling might need access to it (see Mollusk https://github.com/anza-xyz/mollusk/pull/277).

This is a similar change as #13832.

#### Summary of Changes

Conditionally expose `InvokeContext::process_instruction` when `"dev-context-only utils"` is enabled.

#### Testing

No runtime logic changes; this is a visibility-only change gated by feature flag.