### PR TITLE
svm: skip empty program cache replenishment

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -902,6 +902,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         limit_to_load_programs: bool,
         increment_usage_counter: bool,
     ) {
+        if missing_programs.is_empty() {
+            // Nothing to load, so skip the global cache and fork graph locks.
+            // Program-cache hit/miss counters are unchanged for empty work.
+            return;
+        }
         let mut count_hits_and_misses = true;
         loop {
             // Lock the global cache.


### PR DESCRIPTION
## Summary

Return early when there are no missing programs, avoiding unnecessary program-cache and fork-graph locks.

Split from #13681.

## Testing

`cargo check -p solana-svm --lib`
