### PR TITLE
svm-conformance: add VM serialization runner

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8539,11 +8539,15 @@ dependencies = [
 name = "solana-svm-conformance"
 version = "4.3.0-alpha.2"
 dependencies = [
+ "bincode",
  "clap 4.6.1",
  "prost 0.11.9",
  "protosol",
  "solana-compute-budget",
  "solana-program-runtime",
+ "solana-pubkey 4.2.0",
+ "solana-rent",
+ "solana-sdk-ids",
  "solana-svm",
  "solana-syscalls",
 ]

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -44,5 +44,11 @@ solana-program-runtime = { workspace = true, optional = true }
 solana-svm = { workspace = true, optional = true }
 solana-syscalls = { workspace = true, optional = true }
 
+[dev-dependencies]
+bincode = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-rent = { workspace = true }
+solana-sdk-ids = { workspace = true }
+
 [lints]
 workspace = true

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -18,6 +18,11 @@ name = "test_exec_elf_loader"
 path = "src/bin/test_exec_elf_loader.rs"
 required-features = ["cli", "ffi"]
 
+[[bin]]
+name = "test_exec_vm_serialization"
+path = "src/bin/test_exec_vm_serialization.rs"
+required-features = ["cli", "ffi"]
+
 [features]
 default = ["cli", "ffi"]
 agave-unstable-api = []

--- a/svm-conformance/src/bin/test_exec_vm_serialization.rs
+++ b/svm-conformance/src/bin/test_exec_vm_serialization.rs
@@ -1,0 +1,48 @@
+use {clap::Parser, prost::Message, protosol::protos::VmSerializationFixture, std::path::PathBuf};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let Ok(fixture) = VmSerializationFixture::decode(&blob[..]) else {
+        println!("Failed to parse fixture.");
+        return false;
+    };
+
+    let Some(context) = fixture.input else {
+        println!("No context found.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+
+    let effects = solana_svm_conformance::serialization::execute_vm_serialize(context);
+
+    let ok = effects == expected;
+    if ok {
+        println!("OK: {input:?}");
+    } else {
+        println!("FAIL: {input:?}");
+        println!("Expected: {expected:?}");
+        println!("Actual: {effects:?}");
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -5,3 +5,5 @@
 
 #[cfg(feature = "ffi")]
 pub mod elf_loader;
+#[cfg(feature = "ffi")]
+pub mod serialization;

--- a/svm-conformance/src/serialization.rs
+++ b/svm-conformance/src/serialization.rs
@@ -1,0 +1,244 @@
+//! VM serialization conformance harness.
+
+use {
+    prost::Message,
+    protosol::protos::{
+        InstrContext as ProtoInstrContext, VmInputMemoryRegion as ProtoVmInputMemoryRegion,
+        VmSerializationEffects as ProtoVmSerializationEffects,
+        VmSerializedAccountMetadata as ProtoVmSerializedAccountMetadata,
+    },
+    solana_program_runtime::{
+        invoke_context::InvokeContext, loaded_programs::ProgramCacheForTxBatch,
+        memory_context::SerializedAccountMetadata, solana_sbpf::memory_region::MemoryRegion,
+    },
+    solana_svm::conformance::{
+        callback::DefaultCallback,
+        fd_hash::fd_hash,
+        instr::context::InstrContext,
+        serialization::{SerializedParameters, push_and_serialize_parameters},
+        setup::{
+            InvokeContextFields, compute_budget, prepare_invoke_context_fields, program_loader_key,
+            program_runtime_environments, sysvar_cache_from_accounts,
+        },
+    },
+    std::ffi::c_int,
+};
+
+pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEffects {
+    let instr_context = InstrContext::from(input);
+
+    let feature_set = instr_context.feature_set;
+
+    let compute_budget = compute_budget(&feature_set);
+    // No CU limit for this harness.
+
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
+    let program_id = instr_context.instruction.program_id;
+    let loader_key = program_loader_key(&instr_context.accounts, &program_id);
+
+    let program_runtime_environments = program_runtime_environments(&feature_set, &compute_budget);
+
+    // We're only testing the parameter serialization, so use an empty cache.
+    let mut program_cache = ProgramCacheForTxBatch::default();
+
+    let InvokeContextFields {
+        sanitized_message,
+        mut transaction_context,
+        environment_config,
+        log_collector,
+        execution_budget,
+        execution_cost,
+    } = prepare_invoke_context_fields(
+        &instr_context,
+        &DefaultCallback,
+        &loader_key,
+        &sysvar_cache,
+        &compute_budget,
+        &program_runtime_environments,
+    );
+
+    let mut invoke_context = InvokeContext::new(
+        &mut transaction_context,
+        &mut program_cache,
+        environment_config,
+        Some(log_collector.clone()),
+        execution_budget,
+        execution_cost,
+    );
+
+    match push_and_serialize_parameters(&mut invoke_context, &sanitized_message, &feature_set) {
+        Ok(SerializedParameters {
+            aligned_memory,
+            input_memory_regions,
+            account_metadata,
+        }) => {
+            let serialized_memory_hash = fd_hash(0, aligned_memory.as_slice());
+            let vm_input_memory_regions = input_memory_regions
+                .iter()
+                .map(memory_region_to_proto)
+                .collect();
+            let serialized_account_metadata = account_metadata
+                .iter()
+                .map(serialized_acct_meta_to_proto)
+                .collect();
+            ProtoVmSerializationEffects {
+                has_error: false,
+                serialized_memory_hash,
+                vm_input_memory_regions,
+                serialized_account_metadata,
+            }
+        }
+        Err(_) => ProtoVmSerializationEffects {
+            has_error: true,
+            ..Default::default()
+        },
+    }
+}
+
+fn memory_region_to_proto(region: &MemoryRegion) -> ProtoVmInputMemoryRegion {
+    ProtoVmInputMemoryRegion {
+        vm_address: region.vm_addr_range().start,
+        region_size: region.len() as u64,
+        is_writable: region.host_buffer().is_mutable(),
+    }
+}
+
+fn serialized_acct_meta_to_proto(
+    meta: &SerializedAccountMetadata,
+) -> ProtoVmSerializedAccountMetadata {
+    ProtoVmSerializedAccountMetadata {
+        original_data_len: meta.original_data_len as u64,
+        vm_data_addr: meta.vm_data_addr,
+        vm_key_addr: meta.vm_key_addr,
+        vm_lamports_addr: meta.vm_lamports_addr,
+        vm_owner_addr: meta.vm_owner_addr,
+    }
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
+        return 0;
+    };
+
+    let effects = execute_vm_serialize(instr_context);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe { *out_psz = out_vec.len() as u64 };
+
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        protosol::protos::{AcctState as ProtoAcctState, InstrAcct as ProtoInstrAcct},
+        solana_pubkey::Pubkey,
+        solana_rent::Rent,
+        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable, sysvar},
+    };
+
+    const PROGRAM_ID: [u8; 32] = [7; 32];
+
+    fn account(address: u8, owner: Pubkey, data_len: usize) -> ProtoAcctState {
+        ProtoAcctState {
+            address: vec![address; 32],
+            lamports: 1,
+            data: vec![0; data_len],
+            executable: false,
+            owner: owner.to_bytes().to_vec(),
+        }
+    }
+
+    fn instr_acct(index: u32, is_writable: bool, is_signer: bool) -> ProtoInstrAcct {
+        ProtoInstrAcct {
+            index,
+            is_writable,
+            is_signer,
+        }
+    }
+
+    fn rent_sysvar() -> ProtoAcctState {
+        ProtoAcctState {
+            address: sysvar::rent::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(&Rent::default()).unwrap(),
+            executable: false,
+            owner: sysvar::id().to_bytes().to_vec(),
+        }
+    }
+
+    fn serialize(
+        mut accounts: Vec<ProtoAcctState>,
+        instr_accounts: Vec<ProtoInstrAcct>,
+    ) -> ProtoVmSerializationEffects {
+        accounts.push(rent_sysvar()); // <-- Loads Rent into SysvarCache
+        execute_vm_serialize(ProtoInstrContext {
+            program_id: PROGRAM_ID.to_vec(),
+            accounts,
+            instr_accounts,
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn test_serialize_single_account() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+
+    #[test]
+    fn test_serialize_multiple_accounts() {
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 4),
+                account(2, program_id, 16),
+                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
+            ],
+            vec![instr_acct(0, true, true), instr_acct(1, false, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 2);
+    }
+
+    #[test]
+    fn test_serialize_deprecated_loader_program() {
+        // A program owned by the deprecated loader exercises the unaligned
+        // serialization path.
+        let program_id = Pubkey::new_from_array(PROGRAM_ID);
+        let effects = serialize(
+            vec![
+                account(1, program_id, 8),
+                account(PROGRAM_ID[0], bpf_loader_deprecated::id(), 0),
+            ],
+            vec![instr_acct(0, true, false)],
+        );
+        assert!(!effects.has_error);
+        assert_eq!(effects.serialized_account_metadata.len(), 1);
+    }
+}

--- a/svm/src/conformance/serialization.rs
+++ b/svm/src/conformance/serialization.rs
@@ -1,26 +1,10 @@
-//! VM serialization conformance harness.
+//! Program-input parameter serialization, shared by the conformance harnesses.
 
 use {
-    crate::conformance::{
-        callback::DefaultCallback,
-        fd_hash::fd_hash,
-        instr::context::InstrContext,
-        setup::{
-            InvokeContextFields, compute_budget, prepare_invoke_context_fields, program_loader_key,
-            program_runtime_environments, sysvar_cache_from_accounts,
-        },
-    },
-    prost::Message,
-    protosol::protos::{
-        InstrContext as ProtoInstrContext, VmInputMemoryRegion as ProtoVmInputMemoryRegion,
-        VmSerializationEffects as ProtoVmSerializationEffects,
-        VmSerializedAccountMetadata as ProtoVmSerializedAccountMetadata,
-    },
     solana_instruction::error::InstructionError,
     solana_message::SanitizedMessage,
     solana_program_runtime::{
         invoke_context::InvokeContext,
-        loaded_programs::ProgramCacheForTxBatch,
         memory_context::SerializedAccountMetadata,
         serialization::serialize_parameters,
         solana_sbpf::{
@@ -28,91 +12,19 @@ use {
         },
     },
     solana_svm_feature_set::SVMFeatureSet,
-    std::ffi::c_int,
 };
-
-pub fn execute_vm_serialize(input: ProtoInstrContext) -> ProtoVmSerializationEffects {
-    let instr_context = InstrContext::from(input);
-
-    let feature_set = instr_context.feature_set;
-
-    let compute_budget = compute_budget(&feature_set);
-    // No CU limit for this harness.
-
-    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
-    let program_id = instr_context.instruction.program_id;
-    let loader_key = program_loader_key(&instr_context.accounts, &program_id);
-
-    let program_runtime_environments = program_runtime_environments(&feature_set, &compute_budget);
-
-    // We're only testing the parameter serialization, so use an empty cache.
-    let mut program_cache = ProgramCacheForTxBatch::default();
-
-    let InvokeContextFields {
-        sanitized_message,
-        mut transaction_context,
-        environment_config,
-        log_collector,
-        execution_budget,
-        execution_cost,
-    } = prepare_invoke_context_fields(
-        &instr_context,
-        &DefaultCallback,
-        &loader_key,
-        &sysvar_cache,
-        &compute_budget,
-        &program_runtime_environments,
-    );
-
-    let mut invoke_context = InvokeContext::new(
-        &mut transaction_context,
-        &mut program_cache,
-        environment_config,
-        Some(log_collector.clone()),
-        execution_budget,
-        execution_cost,
-    );
-
-    match push_and_serialize_parameters(&mut invoke_context, &sanitized_message, &feature_set) {
-        Ok(SerializedParameters {
-            aligned_memory,
-            input_memory_regions,
-            account_metadata,
-        }) => {
-            let serialized_memory_hash = fd_hash(0, aligned_memory.as_slice());
-            let vm_input_memory_regions = input_memory_regions
-                .iter()
-                .map(memory_region_to_proto)
-                .collect();
-            let serialized_account_metadata = account_metadata
-                .iter()
-                .map(serialized_acct_meta_to_proto)
-                .collect();
-            ProtoVmSerializationEffects {
-                has_error: false,
-                serialized_memory_hash,
-                vm_input_memory_regions,
-                serialized_account_metadata,
-            }
-        }
-        Err(_) => ProtoVmSerializationEffects {
-            has_error: true,
-            ..Default::default()
-        },
-    }
-}
 
 /// The product of serializing a program's input parameters into VM memory: the
 /// serialized region itself plus the metadata needed to map accounts back out.
-pub(crate) struct SerializedParameters {
-    pub(crate) aligned_memory: AlignedMemory<HOST_ALIGN>,
-    pub(crate) input_memory_regions: Vec<MemoryRegion>,
-    pub(crate) account_metadata: Vec<SerializedAccountMetadata>,
+pub struct SerializedParameters {
+    pub aligned_memory: AlignedMemory<HOST_ALIGN>,
+    pub input_memory_regions: Vec<MemoryRegion>,
+    pub account_metadata: Vec<SerializedAccountMetadata>,
 }
 
 /// Push the message's single top-level instruction onto `invoke_context`, then
 /// serialize that instruction's program input parameters into VM memory.
-pub(crate) fn push_and_serialize_parameters<'ix_data>(
+pub fn push_and_serialize_parameters<'ix_data>(
     invoke_context: &mut InvokeContext<'_, 'ix_data>,
     sanitized_message: &'ix_data SanitizedMessage,
     feature_set: &SVMFeatureSet,
@@ -143,152 +55,4 @@ pub(crate) fn push_and_serialize_parameters<'ix_data>(
             }
         },
     )
-}
-
-fn memory_region_to_proto(region: &MemoryRegion) -> ProtoVmInputMemoryRegion {
-    ProtoVmInputMemoryRegion {
-        vm_address: region.vm_addr_range().start,
-        region_size: region.len() as u64,
-        is_writable: region.host_buffer().is_mutable(),
-    }
-}
-
-fn serialized_acct_meta_to_proto(
-    meta: &SerializedAccountMetadata,
-) -> ProtoVmSerializedAccountMetadata {
-    ProtoVmSerializedAccountMetadata {
-        original_data_len: meta.original_data_len as u64,
-        vm_data_addr: meta.vm_data_addr,
-        vm_key_addr: meta.vm_key_addr,
-        vm_lamports_addr: meta.vm_lamports_addr,
-        vm_owner_addr: meta.vm_owner_addr,
-    }
-}
-
-/// # Safety
-///
-/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
-/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
-/// is updated to the number of bytes written.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
-    out_ptr: *mut u8,
-    out_psz: *mut u64,
-    in_ptr: *mut u8,
-    in_sz: u64,
-) -> c_int {
-    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
-    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
-        return 0;
-    };
-
-    let effects = execute_vm_serialize(instr_context);
-    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
-    let out_vec = effects.encode_to_vec();
-    if out_vec.len() > out_slice.len() {
-        return 0;
-    }
-    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
-    unsafe { *out_psz = out_vec.len() as u64 };
-
-    1
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        protosol::protos::{AcctState as ProtoAcctState, InstrAcct as ProtoInstrAcct},
-        solana_pubkey::Pubkey,
-        solana_rent::Rent,
-        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable, sysvar},
-    };
-
-    const PROGRAM_ID: [u8; 32] = [7; 32];
-
-    fn account(address: u8, owner: Pubkey, data_len: usize) -> ProtoAcctState {
-        ProtoAcctState {
-            address: vec![address; 32],
-            lamports: 1,
-            data: vec![0; data_len],
-            executable: false,
-            owner: owner.to_bytes().to_vec(),
-        }
-    }
-
-    fn instr_acct(index: u32, is_writable: bool, is_signer: bool) -> ProtoInstrAcct {
-        ProtoInstrAcct {
-            index,
-            is_writable,
-            is_signer,
-        }
-    }
-
-    fn rent_sysvar() -> ProtoAcctState {
-        ProtoAcctState {
-            address: sysvar::rent::id().to_bytes().to_vec(),
-            lamports: 1,
-            data: bincode::serialize(&Rent::default()).unwrap(),
-            executable: false,
-            owner: sysvar::id().to_bytes().to_vec(),
-        }
-    }
-
-    fn serialize(
-        mut accounts: Vec<ProtoAcctState>,
-        instr_accounts: Vec<ProtoInstrAcct>,
-    ) -> ProtoVmSerializationEffects {
-        accounts.push(rent_sysvar()); // <-- Loads Rent into SysvarCache
-        execute_vm_serialize(ProtoInstrContext {
-            program_id: PROGRAM_ID.to_vec(),
-            accounts,
-            instr_accounts,
-            ..Default::default()
-        })
-    }
-
-    #[test]
-    fn test_serialize_single_account() {
-        let program_id = Pubkey::new_from_array(PROGRAM_ID);
-        let effects = serialize(
-            vec![
-                account(1, program_id, 8),
-                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
-            ],
-            vec![instr_acct(0, true, false)],
-        );
-        assert!(!effects.has_error);
-        assert_eq!(effects.serialized_account_metadata.len(), 1);
-    }
-
-    #[test]
-    fn test_serialize_multiple_accounts() {
-        let program_id = Pubkey::new_from_array(PROGRAM_ID);
-        let effects = serialize(
-            vec![
-                account(1, program_id, 4),
-                account(2, program_id, 16),
-                account(PROGRAM_ID[0], bpf_loader_upgradeable::id(), 0),
-            ],
-            vec![instr_acct(0, true, true), instr_acct(1, false, false)],
-        );
-        assert!(!effects.has_error);
-        assert_eq!(effects.serialized_account_metadata.len(), 2);
-    }
-
-    #[test]
-    fn test_serialize_deprecated_loader_program() {
-        // A program owned by the deprecated loader exercises the unaligned
-        // serialization path.
-        let program_id = Pubkey::new_from_array(PROGRAM_ID);
-        let effects = serialize(
-            vec![
-                account(1, program_id, 8),
-                account(PROGRAM_ID[0], bpf_loader_deprecated::id(), 0),
-            ],
-            vec![instr_acct(0, true, false)],
-        );
-        assert!(!effects.has_error);
-        assert_eq!(effects.serialized_account_metadata.len(), 1);
-    }
 }

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -34,18 +34,18 @@ use {
 };
 
 /// Fields required by `InvokeContext::new`.
-pub(crate) struct InvokeContextFields<'a, 'ix_data> {
-    pub(crate) sanitized_message: SanitizedMessage,
-    pub(crate) transaction_context: TransactionContext<'ix_data>,
-    pub(crate) environment_config: EnvironmentConfig<'a>,
-    pub(crate) log_collector: Rc<RefCell<LogCollector>>,
-    pub(crate) execution_budget: SVMTransactionExecutionBudget,
-    pub(crate) execution_cost: SVMTransactionExecutionCost,
+pub struct InvokeContextFields<'a, 'ix_data> {
+    pub sanitized_message: SanitizedMessage,
+    pub transaction_context: TransactionContext<'ix_data>,
+    pub environment_config: EnvironmentConfig<'a>,
+    pub log_collector: Rc<RefCell<LogCollector>>,
+    pub execution_budget: SVMTransactionExecutionBudget,
+    pub execution_cost: SVMTransactionExecutionCost,
 }
 
 /// Compile a sanitized transaction message then instantiate a transaction
 /// context as well as the remaining fields required by `InvokeContext::new`.
-pub(crate) fn prepare_invoke_context_fields<'a, C: InvokeContextCallback>(
+pub fn prepare_invoke_context_fields<'a, C: InvokeContextCallback>(
     instr_context: &'a InstrContext,
     callback: &'a C,
     loader_key: &Pubkey,
@@ -126,7 +126,7 @@ pub(crate) fn prepare_transaction_invoke_context_fields<'a, 'b, C: InvokeContext
 }
 
 // Create a compute budget from the given feature set.
-pub(crate) fn compute_budget(feature_set: &SVMFeatureSet) -> ComputeBudget {
+pub fn compute_budget(feature_set: &SVMFeatureSet) -> ComputeBudget {
     let simd_0268_active = feature_set.raise_cpi_nesting_limit_to_8;
     ComputeBudget::new_with_defaults(simd_0268_active)
 }
@@ -134,7 +134,7 @@ pub(crate) fn compute_budget(feature_set: &SVMFeatureSet) -> ComputeBudget {
 /// The loader that owns the program account in `accounts`, used as the program
 /// account's owner when compiling the transaction. `None` if the program
 /// account isn't present.
-pub(crate) fn program_loader_key(accounts: &[(Pubkey, Account)], program_id: &Pubkey) -> Pubkey {
+pub fn program_loader_key(accounts: &[(Pubkey, Account)], program_id: &Pubkey) -> Pubkey {
     accounts
         .iter()
         .find(|(key, _)| key == program_id)
@@ -197,7 +197,7 @@ pub fn sanitized_message_from_versioned_message(
 
 /// The paired (execution + deployment) program runtime environments for a
 /// harness invocation. Both halves share one environment.
-pub(crate) fn program_runtime_environments(
+pub fn program_runtime_environments(
     feature_set: &SVMFeatureSet,
     compute_budget: &ComputeBudget,
 ) -> ProgramRuntimeEnvironments {
@@ -226,7 +226,7 @@ pub(crate) fn recent_blockhash(sysvar_cache: &SysvarCache) -> (Hash, u64) {
 /// Build a sysvar cache populated from any sysvar accounts present in the
 /// input account set.
 #[cfg(any(feature = "conformance", test))]
-pub(crate) fn sysvar_cache_from_accounts(accounts: &[(Pubkey, Account)]) -> SysvarCache {
+pub fn sysvar_cache_from_accounts(accounts: &[(Pubkey, Account)]) -> SysvarCache {
     let mut cache = SysvarCache::default();
     cache.fill_missing_entries(|pubkey, set_sysvar| {
         if let Some(data) = sysvar_account_data(accounts, pubkey) {


### PR DESCRIPTION
#### Problem

The `solana-svm-conformance` dev-bin now hosts the ELF loader harness and its
runner, but the remaining harnesses still live in `solana-svm`'s `conformance`
module. That module carries protobuf and prost dependencies the validator does
not need in production, and none of the remaining harnesses have a runner bin
for processing fixtures.

#### Summary of Changes

Move the VM serialization harness and its FFI binding
(`sol_compat_vm_serialize_execute_v1`) into `solana-svm-conformance`, then add
the `test_exec_vm_serialization` runner bin target.

#### Testing

Build the test vectors:

```
git clone https://github.com/firedancer-io/test-vectors.git
cd test-vectors
./scripts/package.sh
```

Build and run the conformance target:

```
cargo build --manifest-path dev-bins/Cargo.toml -p solana-svm-conformance
dev-bins/target/debug/test_exec_vm_serialization -- ~/test-vectors/vm_serialization/fixtures/*.fix
```

Part of #13382