### PR TITLE
Cleanup - `ProgramCacheEntry::account_size`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -277,7 +277,6 @@ fn load_program<'a>(
         program_id: program_id.to_string(),
         ..LoadProgramMetrics::default()
     };
-    let account_size = contents.len();
     let program_runtime_environment = create_program_runtime_environment(
         invoke_context.get_feature_set(),
         invoke_context.get_compute_budget(),
@@ -294,7 +293,6 @@ fn load_program<'a>(
             slot,
             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &contents,
-            account_size,
             &mut load_program_metrics,
         );
         match result {

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -133,7 +133,6 @@ macro_rules! deploy_program {
     ($invoke_context:expr,
      $program_id:expr,
      $loader_key:expr,
-     $_account_size:expr,
      $programdata:expr,
      $deployment_slot:expr,
      $disable_sbpf_v0_v1_v2_deployment:expr $(,)?) => {

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -55,7 +55,6 @@ pub fn deploy_program(
     disable_sbpf_v0_v1_v2_deployment: bool,
     program_id: &Pubkey,
     loader_key: &Pubkey,
-    _account_size: usize,
     programdata: &[u8],
     deployment_slot: Slot,
 ) -> Result<(), InstructionError> {
@@ -134,7 +133,7 @@ macro_rules! deploy_program {
     ($invoke_context:expr,
      $program_id:expr,
      $loader_key:expr,
-     $account_size:expr,
+     $_account_size:expr,
      $programdata:expr,
      $deployment_slot:expr,
      $disable_sbpf_v0_v1_v2_deployment:expr $(,)?) => {
@@ -155,7 +154,6 @@ macro_rules! deploy_program {
             $disable_sbpf_v0_v1_v2_deployment,
             $program_id,
             $loader_key,
-            $account_size,
             $programdata,
             $deployment_slot,
         )?;

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -55,7 +55,7 @@ pub fn deploy_program(
     disable_sbpf_v0_v1_v2_deployment: bool,
     program_id: &Pubkey,
     loader_key: &Pubkey,
-    account_size: usize,
+    _account_size: usize,
     programdata: &[u8],
     deployment_slot: Slot,
 ) -> Result<(), InstructionError> {
@@ -110,7 +110,6 @@ pub fn deploy_program(
             deployment_slot,
             deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             programdata,
-            account_size,
             #[cfg(feature = "metrics")]
             load_program_metrics,
         )

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1063,7 +1063,7 @@ pub fn mock_process_instruction_with_feature_set<
         } else {
             program_owner
         },
-        Arc::new(ProgramCacheEntry::new_builtin(0, 0, builtin)),
+        Arc::new(ProgramCacheEntry::new_builtin(0, builtin)),
     );
     program_cache_for_tx_batch.set_slot_for_tests(
         invoke_context
@@ -1493,7 +1493,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             callee_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1548,7 +1548,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             callee_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1632,7 +1632,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             program_key,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1920,7 +1920,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             TEST_CALLEE_PROGRAM_ID,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 1, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -2139,7 +2139,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_system_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         let account_keys = (0..transaction_context.get_number_of_accounts())
             .map(|index| {
@@ -2357,7 +2357,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
         let account_metas = vec![
             AccountMeta::new(
@@ -2584,7 +2584,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
         );
 
         struct MockCallback {}

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1055,7 +1055,6 @@ pub(crate) mod tests {
         Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot,
             effective_slot,
             stats: Arc::new(stats),
@@ -1070,7 +1069,6 @@ pub(crate) mod tests {
         Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
             account_owner: ProgramCacheEntryOwner::NativeLoader,
-            account_size: 0,
             deployment_slot,
             effective_slot,
             stats: Arc::default(),
@@ -1448,7 +1446,6 @@ pub(crate) mod tests {
                         BuiltinProgram::new_mock(),
                     )), // Assign them different environments
                     account_owner: ProgramCacheEntryOwner::LoaderV2,
-                    account_size: 0,
                     deployment_slot,
                     effective_slot,
                     stats: Arc::default(),
@@ -1511,7 +1508,6 @@ pub(crate) mod tests {
             Arc::new(ProgramCacheEntry {
                 program: old,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
-                account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
                 stats: Arc::default(),
@@ -1525,7 +1521,6 @@ pub(crate) mod tests {
             Arc::new(ProgramCacheEntry {
                 program: new,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
-                account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
                 stats: Arc::default(),
@@ -1561,7 +1556,6 @@ pub(crate) mod tests {
             Arc::new(ProgramCacheEntry {
                 program: old,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
-                account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
                 stats: Arc::default(),
@@ -1575,7 +1569,6 @@ pub(crate) mod tests {
             Arc::new(ProgramCacheEntry {
                 program: new,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
-                account_size: 0,
                 deployment_slot: 10,
                 effective_slot: 11,
                 stats: Arc::default(),
@@ -1592,7 +1585,6 @@ pub(crate) mod tests {
         let closed_other_slot = Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Closed,
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 9,
             effective_slot: 9,
             stats: Arc::default(),
@@ -1601,7 +1593,6 @@ pub(crate) mod tests {
         let closed_current_slot = Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Closed,
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 10,
             effective_slot: 10,
             stats: Arc::default(),
@@ -1610,7 +1601,6 @@ pub(crate) mod tests {
         let loaded_entry_current_env = Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 10,
             effective_slot: 11,
             stats: Arc::default(),
@@ -1621,7 +1611,6 @@ pub(crate) mod tests {
                 BuiltinProgram::new_mock(),
             )),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 10,
             effective_slot: 11,
             stats: Arc::default(),
@@ -2366,7 +2355,6 @@ pub(crate) mod tests {
             let entry = Arc::new(ProgramCacheEntry {
                 program: program_cache_entry_type,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
-                account_size: 0,
                 deployment_slot: 0,
                 effective_slot: 0,
                 stats: Arc::default(),

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -311,11 +311,7 @@ impl ProgramCacheEntry {
     }
 
     /// Creates a new built-in program
-    pub fn new_builtin(
-        deployment_slot: Slot,
-        _account_size: usize,
-        register_fn: BuiltinFunctionRegisterer,
-    ) -> Self {
+    pub fn new_builtin(deployment_slot: Slot, register_fn: BuiltinFunctionRegisterer) -> Self {
         let mut program = BuiltinProgram::new_builtin();
         register_fn(&mut program, "entrypoint").unwrap();
         Self {

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -185,7 +185,7 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        account_size: usize,
+        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Self::new_internal(
@@ -194,7 +194,6 @@ impl ProgramCacheEntry {
             deployment_slot,
             effective_slot,
             elf_bytes,
-            account_size,
             #[cfg(feature = "metrics")]
             metrics,
             false, /* reloading */
@@ -215,7 +214,7 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        account_size: usize,
+        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Self::new_internal(
@@ -224,7 +223,6 @@ impl ProgramCacheEntry {
             deployment_slot,
             effective_slot,
             elf_bytes,
-            account_size,
             #[cfg(feature = "metrics")]
             metrics,
             true, /* reloading */
@@ -237,7 +235,6 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -159,8 +159,6 @@ pub struct ProgramCacheEntry {
     pub program: ProgramCacheEntryType,
     /// The loader of this entry
     pub account_owner: ProgramCacheEntryOwner,
-    /// Size of account that stores the program and program data
-    pub account_size: usize,
     /// Slot in which the program was (re)deployed
     pub deployment_slot: Slot,
     /// Slot in which this entry will become active (can be in the future)
@@ -239,7 +237,7 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        account_size: usize,
+        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -278,7 +276,6 @@ impl ProgramCacheEntry {
         Ok(Self {
             deployment_slot,
             account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),
-            account_size,
             effective_slot,
             program: ProgramCacheEntryType::Loaded(executable),
             stats: entry_stats.into(),
@@ -300,7 +297,6 @@ impl ProgramCacheEntry {
         Some(Self {
             program: ProgramCacheEntryType::Unloaded(environment),
             account_owner: self.account_owner,
-            account_size: self.account_size,
             deployment_slot: self.deployment_slot,
             effective_slot: self.effective_slot,
             stats: Arc::clone(&self.stats),
@@ -317,7 +313,7 @@ impl ProgramCacheEntry {
     /// Creates a new built-in program
     pub fn new_builtin(
         deployment_slot: Slot,
-        account_size: usize,
+        _account_size: usize,
         register_fn: BuiltinFunctionRegisterer,
     ) -> Self {
         let mut program = BuiltinProgram::new_builtin();
@@ -325,7 +321,6 @@ impl ProgramCacheEntry {
         Self {
             deployment_slot,
             account_owner: ProgramCacheEntryOwner::NativeLoader,
-            account_size,
             effective_slot: deployment_slot,
             program: ProgramCacheEntryType::Builtin(program),
             stats: Arc::default(),
@@ -350,7 +345,6 @@ impl ProgramCacheEntry {
         let tombstone = Self {
             program: reason,
             account_owner,
-            account_size: 0,
             deployment_slot: slot,
             effective_slot: slot,
             stats,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -214,7 +214,6 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Self::new_internal(

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -185,7 +185,6 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         effective_slot: Slot,
         elf_bytes: &[u8],
-        _account_size: usize,
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Self::new_internal(

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -951,7 +951,7 @@ impl ProgramTest {
         self.builtin_programs.push((
             program_id,
             program_name,
-            ProgramCacheEntry::new_builtin(0, program_name.len(), builtin),
+            ProgramCacheEntry::new_builtin(0, builtin),
         ));
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -317,7 +317,6 @@ fn process_loader_upgradeable_instruction(
                 invoke_context,
                 &new_program_id,
                 &owner_id,
-                UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
                 buffer
                     .get_data()
                     .get(buffer_data_offset..)
@@ -482,7 +481,6 @@ fn process_loader_upgradeable_instruction(
                 ic_logger_msg!(log_collector, "Invalid ProgramData account");
                 return Err(InstructionError::InvalidAccountData);
             };
-            let programdata_len = programdata.get_data().len();
             drop(programdata);
 
             // Load and verify the program bits
@@ -491,7 +489,6 @@ fn process_loader_upgradeable_instruction(
                 invoke_context,
                 &new_program_id,
                 program_id,
-                UpgradeableLoaderState::size_of_program().saturating_add(programdata_len),
                 buffer
                     .get_data()
                     .get(buffer_data_offset..)
@@ -978,7 +975,6 @@ fn common_extend_program(
         invoke_context,
         &program_key,
         &program_id,
-        UpgradeableLoaderState::size_of_program().saturating_add(new_len),
         programdata_account
             .get_data()
             .get(programdata_data_offset..)
@@ -4049,7 +4045,6 @@ mod tests {
             invoke_context,
             &program_id,
             &bpf_loader_upgradeable::id(),
-            elf.len(),
             &elf,
             2_u64,
             true, // disable_sbpf_v0_v1_v2_deployment

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -4106,7 +4106,6 @@ mod tests {
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 0,
             effective_slot: 0,
             stats: stats.into(),
@@ -4159,7 +4158,6 @@ mod tests {
         let program = ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
-            account_size: 0,
             deployment_slot: 0,
             effective_slot: 0,
             stats: stats.into(),

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -2477,7 +2477,6 @@ mod tests {
                         system_program::id(),
                         Arc::new(ProgramCacheEntry::new_builtin(
                             0,
-                            0,
                             solana_system_program::system_processor::Entrypoint::register,
                         )),
                     );

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1087,7 +1087,6 @@ mod test_utils {
                     0,
                     effective_slot,
                     programdata,
-                    account.data().len(),
                     #[cfg(feature = "metrics")]
                     &mut LoadProgramMetrics::default(),
                 )

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -576,7 +576,6 @@ mod tests {
                     solana_sdk_ids::system_program::id(),
                     Arc::new(ProgramCacheEntry::new_builtin(
                         0,
-                        0,
                         solana_system_program::system_processor::Entrypoint::register,
                     )),
                 );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4802,7 +4802,7 @@ pub mod tests {
             solana_pubkey::pubkey!("TestProgram11111111111111111111111111111111");
 
         fn cache_entry() -> ProgramCacheEntry {
-            ProgramCacheEntry::new_builtin(0, Self::NAME.len(), Self::register)
+            ProgramCacheEntry::new_builtin(0, Self::register)
         }
 
         fn instruction(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5958,7 +5958,7 @@ impl Bank {
         self.add_builtin(
             program_id,
             "mockup",
-            ProgramCacheEntry::new_builtin(self.slot, 0, builtin),
+            ProgramCacheEntry::new_builtin(self.slot, builtin),
         );
     }
 
@@ -6262,7 +6262,6 @@ impl Bank {
                     builtin.name,
                     ProgramCacheEntry::new_builtin(
                         self.feature_set.activated_slot(&feature_id).unwrap_or(0),
-                        builtin.name.len(),
                         builtin.register_fn,
                     ),
                 );
@@ -6418,11 +6417,7 @@ impl Bank {
                     .unwrap_or(0);
                 self.transaction_processor.add_builtin(
                     builtin.program_id,
-                    ProgramCacheEntry::new_builtin(
-                        activation_slot,
-                        builtin.name.len(),
-                        builtin.register_fn,
-                    ),
+                    ProgramCacheEntry::new_builtin(activation_slot, builtin.register_fn),
                 );
             }
         }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -803,7 +803,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, builtin_name.len(), NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
             );
             account
         };
@@ -939,7 +939,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, builtin_name.len(), NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
             );
             account
         };
@@ -989,7 +989,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, builtin_name.len(), NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
             );
             account
         };
@@ -1039,7 +1039,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, builtin_name.len(), NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
             );
             account
         };
@@ -1455,11 +1455,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(
-                0,
-                cpi_program_name.len(),
-                cpi_mockup::Entrypoint::register,
-            ),
+            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
         );
 
         let (builtin_id, config) = prototype.deconstruct();
@@ -1995,11 +1991,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(
-                0,
-                cpi_program_name.len(),
-                cpi_mockup::Entrypoint::register,
-            ),
+            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.
@@ -2254,11 +2246,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(
-                0,
-                cpi_program_name.len(),
-                cpi_mockup::Entrypoint::register,
-            ),
+            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.
@@ -2319,11 +2307,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(
-                0,
-                cpi_program_name.len(),
-                cpi_mockup::Entrypoint::register,
-            ),
+            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -777,10 +777,6 @@ pub(crate) mod tests {
                 .unwrap();
 
             // The target program entry should be updated.
-            assert_eq!(
-                target_entry.account_size,
-                program_account.data().len() + program_data_account.data().len()
-            );
             assert_eq!(target_entry.deployment_slot, migration_or_upgrade_slot);
             assert_eq!(target_entry.effective_slot, migration_or_upgrade_slot + 1);
 

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -134,7 +134,6 @@ impl Bank {
         program_id: &Pubkey,
         programdata: &[u8],
     ) -> Result<(), InstructionError> {
-        let data_len = programdata.len();
         let progradata_metadata_size = UpgradeableLoaderState::size_of_programdata_metadata();
         let elf = &programdata[progradata_metadata_size..];
         // Set up the two `LoadedProgramsForTxBatch` instances, as if
@@ -201,9 +200,6 @@ impl Bank {
                 false, // disable_sbpf_v0_v1_v2_deployment // explicitly continue to allow them for core program migrations
                 program_id,
                 &bpf_loader_upgradeable::id(),
-                // The size of the program cache entry is the size of the program account
-                // + size of the program data account.
-                UpgradeableLoaderState::size_of_program().saturating_add(data_len),
                 elf,
                 self.slot,
             )?;

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5945,10 +5945,6 @@ fn test_bank_load_program() {
             panic!();
         };
         assert_matches!(program.program, ProgramCacheEntryType::Loaded(_));
-        assert_eq!(
-            program.account_size,
-            program_account.data().len() + programdata_account.data().len()
-        );
     }
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3746,12 +3746,12 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         bank.add_builtin(
             vote_id,
             "mock_program1",
-            ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register),
+            ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
         );
         bank.add_builtin(
             stake_id,
             "mock_program2",
-            ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register),
+            ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
         );
         {
             let stakes = bank.stakes_cache.stakes();
@@ -5139,7 +5139,7 @@ fn test_fuzz_instructions() {
             bank.add_builtin(
                 key,
                 name.as_str(),
-                ProgramCacheEntry::new_builtin(0, 0, MockBuiltin::register),
+                ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
             );
             (key, name.as_bytes().to_vec())
         })

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -141,7 +141,6 @@ pub fn add_program_to_program_cache(
         0, // deployment_slot
         0, // effective_slot
         elf,
-        elf.len(),
         #[cfg(feature = "metrics")]
         &mut LoadProgramMetrics::default(),
     )

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -111,11 +111,7 @@ pub fn new_program_cache_with_builtins(slot: u64) -> ProgramCacheForTxBatch {
     for builtin in SVM_BUILTINS {
         cache.replenish(
             builtin.program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(
-                0u64,
-                builtin.name.len(),
-                builtin.register_fn,
-            )),
+            Arc::new(ProgramCacheEntry::new_builtin(0u64, builtin.register_fn)),
         );
     }
 

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -126,7 +126,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
-            program_account.data().len(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
         )
@@ -138,7 +137,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
-            program_account.data().len(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
         )
@@ -159,10 +157,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                     deployment_slot,
                     deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                     programdata,
-                    program_account
-                        .data()
-                        .len()
-                        .saturating_add(programdata_account.data().len()),
                     #[cfg(feature = "metrics")]
                     &mut load_program_metrics,
                 )
@@ -182,7 +176,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                         deployment_slot,
                         deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                         elf_bytes,
-                        program_account.data().len(),
                         #[cfg(feature = "metrics")]
                         &mut load_program_metrics,
                     )
@@ -480,7 +473,6 @@ mod tests {
         #[cfg(feature = "metrics")]
         let mut metrics = LoadProgramMetrics::default();
         let loader = bpf_loader_upgradeable::id();
-        let size = buffer.len();
         let slot: Slot = 2;
         let environment = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
 
@@ -490,7 +482,6 @@ mod tests {
             slot,
             slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &buffer,
-            size,
             #[cfg(feature = "metrics")]
             &mut metrics,
         );
@@ -596,7 +587,6 @@ mod tests {
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
-            account_data.data().len(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
         );
@@ -688,7 +678,6 @@ mod tests {
             0,
             DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
-            account_data.data().len(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
         );

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -843,7 +843,6 @@ mod tests {
                 Arc::new(ProgramCacheEntry {
                     program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
                     account_owner: ProgramCacheEntryOwner::NativeLoader,
-                    account_size: 0,
                     deployment_slot: 0,
                     effective_slot: 0,
                     stats: Arc::default(),

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -2130,7 +2130,6 @@ mod tests {
             TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
 
         let key = Pubkey::new_unique();
-        let name = "a_builtin_name";
         let register_fn: BuiltinFunctionRegisterer = |p, n| {
             p.register_function(
                 n,
@@ -2140,7 +2139,7 @@ mod tests {
                 ),
             )
         };
-        let program = ProgramCacheEntry::new_builtin(0, name.len(), register_fn);
+        let program = ProgramCacheEntry::new_builtin(0, register_fn);
         batch_processor.add_builtin(key, program);
 
         let mut loaded_programs_for_tx_batch = ProgramCacheForTxBatch::new(0);
@@ -2165,7 +2164,7 @@ mod tests {
         let entry = loaded_programs_for_tx_batch.find(&key).unwrap();
 
         // Repeating code because ProgramCacheEntry does not implement clone.
-        let program = ProgramCacheEntry::new_builtin(0, name.len(), register_fn);
+        let program = ProgramCacheEntry::new_builtin(0, register_fn);
         assert_eq!(entry, Arc::new(program));
     }
 

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -284,7 +284,6 @@ pub fn register_builtins(
         loader_v3_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            loader_v3_name.len(),
             solana_bpf_loader_program::Entrypoint::register,
         ),
     );
@@ -297,7 +296,6 @@ pub fn register_builtins(
         loader_v1_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            loader_v1_name.len(),
             solana_bpf_loader_program::Entrypoint::register,
         ),
     );
@@ -309,7 +307,6 @@ pub fn register_builtins(
         loader_v2_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            loader_v2_name.len(),
             solana_bpf_loader_program::Entrypoint::register,
         ),
     );
@@ -323,7 +320,6 @@ pub fn register_builtins(
         system_program_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            system_program_name.len(),
             solana_system_program::system_processor::Entrypoint::register,
         ),
     );
@@ -336,7 +332,6 @@ pub fn register_builtins(
         compute_budget_program_name,
         ProgramCacheEntry::new_builtin(
             DEPLOYMENT_SLOT,
-            compute_budget_program_name.len(),
             solana_compute_budget_program::Entrypoint::register,
         ),
     );


### PR DESCRIPTION
#### Problem

`ProgramCacheEntry::account_size` is not used anymore.

#### Summary of Changes

- Removes `ProgramCacheEntry::account_size`.
- Removes `account_size` parameter from `ProgramCacheEntry::new_builtin()`, `ProgramCacheEntry::new_internal()`, `ProgramCacheEntry::reload()`, `ProgramCacheEntry::new()`, `deploy_program()` and `deploy_program!()`.

#### Testing

No behavior changed.