### PR TITLE
replay: ensure that AG switch bank events clear status cache

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2495,16 +2495,14 @@ impl ReplayStage {
             ancestor_slot = parent_slot;
         }
 
-        let slots_to_clear = bank_forks.read().unwrap().slots_to_clear(
-            blocks_to_switch
-                .iter()
-                .map(|(slot, _)| *slot)
-                .chain(original_dead_slots_to_clear.iter().copied()),
-        );
+        let slots_to_clear = blocks_to_switch
+            .iter()
+            .map(|(slot, _)| *slot)
+            .chain(original_dead_slots_to_clear.iter().copied());
 
-        info!("{my_pubkey}: Clearing banks for switching and descendants: {slots_to_clear:?}");
-        Self::clear_banks(
-            &slots_to_clear,
+        info!("{my_pubkey}: Clearing banks for switching: {slots_to_clear:?}");
+        Self::clear_slots(
+            slots_to_clear,
             bank_forks,
             progress,
             async_verification_freelist,
@@ -2529,19 +2527,22 @@ impl ReplayStage {
         Ok(())
     }
 
-    /// For slots to clear, clear the bank from progress, bank forks, and recycle the async verification
-    fn clear_banks(
-        slots_to_clear: &BTreeSet<Slot>,
+    /// Clear the requested slots and their descendants from progress, bank forks, and shared
+    /// caches. Requested slots are purged from shared caches even if their banks no longer exist.
+    fn clear_slots(
+        slots_to_clear: impl IntoIterator<Item = Slot>,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     ) {
-        if slots_to_clear.is_empty() {
+        let (slots_to_purge, banks_to_clear) =
+            bank_forks.read().unwrap().slots_to_clear(slots_to_clear);
+        if slots_to_purge.is_empty() {
             return;
         }
 
         // Wait for async verify to complete
-        for slot in slots_to_clear {
+        for slot in &slots_to_purge {
             if let Some(replay_progress) = progress.remove(slot) {
                 let mut w_replay_progress = replay_progress.replay_progress.write().unwrap();
                 let _ = w_replay_progress.wait_for_all_verification_results(&mut 0, &mut 0);
@@ -2552,49 +2553,48 @@ impl ReplayStage {
             }
         }
 
-        let banks_to_remove = {
-            let bank_forks = bank_forks.read().unwrap();
-            slots_to_clear
-                .iter()
-                .filter_map(|slot| bank_forks.get_with_scheduler(*slot))
-                .collect::<Vec<_>>()
-        };
-
         // Wait for any in progress execution
-        for bank in banks_to_remove {
+        for bank in banks_to_clear.iter() {
             let _ = bank.wait_for_completed_scheduler();
         }
+        let bank_slots_to_clear = banks_to_clear
+            .iter()
+            .map(|bank| bank.slot())
+            .collect::<BTreeSet<_>>();
 
-        // Dump the banks from bank forks
-        let (root_bank, slots_to_purge, removed_banks) = {
+        // Only dump banks that are still present. `slots_to_purge` can also contain slots that
+        // were already removed, but whose shared cache entries still need to be cleared before the
+        // slots are revived.
+        let (root_bank, slot_bank_ids_to_purge, removed_banks) = {
             let mut w_bank_forks = bank_forks.write().unwrap();
-            let slots_to_clear = slots_to_clear
-                .iter()
-                .copied()
-                .filter(|slot| w_bank_forks.get(*slot).is_some())
-                .collect::<BTreeSet<_>>();
-            if slots_to_clear.is_empty() {
-                return;
-            }
 
             let root_bank = w_bank_forks.root_bank();
-            let (slots_to_purge, removed_banks) =
-                w_bank_forks.dump_slots(slots_to_clear.iter(), false);
-            (root_bank, slots_to_purge, removed_banks)
+            let bank_slots_to_clear = bank_slots_to_clear
+                .into_iter()
+                .filter(|slot| w_bank_forks.get(*slot).is_some())
+                .collect::<BTreeSet<_>>();
+            let (slot_bank_ids_to_purge, removed_banks) =
+                w_bank_forks.dump_slots(bank_slots_to_clear.iter(), false);
+            (root_bank, slot_bank_ids_to_purge, removed_banks)
         };
 
         // Clear the accounts for these slots so that any ongoing RPC scans fail.
         // These have to be atomically cleared together in the same batch, in order
         // to prevent RPC from seeing inconsistent results in scans.
-        root_bank.remove_unrooted_slots(&slots_to_purge);
+        if !slot_bank_ids_to_purge.is_empty() {
+            root_bank.remove_unrooted_slots(&slot_bank_ids_to_purge);
+        }
 
         // Once the slots above have been purged, now it's safe to remove the banks from
         // BankForks, allowing the Bank::drop() purging to run and not race with the
         // `remove_unrooted_slots()` call.
+        drop(banks_to_clear);
         drop(removed_banks);
 
-        // Clear slot signatures from status cache and programs from program cache
-        for (slot, _) in slots_to_purge {
+        // Clear the shared caches even for requested slots whose banks were already removed.
+        // Those slots can be revived by an Alpenglow switch, and stale entries from the old block
+        // version must not affect replay of the new version.
+        for slot in slots_to_purge {
             root_bank.clear_slot_signatures(slot);
             root_bank.prune_program_cache_by_deployment_slot(slot);
         }
@@ -5227,8 +5227,8 @@ impl ReplayStage {
                 slot,
                 response_sender,
             } => {
-                Self::clear_banks(
-                    &BTreeSet::from([slot]),
+                Self::clear_slots(
+                    [slot],
                     &context.bank_forks,
                     progress,
                     async_verification_freelist,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -2579,6 +2579,39 @@ fn test_check_propagation_skip_propagation_check() {
 }
 
 #[test]
+fn test_clear_slots_clears_status_cache_for_removed_bank() {
+    let VoteSimulator {
+        bank_forks,
+        node_pubkeys,
+        validator_keypairs,
+        mut progress,
+        ..
+    } = VoteSimulator::new(1);
+    let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let sender = node_pubkeys[0];
+    let transfer_signature = bank1
+        .transfer(
+            1,
+            &validator_keypairs.get(&sender).unwrap().node_keypair,
+            &Pubkey::new_unique(),
+        )
+        .unwrap();
+    bank_forks.write().unwrap().insert(bank1);
+    let bank1 = bank_forks.read().unwrap().get(1).unwrap();
+    assert!(bank1.get_signature_status(&transfer_signature).is_some());
+
+    let removed_bank = bank_forks.write().unwrap().remove(1).unwrap();
+    drop(removed_bank);
+    assert!(bank_forks.read().unwrap().get(1).is_none());
+    assert!(bank1.get_signature_status(&transfer_signature).is_some());
+
+    ReplayStage::clear_slots([1], &bank_forks, &mut progress, &mut Vec::new());
+
+    assert!(bank1.get_signature_status(&transfer_signature).is_none());
+}
+
+#[test]
 fn test_purge_unconfirmed_duplicate_slot() {
     let (vote_simulator, blockstore) = setup_default_forks(2, None::<GenerateVotes>);
     let VoteSimulator {

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -25,10 +25,7 @@ use {
         bank::Bank, bank_forks::BankForks, leader_schedule_utils::leader_slot_index,
         vote_sender_types::ReplayVoteSender,
     },
-    std::{
-        collections::BTreeSet,
-        sync::{Arc, RwLock},
-    },
+    std::sync::{Arc, RwLock},
 };
 
 /// Replay-start decision for a child bank discovered from blockstore metadata.
@@ -169,12 +166,7 @@ fn try_restart_slot_from_update_parent(
     if let Some(bank) = bank {
         send_invalid_bank(&bank, replay_vote_sender);
     }
-    ReplayStage::clear_banks(
-        &BTreeSet::from([slot]),
-        bank_forks,
-        progress,
-        async_verification_freelist,
-    );
+    ReplayStage::clear_slots([slot], bank_forks, progress, async_verification_freelist);
     true
 }
 
@@ -363,8 +355,8 @@ pub(super) fn handle_abandoned_bank(
 
     // Clear the bank from bank_forks. It will be recreated with the correct
     // parent by generate_new_bank_forks on the next iteration.
-    ReplayStage::clear_banks(
-        &BTreeSet::from([bank_slot]),
+    ReplayStage::clear_slots(
+        [bank_slot],
         bank_forks,
         progress,
         async_verification_freelist,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -194,20 +194,26 @@ impl BankForks {
     /// For use when we want to remove `slots` from `BankForks`. It's not safe to remove
     /// a bank if it's descendant(s) are still in BankForks.
     ///
-    /// Returns the supplied slots and any descendants that are still present in bank forks
-    pub fn slots_to_clear(&self, slots: impl IntoIterator<Item = Slot>) -> BTreeSet<Slot> {
+    /// Returns the supplied unrooted slots and all descendants that are still present in bank
+    /// forks as `slots_to_purge`, plus the subset that still has a bank as `banks_to_clear`.
+    pub fn slots_to_clear(
+        &self,
+        slots: impl IntoIterator<Item = Slot>,
+    ) -> (BTreeSet<Slot>, Vec<BankWithScheduler>) {
         let root = self.root();
-        let mut slots_to_clear = BTreeSet::new();
+        let mut slots_to_purge = BTreeSet::new();
+        let mut bank_slots_to_clear = BTreeSet::new();
 
-        for slot in slots.into_iter() {
+        for slot in slots {
             if slot <= root {
                 continue;
             }
+            slots_to_purge.insert(slot);
             if self.banks.contains_key(&slot) {
-                slots_to_clear.insert(slot);
+                bank_slots_to_clear.insert(slot);
             }
             if let Some(slot_descendants) = self.descendants.get(&slot) {
-                slots_to_clear.extend(
+                bank_slots_to_clear.extend(
                     slot_descendants
                         .iter()
                         .copied()
@@ -216,7 +222,15 @@ impl BankForks {
             }
         }
 
-        slots_to_clear
+        slots_to_purge.extend(&bank_slots_to_clear);
+        let banks_to_clear = bank_slots_to_clear
+            .into_iter()
+            .map(|slot| {
+                self.get_with_scheduler(slot)
+                    .expect("bank slot was present while collecting slots to clear")
+            })
+            .collect();
+        (slots_to_purge, banks_to_clear)
     }
 
     pub fn frozen_banks(&self) -> impl Iterator<Item = (Slot, Arc<Bank>)> + '_ {
@@ -553,6 +567,7 @@ impl BankForks {
         let set_root_start = Instant::now();
         let (removed_banks, set_root_metrics) =
             self.do_set_root_return_metrics(root, snapshot_controller, highest_super_majority_root);
+
         datapoint_info!(
             "bank-forks_set_root",
             (
@@ -1161,17 +1176,43 @@ mod tests {
             &[(0, 1), (1, 2), (1, 3), (2, 4), (0, 5)],
         );
 
+        let slots = |slots: &[Slot]| {
+            let (slots_to_purge, banks_to_clear) = bank_forks
+                .read()
+                .unwrap()
+                .slots_to_clear(slots.iter().copied());
+            let bank_slots_to_clear = banks_to_clear
+                .iter()
+                .map(|bank| bank.slot())
+                .collect::<BTreeSet<_>>();
+            assert_eq!(banks_to_clear.len(), bank_slots_to_clear.len());
+            (slots_to_purge, bank_slots_to_clear)
+        };
         assert_eq!(
-            bank_forks.read().unwrap().slots_to_clear([2]),
-            [2, 4].into_iter().collect()
+            slots(&[2]),
+            ([2, 4].into_iter().collect(), [2, 4].into_iter().collect())
         );
         assert_eq!(
-            bank_forks.read().unwrap().slots_to_clear([1]),
-            [1, 2, 3, 4].into_iter().collect(),
+            slots(&[1]),
+            (
+                [1, 2, 3, 4].into_iter().collect(),
+                [1, 2, 3, 4].into_iter().collect(),
+            )
         );
         assert_eq!(
-            bank_forks.read().unwrap().slots_to_clear([0]),
-            BTreeSet::<Slot>::new()
+            slots(&[0]),
+            (BTreeSet::<Slot>::new(), BTreeSet::<Slot>::new())
+        );
+        assert_eq!(
+            slots(&[6]),
+            ([6].into_iter().collect(), BTreeSet::<Slot>::new())
+        );
+        assert_eq!(
+            slots(&[1, 2, 2, 3]),
+            (
+                [1, 2, 3, 4].into_iter().collect(),
+                [1, 2, 3, 4].into_iter().collect(),
+            )
         );
     }
 


### PR DESCRIPTION
#### Problem
In AG when switching a bank we clear all of the banks descendants and purge them from the status cache.

However (unlikely) there could have been some banks that were already cleared due to `set_root()`. We were not clearing them from the status cache properly.

#### Summary of Changes
Anytime we switch for a slot, also clear it from the status cache even if the bank has already been cleared.

Refactored the bank forks util to return both the slot # and the ones with banks

#### Testing
Unit tests