### PR TITLE
Tombstone only storage is dead

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4109,6 +4109,13 @@ impl AccountsDb {
                 self.handle_reclaims(reclaims.iter(), purge_stats, MarkAccountsObsolete::No);
             // Ensure the expected slot is marked dead
             assert_eq!(dead_slots, IntSet::from_iter(iter::once(remove_slot)));
+        } else if self
+            .storage
+            .get_slot_storage_entry(remove_slot)
+            .is_some_and(|store| store.has_only_tombstones())
+        {
+            // A tombstone-only storage has no index entries to reclaim, so purge it directly
+            self.purge_dead_slots_from_storage(iter::once(&remove_slot), purge_stats);
         }
         handle_reclaims_elapsed.stop();
         purge_stats

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5204,15 +5204,6 @@ impl AccountsDb {
             .remove_dead_accounts_shrink_us
             .fetch_add(measure.as_us(), Ordering::Relaxed);
 
-        dead_slots.retain(|slot| {
-            if let Some(slot_store) = self.storage.get_slot_storage_entry(*slot)
-                && slot_store.count() != 0
-            {
-                return false;
-            }
-            true
-        });
-
         dead_slots
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5177,6 +5177,12 @@ impl AccountsDb {
                 if remaining_accounts == 0 {
                     self.dirty_stores.insert(slot, store);
                     dead_slots.insert(slot);
+                } else if remaining_accounts == store.num_tombstones()
+                    && self.can_purge_zero_lamport_single_ref_after_shrink(slot)
+                {
+                    // Every remaining account is a tombstone and the slot is older than
+                    // the latest full snapshot slot, safe to remove
+                    dead_slots.insert(slot);
                 } else if self.is_shrinking_productive(&store)
                     && self.is_candidate_for_shrink(&store)
                 {

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1376,6 +1376,50 @@ fn test_shrink_does_not_resurrect_dead_account() {
     assert!(!accounts.contains(&pubkey));
 }
 
+/// A storage whose remaining accounts are all tombstones covered by the latest full
+/// snapshot is dead: reclaiming its last live account purges the storage.
+#[test]
+fn test_reclaiming_last_live_account_purges_tombstone_only_storage() {
+    let accounts = AccountsDb::default_for_tests();
+    let tombstone_pubkey = Pubkey::new_unique();
+    let live_pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::default());
+
+    // Slot 1: both accounts stored and flushed
+    accounts.store_for_tests((
+        1,
+        [(&tombstone_pubkey, &account), (&live_pubkey, &account)].as_slice(),
+    ));
+    accounts.add_root_and_flush_write_cache(1);
+
+    // Turn tombstone_pubkey's account into a tombstone, as shrink's carry-forward leaves
+    // it: index entry removed, offset recorded in the storage's tombstone set
+    let storage = accounts.get_and_assert_single_storage(1);
+    let account_offset = accounts
+        .accounts_index
+        .get_with_and_then(
+            &tombstone_pubkey,
+            &Ancestors::from(vec![1]),
+            false,
+            |(_slot, account_info)| account_info.offset(),
+        )
+        .unwrap();
+    accounts.accounts_index.purge_exact(
+        &tombstone_pubkey,
+        [1].into_iter().collect::<HashSet<_>>(),
+        &mut ReclaimsSlotList::new(),
+    );
+    storage.batch_insert_tombstone_offsets(iter::once(account_offset));
+    assert_eq!(storage.num_tombstones(), 1);
+
+    // Slot 2: a newer version of the live account. Its flush reclaims the slot 1 entry,
+    // leaving only the snapshot-covered tombstone, so the storage is dead
+    accounts.set_latest_full_snapshot_slot(1);
+    accounts.store_for_tests((2, [(&live_pubkey, &account)].as_slice()));
+    accounts.add_root_and_flush_write_cache(2);
+    assert!(accounts.storage.get_slot_storage_entry(1).is_none());
+}
+
 #[test]
 fn test_shrink_zero_lamport_single_ref_account() {
     // note that 'None' checks the case based on the default value of `latest_full_snapshot_slot` in `AccountsDb`

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1383,41 +1383,44 @@ fn test_reclaiming_last_live_account_purges_tombstone_only_storage() {
     let accounts = AccountsDb::default_for_tests();
     let tombstone_pubkey = Pubkey::new_unique();
     let live_pubkey = Pubkey::new_unique();
+    let slot = 1;
     let account = AccountSharedData::new(1, 0, &Pubkey::default());
 
-    // Slot 1: both accounts stored and flushed
+    // slot: both accounts stored and flushed
     accounts.store_for_tests((
-        1,
+        slot,
         [(&tombstone_pubkey, &account), (&live_pubkey, &account)].as_slice(),
     ));
-    accounts.add_root_and_flush_write_cache(1);
+    accounts.add_root_and_flush_write_cache(slot);
 
     // Turn tombstone_pubkey's account into a tombstone, as shrink's carry-forward leaves
     // it: index entry removed, offset recorded in the storage's tombstone set
-    let storage = accounts.get_and_assert_single_storage(1);
+    let storage = accounts.get_and_assert_single_storage(slot);
     let account_offset = accounts
         .accounts_index
         .get_with_and_then(
             &tombstone_pubkey,
-            &Ancestors::from(vec![1]),
+            &Ancestors::from(vec![slot]),
             false,
             |(_slot, account_info)| account_info.offset(),
         )
         .unwrap();
     accounts.accounts_index.purge_exact(
         &tombstone_pubkey,
-        [1].into_iter().collect::<HashSet<_>>(),
+        HashSet::from([slot]),
         &mut ReclaimsSlotList::new(),
     );
     storage.batch_insert_tombstone_offsets(iter::once(account_offset));
     assert_eq!(storage.num_tombstones(), 1);
 
-    // Slot 2: a newer version of the live account. Its flush reclaims the slot 1 entry,
-    // leaving only the snapshot-covered tombstone, so the storage is dead
-    accounts.set_latest_full_snapshot_slot(1);
-    accounts.store_for_tests((2, [(&live_pubkey, &account)].as_slice()));
-    accounts.add_root_and_flush_write_cache(2);
-    assert!(accounts.storage.get_slot_storage_entry(1).is_none());
+    // Set the snapshot so the tombstone can be removed
+    accounts.set_latest_full_snapshot_slot(slot);
+
+    // slot + 1: a newer version of the live account. Its flush reclaims the entry at
+    // slot, leaving only the snapshot-covered tombstone, so the storage is dead
+    accounts.store_for_tests((slot + 1, [(&live_pubkey, &account)].as_slice()));
+    accounts.add_root_and_flush_write_cache(slot + 1);
+    assert!(accounts.storage.get_slot_storage_entry(slot).is_none());
 }
 
 #[test]

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -66,6 +66,13 @@ impl<'a> SnapshotMinimizer<'a> {
         minimizer.add_accounts(Self::get_owner_accounts, "owner accounts");
         minimizer.add_accounts(Self::get_programdata_accounts, "programdata accounts");
 
+        // The minimized output is the next full snapshot: no incremental snapshot will
+        // build on an earlier one, so zero-lamport and tombstone retention is measured
+        // against this bank's slot
+        minimizer
+            .accounts_db()
+            .set_latest_full_snapshot_slot(minimizer.bank.slot());
+
         minimizer.minimize_accounts_db();
 
         // Update accounts_cache and capitalization
@@ -629,6 +636,61 @@ mod tests {
                 .ref_count_from_storage(&pubkey_multi),
             1
         );
+    }
+
+    /// A dead slot whose storage carries a shrink-produced tombstone must still purge
+    /// cleanly: `minimize` declares the minimized bank's slot as the latest full snapshot
+    /// slot, so `purge_slot_storage` marks the tombstone-only remainder dead instead of
+    /// panicking.
+    #[test]
+    fn test_minimize_purges_dead_slot_with_tombstone() {
+        let (genesis_config, _) = create_genesis_config(1_000_000);
+        let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let accounts = &bank.accounts().accounts_db;
+
+        let zero_lamport_pubkey = Pubkey::new_unique();
+        let rewritten_pubkey = Pubkey::new_unique();
+        let open_account = AccountSharedData::new(223, 0, &Pubkey::default());
+        let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+        // zero_lamport_pubkey is live in slot 1 and zeroed out in slot 2;
+        // rewritten_pubkey's slot 2 copy becomes dead bytes that make slot 2 worth
+        // shrinking; the filler accounts keep each storage alive
+        accounts.store_for_tests((1, [(&zero_lamport_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(1);
+        accounts.store_for_tests((
+            2,
+            [
+                (&zero_lamport_pubkey, &closed_account),
+                (&rewritten_pubkey, &open_account),
+                (&Pubkey::new_unique(), &open_account),
+            ]
+            .as_slice(),
+        ));
+        accounts.add_root_and_flush_write_cache(2);
+        accounts.store_for_tests((3, [(&rewritten_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(3);
+
+        // With the latest full snapshot behind slot 2, clean retains the zero-lamport
+        // single-ref account and shrink carries it forward as a tombstone: its bytes stay
+        // in slot 2's storage while its index entry is removed
+        accounts.set_latest_full_snapshot_slot(1);
+        accounts.clean_accounts_for_tests();
+        accounts.shrink_all_slots(false, None);
+        assert!(!accounts.contains(&zero_lamport_pubkey));
+        assert_eq!(accounts.get_storages(2..=2).0[0].count(), 2);
+
+        // No slot holds a minimized account, so all three are purged as dead slots;
+        // slot 2's storage still carries the tombstone
+        let child_bank = Bank::new_from_parent(bank.clone(), *bank.leader(), 4);
+        let child_bank = bank_forks
+            .write()
+            .unwrap()
+            .insert(child_bank)
+            .clone_without_scheduler();
+        SnapshotMinimizer::minimize(&child_bank, 4, DashSet::new(), false);
+
+        assert!(accounts.get_storages(1..=3).0.is_empty());
     }
 
     /// Ensure that minimized snapshots are loadable with and without

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -693,6 +693,80 @@ mod tests {
         assert!(accounts.get_storages(1..=3).0.is_empty());
     }
 
+    /// A storage that is already tombstone-only when `minimize` starts has no live index
+    /// entries, so `purge_slot_storage` finds nothing to reclaim; it must still remove
+    /// the storage rather than panicking.
+    #[test]
+    fn test_minimize_purges_tombstone_only_storage() {
+        let (genesis_config, _) = create_genesis_config(1_000_000);
+        let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+        let accounts = &bank.accounts().accounts_db;
+
+        let zero_lamport_pubkey = Pubkey::new_unique();
+        let rewritten_pubkey = Pubkey::new_unique();
+        let open_account = AccountSharedData::new(223, 0, &Pubkey::default());
+        let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+        // zero_lamport_pubkey starts out live
+        let mut slot = 1;
+        accounts.store_for_tests((slot, [(&zero_lamport_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(slot);
+
+        // Zero out zero_lamport_pubkey; rewritten_pubkey's copy here becomes dead bytes
+        // that make the storage worth shrinking; no other account keeps it alive
+        slot += 1;
+        let tombstone_slot = slot;
+        accounts.store_for_tests((
+            tombstone_slot,
+            [
+                (&zero_lamport_pubkey, &closed_account),
+                (&rewritten_pubkey, &open_account),
+            ]
+            .as_slice(),
+        ));
+        accounts.add_root_and_flush_write_cache(tombstone_slot);
+
+        // Rewrite rewritten_pubkey, stranding its copy in tombstone_slot
+        slot += 1;
+        accounts.store_for_tests((slot, [(&rewritten_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(slot);
+
+        // With the latest full snapshot behind the tombstone's slot, clean reclaims
+        // rewritten_pubkey's tombstone_slot copy and shrink carries the zero-lamport
+        // single-ref account forward as a tombstone: the storage enters minimize holding
+        // nothing else
+        accounts.set_latest_full_snapshot_slot(tombstone_slot - 1);
+        accounts.clean_accounts_for_tests();
+        accounts.shrink_all_slots(false, None);
+        assert!(!accounts.contains(&zero_lamport_pubkey));
+        assert_eq!(
+            accounts
+                .storage
+                .get_slot_storage_entry(tombstone_slot)
+                .unwrap()
+                .count(),
+            1
+        );
+
+        // Minimize at the next slot: no stored slot holds a minimized account, so all are
+        // purged as dead slots; tombstone_slot's tombstone-only storage produces no index
+        // reclaims at all
+        let child_bank = Bank::new_from_parent(bank.clone(), *bank.leader(), slot + 1);
+        let child_bank = bank_forks
+            .write()
+            .unwrap()
+            .insert(child_bank)
+            .clone_without_scheduler();
+        SnapshotMinimizer::minimize(&child_bank, slot + 1, DashSet::new(), false);
+
+        assert!(
+            accounts
+                .get_storages(tombstone_slot - 1..=slot)
+                .0
+                .is_empty()
+        );
+    }
+
     /// Ensure that minimized snapshots are loadable with and without
     /// recalculating the accounts lt hash.
     #[test_case(false)]

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -653,13 +653,16 @@ mod tests {
         let open_account = AccountSharedData::new(223, 0, &Pubkey::default());
         let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
-        // zero_lamport_pubkey is live in slot 1 and zeroed out in slot 2;
-        // rewritten_pubkey's slot 2 copy becomes dead bytes that make slot 2 worth
-        // shrinking; the filler accounts keep each storage alive
-        accounts.store_for_tests((1, [(&zero_lamport_pubkey, &open_account)].as_slice()));
-        accounts.add_root_and_flush_write_cache(1);
+        // zero_lamport_pubkey is live in the first slot and zeroed out in tombstone_slot;
+        // rewritten_pubkey's tombstone_slot copy becomes dead bytes that make the storage
+        // worth shrinking; the filler accounts keep each storage alive
+        let mut slot = 1;
+        accounts.store_for_tests((slot, [(&zero_lamport_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(slot);
+        slot += 1;
+        let tombstone_slot = slot;
         accounts.store_for_tests((
-            2,
+            tombstone_slot,
             [
                 (&zero_lamport_pubkey, &closed_account),
                 (&rewritten_pubkey, &open_account),
@@ -667,30 +670,43 @@ mod tests {
             ]
             .as_slice(),
         ));
-        accounts.add_root_and_flush_write_cache(2);
-        accounts.store_for_tests((3, [(&rewritten_pubkey, &open_account)].as_slice()));
-        accounts.add_root_and_flush_write_cache(3);
+        accounts.add_root_and_flush_write_cache(tombstone_slot);
+        slot += 1;
+        accounts.store_for_tests((slot, [(&rewritten_pubkey, &open_account)].as_slice()));
+        accounts.add_root_and_flush_write_cache(slot);
 
-        // With the latest full snapshot behind slot 2, clean retains the zero-lamport
-        // single-ref account and shrink carries it forward as a tombstone: its bytes stay
-        // in slot 2's storage while its index entry is removed
-        accounts.set_latest_full_snapshot_slot(1);
+        // With the latest full snapshot behind tombstone_slot, clean retains the
+        // zero-lamport single-ref account and shrink carries it forward as a tombstone:
+        // its bytes stay in tombstone_slot's storage while its index entry is removed
+        accounts.set_latest_full_snapshot_slot(tombstone_slot - 1);
         accounts.clean_accounts_for_tests();
         accounts.shrink_all_slots(false, None);
         assert!(!accounts.contains(&zero_lamport_pubkey));
-        assert_eq!(accounts.get_storages(2..=2).0[0].count(), 2);
+        assert_eq!(
+            accounts
+                .storage
+                .get_slot_storage_entry(tombstone_slot)
+                .unwrap()
+                .count(),
+            2
+        );
 
         // No slot holds a minimized account, so all three are purged as dead slots;
-        // slot 2's storage still carries the tombstone
-        let child_bank = Bank::new_from_parent(bank.clone(), *bank.leader(), 4);
+        // tombstone_slot's storage still carries the tombstone
+        let child_bank = Bank::new_from_parent(bank.clone(), *bank.leader(), slot + 1);
         let child_bank = bank_forks
             .write()
             .unwrap()
             .insert(child_bank)
             .clone_without_scheduler();
-        SnapshotMinimizer::minimize(&child_bank, 4, DashSet::new(), false);
+        SnapshotMinimizer::minimize(&child_bank, slot + 1, DashSet::new(), false);
 
-        assert!(accounts.get_storages(1..=3).0.is_empty());
+        assert!(
+            accounts
+                .get_storages(tombstone_slot - 1..=slot)
+                .0
+                .is_empty()
+        );
     }
 
     /// A storage that is already tombstone-only when `minimize` starts has no live index


### PR DESCRIPTION
#### Problem
If the snapshot minimizer encounters a storage that is only tombstones, it will panic.

#### Summary of Changes
- Remove some dead code that would conflict
- Set the full snapshot slot in the snapshot minimizer so it can handle tombstones correctly
-- This is safe as the snapshot minimizer is always creating a new full snapshot. It cannot create an incremental snapshot
- Allow remove accounts to remove slots that contain just tombstones older than the latest full snapshot (the bug!)


#### Testing
- Added two unit tests for the scenarios. 

Fixes #
