### PR TITLE
program-runtime: optimize alloc size for transaction containers

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -352,7 +352,10 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         signers: &[Pubkey],
     ) -> Result<(), InstructionError> {
         // We reference accounts by an u8 index, so we have a total of 256 accounts.
-        let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+        let transaction_callee_map_len = (self.transaction_context.get_number_of_accounts()
+            as usize)
+            .min(MAX_ACCOUNTS_PER_TRANSACTION);
+        let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; transaction_callee_map_len];
         let mut instruction_accounts: Vec<InstructionAccount> =
             Vec::with_capacity(instruction.accounts.len());
 
@@ -556,7 +559,11 @@ impl<'a, 'ix_data> InvokeContext<'a, 'ix_data> {
         for (top_level_instruction_index, (_, instruction)) in
             message.program_instructions_iter().enumerate()
         {
-            let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+            let transaction_callee_map_len = message
+                .account_keys()
+                .len()
+                .min(MAX_ACCOUNTS_PER_TRANSACTION);
+            let mut transaction_callee_map: Vec<u16> = vec![u16::MAX; transaction_callee_map_len];
 
             let mut instruction_accounts: Vec<InstructionAccount> =
                 Vec::with_capacity(instruction.accounts.len());
@@ -1153,7 +1160,7 @@ mod tests {
         solana_signer::Signer,
         solana_svm_feature_set::SVMFeatureSet,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
-        solana_transaction_context::MAX_ACCOUNTS_PER_INSTRUCTION,
+        solana_transaction_context::{MAX_ACCOUNTS_PER_INSTRUCTION, MAX_ACCOUNTS_PER_TRANSACTION},
         test_case::test_case,
     };
 
@@ -1410,13 +1417,14 @@ mod tests {
             MAX_INSTRUCTIONS,
             2,
         );
+        let num_transaction_accounts = usize::from(transaction_context.get_number_of_accounts());
 
         transaction_context
             .configure_instruction_at_index(
                 0,
                 0,
                 vec![InstructionAccount::new(0, false, false)],
-                vec![u16::MAX; 256],
+                vec![u16::MAX; num_transaction_accounts],
                 Cow::Owned(Vec::new()),
                 None,
             )
@@ -1427,7 +1435,7 @@ mod tests {
                 1,
                 0,
                 vec![InstructionAccount::new(0, false, false)],
-                vec![u16::MAX; 256],
+                vec![u16::MAX; num_transaction_accounts],
                 Cow::Owned(Vec::new()),
                 None,
             )

--- a/program-runtime/src/serialization.rs
+++ b/program-runtime/src/serialization.rs
@@ -811,6 +811,8 @@ mod tests {
                     instruction_accounts.push(instruction_accounts.last().cloned().unwrap());
                 }
                 let instruction_data = vec![];
+                let num_transaction_accounts =
+                    transaction_accounts.len().min(MAX_ACCOUNTS_PER_TRANSACTION);
 
                 with_mock_invoke_context!(
                     invoke_context,
@@ -821,7 +823,7 @@ mod tests {
                     // Special case implementation of configure_next_instruction_for_tests()
                     // which avoids the overflow when constructing the dedup_map
                     // by simply not filling it.
-                    let dedup_map = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+                    let dedup_map = vec![u16::MAX; num_transaction_accounts];
                     invoke_context
                         .transaction_context
                         .configure_instruction_at_index(

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1568,6 +1568,7 @@ mod tests {
             11,
             4,
         );
+        let num_transaction_accounts = usize::from(transaction_context.get_number_of_accounts());
 
         // Four top level instructions
         for i in 0..4 {
@@ -1576,7 +1577,7 @@ mod tests {
                     i,
                     0,
                     vec![],
-                    vec![u16::MAX; 256],
+                    vec![u16::MAX; num_transaction_accounts],
                     Cow::Owned(vec![i as u8]),
                     None,
                 )
@@ -1795,7 +1796,7 @@ mod tests {
             header: MessageHeader::default(),
             instructions: vec![CompiledInstruction {
                 program_id_index: 0,
-                accounts: vec![2],
+                accounts: vec![1],
                 data: vec![],
             }],
             recent_blockhash: Hash::default(),
@@ -1811,8 +1812,6 @@ mod tests {
             false,
         );
 
-        let mut account_data = AccountSharedData::default();
-        account_data.set_owner(bpf_loader::id());
         let loaded_transaction = LoadedTransaction {
             accounts: vec![
                 (key1, AccountSharedData::default()),

--- a/transaction-context/src/transaction.rs
+++ b/transaction-context/src/transaction.rs
@@ -294,7 +294,10 @@ impl<'ix_data> TransactionContext<'ix_data> {
         instruction_data: Cow<'ix_data, [u8]>,
         caller_index: Option<u16>,
     ) -> Result<(), InstructionError> {
-        debug_assert_eq!(deduplication_map.len(), MAX_ACCOUNTS_PER_TRANSACTION);
+        debug_assert_eq!(
+            deduplication_map.len(),
+            usize::from(self.get_number_of_accounts()).min(MAX_ACCOUNTS_PER_TRANSACTION)
+        );
 
         let instruction = self
             .instruction_trace
@@ -337,8 +340,15 @@ impl<'ix_data> TransactionContext<'ix_data> {
     }
 
     /// For tests only
-    fn deduplicate_accounts_for_tests(instruction_accounts: &[InstructionAccount]) -> Vec<u16> {
-        let mut dedup_map = vec![u16::MAX; MAX_ACCOUNTS_PER_TRANSACTION];
+    fn deduplicate_accounts_for_tests(
+        &self,
+        instruction_accounts: &[InstructionAccount],
+    ) -> Vec<u16> {
+        let mut dedup_map = vec![
+            u16::MAX;
+            usize::from(self.get_number_of_accounts())
+                .min(MAX_ACCOUNTS_PER_TRANSACTION)
+        ];
         for (idx, account) in instruction_accounts.iter().enumerate() {
             let index_in_instruction = dedup_map
                 .get_mut(account.index_in_transaction as usize)
@@ -358,7 +368,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         instruction_data: Vec<u8>,
     ) -> Result<(), InstructionError> {
         debug_assert!(instruction_accounts.len() <= u16::MAX as usize);
-        let dedup_map = Self::deduplicate_accounts_for_tests(&instruction_accounts);
+        let dedup_map = self.deduplicate_accounts_for_tests(&instruction_accounts);
 
         self.configure_instruction_at_index(
             self.next_top_level_instruction_index,
@@ -379,7 +389,7 @@ impl<'ix_data> TransactionContext<'ix_data> {
         instruction_data: Vec<u8>,
     ) -> Result<(), InstructionError> {
         debug_assert!(instruction_accounts.len() <= u16::MAX as usize);
-        let dedup_map = Self::deduplicate_accounts_for_tests(&instruction_accounts);
+        let dedup_map = self.deduplicate_accounts_for_tests(&instruction_accounts);
         let caller_index = self.get_current_instruction_index()?;
         let cpi_index = self.get_instruction_trace_length();
         self.configure_instruction_at_index(
@@ -780,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_instruction_shared_items() {
-        let transaction_accounts = vec![(Pubkey::new_unique(), AccountSharedData::default()); 10];
+        let transaction_accounts = vec![(Pubkey::new_unique(), AccountSharedData::default()); 11];
         let mut transaction_context =
             TransactionContext::new(transaction_accounts, Rent::default(), 20, 20, 3);
 
@@ -919,7 +929,7 @@ mod tests {
                 0,
                 0,
                 vec![InstructionAccount::new(1, false, false)],
-                vec![0; MAX_ACCOUNTS_PER_TRANSACTION],
+                vec![0; 3],
                 Vec::new().into(),
                 None,
             )
@@ -931,7 +941,7 @@ mod tests {
                 1,
                 0,
                 vec![InstructionAccount::new(1, false, false)],
-                vec![0; MAX_ACCOUNTS_PER_TRANSACTION],
+                vec![0; 3],
                 Vec::new().into(),
                 None,
             )
@@ -1362,7 +1372,7 @@ mod tests {
                     InstructionAccount::new(0, false, false),
                     InstructionAccount::new(1, false, false),
                 ],
-                vec![u16::MAX; 256],
+                vec![u16::MAX; 3],
                 Cow::Owned(Vec::new()),
                 None,
             )
@@ -1377,7 +1387,7 @@ mod tests {
                     InstructionAccount::new(0, false, false),
                     InstructionAccount::new(1, false, true),
                 ],
-                vec![u16::MAX; 256],
+                vec![u16::MAX; 3],
                 Cow::Owned(Vec::new()),
                 None,
             )


### PR DESCRIPTION
## Summary

Size transaction callee deduplication maps from the actual account count instead of the maximum transaction limit. Adjust the affected execution error-path test.

Split from #13681.

## Testing

`cargo check -p solana-program-runtime -p solana-svm -p solana-transaction-context --lib`
