### PR TITLE
refactor - move allocated_accounts_data_size logic to its own module

### DIFF
--- a/cost-model/src/allocated_accounts_data_size.rs
+++ b/cost-model/src/allocated_accounts_data_size.rs
@@ -141,12 +141,12 @@ fn calculate_impl<'a>(
     for (program_id, instruction) in instructions {
         match calculate_on_instruction(program_id, instruction, feature_set) {
             SystemProgramAccountAllocation::Failed => {
-                // If any system program instructions can be statically
-                // determined to fail, no allocations will actually be
-                // persisted by the transaction. So return 0 here so that no
-                // account allocation budget is used for this failed
-                // transaction.
-                return 0;
+                // Runtime execution stops at the first failing
+                // instruction. Keep allocations from earlier instructions
+                // because they may have already executed before rollback,
+                // but ignore any later instructions because they will not
+                // be reached.
+                break;
             }
             SystemProgramAccountAllocation::None => continue,
             SystemProgramAccountAllocation::Some(ix_attempted_allocation_size) => {

--- a/cost-model/src/allocated_accounts_data_size.rs
+++ b/cost-model/src/allocated_accounts_data_size.rs
@@ -1,0 +1,398 @@
+use {
+    crate::{
+        block_cost_limits::MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA, cost_tracker::CostTrackerError,
+        transaction_cost::TransactionCost,
+    },
+    agave_feature_set::FeatureSet,
+    solana_bincode::limited_deserialize,
+    solana_pubkey::Pubkey,
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_sdk_ids::system_program,
+    solana_svm_transaction::instruction::SVMInstruction,
+    solana_system_interface::{
+        MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION, MAX_PERMITTED_DATA_LENGTH,
+        instruction::SystemInstruction,
+    },
+    std::num::Saturating,
+};
+
+pub(crate) const DEFAULT_LIMIT: u64 = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
+
+#[derive(Debug, PartialEq)]
+enum SystemProgramAccountAllocation {
+    None,
+    Some(u64),
+    Failed,
+}
+
+pub(crate) fn calculate<'a>(
+    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+    feature_set: &FeatureSet,
+) -> u64 {
+    // NOTE when bank feature gate of track wigth actual accounts_data_size_delta lands,
+    // use the feature gate here:
+    // if !feature_set.snapshot().use_account_data_size_delta_for_cost_tracking {
+    //     calculate_impl(instructions, feature-set)
+    // } else {
+    //     0
+    // }
+
+    calculate_impl(instructions, feature_set)
+}
+
+pub(crate) fn would_fit(
+    current_allocated_accounts_data_size: Saturating<u64>,
+    tx_cost: &TransactionCost<impl TransactionWithMeta>,
+    allocated_data_size_limit: u64,
+) -> Result<(), CostTrackerError> {
+    let allocated_accounts_data_size =
+        current_allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
+
+    if allocated_accounts_data_size.0 > allocated_data_size_limit {
+        return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn add(
+    allocated_accounts_data_size: &mut Saturating<u64>,
+    tx_cost: &TransactionCost<impl TransactionWithMeta>,
+) {
+    *allocated_accounts_data_size += tx_cost.allocated_accounts_data_size();
+}
+
+pub(crate) fn subtract(
+    allocated_accounts_data_size: &mut Saturating<u64>,
+    tx_cost: &TransactionCost<impl TransactionWithMeta>,
+) {
+    *allocated_accounts_data_size -= tx_cost.allocated_accounts_data_size();
+}
+
+pub(crate) fn stats_value(allocated_accounts_data_size: Saturating<u64>) -> u64 {
+    allocated_accounts_data_size.0
+}
+
+fn calculate_on_deserialized_system_instruction(
+    instruction: SystemInstruction,
+    feature_set: &FeatureSet,
+) -> SystemProgramAccountAllocation {
+    let validate_space = |space: u64| {
+        if space > MAX_PERMITTED_DATA_LENGTH {
+            SystemProgramAccountAllocation::Failed
+        } else {
+            SystemProgramAccountAllocation::Some(space)
+        }
+    };
+
+    match instruction {
+        SystemInstruction::CreateAccount { space, .. }
+        | SystemInstruction::CreateAccountWithSeed { space, .. }
+        | SystemInstruction::Allocate { space }
+        | SystemInstruction::AllocateWithSeed { space, .. } => validate_space(space),
+        SystemInstruction::CreateAccountAllowPrefund { space, .. } => {
+            if !feature_set.snapshot().create_account_allow_prefund {
+                return SystemProgramAccountAllocation::Failed;
+            }
+            validate_space(space)
+        }
+        // DEVELOPER WARNING: New allocating instructions MUST return `Failed`
+        // until activated by a feature gate
+        SystemInstruction::Assign { .. }
+        | SystemInstruction::Transfer { .. }
+        | SystemInstruction::AdvanceNonceAccount
+        | SystemInstruction::WithdrawNonceAccount(..)
+        | SystemInstruction::InitializeNonceAccount(..)
+        | SystemInstruction::AuthorizeNonceAccount(..)
+        | SystemInstruction::UpgradeNonceAccount
+        | SystemInstruction::AssignWithSeed { .. }
+        | SystemInstruction::TransferWithSeed { .. } => SystemProgramAccountAllocation::None,
+        // DEVELOPER WARNING: New non-allocating instructions MUST return `Failed`
+        // until activated by a feature gate
+    } // Do not add wildcard pattern (_)
+}
+
+fn calculate_on_instruction(
+    program_id: &Pubkey,
+    instruction: SVMInstruction,
+    feature_set: &FeatureSet,
+) -> SystemProgramAccountAllocation {
+    if program_id == &system_program::id() {
+        if let Ok(instruction) =
+            limited_deserialize(instruction.data, solana_packet::PACKET_DATA_SIZE as u64)
+        {
+            calculate_on_deserialized_system_instruction(instruction, feature_set)
+        } else {
+            SystemProgramAccountAllocation::Failed
+        }
+    } else {
+        SystemProgramAccountAllocation::None
+    }
+}
+
+/// Eventually, `account_data_size_delta` should replace this static estimate.
+/// For now, calculate account data size from top-level system account creation
+/// instructions only.
+fn calculate_impl<'a>(
+    instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
+    feature_set: &FeatureSet,
+) -> u64 {
+    let mut tx_attempted_allocation_size = Saturating(0u64);
+    for (program_id, instruction) in instructions {
+        match calculate_on_instruction(program_id, instruction, feature_set) {
+            SystemProgramAccountAllocation::Failed => {
+                // If any system program instructions can be statically
+                // determined to fail, no allocations will actually be
+                // persisted by the transaction. So return 0 here so that no
+                // account allocation budget is used for this failed
+                // transaction.
+                return 0;
+            }
+            SystemProgramAccountAllocation::None => continue,
+            SystemProgramAccountAllocation::Some(ix_attempted_allocation_size) => {
+                tx_attempted_allocation_size += ix_attempted_allocation_size;
+            }
+        }
+    }
+
+    // The runtime prevents transactions from allocating too much account data
+    // so clamp the attempted allocation size to the max amount.
+    //
+    // Note that if there are any custom bpf instructions in the transaction
+    // it's tricky to know whether a newly allocated account will be freed
+    // or not during an intermediate instruction in the transaction so we
+    // shouldn't assume that a large sum of allocations will necessarily
+    // lead to transaction failure.
+    (MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64)
+        .min(tx_attempted_allocation_size.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        agave_feature_set::FeatureSet,
+        solana_instruction::Instruction,
+        solana_message::Message,
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_svm_transaction::svm_message::SVMStaticMessage,
+        solana_system_interface::instruction::{self as system_instruction},
+        solana_transaction::Transaction,
+    };
+
+    #[test]
+    fn test_calculate_no_allocation() {
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[system_instruction::transfer(
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                1,
+            )],
+            Some(&Pubkey::new_unique()),
+        ));
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+        assert_eq!(
+            calculate(
+                sanitized_tx.program_instructions_iter(),
+                &FeatureSet::all_enabled()
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn test_calculate_multiple_allocations() {
+        let space1 = 100;
+        let space2 = 200;
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    1,
+                    space1,
+                    &Pubkey::new_unique(),
+                ),
+                system_instruction::allocate(&Pubkey::new_unique(), space2),
+            ],
+            Some(&Pubkey::new_unique()),
+        ));
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+        assert_eq!(
+            calculate(
+                sanitized_tx.program_instructions_iter(),
+                &FeatureSet::all_enabled()
+            ),
+            space1 + space2
+        );
+    }
+
+    #[test]
+    fn test_calculate_max_limit() {
+        let spaces = [MAX_PERMITTED_DATA_LENGTH, MAX_PERMITTED_DATA_LENGTH, 100];
+        assert!(
+            spaces.iter().copied().sum::<u64>()
+                > MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64
+        );
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    1,
+                    spaces[0],
+                    &Pubkey::new_unique(),
+                ),
+                system_instruction::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    1,
+                    spaces[1],
+                    &Pubkey::new_unique(),
+                ),
+                system_instruction::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    1,
+                    spaces[2],
+                    &Pubkey::new_unique(),
+                ),
+            ],
+            Some(&Pubkey::new_unique()),
+        ));
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+        assert_eq!(
+            calculate(
+                sanitized_tx.program_instructions_iter(),
+                &FeatureSet::all_enabled()
+            ),
+            MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64,
+        );
+    }
+
+    #[test]
+    fn test_calculate_overflow() {
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::create_account(
+                    &Pubkey::new_unique(),
+                    &Pubkey::new_unique(),
+                    1,
+                    100,
+                    &Pubkey::new_unique(),
+                ),
+                system_instruction::allocate(&Pubkey::new_unique(), u64::MAX),
+            ],
+            Some(&Pubkey::new_unique()),
+        ));
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+        assert_eq!(
+            0, // SystemProgramAccountAllocation::Failed,
+            calculate(
+                sanitized_tx.program_instructions_iter(),
+                &FeatureSet::all_enabled()
+            ),
+        );
+    }
+
+    #[test]
+    fn test_calculate_invalid_ix() {
+        let transaction = Transaction::new_unsigned(Message::new(
+            &[
+                system_instruction::allocate(&Pubkey::new_unique(), 100),
+                Instruction::new_with_bincode(system_program::id(), &(), vec![]),
+            ],
+            Some(&Pubkey::new_unique()),
+        ));
+        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+
+        assert_eq!(
+            0, // SystemProgramAccountAllocation::Failed,
+            calculate(
+                sanitized_tx.program_instructions_iter(),
+                &FeatureSet::all_enabled()
+            ),
+        );
+    }
+
+    #[test]
+    fn test_calculate_on_deserialized_system_instruction() {
+        let lamports = 0;
+        let owner = Pubkey::default();
+        let seed = String::default();
+        let space = 100;
+        let base = Pubkey::default();
+        let feature_set = FeatureSet::all_enabled();
+
+        for instruction in [
+            SystemInstruction::CreateAccount {
+                lamports,
+                space,
+                owner,
+            },
+            SystemInstruction::CreateAccountAllowPrefund {
+                lamports,
+                space,
+                owner,
+            },
+            SystemInstruction::CreateAccountWithSeed {
+                base,
+                seed: seed.clone(),
+                lamports,
+                space,
+                owner,
+            },
+            SystemInstruction::Allocate { space },
+            SystemInstruction::AllocateWithSeed {
+                base,
+                seed,
+                space,
+                owner,
+            },
+        ] {
+            assert_eq!(
+                SystemProgramAccountAllocation::Some(space),
+                calculate_on_deserialized_system_instruction(instruction, &feature_set)
+            );
+        }
+        assert_eq!(
+            SystemProgramAccountAllocation::None,
+            calculate_on_deserialized_system_instruction(
+                SystemInstruction::TransferWithSeed {
+                    lamports,
+                    from_seed: String::default(),
+                    from_owner: Pubkey::default(),
+                },
+                &feature_set
+            )
+        );
+    }
+
+    #[test]
+    fn test_create_account_allow_prefund_feature_gate() {
+        let lamports = 0;
+        let owner = Pubkey::default();
+        let space = 100;
+        let instruction = SystemInstruction::CreateAccountAllowPrefund {
+            lamports,
+            space,
+            owner,
+        };
+
+        let feature_set_enabled = FeatureSet::all_enabled();
+        assert_eq!(
+            SystemProgramAccountAllocation::Some(space),
+            calculate_on_deserialized_system_instruction(instruction.clone(), &feature_set_enabled)
+        );
+
+        let feature_set_disabled = FeatureSet::default();
+        assert_eq!(
+            SystemProgramAccountAllocation::Failed,
+            calculate_on_deserialized_system_instruction(instruction, &feature_set_disabled)
+        );
+    }
+}

--- a/cost-model/src/allocated_accounts_data_size.rs
+++ b/cost-model/src/allocated_accounts_data_size.rs
@@ -29,13 +29,8 @@ pub(crate) fn calculate<'a>(
     instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
     feature_set: &FeatureSet,
 ) -> u64 {
-    // NOTE when bank feature gate of track wigth actual accounts_data_size_delta lands,
-    // use the feature gate here:
-    // if !feature_set.snapshot().use_account_data_size_delta_for_cost_tracking {
-    //     calculate_impl(instructions, feature-set)
-    // } else {
-    //     0
-    // }
+    // NOTE when bank feature gate of track with actual accounts_data_size_delta lands
+    // and activated, return `0`
 
     calculate_impl(instructions, feature_set)
 }

--- a/cost-model/src/allocated_accounts_data_size.rs
+++ b/cost-model/src/allocated_accounts_data_size.rs
@@ -270,13 +270,14 @@ mod tests {
 
     #[test]
     fn test_calculate_overflow() {
+        let space = 100;
         let transaction = Transaction::new_unsigned(Message::new(
             &[
                 system_instruction::create_account(
                     &Pubkey::new_unique(),
                     &Pubkey::new_unique(),
                     1,
-                    100,
+                    space,
                     &Pubkey::new_unique(),
                 ),
                 system_instruction::allocate(&Pubkey::new_unique(), u64::MAX),
@@ -286,7 +287,7 @@ mod tests {
         let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
         assert_eq!(
-            0, // SystemProgramAccountAllocation::Failed,
+            space,
             calculate(
                 sanitized_tx.program_instructions_iter(),
                 &FeatureSet::all_enabled()
@@ -296,9 +297,10 @@ mod tests {
 
     #[test]
     fn test_calculate_invalid_ix() {
+        let space = 100;
         let transaction = Transaction::new_unsigned(Message::new(
             &[
-                system_instruction::allocate(&Pubkey::new_unique(), 100),
+                system_instruction::allocate(&Pubkey::new_unique(), space),
                 Instruction::new_with_bincode(system_program::id(), &(), vec![]),
             ],
             Some(&Pubkey::new_unique()),
@@ -306,7 +308,7 @@ mod tests {
         let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
         assert_eq!(
-            0, // SystemProgramAccountAllocation::Failed,
+            space,
             calculate(
                 sanitized_tx.program_instructions_iter(),
                 &FeatureSet::all_enabled()

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -6,31 +6,17 @@
 //!
 
 use {
-    crate::{block_cost_limits::*, transaction_cost::*},
+    crate::{allocated_accounts_data_size, block_cost_limits::*, transaction_cost::*},
     agave_feature_set::FeatureSet,
-    solana_bincode::limited_deserialize,
     solana_compute_budget::compute_budget_limits::DEFAULT_HEAP_COST,
     solana_pubkey::Pubkey,
     solana_runtime_transaction::transaction_meta::TransactionMeta,
-    solana_sdk_ids::system_program,
     solana_svm_transaction::{instruction::SVMInstruction, svm_message::SVMStaticMessage},
-    solana_system_interface::{
-        MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION, MAX_PERMITTED_DATA_LENGTH,
-        instruction::SystemInstruction,
-    },
-    std::num::Saturating,
 };
 
 const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
 
 pub struct CostModel;
-
-#[derive(Debug, PartialEq)]
-enum SystemProgramAccountAllocation {
-    None,
-    Some(u64),
-    Failed,
-}
 
 impl CostModel {
     pub fn calculate_cost<'a, Tx: TransactionMeta + SVMStaticMessage>(
@@ -113,7 +99,7 @@ impl CostModel {
         let write_lock_cost = Self::get_write_lock_cost(num_write_locks);
 
         let allocated_accounts_data_size =
-            Self::calculate_allocated_accounts_data_size(instructions, feature_set);
+            allocated_accounts_data_size::calculate(instructions, feature_set);
 
         TransactionCost {
             transaction,
@@ -199,106 +185,6 @@ impl CostModel {
     ) -> u64 {
         Self::calculate_pages_cost(Self::calculate_pages_for_bytes(loaded_accounts_data_size))
     }
-
-    fn calculate_account_data_size_on_deserialized_system_instruction(
-        instruction: SystemInstruction,
-        feature_set: &FeatureSet,
-    ) -> SystemProgramAccountAllocation {
-        let validate_space = |space: u64| {
-            if space > MAX_PERMITTED_DATA_LENGTH {
-                SystemProgramAccountAllocation::Failed
-            } else {
-                SystemProgramAccountAllocation::Some(space)
-            }
-        };
-
-        match instruction {
-            SystemInstruction::CreateAccount { space, .. }
-            | SystemInstruction::CreateAccountWithSeed { space, .. }
-            | SystemInstruction::Allocate { space }
-            | SystemInstruction::AllocateWithSeed { space, .. } => validate_space(space),
-            SystemInstruction::CreateAccountAllowPrefund { space, .. } => {
-                if !feature_set.snapshot().create_account_allow_prefund {
-                    return SystemProgramAccountAllocation::Failed;
-                }
-                validate_space(space)
-            }
-            // DEVELOPER WARNING: New allocating instructions MUST return `Failed`
-            // until activated by a feature gate
-            SystemInstruction::Assign { .. }
-            | SystemInstruction::Transfer { .. }
-            | SystemInstruction::AdvanceNonceAccount
-            | SystemInstruction::WithdrawNonceAccount(..)
-            | SystemInstruction::InitializeNonceAccount(..)
-            | SystemInstruction::AuthorizeNonceAccount(..)
-            | SystemInstruction::UpgradeNonceAccount
-            | SystemInstruction::AssignWithSeed { .. }
-            | SystemInstruction::TransferWithSeed { .. } => SystemProgramAccountAllocation::None,
-            // DEVELOPER WARNING: New non-allocating instructions MUST return `Failed`
-            // until activated by a feature gate
-        } // Do not add wildcard pattern (_)
-    }
-
-    fn calculate_account_data_size_on_instruction(
-        program_id: &Pubkey,
-        instruction: SVMInstruction,
-        feature_set: &FeatureSet,
-    ) -> SystemProgramAccountAllocation {
-        if program_id == &system_program::id() {
-            if let Ok(instruction) =
-                limited_deserialize(instruction.data, solana_packet::PACKET_DATA_SIZE as u64)
-            {
-                Self::calculate_account_data_size_on_deserialized_system_instruction(
-                    instruction,
-                    feature_set,
-                )
-            } else {
-                SystemProgramAccountAllocation::Failed
-            }
-        } else {
-            SystemProgramAccountAllocation::None
-        }
-    }
-
-    /// eventually, potentially determine account data size of all writable accounts
-    /// at the moment, calculate account data size of account creation
-    fn calculate_allocated_accounts_data_size<'a>(
-        instructions: impl Iterator<Item = (&'a Pubkey, SVMInstruction<'a>)>,
-        feature_set: &FeatureSet,
-    ) -> u64 {
-        let mut tx_attempted_allocation_size = Saturating(0u64);
-        for (program_id, instruction) in instructions {
-            match Self::calculate_account_data_size_on_instruction(
-                program_id,
-                instruction,
-                feature_set,
-            ) {
-                SystemProgramAccountAllocation::Failed => {
-                    // If any system program instructions can be statically
-                    // determined to fail, no allocations will actually be
-                    // persisted by the transaction. So return 0 here so that no
-                    // account allocation budget is used for this failed
-                    // transaction.
-                    return 0;
-                }
-                SystemProgramAccountAllocation::None => continue,
-                SystemProgramAccountAllocation::Some(ix_attempted_allocation_size) => {
-                    tx_attempted_allocation_size += ix_attempted_allocation_size;
-                }
-            }
-        }
-
-        // The runtime prevents transactions from allocating too much account
-        // data so clamp the attempted allocation size to the max amount.
-        //
-        // Note that if there are any custom bpf instructions in the transaction
-        // it's tricky to know whether a newly allocated account will be freed
-        // or not during an intermediate instruction in the transaction so we
-        // shouldn't assume that a large sum of allocations will necessarily
-        // lead to transaction failure.
-        (MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64)
-            .min(tx_attempted_allocation_size.0)
-    }
 }
 
 #[cfg(test)]
@@ -320,7 +206,6 @@ mod tests {
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::{compute_budget, system_program},
         solana_signer::Signer,
-        solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_system_interface::instruction::{self as system_instruction},
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
@@ -329,233 +214,6 @@ mod tests {
     fn test_setup() -> (Keypair, Hash) {
         agave_logger::setup();
         (Keypair::new(), Hash::new_unique())
-    }
-
-    #[test]
-    fn test_calculate_allocated_accounts_data_size_no_allocation() {
-        let transaction = Transaction::new_unsigned(Message::new(
-            &[system_instruction::transfer(
-                &Pubkey::new_unique(),
-                &Pubkey::new_unique(),
-                1,
-            )],
-            Some(&Pubkey::new_unique()),
-        ));
-        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-
-        assert_eq!(
-            CostModel::calculate_allocated_accounts_data_size(
-                sanitized_tx.program_instructions_iter(),
-                &FeatureSet::all_enabled()
-            ),
-            0
-        );
-    }
-
-    #[test]
-    fn test_calculate_allocated_accounts_data_size_multiple_allocations() {
-        let space1 = 100;
-        let space2 = 200;
-        let transaction = Transaction::new_unsigned(Message::new(
-            &[
-                system_instruction::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    1,
-                    space1,
-                    &Pubkey::new_unique(),
-                ),
-                system_instruction::allocate(&Pubkey::new_unique(), space2),
-            ],
-            Some(&Pubkey::new_unique()),
-        ));
-        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-
-        assert_eq!(
-            CostModel::calculate_allocated_accounts_data_size(
-                sanitized_tx.program_instructions_iter(),
-                &FeatureSet::all_enabled()
-            ),
-            space1 + space2
-        );
-    }
-
-    #[test]
-    fn test_calculate_allocated_accounts_data_size_max_limit() {
-        let spaces = [MAX_PERMITTED_DATA_LENGTH, MAX_PERMITTED_DATA_LENGTH, 100];
-        assert!(
-            spaces.iter().copied().sum::<u64>()
-                > MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64
-        );
-        let transaction = Transaction::new_unsigned(Message::new(
-            &[
-                system_instruction::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    1,
-                    spaces[0],
-                    &Pubkey::new_unique(),
-                ),
-                system_instruction::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    1,
-                    spaces[1],
-                    &Pubkey::new_unique(),
-                ),
-                system_instruction::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    1,
-                    spaces[2],
-                    &Pubkey::new_unique(),
-                ),
-            ],
-            Some(&Pubkey::new_unique()),
-        ));
-        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-
-        assert_eq!(
-            CostModel::calculate_allocated_accounts_data_size(
-                sanitized_tx.program_instructions_iter(),
-                &FeatureSet::all_enabled()
-            ),
-            MAX_PERMITTED_ACCOUNTS_DATA_ALLOCATIONS_PER_TRANSACTION as u64,
-        );
-    }
-
-    #[test]
-    fn test_calculate_allocated_accounts_data_size_overflow() {
-        let transaction = Transaction::new_unsigned(Message::new(
-            &[
-                system_instruction::create_account(
-                    &Pubkey::new_unique(),
-                    &Pubkey::new_unique(),
-                    1,
-                    100,
-                    &Pubkey::new_unique(),
-                ),
-                system_instruction::allocate(&Pubkey::new_unique(), u64::MAX),
-            ],
-            Some(&Pubkey::new_unique()),
-        ));
-        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-
-        assert_eq!(
-            0, // SystemProgramAccountAllocation::Failed,
-            CostModel::calculate_allocated_accounts_data_size(
-                sanitized_tx.program_instructions_iter(),
-                &FeatureSet::all_enabled()
-            ),
-        );
-    }
-
-    #[test]
-    fn test_calculate_allocated_accounts_data_size_invalid_ix() {
-        let transaction = Transaction::new_unsigned(Message::new(
-            &[
-                system_instruction::allocate(&Pubkey::new_unique(), 100),
-                Instruction::new_with_bincode(system_program::id(), &(), vec![]),
-            ],
-            Some(&Pubkey::new_unique()),
-        ));
-        let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-
-        assert_eq!(
-            0, // SystemProgramAccountAllocation::Failed,
-            CostModel::calculate_allocated_accounts_data_size(
-                sanitized_tx.program_instructions_iter(),
-                &FeatureSet::all_enabled()
-            ),
-        );
-    }
-
-    #[test]
-    fn test_cost_model_data_len_cost() {
-        let lamports = 0;
-        let owner = Pubkey::default();
-        let seed = String::default();
-        let space = 100;
-        let base = Pubkey::default();
-        let feature_set = FeatureSet::all_enabled();
-
-        for instruction in [
-            SystemInstruction::CreateAccount {
-                lamports,
-                space,
-                owner,
-            },
-            SystemInstruction::CreateAccountAllowPrefund {
-                lamports,
-                space,
-                owner,
-            },
-            SystemInstruction::CreateAccountWithSeed {
-                base,
-                seed: seed.clone(),
-                lamports,
-                space,
-                owner,
-            },
-            SystemInstruction::Allocate { space },
-            SystemInstruction::AllocateWithSeed {
-                base,
-                seed,
-                space,
-                owner,
-            },
-        ] {
-            assert_eq!(
-                SystemProgramAccountAllocation::Some(space),
-                CostModel::calculate_account_data_size_on_deserialized_system_instruction(
-                    instruction,
-                    &feature_set
-                )
-            );
-        }
-        assert_eq!(
-            SystemProgramAccountAllocation::None,
-            CostModel::calculate_account_data_size_on_deserialized_system_instruction(
-                SystemInstruction::TransferWithSeed {
-                    lamports,
-                    from_seed: String::default(),
-                    from_owner: Pubkey::default(),
-                },
-                &feature_set
-            )
-        );
-    }
-
-    #[test]
-    fn test_cost_model_create_account_allow_prefund_feature_gate() {
-        let lamports = 0;
-        let owner = Pubkey::default();
-        let space = 100;
-        let instruction = SystemInstruction::CreateAccountAllowPrefund {
-            lamports,
-            space,
-            owner,
-        };
-
-        // Test with feature enabled
-        let feature_set_enabled = FeatureSet::all_enabled();
-        assert_eq!(
-            SystemProgramAccountAllocation::Some(space),
-            CostModel::calculate_account_data_size_on_deserialized_system_instruction(
-                instruction.clone(),
-                &feature_set_enabled
-            )
-        );
-
-        // Test with feature disabled
-        let feature_set_disabled = FeatureSet::default();
-        assert_eq!(
-            SystemProgramAccountAllocation::Failed,
-            CostModel::calculate_account_data_size_on_deserialized_system_instruction(
-                instruction,
-                &feature_set_disabled
-            )
-        );
     }
 
     #[test]

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -3,8 +3,8 @@
 //! - try_add, checks the configured limits and records the transaction's cost when it fits.
 use {
     crate::{
-        block_cost_limits::*, cost_tracker_post_analysis::CostTrackerPostAnalysis,
-        transaction_cost::TransactionCost,
+        allocated_accounts_data_size, block_cost_limits::*,
+        cost_tracker_post_analysis::CostTrackerPostAnalysis, transaction_cost::TransactionCost,
     },
     solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
@@ -88,7 +88,7 @@ impl Default for CostTrackerLimits {
         Self {
             account_cost: MAX_WRITABLE_ACCOUNT_UNITS,
             block_cost: MAX_BLOCK_UNITS,
-            allocated_data_size: MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA,
+            allocated_data_size: allocated_accounts_data_size::DEFAULT_LIMIT,
         }
     }
 }
@@ -185,12 +185,11 @@ impl CostTracker {
             return Err(CostTrackerError::WouldExceedAccountMaxLimit);
         }
 
-        let allocated_accounts_data_size =
-            self.allocated_accounts_data_size + Saturating(tx_cost.allocated_accounts_data_size());
-
-        if allocated_accounts_data_size.0 > self.limits.allocated_data_size {
-            return Err(CostTrackerError::WouldExceedAccountDataBlockLimit);
-        }
+        allocated_accounts_data_size::would_fit(
+            self.allocated_accounts_data_size,
+            tx_cost,
+            self.limits.allocated_data_size,
+        )?;
 
         // Check each account against account_cost_limit and apply the cost in
         // the same lookup. On failure, undo the applied prefix.
@@ -222,7 +221,7 @@ impl CostTracker {
         }
 
         // every check passed: publish the block-level state
-        self.allocated_accounts_data_size = allocated_accounts_data_size;
+        allocated_accounts_data_size::add(&mut self.allocated_accounts_data_size, tx_cost);
         self.transaction_count += 1;
         self.transaction_signature_count += tx_cost.num_transaction_signatures();
         self.secp256k1_instruction_signature_count +=
@@ -301,7 +300,7 @@ impl CostTracker {
             ("costliest_account_cost", costliest_account_cost, i64),
             (
                 "allocated_accounts_data_size",
-                self.allocated_accounts_data_size.0,
+                allocated_accounts_data_size::stats_value(self.allocated_accounts_data_size),
                 i64
             ),
             (
@@ -355,7 +354,7 @@ impl CostTracker {
     fn remove_transaction_cost(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
         let cost = tx_cost.sum();
         self.sub_transaction_execution_cost(tx_cost, cost);
-        self.allocated_accounts_data_size -= tx_cost.allocated_accounts_data_size();
+        allocated_accounts_data_size::subtract(&mut self.allocated_accounts_data_size, tx_cost);
         self.transaction_count -= 1;
         self.transaction_signature_count -= tx_cost.num_transaction_signatures();
         self.secp256k1_instruction_signature_count -=

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(feature = "frozen-abi", feature(min_specialization))]
 #![allow(clippy::arithmetic_side_effects)]
 
+pub(crate) mod allocated_accounts_data_size;
 pub mod block_cost_limits;
 pub mod cost_model;
 pub mod cost_tracker;


### PR DESCRIPTION
#### Problem

Would be nice if all logic of current `allocated_accounts_data_size` cost modeling and tracking are in one single place that can be turned on or off with one-liner.

#### Summary of Changes
- move all it's logic into own module allow to turn it on/off with one-liner

#### Testing
CI

Fixes #
