### PR TITLE
svm-conformance: add ELF loader runner

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4514,12 +4514,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
@@ -4534,13 +4544,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.4",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4562,7 +4585,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4592,6 +4615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protosol"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33dd83d3478b5a26cb2c309130ee8447e364ae99dbc3098e9e3156252cce12e"
+dependencies = [
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -7054,7 +7086,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "parking_lot 0.12.5",
- "prost",
+ "prost 0.14.4",
  "qualifier_attr",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -8311,7 +8343,7 @@ dependencies = [
  "http 1.4.2",
  "hyper-util",
  "log",
- "prost",
+ "prost 0.14.4",
  "prost-types",
  "serde",
  "smpl_jwt",
@@ -8340,7 +8372,7 @@ name = "solana-storage-proto"
 version = "4.3.0-alpha.2"
 dependencies = [
  "bs58",
- "prost",
+ "prost 0.14.4",
  "protobuf-src",
  "serde",
  "solana-account-decoder",
@@ -8399,9 +8431,12 @@ name = "solana-svm"
 version = "4.3.0-alpha.2"
 dependencies = [
  "agave-feature-set",
+ "agave-precompiles",
  "ahash 0.8.12",
  "bincode",
  "log",
+ "prost 0.11.9",
+ "protosol",
  "qualifier_attr",
  "serde",
  "solana-account 4.3.1",
@@ -8421,6 +8456,7 @@ dependencies = [
  "solana-message",
  "solana-nonce",
  "solana-nonce-account",
+ "solana-poseidon",
  "solana-precompile-error",
  "solana-program-entrypoint",
  "solana-program-pack",
@@ -8442,8 +8478,11 @@ dependencies = [
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-transaction-error",
+ "solana-vote-program",
+ "solana-zk-elgamal-proof-program",
  "spl-generic-token",
  "thiserror 2.0.19",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -8459,6 +8498,14 @@ dependencies = [
 [[package]]
 name = "solana-svm-conformance"
 version = "4.3.0-alpha.2"
+dependencies = [
+ "prost 0.11.9",
+ "protosol",
+ "solana-compute-budget",
+ "solana-program-runtime",
+ "solana-svm",
+ "solana-syscalls",
+]
 
 [[package]]
 name = "solana-svm-feature-set"
@@ -9880,7 +9927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -10780,6 +10827,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yoke"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -179,7 +179,7 @@ dependencies = [
  "assert_cmd",
  "bincode",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "csv",
  "dashmap",
@@ -361,7 +361,7 @@ name = "agave-store-tool"
 version = "4.3.0-alpha.2"
 dependencies = [
  "ahash 0.8.12",
- "clap",
+ "clap 2.34.0",
  "rayon",
  "solana-account 4.3.1",
  "solana-accounts-db",
@@ -1597,6 +1597,46 @@ dependencies = [
  "textwrap",
  "unicode-width 0.1.14",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
@@ -6079,7 +6119,7 @@ dependencies = [
  "bip39",
  "bs58",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "rpassword",
  "solana-bls-signatures",
  "solana-cli-config",
@@ -6123,7 +6163,7 @@ dependencies = [
  "base64 0.22.1",
  "bitvec",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "console 0.16.4",
  "humantime",
  "indicatif",
@@ -8499,6 +8539,7 @@ dependencies = [
 name = "solana-svm-conformance"
 version = "4.3.0-alpha.2"
 dependencies = [
+ "clap 4.6.1",
  "prost 0.11.9",
  "protosol",
  "solana-compute-budget",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8457,6 +8457,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-svm-conformance"
+version = "4.3.0-alpha.2"
+
+[[package]]
 name = "solana-svm-feature-set"
 version = "4.3.0-alpha.2"
 

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["../accounts-db/store-tool", "../ledger-tool"]
+members = ["../accounts-db/store-tool", "../ledger-tool", "../svm-conformance"]
 
 resolver = "2"
 

--- a/scripts/agave-build-lists.sh
+++ b/scripts/agave-build-lists.sh
@@ -47,7 +47,5 @@ DCOU_TAINTED_PACKAGES=(
   solana-accounts-cluster-bench
   solana-banking-bench
   solana-local-cluster
-  solana-svm-test-harness
-  solana-svm-test-harness-fixture
-  solana-svm-test-harness-instr
+  solana-svm-conformance
 )

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -13,9 +13,15 @@ workspace = "../dev-bins"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "test_exec_elf_loader"
+path = "src/bin/test_exec_elf_loader.rs"
+required-features = ["cli", "ffi"]
+
 [features]
-default = ["ffi"]
+default = ["cli", "ffi"]
 agave-unstable-api = []
+cli = ["dep:clap"]
 dev-context-only-utils = []
 dummy-for-ci-check = []
 ffi = [
@@ -30,6 +36,7 @@ ffi = [
 frozen-abi = []
 
 [dependencies]
+clap = { version = "4.5.59", features = ["derive"], optional = true }
 prost = { version = "0.11", optional = true }
 protosol = { version = "=10.1.0", optional = true }
 solana-compute-budget = { workspace = true, optional = true }

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -14,10 +14,28 @@ workspace = "../dev-bins"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["ffi"]
 agave-unstable-api = []
 dev-context-only-utils = []
 dummy-for-ci-check = []
+ffi = [
+    "dep:prost",
+    "dep:protosol",
+    "dep:solana-compute-budget",
+    "dep:solana-program-runtime",
+    "dep:solana-svm",
+    "dep:solana-syscalls",
+    "solana-svm/conformance",
+]
 frozen-abi = []
+
+[dependencies]
+prost = { version = "0.11", optional = true }
+protosol = { version = "=10.1.0", optional = true }
+solana-compute-budget = { workspace = true, optional = true }
+solana-program-runtime = { workspace = true, optional = true }
+solana-svm = { workspace = true, optional = true }
+solana-syscalls = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-svm-conformance"
+description = "Conformance harnesses for the Solana SVM"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+workspace = "../dev-bins"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+dummy-for-ci-check = []
+frozen-abi = []
+
+[lints]
+workspace = true

--- a/svm-conformance/src/bin/test_exec_elf_loader.rs
+++ b/svm-conformance/src/bin/test_exec_elf_loader.rs
@@ -27,11 +27,11 @@ fn exec(input: &PathBuf) -> bool {
 
     let ok = actual == expected;
     if ok {
-        println!("OK: {:?}", input);
+        println!("OK: {input:?}");
     } else {
-        println!("FAIL: {:?}", input);
-        println!("Expected: {:?}", expected);
-        println!("Actual: {:?}", actual);
+        println!("FAIL: {input:?}");
+        println!("Expected: {expected:?}");
+        println!("Actual: {actual:?}");
     }
     ok
 }

--- a/svm-conformance/src/bin/test_exec_elf_loader.rs
+++ b/svm-conformance/src/bin/test_exec_elf_loader.rs
@@ -1,0 +1,48 @@
+use {clap::Parser, prost::Message, protosol::protos::ElfLoaderFixture, std::path::PathBuf};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let Ok(fixture) = ElfLoaderFixture::decode(&blob[..]) else {
+        println!("Failed to parse fixture.");
+        return false;
+    };
+
+    let Some(context) = fixture.input else {
+        println!("No context found.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+
+    let actual = solana_svm_conformance::elf_loader::execute_elf_loader(&context);
+
+    let ok = actual == expected;
+    if ok {
+        println!("OK: {:?}", input);
+    } else {
+        println!("FAIL: {:?}", input);
+        println!("Expected: {:?}", expected);
+        println!("Actual: {:?}", actual);
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/svm-conformance/src/elf_loader.rs
+++ b/svm-conformance/src/elf_loader.rs
@@ -1,17 +1,17 @@
 //! ELF loader conformance harness.
 
 use {
-    crate::conformance::{
-        err::elf_error_code,
-        fd_hash::{fd_hash_u64_without_seed, fd_hash_without_seed},
-        feature_set::feature_set_from_proto,
-    },
     prost::Message,
     protosol::protos::{
         ElfLoaderCtx as ProtoElfLoaderCtx, ElfLoaderEffects as ProtoElfLoaderEffects,
     },
     solana_compute_budget::compute_budget::ComputeBudget,
     solana_program_runtime::solana_sbpf::{ebpf, elf::Executable},
+    solana_svm::conformance::{
+        err::elf_error_code,
+        fd_hash::{fd_hash_u64_without_seed, fd_hash_without_seed},
+        feature_set::feature_set_from_proto,
+    },
     solana_syscalls::create_program_runtime_environment,
     std::{collections::BTreeSet, ffi::c_int},
 };
@@ -105,11 +105,11 @@ mod tests {
     use {super::*, protosol::protos::FeatureSet as ProtoFeatureSet};
 
     const NOOP_ALIGNED: &[u8] =
-        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
+        include_bytes!("../../programs/bpf_loader/test_elfs/out/noop_aligned.so");
     const NOOP_UNALIGNED: &[u8] =
-        include_bytes!("../../../programs/bpf_loader/test_elfs/out/noop_unaligned.so");
+        include_bytes!("../../programs/bpf_loader/test_elfs/out/noop_unaligned.so");
     const SBPFV3_RETURN_OK: &[u8] =
-        include_bytes!("../../../programs/bpf_loader/test_elfs/out/sbpfv3_return_ok.so");
+        include_bytes!("../../programs/bpf_loader/test_elfs/out/sbpfv3_return_ok.so");
 
     fn assert_loads_ok(elf: &[u8], deploy_checks: bool, features: Option<ProtoFeatureSet>) {
         let effects = execute_elf_loader(&ProtoElfLoaderCtx {

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -2,3 +2,6 @@
 //!
 //! Houses the `sol_compat_*` FFI entrypoints that Firedancer's conformance
 //! tooling links against to exercise Agave's execution layer.
+
+#[cfg(feature = "ffi")]
+pub mod elf_loader;

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -1,0 +1,4 @@
+//! Conformance harnesses for the Solana SVM.
+//!
+//! Houses the `sol_compat_*` FFI entrypoints that Firedancer's conformance
+//! tooling links against to exercise Agave's execution layer.

--- a/svm/src/conformance/err.rs
+++ b/svm/src/conformance/err.rs
@@ -14,7 +14,7 @@ use {
     solana_syscalls::SyscallError,
 };
 
-pub(crate) fn elf_error_code(error: &ElfError) -> u32 {
+pub fn elf_error_code(error: &ElfError) -> u32 {
     (error.discriminant() as u32).saturating_add(1)
 }
 

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -6,8 +6,6 @@ pub mod callback;
 #[cfg(feature = "conformance")]
 pub mod direct_mapping;
 #[cfg(feature = "conformance")]
-pub mod elf_loader;
-#[cfg(feature = "conformance")]
 pub mod err;
 #[cfg(feature = "conformance")]
 pub mod fd_hash;


### PR DESCRIPTION
#### Problem
Most of the conformance harnesses have landed in Agave with their FFI bindings for SolFuzz (or other fuzz targeting tools).  However, a few things are missing:
- The crate with the FFI bindings must have a `cdylib` lib target.
- The original SolFuzz-Agave used a runner bin to process fixtures in CI.

Rather than making both changes in `solana-svm`, we can create a new `svm-conformance` dev-bin to solve both issues. A dev-bin is a better home for the conformance work, since it carries protobuf and clap dependencies that the validator does not need in production.

#### Summary of Changes

Create the `solana-svm-conformance` dev-bin, move the ELF loader harness and its FFI binding into the new lib, and then add a runner bin target.

This allows us to finally run Firedancer test vectors against Agave.

#### Testing

Build the test vectors:

```
git clone https://github.com/firedancer-io/test-vectors.git
cd test-vectors
./scripts/package.sh
```

Build and run the conformance target:

```
cargo build --manifest-path dev-bins/Cargo.toml -p solana-svm-conformance
dev-bins/target/debug/test_exec_elf_loader -- ~/test-vectors/elf_loader/fixtures/*.fix
```

Fixes #13382
