### PR TITLE
Fix - Disallow `ProgramCacheEntry` to only differ in effective slot

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -420,9 +420,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             IndexImplementation::V1 { entries, .. } => {
                 let slot_versions = &mut entries.entry(key).or_default();
                 let insertion_point = slot_versions.binary_search_by(|at| {
-                    at.effective_slot
-                        .cmp(&entry.effective_slot)
-                        .then(at.deployment_slot.cmp(&entry.deployment_slot))
+                    at.deployment_slot
+                        .cmp(&entry.deployment_slot)
                         .then(at.account_owner.cmp(&entry.account_owner))
                         .then(
                             // This `.then()` has no effect during normal operation.
@@ -1438,7 +1437,7 @@ pub(crate) mod tests {
     fn test_fuzz_assign_program_order() {
         use rand::prelude::SliceRandom;
         const EXPECTED_ENTRIES: [(u64, bool); 5] =
-            [(1, true), (5, false), (5, true), (9, true), (10, false)];
+            [(1, true), (3, false), (5, true), (9, true), (10, false)];
         let mut rng = rand::rng();
         let program_id = Pubkey::new_unique();
         let env = get_mock_program_runtime_environment();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -445,6 +445,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 ProgramCacheEntryType::Builtin(_),
                                 ProgramCacheEntryType::Builtin(_),
                             )
+                            | (ProgramCacheEntryType::Closed, ProgramCacheEntryType::Loaded(_))
+                            | (
+                                ProgramCacheEntryType::Closed,
+                                ProgramCacheEntryType::FailedVerification(_),
+                            )
                             | (
                                 ProgramCacheEntryType::Unloaded(_),
                                 ProgramCacheEntryType::Loaded(_),
@@ -1473,7 +1478,6 @@ pub(crate) mod tests {
 
     #[test_matrix(
         (
-            ProgramCacheEntryType::Closed,
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             new_loaded_entry(get_mock_program_runtime_environment()),
         ),
@@ -1487,6 +1491,7 @@ pub(crate) mod tests {
     )]
     #[test_matrix(
         (
+            ProgramCacheEntryType::Closed,
             ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
         ),
         (

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -74,7 +74,7 @@ impl From<ProgramCacheEntryOwner> for Pubkey {
     - Builtin => Builtin in TransactionBatchProcessor::add_builtin
 
     Un/re/deployment (with delay and cooldown):
-    - Empty / Closed => Loaded in UpgradeableLoaderInstruction::DeployWithMaxDataLen
+    - Empty / Closed => Loaded / FailedVerification in UpgradeableLoaderInstruction::DeployWithMaxDataLen
     - Loaded / FailedVerification => Loaded in UpgradeableLoaderInstruction::Upgrade
     - Loaded / FailedVerification => Closed in UpgradeableLoaderInstruction::Close
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10884,11 +10884,11 @@ fn test_feature_activation_loaded_programs_cache_preparation_phase() {
         assert_eq!(slot_versions.len(), 2);
         assert_eq!(
             slot_versions[0].program.get_environment().unwrap(),
-            &upcoming_env,
+            &current_env,
         );
         assert_eq!(
             slot_versions[1].program.get_environment().unwrap(),
-            &current_env,
+            &upcoming_env,
         );
     }
 


### PR DESCRIPTION
#### Problem

When deploying programs a `Closed` entry is created during transaction loading time and then replaced by a `Loaded` entry during the program management instrucion of the loader. Or at least conceptually, that is what is supossed to happen. However, curently we don't actually replace the entry and just overshadow the `Closed` entry with the second entry having the same `deployment_slot` but a higher `effective_slot`.

#### Summary of Changes

- Removes differentiation of `effective_slot` in `ProgramCache::assign_program()`.
- Immediately replaces `Closed` tombstones with new entries in the same slot.

#### Testing

- Adjusts `test_fuzz_assign_program_order()` to not have two entries with the same `deployment_slot`
- Adjusts `test_assign_program_failure()` to allow `Closed` to `Loaded` or `FailedVerification` transitions.
- Adjusts ordering of entries (with different program runtime environments) in `test_feature_activation_loaded_programs_cache_preparation_phase()`.