### PR TITLE
Create tombstones during clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1171,7 +1171,8 @@ impl AccountsDb {
     }
 
     /// While scanning cleaning candidates obtain slots that can be
-    /// reclaimed for each pubkey.
+    /// reclaimed for each pubkey. If the pubkey's entry was removed from the accounts
+    /// index, its secondary index entries are purged with it.
     fn collect_reclaims(
         &self,
         pubkey: &Pubkey,
@@ -1184,10 +1185,13 @@ impl AccountsDb {
             &mut reclaims,
             max_clean_root_inclusive,
         );
-        // Attempting to reclaim version older than the newest rooted version
-        // This should not result in the pubkey being removed from the index
-        assert!(!removed_from_index);
         clean_rooted.stop();
+        if removed_from_index {
+            self.clean_accounts_stats
+                .removed_from_index
+                .fetch_add(1, Ordering::Relaxed);
+            self.purge_secondary_indexes_for_dead_keys(iter::once(pubkey));
+        }
         self.clean_accounts_stats
             .clean_old_root_us
             .fetch_add(clean_rooted.as_us(), Ordering::Relaxed);
@@ -1208,20 +1212,21 @@ impl AccountsDb {
             .ref_count
             .checked_sub(reclaims.len() as RefCount)
             .expect("candidate ref count covers every reclaimed entry");
-        // The reclaimed entries are exactly those below the newest
-        // remaining slot at or below the clean root
-        let newest_slot = reclaims[0].1;
-        candidate_info
-            .slot_list
-            .retain(|(slot, _)| *slot >= newest_slot);
-
-        // Mark any ZLSRs
-        if candidate_info.ref_count == 1
-            && let Some((slot, account_info)) = candidate_info.slot_list.first()
-            && account_info.is_zero_lamport()
-        {
-            self.zero_lamport_single_ref_found(*slot, account_info.offset());
-        }
+        // Remove any entry that was reclaimed from the candidate slot list.
+        let slot_list_len = candidate_info.slot_list.len();
+        candidate_info.slot_list.retain(|(slot, _)| {
+            !reclaims
+                .iter()
+                .any(|((reclaimed_slot, _), _)| reclaimed_slot == slot)
+        });
+        // Ensure that the current slot_list length + the reclaims length is equal
+        // to the original slot list len. This guarantees all reclaimed entries
+        // were removed from the candidate slot list.
+        debug_assert_eq!(
+            candidate_info.slot_list.len() + reclaims.len(),
+            slot_list_len,
+            "every reclaimed entry is in the candidate slot list"
+        );
     }
 
     /// Reclaim older states of accounts older than max_clean_root_inclusive for AccountsDb bloat mitigation.
@@ -1233,8 +1238,9 @@ impl AccountsDb {
             return;
         }
         let (_, reclaim_us) = measure_us!({
-            // Each reclaim is marked obsolete at the slot of its account's newest
-            // surviving entry
+            // Each reclaim is marked obsolete at the slot of its account's newest surviving
+            // entry. A reclaim carrying its own slot is the newest entry itself, already
+            // removed from the index, and is created as a tombstone instead
             self.thread_pool_background.install(|| {
                 reclaims
                     .par_iter()
@@ -2196,6 +2202,13 @@ impl AccountsDb {
                 i64
             ),
             (
+                "removed_from_index",
+                self.clean_accounts_stats
+                    .removed_from_index
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
                 "clean_old_root_us",
                 self.clean_accounts_stats
                     .clean_old_root_us
@@ -2733,6 +2746,7 @@ impl AccountsDb {
     }
 
     /// This function handles the case when zero lamport single ref accounts are found during shrink.
+    #[allow(dead_code)]
     pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: Offset) {
         // This function can be called when a zero lamport single ref account is
         // found during shrink. Therefore, we can't use the safe version of
@@ -5100,7 +5114,15 @@ impl AccountsDb {
                     slot
                 );
 
-                let remaining_accounts = if offsets.len() == store.count() {
+                // Reclaims at the slot itself are tombstones, not obsolete accounts
+                let is_tombstone_reclaim =
+                    mark_accounts_obsolete == MarkAccountsObsolete::Yes(slot);
+
+                let remaining_accounts = if is_tombstone_reclaim {
+                    // Tombstones stay alive in the storage; only record their offsets
+                    store.batch_insert_tombstone_offsets(offsets);
+                    store.count()
+                } else if offsets.len() == store.count() {
                     // all remaining alive accounts in the storage are being removed, so the entire storage/slot is dead
                     store.remove_accounts(store.alive_bytes(), offsets.len())
                 } else {
@@ -5156,6 +5178,10 @@ impl AccountsDb {
                     // because slots should only have one storage entry, namely the one that was
                     // created by `flush_slot_cache()`.
                     new_shrink_candidates.insert(slot);
+                } else if remaining_accounts == store.num_tombstones() {
+                    // The tombstones must survive until an incremental snapshot
+                    // propagates the deletion; hand the storage to a later clean
+                    self.dirty_stores.insert(slot, store);
                 };
             }
         });
@@ -6390,7 +6416,10 @@ enum PubkeysToStore {
 
 /// Specify whether obsolete accounts should be marked or not during reclaims
 /// They should only be marked if they are also getting unreffed in the index
-/// Temporarily allow dead code until the feature is implemented
+///
+/// When an account is marked obsolete at the slot it is present in (Eg. if the account is present
+/// in slot 10 and marked obsolete at slot 10), it means the account was deleted rather than
+/// overwritten to a newer copy. These are marked as tombstones rather than obsolete.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum MarkAccountsObsolete {
     Yes(Slot),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1188,7 +1188,7 @@ impl AccountsDb {
         clean_rooted.stop();
         if removed_from_index {
             self.clean_accounts_stats
-                .removed_from_index
+                .num_accounts_removed_from_index
                 .fetch_add(1, Ordering::Relaxed);
             self.purge_secondary_indexes_for_dead_keys(iter::once(pubkey));
         }
@@ -2202,9 +2202,9 @@ impl AccountsDb {
                 i64
             ),
             (
-                "removed_from_index",
+                "num_accounts_removed_from_index",
                 self.clean_accounts_stats
-                    .removed_from_index
+                    .num_accounts_removed_from_index
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2745,53 +2745,6 @@ impl AccountsDb {
             .fetch_add(time.as_us(), Ordering::Relaxed);
     }
 
-    /// This function handles the case when zero lamport single ref accounts are found during shrink.
-    #[allow(dead_code)]
-    pub(crate) fn zero_lamport_single_ref_found(&self, slot: Slot, offset: Offset) {
-        // This function can be called when a zero lamport single ref account is
-        // found during shrink. Therefore, we can't use the safe version of
-        // `get_slot_storage_entry` because shrink_in_progress map may not be
-        // empty. We have to use the unsafe version to avoid to assert failure.
-        // However, there is a possibility that the storage entry that we get is
-        // an old one, which is being shrunk away, because multiple slots can be
-        // shrunk away in parallel by thread pool. If this happens, any zero
-        // lamport single ref offset marked on the storage will be lost when the
-        // storage is dropped. However, this is not a problem, because after the
-        // storage being shrunk, the new storage will not have any zero lamport
-        // single ref account anyway. Therefore, we don't need to worry about
-        // marking zero lamport single ref offset on the new storage.
-        if let Some(store) = self
-            .storage
-            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-            && store.insert_zero_lamport_single_ref_account_offset(offset)
-        {
-            // this wasn't previously marked as zero lamport single ref
-            self.shrink_stats
-                .num_zero_lamport_single_ref_accounts_found
-                .fetch_add(1, Ordering::Relaxed);
-
-            if store.num_zero_lamport_single_ref_accounts() == store.count() {
-                // all accounts in this storage can be dead
-                self.dirty_stores.entry(slot).or_insert(store);
-                self.shrink_stats
-                    .num_dead_slots_added_to_clean
-                    .fetch_add(1, Ordering::Relaxed);
-            } else if self.is_shrinking_productive(&store) && self.is_candidate_for_shrink(&store) {
-                // this store might be eligible for shrinking now
-                let is_new = self.shrink_candidate_slots.lock().unwrap().insert(slot);
-                if is_new {
-                    self.shrink_stats
-                        .num_slots_with_zero_lamport_accounts_added_to_shrink
-                        .fetch_add(1, Ordering::Relaxed);
-                }
-            } else {
-                self.shrink_stats
-                    .marking_zero_dead_accounts_in_non_shrinkable_store
-                    .fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    }
-
     /// Shrinks `store` by rewriting the alive accounts to a new storage
     fn shrink_storage(&self, store: Arc<AccountStorageEntry>) {
         let slot = store.slot();

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -302,7 +302,7 @@ pub struct CleanAccountsStats {
     pub remove_dead_accounts_shrink_us: AtomicU64,
     pub get_account_sizes_us: AtomicU64,
     pub slots_cleaned: AtomicU64,
-    pub removed_from_index: AtomicU64,
+    pub num_accounts_removed_from_index: AtomicU64,
 }
 
 impl CleanAccountsStats {

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -397,10 +397,6 @@ pub struct ShrinkStats {
     pub num_ancient_slots_shrunk: AtomicU64,
     pub ancient_slots_added_to_shrink: AtomicU64,
     pub ancient_bytes_added_to_shrink: AtomicU64,
-    pub num_dead_slots_added_to_clean: AtomicU64,
-    pub num_slots_with_zero_lamport_accounts_added_to_shrink: AtomicU64,
-    pub marking_zero_dead_accounts_in_non_shrinkable_store: AtomicU64,
-    pub num_zero_lamport_single_ref_accounts_found: AtomicU64,
 }
 
 impl ShrinkStats {
@@ -583,30 +579,6 @@ impl ShrinkStats {
                 (
                     "initial_candidates_count",
                     self.initial_candidates_count.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_dead_slots_added_to_clean",
-                    self.num_dead_slots_added_to_clean
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_slots_with_zero_lamport_accounts_added_to_shrink",
-                    self.num_slots_with_zero_lamport_accounts_added_to_shrink
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "marking_zero_dead_accounts_in_non_shrinkable_store",
-                    self.marking_zero_dead_accounts_in_non_shrinkable_store
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_zero_lamport_single_ref_accounts_found",
-                    self.num_zero_lamport_single_ref_accounts_found
-                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
             );

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -302,6 +302,7 @@ pub struct CleanAccountsStats {
     pub remove_dead_accounts_shrink_us: AtomicU64,
     pub get_account_sizes_us: AtomicU64,
     pub slots_cleaned: AtomicU64,
+    pub removed_from_index: AtomicU64,
 }
 
 impl CleanAccountsStats {

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1094,7 +1094,7 @@ fn test_clean_marks_reclaims_obsolete_at_new_slot() {
 }
 
 #[test]
-fn test_clean_reclaim_marks_zero_lamport_single_ref() {
+fn test_clean_reclaim_tombstones_zero_lamport_single_ref() {
     let accounts = AccountsDb::default_for_tests();
     let pubkey1 = Pubkey::new_unique();
     let pubkey2 = Pubkey::new_unique();
@@ -1119,12 +1119,16 @@ fn test_clean_reclaim_marks_zero_lamport_single_ref() {
     // Reclaiming the slot 10 version made pubkey1 a zero-lamport single-ref account, and
     // slot 10's storage is dead
     assert!(accounts.storage.get_slot_storage_entry(10).is_none());
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
 
-    // The surviving zero-lamport account is marked single-ref in slot 11's storage, so its
-    // bytes count as dead for shrink and the post-snapshot sweep
+    // Clean converted the surviving zero-lamport entry to a tombstone: pubkey1 is removed
+    // from the index and its offset is recorded in slot 11's storage
+    assert!(!accounts.accounts_index.contains(&pubkey1));
     let storage = accounts.storage.get_slot_storage_entry(11).unwrap();
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 1);
+    assert_eq!(storage.num_tombstones(), 1);
+
+    // The storage still holds a live account, so it is queued for shrink to reclaim
+    // the tombstone bytes
+    assert!(accounts.shrink_candidate_slots.lock().unwrap().contains(&11));
 }
 
 #[test]
@@ -1540,7 +1544,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
             .accounts_index
             .get_with_and_then(&pubkey, &ancestors, false, |account_info| account_info)
             .unwrap();
-        accounts_db.remove_dead_accounts([account_info].iter(), MarkAccountsObsolete::Yes(slot1));
+        accounts_db.remove_dead_accounts([account_info].iter(), MarkAccountsObsolete::Yes(slot2));
     }
 
     accounts_db.shrink_slot_forced(slot1);
@@ -3516,8 +3520,11 @@ fn test_reuse_storage_id() {
     });
 }
 
+/// A zero-lamport single-ref account whose entry is newer than `max_clean_root` is not
+/// converted to a tombstone: clean's reclaim path reclaims nothing for it, so it stays on
+/// the classic zero-lamport purge path and is removed once the clean root passes its slot.
 #[test]
-fn test_zero_lamport_new_root_not_cleaned() {
+fn test_clean_does_not_tombstone_zero_lamport_above_clean_root() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let account_key = Pubkey::new_unique();
     let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
@@ -3534,11 +3541,22 @@ fn test_zero_lamport_new_root_not_cleaned() {
     // Only clean zero lamport accounts up to slot 1
     db.clean_accounts(Some(1), false);
 
-    // Should still be able to find zero lamport account in slot 2
+    // The slot 2 entry is above the clean root: still indexed, no tombstone, loadable
+    assert!(db.accounts_index.contains(&account_key));
+    assert_eq!(db.get_and_assert_single_storage(2).num_tombstones(), 0);
     assert_eq!(
         db.do_load_for_tests(&Ancestors::default(), &account_key),
         Some((zero_lamport_account, 2))
     );
+
+    // Once the clean root passes slot 2, the classic zero-lamport purge path removes it
+    db.clean_accounts(Some(2), false);
+    assert!(!db.accounts_index.contains(&account_key));
+    assert_eq!(
+        db.do_load_for_tests(&Ancestors::default(), &account_key),
+        None
+    );
+    assert_no_storages_at_slot(&db, 2);
 }
 
 /// A zero-lamport account that is not in the accounts index is purged at flush rather than
@@ -3598,6 +3616,51 @@ fn test_flush_purged_zero_lamport_account_purges_secondary_index() {
     assert!(!mint_index_pubkeys.contains(&pubkey_purged));
     assert!(mint_index_pubkeys.contains(&pubkey_cached));
     assert!(mint_index_pubkeys.contains(&pubkey_live));
+}
+
+/// When clean converts a zero-lamport single-ref account to a tombstone, the pubkey's
+/// secondary index entries are purged along with its primary index entry.
+#[test]
+fn test_clean_tombstone_purges_secondary_index() {
+    let accounts = AccountsDb {
+        account_indexes: spl_token_mint_index_enabled(),
+        ..AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG)
+    };
+    let pubkey = Pubkey::new_unique();
+
+    // Set up token account data to be added to the secondary index.
+    const SPL_TOKEN_INITIALIZED_OFFSET: usize = 108;
+    let mint_key = Pubkey::new_unique();
+    let mut account_data_with_mint = vec![0; spl_generic_token::token::Account::get_packed_len()];
+    account_data_with_mint[..PUBKEY_BYTES].clone_from_slice(&(mint_key.to_bytes()));
+    account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
+
+    let mut live_account = AccountSharedData::new(1, 0, &spl_generic_token::token::id());
+    live_account.set_data(account_data_with_mint.clone());
+    let mut zero_account = AccountSharedData::new(0, 0, &spl_generic_token::token::id());
+    zero_account.set_data(account_data_with_mint);
+
+    // Slot 1: nonzero version; slot 2: zero-lamport version. Flush without clean so the
+    // slot 1 entry stays in the slot list for clean to reclaim
+    accounts.store_for_tests((1, [(&pubkey, &live_account)].as_slice()));
+    accounts.add_root(1);
+    accounts.flush_rooted_accounts_cache_without_clean();
+    accounts.store_for_tests((2, [(&pubkey, &zero_account)].as_slice()));
+    accounts.add_root(2);
+    accounts.flush_rooted_accounts_cache_without_clean();
+
+    // Clean reclaims the slot 1 entry, leaving a zero-lamport single-ref survivor that is
+    // converted to a tombstone and removed from the index; with no full snapshot holding
+    // the tombstone, the storage is purged in the same pass
+    accounts.clean_accounts_for_tests();
+    assert!(!accounts.accounts_index.contains(&pubkey));
+    assert_no_storages_at_slot(&accounts, 2);
+
+    // The secondary index entry must be purged with it
+    let mint_index_pubkeys = accounts
+        .accounts_index
+        .get_index_key_pubkeys(&IndexKey::SplTokenMint(mint_key));
+    assert!(!mint_index_pubkeys.contains(&pubkey));
 }
 
 #[test]
@@ -4261,7 +4324,7 @@ fn test_alive_bytes() {
             assert_eq!(account_info.0, slot);
             let reclaims = [account_info];
             num_obsolete_accounts += reclaims.len();
-            accounts_db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot));
+            accounts_db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot + 1));
             let after_size = storage0.alive_bytes();
             if storage0.count() == 0 {
                 // when `remove_dead_accounts` reaches 0 accounts, all bytes are marked as dead
@@ -4899,13 +4962,13 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     assert!(db.shrink_candidate_slots.lock().unwrap().contains(&1));
 }
 
-/// Tests that clean purges a zero lamport single ref account in the same pass that
-/// reclaims its older entries, and that a snapshot-gated one is instead marked in its
-/// storage and picked back up once the full snapshot advances.
+/// Tests that clean converts zero lamport single ref accounts to tombstones in the same pass
+/// that reclaims their older entries, and that each tombstone-only storage is dropped once
+/// the full snapshot covers its slot.
 /// This test can be removed if RPC scan is removed since RPC scan is the only path which leads
 /// single ref zero lamport accounts not being marked immediately in flush_write_cache
 #[test]
-fn test_clean_purges_zero_lamport_single_ref_at_reclaim() {
+fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let account_key1 = Pubkey::new_unique();
     let account_key2 = Pubkey::new_unique();
@@ -4936,30 +4999,24 @@ fn test_clean_purges_zero_lamport_single_ref_at_reclaim() {
     // each zero-lamport update as its account's only ref.
     db.clean_accounts(Some(3), false);
 
-    // account_key1's purge is not gated, so the same clean pass purges the account: the
-    // pubkey is removed from the index and slot 1's storage, left with no live accounts,
-    // is dropped.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 0);
+    // The reclaim leaves account_key1 zero-lamport single-ref, so it is tombstoned:
+    // removed from the index, and slot 1's storage, now holding only the tombstone and
+    // already covered by the full snapshot, is purged in the same pass.
     assert!(!db.accounts_index.contains(&account_key1));
     assert_no_storages_at_slot(&db, 1);
 
-    // account_key3's purge is gated behind the full snapshot, so it is instead marked
-    // zero-lamport single-ref in slot 3's storage, which now holds only such accounts and
-    // is queued for clean via dirty_stores rather than shrink.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key3), 1);
-    assert_eq!(
-        db.get_and_assert_single_storage(3)
-            .num_zero_lamport_single_ref_accounts(),
-        1
-    );
+    // account_key3 is likewise tombstoned, but slot 3 is newer than the full snapshot,
+    // so its storage keeps the tombstone for an incremental snapshot to propagate the
+    // deletion and is queued for a later clean via dirty_stores rather than shrink.
+    assert!(!db.accounts_index.contains(&account_key3));
+    assert_eq!(db.get_and_assert_single_storage(3).num_tombstones(), 1);
     assert!(db.dirty_stores.contains_key(&3));
     assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&3));
 
-    // Once the full snapshot advances past slot 3, clean purges account_key3 and drops
-    // slot 3's storage.
+    // Once the full snapshot advances past slot 3, clean drops the tombstone-only
+    // storage.
     db.set_latest_full_snapshot_slot(3);
     db.clean_accounts(Some(3), false);
-    assert!(!db.accounts_index.contains(&account_key3));
     assert_no_storages_at_slot(&db, 3);
 
     // Slot 0 still holds the live account_key2; the other records there are obsolete.
@@ -6440,12 +6497,16 @@ fn test_shrink_collect_with_obsolete_accounts() {
         if i % 3 == 0 {
             continue;
         }
-        // Mark Some accounts obsolete.
+        // Mark Some accounts obsolete. The accounts are marked obsolete as of the next slot;
+        // a mark at the account's own slot would create a tombstone instead.
         if i % 5 == 0 {
             // Lookup the pubkey in the database and find the AccountInfo
             db.accounts_index
                 .get_with_and_then(pubkey, &ancestors, false, |account_info| {
-                    db.remove_dead_accounts([account_info].iter(), MarkAccountsObsolete::Yes(slot));
+                    db.remove_dead_accounts(
+                        [account_info].iter(),
+                        MarkAccountsObsolete::Yes(slot + 1),
+                    );
                 });
 
             obsolete_pubkeys.push(*pubkey);
@@ -6457,7 +6518,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
                 [slot].into_iter().collect::<HashSet<_>>(),
                 &mut reclaims,
             );
-            db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot));
+            db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot + 1));
             purged_pubkeys.push(*pubkey);
         }
     }

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1128,7 +1128,13 @@ fn test_clean_reclaim_tombstones_zero_lamport_single_ref() {
 
     // The storage still holds a live account, so it is queued for shrink to reclaim
     // the tombstone bytes
-    assert!(accounts.shrink_candidate_slots.lock().unwrap().contains(&11));
+    assert!(
+        accounts
+            .shrink_candidate_slots
+            .lock()
+            .unwrap()
+            .contains(&11)
+    );
 }
 
 #[test]

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -906,8 +906,13 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         }) == 0
     }
 
-    /// return true if pubkey does not exist in the accounts index.
-    /// This means it should NOT be unref'd later.
+    /// Remove all older rooted entries for `pubkey` from the accounts index, pushing each
+    /// removed entry into `reclaims`.
+    /// Return true if this call removed the pubkey's entry from the accounts index.
+    ///
+    /// When secondary indexes are enabled and this returns true, callers must pass `pubkey` to
+    /// `AccountsDb::purge_secondary_indexes_for_dead_keys`, otherwise its secondary index
+    /// entries leak.
     #[must_use]
     pub fn clean_rooted_entries(
         &self,
@@ -916,14 +921,32 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         max_clean_root_inclusive: Option<Slot>,
     ) -> bool {
         let map = self.get_bin(pubkey);
+        // `None` means the pubkey is not in the index; nothing was removed.
         map.slot_list_mut_with_entry(pubkey, |mut slot_list, entry| {
             let reclaims_start = reclaims.len();
             self.purge_older_root_entries(&mut slot_list, reclaims, max_clean_root_inclusive);
-            // Unref each reclaimed entry. This must happen inside the closure so the
+            let mut unref_count = (reclaims.len() - reclaims_start) as RefCount;
+
+            // If reclaiming leaves a single ref zero lamport account, it is safe to delete
+            // the account entirely and mark it as a tombstone. An untouched single-entry
+            // zero-lamport account stays on the classic zero-lamport purge path: its offset
+            // is already marked zero-lamport single-ref at flush or index generation.
+            if unref_count > 0
+                && entry.ref_count() == unref_count + 1
+                && let &[(slot, account_info)] = &*slot_list
+                && account_info.is_zero_lamport()
+            {
+                reclaims.push(((slot, account_info), slot));
+                slot_list.clear();
+                unref_count += 1;
+            }
+            // Unref the reclaimed entries. This must happen inside the closure so the
             // updated ref count is visible to the write-through check.
-            entry.unref_by_count((reclaims.len() - reclaims_start) as RefCount);
+            entry.unref_by_count(unref_count);
+            slot_list.is_empty()
         })
-        .is_none()
+        .unwrap_or(false)
+            && map.remove_if_slot_list_empty(*pubkey)
     }
 
     /// Cleans and unrefs all older rooted entries for each pubkey in the accounts index.
@@ -2580,9 +2603,8 @@ mod tests {
         let slot2 = 2;
 
         let mut gc = ReclaimsWithNewestSlot::new();
-        // return true if we don't know anything about 'key_unknown'
-        // the item did not exist in the accounts index at all, so index is up to date
-        assert!(index.clean_rooted_entries(&key_unknown, &mut gc, None));
+        // an unknown key has no index entry, so nothing is removed
+        assert!(!index.clean_rooted_entries(&key_unknown, &mut gc, None));
 
         index.upsert_simple_test(&key, slot1, value);
 

--- a/accounts-db/src/accounts_index/account_map_entry.rs
+++ b/accounts-db/src/accounts_index/account_map_entry.rs
@@ -183,7 +183,6 @@ impl<T> SlotListWriteGuard<'_, T> {
     }
 
     /// Clears the list, removing all elements.
-    #[cfg(test)]
     pub fn clear(&mut self) {
         self.0.clear();
     }


### PR DESCRIPTION
#### Problem
Zero lamport single ref accounts require index entries, while tombstones do not. Clean should be converted to make tombstones instead of ZLSRs

#### Summary of Changes
1st: clean_rooted_entries now reclaims zero lamport entries if they are the only entry remaining. It also deletes any account where the slot list ends up empty
2. In handle reclaims, any slot that is reclaimed at the same slot (ie Account at SlotN is reclaimed at SlotN) will be converted to a tombstone rather than marked obsolete. 

Note: The new path ignores accounts that did not have any reclaims. This is to avoid a double count: If an account is marked ZLSR and then tombstoned later, it would be in two lists, and the accounting would not be correct. This will be cleaned up when ZLSRs are removed. 

#### Testing
This is the new stat that shows clean reclaiming accounts. The first half of the graph has injected scans (which cause the new path to fire). The second half doesn't (as in this case all accounts are marked as ZLSRs during flush, so clean doesn't have anything to do). 

<img width="1685" height="447" alt="image" src="https://github.com/user-attachments/assets/050d7ecd-0a14-48c2-8616-4cb6fa8d3254" />

Performance is not really a concern on the clean path since it is background, and significantly faster than in the past. 

Added some new tests to cover secondary keys 


Fixes #
