### PR TITLE
Refactor - dcou in `ProgramCacheEntry`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -485,7 +485,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             .zip(entry.program.get_environment())
                             .map(|(a, b)| a != b)
                             .unwrap_or(false)
-                        || existing == &entry
+                        || Arc::ptr_eq(existing, &entry)
                 });
             }
         }
@@ -949,7 +949,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 let second_level = entries.get_mut(&id).expect("Cache lookup failed");
                 let candidate = second_level
                     .iter_mut()
-                    .find(|entry| entry == &remove_entry)
+                    .find(|entry| Arc::ptr_eq(entry, remove_entry))
                     .expect("Program entry not found");
 
                 // Only loaded entries shall be unloaded by eviction.

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -187,6 +187,7 @@ impl std::fmt::Debug for ProgramCacheEntry {
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 impl PartialEq for ProgramCacheEntry {
     fn eq(&self, other: &Self) -> bool {
         self.effective_slot == other.effective_slot

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -153,7 +153,7 @@ impl ProgramCacheEntryType {
 /// Holds a program version at a specific address and on a specific slot / fork.
 ///
 /// It contains the actual program in [ProgramCacheEntryType] and a bunch of meta-data.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct ProgramCacheEntry {
     /// The program of this entry
     pub program: ProgramCacheEntryType,
@@ -168,6 +168,23 @@ pub struct ProgramCacheEntry {
     /// How often this entry was used by a transaction
     pub stats: Arc<ProgramStatistics>,
     pub latest_access_slot: AtomicU64,
+}
+
+impl std::fmt::Debug for ProgramCacheEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProgramCacheEntry")
+            .field("slot", &self.deployment_slot)
+            .field(
+                "env",
+                &self
+                    .program
+                    .get_environment()
+                    .map(|env| Arc::as_ptr(env))
+                    .unwrap_or(std::ptr::null()),
+            )
+            .field("type", &self.program)
+            .finish()
+    }
 }
 
 impl PartialEq for ProgramCacheEntry {


### PR DESCRIPTION
#### Problem

In the recent work on the global program cache these small adjustments were helpful for debugging.

#### Summary of Changes

- `impl Debug for ProgramCacheEntry` manually to skip uninteresting statistics and instead print the program runtime environment.
- Puts `impl PartialEq for ProgramCacheEntry` behind `dev-context-only-utils`.
- Replaces `PartialEq` with `Arc::ptr_eq()`.

#### Testing
No behavior changed.