### PR TITLE
use a custom pool for async verification

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -64,7 +64,7 @@ use {
         blockstore_processor::{
             self, AsyncVerificationProgress, BlockstoreProcessorError, ChainedBlockIdCheck,
             ConfirmationProgress, ExecuteBatchesInternalMetrics, ReplaySlotStats,
-            check_chained_block_id,
+            ReplayVerificationWorkerPool, check_chained_block_id,
         },
         entry_notifier_service::EntryNotifierSender,
         leader_schedule_cache::LeaderScheduleCache,
@@ -263,7 +263,7 @@ struct ProcessActiveBanksContext {
     block_metadata_notifier: Option<BlockMetadataNotifierArc>,
     votor_event_sender: VotorEventSender,
     replay_mode: ForkReplayMode,
-    replay_tx_thread_pool: ThreadPool,
+    replay_verification_worker_pool: ReplayVerificationWorkerPool,
     migration_status: Arc<MigrationStatus>,
 }
 
@@ -899,13 +899,8 @@ impl ReplayStage {
                     .expect("new rayon threadpool");
                 ForkReplayMode::Parallel(pool)
             };
-            // Thread pool to replay multiple transactions within one block in parallel
-            let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
-                .num_threads(replay_transactions_threads.get())
-                .stack_size(8 * 1024 * 1024)
-                .thread_name(|i| format!("solReplayTx{i:02}"))
-                .build()
-                .expect("new rayon threadpool");
+            let replay_verification_worker_pool =
+                ReplayVerificationWorkerPool::new(replay_transactions_threads.get());
 
             let process_active_banks_context = ProcessActiveBanksContext {
                 bank_forks: bank_forks.clone(),
@@ -922,7 +917,7 @@ impl ReplayStage {
                 block_metadata_notifier: block_metadata_notifier.clone(),
                 votor_event_sender: votor_event_sender.clone(),
                 replay_mode,
-                replay_tx_thread_pool,
+                replay_verification_worker_pool,
                 migration_status: migration_status.clone(),
             };
             let process_bank_forks_context = ProcessBankForksContext {
@@ -3016,7 +3011,7 @@ impl ReplayStage {
             &process_active_banks_context.blockstore,
             bank,
             my_shred_version,
-            &process_active_banks_context.replay_tx_thread_pool,
+            &process_active_banks_context.replay_verification_worker_pool,
             &mut w_replay_stats,
             &mut w_replay_progress,
             false,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -100,11 +100,7 @@ impl ProcessActiveBanksContext {
         let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
         let (votor_event_sender, _) = bounded(1024);
         let migration_status = Arc::new(MigrationStatus::default());
-        let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(1)
-            .thread_name(|i| format!("solReplayTest{i:02}"))
-            .build()
-            .expect("new rayon threadpool");
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
         Self {
             bank_forks,
             blockstore,
@@ -120,7 +116,7 @@ impl ProcessActiveBanksContext {
             block_metadata_notifier: None,
             votor_event_sender,
             replay_mode: ForkReplayMode::Serial,
-            replay_tx_thread_pool,
+            replay_verification_worker_pool,
             migration_status,
         }
     }
@@ -1057,26 +1053,29 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
     let bank = bank_forks.write().unwrap().insert(child_bank);
 
     let slot = bank.slot();
-    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (replay_vote_sender, replay_vote_receiver) = bounded(match failure {
+        CompleteBankFailure::ReplayError => 1024,
+        CompleteBankFailure::VerifyError => 0,
+    });
     let (finalization_cert_sender, _finalization_cert_receiver) = bounded(1024);
     let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
         bank_forks.clone(),
         blockstore.clone(),
         replay_vote_sender,
     );
-    let finish_verify = match failure {
+    let replay_vote_message_thread = match failure {
         CompleteBankFailure::ReplayError => None,
         CompleteBankFailure::VerifyError => {
-            let finish_verify = Arc::new(Barrier::new(2));
-            process_active_banks_context.replay_tx_thread_pool.spawn({
-                let finish_verify = finish_verify.clone();
-                move || {
-                    // stall verify so we can collect the result after replay finishes
-                    finish_verify.wait();
-                }
+            let start = Arc::new(Barrier::new(2));
+            let thread_start = Arc::clone(&start);
+            let handle = std::thread::spawn(move || {
+                // verification will block sending to replay_vote_sender. We use this to model
+                // getting a verify error after replay has completed.
+                thread_start.wait();
+                // pop until the channel gets closed
+                for _ in replay_vote_receiver {}
             });
-
-            Some(finish_verify)
+            Some((start, handle))
         }
     };
     let replay_result = {
@@ -1127,8 +1126,8 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
     // the sync path succeeded, we want to hit async failures
     assert_matches!(replay_result.replay_result, Some(Ok(1)));
 
-    if let Some(finish_verify) = finish_verify {
-        finish_verify.wait();
+    if let Some((start, _handle)) = &replay_vote_message_thread {
+        start.wait();
     }
 
     let my_pubkey = Pubkey::default();
@@ -1150,6 +1149,12 @@ fn do_test_dead_slot_on_complete_bank(failure: CompleteBankFailure) {
         &[replay_result],
         &my_pubkey,
     );
+
+    if let Some((_, handle)) = replay_vote_message_thread {
+        // drop the context so replay_vote_sender is dropped and the thread can exit
+        drop(process_active_banks_context);
+        handle.join().unwrap();
+    }
 
     assert!(progress.get(&slot).unwrap().dead_reason.is_some());
     assert!(blockstore.is_dead(slot));
@@ -1175,7 +1180,7 @@ fn test_complete_replay_verification_recycles_async_verification() {
     }
     let replay_progress = RwLock::new(ConfirmationProgress::new_with_async_verification(
         Hash::new_unique(),
-        Some(AsyncVerificationProgress::new()),
+        Some(AsyncVerificationProgress::new(1)),
     ));
     let mut async_verification_freelist = Vec::new();
 
@@ -1222,7 +1227,7 @@ fn test_complete_bank_replay_sends_bank_complete() {
         None,
         0,
         0,
-        Some(AsyncVerificationProgress::new()),
+        Some(AsyncVerificationProgress::new(1)),
     );
     let mut async_verification_freelist = Vec::new();
 
@@ -6382,17 +6387,13 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
     let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
     let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
     let shred_version = compute_shred_version(&genesis_config.hash(), None);
-    let replay_tx_thread_pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(1)
-        .thread_name(|i| format!("solReplayTx{i:02}"))
-        .build()
-        .expect("new rayon threadpool");
+    let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
 
     process_bank_0(
         &bank0,
         shred_version,
         &blockstore,
-        &replay_tx_thread_pool,
+        &replay_verification_worker_pool,
         &ProcessOptions::default(),
         None,
         None,
@@ -6413,7 +6414,7 @@ fn test_initialize_progress_and_fork_choice_with_duplicates() {
         &blockstore,
         &bank1,
         shred_version,
-        &replay_tx_thread_pool,
+        &replay_verification_worker_pool,
         &ProcessOptions::default(),
         &mut ConfirmationProgress::new(bank0.last_blockhash()),
         None,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -190,6 +190,30 @@ impl UnverifiedSignatures {
         })
     }
 
+    pub fn len(&self) -> usize {
+        self.signatures.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.signatures.is_empty()
+    }
+
+    pub fn verify_signatures(&self, index: usize) -> bool {
+        let tx_data = &self.signatures[index];
+        tx_data
+            .signatures
+            .iter()
+            .zip(&tx_data.signer_pubkeys)
+            .all(|(signature, pubkey)| {
+                signature.verify(pubkey.as_ref(), &tx_data.serialized_message)
+            })
+    }
+
+    pub fn vote_transaction_message_hash(&self, index: usize) -> Option<Hash> {
+        let tx_data = &self.signatures[index];
+        (tx_data.is_simple_vote && !tx_data.signatures.is_empty()).then_some(tx_data.message_hash)
+    }
+
     pub fn vote_transaction_message_hashes(&self) -> Vec<Hash> {
         self.signatures
             .iter()

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5157,6 +5157,128 @@ pub mod tests {
     }
 
     #[test]
+    fn test_verification_workers_small_capacity() {
+        let num_workers = 2;
+        let channel_capacity = 1;
+        let worker_pool =
+            ReplayVerificationWorkerPool::with_capacity(num_workers, channel_capacity);
+        let mut progress = AsyncVerificationProgress::new(channel_capacity);
+        let start_hash = Hash::new_unique();
+        let verification_entries = entry::entries_to_verification_data(&create_ticks(
+            (num_workers + 1) as u64,
+            1,
+            start_hash,
+        ));
+
+        for _ in 0..10 {
+            progress
+                .spawn_poh_verification(&worker_pool, verification_entries.clone(), start_hash, 0)
+                .unwrap();
+            assert_eq!(progress.pending_jobs, channel_capacity);
+        }
+
+        progress.wait_for_all_results().unwrap();
+        assert_eq!(progress.pending_jobs, 0);
+    }
+
+    #[test]
+    fn test_verification_workers_max_results() {
+        let num_workers = 4;
+        // ideally we'd use MAX_FEC_SETS_PER_SLOT here, but CI is too slow to be true
+        let fake_max_fec_sets_per_slot = 10usize;
+        let job_capacity = fake_max_fec_sets_per_slot
+            // poh + signature verification
+            .checked_mul(2)
+            .unwrap()
+            // each poh/signature batch can be split into multiple jobs, at most 1 for each worker
+            .checked_mul(num_workers)
+            .expect("verification job queue capacity overflow");
+        let worker_pool = ReplayVerificationWorkerPool::with_capacity(num_workers, job_capacity);
+
+        // make sure that each batch generates work for each worker
+        let num_items = num_workers + 1;
+
+        let start_hash = Hash::new_unique();
+        let verification_entries =
+            entry::entries_to_verification_data(&create_ticks(num_items as u64, 1, start_hash));
+        let transaction = system_transaction::transfer(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            1,
+            Hash::new_unique(),
+        );
+        let entry = Entry::new(&Hash::new_unique(), 1, vec![transaction; num_items]);
+
+        // Simulate two parallel banks. This tests that we make progress even when the number of
+        // jobs exceeds the capacity of the pool.
+        let result_channel_capacity = worker_pool.job_capacity;
+        let mut progresses = [
+            AsyncVerificationProgress::new(result_channel_capacity),
+            AsyncVerificationProgress::new(result_channel_capacity),
+        ];
+
+        // simulate full slots
+        for _ in 0..fake_max_fec_sets_per_slot {
+            for (slot, progress) in progresses.iter_mut().enumerate() {
+                let slot = slot as Slot;
+                progress
+                    .spawn_poh_verification(
+                        &worker_pool,
+                        verification_entries.clone(),
+                        start_hash,
+                        slot,
+                    )
+                    .unwrap();
+                let unverified_signatures = entry::validate_and_hash_transactions(
+                    vec![entry.clone()],
+                    num_items,
+                    transaction_hash_verify_thread_pool(),
+                    |transaction, _| {
+                        Ok(RuntimeTransaction::from_transaction_for_tests(
+                            transaction.into_legacy_transaction().unwrap(),
+                        ))
+                    },
+                )
+                .unwrap()
+                .unverified_signatures;
+                progress
+                    .spawn_signature_verification(
+                        &worker_pool,
+                        unverified_signatures,
+                        slot,
+                        slot,
+                        None,
+                    )
+                    .unwrap();
+            }
+        }
+
+        let expected_results = result_channel_capacity;
+        for progress in &progresses {
+            assert_eq!(progress.pending_jobs, expected_results);
+        }
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while progresses
+            .iter()
+            .any(|progress| progress.receiver.len() < expected_results)
+            && Instant::now() < deadline
+        {
+            thread::yield_now();
+        }
+        let result_counts = progresses
+            .each_ref()
+            .map(|progress| progress.receiver.len());
+
+        for progress in &mut progresses {
+            progress.wait_for_all_results().unwrap();
+        }
+        assert_eq!(
+            result_counts, [expected_results; 2],
+            "verification workers did not send all results before the timeout"
+        );
+    }
+
+    #[test]
     fn test_async_verification_progress_drop() {
         struct BlockingVerificationJob {
             job: VerificationJob,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -55,6 +55,7 @@ use {
     std::{
         cmp,
         collections::{HashMap, HashSet},
+        mem,
         num::Saturating,
         ops::Index,
         path::PathBuf,
@@ -935,7 +936,7 @@ impl ConfirmationProgress {
         debug_assert!(
             async_verification
                 .as_ref()
-                .map(|av| av.pending_jobs == 0 && av.first_error.is_none())
+                .map(|av| { av.pending_jobs == 0 && av.first_error.is_none() })
                 .unwrap_or(true)
         );
         Self {
@@ -955,12 +956,14 @@ impl ConfirmationProgress {
         poh_verify_elapsed: &mut u64,
         transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
-        self.async_verification
-            .as_mut()
-            .map_or(Ok(()), |async_verification| {
-                async_verification
-                    .collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)
-            })
+        let Some(async_verification) = self.async_verification.as_mut() else {
+            return Ok(());
+        };
+        let result = async_verification.collect_available_results();
+        let (poh_us, transaction_us) = async_verification.take_timings();
+        *poh_verify_elapsed = poh_verify_elapsed.saturating_add(poh_us);
+        *transaction_verify_elapsed = transaction_verify_elapsed.saturating_add(transaction_us);
+        result
     }
 
     pub fn wait_for_all_verification_results(
@@ -968,19 +971,21 @@ impl ConfirmationProgress {
         poh_verify_elapsed: &mut u64,
         transaction_verify_elapsed: &mut u64,
     ) -> result::Result<(), BlockstoreProcessorError> {
-        self.async_verification
-            .as_mut()
-            .map_or(Ok(()), |async_verification| {
-                async_verification
-                    .wait_for_all_results(poh_verify_elapsed, transaction_verify_elapsed)
-            })
+        let Some(async_verification) = self.async_verification.as_mut() else {
+            return Ok(());
+        };
+        let result = async_verification.wait_for_all_results();
+        let (poh_us, transaction_us) = async_verification.take_timings();
+        *poh_verify_elapsed = poh_verify_elapsed.saturating_add(poh_us);
+        *transaction_verify_elapsed = transaction_verify_elapsed.saturating_add(transaction_us);
+        result
     }
 
     pub fn take_async_verification(&mut self) -> Option<AsyncVerificationProgress> {
         debug_assert!(
             self.async_verification
                 .as_ref()
-                .map(|av| av.pending_jobs == 0 && av.first_error.is_none())
+                .map(|av| { av.pending_jobs == 0 && av.first_error.is_none() })
                 .unwrap_or(true)
         );
         self.async_verification.take()
@@ -998,6 +1003,8 @@ pub struct AsyncVerificationProgress {
     receiver: Receiver<AsyncVerificationResult>,
     pending_jobs: usize,
     first_error: Option<BlockstoreProcessorError>,
+    poh_verify_elapsed: u64,
+    transaction_verify_elapsed: u64,
 }
 
 impl Default for AsyncVerificationProgress {
@@ -1019,6 +1026,8 @@ impl AsyncVerificationProgress {
             receiver,
             pending_jobs: 0,
             first_error: None,
+            poh_verify_elapsed: 0,
+            transaction_verify_elapsed: 0,
         }
     }
 
@@ -1028,8 +1037,6 @@ impl AsyncVerificationProgress {
     fn spawn(
         &mut self,
         replay_tx_thread_pool: &ThreadPool,
-        poh_verify_elapsed: &mut u64,
-        transaction_verify_elapsed: &mut u64,
         work: impl FnOnce() -> AsyncVerificationResult + Send + 'static,
     ) -> result::Result<(), BlockstoreProcessorError> {
         while self.sender.is_full() {
@@ -1039,7 +1046,7 @@ impl AsyncVerificationProgress {
             //
             // We also really don't want sender.send(result) below to sleep, because that would
             // block rayon threads slowing down progress even more.
-            self.collect_available_results(poh_verify_elapsed, transaction_verify_elapsed)?;
+            self.collect_available_results()?;
         }
         self.pending_jobs = self.pending_jobs.saturating_add(1);
         let sender = self.sender.clone();
@@ -1050,13 +1057,9 @@ impl AsyncVerificationProgress {
     }
 
     // Collects all available results from the channel.
-    fn collect_available_results(
-        &mut self,
-        poh_verify_elapsed: &mut u64,
-        transaction_verify_elapsed: &mut u64,
-    ) -> result::Result<(), BlockstoreProcessorError> {
+    fn collect_available_results(&mut self) -> result::Result<(), BlockstoreProcessorError> {
         while let Ok(result) = self.receiver.try_recv() {
-            self.apply_result(result, poh_verify_elapsed, transaction_verify_elapsed);
+            self.apply_result(result);
         }
         if let Some(error) = self.first_error.take() {
             return Err(error);
@@ -1067,16 +1070,12 @@ impl AsyncVerificationProgress {
     // Waits for all pending jobs to complete and collects their results.
     //
     // This MUST be called at the end of a slot.
-    fn wait_for_all_results(
-        &mut self,
-        poh_verify_elapsed: &mut u64,
-        transaction_verify_elapsed: &mut u64,
-    ) -> result::Result<(), BlockstoreProcessorError> {
+    fn wait_for_all_results(&mut self) -> result::Result<(), BlockstoreProcessorError> {
         while self.pending_jobs > 0 {
             let result = self.receiver.recv().map_err(|_| {
                 BlockstoreProcessorError::InvalidBlock(BlockError::InvalidEntryHash)
             })?;
-            self.apply_result(result, poh_verify_elapsed, transaction_verify_elapsed);
+            self.apply_result(result);
         }
         if let Some(error) = self.first_error.take() {
             return Err(error);
@@ -1087,19 +1086,26 @@ impl AsyncVerificationProgress {
     fn apply_result(
         &mut self,
         AsyncVerificationResult {
-            poh_verify_elapsed: poh_us,
-            transaction_verify_elapsed: tx_verify_us,
+            poh_verify_elapsed,
+            transaction_verify_elapsed,
             error,
         }: AsyncVerificationResult,
-        poh_verify_elapsed: &mut u64,
-        transaction_verify_elapsed: &mut u64,
     ) {
         self.pending_jobs = self.pending_jobs.saturating_sub(1);
-        *poh_verify_elapsed = poh_verify_elapsed.saturating_add(poh_us);
-        *transaction_verify_elapsed = transaction_verify_elapsed.saturating_add(tx_verify_us);
+        self.poh_verify_elapsed = self.poh_verify_elapsed.saturating_add(poh_verify_elapsed);
+        self.transaction_verify_elapsed = self
+            .transaction_verify_elapsed
+            .saturating_add(transaction_verify_elapsed);
         if self.first_error.is_none() {
             self.first_error = error;
         }
+    }
+
+    fn take_timings(&mut self) -> (u64, u64) {
+        (
+            mem::take(&mut self.poh_verify_elapsed),
+            mem::take(&mut self.transaction_verify_elapsed),
+        )
     }
 }
 
@@ -1353,11 +1359,9 @@ fn confirm_slot_entries(
     if !skip_verification {
         let start_hash = progress.last_entry;
         let verify_entries = entry::entries_to_verification_data(&entries);
-        progress.async_verification().spawn(
-            replay_tx_thread_pool,
-            poh_verify_elapsed,
-            transaction_verify_elapsed,
-            move || {
+        progress
+            .async_verification()
+            .spawn(replay_tx_thread_pool, move || {
                 datapoint_debug!(
                     "verify-batch-size",
                     ("size", verify_entries.len() as i64, i64)
@@ -1376,8 +1380,7 @@ fn confirm_slot_entries(
                     transaction_verify_elapsed: 0,
                     error,
                 }
-            },
-        )?;
+            })?;
     }
 
     let validate_and_hash_transaction = {
@@ -1423,11 +1426,9 @@ fn confirm_slot_entries(
         }
     } else {
         let replay_vote_sender = replay_vote_sender.cloned();
-        progress.async_verification().spawn(
-            replay_tx_thread_pool,
-            poh_verify_elapsed,
-            transaction_verify_elapsed,
-            move || {
+        progress
+            .async_verification()
+            .spawn(replay_tx_thread_pool, move || {
                 let verification_start = Instant::now();
                 let error = unverified_signatures
                     .verify()
@@ -1456,8 +1457,7 @@ fn confirm_slot_entries(
                     transaction_verify_elapsed: verification_start.elapsed().as_micros() as u64,
                     error,
                 }
-            },
-        )?;
+            })?;
     }
 
     let mut replay_timer = Measure::start("replay_elapsed");
@@ -4973,7 +4973,7 @@ pub mod tests {
 
         let mut progress = AsyncVerificationProgress::new();
         progress
-            .spawn(&pool, &mut 0, &mut 0, {
+            .spawn(&pool, {
                 let drop_barrier = drop_barrier.clone();
                 move || {
                     // wait for the test to drop `progress` so the channel spawn() sends results to

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -23,7 +23,7 @@ use {
     solana_clock::{BankId, Slot},
     solana_entry::{
         block_component::{BlockComponent, VersionedBlockMarker},
-        entry::{self, Entry, EntrySlice, EntryType, create_ticks},
+        entry::{self, Entry, EntrySlice, EntryType, UnverifiedSignatures, create_ticks},
     },
     solana_genesis_config::GenesisConfig,
     solana_hash::Hash,
@@ -998,6 +998,83 @@ struct AsyncVerificationResult {
     error: Option<BlockstoreProcessorError>,
 }
 
+struct PohVerificationJob {
+    entries: Vec<entry::EntryVerificationData>,
+    start_hash: Hash,
+    slot: Slot,
+}
+
+impl PohVerificationJob {
+    fn run(self) -> AsyncVerificationResult {
+        let Self {
+            entries,
+            start_hash,
+            slot,
+        } = self;
+        datapoint_debug!("verify-batch-size", ("size", entries.len() as i64, i64));
+        let state = entry::verify_entries_cpu(&entries, &start_hash);
+        let error = if state.status() {
+            None
+        } else {
+            warn!("Ledger proof of history failed at slot: {slot}");
+            Some(BlockstoreProcessorError::InvalidBlock(
+                BlockError::InvalidEntryHash,
+            ))
+        };
+        AsyncVerificationResult {
+            poh_verify_elapsed: state.poh_duration_us(),
+            transaction_verify_elapsed: 0,
+            error,
+        }
+    }
+}
+
+struct SignaturesVerificationJob {
+    signatures: UnverifiedSignatures,
+    slot: Slot,
+    bank_id: BankId,
+    replay_vote_sender: Option<ReplayVoteSender>,
+}
+
+impl SignaturesVerificationJob {
+    fn run(self) -> AsyncVerificationResult {
+        let Self {
+            signatures,
+            slot,
+            bank_id,
+            replay_vote_sender,
+        } = self;
+        let verification_start = Instant::now();
+        let error = signatures
+            .verify()
+            .map_err(BlockstoreProcessorError::from)
+            .err();
+        if let Some(err) = &error {
+            warn!("Ledger transaction signature verification failed at slot {slot}: {err}");
+            if let Some(replay_vote_sender) = &replay_vote_sender {
+                let _ = replay_vote_sender.send(ReplayVoteMessage::InvalidBank {
+                    replay_bank_id: bank_id,
+                    replay_slot: slot,
+                });
+            }
+        } else if let Some(replay_vote_sender) = &replay_vote_sender {
+            let message_hashes = signatures.vote_transaction_message_hashes();
+            if !message_hashes.is_empty() {
+                let _ = replay_vote_sender.send(ReplayVoteMessage::Verified {
+                    replay_bank_id: bank_id,
+                    replay_slot: slot,
+                    message_hashes,
+                });
+            }
+        }
+        AsyncVerificationResult {
+            poh_verify_elapsed: 0,
+            transaction_verify_elapsed: verification_start.elapsed().as_micros() as u64,
+            error,
+        }
+    }
+}
+
 pub struct AsyncVerificationProgress {
     sender: Sender<AsyncVerificationResult>,
     receiver: Receiver<AsyncVerificationResult>,
@@ -1029,6 +1106,38 @@ impl AsyncVerificationProgress {
             poh_verify_elapsed: 0,
             transaction_verify_elapsed: 0,
         }
+    }
+
+    fn spawn_poh_verification(
+        &mut self,
+        replay_tx_thread_pool: &ThreadPool,
+        entries: Vec<entry::EntryVerificationData>,
+        start_hash: Hash,
+        slot: Slot,
+    ) -> result::Result<(), BlockstoreProcessorError> {
+        let job = PohVerificationJob {
+            entries,
+            start_hash,
+            slot,
+        };
+        self.spawn(replay_tx_thread_pool, move || job.run())
+    }
+
+    fn spawn_signature_verification(
+        &mut self,
+        replay_tx_thread_pool: &ThreadPool,
+        signatures: UnverifiedSignatures,
+        slot: Slot,
+        bank_id: BankId,
+        replay_vote_sender: Option<ReplayVoteSender>,
+    ) -> result::Result<(), BlockstoreProcessorError> {
+        let job = SignaturesVerificationJob {
+            signatures,
+            slot,
+            bank_id,
+            replay_vote_sender,
+        };
+        self.spawn(replay_tx_thread_pool, move || job.run())
     }
 
     // Spawns the given work on the given thread pool. The result, once
@@ -1359,28 +1468,12 @@ fn confirm_slot_entries(
     if !skip_verification {
         let start_hash = progress.last_entry;
         let verify_entries = entry::entries_to_verification_data(&entries);
-        progress
-            .async_verification()
-            .spawn(replay_tx_thread_pool, move || {
-                datapoint_debug!(
-                    "verify-batch-size",
-                    ("size", verify_entries.len() as i64, i64)
-                );
-                let state = entry::verify_entries_cpu(&verify_entries, &start_hash);
-                let error = if state.status() {
-                    None
-                } else {
-                    warn!("Ledger proof of history failed at slot: {slot}");
-                    Some(BlockstoreProcessorError::InvalidBlock(
-                        BlockError::InvalidEntryHash,
-                    ))
-                };
-                AsyncVerificationResult {
-                    poh_verify_elapsed: state.poh_duration_us(),
-                    transaction_verify_elapsed: 0,
-                    error,
-                }
-            })?;
+        progress.async_verification().spawn_poh_verification(
+            replay_tx_thread_pool,
+            verify_entries,
+            start_hash,
+            slot,
+        )?;
     }
 
     let validate_and_hash_transaction = {
@@ -1426,38 +1519,13 @@ fn confirm_slot_entries(
         }
     } else {
         let replay_vote_sender = replay_vote_sender.cloned();
-        progress
-            .async_verification()
-            .spawn(replay_tx_thread_pool, move || {
-                let verification_start = Instant::now();
-                let error = unverified_signatures
-                    .verify()
-                    .map_err(BlockstoreProcessorError::from)
-                    .err();
-                if let Some(err) = &error {
-                    warn!("Ledger transaction signature verification failed at slot {slot}: {err}");
-                    if let Some(replay_vote_sender) = &replay_vote_sender {
-                        let _ = replay_vote_sender.send(ReplayVoteMessage::InvalidBank {
-                            replay_bank_id: bank_id,
-                            replay_slot: slot,
-                        });
-                    }
-                } else if let Some(replay_vote_sender) = &replay_vote_sender {
-                    let message_hashes = unverified_signatures.vote_transaction_message_hashes();
-                    if !message_hashes.is_empty() {
-                        let _ = replay_vote_sender.send(ReplayVoteMessage::Verified {
-                            replay_bank_id: bank_id,
-                            replay_slot: slot,
-                            message_hashes,
-                        });
-                    }
-                }
-                AsyncVerificationResult {
-                    poh_verify_elapsed: 0,
-                    transaction_verify_elapsed: verification_start.elapsed().as_micros() as u64,
-                    error,
-                }
-            })?;
+        progress.async_verification().spawn_signature_verification(
+            replay_tx_thread_pool,
+            unverified_signatures,
+            slot,
+            bank_id,
+            replay_vote_sender,
+        )?;
     }
 
     let mut replay_timer = Measure::start("replay_elapsed");

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5,6 +5,8 @@ use {
         blockstore_meta::SlotMeta,
         entry_notifier_service::{EntryNotification, EntryNotifierSender},
         leader_schedule_cache::LeaderScheduleCache,
+        shred::MAX_FEC_SETS_PER_SLOT,
+        thread_pool::{WorkerJob, WorkerPool},
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
     ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
@@ -57,10 +59,13 @@ use {
         collections::{HashMap, HashSet},
         mem,
         num::Saturating,
-        ops::Index,
+        ops::{Index, Range},
         path::PathBuf,
         result,
-        sync::{Arc, OnceLock, RwLock, atomic::AtomicBool},
+        sync::{
+            Arc, OnceLock, RwLock,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -83,16 +88,6 @@ pub enum ChainedBlockIdCheck {
     Mismatch,
     /// Data shred 0 not received yet; cannot determine chained block ID.
     Unavailable,
-}
-
-#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn create_thread_pool(num_threads: usize) -> ThreadPool {
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(num_threads)
-        .stack_size(8 * 1024 * 1024)
-        .thread_name(|i| format!("solReplayTx{i:02}"))
-        .build()
-        .expect("new rayon threadpool")
 }
 
 fn transaction_hash_verify_thread_pool() -> &'static ThreadPool {
@@ -159,7 +154,6 @@ pub fn process_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) 
 }
 
 fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> Result<()> {
-    let replay_tx_thread_pool = create_thread_pool(1);
     let validate_and_hash_transaction = {
         let bank = bank.clone_with_scheduler();
         move |versioned_tx: VersionedTransaction,
@@ -180,7 +174,7 @@ fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> 
     } = entry::validate_and_hash_transactions(
         entries,
         num_txs,
-        &replay_tx_thread_pool,
+        transaction_hash_verify_thread_pool(),
         validate_and_hash_transaction,
     )?;
     unverified_signatures.verify()?;
@@ -359,7 +353,7 @@ pub(crate) fn process_blockstore_for_bank_0(
     let bank_forks = BankForks::new_rw_arc(bank0);
 
     info!("Processing ledger for slot 0...");
-    let replay_tx_thread_pool = create_thread_pool(num_cpus::get());
+    let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(num_cpus::get());
     process_bank_0(
         &bank_forks
             .read()
@@ -368,7 +362,7 @@ pub(crate) fn process_blockstore_for_bank_0(
             .unwrap(),
         compute_shred_version(&genesis_config.hash(), Some(&hard_forks)),
         blockstore,
-        &replay_tx_thread_pool,
+        &replay_verification_worker_pool,
         opts,
         transaction_status_sender,
         entry_notification_sender,
@@ -438,13 +432,13 @@ pub fn process_blockstore_from_root(
         .meta(start_slot)
         .unwrap_or_else(|_| panic!("Failed to get meta for slot {start_slot}"))
     {
-        let replay_tx_thread_pool = create_thread_pool(num_cpus::get());
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(num_cpus::get());
         load_frozen_forks(
             bank_forks,
             shred_version,
             &start_slot_meta,
             blockstore,
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             leader_schedule_cache,
             opts,
             transaction_status_sender,
@@ -561,7 +555,7 @@ fn confirm_full_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
     shred_version: u16,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     opts: &ProcessOptions,
     progress: &mut ConfirmationProgress,
     entry_notification_sender: Option<&EntryNotifierSender>,
@@ -586,7 +580,7 @@ fn confirm_full_slot(
         blockstore,
         bank,
         shred_version,
-        replay_tx_thread_pool,
+        replay_verification_worker_pool,
         &mut confirmation_timing,
         progress,
         skip_verification,
@@ -946,9 +940,12 @@ impl ConfirmationProgress {
         }
     }
 
-    fn async_verification(&mut self) -> &mut AsyncVerificationProgress {
+    fn async_verification(
+        &mut self,
+        worker_pool: &ReplayVerificationWorkerPool,
+    ) -> &mut AsyncVerificationProgress {
         self.async_verification
-            .get_or_insert_with(AsyncVerificationProgress::new)
+            .get_or_insert_with(|| AsyncVerificationProgress::new(worker_pool.job_capacity))
     }
 
     fn collect_available_verification_results(
@@ -998,57 +995,89 @@ struct AsyncVerificationResult {
     error: Option<BlockstoreProcessorError>,
 }
 
-struct PohVerificationJob {
-    entries: Vec<entry::EntryVerificationData>,
-    start_hash: Hash,
-    slot: Slot,
+// Wrapper used to track wall clock time for work that is split into multiple jobs and executed in
+// parallel. The last job to finish will decrement remaining_jobs to 0 and record the total elapsed
+// time since the batch was started.
+struct VerificationBatch<T> {
+    data: T,
+    started: Instant,
+    remaining_jobs: AtomicUsize,
 }
 
-impl PohVerificationJob {
-    fn run(self) -> AsyncVerificationResult {
-        let Self {
-            entries,
-            start_hash,
-            slot,
-        } = self;
-        datapoint_debug!("verify-batch-size", ("size", entries.len() as i64, i64));
-        let state = entry::verify_entries_cpu(&entries, &start_hash);
-        let error = if state.status() {
-            None
+impl<T> VerificationBatch<T> {
+    fn finish_job(&self) -> u64 {
+        if self.remaining_jobs.fetch_sub(1, Ordering::Relaxed) == 1 {
+            self.started.elapsed().as_micros() as u64
         } else {
-            warn!("Ledger proof of history failed at slot: {slot}");
-            Some(BlockstoreProcessorError::InvalidBlock(
-                BlockError::InvalidEntryHash,
-            ))
-        };
-        AsyncVerificationResult {
-            poh_verify_elapsed: state.poh_duration_us(),
-            transaction_verify_elapsed: 0,
-            error,
+            0
         }
     }
 }
 
+struct PohVerificationJob {
+    entries: Arc<VerificationBatch<Vec<entry::EntryVerificationData>>>,
+    range: Range<usize>,
+    start_hash: Hash,
+    slot: Slot,
+    result_sender: Sender<AsyncVerificationResult>,
+}
+
+impl PohVerificationJob {
+    fn run(self) {
+        let Self {
+            entries,
+            range,
+            start_hash,
+            slot,
+            result_sender,
+        } = self;
+        let verified = range.into_iter().all(|index| {
+            let previous_hash = if index == 0 {
+                &start_hash
+            } else {
+                &entries.data[index - 1].hash
+            };
+            entries.data[index].verify(previous_hash)
+        });
+        let elapsed_us = entries.finish_job();
+        let error = (!verified).then(|| {
+            warn!("Ledger proof of history failed at slot: {slot}");
+            BlockstoreProcessorError::InvalidBlock(BlockError::InvalidEntryHash)
+        });
+        let _ = result_sender.send(AsyncVerificationResult {
+            poh_verify_elapsed: elapsed_us,
+            transaction_verify_elapsed: 0,
+            error,
+        });
+    }
+}
+
 struct SignaturesVerificationJob {
-    signatures: UnverifiedSignatures,
+    signatures: Arc<VerificationBatch<UnverifiedSignatures>>,
+    range: Range<usize>,
     slot: Slot,
     bank_id: BankId,
+    result_sender: Sender<AsyncVerificationResult>,
     replay_vote_sender: Option<ReplayVoteSender>,
 }
 
 impl SignaturesVerificationJob {
-    fn run(self) -> AsyncVerificationResult {
+    fn run(self) {
         let Self {
             signatures,
+            range,
             slot,
             bank_id,
+            result_sender,
             replay_vote_sender,
         } = self;
-        let verification_start = Instant::now();
-        let error = signatures
-            .verify()
-            .map_err(BlockstoreProcessorError::from)
-            .err();
+        let verified = range
+            .clone()
+            .all(|index| signatures.data.verify_signatures(index));
+        let elapsed_us = signatures.finish_job();
+        let error = (!verified).then_some(BlockstoreProcessorError::InvalidTransaction(
+            TransactionError::SignatureFailure,
+        ));
         if let Some(err) = &error {
             warn!("Ledger transaction signature verification failed at slot {slot}: {err}");
             if let Some(replay_vote_sender) = &replay_vote_sender {
@@ -1058,7 +1087,9 @@ impl SignaturesVerificationJob {
                 });
             }
         } else if let Some(replay_vote_sender) = &replay_vote_sender {
-            let message_hashes = signatures.vote_transaction_message_hashes();
+            let message_hashes = range
+                .filter_map(|index| signatures.data.vote_transaction_message_hash(index))
+                .collect::<Vec<_>>();
             if !message_hashes.is_empty() {
                 let _ = replay_vote_sender.send(ReplayVoteMessage::Verified {
                     replay_bank_id: bank_id,
@@ -1067,11 +1098,57 @@ impl SignaturesVerificationJob {
                 });
             }
         }
-        AsyncVerificationResult {
+        let _ = result_sender.send(AsyncVerificationResult {
             poh_verify_elapsed: 0,
-            transaction_verify_elapsed: verification_start.elapsed().as_micros() as u64,
+            transaction_verify_elapsed: elapsed_us,
             error,
+        });
+    }
+}
+
+enum VerificationJob {
+    Poh(PohVerificationJob),
+    Signatures(SignaturesVerificationJob),
+}
+
+impl WorkerJob for VerificationJob {
+    fn run(self) {
+        match self {
+            Self::Poh(job) => job.run(),
+            Self::Signatures(job) => job.run(),
         }
+    }
+}
+
+pub struct ReplayVerificationWorkerPool {
+    inner: WorkerPool<VerificationJob>,
+    job_capacity: usize,
+}
+
+impl ReplayVerificationWorkerPool {
+    pub fn new(num_workers: usize) -> Self {
+        // set the maximum number of jobs that can be sent replaying a completely full slot as
+        // the capacity, so we avoid blocking the replay thread when sending work. ~8MB of
+        // memory. Not load bearing, a smaller capacity would do, just cause more stalls.
+        let job_capacity = (MAX_FEC_SETS_PER_SLOT as usize)
+            // poh + signature verification
+            .checked_mul(2)
+            .unwrap()
+            // each poh/signature batch can be split into multiple jobs, at most 1 for each worker
+            .checked_mul(num_workers)
+            .expect("verification job queue capacity overflow");
+        Self::with_capacity(num_workers, job_capacity)
+    }
+
+    fn with_capacity(num_workers: usize, job_capacity: usize) -> Self {
+        Self {
+            inner: WorkerPool::new("solReplayVer", num_workers, job_capacity),
+            job_capacity,
+        }
+    }
+
+    fn send(&self, job: VerificationJob) {
+        self.inner.send(job);
     }
 }
 
@@ -1084,20 +1161,13 @@ pub struct AsyncVerificationProgress {
     transaction_verify_elapsed: u64,
 }
 
-impl Default for AsyncVerificationProgress {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AsyncVerificationProgress {
-    // The capacity of the channel is somewhat arbitrary. At the time of this writing this is 100x
-    // the number of max entries per slot on mnb. The channel will effectively never fill up, but if
-    // it does, that condition is handled gracefully in spawn().
-    const RESULT_CHANNEL_CAPACITY: usize = 100000;
-
-    pub fn new() -> Self {
-        let (sender, receiver) = crossbeam_channel::bounded(Self::RESULT_CHANNEL_CAPACITY);
+    pub fn new(result_channel_capacity: usize) -> Self {
+        assert_ne!(
+            result_channel_capacity, 0,
+            "verification result channel capacity must be nonzero"
+        );
+        let (sender, receiver) = crossbeam_channel::bounded(result_channel_capacity);
         Self {
             sender,
             receiver,
@@ -1110,58 +1180,110 @@ impl AsyncVerificationProgress {
 
     fn spawn_poh_verification(
         &mut self,
-        replay_tx_thread_pool: &ThreadPool,
+        worker_pool: &ReplayVerificationWorkerPool,
         entries: Vec<entry::EntryVerificationData>,
         start_hash: Hash,
         slot: Slot,
     ) -> result::Result<(), BlockstoreProcessorError> {
-        let job = PohVerificationJob {
-            entries,
-            start_hash,
-            slot,
-        };
-        self.spawn(replay_tx_thread_pool, move || job.run())
+        let item_count = entries.len();
+        if item_count == 0 {
+            return Ok(());
+        }
+        let sender = self.sender.clone();
+        self.send_jobs(worker_pool, entries, item_count, move |range, entries| {
+            VerificationJob::Poh(PohVerificationJob {
+                entries,
+                range,
+                start_hash,
+                slot,
+                result_sender: sender.clone(),
+            })
+        })
     }
 
     fn spawn_signature_verification(
         &mut self,
-        replay_tx_thread_pool: &ThreadPool,
+        worker_pool: &ReplayVerificationWorkerPool,
         signatures: UnverifiedSignatures,
         slot: Slot,
         bank_id: BankId,
         replay_vote_sender: Option<ReplayVoteSender>,
     ) -> result::Result<(), BlockstoreProcessorError> {
-        let job = SignaturesVerificationJob {
+        let item_count = signatures.len();
+        if item_count == 0 {
+            return Ok(());
+        }
+        let sender = self.sender.clone();
+        self.send_jobs(
+            worker_pool,
             signatures,
-            slot,
-            bank_id,
-            replay_vote_sender,
-        };
-        self.spawn(replay_tx_thread_pool, move || job.run())
+            item_count,
+            move |range, signatures| {
+                VerificationJob::Signatures(SignaturesVerificationJob {
+                    signatures,
+                    range,
+                    slot,
+                    bank_id,
+                    result_sender: sender.clone(),
+                    replay_vote_sender: replay_vote_sender.clone(),
+                })
+            },
+        )
     }
 
-    // Spawns the given work on the given thread pool. The result, once
-    // available, can be collected by calling `collect_available_results()` or
-    // `wait_for_all_results()`.
-    fn spawn(
+    fn send_jobs<T>(
         &mut self,
-        replay_tx_thread_pool: &ThreadPool,
-        work: impl FnOnce() -> AsyncVerificationResult + Send + 'static,
+        worker_pool: &ReplayVerificationWorkerPool,
+        data: T,
+        item_count: usize,
+        create_job: impl Fn(Range<usize>, Arc<VerificationBatch<T>>) -> VerificationJob,
     ) -> result::Result<(), BlockstoreProcessorError> {
-        while self.sender.is_full() {
-            // Note that we spin here if the channel is full. This is fine because it can only be
-            // full if we are not keeping up, in which case pulling results as fast as possible is
-            // the right thing to do.
-            //
-            // We also really don't want sender.send(result) below to sleep, because that would
-            // block rayon threads slowing down progress even more.
-            self.collect_available_results()?;
-        }
-        self.pending_jobs = self.pending_jobs.saturating_add(1);
-        let sender = self.sender.clone();
-        replay_tx_thread_pool.spawn(move || {
-            let _ = sender.send(work());
+        debug_assert!(item_count > 0);
+        let job_count = worker_pool.inner.num_workers().min(item_count);
+        let result_capacity = self.sender.capacity().unwrap();
+        assert!(
+            self.pending_jobs <= result_capacity,
+            "verification pending job count exceeds result channel capacity"
+        );
+
+        // Split the work evenly across workers. This is kinda naive but a good first impl.
+        let items_per_job = item_count / job_count;
+        let remainder = item_count % job_count;
+
+        // wrap the data in Arc<VerificationBatch> so that we can track the wall clock time to
+        // verify the whole thing
+        let data = Arc::new(VerificationBatch {
+            data,
+            started: Instant::now(),
+            remaining_jobs: AtomicUsize::new(job_count),
         });
+
+        let mut range_start = 0;
+        for job_index in 0..job_count {
+            // The workers can be shared across banks. We never want them to stall because they've
+            // done their job but can't post the result.
+            if self.pending_jobs == result_capacity {
+                let result = self.receiver.recv().map_err(|_| {
+                    BlockstoreProcessorError::InvalidBlock(BlockError::InvalidEntryHash)
+                })?;
+                self.apply_result(result);
+            }
+
+            // the first `remainder` workers get an extra item each
+            let range_end = range_start + items_per_job + usize::from(job_index < remainder);
+            self.pending_jobs = self
+                .pending_jobs
+                .checked_add(1)
+                .expect("verification pending job count overflow");
+            worker_pool.send(create_job(range_start..range_end, Arc::clone(&data)));
+            range_start = range_end;
+        }
+
+        // all jobs must be sent before returning an error because
+        // `VerificationBatch::remaining_jobs` was initialized with `job_count`
+        if let Some(error) = self.first_error.take() {
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -1200,7 +1322,10 @@ impl AsyncVerificationProgress {
             error,
         }: AsyncVerificationResult,
     ) {
-        self.pending_jobs = self.pending_jobs.saturating_sub(1);
+        self.pending_jobs = self
+            .pending_jobs
+            .checked_sub(1)
+            .expect("verification result without a pending job");
         self.poh_verify_elapsed = self.poh_verify_elapsed.saturating_add(poh_verify_elapsed);
         self.transaction_verify_elapsed = self
             .transaction_verify_elapsed
@@ -1223,7 +1348,7 @@ pub fn confirm_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
     shred_version: u16,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
     skip_verification: bool,
@@ -1308,7 +1433,7 @@ pub fn confirm_slot(
 
                 confirm_slot_entries(
                     bank,
-                    replay_tx_thread_pool,
+                    replay_verification_worker_pool,
                     (entries, num_shreds as u64, slot_full),
                     timing,
                     progress,
@@ -1384,7 +1509,7 @@ pub fn confirm_slot(
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn confirm_slot_entries(
     bank: &BankWithScheduler,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     slot_entries_load_result: (Vec<Entry>, u64, bool),
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
@@ -1468,12 +1593,18 @@ fn confirm_slot_entries(
     if !skip_verification {
         let start_hash = progress.last_entry;
         let verify_entries = entry::entries_to_verification_data(&entries);
-        progress.async_verification().spawn_poh_verification(
-            replay_tx_thread_pool,
-            verify_entries,
-            start_hash,
-            slot,
-        )?;
+        datapoint_debug!(
+            "verify-batch-size",
+            ("size", verify_entries.len() as i64, i64)
+        );
+        progress
+            .async_verification(replay_verification_worker_pool)
+            .spawn_poh_verification(
+                replay_verification_worker_pool,
+                verify_entries,
+                start_hash,
+                slot,
+            )?;
     }
 
     let validate_and_hash_transaction = {
@@ -1519,13 +1650,15 @@ fn confirm_slot_entries(
         }
     } else {
         let replay_vote_sender = replay_vote_sender.cloned();
-        progress.async_verification().spawn_signature_verification(
-            replay_tx_thread_pool,
-            unverified_signatures,
-            slot,
-            bank_id,
-            replay_vote_sender,
-        )?;
+        progress
+            .async_verification(replay_verification_worker_pool)
+            .spawn_signature_verification(
+                replay_verification_worker_pool,
+                unverified_signatures,
+                slot,
+                bank_id,
+                replay_vote_sender,
+            )?;
     }
 
     let mut replay_timer = Measure::start("replay_elapsed");
@@ -1578,12 +1711,13 @@ fn confirm_slot_entries(
 }
 
 // Special handling required for processing the entries in slot 0
+#[allow(clippy::too_many_arguments)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 fn process_bank_0(
     bank0: &BankWithScheduler,
     shred_version: u16,
     blockstore: &Blockstore,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     opts: &ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
     entry_notification_sender: Option<&EntryNotifierSender>,
@@ -1595,7 +1729,7 @@ fn process_bank_0(
         blockstore,
         bank0,
         shred_version,
-        replay_tx_thread_pool,
+        replay_verification_worker_pool,
         opts,
         &mut progress,
         entry_notification_sender,
@@ -1807,7 +1941,7 @@ fn load_frozen_forks(
     shred_version: u16,
     start_slot_meta: &SlotMeta,
     blockstore: &Blockstore,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     leader_schedule_cache: &LeaderScheduleCache,
     opts: &ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
@@ -1904,7 +2038,7 @@ fn load_frozen_forks(
                 blockstore,
                 &bank,
                 shred_version,
-                replay_tx_thread_pool,
+                replay_verification_worker_pool,
                 opts,
                 &mut progress,
                 transaction_status_sender,
@@ -2198,7 +2332,7 @@ pub fn process_single_slot(
     blockstore: &Blockstore,
     bank: &BankWithScheduler,
     shred_version: u16,
-    replay_tx_thread_pool: &ThreadPool,
+    replay_verification_worker_pool: &ReplayVerificationWorkerPool,
     opts: &ProcessOptions,
     progress: &mut ConfirmationProgress,
     transaction_status_sender: Option<&TransactionStatusSender>,
@@ -2232,7 +2366,7 @@ pub fn process_single_slot(
         blockstore,
         bank,
         shred_version,
-        replay_tx_thread_pool,
+        replay_verification_worker_pool,
         opts,
         progress,
         entry_notification_sender,
@@ -2330,7 +2464,6 @@ pub mod tests {
         assert_matches::assert_matches,
         crossbeam_channel::bounded,
         rand::{Rng, rng},
-        rayon::ThreadPoolBuilder,
         solana_account::{AccountSharedData, WritableAccount},
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_entry::{
@@ -4258,12 +4391,12 @@ pub mod tests {
             run_verification: true,
             ..ProcessOptions::default()
         };
-        let replay_tx_thread_pool = create_thread_pool(1);
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
         process_bank_0(
             &bank0,
             compute_shred_version(&genesis_config.hash(), None),
             &blockstore,
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &opts,
             None,
             None,
@@ -4278,7 +4411,7 @@ pub mod tests {
             &blockstore,
             &bank1,
             compute_shred_version(&genesis_config.hash(), None),
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &opts,
             &mut ConfirmationProgress::new(bank0_last_blockhash),
             None,
@@ -4832,11 +4965,11 @@ pub mod tests {
         slot_full: bool,
         progress: &mut ConfirmationProgress,
     ) -> result::Result<(), BlockstoreProcessorError> {
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
         let bank = take_bank_with_scheduler_for_tests(pool, bank.clone());
-        let replay_tx_thread_pool = create_thread_pool(1);
         let result = confirm_slot_entries(
             &bank,
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             (slot_entries, 0, slot_full),
             &mut ConfirmationTiming::default(),
             progress,
@@ -5025,43 +5158,43 @@ pub mod tests {
 
     #[test]
     fn test_async_verification_progress_drop() {
-        let exit_barrier = Arc::new(Barrier::new(2));
-        let drop_barrier = Arc::new(Barrier::new(2));
+        struct BlockingVerificationJob {
+            job: VerificationJob,
+            barrier: Arc<Barrier>,
+        }
 
-        let pool = ThreadPoolBuilder::new()
-            .num_threads(1)
-            .exit_handler({
-                let exit_barrier = exit_barrier.clone();
-                move |_| {
-                    exit_barrier.wait();
-                }
-            })
-            .build()
-            .unwrap();
+        impl WorkerJob for BlockingVerificationJob {
+            fn run(self) {
+                self.barrier.wait();
+                self.job.run();
+            }
+        }
 
-        let mut progress = AsyncVerificationProgress::new();
-        progress
-            .spawn(&pool, {
-                let drop_barrier = drop_barrier.clone();
-                move || {
-                    // wait for the test to drop `progress` so the channel spawn() sends results to
-                    // gets disconnected
-                    drop_barrier.wait();
-                    AsyncVerificationResult {
-                        poh_verify_elapsed: 0,
-                        transaction_verify_elapsed: 0,
-                        error: None,
-                    }
-                }
-            })
-            .unwrap();
-
-        // ensure that in flight or pending tasks don't panic if AsyncVerificationProgress gets
-        // dropped
+        let pool = WorkerPool::new("solReplayTest", 1, 1);
+        let barrier = Arc::new(Barrier::new(2));
+        let progress = AsyncVerificationProgress::new(1);
+        let entries = Arc::new(VerificationBatch {
+            data: Vec::new(),
+            started: Instant::now(),
+            remaining_jobs: AtomicUsize::new(1),
+        });
+        let result_sender = progress.sender.clone();
+        pool.send(BlockingVerificationJob {
+            job: VerificationJob::Poh(PohVerificationJob {
+                entries,
+                range: 0..0,
+                start_hash: Hash::default(),
+                slot: 0,
+                result_sender,
+            }),
+            barrier: Arc::clone(&barrier),
+        });
+        // this tests that dropping the progress while a job is running does not panic. Can happen
+        // when a slot is dumped.
         drop(progress);
-        drop_barrier.wait();
+        barrier.wait();
+        // this will join the pool
         drop(pool);
-        exit_barrier.wait();
     }
 
     #[test]
@@ -5310,7 +5443,12 @@ pub mod tests {
 
     fn confirm_slot_with_block_markers_common(
         footer_before_alpentick: bool,
-    ) -> (Blockstore, GenesisConfig, tempfile::TempDir, ThreadPool) {
+    ) -> (
+        Blockstore,
+        GenesisConfig,
+        tempfile::TempDir,
+        ReplayVerificationWorkerPool,
+    ) {
         let GenesisConfigInfo {
             mut genesis_config, ..
         } = create_genesis_config(100 * LAMPORTS_PER_SOL);
@@ -5433,19 +5571,19 @@ pub mod tests {
         }
         blockstore.insert_shreds(all_shreds, true).unwrap();
 
-        let replay_tx_thread_pool = create_thread_pool(1);
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
 
         (
             blockstore,
             genesis_config,
             ledger_path,
-            replay_tx_thread_pool,
+            replay_verification_worker_pool,
         )
     }
 
     #[test]
     fn test_confirm_slot_block_with_markers_fails_without_alpenglow() {
-        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+        let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
             confirm_slot_with_block_markers_common(true);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
@@ -5462,7 +5600,7 @@ pub mod tests {
             &blockstore,
             &bank1,
             compute_shred_version(&genesis_config.hash(), None),
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &mut ConfirmationTiming::default(),
             &mut ConfirmationProgress::new(bank0.last_blockhash()),
             false,
@@ -5477,7 +5615,7 @@ pub mod tests {
 
     #[test]
     fn test_confirm_slot_block_with_markers_succeeds_with_alpenglow() {
-        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+        let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
             confirm_slot_with_block_markers_common(true);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
@@ -5497,7 +5635,7 @@ pub mod tests {
             &blockstore,
             &bank1,
             compute_shred_version(&genesis_config.hash(), None),
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &mut ConfirmationTiming::default(),
             &mut ConfirmationProgress::new(bank0.last_blockhash()),
             true,
@@ -5556,7 +5694,7 @@ pub mod tests {
 
     #[test]
     fn test_confirm_slot_rejects_alpentick_before_footer() {
-        let (blockstore, genesis_config, _ledger_path, replay_tx_thread_pool) =
+        let (blockstore, genesis_config, _ledger_path, replay_verification_worker_pool) =
             confirm_slot_with_block_markers_common(false);
 
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
@@ -5569,7 +5707,7 @@ pub mod tests {
             &blockstore,
             &bank1,
             compute_shred_version(&genesis_config.hash(), None),
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &mut ConfirmationTiming::default(),
             &mut ConfirmationProgress::new(bank0.last_blockhash()),
             true,
@@ -5873,12 +6011,12 @@ pub mod tests {
             ..ProcessOptions::default()
         };
         let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
-        let replay_tx_thread_pool = create_thread_pool(1);
+        let replay_verification_worker_pool = ReplayVerificationWorkerPool::new(1);
         process_bank_0(
             &bank0,
             compute_shred_version(&genesis_config.hash(), None),
             &blockstore,
-            &replay_tx_thread_pool,
+            &replay_verification_worker_pool,
             &opts,
             None,
             None,

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -30,6 +30,7 @@ mod shredder;
 pub mod sigverify_shreds;
 pub mod slot_stats;
 mod staking_utils;
+mod thread_pool;
 mod transaction_address_lookup_table_scanner;
 pub mod use_snapshot_archives_at_startup;
 

--- a/ledger/src/thread_pool.rs
+++ b/ledger/src/thread_pool.rs
@@ -1,0 +1,69 @@
+use {
+    crossbeam_channel::Sender,
+    log::error,
+    std::{
+        mem,
+        thread::{self, JoinHandle},
+    },
+};
+
+pub(crate) trait WorkerJob: Send + 'static {
+    fn run(self);
+}
+
+pub(crate) struct WorkerPool<J: WorkerJob> {
+    job_sender: Sender<J>,
+    worker_handles: Vec<JoinHandle<()>>,
+}
+
+impl<J: WorkerJob> WorkerPool<J> {
+    pub(crate) fn new(
+        thread_name_prefix: &str,
+        num_workers: usize,
+        job_queue_capacity: usize,
+    ) -> Self {
+        assert_ne!(num_workers, 0, "worker pool must have at least one worker");
+        let (job_sender, job_receiver) = crossbeam_channel::bounded::<J>(job_queue_capacity);
+        let worker_handles = (0..num_workers)
+            .map(|index| {
+                let job_receiver = job_receiver.clone();
+                thread::Builder::new()
+                    .name(format!("{thread_name_prefix}{index:02}"))
+                    .stack_size(2 * 1024 * 1024)
+                    .spawn(move || {
+                        while let Ok(job) = job_receiver.recv() {
+                            job.run();
+                        }
+                    })
+                    .expect("failed to spawn worker thread")
+            })
+            .collect();
+        Self {
+            job_sender,
+            worker_handles,
+        }
+    }
+
+    pub(crate) fn send(&self, job: J) {
+        self.job_sender
+            .send(job)
+            .expect("worker threads exited unexpectedly");
+    }
+
+    pub(crate) fn num_workers(&self) -> usize {
+        self.worker_handles.len()
+    }
+}
+
+impl<J: WorkerJob> Drop for WorkerPool<J> {
+    fn drop(&mut self) {
+        // drop the sender so the workers exit
+        let (tmp, _) = crossbeam_channel::bounded(0);
+        drop(mem::replace(&mut self.job_sender, tmp));
+        for worker_handle in self.worker_handles.drain(..) {
+            if let Err(err) = worker_handle.join() {
+                error!("worker thread failed: {err:?}");
+            }
+        }
+    }
+}

--- a/validator/src/cli/thread_args.rs
+++ b/validator/src/cli/thread_args.rs
@@ -316,7 +316,8 @@ struct ReplayTransactionsThreadsArg;
 impl ThreadArg for ReplayTransactionsThreadsArg {
     const NAME: &'static str = "replay_transactions_threads";
     const LONG_NAME: &'static str = "replay-transactions-threads";
-    const HELP: &'static str = "Number of threads to use for transaction replay";
+    const HELP: &'static str =
+        "Number of threads to use for PoH and transaction signature verification during replay";
 
     fn default() -> usize {
         num_cpus::get()


### PR DESCRIPTION
Rayon is the bane of my existence. This removes it from async verification and switches the code to using a custom thread pool instead. 

~~With this PR the big `solReplayTxXX` rayon pool becomes unused. It can't be completely removed from the code since technically there's a way to have replay use it in favor of the unified scheduler. In a follow up I'm going to remove that and rip out the pool entirely.~~ EDIT: rebased and it's gone!

I've been running this on mnb for a few days and perf wise it's comparable to slightly lower latency than rayon. 

The PR is split in self contained commits, where the meat is in `ledger: move replay verification to dedicated workers`