### PR TITLE
Asserting accounts are alive in shrink now, as unref is no longer used

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -254,7 +254,6 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
 pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
     pub(crate) slot: Slot,
     pub(crate) written_bytes: u64,
-    pub(crate) pubkeys_to_unref: Vec<&'a Pubkey>,
     pub(crate) zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
     pub(crate) alive_accounts: T,
     /// Zero-lamport accounts written to the new storage as tombstones rather than live accounts.
@@ -271,9 +270,6 @@ pub(crate) struct ShrinkCollect<'a, T: ShrinkCollectRefs<'a>> {
 struct LoadAccountsIndexForShrink<'a, T: ShrinkCollectRefs<'a>> {
     /// all alive accounts
     alive_accounts: T,
-    /// pubkeys that are going to be unref'd in the accounts index after we are
-    /// done with shrinking, because they are dead
-    pubkeys_to_unref: Vec<&'a Pubkey>,
     /// pubkeys that are the last remaining zero lamport instance of an account
     zero_lamport_single_ref_pubkeys: Vec<&'a Pubkey>,
     /// accounts that are zero lamport but not indexed
@@ -2426,7 +2422,6 @@ impl AccountsDb {
 
     /// load the account index entry for the first `count` items in `accounts`
     /// store a reference to all alive accounts in `alive_accounts`
-    /// store all pubkeys dead in `slot_to_shrink` in `pubkeys_to_unref`
     /// return sum of account size for all alive accounts
     fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
         &self,
@@ -2438,12 +2433,10 @@ impl AccountsDb {
             self.can_purge_zero_lamport_single_ref_after_shrink(slot_to_shrink);
         let count = accounts.len();
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
-        let mut pubkeys_to_unref = Vec::with_capacity(count);
         let mut zero_lamport_single_ref_pubkeys = Vec::with_capacity(count);
         let mut tombstones = Vec::new();
 
         let mut alive = 0;
-        let mut dead = 0;
         let mut index = 0;
         let mut index_scan_returned_some_count = 0;
         let mut index_scan_returned_none_count = 0;
@@ -2476,16 +2469,9 @@ impl AccountsDb {
                         *slot == slot_to_shrink
                     });
 
-                    if !is_alive {
-                        // This pubkey was found in the storage, but no longer exists in the index.
-                        // It would have had a ref to the storage from the initial store, but it will
-                        // not exist in the re-written slot. Unref it to keep the index consistent with
-                        // rewriting the storage entries.
-                        pubkeys_to_unref.push(pubkey);
-                        dead += 1;
-                    } else {
-                        do_populate_accounts_for_shrink(ref_count, slot_list);
-                    }
+                    // All obsolete and tombstones have been filtered. Account MUST be alive in this slot
+                    assert!(is_alive);
+                    do_populate_accounts_for_shrink(ref_count, slot_list);
                 } else {
                     index_scan_returned_none_count += 1;
                     // getting None here means the account is 'normal' and was written to disk. This means it must have ref_count=1 and
@@ -2511,11 +2497,9 @@ impl AccountsDb {
             .index_scan_returned_none
             .fetch_add(index_scan_returned_none_count, Ordering::Relaxed);
         stats.alive_accounts.fetch_add(alive, Ordering::Relaxed);
-        stats.dead_accounts.fetch_add(dead, Ordering::Relaxed);
 
         LoadAccountsIndexForShrink {
             alive_accounts,
-            pubkeys_to_unref,
             zero_lamport_single_ref_pubkeys,
             tombstones,
             all_are_zero_lamports,
@@ -2627,7 +2611,6 @@ impl AccountsDb {
         let shrink_collect = Mutex::new(ShrinkCollect {
             slot,
             written_bytes: *written_bytes,
-            pubkeys_to_unref: Vec::with_capacity(len),
             zero_lamport_single_ref_pubkeys: Vec::new(),
             alive_accounts: T::with_capacity(len, slot),
             tombstones_to_carry_forward,
@@ -2649,7 +2632,6 @@ impl AccountsDb {
                 .for_each(|stored_accounts| {
                     let LoadAccountsIndexForShrink {
                         alive_accounts,
-                        mut pubkeys_to_unref,
                         all_are_zero_lamports,
                         mut zero_lamport_single_ref_pubkeys,
                         mut tombstones,
@@ -2658,9 +2640,6 @@ impl AccountsDb {
                     // collect
                     let mut shrink_collect = shrink_collect.lock().unwrap();
                     shrink_collect.alive_accounts.collect(alive_accounts);
-                    shrink_collect
-                        .pubkeys_to_unref
-                        .append(&mut pubkeys_to_unref);
                     shrink_collect
                         .zero_lamport_single_ref_pubkeys
                         .append(&mut zero_lamport_single_ref_pubkeys);
@@ -2755,19 +2734,11 @@ impl AccountsDb {
         let dead_storages = self.mark_dirty_dead_stores(
             shrink_collect.slot,
             // If all accounts are zero lamports, then we want to mark the entire OLD append vec as dirty.
-            // otherwise, we'll call 'add_uncleaned_pubkeys_after_shrink' just on the unref'd keys below.
             shrink_collect.all_are_zero_lamports,
             shrink_in_progress,
             shrink_can_be_active,
         );
         let dead_storages_len = dead_storages.len();
-
-        if !shrink_collect.all_are_zero_lamports {
-            self.add_uncleaned_pubkeys_after_shrink(
-                shrink_collect.slot,
-                shrink_collect.pubkeys_to_unref.iter().cloned().cloned(),
-            );
-        }
 
         let (_, drop_storage_entries_elapsed) = measure_us!(drop(dead_storages));
         time.stop();
@@ -2781,47 +2752,6 @@ impl AccountsDb {
         stats
             .remove_old_stores_shrink_us
             .fetch_add(time.as_us(), Ordering::Relaxed);
-    }
-
-    pub(crate) fn unref_shrunk_dead_accounts<'a>(
-        &self,
-        pubkeys: impl Iterator<Item = &'a Pubkey>,
-        slot: Slot,
-    ) {
-        self.accounts_index.scan(
-            pubkeys,
-            |pubkey, slot_refs| {
-                match slot_refs {
-                    Some((slot_list, ref_count)) => {
-                        // Let's handle the special case - after unref, the result is a single ref zero lamport account.
-                        if slot_list.len() == 1
-                            && ref_count == 2
-                            && let Some((slot_alive, acct_info)) = slot_list.first()
-                            && acct_info.is_zero_lamport()
-                        {
-                            self.zero_lamport_single_ref_found(*slot_alive, acct_info.offset());
-                        }
-                    }
-                    None => {
-                        // We also expect that the accounts index must contain an
-                        // entry for `pubkey`. Log a warning for now. In future,
-                        // we will panic when this happens.
-                        warn!(
-                            "pubkey {pubkey} in slot {slot} was NOT found in accounts index \
-                             during shrink"
-                        );
-                        datapoint_warn!(
-                            "accounts_db-shink_pubkey_missing_from_index",
-                            ("store_slot", slot, i64),
-                            ("pubkey", pubkey.to_string(), String),
-                        );
-                    }
-                }
-                AccountsIndexScanResult::Unref
-            },
-            None,
-            ScanFilter::All,
-        );
     }
 
     /// This function handles the case when zero lamport single ref accounts are found during shrink.
@@ -2923,8 +2853,6 @@ impl AccountsDb {
                 .fetch_add(1, Ordering::Relaxed);
             return;
         }
-
-        self.unref_shrunk_dead_accounts(shrink_collect.pubkeys_to_unref.iter().cloned(), slot);
 
         let total_accounts_after_shrink = shrink_collect.alive_accounts.len();
         debug!(
@@ -3190,36 +3118,6 @@ impl AccountsDb {
             .select_slots_us
             .fetch_add(select_slots_us, Ordering::Relaxed);
         self.combine_ancient_slots_packed(sorted_slots, can_randomly_shrink);
-    }
-
-    /// add all 'pubkeys' into the set of pubkeys that are 'uncleaned', associated with 'slot'
-    /// clean will visit these pubkeys next time it runs
-    fn add_uncleaned_pubkeys_after_shrink(
-        &self,
-        slot: Slot,
-        pubkeys: impl Iterator<Item = Pubkey>,
-    ) {
-        /*
-        This is only called during 'shrink'-type operations.
-        Original accounts were separated into 'accounts' and 'pubkeys_to_unref'.
-        These sets correspond to 'alive' and 'dead'.
-        'alive' means this account in this slot is in the accounts index.
-        'dead' means this account in this slot is NOT in the accounts index.
-        If dead, nobody will care if this version of this account is not written into the newly shrunk append vec for this slot.
-        For all dead accounts, they were already unrefed and are now absent in the new append vec.
-        This means that another version of this pubkey could possibly now be cleaned since this one is now gone.
-        For example, a zero lamport account in a later slot can be removed if we just removed the only non-zero lamport account for that pubkey in this slot.
-        So, for all unrefed accounts, send them to clean to be revisited next time clean runs.
-        If an account is alive, then its status has not changed. It was previously alive in this slot. It is still alive in this slot.
-        Clean doesn't care about alive accounts that remain alive.
-        Except... A slightly different case is if ALL the alive accounts in this slot are zero lamport accounts, then it is possible that
-        this slot can be marked dead. So, if all alive accounts are zero lamports, we send the entire OLD/pre-shrunk append vec
-        to clean so that all the pubkeys are visited.
-        It is a performance optimization to not send the ENTIRE old/pre-shrunk append vec to clean in the normal case.
-        */
-
-        let mut uncleaned_pubkeys = self.uncleaned_pubkeys.entry(slot).or_default();
-        uncleaned_pubkeys.extend(pubkeys);
     }
 
     pub fn shrink_candidate_slots(&self, epoch_schedule: &EpochSchedule) -> usize {

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -386,7 +386,6 @@ pub struct ShrinkStats {
     pub bytes_removed: AtomicU64,
     pub bytes_written: AtomicU64,
     pub skipped_shrink: AtomicU64,
-    pub dead_accounts: AtomicU64,
     pub alive_accounts: AtomicU64,
     pub index_scan_returned_none: AtomicU64,
     pub index_scan_returned_some: AtomicU64,
@@ -563,11 +562,6 @@ impl ShrinkStats {
                 (
                     "alive_accounts",
                     self.alive_accounts.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "dead_accounts",
-                    self.dead_accounts.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -781,11 +775,6 @@ impl ShrinkAncientStats {
             (
                 "alive_accounts",
                 self.shrink_stats.alive_accounts.swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "dead_accounts",
-                self.shrink_stats.dead_accounts.swap(0, Ordering::Relaxed),
                 i64
             ),
             (

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1369,9 +1369,9 @@ fn test_shrink_does_not_resurrect_dead_account() {
     assert!(accounts.contains(&pubkey2));
     assert_eq!(accounts.alive_account_count_in_slot(1), 1);
 
-    // Shrink's dead-account unref above released the stale slot 1 ref, leaving the zero-lamport
-    // version single-ref. With no full snapshot retaining it, a final clean fully purges the
-    // pubkey.
+    // Clean's reclaims released the refs for the superseded slot 1 and slot 2 versions, leaving
+    // the zero-lamport version single-ref. With no full snapshot retaining it, the final clean
+    // fully purges the pubkey.
     accounts.clean_accounts_for_tests();
     assert!(!accounts.contains(&pubkey));
 }
@@ -5976,15 +5976,6 @@ fn test_mark_dirty_dead_stores() {
 }
 
 #[test]
-fn test_add_uncleaned_pubkeys_after_shrink() {
-    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let slot = 0;
-    let pubkey = Pubkey::from([1; 32]);
-    db.add_uncleaned_pubkeys_after_shrink(slot, vec![pubkey].into_iter());
-    assert_eq!(&*db.uncleaned_pubkeys.get(&slot).unwrap(), &vec![pubkey]);
-}
-
-#[test]
 fn test_sweep_get_oldest_non_ancient_slot_max() {
     let epoch_schedule = EpochSchedule::default();
     // way into future
@@ -6271,15 +6262,34 @@ fn test_shrink_collect_simple() {
                                 }
                             }
                             db.add_root_and_flush_write_cache(slot5);
+                            let storage = db.get_storage_for_slot(slot5).unwrap();
+                            // mark dead accounts obsolete and remove them from the index, as
+                            // clean does when it reclaims an account
                             to_purge.iter().for_each(|pubkey| {
+                                let account_info = db
+                                    .accounts_index
+                                    .get_with_and_then(
+                                        pubkey,
+                                        &Ancestors::from(vec![slot5]),
+                                        false,
+                                        |(_slot, account_info)| account_info,
+                                    )
+                                    .unwrap();
+                                let data_len = if is_zero_lamport(pubkey) { 0 } else { space };
+                                storage
+                                    .obsolete_accounts
+                                    .write()
+                                    .unwrap()
+                                    .mark_accounts_obsolete(
+                                        std::iter::once((account_info.offset(), data_len)),
+                                        slot5,
+                                    );
                                 db.accounts_index.purge_exact(
                                     pubkey,
                                     [slot5].into_iter().collect::<HashSet<_>>(),
                                     &mut ReclaimsSlotList::new(),
                                 );
                             });
-
-                            let storage = db.get_storage_for_slot(slot5).unwrap();
                             let mut unique_accounts = db
                                 .get_unique_accounts_from_storage_for_shrink(
                                     &storage,
@@ -6331,16 +6341,6 @@ fn test_shrink_collect_simple() {
                                     .collect::<Vec<_>>()
                             };
 
-                            let expected_unrefed = if alive {
-                                expect_single_opposite_alive_account.clone()
-                            } else {
-                                pubkeys[..normal_account_count]
-                                    .iter()
-                                    .sorted()
-                                    .cloned()
-                                    .collect::<Vec<_>>()
-                            };
-
                             assert_eq!(shrink_collect.slot, slot5);
 
                             assert_eq!(
@@ -6373,16 +6373,6 @@ fn test_shrink_collect_simple() {
                                     .sorted()
                                     .collect::<Vec<_>>(),
                                 expected_tombstones
-                            );
-                            assert_eq!(
-                                shrink_collect
-                                    .pubkeys_to_unref
-                                    .iter()
-                                    .sorted()
-                                    .cloned()
-                                    .cloned()
-                                    .collect::<Vec<_>>(),
-                                expected_unrefed
                             );
 
                             let alive_total_one_account = AppendVec::calculate_stored_size(space);
@@ -6435,7 +6425,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
 
     let mut regular_pubkeys = Vec::new();
     let mut obsolete_pubkeys = Vec::new();
-    let mut unref_pubkeys = Vec::new();
+    let mut purged_pubkeys = Vec::new();
 
     for (i, pubkey) in pubkeys.iter().enumerate() {
         if i % 3 == 0 {
@@ -6472,13 +6462,15 @@ fn test_shrink_collect_with_obsolete_accounts() {
 
             obsolete_pubkeys.push(*pubkey);
         } else if i % 4 == 0 {
-            // Purge accounts via clean and ensure that they will be unreffed.
+            // Remove from the index and mark obsolete, as clean does when it reclaims an account
+            let mut reclaims = ReclaimsSlotList::new();
             db.accounts_index.purge_exact(
                 pubkey,
                 [slot].into_iter().collect::<HashSet<_>>(),
-                &mut ReclaimsSlotList::new(),
+                &mut reclaims,
             );
-            unref_pubkeys.push(*pubkey);
+            db.remove_dead_accounts(reclaims.iter(), MarkAccountsObsolete::Yes(slot));
+            purged_pubkeys.push(*pubkey);
         }
     }
 
@@ -6493,15 +6485,6 @@ fn test_shrink_collect_with_obsolete_accounts() {
 
     assert_eq!(shrink_collect.slot, slot);
 
-    // Ensure that the keys to unref does not include the obsolete accounts and only includes the unreferenced accounts
-    assert_eq!(
-        shrink_collect
-            .pubkeys_to_unref
-            .into_iter()
-            .collect::<HashSet<_>>(),
-        unref_pubkeys.iter().clone().collect::<HashSet<_>>()
-    );
-
     // Ensure that the obsolete accounts and accounts to unref are not in the alive list
     assert_eq!(
         shrink_collect
@@ -6513,7 +6496,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
             .collect::<Vec<Pubkey>>(),
         regular_pubkeys
             .into_iter()
-            .filter(|account| !unref_pubkeys.contains(account))
+            .filter(|account| !purged_pubkeys.contains(account))
             .filter(|account| !obsolete_pubkeys.contains(account))
             .sorted()
             .collect::<Vec<Pubkey>>()

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -508,16 +508,6 @@ impl AccountsDb {
             return;
         }
 
-        accounts_to_combine
-            .accounts_to_combine
-            .iter()
-            .for_each(|combine| {
-                self.unref_shrunk_dead_accounts(
-                    combine.pubkeys_to_unref.iter().cloned(),
-                    combine.slot,
-                );
-            });
-
         let write_ancient_accounts = self.write_packed_storages(&accounts_to_combine, pack);
 
         self.finish_combine_ancient_slots_packed_internal(
@@ -894,8 +884,7 @@ impl AccountsDb {
                 // This would fail the invariant that the highest slot # where an account exists defines the most recent account.
                 // It could be a clean error or a transient condition that will resolve if we encounter this situation.
                 // The count of these accounts per call will be reported by metrics in `unpackable_slots_count`
-                if shrink_collect.pubkeys_to_unref.is_empty()
-                    && shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                if shrink_collect.alive_accounts.one_ref.accounts.is_empty()
                     && shrink_collect
                         .alive_accounts
                         .many_refs_this_is_newest_alive
@@ -1143,9 +1132,7 @@ mod tests {
                     remove_account_for_tests,
                 },
             },
-            accounts_index::{
-                AccountsIndexScanResult, ReclaimsSlotList, RefCount, ScanFilter, UpsertReclaim,
-            },
+            accounts_index::{ReclaimsSlotList, UpsertReclaim},
             append_vec::{self, AppendVec},
             storable_accounts::StorableAccountsBySlot,
             utils::create_account_shared_data,
@@ -1190,6 +1177,27 @@ mod tests {
             slot1..(slot1 + slots as Slot),
             slot_infos,
         )
+    }
+
+    /// Give every account backing `storages` a second index entry at slot 0. Sample-storage
+    /// slots start at 1, so slot 0 is older than all of them: each account ends up with
+    /// slot_list.len() == 2 while its storage slot stays newest
+    fn add_older_ref(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
+        storages.iter().for_each(|storage| {
+            db.get_unique_accounts_from_storage(storage)
+                .stored_accounts
+                .iter()
+                .for_each(|account| {
+                    db.accounts_index.upsert(
+                        0,
+                        0,
+                        account.pubkey(),
+                        AccountInfo::new(StorageLocation::AppendVec(0, 0), false),
+                        &mut ReclaimsSlotList::new(),
+                        UpsertReclaim::IgnoreReclaims,
+                    );
+                });
+        });
     }
 
     fn unique_to_accounts<'a>(
@@ -1756,19 +1764,8 @@ mod tests {
                                     slots_vec = slots.collect::<Vec<_>>()
                                 }
 
-                                let original_results = storages
-                                    .iter()
-                                    .map(|store| db.get_unique_accounts_from_storage(store))
-                                    .collect::<Vec<_>>();
                                 if two_refs {
-                                    original_results.iter().for_each(|results| {
-                                        results.stored_accounts.iter().for_each(|account| {
-                                            db.accounts_index
-                                                .get_and_then(account.pubkey(), |entry| {
-                                                    (false, entry.unwrap().addref())
-                                                });
-                                        })
-                                    });
+                                    add_older_ref(&db, &storages);
                                 }
 
                                 if add_dead_account {
@@ -1782,6 +1779,22 @@ mod tests {
                                             alive,
                                             Some(&db.accounts_index),
                                         );
+                                        // mark the account obsolete and remove it from the index,
+                                        // as clean does when it reclaims an account
+                                        let account_offset =
+                                            db.accounts_index.get_and_then(&pk, |entry| {
+                                                let slot_list =
+                                                    entry.unwrap().slot_list_read_lock();
+                                                (false, slot_list.first().unwrap().1.offset())
+                                            });
+                                        storage
+                                            .obsolete_accounts
+                                            .write()
+                                            .unwrap()
+                                            .mark_accounts_obsolete(
+                                                std::iter::once((account_offset, 0)),
+                                                storage.slot(),
+                                            );
                                         assert!(
                                             db.accounts_index.purge_exact(
                                                 &pk,
@@ -1831,14 +1844,6 @@ mod tests {
                                      {two_refs}, many_refs: {many_ref_slots:?}"
                                 );
 
-                                if add_dead_account {
-                                    assert!(
-                                        !accounts_to_combine
-                                            .accounts_to_combine
-                                            .iter()
-                                            .any(|a| a.pubkeys_to_unref.is_empty())
-                                    );
-                                }
                                 let expected_target_slots_sorted = if !two_refs
                                     || many_ref_slots == IncludeManyRefSlots::Include
                                     || num_slots == 1
@@ -3767,89 +3772,6 @@ mod tests {
             &target_slots_sorted,
             &tuning
         ));
-    }
-
-    #[test]
-    fn test_shrink_ancient_expected_unref() {
-        let db = AccountsDb::default_for_tests();
-        for count in 0..3 {
-            let pubkeys_to_unref = (0..count)
-                .map(|_| solana_pubkey::new_rand())
-                .collect::<Vec<_>>();
-            // how many of `many_ref_accounts` should be found in the index with ref_count=1
-            let mut expected_ref_counts_before_unref = HashMap::<Pubkey, RefCount>::default();
-            let mut expected_ref_counts_after_unref = HashMap::<Pubkey, RefCount>::default();
-
-            pubkeys_to_unref.iter().for_each(|k| {
-                for slot in 0..2 {
-                    // each upsert here (to a different slot) adds a refcount of 1 since entry is NOT cached
-                    db.accounts_index.upsert(
-                        slot,
-                        slot,
-                        k,
-                        AccountInfo::default(),
-                        &mut ReclaimsSlotList::new(),
-                        UpsertReclaim::IgnoreReclaims,
-                    );
-                }
-                expected_ref_counts_before_unref.insert(*k, 2);
-                expected_ref_counts_after_unref.insert(*k, 1);
-            });
-
-            let shrink_collect = ShrinkCollect::<ShrinkCollectAliveSeparatedByRefs> {
-                // the only interesting field
-                pubkeys_to_unref: pubkeys_to_unref.iter().collect(),
-
-                // irrelevant fields
-                zero_lamport_single_ref_pubkeys: Vec::default(),
-                slot: 0,
-                written_bytes: 0,
-                alive_accounts: ShrinkCollectAliveSeparatedByRefs {
-                    one_ref: AliveAccounts::default(),
-                    many_refs_this_is_newest_alive: AliveAccounts::default(),
-                    many_refs_old_alive: AliveAccounts::default(),
-                },
-                tombstones_to_carry_forward: Vec::new(),
-                tombstones_total_bytes: 0,
-                alive_total_bytes: 0,
-                total_starting_accounts: 0,
-                all_are_zero_lamports: false,
-            };
-
-            // Assert ref_counts before unref.
-            db.accounts_index.scan(
-                shrink_collect.pubkeys_to_unref.iter().cloned(),
-                |k, slot_refs| {
-                    assert_eq!(
-                        expected_ref_counts_before_unref.remove(k).unwrap(),
-                        slot_refs.unwrap().1
-                    );
-                    AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
-                },
-                None,
-                ScanFilter::All,
-            );
-            assert!(expected_ref_counts_before_unref.is_empty());
-
-            // unref ref_counts
-            db.unref_shrunk_dead_accounts(shrink_collect.pubkeys_to_unref.iter().cloned(), 0);
-
-            // Assert ref_counts after unref
-            db.accounts_index.scan(
-                shrink_collect.pubkeys_to_unref.iter().cloned(),
-                |k, slot_refs| {
-                    assert_eq!(
-                        expected_ref_counts_after_unref.remove(k).unwrap(),
-                        slot_refs.unwrap().1
-                    );
-                    AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
-                },
-                None,
-                ScanFilter::All,
-            );
-            // should have removed all of them
-            assert!(expected_ref_counts_after_unref.is_empty());
-        }
     }
 
     /// The purpose of this test is to ensure the correct control flow


### PR DESCRIPTION
#### Problem
Accounts can no longer be dead in shrink. The last location where a slot list entry could be removed without reducing ref_count was removed in https://github.com/anza-xyz/agave/pull/14012

Previously dead_accounts was zero unless scan was involved. Now even with scan involved there are no dead_accounts
<img width="1685" height="573" alt="image" src="https://github.com/user-attachments/assets/39887b71-d3e2-488f-a2a5-15343cef7112" />

This makes it safe to remove all the handling code (and make ref_count removal fairly obvious in the next PR).

#### Summary of Changes
- Assert in shrink that any account that is not obsolete, and not a tombstone is still alive
- Corresponding dead code removal

#### Testing
Verif

Fixes #
