### PR TITLE
Some `AggregateAccumulator` related changes

### DIFF
--- a/core/src/block_creation_loop/rewards/certs_builder/entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry.rs
@@ -1,27 +1,21 @@
 use {
     super::BuildRewardCertsRespError,
-    crate::block_creation_loop::rewards::msg_types::RewardRespSucc,
+    crate::block_creation_loop::rewards::{
+        certs_builder::entry::partial_cert::BuildResult, msg_types::RewardRespSucc,
+    },
+    agave_votor::aggregate_accumulator::AggregateAccumulatorError,
     agave_votor_messages::{
-        aggregate_accumulator::AggregateAccumulatorError, consensus_message::VoteMessage,
-        reward_certificate::SkipRewardCertificate, sig_verified_messages::VoteAggregate,
-        vote::Vote,
+        consensus_message::VoteMessage, reward_certificate::SkipRewardCertificate,
+        sig_verified_messages::VoteAggregate, vote::Vote,
     },
     notar_entry::NotarEntry,
-    partial_cert::{BuildSigBitmapError, PartialCert},
+    partial_cert::PartialCert,
     solana_clock::Slot,
     solana_pubkey::Pubkey,
-    thiserror::Error,
 };
 
 mod notar_entry;
 mod partial_cert;
-
-/// Different types of errors that can be returned from adding votes.
-#[derive(Debug, Error)]
-pub(super) enum AddAggregateError {
-    #[error("AggregateAccumulator failed with {0}")]
-    Accumulating(#[from] AggregateAccumulatorError),
-}
 
 #[derive(Clone)]
 /// Per slot container for storing notar and skip votes for creating rewards certificates.
@@ -49,7 +43,7 @@ impl Entry {
         &mut self,
         aggregate: VoteAggregate,
         vote_account_pubkeys: Vec<Pubkey>,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         match *aggregate.vote() {
             Vote::Notarize(notar) => self.notar.add_aggregate(
                 aggregate,
@@ -67,7 +61,7 @@ impl Entry {
         &mut self,
         vote_msg: VoteMessage,
         vote_account_pubkey: Pubkey,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         match vote_msg.vote {
             Vote::Notarize(notar) => self.notar.add_own_msg(
                 vote_msg,
@@ -87,15 +81,15 @@ impl Entry {
     ) -> Result<RewardRespSucc, BuildRewardCertsRespError> {
         let notar = self.notar.build_cert(reward_slot)?;
         let skip = match self.skip.build_sig_bitmap() {
-            Err(e) => match e {
-                BuildSigBitmapError::Empty => None,
-                BuildSigBitmapError::Accumulating(e) => {
-                    return Err(BuildRewardCertsRespError::RewardCertTryNew(e.into()));
-                }
-            },
-            Ok((signature, bitmap, skip_validators)) => {
+            BuildResult::Empty => None,
+            BuildResult::EncodingError(e) => return Err(BuildRewardCertsRespError::Encoding(e)),
+            BuildResult::Success {
+                signature,
+                bitmap,
+                validators,
+            } => {
                 let cert = SkipRewardCertificate::try_new(reward_slot, signature, bitmap)?;
-                Some((cert, skip_validators))
+                Some((cert, validators))
             }
         };
 

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/notar_entry.rs
@@ -2,8 +2,9 @@
 
 use {
     crate::block_creation_loop::rewards::certs_builder::entry::{
-        AddAggregateError, BuildSigBitmapError, PartialCert,
+        PartialCert, partial_cert::BuildResult,
     },
+    agave_votor::aggregate_accumulator::AggregateAccumulatorError,
     agave_votor_messages::{
         consensus_message::VoteMessage,
         reward_certificate::{BuildRewardCertsRespError, NotarRewardCertificate},
@@ -39,7 +40,7 @@ impl NotarEntry {
         vote_account_pubkeys: Vec<Pubkey>,
         block_id: Hash,
         max_validators: usize,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         let partial = self
             .partials
             .entry(block_id)
@@ -54,7 +55,7 @@ impl NotarEntry {
         vote_account_pubkey: Pubkey,
         block_id: Hash,
         max_validators: usize,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         let partial = self
             .partials
             .entry(block_id)
@@ -77,13 +78,13 @@ impl NotarEntry {
             return Ok(None);
         };
         match partial.build_sig_bitmap() {
-            Err(e) => match e {
-                BuildSigBitmapError::Empty => Ok(None),
-                BuildSigBitmapError::Accumulating(e) => {
-                    Err(BuildRewardCertsRespError::RewardCertTryNew(e.into()))
-                }
-            },
-            Ok((signature, bitmap, validators)) => {
+            BuildResult::Empty => Ok(None),
+            BuildResult::EncodingError(e) => Err(BuildRewardCertsRespError::Encoding(e)),
+            BuildResult::Success {
+                signature,
+                bitmap,
+                validators,
+            } => {
                 let cert =
                     NotarRewardCertificate::try_new(reward_slot, block_id, signature, bitmap)?;
                 Ok(Some((cert, validators)))

--- a/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder/entry/partial_cert.rs
@@ -1,22 +1,19 @@
 use {
-    crate::block_creation_loop::rewards::certs_builder::entry::AddAggregateError,
-    agave_votor_messages::{
-        aggregate_accumulator::{AggregateAccumulator, AggregateAccumulatorError},
-        consensus_message::VoteMessage,
-        sig_verified_messages::VoteAggregate,
-    },
+    agave_votor::aggregate_accumulator::{AggregateAccumulator, AggregateAccumulatorError},
+    agave_votor_messages::{consensus_message::VoteMessage, sig_verified_messages::VoteAggregate},
     solana_bls_signatures::SignatureCompressed as BLSSignatureCompressed,
     solana_pubkey::Pubkey,
-    thiserror::Error,
+    solana_signer_store::EncodeError,
 };
 
-/// Different types of errors that can be returned from building signature and the associated bitmap.
-#[derive(Debug, Error)]
-pub(super) enum BuildSigBitmapError {
-    #[error("Empty bitvec")]
+pub(super) enum BuildResult {
     Empty,
-    #[error("AggregateAccumulator failed with {0}")]
-    Accumulating(#[from] AggregateAccumulatorError),
+    EncodingError(EncodeError),
+    Success {
+        signature: BLSSignatureCompressed,
+        bitmap: Vec<u8>,
+        validators: Vec<Pubkey>,
+    },
 }
 
 #[derive(Clone)]
@@ -40,7 +37,7 @@ impl PartialCert {
         &mut self,
         aggregate: VoteAggregate,
         mut vote_account_pubkeys: Vec<Pubkey>,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         self.accumulator.add_aggregate(&aggregate)?;
         self.validators.append(&mut vote_account_pubkeys);
         Ok(())
@@ -51,7 +48,7 @@ impl PartialCert {
         &mut self,
         vote_msg: VoteMessage,
         vote_account_pubkey: Pubkey,
-    ) -> Result<(), AddAggregateError> {
+    ) -> Result<(), AggregateAccumulatorError> {
         self.accumulator.add_own_vote_message(&vote_msg)?;
         self.validators.push(vote_account_pubkey);
         Ok(())
@@ -60,14 +57,19 @@ impl PartialCert {
     /// Builds a signature and associated bitmap from the collected votes.
     ///
     /// On success, returns the built signature, bitmap, and the list of validators in the bitmap.
-    pub(super) fn build_sig_bitmap(
-        self,
-    ) -> Result<(BLSSignatureCompressed, Vec<u8>, Vec<Pubkey>), BuildSigBitmapError> {
+    pub(super) fn build_sig_bitmap(self) -> BuildResult {
         if self.validators.is_empty() {
-            return Err(BuildSigBitmapError::Empty);
+            return BuildResult::Empty;
         }
-        let (signature, ranks) = self.accumulator.into_sig_and_ranks()?;
-        Ok((signature, ranks, self.validators))
+        let (signature, bitmap) = match self.accumulator.into_sig_and_ranks() {
+            Ok(res) => res,
+            Err(e) => return BuildResult::EncodingError(e),
+        };
+        BuildResult::Success {
+            signature,
+            bitmap,
+            validators: self.validators,
+        }
     }
 
     /// Returns how much stake has been observed.
@@ -96,7 +98,7 @@ mod tests {
         let mut partial_cert = PartialCert::new(max_validators);
         assert!(matches!(
             partial_cert.clone().build_sig_bitmap(),
-            Err(BuildSigBitmapError::Empty)
+            BuildResult::Empty
         ));
         let skip = Vote::new_skip_vote(slot);
         for rank in 0..max_validators {
@@ -105,7 +107,10 @@ mod tests {
             partial_cert
                 .add_aggregate(aggregate, vote_account_pubkeys)
                 .unwrap();
-            let (_signature, bitmap, _) = partial_cert.clone().build_sig_bitmap().unwrap();
+            let BuildResult::Success { bitmap, .. } = partial_cert.clone().build_sig_bitmap()
+            else {
+                panic!("wrong type");
+            };
             validate_bitmap(&bitmap, rank + 1, max_validators);
         }
     }

--- a/votor-messages/src/lib.rs
+++ b/votor-messages/src/lib.rs
@@ -9,7 +9,6 @@ use {
     solana_pubkey::Pubkey,
 };
 
-pub mod aggregate_accumulator;
 pub mod certificate;
 pub mod consensus_message;
 pub mod finalized_slot;

--- a/votor-messages/src/reward_certificate.rs
+++ b/votor-messages/src/reward_certificate.rs
@@ -1,11 +1,11 @@
 //! Defines aggregates used for vote rewards.
 
 use {
-    crate::aggregate_accumulator::AggregateAccumulatorError,
     solana_bls_signatures::SignatureCompressed as BLSSignatureCompressed,
     solana_clock::Slot,
     solana_hash::Hash,
     solana_short_vec::ShortU16,
+    solana_signer_store::EncodeError,
     thiserror::Error,
     wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, pod_wrapper},
 };
@@ -25,9 +25,6 @@ pub enum RewardCertError {
     /// Invalid bitmap was supplied.
     #[error("invalid bitmap was supplied")]
     InvalidBitmap,
-    /// Accumilating into aggregator failed.
-    #[error("AggregateAccumulator failed with {0}")]
-    Accumulating(#[from] AggregateAccumulatorError),
 }
 
 /// Reward certificate for the validators that voted skip.
@@ -124,4 +121,7 @@ pub enum BuildRewardCertsRespError {
     /// Building either the skip or the notar reward cert failed.
     #[error("try_new() on skip or notar cert failed with {0}")]
     RewardCertTryNew(#[from] RewardCertError),
+    /// Encoding failed
+    #[error("encoding failed with {0:?}")]
+    Encoding(EncodeError),
 }

--- a/votor/src/aggregate_accumulator.rs
+++ b/votor/src/aggregate_accumulator.rs
@@ -1,7 +1,7 @@
 //! Defines `AggregateAccumulator` that can used to aggregate votes and produce certificates.
 
 use {
-    crate::{
+    agave_votor_messages::{
         certificate::{Certificate, CertificateType},
         consensus_message::VoteMessage,
         fraction::Fraction,
@@ -156,13 +156,11 @@ impl AggregateAccumulator {
     }
 
     /// Returns the aggregated signature and ranks from the accumulated VoteAggregates so far.
-    pub fn into_sig_and_ranks(
-        self,
-    ) -> Result<(BLSSignatureCompressed, Vec<u8>), AggregateAccumulatorError> {
+    pub fn into_sig_and_ranks(self) -> Result<(BLSSignatureCompressed, Vec<u8>), EncodeError> {
         let mut ranks = self.ranks;
         let new_len = ranks.last_one().map_or(0, |i| i.saturating_add(1));
         ranks.resize(new_len, false);
-        let ranks = encode_base2(&ranks).map_err(AggregateAccumulatorError::EncodingFailed)?;
+        let ranks = encode_base2(&ranks)?;
         let signature = BLSSignature::from(self.signature).try_into().unwrap();
         Ok((signature, ranks))
     }

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -1,11 +1,12 @@
 //! Defines ConsensusPool to store received and generated votes and certificates.
 use {
     crate::{
+        aggregate_accumulator::AggregateAccumulatorError,
         consensus_pool::{
             parent_ready_tracker::{ParentReady, ParentReadyTracker},
             slot_stake_counters::SlotStakeCounters,
             stats::ConsensusPoolStats,
-            vote_pool::{VotePool, VotePoolError},
+            vote_pool::VotePool,
         },
         consensus_pool_service::{PoolMessage, PoolVote},
         event::VotorEvent,
@@ -45,7 +46,7 @@ pub(crate) enum AddVoteError {
     #[error("Received old msg with slot:{slot} in root_slot:{root_slot}")]
     OldMessage { slot: Slot, root_slot: Slot },
     #[error("Adding vote to vote_pool failed with {0}")]
-    VotePoolAddVote(VotePoolError),
+    VotePoolAddVote(AggregateAccumulatorError),
 }
 
 fn get_rank_map(bank: &Bank, slot: Slot) -> Result<&BLSPubkeyToRankMap, AddVoteError> {

--- a/votor/src/consensus_pool/vote_pool.rs
+++ b/votor/src/consensus_pool/vote_pool.rs
@@ -5,9 +5,11 @@
 //! The pool assumes that the bls-sigverifier has performed all conflicting votes checks.
 
 use {
-    crate::consensus_pool_service::PoolVote,
-    agave_votor_messages::{
+    crate::{
         aggregate_accumulator::{AggregateAccumulator, AggregateAccumulatorError},
+        consensus_pool_service::PoolVote,
+    },
+    agave_votor_messages::{
         certificate::{Certificate, CertificateType},
         vote::Vote,
     },
@@ -16,14 +18,7 @@ use {
         num::NonZero,
         sync::Arc,
     },
-    thiserror::Error,
 };
-
-#[derive(Debug, PartialEq, Eq, Error)]
-pub(crate) enum VotePoolError {
-    #[error("AggregateAccumulator failed with {0}")]
-    Accumulating(#[from] AggregateAccumulatorError),
-}
 
 pub(super) struct VotePool {
     max_validators: usize,
@@ -44,7 +39,7 @@ impl VotePool {
         vote: Vote,
         completed_certs: &BTreeMap<CertificateType, Arc<Certificate>>,
         acc: &AggregateAccumulator,
-    ) -> Result<Option<Certificate>, VotePoolError> {
+    ) -> Result<Option<Certificate>, AggregateAccumulatorError> {
         match vote {
             Vote::Notarize(notar) => {
                 for cert_type in [
@@ -150,7 +145,7 @@ impl VotePool {
         total_stake: NonZero<u64>,
         msg: &PoolVote,
         completed_certs: &BTreeMap<CertificateType, Arc<Certificate>>,
-    ) -> Result<(u64, Option<Certificate>), VotePoolError> {
+    ) -> Result<(u64, Option<Certificate>), AggregateAccumulatorError> {
         let vote = *msg.vote();
         let acc = self
             .accumulators

--- a/votor/src/lib.rs
+++ b/votor/src/lib.rs
@@ -4,6 +4,7 @@
 #[macro_use]
 extern crate log;
 
+pub mod aggregate_accumulator;
 pub mod commitment;
 pub mod common;
 pub mod consensus_metrics;


### PR DESCRIPTION
#### Problem

Improves some of the error handling and code quality around `AggregateAccumulator`


#### Summary of Changes

- Moves `AggregateAccumulator` into votor crate as it is only used by votor and core crates.
- There were a couple of error enums with a single variant so eliminates them.
- Simplifies some complex return types that clippy found unacceptable


#### Testing

Just CI
