### PR TITLE
program-runtime: defer account range construction

### DIFF
--- a/program-runtime/src/vm.rs
+++ b/program-runtime/src/vm.rs
@@ -220,23 +220,6 @@ pub fn execute<'a, 'b: 'a>(
         )?;
     serialize_time.stop();
 
-    // save the account addresses so in case we hit an AccessViolation error we
-    // can map to a more specific error
-    let account_region_addrs = accounts_metadata
-        .iter()
-        .map(|m| {
-            let vm_end = m
-                .vm_data_addr
-                .saturating_add(m.original_data_len as u64)
-                .saturating_add(if !is_loader_deprecated {
-                    MAX_PERMITTED_DATA_INCREASE as u64
-                } else {
-                    0
-                });
-            m.vm_data_addr..vm_end
-        })
-        .collect::<Vec<_>>();
-
     #[cfg(feature = "sbpf-debugger")]
     let (debug_port, debug_metadata) = if invoke_context.debug_port.is_some() {
         (
@@ -396,11 +379,24 @@ pub fn execute<'a, 'b: 'a>(
                         // If virtual_address_space_adjustments is enabled and a program tries to write to a readonly
                         // region we'll get a memory access violation. Map it to a more specific
                         // error so it's easier for developers to see what happened.
-                        if let Some((instruction_account_index, vm_addr_range)) =
-                            account_region_addrs
-                                .iter()
-                                .enumerate()
-                                .find(|(_, vm_addr_range)| vm_addr_range.contains(&vm_addr))
+                        let account_data_increase = if is_loader_deprecated {
+                            0
+                        } else {
+                            MAX_PERMITTED_DATA_INCREASE as u64
+                        };
+                        if let Some((instruction_account_index, metadata)) = invoke_context
+                            .memory_contexts
+                            .memory_context_abi_v1()?
+                            .accounts_metadata
+                            .iter()
+                            .enumerate()
+                            .find(|(_, metadata)| {
+                                let vm_data_end = metadata
+                                    .vm_data_addr
+                                    .saturating_add(metadata.original_data_len as u64)
+                                    .saturating_add(account_data_increase);
+                                (metadata.vm_data_addr..vm_data_end).contains(&vm_addr)
+                            })
                         {
                             let transaction_context = &invoke_context.transaction_context;
                             let instruction_context =
@@ -408,12 +404,16 @@ pub fn execute<'a, 'b: 'a>(
                             let account = instruction_context.try_borrow_instruction_account(
                                 instruction_account_index as IndexOfAccount,
                             )?;
-                            if vm_addr.saturating_add(len) <= vm_addr_range.end {
+                            let vm_data_end = metadata
+                                .vm_data_addr
+                                .saturating_add(metadata.original_data_len as u64)
+                                .saturating_add(account_data_increase);
+                            if vm_addr.saturating_add(len) <= vm_data_end {
                                 // The access was within the range of the accounts address space,
                                 // but it might not be within the range of the actual data.
                                 let is_access_outside_of_data = vm_addr
                                     .saturating_add(len)
-                                    .saturating_sub(vm_addr_range.start)
+                                    .saturating_sub(metadata.vm_data_addr)
                                     as usize
                                     > account.get_data().len();
                                 error = EbpfError::SyscallError(Box::new(match access_type {


### PR DESCRIPTION
## Summary

Build account address ranges only when mapping an access violation, avoiding eager allocation during successful execution.

Split from #13681.

## Benchmark

A read-only two-minute sample from a mainnet replay validator covered 284 slots:

- 1,721 transactions/slot on average (p90 2,060)
- 18.33 loaded accounts/transaction and 2.57 changed accounts/transaction
- 193 µs accumulated execution CPU/transaction
- all three related VM features are currently inactive

A finalized block had mean 18.12 account keys, median 5, and p90 54. The local benchmark models that as a 64-transaction batch: 32 transactions with 5 loaded accounts, 24 with 24, and 8 with 54. It uses one short successful SBF invocation per transaction and the current mainnet feature configuration.

Two order-reversed runs, each with 5,050 measured batch iterations:

| Counter | Change |
|---|---:|
| Retired instructions | −0.16% and −0.24% |
| Branches | −0.118% average |
| Approximate saving | 379 instructions and 33 branches/transaction |

Wall-clock results changed sign with run order, so no latency/throughput speedup is claimed. The stable result is a small reduction in CPU work; production impact is expected to be below the benchmark percentage for compute-heavy programs.

<details>
<summary>Benchmark harness and commands</summary>

Add this bench target to `runtime/Cargo.toml`:

```toml
[[bench]]
name = "load_and_execute_transactions"
harness = false
```

`runtime/benches/load_and_execute_transactions.rs`:

```rust
#![allow(clippy::arithmetic_side_effects)]
//! Benchmarks for `Bank::load_and_execute_transactions()`.
//!
//! Because `load_and_execute_transactions` does not commit, the same locked
//! batch can be re-executed on the same bank every iteration: account state,
//! the status cache, and the blockhash queue are unchanged across iterations.
//! Criterion's warm-up populates the global program cache, so steady-state
//! numbers measure the warm path.

use {
    criterion::{Criterion, criterion_group, criterion_main},
    solana_account::Account,
    solana_clock::MAX_PROCESSING_AGE,
    solana_instruction::{AccountMeta, Instruction},
    solana_keypair::Keypair,
    solana_leader_schedule::SlotLeader,
    solana_native_token::LAMPORTS_PER_SOL,
    solana_pubkey::Pubkey,
    solana_rent::Rent,
    solana_runtime::{
        bank::Bank,
        bank_forks::BankForks,
        genesis_utils::{GenesisConfigInfo, create_genesis_config, deactivate_features},
    },
    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
    solana_sdk_ids::system_program,
    solana_signer::Signer,
    solana_svm::{
        transaction_error_metrics::TransactionErrorMetrics,
        transaction_processor::TransactionProcessingConfig,
    },
    solana_svm_timings::ExecuteTimings,
    solana_transaction::{Transaction, sanitized::SanitizedTransaction},
    std::{
        hint::black_box,
        sync::{Arc, RwLock},
        time::Duration,
    },
};

#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
#[global_allocator]
static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;

const HELLO_SOLANA_ELF: &[u8] =
    include_bytes!("../../svm/tests/example-programs/hello-solana/hello_solana_program.so");
const PAYER_LAMPORTS: u64 = LAMPORTS_PER_SOL;

const DATA_ACCOUNT_SIZE: usize = 0;

// Matches a sampled finalized mainnet block:
// mean 18.25 loaded accounts, median 5, p90 54.
fn data_accounts_per_tx(index: usize) -> usize {
    match index % 64 {
        0..32 => 3,   // 5 loaded accounts including payer and program
        32..56 => 22, // 24 loaded accounts
        _ => 52,      // 54 loaded accounts
    }
}

struct BenchSetup {
    bank: Arc<Bank>,
    // Parent banks must stay alive so the program cache retains its fork graph.
    _bank_forks: Arc<RwLock<BankForks>>,
    program_id: Pubkey,
    payers: Vec<Keypair>,
    // Per-payer account sets, so transactions in a batch do not contend.
    data_accounts: Vec<Vec<Pubkey>>,
}

fn setup(num_payers: usize) -> BenchSetup {
    let GenesisConfigInfo {
        mut genesis_config, ..
    } = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);

    let payers: Vec<Keypair> = (0..num_payers).map(|_| Keypair::new()).collect();
    for payer in &payers {
        genesis_config.accounts.insert(
            payer.pubkey(),
            Account::new(PAYER_LAMPORTS, 0, &system_program::id()),
        );
    }

    // Register the BPF program directly in genesis (deployment slot 0), so it
    // is visible from slot 1 onward (delay visibility).
    let program_id = Pubkey::new_unique();
    for (key, account) in solana_program_binaries::bpf_loader_upgradeable_program_accounts(
        &program_id,
        HELLO_SOLANA_ELF,
        &Rent::default(),
    ) {
        genesis_config.accounts.insert(key, account);
    }

    // Zero-data accounts isolate account metadata/range construction while
    // retaining the current mainnet realloc-reservation serialization path.
    let rent_exempt = Rent::default().minimum_balance(DATA_ACCOUNT_SIZE);
    let data_accounts: Vec<Vec<Pubkey>> = (0..num_payers)
        .enumerate()
        .map(|(index, _)| {
            (0..data_accounts_per_tx(index))
                .map(|_| {
                    let key = Pubkey::new_unique();
                    genesis_config.accounts.insert(
                        key,
                        Account::new(rent_exempt, DATA_ACCOUNT_SIZE, &program_id),
                    );
                    key
                })
                .collect()
        })
        .collect();

    // Test banks activate every feature gate; mainnet does not have the
    // direct-mapping family yet, and with it on the serializer skips the
    // account-data copies this bench is meant to exercise.
    deactivate_features(
        &mut genesis_config,
        &vec![
            agave_feature_set::account_data_direct_mapping::id(),
            agave_feature_set::direct_account_pointers_in_program_input::id(),
            agave_feature_set::virtual_address_space_adjustments::id(),
        ],
    );

    let (genesis_bank, bank_forks) =
        Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
    let bank = Bank::new_from_parent(genesis_bank, SlotLeader::default(), 1);
    let bank = bank_forks
        .write()
        .unwrap()
        .insert(bank)
        .clone_without_scheduler();

    BenchSetup {
        bank,
        _bank_forks: bank_forks,
        program_id,
        payers,
        data_accounts,
    }
}

fn transfer_transactions(
    bank: &Bank,
    payers: &[Keypair],
) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
    payers
        .iter()
        .map(|payer| {
            RuntimeTransaction::from_transaction_for_tests(solana_system_transaction::transfer(
                payer,
                &Pubkey::new_unique(),
                1,
                bank.last_blockhash(),
            ))
        })
        .collect()
}

fn bpf_transactions(
    bank: &Bank,
    payers: &[Keypair],
    program_id: &Pubkey,
) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
    payers
        .iter()
        .map(|payer| {
            let instruction = Instruction::new_with_bytes(*program_id, &[], vec![]);
            RuntimeTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
                &[instruction],
                Some(&payer.pubkey()),
                &[payer],
                bank.last_blockhash(),
            ))
        })
        .collect()
}

/// Like `bpf_transactions`, but with the sampled mainnet account-count
/// distribution. The first two data accounts are writable and the rest are
/// readonly; all are unique across transactions.
fn bpf_data_transactions(
    bank: &Bank,
    payers: &[Keypair],
    program_id: &Pubkey,
    data_accounts: &[Vec<Pubkey>],
) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
    payers
        .iter()
        .zip(data_accounts)
        .map(|(payer, accounts)| {
            let account_metas = accounts
                .iter()
                .enumerate()
                .map(|(index, key)| {
                    if index < 2 {
                        AccountMeta::new(*key, false)
                    } else {
                        AccountMeta::new_readonly(*key, false)
                    }
                })
                .collect();
            let instruction = Instruction::new_with_bytes(*program_id, &[], account_metas);
            RuntimeTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
                &[instruction],
                Some(&payer.pubkey()),
                &[payer],
                bank.last_blockhash(),
            ))
        })
        .collect()
}

fn run_bench(
    c: &mut Criterion,
    name: &str,
    bank: &Bank,
    transactions: Vec<RuntimeTransaction<SanitizedTransaction>>,
) {
    let num_transactions = transactions.len();
    let batch = bank.prepare_sanitized_batch(&transactions);
    assert!(
        batch.lock_results().iter().all(|result| result.is_ok()),
        "account locks failed for {name}"
    );

    // Pre-flight: every transaction must execute successfully, otherwise the
    // bench would silently measure an error path.
    let mut timings = ExecuteTimings::default();
    let mut error_counters = TransactionErrorMetrics::default();
    let output = bank.load_and_execute_transactions(
        &batch,
        MAX_PROCESSING_AGE,
        &mut timings,
        &mut error_counters,
        // Default config matches replay: all recording disabled.
        TransactionProcessingConfig::default(),
    );
    assert_eq!(
        output
            .processed_counts
            .processed_with_successful_result_count,
        num_transactions as u64,
        "pre-flight execution failed for {name}: {:?}",
        output
            .processing_results
            .iter()
            .find(|result| result.is_err())
    );

    c.bench_function(name, |b| {
        b.iter(|| {
            black_box(bank.load_and_execute_transactions(
                &batch,
                MAX_PROCESSING_AGE,
                &mut timings,
                &mut error_counters,
                TransactionProcessingConfig::default(),
            ))
        })
    });

    // Cumulative ExecuteTimings across all iterations; the ratios between
    // buckets attribute where bench time goes (matches production metrics).
    if std::env::var_os("DUMP_TIMINGS").is_some() {
        eprintln!("=== {name} cumulative timings ===\n{timings:#?}");
    }
}

fn bench_transfers_64(c: &mut Criterion) {
    let setup = setup(64);
    let transactions = transfer_transactions(&setup.bank, &setup.payers);
    run_bench(c, "transfer_64", &setup.bank, transactions);
}

fn bench_transfers_1(c: &mut Criterion) {
    let setup = setup(1);
    let transactions = transfer_transactions(&setup.bank, &setup.payers);
    run_bench(c, "transfer_1", &setup.bank, transactions);
}

fn bench_bpf_64(c: &mut Criterion) {
    let setup = setup(64);
    let transactions = bpf_transactions(&setup.bank, &setup.payers, &setup.program_id);
    run_bench(c, "bpf_64", &setup.bank, transactions);
}

fn bench_bpf_data_1(c: &mut Criterion) {
    let setup = setup(1);
    let transactions = bpf_data_transactions(
        &setup.bank,
        &setup.payers,
        &setup.program_id,
        &setup.data_accounts,
    );
    run_bench(c, "bpf_data_1", &setup.bank, transactions);
}

fn bench_bpf_data_64(c: &mut Criterion) {
    let setup = setup(64);
    let transactions = bpf_data_transactions(
        &setup.bank,
        &setup.payers,
        &setup.program_id,
        &setup.data_accounts,
    );
    run_bench(c, "bpf_data_64", &setup.bank, transactions);
}

fn config() -> Criterion {
    Criterion::default()
        .warm_up_time(Duration::from_secs(3))
        .measurement_time(Duration::from_secs(10))
}

criterion_group! {
    name = benches;
    config = config();
    targets = bench_transfers_64, bench_transfers_1, bench_bpf_64, bench_bpf_data_1, bench_bpf_data_64
}
criterion_main!(benches);
```

Run Criterion:

```bash
cargo bench -p solana-runtime --bench load_and_execute_transactions -- \
  bpf_data_64 --noplot --save-baseline base

cargo bench -p solana-runtime --bench load_and_execute_transactions -- \
  bpf_data_64 --noplot --baseline base
```

The hardware-counter runs used the optimized base/head binaries, pinned to the same CPU:

```bash
perf stat -x, \
  -e instructions:u,cycles:u,branches:u,branch-misses:u -- \
  taskset -c 2 ./load_and_execute_transactions \
  --bench bpf_data_64 --exact --noplot \
  --measurement-time 5 --warm-up-time 0.1 --sample-size 100
```

</details>

