### PR TITLE
[syscalls] Use curve constants from `solana-define-syscalls` for the syscall logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7140,7 +7140,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-nullable",
@@ -7273,7 +7273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
  "num-bigint",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -7374,7 +7374,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -8171,7 +8171,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.18",
 ]
@@ -8190,9 +8190,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-derivation-path"
@@ -8611,7 +8611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
  "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
@@ -8809,7 +8809,7 @@ dependencies = [
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "wincode",
@@ -9249,7 +9249,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -9541,7 +9541,7 @@ dependencies = [
  "solana-blake3-hasher",
  "solana-clock",
  "solana-cpi",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-epoch-stake",
@@ -10415,7 +10415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
 dependencies = [
  "k256",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -10530,7 +10530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
 dependencies = [
  "sha2 0.10.9",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-hash-512",
 ]
 
@@ -10980,6 +10980,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -11105,7 +11106,7 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,6 +383,7 @@ solana-core = { path = "core", version = "=4.3.0-alpha.2", features = ["agave-un
 solana-cost-model = { path = "cost-model", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-cpi = "3.1.0"
 solana-curve25519 = "4.0.1"
+solana-define-syscall = "5.2.0"
 solana-derivation-path = "3.0.0"
 solana-download-utils = { path = "download-utils", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-ed25519-program = "3.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5824,7 +5824,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
@@ -5867,7 +5867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
  "num-bigint",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -5957,7 +5957,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -6479,7 +6479,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.18",
 ]
@@ -6492,9 +6492,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-derivation-path"
@@ -6748,7 +6748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
  "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
@@ -6906,7 +6906,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "wincode",
@@ -7211,7 +7211,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -8055,7 +8055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
 dependencies = [
  "k256",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -8161,7 +8161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
 dependencies = [
  "sha2 0.10.9",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-hash-512",
 ]
 
@@ -8517,6 +8517,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519",
+ "solana-define-syscall 5.2.0",
  "solana-hash 4.5.0",
  "solana-hash-512",
  "solana-instruction",
@@ -8623,7 +8624,7 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5895,7 +5895,7 @@ dependencies = [
  "serde_derive",
  "sha2-const-stable",
  "solana-atomic-u64",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-nullable",
  "solana-program-error",
  "solana-sanitize",
@@ -6022,7 +6022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05789c4afc39164132db9dcc117218d412ca1f1271d2c629fc6f554c19e5a44"
 dependencies = [
  "num-bigint",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -6112,7 +6112,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "bytemuck",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -6634,7 +6634,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "subtle",
  "thiserror 2.0.18",
 ]
@@ -6653,9 +6653,9 @@ checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-define-syscall"
-version = "5.1.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
+checksum = "bf8209ece2bd9f1450e672858ffc0e5c8c786ff6916d2a862b126dd0128f380f"
 
 [[package]]
 name = "solana-derivation-path"
@@ -6936,7 +6936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef3bc859fc036ed490146793557386cbfae614ebba4adc704c37d94350824ed4"
 dependencies = [
  "solana-address 2.6.1",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-program-error",
 ]
 
@@ -7096,7 +7096,7 @@ dependencies = [
  "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-instruction-error",
  "solana-pubkey 4.2.0",
  "wincode",
@@ -7401,7 +7401,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726b7cbbc6be6f1c6f29146ac824343b9415133eee8cce156452ad1db93f8008"
 dependencies = [
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
 ]
 
 [[package]]
@@ -7635,7 +7635,7 @@ dependencies = [
  "solana-borsh",
  "solana-clock",
  "solana-cpi",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-epoch-stake",
@@ -9081,7 +9081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a1ad3ed7846631c88c71c5d2f21a2ecb6b61da333d9be173b6b061b35609ae"
 dependencies = [
  "k256",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "thiserror 2.0.18",
 ]
 
@@ -9187,7 +9187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11e10e103ab5bd52af341e7bc2f4123a2f4e66bb7ba4e6ca40f1e00cd6314e02"
 dependencies = [
  "sha2 0.10.9",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-hash-512",
 ]
 
@@ -9543,6 +9543,7 @@ dependencies = [
  "solana-clock",
  "solana-cpi",
  "solana-curve25519",
+ "solana-define-syscall 5.2.0",
  "solana-hash 4.5.0",
  "solana-hash-512",
  "solana-instruction",
@@ -9651,7 +9652,7 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall 5.1.0",
+ "solana-define-syscall 5.2.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -38,6 +38,7 @@ solana-bn254 = { workspace = true }
 solana-clock = { workspace = true }
 solana-cpi = { workspace = true }
 solana-curve25519 = { workspace = true }
+solana-define-syscall = { workspace = true }
 solana-hash = { workspace = true, features = ["wincode"] }
 solana-hash-512 = { workspace = true }
 solana-instruction = { workspace = true }

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -6814,8 +6814,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_add() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::ADD,
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
         };
 
         let config = Config::default();
@@ -6934,8 +6934,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_sub() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::SUB,
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
         };
 
         let config = Config::default();
@@ -7057,8 +7057,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_mul() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::MUL,
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
         };
 
         let config = Config::default();
@@ -7173,8 +7173,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_add() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::ADD,
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
         };
 
         let config = Config::default();
@@ -7325,8 +7325,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_sub() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::SUB,
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
         };
 
         let config = Config::default();
@@ -7480,8 +7480,8 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_mul() {
         use {
-            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::MUL,
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
         };
 
         let config = Config::default();

--- a/syscalls/src/lib.rs
+++ b/syscalls/src/lib.rs
@@ -299,22 +299,6 @@ impl HasherImpl for Sha512Hasher {
     }
 }
 
-// NOTE: These constants are temporarily defined here and will be
-// moved to a dedicated crate in the future.
-mod bls12_381_curve_id {
-    /// Curve ID for BLS12-381 pairing operations
-    pub(crate) const BLS12_381_LE: u64 = 4;
-    pub(crate) const BLS12_381_BE: u64 = 4 | 0x80;
-
-    /// Curve ID for BLS12-381 G1 group operations
-    pub(crate) const BLS12_381_G1_LE: u64 = 5;
-    pub(crate) const BLS12_381_G1_BE: u64 = 5 | 0x80;
-
-    /// Curve ID for BLS12-381 G2 group operations
-    pub(crate) const BLS12_381_G2_LE: u64 = 6;
-    pub(crate) const BLS12_381_G2_BE: u64 = 6 | 0x80;
-}
-
 // NOTE: This macro name is checked by gen-syscall-list to create the list of
 // syscalls. If this macro name is changed, or if a new one is added, then
 // gen-syscall-list/build.rs must also be updated.
@@ -1012,8 +996,8 @@ declare_builtin_function!(
         _arg5: u64,
     ) -> Result<u64, Error> {
         use {
-            crate::bls12_381_curve_id::*,
-            solana_curve25519::{curve_syscall_traits::*, edwards, ristretto},
+            solana_curve25519::{edwards, ristretto},
+            solana_define_syscall::curve_constants::*,
         };
 
         // SIMD-0388: BLS12-381 syscalls
@@ -1147,11 +1131,11 @@ declare_builtin_function!(
         _arg5: u64,
     ) -> Result<u64, Error> {
         use {
-            crate::bls12_381_curve_id::*,
             solana_bls12_381_syscall::{
                 PodG1Compressed as PodBLSG1Compressed, PodG1Point as PodBLSG1Point,
                 PodG2Compressed as PodBLSG2Compressed, PodG2Point as PodBLSG2Point,
             },
+            solana_define_syscall::curve_constants::*,
         };
 
         let check_aligned = invoke_context.get_check_aligned();
@@ -1247,16 +1231,15 @@ declare_builtin_function!(
         result_point_addr: u64,
     ) -> Result<u64, Error> {
         use {
-            crate::bls12_381_curve_id::*,
             solana_bls12_381_syscall::{
                 PodG1Point as PodBLSG1Point, PodG2Point as PodBLSG2Point, PodScalar as PodBLSScalar,
             },
             solana_curve25519::{
-                curve_syscall_traits::*,
                 edwards::{self, PodEdwardsPoint},
                 ristretto::{self, PodRistrettoPoint},
                 scalar,
             },
+            solana_define_syscall::curve_constants::*,
         };
 
         if !invoke_context.get_feature_set().enable_bls12_381_syscall
@@ -1271,7 +1254,7 @@ declare_builtin_function!(
         let check_aligned = invoke_context.get_check_aligned();
         match curve_id {
             CURVE25519_EDWARDS => match group_op {
-                ADD => {
+                GROUP_OP_ADD => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_add_cost;
@@ -1301,7 +1284,7 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                SUB => {
+                GROUP_OP_SUB => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_subtract_cost;
@@ -1331,7 +1314,7 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                MUL => {
+                GROUP_OP_MUL => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_edwards_multiply_cost;
@@ -1371,7 +1354,7 @@ declare_builtin_function!(
             },
 
             CURVE25519_RISTRETTO => match group_op {
-                ADD => {
+                GROUP_OP_ADD => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_add_cost;
@@ -1401,7 +1384,7 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                SUB => {
+                GROUP_OP_SUB => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_subtract_cost;
@@ -1433,7 +1416,7 @@ declare_builtin_function!(
                         Ok(1)
                     }
                 }
-                MUL => {
+                GROUP_OP_MUL => {
                     let cost = invoke_context
                         .get_execution_cost()
                         .curve25519_ristretto_multiply_cost;
@@ -1480,7 +1463,7 @@ declare_builtin_function!(
                 };
 
                 match group_op {
-                    ADD => {
+                    GROUP_OP_ADD => {
                         let cost = invoke_context.get_execution_cost().bls12_381_g1_add_cost;
                         invoke_context.compute_meter.consume_checked(cost)?;
 
@@ -1515,7 +1498,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    SUB => {
+                    GROUP_OP_SUB => {
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g1_subtract_cost;
@@ -1552,7 +1535,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    MUL => {
+                    GROUP_OP_MUL => {
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g1_multiply_cost;
@@ -1602,7 +1585,7 @@ declare_builtin_function!(
                 };
 
                 match group_op {
-                    ADD => {
+                    GROUP_OP_ADD => {
                         let cost = invoke_context.get_execution_cost().bls12_381_g2_add_cost;
                         invoke_context.compute_meter.consume_checked(cost)?;
 
@@ -1637,7 +1620,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    SUB => {
+                    GROUP_OP_SUB => {
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g2_subtract_cost;
@@ -1674,7 +1657,7 @@ declare_builtin_function!(
                             Ok(1)
                         }
                     }
-                    MUL => {
+                    GROUP_OP_MUL => {
                         let cost = invoke_context
                             .get_execution_cost()
                             .bls12_381_g2_multiply_cost;
@@ -1740,11 +1723,13 @@ declare_builtin_function!(
         points_len: u64,
         result_point_addr: u64,
     ) -> Result<u64, Error> {
-        use solana_curve25519::{
-            curve_syscall_traits::*,
-            edwards::{self, PodEdwardsPoint},
-            ristretto::{self, PodRistrettoPoint},
-            scalar,
+        use {
+            solana_curve25519::{
+                edwards::{self, PodEdwardsPoint},
+                ristretto::{self, PodRistrettoPoint},
+                scalar,
+            },
+            solana_define_syscall::curve_constants::*,
         };
 
         if points_len > 512 {
@@ -1861,7 +1846,7 @@ declare_builtin_function!(
         result_addr: u64,
     ) -> Result<u64, Error> {
         use {
-            crate::bls12_381_curve_id::*,
+            solana_define_syscall::curve_constants::*,
             solana_bls12_381_syscall::{
                 PodG1Point as PodBLSG1Point, PodG2Point as PodBLSG2Point,
                 PodGtElement as PodBLSGtElement,
@@ -6829,7 +6814,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_add() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::ADD,
         };
 
@@ -6949,7 +6934,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_sub() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::SUB,
         };
 
@@ -7072,7 +7057,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g1_mul() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE},
             solana_curve25519::curve_syscall_traits::MUL,
         };
 
@@ -7188,7 +7173,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_add() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::ADD,
         };
 
@@ -7340,7 +7325,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_sub() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::SUB,
         };
 
@@ -7495,7 +7480,7 @@ mod tests {
     #[test]
     fn test_syscall_bls12_381_g2_mul() {
         use {
-            crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE},
+            solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE},
             solana_curve25519::curve_syscall_traits::MUL,
         };
 
@@ -7631,7 +7616,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_pairing_be() {
-        use crate::bls12_381_curve_id::BLS12_381_BE;
+        use solana_define_syscall::curve_constants::BLS12_381_BE;
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -7738,7 +7723,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_pairing_le() {
-        use crate::bls12_381_curve_id::BLS12_381_LE;
+        use solana_define_syscall::curve_constants::BLS12_381_LE;
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -7845,7 +7830,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_decompress_g1() {
-        use crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE};
+        use solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE};
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -7941,7 +7926,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_decompress_g2() {
-        use crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE};
+        use solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE};
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -8053,7 +8038,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_validate_g1() {
-        use crate::bls12_381_curve_id::{BLS12_381_G1_BE, BLS12_381_G1_LE};
+        use solana_define_syscall::curve_constants::{BLS12_381_G1_BE, BLS12_381_G1_LE};
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {
@@ -8130,7 +8115,7 @@ mod tests {
 
     #[test]
     fn test_syscall_bls12_381_validate_g2() {
-        use crate::bls12_381_curve_id::{BLS12_381_G2_BE, BLS12_381_G2_LE};
+        use solana_define_syscall::curve_constants::{BLS12_381_G2_BE, BLS12_381_G2_LE};
 
         let config = Config::default();
         let feature_set = SVMFeatureSet {


### PR DESCRIPTION
#### Problem

The syscall functions associated with elliptic curves takes in a curve ID and perform operations based on it.

Currently, these constants live in various places:
- The curve25519 curve ID live in the `solana-curve25519` crate in the sdk
- The BLS12-381 curve ID live in the `solana-syscalls` crate in agave.

In https://github.com/anza-xyz/solana-sdk/pull/833, we added the curve constants to the `solana-define-syscall` crate.

#### Summary of Changes

- Added the `solana-define-syscall` crate as a dependency for the `solana-syscalls` crate
- Updated the logic in `solana-syscalls` crate to use the constants from `solana-define-syscall`
- Removed the BLS12-381 curve IDs in the `solana-syscall` crate