### PR TITLE
chore(secpol): declare vm interpreter out of scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -191,6 +191,9 @@ the no-Alpenglow code path remain in scope
 * Loader V4 (the `loader-v4` crate and associated code paths). Loader V4 is
 being removed from the codebase and its feature ID has been stubbed out. Bugs
 relating to Loader V4 functionality are disqualified from reports and bounties.
+* Issues affecting the virtual machine interpreter. The interpreter performance is not
+presently suitable for production environments, so it is safe to address any security
+vulnerabilies or inconsistencies with jit behavior in public issues
 
 ### Eligibility:
 * Vulnerabilities must have been committed to the master branch for at least


### PR DESCRIPTION
#### Problem
vm interpreter is not production-ready

#### Summary of Changes
mark it out of scope from bbp

#### Testing
it's markdown. i proofread it?