### PR TITLE
Cleanup - `ProgramCacheEntry::effective_slot`

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -291,7 +291,6 @@ fn load_program<'a>(
             &loader_key,
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             slot,
-            slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &contents,
             &mut load_program_metrics,
         );

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         invoke_context::InvokeContext,
         loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
-        program_cache_entry::{DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry},
+        program_cache_entry::ProgramCacheEntry,
     },
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
@@ -107,7 +107,6 @@ pub fn deploy_program(
             loader_key,
             program_runtime_environment,
             deployment_slot,
-            deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             programdata,
             #[cfg(feature = "metrics")]
             load_program_metrics,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -675,7 +675,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 );
                             if entry_in_same_branch {
                                 let entry_is_effective =
-                                    loaded_programs_for_tx_batch.slot >= entry.effective_slot;
+                                    loaded_programs_for_tx_batch.slot >= entry.effective_slot();
                                 let entry_to_return = if entry_is_effective {
                                     if !Self::matches_environment(
                                         entry,
@@ -1411,7 +1411,7 @@ pub(crate) mod tests {
                     // Test that the usage counter is retained for the unloaded program
                     assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
                     assert_eq!(program.deployment_slot, 0);
-                    assert_eq!(program.effective_slot, 1);
+                    assert_eq!(program.effective_slot(), 1);
                 }
             });
 
@@ -1430,7 +1430,7 @@ pub(crate) mod tests {
             .for_each(|(_key, program)| {
                 if matches!(program.program, ProgramCacheEntryType::Unloaded(_))
                     && program.deployment_slot == 0
-                    && program.effective_slot == 1
+                    && program.effective_slot() == 1
                 {
                     // Test that the usage counter was correctly updated.
                     assert_eq!(program.stats.uses.load(Ordering::Relaxed), 10);
@@ -1479,7 +1479,7 @@ pub(crate) mod tests {
             {
                 assert_eq!(entry.deployment_slot, *deployment_slot);
                 assert_eq!(
-                    entry.effective_slot,
+                    entry.effective_slot(),
                     deployment_slot.saturating_add(*delay_visibility as u64)
                 );
             }
@@ -1668,7 +1668,7 @@ pub(crate) mod tests {
         );
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 0);
-        assert_eq!(tombstone.effective_slot, 0);
+        assert_eq!(tombstone.effective_slot(), 0);
 
         let tombstone = ProgramCacheEntry::new_tombstone(
             100,
@@ -1678,7 +1678,7 @@ pub(crate) mod tests {
         assert_matches!(tombstone.program, ProgramCacheEntryType::Closed);
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 100);
-        assert_eq!(tombstone.effective_slot, 100);
+        assert_eq!(tombstone.effective_slot(), 100);
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
         let program1 = Pubkey::new_unique();
@@ -1692,7 +1692,7 @@ pub(crate) mod tests {
         assert_eq!(slot_versions.len(), 1);
         assert!(slot_versions.first().unwrap().is_tombstone());
         assert_eq!(tombstone.deployment_slot, 10);
-        assert_eq!(tombstone.effective_slot, 10);
+        assert_eq!(tombstone.effective_slot(), 10);
 
         // Add a program at slot 50, and a tombstone for the program at slot 60
         let program2 = Pubkey::new_unique();
@@ -1713,7 +1713,7 @@ pub(crate) mod tests {
         assert!(slot_versions.get(1).unwrap().is_tombstone());
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 60);
-        assert_eq!(tombstone.effective_slot, 60);
+        assert_eq!(tombstone.effective_slot(), 60);
     }
 
     struct TestForkGraph {
@@ -2400,7 +2400,7 @@ pub(crate) mod tests {
         let entry = new_test_entry_with_usage(1, 2, stats);
         let unloaded_entry = entry.to_unloaded().unwrap();
         assert_eq!(unloaded_entry.deployment_slot, 1);
-        assert_eq!(unloaded_entry.effective_slot, 2);
+        assert_eq!(unloaded_entry.effective_slot(), 2);
         assert_eq!(unloaded_entry.latest_access_slot.load(Ordering::Relaxed), 1);
         assert_eq!(unloaded_entry.stats.uses.load(Ordering::Relaxed), 3);
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1033,10 +1033,10 @@ pub(crate) mod tests {
         test_case::{test_case, test_matrix},
     };
 
-    fn new_test_entry(deployment_slot: Slot, effective_slot: Slot) -> Arc<ProgramCacheEntry> {
+    fn new_test_entry(deployment_slot: Slot, _effective_slot: Slot) -> Arc<ProgramCacheEntry> {
         new_test_entry_with_usage(
             deployment_slot,
-            effective_slot,
+            _effective_slot,
             ProgramStatistics::default(),
         )
     }
@@ -1053,18 +1053,17 @@ pub(crate) mod tests {
 
     pub(crate) fn new_test_entry_with_usage(
         deployment_slot: Slot,
-        effective_slot: Slot,
+        _effective_slot: Slot,
         stats: ProgramStatistics,
     ) -> Arc<ProgramCacheEntry> {
         debug_assert_eq!(
-            effective_slot,
+            _effective_slot,
             deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
         );
         Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot,
-            effective_slot,
             stats: Arc::new(stats),
             latest_access_slot: AtomicU64::new(deployment_slot),
         })
@@ -1072,14 +1071,13 @@ pub(crate) mod tests {
 
     fn new_test_builtin_entry(
         deployment_slot: Slot,
-        effective_slot: Slot,
+        _effective_slot: Slot,
     ) -> Arc<ProgramCacheEntry> {
-        debug_assert_eq!(effective_slot, deployment_slot);
+        debug_assert_eq!(_effective_slot, deployment_slot);
         Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
             account_owner: ProgramCacheEntryOwner::NativeLoader,
             deployment_slot,
-            effective_slot,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         })
@@ -1458,7 +1456,6 @@ pub(crate) mod tests {
                         )), // Assign them different environments
                         account_owner: ProgramCacheEntryOwner::LoaderV2,
                         deployment_slot,
-                        effective_slot: deployment_slot.saturating_add(delay_visibility as u64),
                         stats: Arc::default(),
                         latest_access_slot: AtomicU64::new(deployment_slot),
                     }
@@ -1532,7 +1529,6 @@ pub(crate) mod tests {
                 program: old,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
                 deployment_slot: 10,
-                effective_slot: 11,
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
@@ -1545,7 +1541,6 @@ pub(crate) mod tests {
                 program: new,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
                 deployment_slot: 10,
-                effective_slot: 11,
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
@@ -1580,7 +1575,6 @@ pub(crate) mod tests {
                 program: old,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
                 deployment_slot: 10,
-                effective_slot: 11,
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
@@ -1593,7 +1587,6 @@ pub(crate) mod tests {
                 program: new,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
                 deployment_slot: 10,
-                effective_slot: 11,
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             }),
@@ -1609,7 +1602,6 @@ pub(crate) mod tests {
             program: ProgramCacheEntryType::Closed,
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 9,
-            effective_slot: 9,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
@@ -1617,7 +1609,6 @@ pub(crate) mod tests {
             program: ProgramCacheEntryType::Closed,
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 10,
-            effective_slot: 10,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
@@ -1625,7 +1616,6 @@ pub(crate) mod tests {
             program: ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 10,
-            effective_slot: 11,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
@@ -1635,7 +1625,6 @@ pub(crate) mod tests {
             )),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 10,
-            effective_slot: 11,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::default(),
         });
@@ -1794,7 +1783,6 @@ pub(crate) mod tests {
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 20,
-            effective_slot: 21,
             ..Default::default()
         });
         cache.assign_program(&env, program1, 20, updated_program.clone());
@@ -1822,25 +1810,21 @@ pub(crate) mod tests {
         let old_program_old_env = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(env.clone()),
             deployment_slot: 10,
-            effective_slot: 11,
             ..Default::default()
         });
         let old_program_new_env = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 10,
-            effective_slot: 11,
             ..Default::default()
         });
         let new_program_old_env = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(env.clone()),
             deployment_slot: 20,
-            effective_slot: 21,
             ..Default::default()
         });
         let new_program_new_env = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 20,
-            effective_slot: 21,
             ..Default::default()
         });
         cache.assign_program(&env, program1, 10, old_program_old_env.clone());
@@ -2379,7 +2363,6 @@ pub(crate) mod tests {
                 program: program_cache_entry_type,
                 account_owner: ProgramCacheEntryOwner::LoaderV2,
                 deployment_slot: 0,
-                effective_slot: 0,
                 stats: Arc::default(),
                 latest_access_slot: AtomicU64::default(),
             });

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1016,8 +1016,7 @@ pub(crate) mod tests {
                 get_mock_program_runtime_environment,
             },
             program_cache_entry::{
-                DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
-                ProgramCacheEntryType,
+                ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
             },
             program_metrics::ProgramStatistics,
         },
@@ -1033,12 +1032,8 @@ pub(crate) mod tests {
         test_case::{test_case, test_matrix},
     };
 
-    fn new_test_entry(deployment_slot: Slot, _effective_slot: Slot) -> Arc<ProgramCacheEntry> {
-        new_test_entry_with_usage(
-            deployment_slot,
-            _effective_slot,
-            ProgramStatistics::default(),
-        )
+    fn new_test_entry(deployment_slot: Slot) -> Arc<ProgramCacheEntry> {
+        new_test_entry_with_usage(deployment_slot, ProgramStatistics::default())
     }
 
     fn new_loaded_entry(env: ProgramRuntimeEnvironment) -> ProgramCacheEntryType {
@@ -1053,13 +1048,8 @@ pub(crate) mod tests {
 
     pub(crate) fn new_test_entry_with_usage(
         deployment_slot: Slot,
-        _effective_slot: Slot,
         stats: ProgramStatistics,
     ) -> Arc<ProgramCacheEntry> {
-        debug_assert_eq!(
-            _effective_slot,
-            deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-        );
         Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(get_mock_program_runtime_environment()),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
@@ -1069,11 +1059,7 @@ pub(crate) mod tests {
         })
     }
 
-    fn new_test_builtin_entry(
-        deployment_slot: Slot,
-        _effective_slot: Slot,
-    ) -> Arc<ProgramCacheEntry> {
-        debug_assert_eq!(_effective_slot, deployment_slot);
+    fn new_test_builtin_entry(deployment_slot: Slot) -> Arc<ProgramCacheEntry> {
         Arc::new(ProgramCacheEntry {
             program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
             account_owner: ProgramCacheEntryOwner::NativeLoader,
@@ -1105,11 +1091,7 @@ pub(crate) mod tests {
         current_slot: Slot,
     ) -> Arc<ProgramCacheEntry> {
         let env = get_mock_program_runtime_environment();
-        let loaded = new_test_entry_with_usage(
-            current_slot,
-            current_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-            ProgramStatistics::default(),
-        );
+        let loaded = new_test_entry_with_usage(current_slot, ProgramStatistics::default());
         let unloaded = Arc::new(loaded.to_unloaded().expect("Failed to unload the program"));
         cache.assign_program(&env, key, current_slot, unloaded.clone());
         unloaded
@@ -1149,11 +1131,7 @@ pub(crate) mod tests {
                     &env,
                     program,
                     *deployment_slot,
-                    new_test_entry_with_usage(
-                        *deployment_slot,
-                        (*deployment_slot).saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-                        stats,
-                    ),
+                    new_test_entry_with_usage(*deployment_slot, stats),
                 );
                 programs.push((program, *deployment_slot, usage_counter));
             });
@@ -1389,8 +1367,7 @@ pub(crate) mod tests {
                 uses: (i + 10).into(),
                 ..Default::default()
             };
-            let entry =
-                new_test_entry_with_usage(i, i.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET), stats);
+            let entry = new_test_entry_with_usage(i, stats);
             cache.assign_program(&env, program, i, entry);
         });
 
@@ -1419,7 +1396,7 @@ pub(crate) mod tests {
             &env,
             program,
             0,
-            new_test_entry_with_usage(0, 1, ProgramStatistics::default()),
+            new_test_entry_with_usage(0, ProgramStatistics::default()),
         );
 
         cache
@@ -1685,7 +1662,7 @@ pub(crate) mod tests {
 
         // Add a program at slot 50, and a tombstone for the program at slot 60
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 50, new_test_builtin_entry(50, 50));
+        cache.assign_program(&env, program2, 50, new_test_builtin_entry(50));
         let slot_versions = cache.get_slot_versions_for_tests(&program2);
         assert_eq!(slot_versions.len(), 1);
         assert!(!slot_versions.first().unwrap().is_tombstone());
@@ -1779,7 +1756,7 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 10, new_test_entry(10, 11));
+        cache.assign_program(&env, program1, 10, new_test_entry(10));
         let updated_program = Arc::new(ProgramCacheEntry {
             program: new_loaded_entry(new_env.clone()),
             deployment_slot: 20,
@@ -1978,32 +1955,22 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program1, 10, new_test_entry(10, 11));
-        cache.assign_program(&env, program1, 20, new_test_entry(20, 21));
+        cache.assign_program(&env, program1, 0, new_test_entry(0));
+        cache.assign_program(&env, program1, 10, new_test_entry(10));
+        cache.assign_program(&env, program1, 20, new_test_entry(20));
 
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 5, new_test_entry(5, 6));
-        cache.assign_program(
-            &env,
-            program2,
-            11,
-            new_test_entry(11, 11 + DELAY_VISIBILITY_SLOT_OFFSET),
-        );
+        cache.assign_program(&env, program2, 5, new_test_entry(5));
+        cache.assign_program(&env, program2, 11, new_test_entry(11));
 
         let program3 = Pubkey::new_unique();
-        cache.assign_program(&env, program3, 25, new_test_entry(25, 26));
+        cache.assign_program(&env, program3, 25, new_test_entry(25));
 
         let program4 = Pubkey::new_unique();
-        cache.assign_program(&env, program4, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program4, 5, new_test_entry(5, 6));
+        cache.assign_program(&env, program4, 0, new_test_entry(0));
+        cache.assign_program(&env, program4, 5, new_test_entry(5));
         // The following is a special case, where effective slot is 3 slots in the future
-        cache.assign_program(
-            &env,
-            program4,
-            15,
-            new_test_entry(15, 15 + DELAY_VISIBILITY_SLOT_OFFSET),
-        );
+        cache.assign_program(&env, program4, 15, new_test_entry(15));
 
         // Current fork graph
         //                   0
@@ -2171,15 +2138,15 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program1, 20, new_test_entry(20, 21));
+        cache.assign_program(&env, program1, 0, new_test_entry(0));
+        cache.assign_program(&env, program1, 20, new_test_entry(20));
 
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 5, new_test_entry(5, 6));
-        cache.assign_program(&env, program2, 11, new_test_entry(11, 12));
+        cache.assign_program(&env, program2, 5, new_test_entry(5));
+        cache.assign_program(&env, program2, 11, new_test_entry(11));
 
         let program3 = Pubkey::new_unique();
-        cache.assign_program(&env, program3, 25, new_test_entry(25, 26));
+        cache.assign_program(&env, program3, 25, new_test_entry(25));
 
         // Testing fork 0 - 5 - 11 - 15 - 16 - 19 - 21 - 23 with current slot at 19
         let keys = &[program1, program2, program3];
@@ -2232,12 +2199,12 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program1, 20, new_test_entry(20, 21));
+        cache.assign_program(&env, program1, 0, new_test_entry(0));
+        cache.assign_program(&env, program1, 20, new_test_entry(20));
 
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 5, new_test_entry(5, 6));
-        cache.assign_program(&env, program2, 11, new_test_entry(11, 12));
+        cache.assign_program(&env, program2, 5, new_test_entry(5));
+        cache.assign_program(&env, program2, 11, new_test_entry(11));
 
         let program3 = Pubkey::new_unique();
         // Insert an unloaded program with correct/cache's environment at slot 25
@@ -2251,7 +2218,7 @@ pub(crate) mod tests {
             program3,
             20,
             Arc::new(
-                new_test_entry(20, 21)
+                new_test_entry(20)
                     .to_unloaded()
                     .expect("Failed to create unloaded program"),
             ),
@@ -2315,7 +2282,7 @@ pub(crate) mod tests {
                 ProgramCacheEntryType::Closed,
             )),
         );
-        cache.assign_program(&env, program1, 20, new_test_entry(20, 21));
+        cache.assign_program(&env, program1, 20, new_test_entry(20));
 
         // Testing fork 0 - 10 - 20 - 22 with current slot at 22
         let keys = &[program1];
@@ -2380,7 +2347,7 @@ pub(crate) mod tests {
             uses: 3.into(),
             ..Default::default()
         };
-        let entry = new_test_entry_with_usage(1, 2, stats);
+        let entry = new_test_entry_with_usage(1, stats);
         let unloaded_entry = entry.to_unloaded().unwrap();
         assert_eq!(unloaded_entry.deployment_slot, 1);
         assert_eq!(unloaded_entry.effective_slot(), 2);
@@ -2416,8 +2383,8 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program1, 5, new_test_entry(5, 6));
+        cache.assign_program(&env, program1, 0, new_test_entry(0));
+        cache.assign_program(&env, program1, 5, new_test_entry(5));
 
         cache.prune(10, None, &fork_graph.read().unwrap());
 
@@ -2458,11 +2425,11 @@ pub(crate) mod tests {
         cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 0, new_test_entry(0, 1));
-        cache.assign_program(&env, program1, 5, new_test_entry(5, 6));
+        cache.assign_program(&env, program1, 0, new_test_entry(0));
+        cache.assign_program(&env, program1, 5, new_test_entry(5));
 
         let program2 = Pubkey::new_unique();
-        cache.assign_program(&env, program2, 10, new_test_entry(10, 11));
+        cache.assign_program(&env, program2, 10, new_test_entry(10));
 
         let keys = &[program1, program2];
         let mut missing = get_entries_to_load(&cache, 20, keys);
@@ -2533,7 +2500,7 @@ pub(crate) mod tests {
             &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
         ));
 
-        let program = new_test_entry(0, 1);
+        let program = new_test_entry(0);
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &program,
@@ -2555,11 +2522,7 @@ pub(crate) mod tests {
             &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
         ));
 
-        let program = Arc::new(new_test_entry_with_usage(
-            0,
-            1,
-            ProgramStatistics::default(),
-        ));
+        let program = Arc::new(new_test_entry_with_usage(0, ProgramStatistics::default()));
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &program,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1451,15 +1451,25 @@ pub(crate) mod tests {
             entries.shuffle(&mut rng);
             let mut cache = ProgramCache::<TestForkGraph>::new(0);
             for (deployment_slot, delay_visibility) in entries {
-                let entry = Arc::new(ProgramCacheEntry {
-                    program: new_loaded_entry(ProgramRuntimeEnvironment::from(
-                        BuiltinProgram::new_mock(),
-                    )), // Assign them different environments
-                    account_owner: ProgramCacheEntryOwner::LoaderV2,
-                    deployment_slot,
-                    effective_slot: deployment_slot.saturating_add(delay_visibility as u64),
-                    stats: Arc::default(),
-                    latest_access_slot: AtomicU64::new(deployment_slot),
+                let entry = Arc::new(if delay_visibility {
+                    ProgramCacheEntry {
+                        program: new_loaded_entry(ProgramRuntimeEnvironment::from(
+                            BuiltinProgram::new_mock(),
+                        )), // Assign them different environments
+                        account_owner: ProgramCacheEntryOwner::LoaderV2,
+                        deployment_slot,
+                        effective_slot: deployment_slot.saturating_add(delay_visibility as u64),
+                        stats: Arc::default(),
+                        latest_access_slot: AtomicU64::new(deployment_slot),
+                    }
+                } else {
+                    ProgramCacheEntry::new_tombstone(
+                        deployment_slot,
+                        ProgramCacheEntryOwner::LoaderV2,
+                        ProgramCacheEntryType::FailedVerification(ProgramRuntimeEnvironment::from(
+                            BuiltinProgram::new_mock(),
+                        )), // Assign them different environments
+                    )
                 });
                 assert!(!cache.assign_program(&env, program_id, deployment_slot, entry));
             }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -188,7 +188,7 @@ impl std::fmt::Debug for ProgramCacheEntry {
 #[cfg(feature = "dev-context-only-utils")]
 impl PartialEq for ProgramCacheEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.effective_slot == other.effective_slot
+        self.effective_slot() == other.effective_slot()
             && self.deployment_slot == other.deployment_slot
             && self.account_owner == other.account_owner
             && self.is_tombstone() == other.is_tombstone()
@@ -378,10 +378,10 @@ impl ProgramCacheEntry {
 
     pub(crate) fn is_implicit_delay_visibility_tombstone(&self, slot: Slot) -> bool {
         !matches!(self.program, ProgramCacheEntryType::Builtin(_))
-            && self.effective_slot.saturating_sub(self.deployment_slot)
+            && self.effective_slot().saturating_sub(self.deployment_slot)
                 == DELAY_VISIBILITY_SLOT_OFFSET
             && slot >= self.deployment_slot
-            && slot < self.effective_slot
+            && slot < self.effective_slot()
     }
 
     pub fn effective_slot(&self) -> Slot {

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -198,7 +198,6 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -206,7 +205,6 @@ impl ProgramCacheEntry {
             loader_key,
             program_runtime_environment,
             deployment_slot,
-            _effective_slot,
             elf_bytes,
             #[cfg(feature = "metrics")]
             metrics,
@@ -226,7 +224,6 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -234,7 +231,6 @@ impl ProgramCacheEntry {
             loader_key,
             program_runtime_environment,
             deployment_slot,
-            _effective_slot,
             elf_bytes,
             #[cfg(feature = "metrics")]
             metrics,
@@ -246,15 +242,10 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        debug_assert_eq!(
-            _effective_slot,
-            deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
-        );
         let entry_stats = ProgramStatistics::default();
         #[cfg(feature = "metrics")]
         let load_elf_time = solana_svm_measure::measure::Measure::start("load_elf_time");
@@ -460,7 +451,7 @@ mod tests {
             compilation_time_ema: AtomicU64::new(u64::MAX),
             ..Default::default()
         };
-        let program = new_test_entry_with_usage(0, 1, stats);
+        let program = new_test_entry_with_usage(0, stats);
         program.update_access_slot(1);
         assert!(
             dbg!(program.retention_score()) <= 129,
@@ -476,7 +467,7 @@ mod tests {
             compilation_time_ema: AtomicU64::new(1),
             ..Default::default()
         };
-        let program = new_test_entry_with_usage(10, 11, stats);
+        let program = new_test_entry_with_usage(10, stats);
         program.update_access_slot(15);
         let less_used_retention_score = program.retention_score();
         program.stats.uses.fetch_max(1024, Ordering::Relaxed);
@@ -499,7 +490,7 @@ mod tests {
             compilation_time_ema: AtomicU64::new(1000),
             ..Default::default()
         };
-        let program = new_test_entry_with_usage(10, 11, stats);
+        let program = new_test_entry_with_usage(10, stats);
         program.update_access_slot(15);
         let cheaper_to_compile_score = program.retention_score();
         program
@@ -526,7 +517,7 @@ mod tests {
             compilation_time_ema: AtomicU64::new(1000),
             ..Default::default()
         };
-        let program = new_test_entry_with_usage(10, 11, stats);
+        let program = new_test_entry_with_usage(10, stats);
         program.update_access_slot(15);
         let previous_score = program.retention_score();
         program

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -161,8 +161,6 @@ pub struct ProgramCacheEntry {
     pub account_owner: ProgramCacheEntryOwner,
     /// Slot in which the program was (re)deployed
     pub deployment_slot: Slot,
-    /// Slot in which this entry will become active (can be in the future)
-    pub effective_slot: Slot,
     /// How often this entry was used by a transaction
     pub stats: Arc<ProgramStatistics>,
     pub latest_access_slot: AtomicU64,
@@ -188,8 +186,7 @@ impl std::fmt::Debug for ProgramCacheEntry {
 #[cfg(feature = "dev-context-only-utils")]
 impl PartialEq for ProgramCacheEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.effective_slot() == other.effective_slot()
-            && self.deployment_slot == other.deployment_slot
+        self.deployment_slot == other.deployment_slot
             && self.account_owner == other.account_owner
             && self.is_tombstone() == other.is_tombstone()
     }
@@ -201,7 +198,7 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        effective_slot: Slot,
+        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -209,7 +206,7 @@ impl ProgramCacheEntry {
             loader_key,
             program_runtime_environment,
             deployment_slot,
-            effective_slot,
+            _effective_slot,
             elf_bytes,
             #[cfg(feature = "metrics")]
             metrics,
@@ -229,7 +226,7 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        effective_slot: Slot,
+        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -237,7 +234,7 @@ impl ProgramCacheEntry {
             loader_key,
             program_runtime_environment,
             deployment_slot,
-            effective_slot,
+            _effective_slot,
             elf_bytes,
             #[cfg(feature = "metrics")]
             metrics,
@@ -249,13 +246,13 @@ impl ProgramCacheEntry {
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,
-        effective_slot: Slot,
+        _effective_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
         reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         debug_assert_eq!(
-            effective_slot,
+            _effective_slot,
             deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
         );
         let entry_stats = ProgramStatistics::default();
@@ -293,7 +290,6 @@ impl ProgramCacheEntry {
         Ok(Self {
             deployment_slot,
             account_owner: ProgramCacheEntryOwner::try_from(loader_key).unwrap(),
-            effective_slot,
             program: ProgramCacheEntryType::Loaded(executable),
             stats: entry_stats.into(),
             latest_access_slot: AtomicU64::new(0),
@@ -315,7 +311,6 @@ impl ProgramCacheEntry {
             program: ProgramCacheEntryType::Unloaded(environment),
             account_owner: self.account_owner,
             deployment_slot: self.deployment_slot,
-            effective_slot: self.effective_slot,
             stats: Arc::clone(&self.stats),
             latest_access_slot: AtomicU64::new(self.latest_access_slot.load(Ordering::Relaxed)),
         })
@@ -334,7 +329,6 @@ impl ProgramCacheEntry {
         Self {
             deployment_slot,
             account_owner: ProgramCacheEntryOwner::NativeLoader,
-            effective_slot: deployment_slot,
             program: ProgramCacheEntryType::Builtin(program),
             stats: Arc::default(),
             latest_access_slot: AtomicU64::new(0),
@@ -359,7 +353,6 @@ impl ProgramCacheEntry {
             program: reason,
             account_owner,
             deployment_slot: slot,
-            effective_slot: slot,
             stats,
             latest_access_slot: AtomicU64::new(0),
         };
@@ -390,8 +383,7 @@ impl ProgramCacheEntry {
             | ProgramCacheEntryType::DelayVisibility
             | ProgramCacheEntryType::FailedVerification(_)
             | ProgramCacheEntryType::Builtin(_) => self.deployment_slot,
-            ProgramCacheEntryType::Unloaded(_)
-            | ProgramCacheEntryType::Loaded(_) => self
+            ProgramCacheEntryType::Unloaded(_) | ProgramCacheEntryType::Loaded(_) => self
                 .deployment_slot
                 .saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
         }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -361,11 +361,19 @@ impl ProgramCacheEntry {
     }
 
     pub(crate) fn is_implicit_delay_visibility_tombstone(&self, slot: Slot) -> bool {
-        !matches!(self.program, ProgramCacheEntryType::Builtin(_))
-            && self.effective_slot().saturating_sub(self.deployment_slot)
-                == DELAY_VISIBILITY_SLOT_OFFSET
-            && slot >= self.deployment_slot
-            && slot < self.effective_slot()
+        match self.program {
+            ProgramCacheEntryType::Closed
+            | ProgramCacheEntryType::DelayVisibility
+            | ProgramCacheEntryType::FailedVerification(_)
+            | ProgramCacheEntryType::Builtin(_) => false,
+            ProgramCacheEntryType::Unloaded(_) | ProgramCacheEntryType::Loaded(_) => {
+                slot >= self.deployment_slot
+                    && slot
+                        < self
+                            .deployment_slot
+                            .saturating_add(DELAY_VISIBILITY_SLOT_OFFSET)
+            }
+        }
     }
 
     pub fn effective_slot(&self) -> Slot {

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -384,6 +384,19 @@ impl ProgramCacheEntry {
             && slot < self.effective_slot
     }
 
+    pub fn effective_slot(&self) -> Slot {
+        match self.program {
+            ProgramCacheEntryType::Closed
+            | ProgramCacheEntryType::DelayVisibility
+            | ProgramCacheEntryType::FailedVerification(_)
+            | ProgramCacheEntryType::Builtin(_) => self.deployment_slot,
+            ProgramCacheEntryType::Unloaded(_)
+            | ProgramCacheEntryType::Loaded(_) => self
+                .deployment_slot
+                .saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
+        }
+    }
+
     pub fn update_access_slot(&self, slot: Slot) {
         let _ = self.latest_access_slot.fetch_max(slot, Ordering::Relaxed);
     }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -361,19 +361,7 @@ impl ProgramCacheEntry {
     }
 
     pub(crate) fn is_implicit_delay_visibility_tombstone(&self, slot: Slot) -> bool {
-        match self.program {
-            ProgramCacheEntryType::Closed
-            | ProgramCacheEntryType::DelayVisibility
-            | ProgramCacheEntryType::FailedVerification(_)
-            | ProgramCacheEntryType::Builtin(_) => false,
-            ProgramCacheEntryType::Unloaded(_) | ProgramCacheEntryType::Loaded(_) => {
-                slot >= self.deployment_slot
-                    && slot
-                        < self
-                            .deployment_slot
-                            .saturating_add(DELAY_VISIBILITY_SLOT_OFFSET)
-            }
-        }
+        slot >= self.deployment_slot && slot < self.effective_slot()
     }
 
     pub fn effective_slot(&self) -> Slot {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1035,7 +1035,6 @@ mod test_utils {
     use {
         super::*, solana_account::ReadableAccount,
         solana_program_runtime::loaded_programs::ProgramRuntimeEnvironment,
-        solana_program_runtime::program_cache_entry::DELAY_VISIBILITY_SLOT_OFFSET,
         solana_syscalls::create_program_runtime_environment,
     };
 
@@ -1076,12 +1075,10 @@ mod test_utils {
                     .data()
                     .get(programdata_data_offset.min(account.data().len())..)
                     .unwrap();
-                let effective_slot = DELAY_VISIBILITY_SLOT_OFFSET;
                 let loaded_program = ProgramCacheEntry::new(
                     owner,
                     ProgramRuntimeEnvironment::clone(&program_runtime_environment),
                     0,
-                    effective_slot,
                     programdata,
                     #[cfg(feature = "metrics")]
                     &mut LoadProgramMetrics::default(),
@@ -4100,7 +4097,6 @@ mod tests {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 0,
-            effective_slot: 0,
             stats: stats.into(),
             latest_access_slot: AtomicU64::new(0),
         };
@@ -4152,7 +4148,6 @@ mod tests {
             program: ProgramCacheEntryType::Unloaded(env),
             account_owner: ProgramCacheEntryOwner::LoaderV2,
             deployment_slot: 0,
-            effective_slot: 0,
             stats: stats.into(),
             latest_access_slot: AtomicU64::new(0),
         };

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -774,7 +774,7 @@ pub(crate) mod tests {
 
             // The target program entry should be updated.
             assert_eq!(target_entry.deployment_slot, migration_or_upgrade_slot);
-            assert_eq!(target_entry.effective_slot, migration_or_upgrade_slot + 1);
+            assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
 
             // The target program entry should be a BPF program.
             assert_matches!(target_entry.program, ProgramCacheEntryType::Loaded(..));

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6466,7 +6466,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 1);
         assert_eq!(slot_versions[0].deployment_slot, bank.slot());
-        assert_eq!(slot_versions[0].effective_slot, bank.slot());
+        assert_eq!(slot_versions[0].effective_slot(), bank.slot());
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Closed,
@@ -6494,7 +6494,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let slot_versions = program_cache.get_slot_versions_for_tests(&buffer_address);
         assert_eq!(slot_versions.len(), 1);
         assert_eq!(slot_versions[0].deployment_slot, bank.slot());
-        assert_eq!(slot_versions[0].effective_slot, bank.slot());
+        assert_eq!(slot_versions[0].effective_slot(), bank.slot());
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Closed,
@@ -6603,7 +6603,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 1);
         assert_eq!(slot_versions[0].deployment_slot, bank.slot() - 1);
-        assert_eq!(slot_versions[0].effective_slot, bank.slot());
+        assert_eq!(slot_versions[0].effective_slot(), bank.slot());
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Loaded(_),

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -139,7 +139,6 @@ pub fn add_program_to_program_cache(
         loader_key,
         program_runtime_environment,
         0, // deployment_slot
-        1, // effective_slot
         elf,
         #[cfg(feature = "metrics")]
         &mut LoadProgramMetrics::default(),

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,10 +11,7 @@ use {
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
             ProgramToLoad,
         },
-        program_cache_entry::{
-            DELAY_VISIBILITY_SLOT_OFFSET, ProgramCacheEntry, ProgramCacheEntryOwner,
-            ProgramCacheEntryType,
-        },
+        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
@@ -124,7 +121,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             program_account.owner(),
             ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
-            DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
@@ -135,7 +131,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             program_account.owner(),
             ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
-            DELAY_VISIBILITY_SLOT_OFFSET,
             program_account.data(),
             #[cfg(feature = "metrics")]
             &mut load_program_metrics,
@@ -155,7 +150,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                     program_account.owner(),
                     ProgramRuntimeEnvironment::clone(program_runtime_environment),
                     deployment_slot,
-                    deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                     programdata,
                     #[cfg(feature = "metrics")]
                     &mut load_program_metrics,
@@ -174,7 +168,6 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                         &loader_v4::id(),
                         ProgramRuntimeEnvironment::clone(program_runtime_environment),
                         deployment_slot,
-                        deployment_slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
                         elf_bytes,
                         #[cfg(feature = "metrics")]
                         &mut load_program_metrics,
@@ -480,7 +473,6 @@ mod tests {
             &loader,
             ProgramRuntimeEnvironment::clone(&environment),
             slot,
-            slot.saturating_add(DELAY_VISIBILITY_SLOT_OFFSET),
             &buffer,
             #[cfg(feature = "metrics")]
             &mut metrics,
@@ -585,7 +577,6 @@ mod tests {
             account_data.owner(),
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
-            DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
@@ -676,7 +667,6 @@ mod tests {
             account_data.owner(),
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
-            DELAY_VISIBILITY_SLOT_OFFSET,
             account_data.data(),
             #[cfg(feature = "metrics")]
             &mut LoadProgramMetrics::default(),
@@ -833,7 +823,6 @@ mod tests {
                     program: ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
                     account_owner: ProgramCacheEntryOwner::NativeLoader,
                     deployment_slot: 0,
-                    effective_slot: 0,
                     stats: Arc::default(),
                     latest_access_slot: AtomicU64::default(),
                 }),

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -367,7 +367,7 @@ impl SvmTestEnvironment<'_> {
         // in a later batch, the same loaderv3 program will have a DelayedVisibility tombstone
         // a new loaderv1/v2 account will have a FailedVerification tombstone
         // and a closed loaderv3 program or any loaderv3 buffer will have a Closed tombstone
-        program_cache_entry.effective_slot > EXECUTION_SLOT || program_cache_entry.is_tombstone()
+        program_cache_entry.effective_slot() > EXECUTION_SLOT || program_cache_entry.is_tombstone()
     }
 }
 


### PR DESCRIPTION
#### Problem

Continuing to cleanup unnecessary fields in `ProgramCacheEntry`.

`ProgramCacheEntry::effective_slot` should be infered from `ProgramCacheEntry::deployment_slot` and `ProgramCacheEntry::program`, not stored explicitly. That way it can't become inconsistent.

#### Summary of Changes

- Adds `ProgramCacheEntry::effective_slot()`.
- Uses `ProgramCacheEntry::effective_slot()` everywhere instead of the explicitly stored field.
- Removes explicitly stored `ProgramCacheEntry::effective_slot`.
- Removes `effective_slot` from allconstructors of `ProgramCacheEntry`.
- Inlines `ProgramCacheEntry::effective_slot()` in `ProgramCacheEntry::simplicit_delay_visibility_tombstone()`.

#### Testing

- Adjusts `test_fuzz_assign_program_order()` to create entries matching the `delay_visibility` flag.

