### PR TITLE
replay: account for bank switch during ag set root

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1412,6 +1412,7 @@ mod tests {
             &self,
             _parent_slot: Slot,
             new_root: Slot,
+            _block_id: Hash,
             highest_super_majority_root: Option<Slot>,
         ) {
             // Test code only so we allow writing bank forks directly.

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1408,18 +1408,13 @@ mod tests {
             Ok(self.bank_forks.write().unwrap().insert(bank))
         }
 
-        fn enqueue_set_root(
-            &self,
-            _parent_slot: Slot,
-            new_root: Slot,
-            _block_id: Hash,
-            highest_super_majority_root: Option<Slot>,
-        ) {
+        fn enqueue_set_root(&self, new_root: Block) {
+            let new_root = new_root.slot;
             // Test code only so we allow writing bank forks directly.
             self.bank_forks
                 .write()
                 .unwrap()
-                .set_root(new_root, None, highest_super_majority_root);
+                .set_root(new_root, None, Some(new_root));
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5166,9 +5166,19 @@ impl ReplayStage {
         my_pubkey: &Pubkey,
         progress: &mut ProgressMap,
     ) {
+        if !command.matches_frozen_bank(&context.bank_forks.read().unwrap()) {
+            warn!(
+                "{my_pubkey}: Ignoring stale SetRoot for slot {} block_id {}; the matching frozen \
+                 bank is no longer newer than the applied root",
+                command.new_root, command.block_id,
+            );
+            return;
+        }
+
         let SetRootCommand {
             parent_slot,
             new_root,
+            block_id: _,
             highest_super_majority_root,
         } = command;
         root_utils::check_and_handle_new_root(

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5170,22 +5170,17 @@ impl ReplayStage {
             warn!(
                 "{my_pubkey}: Ignoring stale SetRoot for slot {} block_id {}; the matching frozen \
                  bank is no longer newer than the applied root",
-                command.new_root, command.block_id,
+                command.new_root.slot, command.new_root.block_id,
             );
             return;
         }
 
-        let SetRootCommand {
-            parent_slot,
-            new_root,
-            block_id: _,
-            highest_super_majority_root,
-        } = command;
+        let new_root = command.new_root.slot;
         root_utils::check_and_handle_new_root(
-            parent_slot,
+            new_root,
             new_root,
             context.snapshot_controller.as_deref(),
-            highest_super_majority_root,
+            Some(new_root),
             &context.bank_notification_sender,
             &context.drop_bank_sender,
             &context.blockstore,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -622,10 +622,10 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
     let my_pubkey = Pubkey::new_unique();
 
     let missing_command = SetRootCommand {
-        parent_slot: 2,
-        new_root: 2,
-        block_id: Hash::new_unique(),
-        highest_super_majority_root: Some(2),
+        new_root: Block {
+            slot: 2,
+            block_id: Hash::new_unique(),
+        },
     };
     ReplayStage::process_set_root_command(
         missing_command,
@@ -637,10 +637,10 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
     assert!(!blockstore.is_root(2));
 
     let mismatched_command = SetRootCommand {
-        parent_slot: 1,
-        new_root: 1,
-        block_id: Hash::new_unique(),
-        highest_super_majority_root: Some(1),
+        new_root: Block {
+            slot: 1,
+            block_id: Hash::new_unique(),
+        },
     };
     ReplayStage::process_set_root_command(
         mismatched_command,
@@ -656,10 +656,10 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
     unfrozen_bank.set_block_id(Some(unfrozen_block_id));
     bank_forks.write().unwrap().insert(unfrozen_bank);
     let unfrozen_command = SetRootCommand {
-        parent_slot: 2,
-        new_root: 2,
-        block_id: unfrozen_block_id,
-        highest_super_majority_root: Some(2),
+        new_root: Block {
+            slot: 2,
+            block_id: unfrozen_block_id,
+        },
     };
     ReplayStage::process_set_root_command(
         unfrozen_command,
@@ -672,10 +672,7 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
 
     let block_id = bank_forks.read().unwrap().block_id(1).unwrap();
     let matching_command = SetRootCommand {
-        parent_slot: 1,
-        new_root: 1,
-        block_id,
-        highest_super_majority_root: Some(1),
+        new_root: Block { slot: 1, block_id },
     };
     ReplayStage::process_set_root_command(
         matching_command,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -603,6 +603,91 @@ fn test_handle_new_root() {
 }
 
 #[test]
+fn test_process_set_root_command_requires_matching_frozen_bank() {
+    let (mut vote_simulator, blockstore) = setup_forks_from_tree(tr(0) / tr(1), 1, None);
+    let bank_forks = vote_simulator.bank_forks.clone();
+    let blockstore = Arc::new(blockstore);
+    let root_bank = bank_forks.read().unwrap().root_bank();
+    let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&root_bank));
+    let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
+    let context = ProcessBankForksContext {
+        bank_forks: bank_forks.clone(),
+        blockstore: blockstore.clone(),
+        snapshot_controller: None,
+        bank_notification_sender: None,
+        rpc_subscriptions: None,
+        drop_bank_sender,
+        leader_schedule_cache,
+    };
+    let my_pubkey = Pubkey::new_unique();
+
+    let missing_command = SetRootCommand {
+        parent_slot: 2,
+        new_root: 2,
+        block_id: Hash::new_unique(),
+        highest_super_majority_root: Some(2),
+    };
+    ReplayStage::process_set_root_command(
+        missing_command,
+        &context,
+        &my_pubkey,
+        &mut vote_simulator.progress,
+    );
+    assert_eq!(bank_forks.read().unwrap().root(), 0);
+    assert!(!blockstore.is_root(2));
+
+    let mismatched_command = SetRootCommand {
+        parent_slot: 1,
+        new_root: 1,
+        block_id: Hash::new_unique(),
+        highest_super_majority_root: Some(1),
+    };
+    ReplayStage::process_set_root_command(
+        mismatched_command,
+        &context,
+        &my_pubkey,
+        &mut vote_simulator.progress,
+    );
+    assert_eq!(bank_forks.read().unwrap().root(), 0);
+    assert!(!blockstore.is_root(1));
+
+    let unfrozen_block_id = Hash::new_unique();
+    let unfrozen_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 2);
+    unfrozen_bank.set_block_id(Some(unfrozen_block_id));
+    bank_forks.write().unwrap().insert(unfrozen_bank);
+    let unfrozen_command = SetRootCommand {
+        parent_slot: 2,
+        new_root: 2,
+        block_id: unfrozen_block_id,
+        highest_super_majority_root: Some(2),
+    };
+    ReplayStage::process_set_root_command(
+        unfrozen_command,
+        &context,
+        &my_pubkey,
+        &mut vote_simulator.progress,
+    );
+    assert_eq!(bank_forks.read().unwrap().root(), 0);
+    assert!(!blockstore.is_root(2));
+
+    let block_id = bank_forks.read().unwrap().block_id(1).unwrap();
+    let matching_command = SetRootCommand {
+        parent_slot: 1,
+        new_root: 1,
+        block_id,
+        highest_super_majority_root: Some(1),
+    };
+    ReplayStage::process_set_root_command(
+        matching_command,
+        &context,
+        &my_pubkey,
+        &mut vote_simulator.progress,
+    );
+    assert_eq!(bank_forks.read().unwrap().root(), 1);
+    assert!(blockstore.is_root(1));
+}
+
+#[test]
 fn test_handle_new_root_ahead_of_highest_super_majority_root() {
     let genesis_config = create_genesis_config(10_000).genesis_config;
     let bank0 = Bank::new_for_tests(&genesis_config);

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -1,8 +1,9 @@
 use {
-    crate::{bank::Bank, installed_scheduler_pool::BankWithScheduler},
+    crate::{bank::Bank, bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler},
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded},
     log::warn,
     solana_clock::Slot,
+    solana_hash::Hash,
     solana_metrics::datapoint_info,
     std::{
         fmt,
@@ -33,10 +34,22 @@ pub enum BankForksCommand {
     },
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct SetRootCommand {
     pub parent_slot: Slot,
     pub new_root: Slot,
+    pub block_id: Hash,
     pub highest_super_majority_root: Option<Slot>,
+}
+
+impl SetRootCommand {
+    /// Whether the requested root still identifies a frozen bank newer than the applied root.
+    pub fn matches_frozen_bank(&self, bank_forks: &BankForks) -> bool {
+        self.new_root > bank_forks.root()
+            && bank_forks
+                .get(self.new_root)
+                .is_some_and(|bank| bank.is_frozen() && bank.block_id() == Some(self.block_id))
+    }
 }
 
 impl BankForksCommand {
@@ -64,6 +77,7 @@ pub trait BankForksController: Send + Sync {
         &self,
         parent_slot: Slot,
         new_root: Slot,
+        block_id: Hash,
         highest_super_majority_root: Option<Slot>,
     );
 
@@ -161,12 +175,14 @@ impl BankForksController for BankForksControllerHandle {
         &self,
         parent_slot: Slot,
         new_root: Slot,
+        block_id: Hash,
         highest_super_majority_root: Option<Slot>,
     ) {
         let total_start = Instant::now();
         let command = SetRootCommand {
             parent_slot,
             new_root,
+            block_id,
             highest_super_majority_root,
         };
 
@@ -236,13 +252,16 @@ mod tests {
     fn test_bank_forks_controller_keeps_highest_pending_set_root() {
         let (controller, receiver) = BankForksControllerHandle::new();
 
-        controller.enqueue_set_root(5, 5, Some(5));
-        controller.enqueue_set_root(3, 3, Some(3));
-        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 5);
+        let block_id_5 = Hash::new_unique();
+        controller.enqueue_set_root(5, 5, block_id_5, Some(5));
+        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
+        let command = receiver.take_set_root_command().unwrap();
+        assert_eq!(command.new_root, 5);
+        assert_eq!(command.block_id, block_id_5);
         assert!(receiver.take_set_root_command().is_none());
 
-        controller.enqueue_set_root(3, 3, Some(3));
-        controller.enqueue_set_root(5, 5, Some(5));
+        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
+        controller.enqueue_set_root(5, 5, block_id_5, Some(5));
         assert_eq!(receiver.take_set_root_command().unwrap().new_root, 5);
     }
 
@@ -250,21 +269,63 @@ mod tests {
     fn test_bank_forks_controller_signals_pending_set_root() {
         let (controller, receiver) = BankForksControllerHandle::new();
 
-        controller.enqueue_set_root(1, 1, Some(1));
+        controller.enqueue_set_root(1, 1, Hash::new_unique(), Some(1));
         receiver
             .set_root_signal_receiver()
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
         assert_eq!(receiver.take_set_root_command().unwrap().new_root, 1);
 
-        controller.enqueue_set_root(2, 2, Some(2));
-        controller.enqueue_set_root(3, 3, Some(3));
+        controller.enqueue_set_root(2, 2, Hash::new_unique(), Some(2));
+        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
         receiver
             .set_root_signal_receiver()
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
         assert!(receiver.set_root_signal_receiver().try_recv().is_err());
         assert_eq!(receiver.take_set_root_command().unwrap().new_root, 3);
+    }
+
+    #[test]
+    fn test_set_root_command_matches_frozen_bank() {
+        let genesis = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
+        let parent_bank = bank_forks.read().unwrap().root_bank();
+        let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 1);
+        let block_id = Hash::new_unique();
+        bank.set_block_id(Some(block_id));
+        let bank = bank_forks
+            .write()
+            .unwrap()
+            .insert(bank)
+            .clone_without_scheduler();
+        let command = SetRootCommand {
+            parent_slot: 1,
+            new_root: 1,
+            block_id,
+            highest_super_majority_root: Some(1),
+        };
+
+        assert!(!command.matches_frozen_bank(&bank_forks.read().unwrap()));
+        bank.freeze();
+        assert!(command.matches_frozen_bank(&bank_forks.read().unwrap()));
+
+        let mismatched_command = SetRootCommand {
+            block_id: Hash::new_unique(),
+            ..command
+        };
+        assert!(!mismatched_command.matches_frozen_bank(&bank_forks.read().unwrap()));
+
+        let missing_command = SetRootCommand {
+            parent_slot: 2,
+            new_root: 2,
+            block_id: Hash::new_unique(),
+            highest_super_majority_root: Some(2),
+        };
+        assert!(!missing_command.matches_frozen_bank(&bank_forks.read().unwrap()));
+
+        bank_forks.write().unwrap().set_root(1, None, None);
+        assert!(!command.matches_frozen_bank(&bank_forks.read().unwrap()));
     }
 
     #[test]
@@ -321,12 +382,14 @@ mod tests {
 
         let parent_bank = bank_forks.read().unwrap().root_bank();
         let bank = Bank::new_from_parent(parent_bank, SlotLeader::default(), 1);
+        let block_id = Hash::new_unique();
+        bank.set_block_id(Some(block_id));
         bank.freeze();
         let inserted_bank = controller.insert_bank(bank).unwrap();
         assert_eq!(inserted_bank.slot(), 1);
         assert!(bank_forks.read().unwrap().get(1).is_some());
 
-        controller.enqueue_set_root(1, 1, None);
+        controller.enqueue_set_root(1, 1, block_id, None);
         assert_eq!(root_receiver.recv().unwrap(), 1);
         assert_eq!(bank_forks.read().unwrap().root(), 1);
 

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -1,9 +1,9 @@
 use {
     crate::{bank::Bank, bank_forks::BankForks, installed_scheduler_pool::BankWithScheduler},
+    agave_votor_messages::consensus_message::Block,
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, bounded},
     log::warn,
     solana_clock::Slot,
-    solana_hash::Hash,
     solana_metrics::datapoint_info,
     std::{
         fmt,
@@ -36,19 +36,16 @@ pub enum BankForksCommand {
 
 #[derive(Clone, Copy, Debug)]
 pub struct SetRootCommand {
-    pub parent_slot: Slot,
-    pub new_root: Slot,
-    pub block_id: Hash,
-    pub highest_super_majority_root: Option<Slot>,
+    pub new_root: Block,
 }
 
 impl SetRootCommand {
     /// Whether the requested root still identifies a frozen bank newer than the applied root.
     pub fn matches_frozen_bank(&self, bank_forks: &BankForks) -> bool {
-        self.new_root > bank_forks.root()
-            && bank_forks
-                .get(self.new_root)
-                .is_some_and(|bank| bank.is_frozen() && bank.block_id() == Some(self.block_id))
+        self.new_root.slot > bank_forks.root()
+            && bank_forks.get(self.new_root.slot).is_some_and(|bank| {
+                bank.is_frozen() && bank.block_id() == Some(self.new_root.block_id)
+            })
     }
 }
 
@@ -73,13 +70,7 @@ impl fmt::Display for BankForksCommand {
 pub trait BankForksController: Send + Sync {
     fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError>;
 
-    fn enqueue_set_root(
-        &self,
-        parent_slot: Slot,
-        new_root: Slot,
-        block_id: Hash,
-        highest_super_majority_root: Option<Slot>,
-    );
+    fn enqueue_set_root(&self, new_root: Block);
 
     fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError>;
 }
@@ -171,27 +162,16 @@ impl BankForksController for BankForksControllerHandle {
         bank.ok_or(BankForksControllerError::UnableToInsertStaleBank(slot))
     }
 
-    fn enqueue_set_root(
-        &self,
-        parent_slot: Slot,
-        new_root: Slot,
-        block_id: Hash,
-        highest_super_majority_root: Option<Slot>,
-    ) {
+    fn enqueue_set_root(&self, new_root: Block) {
         let total_start = Instant::now();
-        let command = SetRootCommand {
-            parent_slot,
-            new_root,
-            block_id,
-            highest_super_majority_root,
-        };
+        let command = SetRootCommand { new_root };
 
         {
             let mut pending_set_root = self.pending_set_root.lock().unwrap();
             // Replay only needs to process the highest pending root.
             if pending_set_root
                 .as_ref()
-                .is_none_or(|pending| command.new_root > pending.new_root)
+                .is_none_or(|pending| command.new_root.slot > pending.new_root.slot)
             {
                 *pending_set_root = Some(command);
             }
@@ -203,7 +183,7 @@ impl BankForksController for BankForksControllerHandle {
         datapoint_info!(
             "bank_forks_controller-command",
             ("command", "set_root", String),
-            ("slot", new_root as i64, i64),
+            ("slot", new_root.slot as i64, i64),
             ("total_us", total_us, i64),
         );
     }
@@ -245,6 +225,7 @@ mod tests {
     use {
         super::*,
         crate::{bank::SlotLeader, bank_forks::BankForks, genesis_utils::create_genesis_config},
+        solana_hash::Hash,
         std::{thread, time::Duration},
     };
 
@@ -253,37 +234,58 @@ mod tests {
         let (controller, receiver) = BankForksControllerHandle::new();
 
         let block_id_5 = Hash::new_unique();
-        controller.enqueue_set_root(5, 5, block_id_5, Some(5));
-        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
+        controller.enqueue_set_root(Block {
+            slot: 5,
+            block_id: block_id_5,
+        });
+        controller.enqueue_set_root(Block {
+            slot: 3,
+            block_id: Hash::new_unique(),
+        });
         let command = receiver.take_set_root_command().unwrap();
-        assert_eq!(command.new_root, 5);
-        assert_eq!(command.block_id, block_id_5);
+        assert_eq!(command.new_root.slot, 5);
+        assert_eq!(command.new_root.block_id, block_id_5);
         assert!(receiver.take_set_root_command().is_none());
 
-        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
-        controller.enqueue_set_root(5, 5, block_id_5, Some(5));
-        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 5);
+        controller.enqueue_set_root(Block {
+            slot: 3,
+            block_id: Hash::new_unique(),
+        });
+        controller.enqueue_set_root(Block {
+            slot: 5,
+            block_id: block_id_5,
+        });
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root.slot, 5);
     }
 
     #[test]
     fn test_bank_forks_controller_signals_pending_set_root() {
         let (controller, receiver) = BankForksControllerHandle::new();
 
-        controller.enqueue_set_root(1, 1, Hash::new_unique(), Some(1));
+        controller.enqueue_set_root(Block {
+            slot: 1,
+            block_id: Hash::new_unique(),
+        });
         receiver
             .set_root_signal_receiver()
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
-        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 1);
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root.slot, 1);
 
-        controller.enqueue_set_root(2, 2, Hash::new_unique(), Some(2));
-        controller.enqueue_set_root(3, 3, Hash::new_unique(), Some(3));
+        controller.enqueue_set_root(Block {
+            slot: 2,
+            block_id: Hash::new_unique(),
+        });
+        controller.enqueue_set_root(Block {
+            slot: 3,
+            block_id: Hash::new_unique(),
+        });
         receiver
             .set_root_signal_receiver()
             .recv_timeout(Duration::from_secs(1))
             .unwrap();
         assert!(receiver.set_root_signal_receiver().try_recv().is_err());
-        assert_eq!(receiver.take_set_root_command().unwrap().new_root, 3);
+        assert_eq!(receiver.take_set_root_command().unwrap().new_root.slot, 3);
     }
 
     #[test]
@@ -300,10 +302,7 @@ mod tests {
             .insert(bank)
             .clone_without_scheduler();
         let command = SetRootCommand {
-            parent_slot: 1,
-            new_root: 1,
-            block_id,
-            highest_super_majority_root: Some(1),
+            new_root: Block { slot: 1, block_id },
         };
 
         assert!(!command.matches_frozen_bank(&bank_forks.read().unwrap()));
@@ -311,16 +310,18 @@ mod tests {
         assert!(command.matches_frozen_bank(&bank_forks.read().unwrap()));
 
         let mismatched_command = SetRootCommand {
-            block_id: Hash::new_unique(),
-            ..command
+            new_root: Block {
+                block_id: Hash::new_unique(),
+                ..command.new_root
+            },
         };
         assert!(!mismatched_command.matches_frozen_bank(&bank_forks.read().unwrap()));
 
         let missing_command = SetRootCommand {
-            parent_slot: 2,
-            new_root: 2,
-            block_id: Hash::new_unique(),
-            highest_super_majority_root: Some(2),
+            new_root: Block {
+                slot: 2,
+                block_id: Hash::new_unique(),
+            },
         };
         assert!(!missing_command.matches_frozen_bank(&bank_forks.read().unwrap()));
 
@@ -338,11 +339,12 @@ mod tests {
         let replay_thread = thread::spawn(move || {
             loop {
                 if let Some(command) = receiver.take_set_root_command() {
+                    let new_root = command.new_root.slot;
                     {
                         let mut bank_forks = replay_bank_forks.write().unwrap();
-                        bank_forks.set_root(command.new_root, None, None);
+                        bank_forks.set_root(new_root, None, None);
                     }
-                    root_sender.send(command.new_root).unwrap();
+                    root_sender.send(new_root).unwrap();
                 }
                 let command = match receiver.receiver().recv_timeout(Duration::from_millis(10)) {
                     Ok(command) => command,
@@ -389,7 +391,7 @@ mod tests {
         assert_eq!(inserted_bank.slot(), 1);
         assert!(bank_forks.read().unwrap().get(1).is_some());
 
-        controller.enqueue_set_root(1, 1, block_id, None);
+        controller.enqueue_set_root(Block { slot: 1, block_id });
         assert_eq!(root_receiver.recv().unwrap(), 1);
         assert_eq!(bank_forks.read().unwrap().root(), 1);
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1047,18 +1047,13 @@ mod tests {
             Ok(self.bank_forks.write().unwrap().insert(bank))
         }
 
-        fn enqueue_set_root(
-            &self,
-            parent_slot: Slot,
-            new_root: Slot,
-            _block_id: Hash,
-            highest_super_majority_root: Option<Slot>,
-        ) {
+        fn enqueue_set_root(&self, new_root: Block) {
+            let new_root = new_root.slot;
             root_utils::check_and_handle_new_root(
-                parent_slot,
+                new_root,
                 new_root,
                 None,
-                highest_super_majority_root,
+                Some(new_root),
                 &None,
                 &self.drop_bank_sender,
                 &self.blockstore,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -869,7 +869,7 @@ impl EventHandler {
     ) {
         let bank_forks_r = ctx.bank_forks.read().unwrap();
         let old_root = bank_forks_r.root().max(vctx.vote_history.root());
-        let Some(new_root) = finalized_blocks
+        let Some((new_root, bank_hash)) = finalized_blocks
             .iter()
             .filter_map(|&block| {
                 let bank = bank_forks_r.get(block.slot)?;
@@ -897,9 +897,9 @@ impl EventHandler {
                     && vctx.vote_history.voted(block.slot)
                     && bank.is_frozen()
                     && bank.block_id().is_some_and(|bid| bid == block.block_id))
-                .then_some(block.slot)
+                .then_some((block, bank.hash()))
             })
-            .max()
+            .max_by_key(|(block, _)| block.slot)
         else {
             // No rootable banks
             return;
@@ -908,6 +908,7 @@ impl EventHandler {
         root_utils::set_root(
             my_pubkey,
             new_root,
+            bank_hash,
             ctx,
             vctx,
             rctx,
@@ -915,7 +916,7 @@ impl EventHandler {
             finalized_blocks,
             received_shred,
         );
-        stats.set_root(new_root);
+        stats.set_root(new_root.slot);
     }
 
     pub(crate) fn join(self) -> thread::Result<()> {
@@ -1050,6 +1051,7 @@ mod tests {
             &self,
             parent_slot: Slot,
             new_root: Slot,
+            _block_id: Hash,
             highest_super_majority_root: Option<Slot>,
         ) {
             root_utils::check_and_handle_new_root(

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -56,12 +56,7 @@ pub(crate) fn set_root(
     });
     *received_shred = received_shred.split_off(&new_root_slot);
 
-    rctx.bank_forks_controller.enqueue_set_root(
-        new_root_slot,
-        new_root_slot,
-        new_root.block_id,
-        Some(new_root_slot),
-    );
+    rctx.bank_forks_controller.enqueue_set_root(new_root);
 
     if let Err(e) = ctx.blockstore.insert_optimistic_slot(
         new_root_slot,

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -37,7 +37,8 @@ pub(crate) struct RootContext {
 /// except the certificate pool
 pub(crate) fn set_root(
     my_pubkey: &Pubkey,
-    new_root: Slot,
+    new_root: Block,
+    bank_hash: Hash,
     ctx: &SharedContext,
     vctx: &mut VotingContext,
     rctx: &RootContext,
@@ -45,31 +46,37 @@ pub(crate) fn set_root(
     finalized_blocks: &mut BTreeSet<Block>,
     received_shred: &mut BTreeSet<Slot>,
 ) {
-    info!("{my_pubkey}: setting root {new_root}");
-    vctx.vote_history.set_root(new_root);
-    *pending_blocks = pending_blocks.split_off(&new_root);
+    let new_root_slot = new_root.slot;
+    info!("{my_pubkey}: setting root {new_root:?}");
+    vctx.vote_history.set_root(new_root_slot);
+    *pending_blocks = pending_blocks.split_off(&new_root_slot);
     *finalized_blocks = finalized_blocks.split_off(&Block {
-        slot: new_root,
+        slot: new_root_slot,
         block_id: Hash::default(),
     });
-    *received_shred = received_shred.split_off(&new_root);
+    *received_shred = received_shred.split_off(&new_root_slot);
 
-    rctx.bank_forks_controller
-        .enqueue_set_root(new_root, new_root, Some(new_root));
+    rctx.bank_forks_controller.enqueue_set_root(
+        new_root_slot,
+        new_root_slot,
+        new_root.block_id,
+        Some(new_root_slot),
+    );
 
-    // Distinguish between duplicate versions of same slot
-    let hash = ctx.bank_forks.read().unwrap().bank_hash(new_root).unwrap();
-    if let Err(e) =
-        ctx.blockstore
-            .insert_optimistic_slot(new_root, &hash, timestamp().try_into().unwrap())
-    {
-        error!("failed to record optimistic slot in blockstore: slot={new_root}: {e:?}");
+    if let Err(e) = ctx.blockstore.insert_optimistic_slot(
+        new_root_slot,
+        &bank_hash,
+        timestamp().try_into().unwrap(),
+    ) {
+        error!("failed to record optimistic slot in blockstore: slot={new_root_slot}: {e:?}");
     }
 
-    if let Err(err) =
-        update_commitment_cache(CommitmentType::Rooted, new_root, &vctx.commitment_sender)
-    {
-        warn!("failed to update Alpenglow rooted commitment for root {new_root}: {err}");
+    if let Err(err) = update_commitment_cache(
+        CommitmentType::Rooted,
+        new_root_slot,
+        &vctx.commitment_sender,
+    ) {
+        warn!("failed to update Alpenglow rooted commitment for root {new_root_slot}: {err}");
     }
 
     // It is critical to send the OC notification in order to keep compatibility with
@@ -81,9 +88,8 @@ pub(crate) fn set_root(
             .dependency_tracker
             .as_ref()
             .map(|s| s.get_current_declared_work());
-        // TODO: propagate error
         let _ = config.sender.send((
-            BankNotification::OptimisticallyConfirmed(new_root, hash),
+            BankNotification::OptimisticallyConfirmed(new_root_slot, bank_hash),
             dependency_work,
         ));
     }


### PR DESCRIPTION
#### Problem
It's possible for AG to send the asynchronous `SetRootCommand` and then for replay stage to switch out the bank before processing the command.

Currently this would lead to a panic.

#### Summary of Changes
Have `SetRootCommand` additionally hold the `block_id`. Only process the `SetRootCommand` if:
- Bank exists and is frozen
- Has matching `block_id`

Otherwise ignore the request. It's fine if some requests are ignored because the bank is switched away - `SetRootCommand` only occurs because the block has been finalized, meaning that all further finalization/set roots will occur on descendants.

There's no need to manually force a switch bank, because this finalized block naturally results in a `ParentReady` / switch event to be emitted.

Additionally `root_utils` was grabbing the `bank_hash` off the bank again. This is not safe as the bank could have been switched away. Instead pass in the bank hash.

#### Testing
CI

Fixes https://github.com/anza-xyz/agave/issues/14194