### PR TITLE
Runs frozen abi tests with agave-unstable-api

### DIFF
--- a/ci/test-frozen-abi.sh
+++ b/ci/test-frozen-abi.sh
@@ -11,11 +11,7 @@ source "$here/rust-version.sh" nightly
 
 packages=$(cargo +"$rust_nightly" metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.features | has("frozen-abi")) | .name')
 for package in $packages; do
-  features=frozen-abi
-  if [[ $package == agave-votor-messages || $package == agave-votor ]]; then
-    features+=,agave-unstable-api
-  fi
-  cmd="cargo +$rust_nightly test -p $package --features $features --lib -- test_abi_digest test_api_digest --nocapture"
+  cmd="cargo +$rust_nightly test -p $package --features frozen-abi,agave-unstable-api --lib -- test_abi_digest test_api_digest --nocapture"
   echo "--- $cmd"
   $cmd
 done

--- a/ci/test-frozen-abi.sh
+++ b/ci/test-frozen-abi.sh
@@ -11,7 +11,11 @@ source "$here/rust-version.sh" nightly
 
 packages=$(cargo +"$rust_nightly" metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.features | has("frozen-abi")) | .name')
 for package in $packages; do
-  cmd="cargo +$rust_nightly test -p $package --features frozen-abi --lib -- test_abi_digest test_api_digest --nocapture"
+  features=frozen-abi
+  if [[ $package == agave-votor-messages || $package == agave-votor ]]; then
+    features+=,agave-unstable-api
+  fi
+  cmd="cargo +$rust_nightly test -p $package --features $features --lib -- test_abi_digest test_api_digest --nocapture"
   echo "--- $cmd"
   $cmd
 done


### PR DESCRIPTION
#### Problem

Commit https://github.com/anza-xyz/agave/pull/14166/changes/10facde841cccdec45e3a438b418cd0f1cf61cbd in #14166  had modified some types that should've caused the frozen abi test to fail.  The failure was caught in the coverage test and not in the frozen abi test: https://buildkite.com/anza/agave/builds/56025

I believe this is because the frozen abi test is running without the `agave-unstable-api` feature which is preventing some tests from running.

#### Summary of Changes

Added the `agave-unstable-api` feature to the ci script


#### Testing

It does appear that in https://buildkite.com/anza/agave/builds/56025 we didn't run any tests for votor and votor-messages crate and in https://buildkite.com/anza/agave/builds/56036#019fa9c9-95af-41ae-93cb-50c39d89ffae we ran tests for both of them.
