### PR TITLE
chore: Remove publish = true from TOML files

### DIFF
--- a/cpu-utils/Cargo.toml
+++ b/cpu-utils/Cargo.toml
@@ -6,7 +6,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-publish = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -6,7 +6,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-publish = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
#### Problem
Default behavior is to publish so remove the redundant line to match all other crates in the workspace

Noticed while reviewing https://github.com/anza-xyz/agave/pull/14010