### PR TITLE
Fix - Unrealistic `effective_slot`s in tests

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1052,6 +1052,10 @@ pub(crate) mod tests {
         effective_slot: Slot,
         stats: ProgramStatistics,
     ) -> Arc<ProgramCacheEntry> {
+        debug_assert_eq!(
+            effective_slot,
+            deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+        );
         Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
@@ -1067,6 +1071,7 @@ pub(crate) mod tests {
         deployment_slot: Slot,
         effective_slot: Slot,
     ) -> Arc<ProgramCacheEntry> {
+        debug_assert_eq!(effective_slot, deployment_slot);
         Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
             account_owner: ProgramCacheEntryOwner::NativeLoader,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1102,7 +1102,7 @@ pub(crate) mod tests {
         let env = get_mock_program_runtime_environment();
         let loaded = new_test_entry_with_usage(
             current_slot,
-            current_slot.saturating_add(1),
+            current_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             ProgramStatistics::default(),
         );
         let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
@@ -1146,7 +1146,7 @@ pub(crate) mod tests {
                     *deployment_slot,
                     new_test_entry_with_usage(
                         *deployment_slot,
-                        (*deployment_slot).saturating_add(2),
+                        (*deployment_slot).saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                         stats,
                     ),
                 );
@@ -1384,7 +1384,8 @@ pub(crate) mod tests {
                 uses: (i + 10).into(),
                 ..Default::default()
             };
-            let entry = new_test_entry_with_usage(i, i + 2, stats);
+            let entry =
+                new_test_entry_with_usage(i, i.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET), stats);
             cache.assign_program(&env, program, i, entry);
         });
 
@@ -1403,7 +1404,7 @@ pub(crate) mod tests {
                     // Test that the usage counter is retained for the unloaded program
                     assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
                     assert_eq!(program.deployment_slot, 0);
-                    assert_eq!(program.effective_slot, 2);
+                    assert_eq!(program.effective_slot, 1);
                 }
             });
 
@@ -1413,7 +1414,7 @@ pub(crate) mod tests {
             &env,
             program,
             0,
-            new_test_entry_with_usage(0, 2, ProgramStatistics::default()),
+            new_test_entry_with_usage(0, 1, ProgramStatistics::default()),
         );
 
         cache
@@ -1422,7 +1423,7 @@ pub(crate) mod tests {
             .for_each(|(_key, program)| {
                 if matches!(program.program, ProgramCacheEntryType::Unloaded(_))
                     && program.deployment_slot == 0
-                    && program.effective_slot == 2
+                    && program.effective_slot == 1
                 {
                     // Test that the usage counter was correctly updated.
                     assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
@@ -1433,8 +1434,8 @@ pub(crate) mod tests {
     #[test]
     fn test_fuzz_assign_program_order() {
         use rand::prelude::SliceRandom;
-        const EXPECTED_ENTRIES: [(u64, u64); 7] =
-            [(1, 2), (5, 5), (5, 6), (5, 10), (9, 10), (10, 10), (3, 12)];
+        const EXPECTED_ENTRIES: [(u64, bool); 5] =
+            [(1, true), (5, false), (5, true), (9, true), (10, false)];
         let mut rng = rand::rng();
         let program_id = Pubkey::new_unique();
         let env = get_mock_program_runtime_environment();
@@ -1442,7 +1443,7 @@ pub(crate) mod tests {
             let mut entries = EXPECTED_ENTRIES.to_vec();
             entries.shuffle(&mut rng);
             let mut cache = ProgramCache::<TestForkGraph>::new(0);
-            for (deployment_slot, effective_slot) in entries {
+            for (deployment_slot, delay_visibility) in entries {
                 let entry = Arc::new(ProgramCacheEntry {
                     program: new_loaded_entry(ProgramRuntimeEnvironment::from(
                         BuiltinProgram::new_mock(),
@@ -1450,18 +1451,21 @@ pub(crate) mod tests {
                     account_owner: ProgramCacheEntryOwner::LoaderV2,
                     account_size: 0,
                     deployment_slot,
-                    effective_slot,
+                    effective_slot: deployment_slot.saturating_add(delay_visibility as u64),
                     stats: Arc::default(),
                     latest_access_slot: AtomicU64::new(deployment_slot),
                 });
                 assert!(!cache.assign_program(&env, program_id, deployment_slot, entry));
             }
-            for ((deployment_slot, effective_slot), entry) in EXPECTED_ENTRIES
+            for ((deployment_slot, delay_visibility), entry) in EXPECTED_ENTRIES
                 .iter()
                 .zip(cache.get_slot_versions_for_tests(&program_id).iter())
             {
                 assert_eq!(entry.deployment_slot, *deployment_slot);
-                assert_eq!(entry.effective_slot, *effective_slot);
+                assert_eq!(
+                    entry.effective_slot,
+                    deployment_slot.saturating_add(*delay_visibility as u64)
+                );
             }
         }
     }
@@ -1684,7 +1688,7 @@ pub(crate) mod tests {
 
         // Add a program at slot 50, and a tombstone for the program at slot 60
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 50, new_test_builtin_entry(50, 51));
+        cache.assign_program(&env, program2, 50, new_test_builtin_entry(50, 50));
         let slot_versions = cache.get_slot_versions_for_tests(&program2);
         assert_eq!(slot_versions.len(), 1);
         assert!(!slot_versions.first().unwrap().is_tombstone());
@@ -1778,11 +1782,11 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 10, new_test_entry(10, 10));
+        cache.assign_program(&env, program1, 10, new_test_entry(10, 11));
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 20,
-            effective_slot: 20,
+            effective_slot: 21,
             ..Default::default()
         });
         cache.assign_program(&env, program1, 20, updated_program.clone());

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -261,6 +261,10 @@ impl ProgramCacheEntry {
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        debug_assert_eq!(
+            effective_slot,
+            deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+        );
         let entry_stats = ProgramStatistics::default();
         #[cfg(feature = "metrics")]
         let load_elf_time = solana_svm_measure::measure::Measure::start("load_elf_time");

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -466,7 +466,7 @@ mod tests {
             compilation_time_ema: AtomicU64::new(u64::MAX),
             ..Default::default()
         };
-        let program = new_test_entry_with_usage(0, 0, stats);
+        let program = new_test_entry_with_usage(0, 1, stats);
         program.update_access_slot(1);
         assert!(
             dbg!(program.retention_score()) <= 129,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -102,7 +102,7 @@ fn load_program_elf(program_name: &str) -> Vec<u8> {
 
 #[cfg(feature = "sbf_rust")]
 fn default_program_cache() -> solana_program_runtime::loaded_programs::ProgramCacheForTxBatch {
-    new_program_cache_with_builtins(/* slot */ 0)
+    new_program_cache_with_builtins(/* slot */ 1)
 }
 
 fn default_program_cache_with_program(
@@ -491,7 +491,7 @@ fn test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader() {
         (authority_pubkey, Account::default()),
     ];
 
-    let mut program_cache = default_program_cache();
+    let mut program_cache = new_program_cache_with_builtins(0);
     let sysvar_cache = default_sysvar_cache();
 
     // Build the deploy instruction (DeployWithMaxDataLen only, skip CreateAccount)
@@ -1417,7 +1417,7 @@ fn test_program_sbf_program_id_spoofing() {
         (to_pubkey, Account::new(0, 0, &system_program::id())),
     ]);
 
-    let mut program_cache = new_program_cache_with_builtins(0);
+    let mut program_cache = default_program_cache();
     add_program_to_program_cache(
         &mut program_cache,
         &malicious_swap_pubkey,
@@ -1476,7 +1476,7 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
         &caller_access_elf,
     ));
 
-    let mut program_cache = new_program_cache_with_builtins(0);
+    let mut program_cache = default_program_cache();
     add_program_to_program_cache(
         &mut program_cache,
         &caller_pubkey,
@@ -2345,7 +2345,7 @@ fn test_program_reads_from_program_account() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let mut program_cache = new_program_cache_with_builtins(0);
+    let mut program_cache = default_program_cache();
     add_program_to_program_cache(
         &mut program_cache,
         &program_id,
@@ -2387,7 +2387,7 @@ fn test_program_sbf_c_dup() {
     let program_id = Pubkey::new_unique();
 
     let feature_set = SVMFeatureSet::all_enabled();
-    let mut program_cache = new_program_cache_with_builtins(0);
+    let mut program_cache = default_program_cache();
     add_program_to_program_cache(
         &mut program_cache,
         &program_id,

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -413,7 +413,7 @@ mod tests {
         );
         let sysvar_cache = sysvar_cache_with_rent();
 
-        let mut program_cache = new_program_cache_with_builtins(0);
+        let mut program_cache = new_program_cache_with_builtins(1);
         add_program_to_program_cache(
             &mut program_cache,
             &program_id,

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -143,7 +143,7 @@ pub fn add_program_to_program_cache(
         loader_key,
         program_runtime_environment,
         0, // deployment_slot
-        0, // effective_slot
+        1, // effective_slot
         elf,
         elf.len(),
         #[cfg(feature = "metrics")]


### PR DESCRIPTION
#### Problem

Many tests have incorrect `effective_slot`s which wouldn't occur in production.

#### Summary of Changes

Fixes unrealistic `effective_slot` in tests.

#### Testing

Asserts that `effective_slot` does equal `deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET)` for all loaded entries. Also, asserts that `effective_slot` does equal `deployment_slot` for all tombstones and built-in entries.

