### PR TITLE
refactor - remove transaction-cost wrapping of usage-cost-details

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1269,9 +1269,8 @@ mod tests {
                 };
 
             let mut cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set);
-            let usage_cost = cost.usage_cost_details_mut();
-            usage_cost.programs_execution_cost = actual_programs_execution_cost;
-            usage_cost.loaded_accounts_data_size_cost = actual_loaded_accounts_data_size_cost;
+            cost.programs_execution_cost = actual_programs_execution_cost;
+            cost.loaded_accounts_data_size_cost = actual_loaded_accounts_data_size_cost;
 
             block_cost + cost.sum()
         };

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -115,7 +115,7 @@ impl CostModel {
         let allocated_accounts_data_size =
             Self::calculate_allocated_accounts_data_size(instructions, feature_set);
 
-        let usage_cost_details = UsageCostDetails {
+        TransactionCost {
             transaction,
             signature_cost,
             write_lock_cost,
@@ -123,9 +123,7 @@ impl CostModel {
             programs_execution_cost,
             loaded_accounts_data_size_cost,
             allocated_accounts_data_size,
-        };
-
-        TransactionCost::new(usage_cost_details)
+        }
     }
 
     /// Returns signature details and the total signature cost

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -480,11 +480,11 @@ mod tests {
         }
     }
 
-    fn simple_usage_cost_details(
+    fn simple_transaction_cost(
         transaction: &WritableKeysTransaction,
         programs_execution_cost: u64,
-    ) -> UsageCostDetails<'_, WritableKeysTransaction> {
-        UsageCostDetails {
+    ) -> TransactionCost<'_, WritableKeysTransaction> {
+        TransactionCost {
             transaction,
             signature_cost: 0,
             write_lock_cost: 0,
@@ -495,20 +495,10 @@ mod tests {
         }
     }
 
-    fn simple_transaction_cost(
-        transaction: &WritableKeysTransaction,
-        programs_execution_cost: u64,
-    ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost::new(simple_usage_cost_details(
-            transaction,
-            programs_execution_cost,
-        ))
-    }
-
     fn simple_vote_transaction_cost(
         transaction: &WritableKeysTransaction,
     ) -> TransactionCost<'_, WritableKeysTransaction> {
-        TransactionCost::new(UsageCostDetails {
+        TransactionCost {
             transaction,
             signature_cost: 1,
             write_lock_cost: 2,
@@ -516,7 +506,7 @@ mod tests {
             programs_execution_cost: solana_vote_program::vote_processor::DEFAULT_COMPUTE_UNITS,
             loaded_accounts_data_size_cost: 8,
             allocated_accounts_data_size: 0,
-        })
+        }
     }
 
     #[test]
@@ -565,9 +555,7 @@ mod tests {
         let mint_keypair = test_setup();
         let tx = build_simple_transaction(&mint_keypair);
         let mut tx_cost = simple_transaction_cost(&tx, 5);
-        tx_cost
-            .usage_cost_details_mut()
-            .allocated_accounts_data_size = 1;
+        tx_cost.allocated_accounts_data_size = 1;
         let cost = tx_cost.sum();
 
         // build testee to have capacity for one simple transaction
@@ -714,12 +702,8 @@ mod tests {
         let mut tx_cost1 = simple_transaction_cost(&tx1, 5);
         let tx2 = build_simple_transaction(&second_account);
         let mut tx_cost2 = simple_transaction_cost(&tx2, 5);
-        tx_cost1
-            .usage_cost_details_mut()
-            .allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
-        tx_cost2
-            .usage_cost_details_mut()
-            .allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA + 1;
+        tx_cost1.allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA;
+        tx_cost2.allocated_accounts_data_size = MAX_BLOCK_ACCOUNTS_DATA_SIZE_DELTA + 1;
         let cost1 = tx_cost1.sum();
         let cost2 = tx_cost2.sum();
 
@@ -739,9 +723,7 @@ mod tests {
         let mint_keypair = test_setup();
         let tx = build_simple_transaction(&mint_keypair);
         let mut tx_cost = simple_transaction_cost(&tx, 5);
-        tx_cost
-            .usage_cost_details_mut()
-            .allocated_accounts_data_size = 2;
+        tx_cost.allocated_accounts_data_size = 2;
 
         // Transaction fits with default limit.
         let mut testee = CostTracker::new(u64::MAX, u64::MAX);
@@ -915,10 +897,8 @@ mod tests {
                 .collect(),
         );
 
-        let mut usage_cost =
-            simple_usage_cost_details(&transaction, estimated_programs_execution_cost);
-        usage_cost.loaded_accounts_data_size_cost = estimated_loaded_accounts_data_size_cost;
-        let tx_cost = TransactionCost::new(usage_cost);
+        let mut tx_cost = simple_transaction_cost(&transaction, estimated_programs_execution_cost);
+        tx_cost.loaded_accounts_data_size_cost = estimated_loaded_accounts_data_size_cost;
         // confirm tx_cost is only made up by programs_execution_cost and
         // loaded_accounts_data_size_cost
         let estimated_tx_cost = tx_cost.sum();

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -176,34 +176,6 @@ impl CostTracker {
         })
     }
 
-    pub fn update_execution_cost(
-        &mut self,
-        estimated_tx_cost: &TransactionCost<impl TransactionWithMeta>,
-        actual_execution_units: u64,
-        actual_loaded_accounts_data_size_cost: u64,
-    ) {
-        let actual_load_and_execution_units =
-            actual_execution_units.saturating_add(actual_loaded_accounts_data_size_cost);
-        let estimated_load_and_execution_units = estimated_tx_cost
-            .programs_execution_cost()
-            .saturating_add(estimated_tx_cost.loaded_accounts_data_size_cost());
-        match actual_load_and_execution_units.cmp(&estimated_load_and_execution_units) {
-            std::cmp::Ordering::Equal => (),
-            std::cmp::Ordering::Greater => {
-                self.add_transaction_execution_cost(
-                    estimated_tx_cost,
-                    actual_load_and_execution_units - estimated_load_and_execution_units,
-                );
-            }
-            std::cmp::Ordering::Less => {
-                self.sub_transaction_execution_cost(
-                    estimated_tx_cost,
-                    estimated_load_and_execution_units - actual_load_and_execution_units,
-                );
-            }
-        }
-    }
-
     pub fn remove(&mut self, tx_cost: &TransactionCost<impl TransactionWithMeta>) {
         self.remove_transaction_cost(tx_cost);
     }
@@ -884,70 +856,6 @@ mod tests {
                     assert_eq!(expected_block_cost, *units);
                 });
         }
-    }
-
-    #[test]
-    fn test_update_execution_cost() {
-        let estimated_programs_execution_cost = 100;
-        let estimated_loaded_accounts_data_size_cost = 200;
-        let number_writeble_accounts = 3;
-        let transaction = WritableKeysTransaction::new(
-            std::iter::repeat_with(Pubkey::new_unique)
-                .take(number_writeble_accounts)
-                .collect(),
-        );
-
-        let mut tx_cost = simple_transaction_cost(&transaction, estimated_programs_execution_cost);
-        tx_cost.loaded_accounts_data_size_cost = estimated_loaded_accounts_data_size_cost;
-        // confirm tx_cost is only made up by programs_execution_cost and
-        // loaded_accounts_data_size_cost
-        let estimated_tx_cost = tx_cost.sum();
-        assert_eq!(
-            estimated_tx_cost,
-            estimated_programs_execution_cost + estimated_loaded_accounts_data_size_cost
-        );
-
-        let test_update_cost_tracker =
-            |execution_cost_adjust: i64, loaded_accounts_data_size_cost_adjust: i64| {
-                let mut cost_tracker = CostTracker::default();
-                assert!(cost_tracker.try_add(&tx_cost).is_ok());
-
-                let actual_programs_execution_cost =
-                    (estimated_programs_execution_cost as i64 + execution_cost_adjust) as u64;
-                let actual_loaded_accounts_data_size_cost =
-                    (estimated_loaded_accounts_data_size_cost as i64
-                        + loaded_accounts_data_size_cost_adjust) as u64;
-                let expected_cost = (estimated_tx_cost as i64
-                    + execution_cost_adjust
-                    + loaded_accounts_data_size_cost_adjust)
-                    as u64;
-
-                cost_tracker.update_execution_cost(
-                    &tx_cost,
-                    actual_programs_execution_cost,
-                    actual_loaded_accounts_data_size_cost,
-                );
-
-                assert_eq!(expected_cost, cost_tracker.block_cost());
-                assert_eq!(
-                    number_writeble_accounts,
-                    cost_tracker.cost_by_writable_accounts.len()
-                );
-                for writable_account_cost in cost_tracker.cost_by_writable_accounts.values() {
-                    assert_eq!(expected_cost, *writable_account_cost);
-                }
-                assert_eq!(1, cost_tracker.transaction_count.0);
-            };
-
-        test_update_cost_tracker(0, 0);
-        test_update_cost_tracker(0, 9);
-        test_update_cost_tracker(0, -9);
-        test_update_cost_tracker(9, 0);
-        test_update_cost_tracker(9, 9);
-        test_update_cost_tracker(9, -9);
-        test_update_cost_tracker(-9, 0);
-        test_update_cost_tracker(-9, 9);
-        test_update_cost_tracker(-9, -9);
     }
 
     #[test]

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -3,56 +3,70 @@ use {
     solana_svm_transaction::svm_message::SVMMessage,
 };
 
+// Costs are stored in compute units.
 #[derive(Debug)]
 pub struct TransactionCost<'a, Tx> {
-    usage_cost: UsageCostDetails<'a, Tx>,
+    pub transaction: &'a Tx,
+    pub signature_cost: u64,
+    pub write_lock_cost: u64,
+    pub data_bytes_cost: u16,
+    pub programs_execution_cost: u64,
+    pub loaded_accounts_data_size_cost: u64,
+    pub allocated_accounts_data_size: u64,
 }
+
+/// Backward-compatible alias for callers that still name the old inner type.
+pub type UsageCostDetails<'a, Tx> = TransactionCost<'a, Tx>;
 
 impl<'a, Tx> TransactionCost<'a, Tx> {
     pub fn new(usage_cost: UsageCostDetails<'a, Tx>) -> Self {
-        Self { usage_cost }
+        usage_cost
     }
 
     pub fn usage_cost_details(&self) -> &UsageCostDetails<'a, Tx> {
-        &self.usage_cost
+        self
     }
 
     pub fn usage_cost_details_mut(&mut self) -> &mut UsageCostDetails<'a, Tx> {
-        &mut self.usage_cost
+        self
     }
 
     pub fn sum(&self) -> u64 {
-        self.usage_cost.sum()
+        self.signature_cost
+            .saturating_add(self.write_lock_cost)
+            .saturating_add(u64::from(self.data_bytes_cost))
+            .saturating_add(self.programs_execution_cost)
+            .saturating_add(self.loaded_accounts_data_size_cost)
     }
 
     pub fn programs_execution_cost(&self) -> u64 {
-        self.usage_cost.programs_execution_cost
+        self.programs_execution_cost
     }
 
     pub fn data_bytes_cost(&self) -> u16 {
-        self.usage_cost.data_bytes_cost
+        self.data_bytes_cost
     }
 
     pub fn allocated_accounts_data_size(&self) -> u64 {
-        self.usage_cost.allocated_accounts_data_size
+        self.allocated_accounts_data_size
     }
 
     pub fn loaded_accounts_data_size_cost(&self) -> u64 {
-        self.usage_cost.loaded_accounts_data_size_cost
+        self.loaded_accounts_data_size_cost
     }
 
     pub fn signature_cost(&self) -> u64 {
-        self.usage_cost.signature_cost
+        self.signature_cost
     }
 
     pub fn write_lock_cost(&self) -> u64 {
-        self.usage_cost.write_lock_cost
+        self.write_lock_cost
     }
 }
 
 impl<Tx: SVMMessage> TransactionCost<'_, Tx> {
     pub fn writable_accounts(&self) -> impl Iterator<Item = &Pubkey> {
-        let transaction = self.usage_cost.transaction;
+        let transaction = self.transaction;
         transaction
             .account_keys()
             .iter()
@@ -63,53 +77,27 @@ impl<Tx: SVMMessage> TransactionCost<'_, Tx> {
 
 impl<Tx: TransactionMeta> TransactionCost<'_, Tx> {
     pub fn num_transaction_signatures(&self) -> u64 {
-        self.usage_cost
-            .transaction
+        self.transaction
             .signature_details()
             .num_transaction_signatures()
     }
 
     pub fn num_secp256k1_instruction_signatures(&self) -> u64 {
-        self.usage_cost
-            .transaction
+        self.transaction
             .signature_details()
             .num_secp256k1_instruction_signatures()
     }
 
     pub fn num_ed25519_instruction_signatures(&self) -> u64 {
-        self.usage_cost
-            .transaction
+        self.transaction
             .signature_details()
             .num_ed25519_instruction_signatures()
     }
 
     pub fn num_secp256r1_instruction_signatures(&self) -> u64 {
-        self.usage_cost
-            .transaction
+        self.transaction
             .signature_details()
             .num_secp256r1_instruction_signatures()
-    }
-}
-
-// costs are stored in number of 'compute unit's
-#[derive(Debug)]
-pub struct UsageCostDetails<'a, Tx> {
-    pub transaction: &'a Tx,
-    pub signature_cost: u64,
-    pub write_lock_cost: u64,
-    pub data_bytes_cost: u16,
-    pub programs_execution_cost: u64,
-    pub loaded_accounts_data_size_cost: u64,
-    pub allocated_accounts_data_size: u64,
-}
-
-impl<Tx> UsageCostDetails<'_, Tx> {
-    pub fn sum(&self) -> u64 {
-        self.signature_cost
-            .saturating_add(self.write_lock_cost)
-            .saturating_add(u64::from(self.data_bytes_cost))
-            .saturating_add(self.programs_execution_cost)
-            .saturating_add(self.loaded_accounts_data_size_cost)
     }
 }
 
@@ -351,7 +339,7 @@ mod tests {
                     MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES.get(),
                     &feature_set,
                 );
-            let vote_program_usage_details = UsageCostDetails {
+            let vote_program_cost = TransactionCost {
                 transaction: &vote_transaction,
                 signature_cost,
                 write_lock_cost,
@@ -360,7 +348,7 @@ mod tests {
                 loaded_accounts_data_size_cost,
                 allocated_accounts_data_size: 0,
             };
-            let expected_cost = vote_program_usage_details.sum();
+            let expected_cost = vote_program_cost.sum();
 
             let vote_cost = CostModel::calculate_cost(&vote_transaction, &feature_set);
             assert_eq!(expected_cost, vote_cost.sum());

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -15,22 +15,7 @@ pub struct TransactionCost<'a, Tx> {
     pub allocated_accounts_data_size: u64,
 }
 
-/// Backward-compatible alias for callers that still name the old inner type.
-pub type UsageCostDetails<'a, Tx> = TransactionCost<'a, Tx>;
-
 impl<'a, Tx> TransactionCost<'a, Tx> {
-    pub fn new(usage_cost: UsageCostDetails<'a, Tx>) -> Self {
-        usage_cost
-    }
-
-    pub fn usage_cost_details(&self) -> &UsageCostDetails<'a, Tx> {
-        self
-    }
-
-    pub fn usage_cost_details_mut(&mut self) -> &mut UsageCostDetails<'a, Tx> {
-        self
-    }
-
     pub fn sum(&self) -> u64 {
         self.signature_cost
             .saturating_add(self.write_lock_cost)

--- a/runtime/src/transaction_execution.rs
+++ b/runtime/src/transaction_execution.rs
@@ -327,9 +327,8 @@ mod tests {
         let mut tx_cost = CostModel::calculate_cost(&tx, &bank.feature_set);
         let actual_execution_cu = 1;
         let actual_loaded_accounts_data_size = 64 * 1024;
-        let usage_cost_details = tx_cost.usage_cost_details_mut();
-        usage_cost_details.programs_execution_cost = actual_execution_cu;
-        usage_cost_details.loaded_accounts_data_size_cost =
+        tx_cost.programs_execution_cost = actual_execution_cu;
+        tx_cost.loaded_accounts_data_size_cost =
             CostModel::calculate_loaded_accounts_data_size_cost(
                 actual_loaded_accounts_data_size,
                 &bank.feature_set,


### PR DESCRIPTION
#### Problem

SimpleVoteTransactionCost has been removed from `TransactionCost`, it's wrapping on `UsageCostDetails` became unnecessary.

#### Summary of Changes
- remove wrapping by moving fields from `UsageCostDetails` to `TransactionCost` self
- remove function `update_execution_cost()` which is no longer used
- no functional change

#### Testing
CI

Fixes #
