### PR TITLE
v4.2: fix: bound wincode-related sdk deps to <= wincode 0.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,20 +349,20 @@ smallvec = { version = "1.15.2", default-features = false, features = ["union"] 
 smpl_jwt = "0.9.0"
 socket2 = "0.6.3"
 soketto = "0.8"
-solana-account = "4.3.1"
+solana-account = ">=4.3.1,<4.4.0"
 solana-account-decoder = { path = "account-decoder", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-account-info = "3.1.1"
 solana-accounts-db = { path = "accounts-db", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-address = "2.6.1"
-solana-address-lookup-table-interface = "3.1.0"
+solana-address = ">=2.6.1,<2.7.0"
+solana-address-lookup-table-interface = ">=3.1.0,<3.2.0"
 solana-banks-client = { path = "banks-client", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-banks-interface = { path = "banks-interface", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-banks-server = { path = "banks-server", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-bincode = "3.1.0"
 solana-blake3-hasher = "3.1.0"
 solana-bloom = { path = "bloom", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-bls-signatures = { version = "3.3.0", features = ["serde"] }
+solana-bls-signatures = { version = ">=3.3.0,<3.4.0", features = ["serde"] }
 solana-bls12-381-syscall = "0.1.0"
 solana-bn254 = "3.2.1"
 solana-borsh = "3.0.2"
@@ -375,8 +375,8 @@ solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.2.0-rc.0", featur
 solana-cli-config = { path = "cli-config", version = "=4.2.0-rc.0" }
 solana-cli-output = { path = "cli-output", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-client = { path = "client", version = "=4.2.0-rc.0" }
-solana-client-traits = "4.0.0"
-solana-clock = "3.0.1"
+solana-client-traits = ">=4.0.0,<4.1.0"
+solana-clock = ">=3.0.1,<3.2.0"
 solana-cluster-type = "3.1.0"
 solana-commitment-config = "3.1.1"
 solana-compute-budget = { path = "compute-budget", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -394,32 +394,32 @@ solana-download-utils = { path = "download-utils", version = "=4.2.0-rc.0", feat
 solana-ed25519-program = "3.0.0"
 solana-entry = { path = "entry", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-epoch-info = "3.1.0"
-solana-epoch-rewards = "3.1.0"
+solana-epoch-rewards = ">=3.1.0,<3.2.0"
 solana-epoch-rewards-hasher = "3.1.0"
-solana-epoch-schedule = "3.2.0"
+solana-epoch-schedule = ">=3.2.0,<3.3.0"
 solana-faucet = { path = "faucet", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee = { path = "fee", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-fee-calculator = "3.2.2"
+solana-fee-calculator = ">=3.2.2,<3.3.0"
 solana-fee-structure = "3.0.0"
 solana-file-download = "3.1.4"
-solana-frozen-abi = "3.7.0"
+solana-frozen-abi = ">=3.7.0,<3.8.0"
 solana-frozen-abi-macro = "3.6.0"
 solana-genesis = { path = "genesis", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "genesis-utils", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-gossip = { path = "gossip", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-hard-forks = "3.1.1"
-solana-hash = "4.4.0"
-solana-hash-512 = "1.1.0"
-solana-inflation = "3.1.1"
-solana-instruction = "3.4.0"
-solana-instruction-error = "2.4.0"
+solana-hard-forks = ">=3.1.1,<3.2.0"
+solana-hash = ">=4.4.0,<4.6.0"
+solana-hash-512 = ">=1.1.0,<1.2.0"
+solana-inflation = ">=3.1.1,<3.2.0"
+solana-instruction = ">=3.4.0,<3.5.0"
+solana-instruction-error = ">=2.4.0,<2.5.0"
 solana-instructions-sysvar = "4.0.0"
 solana-keccak-hasher = "3.1.0"
 solana-keypair = "3.1.2"
-solana-last-restart-slot = "3.0.1"
+solana-last-restart-slot = ">=3.0.1,<3.2.0"
 solana-lattice-hash = { path = "lattice-hash", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-leader-schedule = { path = "leader-schedule", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-ledger = { path = "ledger", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -429,17 +429,17 @@ solana-loader-v4-interface = "3.1.0"
 solana-local-cluster = { path = "local-cluster", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "measure", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-merkle-tree = { path = "merkle-tree", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-message = "4.2.3"
+solana-message = ">=4.2.3,<4.5.0"
 solana-metrics = { path = "metrics", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"
 solana-net-utils = { path = "net-utils", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-nohash-hasher = "0.2.1"
-solana-nonce = "3.2.0"
-solana-nonce-account = "4.1.0"
+solana-nonce = ">=3.2.0,<3.3.0"
+solana-nonce-account = ">=4.1.0,<4.2.0"
 solana-notifier = { path = "notifier", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-offchain-message = "3.0.0"
-solana-packet = "4.1.0"
+solana-packet = ">=4.1.0,<4.3.0"
 solana-perf = { path = "perf", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-poh = { path = "poh", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-poh-config = "3.0.0"
@@ -454,13 +454,13 @@ solana-program-option = "3.1.0"
 solana-program-pack = "3.1.0"
 solana-program-runtime = { path = "program-runtime", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-program-test = { path = "program-test", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-pubkey = { version = "4.2.0", default-features = false }
+solana-pubkey = { version = ">=4.2.0,<4.3.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=4.2.0-rc.0" }
 solana-quic-client = { path = "quic-client", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-remote-wallet = { path = "remote-wallet", version = "=4.2.0-rc.0", default-features = false, features = ["agave-unstable-api"] }
-solana-rent = "4.2.1"
-solana-reward-info = "6.2.0"
+solana-rent = ">=4.2.1,<4.4.0"
+solana-reward-info = ">=6.2.0,<6.3.0"
 solana-rpc = { path = "rpc", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "rpc-client", version = "=4.2.0-rc.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.2.0-rc.0" }
@@ -482,15 +482,15 @@ solana-serde-varint = "3.0.1"
 solana-serialize-utils = "3.1.2"
 solana-sha256-hasher = "3.1.0"
 solana-sha512-hasher = "1.0.1"
-solana-short-vec = "3.2.2"
+solana-short-vec = ">=3.2.2,<3.3.0"
 solana-shred-version = "3.0.1"
-solana-signature = { version = "3.4.1", default-features = false }
+solana-signature = { version = ">=3.4.1,<3.5.0", default-features = false }
 solana-signer = "3.0.1"
 solana-signer-store = "0.1.0"
-solana-slot-hashes = "3.1.0"
-solana-slot-history = "3.0.1"
+solana-slot-hashes = ">=3.1.0,<3.2.0"
+solana-slot-history = ">=3.0.1,<3.2.0"
 solana-stable-layout = "3.0.1"
-solana-stake-interface = "4.3.0"
+solana-stake-interface = ">=4.3.0,<4.3.1"
 solana-storage-bigtable = { path = "storage-bigtable", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-storage-proto = { path = "storage-proto", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "streamer", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -500,22 +500,22 @@ solana-svm-feature-set = { path = "svm-feature-set", version = "=4.2.0-rc.0", fe
 solana-svm-log-collector = { path = "svm-log-collector", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-svm-measure = { path = "svm-measure", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-svm-timings = { path = "svm-timings", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-svm-transaction = "4.2.0"
+solana-svm-transaction = ">=4.2.0,<4.3.0"
 solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-syscalls = { path = "syscalls", version = "=4.2.0-rc.0", default-features = false, features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.2", features = ["alloc", "bincode", "serde", "wincode"] }
+solana-system-interface = { version = ">=3.2.0,<3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }
 solana-system-program = { path = "programs/system", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-system-transaction = "4.0.0"
-solana-sysvar = "4.0.0"
+solana-system-transaction = ">=4.0.0,<4.1.0"
+solana-sysvar = ">=4.0.0,<4.2.0"
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "test-validator", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-time-utils = "3.0.0"
 solana-tls-utils = { path = "tls-utils", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-tpu-client = { path = "tpu-client", version = "=4.2.0-rc.0", default-features = false, features = ["agave-unstable-api"] }
 solana-tpu-client-next = { path = "tpu-client-next", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-transaction = "4.1.4"
+solana-transaction = ">=4.1.4,<4.2.0"
 solana-transaction-context = { path = "transaction-context", version = "=4.2.0-rc.0", features = ["agave-unstable-api", "bincode"] }
-solana-transaction-error = "3.3.1"
+solana-transaction-error = ">=3.3.1,<3.4.0"
 solana-transaction-status = { path = "transaction-status", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-turbine = { path = "turbine", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -525,9 +525,9 @@ solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-vote = { path = "vote", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-vote-interface = "6.0.2"
+solana-vote-interface = ">=6.0.2,<6.1.0"
 solana-vote-program = { path = "programs/vote", version = "=4.2.0-rc.0", default-features = false, features = ["agave-unstable-api"] }
-solana-wincode-varint = "1.0.0"
+solana-wincode-varint = ">=1.0.0,<1.1.0"
 solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-zk-sdk = "5.0.1"
 solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1.0.150"
 serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
-solana-account = "4.3.1"
+solana-account = ">=4.3.1,<4.4.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -77,7 +77,7 @@ solana-clap-utils = { path = "../clap-utils", version = "=4.2.0-rc.0", features 
 solana-cli-config = { path = "../cli-config", version = "=4.2.0-rc.0" }
 solana-cli-output = { path = "../cli-output", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-client = { path = "../client", version = "=4.2.0-rc.0" }
-solana-clock = "3.1.1"
+solana-clock = ">=3.1.1,<3.2.0"
 solana-cluster-type = "3.1.0"
 solana-commitment-config = "3.0.0"
 solana-compute-budget = { path = "../compute-budget", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -89,31 +89,31 @@ solana-cost-model = { path = "../cost-model", version = "=4.2.0-rc.0", features 
 solana-entry = { path = "../entry", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-faucet = { path = "../faucet", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
-solana-fee-calculator = "3.2.2"
+solana-fee-calculator = ">=3.2.2,<3.3.0"
 solana-genesis = { path = "../genesis", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.0.0"
 solana-genesis-utils = { path = "../genesis-utils", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-hash = "4.4.0"
-solana-inflation = "3.1.1"
-solana-instruction = "3.4.0"
-solana-instruction-error = "2.4.0"
+solana-hash = ">=4.4.0,<4.6.0"
+solana-inflation = ">=3.1.1,<3.2.0"
+solana-instruction = ">=3.4.0,<3.5.0"
+solana-instruction-error = ">=2.4.0,<2.5.0"
 solana-keypair = "3.1.2"
 solana-ledger = { path = "../ledger", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
 solana-local-cluster = { path = "../local-cluster", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-measure = { path = "../measure", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-message = "4.1.0"
+solana-message = ">=4.1.0,<4.5.0"
 solana-metrics = { path = "../metrics", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-native-token = "3.0.0"
 solana-net-utils = { path = "../net-utils", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-nonce = "3.2.0"
+solana-nonce = ">=3.2.0,<3.3.0"
 solana-precompile-error = "3.0.0"
 solana-program-runtime = { path = "../program-runtime", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-pubkey = { version = "4.2.0", default-features = false }
+solana-pubkey = { version = ">=4.2.0,<4.3.0", default-features = false }
 solana-quic-client = { path = "../quic-client", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-rent = "4.2.1"
+solana-rent = ">=4.2.1,<4.4.0"
 solana-rpc = { path = "../rpc", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "../rpc-client", version = "=4.2.0-rc.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.2.0-rc.0" }
@@ -122,10 +122,10 @@ solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.2.
 solana-sbpf = { version = "=0.21.1", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
-solana-signature = { version = "3.4.1", default-features = false }
+solana-signature = { version = ">=3.4.1,<3.5.0", default-features = false }
 solana-signer = "3.0.1"
 solana-signer-store = "0.1.0"
-solana-stake-interface = "4.3.0"
+solana-stake-interface = ">=4.3.0,<4.3.1"
 solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-streamer = { path = "../streamer", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-svm = { path = "../svm", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
@@ -133,15 +133,15 @@ solana-svm-callback = { path = "../svm-callback", version = "=4.2.0-rc.0", featu
 solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-svm-timings = { path = "../svm-timings", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-svm-transaction = "4.2.0"
+solana-svm-transaction = ">=4.2.0,<4.3.0"
 solana-syscalls = { path = "../syscalls", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
-solana-system-interface = "3.2"
+solana-system-interface = ">=3.2.0,<3.3.0"
 solana-system-program = { path = "../programs/system", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.2.0-rc.0" }
 solana-time-utils = "3.0.0"
 solana-tpu-client = { path = "../tpu-client", version = "=4.2.0-rc.0", default-features = false, features = ["agave-unstable-api"] }
-solana-transaction = "4.1.0"
+solana-transaction = ">=4.1.0,<4.2.0"
 solana-transaction-context = { path = "../transaction-context", version = "=4.2.0-rc.0", features = ["agave-unstable-api", "bincode"] }
 solana-transaction-status = { path = "../transaction-status", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }
 solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.2.0-rc.0", features = ["agave-unstable-api"] }


### PR DESCRIPTION
Similar in spirit to https://github.com/anza-xyz/agave/pull/12227
## Problem

Downstream users consuming Agave crates from git do not inherit Agave’s `Cargo.lock`.

Following the SDK upgrade to wincode 0.6.0, Cargo can select newer semver-compatible SDK releases and produce a mixed wincode graph. Because wincode traits from 0.5 and 0.6 are distinct types, this can cause trait-coherence compilation failures.

E.g.,
```text
solana-account-decoder
└── solana-slot-history 3.2.0
    └── wincode 0.6.0
```

and:

```text
solana-account-decoder
└── solana-slot-hashes 3.1.0
    └── solana-hash 4.6.0
        └── wincode 0.6.0
```

## Summary of changes

Adds upper bounds to v4.2’s SDK dependencies to before the release that added wincode 0.6

| SDK crate | v4.2-compatible range | First excluded release |
|---|---:|---:|
| `solana-account` | `>=4.3.1,<4.4.0` | 4.4.0 |
| `solana-address` | `>=2.6.1,<2.7.0` | 2.7.0 |
| `solana-address-lookup-table-interface` | `>=3.1.0,<3.2.0` | 3.2.0 |
| `solana-bls-signatures` | `>=3.3.0,<3.4.0` | 3.4.0 |
| `solana-client-traits` | `>=4.0.0,<4.1.0` | 4.1.0 |
| `solana-clock` | `>=3.0.1,<3.2.0` | 3.2.0 |
| `solana-epoch-rewards` | `>=3.1.0,<3.2.0` | 3.2.0 |
| `solana-epoch-schedule` | `>=3.2.0,<3.3.0` | 3.3.0 |
| `solana-fee-calculator` | `>=3.2.2,<3.3.0` | 3.3.0 |
| `solana-frozen-abi` | `>=3.7.0,<3.8.0` | 3.8.0 |
| `solana-hard-forks` | `>=3.1.1,<3.2.0` | 3.2.0 |
| `solana-hash` | `>=4.4.0,<4.6.0` | 4.6.0 |
| `solana-hash-512` | `>=1.1.0,<1.2.0` | 1.2.0 |
| `solana-inflation` | `>=3.1.1,<3.2.0` | 3.2.0 |
| `solana-instruction` | `>=3.4.0,<3.5.0` | 3.5.0 |
| `solana-instruction-error` | `>=2.4.0,<2.5.0` | 2.5.0 |
| `solana-last-restart-slot` | `>=3.0.1,<3.2.0` | 3.2.0 |
| `solana-message` | `>=4.2.3,<4.5.0` | 4.5.0 |
| `solana-nonce` | `>=3.2.0,<3.3.0` | 3.3.0 |
| `solana-nonce-account` | `>=4.1.0,<4.2.0` | 4.2.0 |
| `solana-packet` | `>=4.1.0,<4.3.0` | 4.3.0 |
| `solana-pubkey` | `>=4.2.0,<4.3.0` | 4.3.0 |
| `solana-rent` | `>=4.2.1,<4.4.0` | 4.4.0 |
| `solana-reward-info` | `>=6.2.0,<6.3.0` | 6.3.0 |
| `solana-short-vec` | `>=3.2.2,<3.3.0` | 3.3.0 |
| `solana-signature` | `>=3.4.1,<3.5.0` | 3.5.0 |
| `solana-slot-hashes` | `>=3.1.0,<3.2.0` | 3.2.0 |
| `solana-slot-history` | `>=3.0.1,<3.2.0` | 3.2.0 |
| `solana-stake-interface` | `>=4.3.0,<4.3.1` | 4.3.1 |
| `solana-svm-transaction` | `>=4.2.0,<4.3.0` | 4.3.0 |
| `solana-system-interface` | `>=3.2.0,<3.3.0` | 3.3.0 |
| `solana-system-transaction` | `>=4.0.0,<4.1.0` | 4.1.0 |
| `solana-sysvar` | `>=4.0.0,<4.2.0` | 4.2.0 |
| `solana-transaction` | `>=4.1.4,<4.2.0` | 4.2.0 |
| `solana-transaction-error` | `>=3.3.1,<3.4.0` | 3.4.0 |
| `solana-vote-interface` | `>=6.0.2,<6.1.0` | 6.1.0 |
| `solana-wincode-varint` | `>=1.0.0,<1.1.0` | 1.1.0 |