### PR TITLE
epoch_stakes: do not store mapping from BLSPubkey to rank

### DIFF
--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -677,7 +677,7 @@ fn convert_packet_to_vote_message(
     let bank = bank_forks.read().unwrap().root_bank();
     let rank_map = bank.get_rank_map(vote_msg.vote.slot())?;
     let sender_entry = rank_map.node_pubkey_to_stake_entry(&sender)?;
-    let rank = *rank_map.get_rank(&sender_entry.bls_pubkey)?;
+    let rank = *rank_map.get_rank_for_vote_pubkey(&sender_entry.vote_account_pubkey)?;
     Some(VoteMessage {
         vote: vote_msg.vote,
         signature: vote_msg.signature,

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -49,8 +49,6 @@ pub struct BLSPubkeyStakeEntry {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct BLSPubkeyToRankMap {
-    /// stores a mapping from the bls pubkey to the node's rank.
-    rank_map: HashMap<BLSPubkeyCompressed, u16>,
     /// stores a mapping from the vote account pubkey to the node's rank.
     vote_pubkey_to_rank: HashMap<Pubkey, u16>,
     /// a mapping from rank to [`BLSPubkeyStakeEntry`].
@@ -67,7 +65,6 @@ pub struct BLSPubkeyToRankMap {
 impl solana_frozen_abi::abi_example::AbiExample for BLSPubkeyToRankMap {
     fn example() -> Self {
         Self {
-            rank_map: HashMap::new(),
             vote_pubkey_to_rank: HashMap::new(),
             sorted_pubkeys: Vec::new(),
             total_stake: NonZero::new(1).unwrap(),
@@ -139,21 +136,17 @@ impl BLSPubkeyToRankMap {
             },
         );
         let mut sorted_pubkeys = Vec::with_capacity(keys_stake_entry_with_compressed.len());
-        let mut bls_pubkey_to_rank_map =
-            HashMap::with_capacity(keys_stake_entry_with_compressed.len());
         let mut vote_pubkey_to_rank_map =
             HashMap::with_capacity(keys_stake_entry_with_compressed.len());
         let mut node_pubkey_map = HashMap::with_capacity(keys_stake_entry_with_compressed.len());
-        for (rank, (entry, bls_pubkey_compressed)) in
+        for (rank, (entry, _bls_pubkey_compressed)) in
             keys_stake_entry_with_compressed.into_iter().enumerate()
         {
             vote_pubkey_to_rank_map.insert(entry.vote_account_pubkey, rank as u16);
-            bls_pubkey_to_rank_map.insert(bls_pubkey_compressed, rank as u16);
             node_pubkey_map.insert(entry.node_pubkey, entry.clone());
             sorted_pubkeys.push(entry);
         }
         Self {
-            rank_map: bls_pubkey_to_rank_map,
             vote_pubkey_to_rank: vote_pubkey_to_rank_map,
             sorted_pubkeys,
             total_stake,
@@ -162,7 +155,7 @@ impl BLSPubkeyToRankMap {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.rank_map.is_empty()
+        self.sorted_pubkeys.is_empty()
     }
 
     pub fn len(&self) -> usize {
@@ -171,11 +164,6 @@ impl BLSPubkeyToRankMap {
 
     pub fn total_stake(&self) -> NonZero<u64> {
         self.total_stake
-    }
-
-    pub fn get_rank(&self, bls_pubkey: &PopVerified<BLSPubkeyAffine>) -> Option<&u16> {
-        let bls_pubkey_compressed = BLSPubkeyCompressed(bls_pubkey.to_bytes_compressed());
-        self.rank_map.get(&bls_pubkey_compressed)
     }
 
     pub fn get_rank_for_vote_pubkey(&self, vote_pubkey: &Pubkey) -> Option<&u16> {
@@ -798,25 +786,6 @@ pub(crate) mod tests {
             bls_pubkey_to_rank_map.total_stake().get(),
             expected_total_stake
         );
-        for (vote_account_pubkey, (stake, vote_account)) in epoch_vote_accounts {
-            let vote_state_view = vote_account.vote_state_view();
-            let (_comp, bls_pubkey) = bls_pubkey_compressed_bytes_to_bls_pubkey(
-                vote_state_view.bls_pubkey_compressed().unwrap(),
-            )
-            .unwrap();
-            let node_pubkey = *vote_state_view.node_pubkey();
-            let index = bls_pubkey_to_rank_map.get_rank(&bls_pubkey).unwrap();
-            assert!(index >= &0 && index < &(expected_num_vote_accounts as u16));
-            assert_eq!(
-                bls_pubkey_to_rank_map.get_pubkey_stake_entry(*index as usize),
-                Some(&BLSPubkeyStakeEntry {
-                    vote_account_pubkey,
-                    node_pubkey,
-                    bls_pubkey,
-                    stake: NonZero::new(stake).unwrap(),
-                })
-            );
-        }
 
         // Convert it to versioned and back, we should get the same rank map
         let mut bank_epoch_stakes = HashMap::new();
@@ -850,24 +819,16 @@ pub(crate) mod tests {
     #[test]
     fn test_bls_pubkey_rank_map_excludes_duplicate_bls_and_identity() {
         let new_bls_pubkey = || {
-            let bls_pubkey_compressed: BLSPubkeyCompressed = (*BLSKeypair::new().public).into();
-            let bls_pubkey_compressed_serialized = wincode::serialize(&bls_pubkey_compressed)
-                .unwrap()
-                .try_into()
-                .unwrap();
-            let (_bls_pubkey_compressed, bls_pubkey) =
-                bls_pubkey_compressed_bytes_to_bls_pubkey(bls_pubkey_compressed_serialized)
-                    .unwrap();
-            (bls_pubkey_compressed_serialized, bls_pubkey)
+            let compressed: BLSPubkeyCompressed = (*BLSKeypair::new().public).into();
+            wincode::serialize(&compressed).unwrap().try_into().unwrap()
         };
 
-        let (duplicate_bls_pubkey_serialized, duplicate_bls_pubkey) = new_bls_pubkey();
-        let (duplicate_node_bls_pubkey_serialized, duplicate_node_bls_pubkey) = new_bls_pubkey();
-        let (duplicate_node_bls_pubkey_serialized_2, duplicate_node_bls_pubkey_2) =
-            new_bls_pubkey();
-        let (shared_voter_bls_pubkey_serialized, shared_voter_bls_pubkey) = new_bls_pubkey();
-        let (shared_voter_bls_pubkey_serialized_2, shared_voter_bls_pubkey_2) = new_bls_pubkey();
-        let (unique_bls_pubkey_serialized, unique_bls_pubkey) = new_bls_pubkey();
+        let duplicate_bls_pubkey_serialized = new_bls_pubkey();
+        let duplicate_node_bls_pubkey_serialized = new_bls_pubkey();
+        let duplicate_node_bls_pubkey_serialized_2 = new_bls_pubkey();
+        let shared_voter_bls_pubkey_serialized = new_bls_pubkey();
+        let shared_voter_bls_pubkey_serialized_2 = new_bls_pubkey();
+        let unique_bls_pubkey_serialized = new_bls_pubkey();
 
         let duplicate_bls_vote_pubkey = Pubkey::new_unique();
         let duplicate_bls_vote_pubkey_2 = Pubkey::new_unique();
@@ -982,13 +943,6 @@ pub(crate) mod tests {
 
         assert_eq!(rank_map.len(), 3);
         assert_eq!(rank_map.total_stake().get(), 250);
-        for bls_pubkey in [
-            duplicate_bls_pubkey,
-            duplicate_node_bls_pubkey,
-            duplicate_node_bls_pubkey_2,
-        ] {
-            assert!(rank_map.get_rank(&bls_pubkey).is_none());
-        }
         for vote_pubkey in [
             duplicate_bls_vote_pubkey,
             duplicate_bls_vote_pubkey_2,
@@ -997,49 +951,6 @@ pub(crate) mod tests {
         ] {
             assert!(rank_map.get_rank_for_vote_pubkey(&vote_pubkey).is_none());
         }
-
-        for (vote_account_pubkey, node_pubkey, bls_pubkey) in [
-            (
-                shared_voter_vote_pubkey,
-                shared_voter_node_pubkey,
-                shared_voter_bls_pubkey,
-            ),
-            (
-                shared_voter_vote_pubkey_2,
-                shared_voter_node_pubkey_2,
-                shared_voter_bls_pubkey_2,
-            ),
-        ] {
-            let rank = *rank_map.get_rank(&bls_pubkey).unwrap();
-            assert_eq!(
-                rank_map.get_rank_for_vote_pubkey(&vote_account_pubkey),
-                Some(&rank)
-            );
-            assert_eq!(
-                rank_map.get_pubkey_stake_entry(rank as usize),
-                Some(&BLSPubkeyStakeEntry {
-                    vote_account_pubkey,
-                    node_pubkey,
-                    bls_pubkey,
-                    stake: NonZero::new(100).unwrap(),
-                })
-            );
-        }
-
-        let unique_rank = *rank_map.get_rank(&unique_bls_pubkey).unwrap();
-        assert_eq!(
-            rank_map.get_rank_for_vote_pubkey(&unique_vote_pubkey),
-            Some(&unique_rank)
-        );
-        assert_eq!(
-            rank_map.get_pubkey_stake_entry(unique_rank as usize),
-            Some(&BLSPubkeyStakeEntry {
-                vote_account_pubkey: unique_vote_pubkey,
-                node_pubkey: unique_node_pubkey,
-                bls_pubkey: unique_bls_pubkey,
-                stake: NonZero::new(50).unwrap(),
-            })
-        );
         assert!(rank_map.get_pubkey_stake_entry(rank_map.len()).is_none());
     }
 


### PR DESCRIPTION
#### Problem

epoch_stakes currently includes a mapping from `BLSPubkey` to rank.  This is not used by any production code.


#### Summary of Changes

Removes the mapping.


#### Testing

CI
