### PR TITLE
Add scan wrapper around account storage entry

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -1,10 +1,12 @@
 use {
     crate::{
         account_info::Offset,
+        account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::AccountsFileId,
         accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider},
         obsolete_accounts::ObsoleteAccounts,
     },
+    agave_fs::buffered_reader::RequiredLenBufFileRead,
     solana_clock::Slot,
     solana_nohash_hasher::IntSet,
     std::{
@@ -286,6 +288,35 @@ impl AccountStorageEntry {
         prev_num_alive_accounts - num_accounts
     }
 
+    /// Collect the offsets that should be excluded from scans
+    fn excluded_offsets(&self) -> IntSet<Offset> {
+        let mut offsets: IntSet<Offset> = self
+            .obsolete_accounts_read_lock()
+            .filter_obsolete_accounts(None)
+            .map(|(offset, _)| offset)
+            .collect();
+        offsets.extend(self.tombstone_offsets_read_lock().iter().copied());
+        offsets
+    }
+
+    /// Iterate over the alive accounts in this storage, excluding obsolete accounts and tombstones.
+    /// The return value is the number of values excluded from the scan.
+    pub(crate) fn scan_accounts<'a>(
+        &'a self,
+        reader: &mut impl RequiredLenBufFileRead<'a>,
+        mut callback: impl for<'local> FnMut(Offset, StoredAccountInfo<'local>),
+    ) -> Result<u64, AccountsFileError> {
+        let excluded_offsets = self.excluded_offsets();
+        let mut num_excluded = 0;
+        self.accounts.scan_accounts(reader, |offset, account| {
+            if excluded_offsets.contains(&offset) {
+                num_excluded += 1;
+                return;
+            }
+            callback(offset, account);
+        })?;
+        Ok(num_excluded)
+    }
     /// Returns the path to the underlying accounts storage file
     pub fn path(&self) -> &Path {
         self.accounts.path()
@@ -301,5 +332,73 @@ impl AccountStorageEntry {
 
     pub(crate) fn zero_lamport_single_ref_offsets(&self) -> &RwLock<IntSet<Offset>> {
         &self.zero_lamport_single_ref_offsets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{accounts_db::get_temp_accounts_paths, append_vec::new_scan_accounts_reader},
+        solana_account::AccountSharedData,
+        solana_pubkey::Pubkey,
+    };
+
+    /// scan_accounts visits every account except those marked obsolete or recorded as a tombstone,
+    /// and returns the number of accounts it excluded.
+    #[test]
+    fn test_scan_accounts_excludes_obsolete_and_tombstones() {
+        let slot = 0;
+        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let storage = AccountStorageEntry::new(
+            &paths[0],
+            slot,
+            0,
+            1024 * 1024,
+            AccountsFileProvider::AppendVec,
+        );
+
+        // Write five accounts and capture their offsets.
+        let accounts: Vec<_> = (0..5)
+            .map(|_| {
+                (
+                    Pubkey::new_unique(),
+                    AccountSharedData::new(1, 10, &Pubkey::default()),
+                )
+            })
+            .collect();
+        let offsets = storage
+            .accounts
+            .write_accounts(&(slot, &accounts[..]))
+            .unwrap()
+            .offsets;
+
+        // Mark account 1 obsolete and record account 3 as a tombstone.
+        let obsolete_offset = offsets[1];
+        let tombstone_offset = offsets[3];
+        let data_lens = storage.accounts.get_account_data_lens(&[obsolete_offset]);
+        storage
+            .obsolete_accounts()
+            .write()
+            .unwrap()
+            .mark_accounts_obsolete(std::iter::once((obsolete_offset, data_lens[0])), slot);
+        storage.batch_insert_tombstone_offsets([tombstone_offset]);
+
+        // Scan and collect the accounts that were visited, in offset order.
+        let mut reader = new_scan_accounts_reader();
+        let mut visited = Vec::new();
+        let num_excluded = storage
+            .scan_accounts(&mut reader, |offset, account| {
+                visited.push((offset, *account.pubkey()));
+            })
+            .unwrap();
+
+        // Accounts 0, 2, and 4 are alive; 1 (obsolete) and 3 (tombstone) are excluded.
+        assert_eq!(num_excluded, 2);
+        let expected: Vec<_> = [0, 2, 4]
+            .iter()
+            .map(|&i| (offsets[i], accounts[i].0))
+            .collect();
+        assert_eq!(visited, expected);
     }
 }

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -290,7 +290,7 @@ impl AccountStorageEntry {
 
     /// Collect the offsets that should be excluded from scans
     fn excluded_offsets(&self) -> IntSet<Offset> {
-        let mut offsets: IntSet<Offset> = self
+        let mut offsets: IntSet<_> = self
             .obsolete_accounts_read_lock()
             .filter_obsolete_accounts(None)
             .map(|(offset, _)| offset)
@@ -358,10 +358,8 @@ impl AccountStorageEntry {
 #[cfg(test)]
 mod tests {
     use {
-        super::*,
-        crate::{accounts_db::get_temp_accounts_paths, append_vec::new_scan_accounts_reader},
-        solana_account::AccountSharedData,
-        solana_pubkey::Pubkey,
+        super::*, crate::append_vec::new_scan_accounts_reader, solana_account::AccountSharedData,
+        solana_pubkey::Pubkey, std::iter, tempfile::TempDir,
     };
 
     /// scan_accounts and scan_accounts_without_data each visit every account except those marked
@@ -369,9 +367,9 @@ mod tests {
     #[test]
     fn test_scan_accounts_excludes_obsolete_and_tombstones() {
         let slot = 0;
-        let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
+        let temp_dir = TempDir::new().unwrap();
         let storage = AccountStorageEntry::new(
-            &paths[0],
+            temp_dir.path(),
             slot,
             0,
             1024 * 1024,
@@ -379,14 +377,14 @@ mod tests {
         );
 
         // Write five accounts and capture their offsets.
-        let accounts: Vec<_> = (0..5)
-            .map(|_| {
-                (
-                    Pubkey::new_unique(),
-                    AccountSharedData::new(1, 10, &Pubkey::default()),
-                )
-            })
-            .collect();
+        let accounts: Vec<_> = iter::repeat_with(|| {
+            (
+                Pubkey::new_unique(),
+                AccountSharedData::new(1, 10, &Pubkey::default()),
+            )
+        })
+        .take(5)
+        .collect();
         let offsets = storage
             .accounts
             .write_accounts(&(slot, &accounts[..]))
@@ -401,7 +399,7 @@ mod tests {
             .obsolete_accounts()
             .write()
             .unwrap()
-            .mark_accounts_obsolete(std::iter::once((obsolete_offset, data_lens[0])), slot);
+            .mark_accounts_obsolete(iter::once((obsolete_offset, data_lens[0])), slot);
         storage.batch_insert_tombstone_offsets([tombstone_offset]);
 
         // Scan and collect the accounts that were visited, in offset order.

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         account_info::Offset,
-        account_storage::stored_account_info::StoredAccountInfo,
+        account_storage::stored_account_info::{StoredAccountInfo, StoredAccountInfoWithoutData},
         accounts_db::AccountsFileId,
         accounts_file::{AccountsFile, AccountsFileError, AccountsFileProvider},
         obsolete_accounts::ObsoleteAccounts,
@@ -317,6 +317,26 @@ impl AccountStorageEntry {
         })?;
         Ok(num_excluded)
     }
+
+    /// Iterate over the alive accounts in this storage without reading data, excluding obsolete
+    /// accounts and tombstones. The return value is the number of values excluded from the scan.
+    pub(crate) fn scan_accounts_without_data(
+        &self,
+        mut callback: impl for<'local> FnMut(Offset, StoredAccountInfoWithoutData<'local>),
+    ) -> Result<u64, AccountsFileError> {
+        let excluded_offsets = self.excluded_offsets();
+        let mut num_excluded = 0;
+        self.accounts
+            .scan_accounts_without_data(|offset, account| {
+                if excluded_offsets.contains(&offset) {
+                    num_excluded += 1;
+                    return;
+                }
+                callback(offset, account);
+            })?;
+        Ok(num_excluded)
+    }
+
     /// Returns the path to the underlying accounts storage file
     pub fn path(&self) -> &Path {
         self.accounts.path()
@@ -344,8 +364,8 @@ mod tests {
         solana_pubkey::Pubkey,
     };
 
-    /// scan_accounts visits every account except those marked obsolete or recorded as a tombstone,
-    /// and returns the number of accounts it excluded.
+    /// scan_accounts and scan_accounts_without_data each visit every account except those marked
+    /// obsolete or recorded as a tombstone, and return the number of accounts excluded.
     #[test]
     fn test_scan_accounts_excludes_obsolete_and_tombstones() {
         let slot = 0;
@@ -399,6 +419,16 @@ mod tests {
             .iter()
             .map(|&i| (offsets[i], accounts[i].0))
             .collect();
+        assert_eq!(visited, expected);
+
+        // scan_accounts_without_data excludes the same offsets from the same storage.
+        let mut visited = Vec::new();
+        let num_excluded = storage
+            .scan_accounts_without_data(|offset, account| {
+                visited.push((offset, *account.pubkey()));
+            })
+            .unwrap();
+        assert_eq!(num_excluded, 2);
         assert_eq!(visited, expected);
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4165,9 +4165,8 @@ impl AccountsDb {
             .get_slot_storage_entry_shrinking_in_progress_ok(remove_slot)
         {
             storage
-                .accounts
-                .scan_pubkeys(|pk| {
-                    stored_keys.insert((*pk, remove_slot));
+                .scan_accounts_without_data(|_offset, account| {
+                    stored_keys.insert((*account.pubkey(), remove_slot));
                 })
                 .expect("must scan accounts storage");
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6092,7 +6092,6 @@ impl AccountsDb {
                 let store_id = storage.id();
                 let slot = storage.slot();
                 storage
-                    .accounts
                     .scan_accounts_without_data(|offset, account| {
                         let key = account.pubkey();
                         self.accounts_index.get_and_then(key, |entry| {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1781,25 +1781,8 @@ impl AccountsDb {
             || Box::new(append_vec::new_scan_accounts_reader()),
             |reader, storage| {
                 let slot = storage.slot();
-                // Obsolete accounts and tombstones are not tracked by the accounts index — obsolete
-                // accounts are skipped during index generation, and tombstones were removed from the
-                // index when shrink created them — so neither contributes to the index refcount.
-                // Skip them here too, otherwise we would count a physical copy the index never
-                // tracked and report a spurious mismatch.
-                let obsolete_accounts: IntSet<_> = storage
-                    .obsolete_accounts_read_lock()
-                    .filter_obsolete_accounts(None)
-                    .map(|(offset, _)| offset)
-                    .collect();
-                let tombstone_offsets = storage.tombstone_offsets_read_lock();
                 storage
-                    .accounts
-                    .scan_accounts(reader.as_mut(), |offset, account| {
-                        if obsolete_accounts.contains(&offset)
-                            || tombstone_offsets.contains(&offset)
-                        {
-                            return;
-                        }
+                    .scan_accounts(reader.as_mut(), |_offset, account| {
                         let pk = account.pubkey();
                         match pubkey_refcount.entry(*pk) {
                             dashmap::mapref::entry::Entry::Occupied(mut occupied_entry) => {
@@ -1812,7 +1795,7 @@ impl AccountsDb {
                             }
                         }
                     })
-                    .expect("must scan accounts storage")
+                    .expect("must scan accounts storage");
             },
         );
         let total = pubkey_refcount.len();
@@ -5871,26 +5854,8 @@ impl AccountsDb {
         // Since we scan the storage from oldest to newest, we can simply increment a local
         // counter per account and use that for the write version.
         let mut write_version_for_geyser = 0;
-
-        // Collect all the obsolete accounts in this storage into a hashset for fast lookup.
-        // Safe to pass in 'None' which will return all obsolete accounts in this Slot.
-        // Any accounts marked obsolete in a slot newer than the snapshot slot were filtered out
-        // when the obsolete account data was serialized to disk for fastboot
-        let obsolete_accounts: IntSet<_> = storage
-            .obsolete_accounts_read_lock()
-            .filter_obsolete_accounts(None)
-            .map(|(offset, _)| offset)
-            .collect();
-        let mut num_obsolete_accounts_skipped = 0;
-
-        storage
-            .accounts
+        let num_obsolete_accounts_skipped = storage
             .scan_accounts(reader, |offset, account| {
-                if obsolete_accounts.contains(&offset) {
-                    num_obsolete_accounts_skipped += 1;
-                    return;
-                }
-
                 let data_len = account.data.len();
                 stored_size_alive += storage.accounts.calculate_stored_size(data_len);
                 let is_account_zero_lamport = account.is_zero_lamport();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -43,7 +43,7 @@ use {
             StoreAccountsForFlushStats, StoreAccountsForShrinkStats, StoreAccountsForSquashStats,
             StoreAccountsUnfrozenStats, WriteAccountsToCacheStats,
         },
-        accounts_file::{AccountsFile, AccountsFileProvider},
+        accounts_file::AccountsFileProvider,
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, AccountsIndexScanResult, IndexKey,
@@ -3566,7 +3566,7 @@ impl AccountsDb {
         &self,
         slot: Slot,
         cache_map_func: impl Fn(&LoadedAccount) -> Option<R> + Sync,
-        storage_fallback_func: impl Fn(&mut B, &AccountsFile) + Sync,
+        storage_fallback_func: impl Fn(&mut B, &AccountStorageEntry) + Sync,
     ) -> ScanStorageResult<R, B>
     where
         R: Send,
@@ -3616,7 +3616,7 @@ impl AccountsDb {
                 .storage
                 .get_slot_storage_entry_shrinking_in_progress_ok(slot)
             {
-                storage_fallback_func(&mut retval, &storage.accounts);
+                storage_fallback_func(&mut retval, &storage);
             }
 
             ScanStorageResult::Stored(retval)

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1641,7 +1641,6 @@ impl AccountsDb {
                 .for_each(|dirty_store_chunk| {
                     dirty_store_chunk.iter().for_each(|(_slot, store)| {
                         store
-                            .accounts
                             .scan_accounts_without_data(|_offset, account| {
                                 let pubkey = *account.pubkey();
                                 let is_zero_lamport = account.is_zero_lamport();

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4912,25 +4912,6 @@ impl AccountsDb {
         }
     }
 
-    /// Returns all of the accounts' pubkeys for a given slot
-    pub fn get_pubkeys_for_slot(&self, slot: Slot) -> Vec<Pubkey> {
-        let scan_result = self.scan_cache_storage_fallback(
-            slot,
-            |loaded_account| Some(*loaded_account.pubkey()),
-            |accum: &mut HashSet<Pubkey>, storage| {
-                storage
-                    .scan_pubkeys(|pubkey| {
-                        accum.insert(*pubkey);
-                    })
-                    .expect("must scan accounts storage");
-            },
-        );
-        match scan_result {
-            ScanStorageResult::Cached(cached_result) => cached_result,
-            ScanStorageResult::Stored(stored_result) => stored_result.into_iter().collect(),
-        }
-    }
-
     /// Return all of the accounts for a given slot
     pub fn get_pubkey_account_for_slot(&self, slot: Slot) -> Vec<(Pubkey, AccountSharedData)> {
         let scan_result = self.scan_account_storage(

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1,7 +1,7 @@
 use {
     super::*,
     crate::{
-        accounts_file::AccountsFileProvider,
+        accounts_file::{AccountsFile, AccountsFileProvider},
         accounts_index::{
             ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountIndex, AccountSecondaryIndexesIncludeExclude,
             AccountsIndexConfig, IndexLimit, IndexLimitThreshold, test_utils::*,

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -6634,7 +6634,6 @@ fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
         if let Some(storage) = db.get_storage_for_slot(slot) {
             let mut reader = crate::append_vec::new_scan_accounts_reader();
             storage
-                .accounts
                 .scan_accounts(&mut reader, |offset, account| {
                     let info = AccountInfo::new(
                         StorageLocation::AppendVec(storage.id(), offset),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11343,13 +11343,8 @@ fn test_register_hard_fork() {
 #[test]
 fn test_last_restart_slot() {
     fn last_restart_slot_dirty(bank: &Bank) -> bool {
-        let dirty_accounts = bank
-            .rc
-            .accounts
-            .accounts_db
-            .get_pubkeys_for_slot(bank.slot());
-        let dirty_accounts: HashSet<_> = dirty_accounts.into_iter().collect();
-        dirty_accounts.contains(&sysvar::last_restart_slot::id())
+        bank.get_account_modified_slot(&sysvar::last_restart_slot::id())
+            .is_some_and(|(_, slot)| slot == bank.slot())
     }
 
     fn get_last_restart_slot(bank: &Bank) -> Option<Slot> {


### PR DESCRIPTION
#### Problem
Scan_accounts and scan_accounts_without_data should generally skip tombstones and obsolete accounts. This is currently done manually at the callsites. This leads to bugs and wasted work (eg ref_count bug previously, index verification bug)

#### Summary of Changes
Several commits, best looked at individually. All quite small. 
1. add a scan_accounts function to account storage entry that excludes tombstones and obsolete accounts. Modify existing callers that exclude in caller to exclude in function
2. Move populate_index to use the new function. Note that this function currently creates the storages and populates the index directly, so currently does not have any obsolete/tombstones (ie net zero change). After this it could be modified to include tombstones/obsolete accounts easily
3. Add a scan_accounts_without_data function similar to scan_accounts. Use this in clean as tombstones and obsolete accounts do not need to be recleaned
4. Modify index verify to use new scan_accounts_without_data function, as it matches index generation. Note that tombstones are not created during index generation yet, so just skips obsolete accounts during fastboot
5. Convert purge to use new function. Obsolete and tombstoned accounts should not be touched by purge
6. Remove get_pubkeys_for_slot and replace single test caller with a more correct function
7. Switch scan_cache_storage_fallback to use account storage entries rather than accounts files


Note that exclude terminology comes from account storage reader. 

#### Testing
Added testing of new functions

Fixes #
