### PR TITLE
runtime: do not rewrite inactive stakes

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1485,7 +1485,7 @@ pub mod enable_sha512_syscall {
 }
 
 pub mod relax_post_exec_min_balance_check {
-    solana_pubkey::declare_id!("DEJmsCntuYqbXtL5z5TxbaxJXFUJAFjf7TqWSF7YWjQg");
+    solana_pubkey::declare_id!("BY4JhHLahVzS9ynfDz4exzGPbVXhFmJvEyMWsXbDBqME");
 }
 
 pub mod enable_tx_v1 {

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1278,12 +1278,12 @@ mod tests {
         solana_rent::Rent,
         solana_sdk_ids::incinerator,
         solana_signer::Signer,
-        solana_stake_history::StakeHistoryEntry,
+        solana_stake_history::{StakeHistory, StakeHistoryEntry},
         solana_stake_interface::{
             stake_flags::StakeFlags,
             state::{Authorized, Delegation, Meta, Stake, StakeStateV2},
         },
-        solana_vote::vote_account::VoteAccount,
+        solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
         solana_vote_interface::state::{
             BLS_PUBLIC_KEY_COMPRESSED_SIZE, VoteInitV2, VoteStateV4, VoteStateVersions,
         },
@@ -1299,6 +1299,120 @@ mod tests {
         RewardEpochDelegatedStakes {
             epoch,
             delegated_stakes: HashMap::default(),
+        }
+    }
+
+    #[test_case(55_555, 0, 0, u64::MAX, true ; "active_rewrite_to_zero")]
+    #[test_case(55_555, 0, 1, u64::MAX, true ; "activating_rewrite_to_zero")]
+    #[test_case(55_555, 100, 0, u64::MAX, true ; "active_reduce_stays_active")]
+    #[test_case(55_555, 100, 1, u64::MAX, true ; "activating_reduce_stays_active")]
+    #[test_case(0, 5, 0, 0, false ; "inactive_extra_ignore")]
+    #[test_case(1, 1, 0, 0, false ; "inactive_equal_ignore")]
+    #[test_case(1, 0, 0, 0, false ; "inactive_short_to_zero_ignore")]
+    #[test_case(2, 1, 0, 0, false ; "inactive_short_to_one_ignore")]
+    fn test_redeem_delegation_rewards_excludes_inactive_from_partition(
+        starting_delegation: u64,
+        non_rent_lamports: u64,
+        activation_epoch: Epoch,
+        deactivation_epoch: Epoch,
+        force_rewrite: bool,
+    ) {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            0,
+            StakeHistoryEntry {
+                effective: 1_000_000 * LAMPORTS_PER_SOL,
+                activating: LAMPORTS_PER_SOL,
+                deactivating: LAMPORTS_PER_SOL,
+            },
+        );
+        let rewarded_epoch = 1;
+        let rent_exempt_reserve = bank
+            .rent_collector
+            .rent
+            .minimum_balance(StakeStateV2::size_of());
+
+        let ((vote_pubkey, vote_account_data), _) =
+            create_staked_node_accounts(10_000, &bank.rent_collector.rent);
+
+        // observe exact vote credits so stake earns no rewards
+        // PER inclusion is then solely determined by `needs_adjustment`
+        let vote_credits = VoteStateV4::deserialize(vote_account_data.data(), &vote_pubkey)
+            .unwrap()
+            .credits();
+
+        let stake = Stake {
+            delegation: Delegation {
+                voter_pubkey: vote_pubkey,
+                stake: starting_delegation,
+                activation_epoch,
+                deactivation_epoch,
+                ..Delegation::default()
+            },
+            credits_observed: vote_credits,
+        };
+        let mut account = AccountSharedData::new(
+            rent_exempt_reserve + non_rent_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+        let stake_account = StakeAccount::try_from(account).unwrap();
+        let stake_pubkey = Pubkey::new_unique();
+        let point_value = PointValue {
+            rewards: 1_000_000_000,
+            points: 1,
+        };
+
+        // there are two distinct paths that can hit `delegation_may_need_adjustment()`:
+        // * vote account: standard rewards path
+        // * no vote account: early exit that goes to adjustment-detection directly
+        for has_vote_account in [true, false] {
+            let mut vote_accounts_map = VoteAccountsHashMap::default();
+            if has_vote_account {
+                vote_accounts_map.insert(
+                    vote_pubkey,
+                    (0, VoteAccount::try_from(vote_account_data.clone()).unwrap()),
+                );
+            }
+            let distribution_epoch_vote_accounts = VoteAccounts::from(Arc::new(vote_accounts_map));
+            let cached_vote_accounts = CachedVoteAccounts {
+                snapshot_epoch_vote_accounts: None,
+                rewarded_epoch_vote_accounts: None,
+                distribution_epoch_vote_accounts: &distribution_epoch_vote_accounts,
+            };
+
+            let maybe_reward = bank.redeem_delegation_rewards(
+                rewarded_epoch,
+                &stake_pubkey,
+                &stake_account,
+                &point_value,
+                &stake_history,
+                &cached_vote_accounts,
+                null_tracer(),
+                None,  // new_rate_activation_epoch
+                false, // delay_commission_updates
+                true,  // commission_rate_in_basis_points
+                true,  // adjust_delegations_for_rent (SIMD-0392)
+                &AlpenglowEpochType::Tower,
+                false, // custom_commission_collector
+                true,  // use_fixed_point_stake_math
+            );
+
+            // `Some`: included in PER, `None`: excluded
+            assert_eq!(
+                maybe_reward.is_some(),
+                force_rewrite,
+                "has_vote_account={has_vote_account}"
+            );
         }
     }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -23,7 +23,7 @@ use {
         },
         reward_info::RewardInfo,
         stake_account::StakeAccount,
-        stake_delegation::delegation_effective_stake,
+        stake_delegation::{delegation_activation_status, delegation_effective_stake},
         stakes::Stakes,
     },
     log::{debug, info},
@@ -653,12 +653,24 @@ impl Bank {
             // Even if the vote account doesn't exist, there might still be a
             // need to adjust the stake delegation
             if adjust_delegations_for_rent {
-                if delegation_may_need_adjustment(
-                    stake.delegation.stake,
-                    stake.delegation.stake,
-                    current_lamports,
-                    minimum_lamports,
-                ) {
+                let has_activating_or_effective = {
+                    let status = delegation_activation_status(
+                        &stake.delegation,
+                        rewarded_epoch,
+                        stake_history,
+                        new_rate_activation_epoch,
+                        use_fixed_point_stake_math,
+                    );
+                    status.effective > 0 || status.activating > 0
+                };
+                if has_activating_or_effective
+                    && delegation_may_need_adjustment(
+                        stake.delegation.stake,
+                        stake.delegation.stake,
+                        current_lamports,
+                        minimum_lamports,
+                    )
+                {
                     debug!(
                         "delegation for stake {stake_pubkey} may be adjusted at distribution, \
                          unless lamports are transferred before distribution block"

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -653,24 +653,20 @@ impl Bank {
             // Even if the vote account doesn't exist, there might still be a
             // need to adjust the stake delegation
             if adjust_delegations_for_rent {
-                let has_activating_or_effective = {
-                    let status = delegation_activation_status(
-                        &stake.delegation,
-                        rewarded_epoch,
-                        stake_history,
-                        new_rate_activation_epoch,
-                        use_fixed_point_stake_math,
-                    );
-                    status.effective > 0 || status.activating > 0
-                };
-                if has_activating_or_effective
-                    && delegation_may_need_adjustment(
-                        stake.delegation.stake,
-                        stake.delegation.stake,
-                        current_lamports,
-                        minimum_lamports,
-                    )
-                {
+                let status = delegation_activation_status(
+                    &stake.delegation,
+                    rewarded_epoch,
+                    stake_history,
+                    new_rate_activation_epoch,
+                    use_fixed_point_stake_math,
+                );
+                if delegation_may_need_adjustment(
+                    stake.delegation.stake,
+                    stake.delegation.stake,
+                    current_lamports,
+                    minimum_lamports,
+                    status,
+                ) {
                     debug!(
                         "delegation for stake {stake_pubkey} may be adjusted at distribution, \
                          unless lamports are transferred before distribution block"

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -9,7 +9,7 @@ use {
             partitioned_epoch_rewards::EpochRewardPhase,
         },
         stake_account::StakeAccount,
-        stake_delegation::delegation_effective_stake,
+        stake_delegation::{delegation_activation_status, delegation_effective_stake},
     },
     log::error,
     serde::{Deserialize, Serialize},
@@ -271,16 +271,29 @@ impl Bank {
             let minimum_balance = rent.minimum_balance(account.data().len());
             // The rewarded epoch is right before the distribution epoch
             let rewarded_epoch = distribution_epoch.saturating_sub(1);
-            // The entry in `partitioned_stake_reward` contains the rewards,
-            // calculated during the calculation phase
-            let delegation_with_rewards = new_stake.delegation.stake;
-            adjust_delegation_for_rent(
-                &mut new_stake.delegation,
+
+            let status = delegation_activation_status(
+                &new_stake.delegation,
                 rewarded_epoch,
-                delegation_with_rewards,
-                account.lamports(),
-                minimum_balance,
+                stake_history,
+                new_warmup_cooldown_rate_epoch,
+                use_fixed_point_stake_math,
             );
+
+            // We do not adjust fully inactive stakes; their delegated stake values
+            // are meaningless, and their deactivation epochs are already in the past.
+            if status.effective > 0 || status.activating > 0 {
+                // The entry in `partitioned_stake_reward` contains the rewards,
+                // calculated during the calculation phase
+                let delegation_with_rewards = new_stake.delegation.stake;
+                adjust_delegation_for_rent(
+                    &mut new_stake.delegation,
+                    rewarded_epoch,
+                    delegation_with_rewards,
+                    account.lamports(),
+                    minimum_balance,
+                );
+            }
         } else {
             let expected_delegation = stake
                 .delegation
@@ -1032,6 +1045,113 @@ mod tests {
             expected_stake_reward
         );
         drop(stakes_cache);
+    }
+
+    #[test_case(55_555, 0, 0, u64::MAX, true ; "active_rewrite_to_zero")]
+    #[test_case(55_555, 0, 1, u64::MAX, true ; "activating_rewrite_to_zero")]
+    #[test_case(55_555, 100, 0, u64::MAX, true ; "active_reduce_stays_active")]
+    #[test_case(55_555, 100, 1, u64::MAX, true ; "activating_reduce_stays_active")]
+    #[test_case(0, 5, 0, 0, false ; "inactive_extra_ignore")]
+    #[test_case(1, 1, 0, 0, false ; "inactive_equal_ignore")]
+    #[test_case(1, 0, 0, 0, false ; "inactive_short_to_zero_ignore")]
+    #[test_case(2, 1, 0, 0, false ; "inactive_short_to_one_ignore")]
+    fn test_adjust_delegation_skips_inactive_stakes(
+        starting_delegation: u64,
+        non_rent_lamports: u64,
+        activation_epoch: Epoch,
+        deactivation_epoch: Epoch,
+        force_rewrite: bool,
+    ) {
+        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let mut stake_history = StakeHistory::default();
+        stake_history.add(
+            0,
+            StakeHistoryEntry {
+                effective: 1_000_000 * LAMPORTS_PER_SOL,
+                activating: LAMPORTS_PER_SOL,
+                deactivating: LAMPORTS_PER_SOL,
+            },
+        );
+        let distribution_epoch = bank.epoch + 2;
+        let new_warmup_cooldown_rate_epoch = bank.new_warmup_cooldown_rate_epoch();
+        let rent = bank.rent_collector.rent.clone();
+        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
+        let voter_pubkey = Pubkey::new_unique();
+        let stake_pubkey = Pubkey::new_unique();
+
+        let old_stake = Stake {
+            delegation: Delegation {
+                voter_pubkey,
+                stake: starting_delegation,
+                activation_epoch,
+                deactivation_epoch,
+                ..Delegation::default()
+            },
+            credits_observed: 0,
+        };
+        let mut account = AccountSharedData::new(
+            rent_exempt_reserve + non_rent_lamports,
+            StakeStateV2::size_of(),
+            &solana_stake_interface::program::id(),
+        );
+        account
+            .set_state(&StakeStateV2::Stake(
+                Meta::default(),
+                old_stake,
+                StakeFlags::default(),
+            ))
+            .unwrap();
+        bank.store_account(&stake_pubkey, &account);
+
+        let partitioned_stake_reward = PartitionedStakeReward {
+            stake_pubkey,
+            inflation: InflationReward {
+                stake: old_stake,
+                stake_reward: 0,
+                commission_bps: Some(0),
+            },
+            block_reward: 0,
+        };
+        let stakes_cache = bank.stakes_cache.stakes();
+        let stake_reward = Bank::build_updated_stake_reward(
+            distribution_epoch,
+            &stake_history,
+            new_warmup_cooldown_rate_epoch,
+            stakes_cache.stake_delegations(),
+            &partitioned_stake_reward,
+            &rent,
+            true, // adjust_delegations_for_rent (SIMD-0392)
+            true, // use_fixed_point_stake_math
+        )
+        .unwrap();
+
+        let Ok(StakeStateV2::Stake(_, stake, _)) = stake_reward
+            .stake_account
+            .deserialize_data::<StakeStateV2>()
+        else {
+            panic!("expected Stake state");
+        };
+
+        if force_rewrite {
+            // activating / active delegation is reduced if lacking lamports,
+            // and deactivated if delegation would become zero
+            let new_delegation = starting_delegation.min(non_rent_lamports);
+            let new_deactivation_epoch = if new_delegation == 0 {
+                distribution_epoch - 1
+            } else {
+                // sanity
+                assert_eq!(deactivation_epoch, u64::MAX);
+                deactivation_epoch
+            };
+
+            assert_eq!(stake.delegation.stake, new_delegation);
+            assert_eq!(stake.delegation.deactivation_epoch, new_deactivation_epoch);
+        } else {
+            // inactive stake is untouched
+            assert_eq!(stake.delegation.stake, starting_delegation);
+            assert_eq!(stake.delegation.deactivation_epoch, deactivation_epoch);
+        }
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -9,7 +9,7 @@ use {
             partitioned_epoch_rewards::EpochRewardPhase,
         },
         stake_account::StakeAccount,
-        stake_delegation::{delegation_activation_status, delegation_effective_stake},
+        stake_delegation::delegation_effective_stake,
     },
     log::error,
     serde::{Deserialize, Serialize},
@@ -271,29 +271,16 @@ impl Bank {
             let minimum_balance = rent.minimum_balance(account.data().len());
             // The rewarded epoch is right before the distribution epoch
             let rewarded_epoch = distribution_epoch.saturating_sub(1);
-
-            let status = delegation_activation_status(
-                &new_stake.delegation,
+            // The entry in `partitioned_stake_reward` contains the rewards,
+            // calculated during the calculation phase
+            let delegation_with_rewards = new_stake.delegation.stake;
+            adjust_delegation_for_rent(
+                &mut new_stake.delegation,
                 rewarded_epoch,
-                stake_history,
-                new_warmup_cooldown_rate_epoch,
-                use_fixed_point_stake_math,
+                delegation_with_rewards,
+                account.lamports(),
+                minimum_balance,
             );
-
-            // We do not adjust fully inactive stakes; their delegated stake values
-            // are meaningless, and their deactivation epochs are already in the past.
-            if status.effective > 0 || status.activating > 0 {
-                // The entry in `partitioned_stake_reward` contains the rewards,
-                // calculated during the calculation phase
-                let delegation_with_rewards = new_stake.delegation.stake;
-                adjust_delegation_for_rent(
-                    &mut new_stake.delegation,
-                    rewarded_epoch,
-                    delegation_with_rewards,
-                    account.lamports(),
-                    minimum_balance,
-                );
-            }
         } else {
             let expected_delegation = stake
                 .delegation
@@ -1045,113 +1032,6 @@ mod tests {
             expected_stake_reward
         );
         drop(stakes_cache);
-    }
-
-    #[test_case(55_555, 0, 0, u64::MAX, true ; "active_rewrite_to_zero")]
-    #[test_case(55_555, 0, 1, u64::MAX, true ; "activating_rewrite_to_zero")]
-    #[test_case(55_555, 100, 0, u64::MAX, true ; "active_reduce_stays_active")]
-    #[test_case(55_555, 100, 1, u64::MAX, true ; "activating_reduce_stays_active")]
-    #[test_case(0, 5, 0, 0, false ; "inactive_extra_ignore")]
-    #[test_case(1, 1, 0, 0, false ; "inactive_equal_ignore")]
-    #[test_case(1, 0, 0, 0, false ; "inactive_short_to_zero_ignore")]
-    #[test_case(2, 1, 0, 0, false ; "inactive_short_to_one_ignore")]
-    fn test_adjust_delegation_skips_inactive_stakes(
-        starting_delegation: u64,
-        non_rent_lamports: u64,
-        activation_epoch: Epoch,
-        deactivation_epoch: Epoch,
-        force_rewrite: bool,
-    ) {
-        let (genesis_config, _mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-        let bank = Bank::new_for_tests(&genesis_config);
-        let mut stake_history = StakeHistory::default();
-        stake_history.add(
-            0,
-            StakeHistoryEntry {
-                effective: 1_000_000 * LAMPORTS_PER_SOL,
-                activating: LAMPORTS_PER_SOL,
-                deactivating: LAMPORTS_PER_SOL,
-            },
-        );
-        let distribution_epoch = bank.epoch + 2;
-        let new_warmup_cooldown_rate_epoch = bank.new_warmup_cooldown_rate_epoch();
-        let rent = bank.rent_collector.rent.clone();
-        let rent_exempt_reserve = rent.minimum_balance(StakeStateV2::size_of());
-        let voter_pubkey = Pubkey::new_unique();
-        let stake_pubkey = Pubkey::new_unique();
-
-        let old_stake = Stake {
-            delegation: Delegation {
-                voter_pubkey,
-                stake: starting_delegation,
-                activation_epoch,
-                deactivation_epoch,
-                ..Delegation::default()
-            },
-            credits_observed: 0,
-        };
-        let mut account = AccountSharedData::new(
-            rent_exempt_reserve + non_rent_lamports,
-            StakeStateV2::size_of(),
-            &solana_stake_interface::program::id(),
-        );
-        account
-            .set_state(&StakeStateV2::Stake(
-                Meta::default(),
-                old_stake,
-                StakeFlags::default(),
-            ))
-            .unwrap();
-        bank.store_account(&stake_pubkey, &account);
-
-        let partitioned_stake_reward = PartitionedStakeReward {
-            stake_pubkey,
-            inflation: InflationReward {
-                stake: old_stake,
-                stake_reward: 0,
-                commission_bps: Some(0),
-            },
-            block_reward: 0,
-        };
-        let stakes_cache = bank.stakes_cache.stakes();
-        let stake_reward = Bank::build_updated_stake_reward(
-            distribution_epoch,
-            &stake_history,
-            new_warmup_cooldown_rate_epoch,
-            stakes_cache.stake_delegations(),
-            &partitioned_stake_reward,
-            &rent,
-            true, // adjust_delegations_for_rent (SIMD-0392)
-            true, // use_fixed_point_stake_math
-        )
-        .unwrap();
-
-        let Ok(StakeStateV2::Stake(_, stake, _)) = stake_reward
-            .stake_account
-            .deserialize_data::<StakeStateV2>()
-        else {
-            panic!("expected Stake state");
-        };
-
-        if force_rewrite {
-            // activating / active delegation is reduced if lacking lamports,
-            // and deactivated if delegation would become zero
-            let new_delegation = starting_delegation.min(non_rent_lamports);
-            let new_deactivation_epoch = if new_delegation == 0 {
-                distribution_epoch - 1
-            } else {
-                // sanity
-                assert_eq!(deactivation_epoch, u64::MAX);
-                deactivation_epoch
-            };
-
-            assert_eq!(stake.delegation.stake, new_delegation);
-            assert_eq!(stake.delegation.deactivation_epoch, new_deactivation_epoch);
-        } else {
-            // inactive stake is untouched
-            assert_eq!(stake.delegation.stake, starting_delegation);
-            assert_eq!(stake.delegation.deactivation_epoch, deactivation_epoch);
-        }
     }
 
     #[test]

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -108,11 +108,18 @@ fn redeem_stake_rewards<'a>(
         ));
     }
 
-    let rewarded_epoch = calculation_environment.rewarded_epoch;
-    let stake_history = calculation_environment.stake_history;
-    let new_rate_activation_epoch = calculation_environment.new_rate_activation_epoch;
-    let use_fixed_point_stake_math = calculation_environment.use_fixed_point_stake_math;
     let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
+
+    let has_activating_or_effective = {
+        let status = delegation_activation_status(
+            &stake.delegation,
+            calculation_environment.rewarded_epoch,
+            calculation_environment.stake_history,
+            calculation_environment.new_rate_activation_epoch,
+            calculation_environment.use_fixed_point_stake_math,
+        );
+        status.effective > 0 || status.activating > 0
+    };
 
     let maybe_rewards = calculate_stake_rewards(
         stake,
@@ -138,16 +145,6 @@ fn redeem_stake_rewards<'a>(
 
     let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
     if adjust_delegations_for_rent {
-        let has_activating_or_effective = {
-            let status = delegation_activation_status(
-                &stake.delegation,
-                rewarded_epoch,
-                stake_history,
-                new_rate_activation_epoch,
-                use_fixed_point_stake_math,
-            );
-            status.effective > 0 || status.activating > 0
-        };
         let new_delegation_with_rewards = stake.delegation.stake.saturating_add(staker_rewards);
         let needs_adjustment = has_activating_or_effective
             && delegation_may_need_adjustment(

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -11,7 +11,10 @@ use {
         stake_delegation::{delegation_activation_status, effective_stake},
     },
     solana_instruction::error::InstructionError,
-    solana_stake_interface::{error::StakeError, state::Stake},
+    solana_stake_interface::{
+        error::StakeError,
+        state::{Stake, StakeActivationStatus},
+    },
 };
 
 pub mod points;
@@ -110,16 +113,13 @@ fn redeem_stake_rewards<'a>(
 
     let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
 
-    let has_activating_or_effective = {
-        let status = delegation_activation_status(
-            &stake.delegation,
-            calculation_environment.rewarded_epoch,
-            calculation_environment.stake_history,
-            calculation_environment.new_rate_activation_epoch,
-            calculation_environment.use_fixed_point_stake_math,
-        );
-        status.effective > 0 || status.activating > 0
-    };
+    let status = delegation_activation_status(
+        &stake.delegation,
+        calculation_environment.rewarded_epoch,
+        calculation_environment.stake_history,
+        calculation_environment.new_rate_activation_epoch,
+        calculation_environment.use_fixed_point_stake_math,
+    );
 
     let maybe_rewards = calculate_stake_rewards(
         stake,
@@ -146,13 +146,13 @@ fn redeem_stake_rewards<'a>(
     let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
     if adjust_delegations_for_rent {
         let new_delegation_with_rewards = stake.delegation.stake.saturating_add(staker_rewards);
-        let needs_adjustment = has_activating_or_effective
-            && delegation_may_need_adjustment(
-                stake.delegation.stake,
-                new_delegation_with_rewards,
-                current_lamports.saturating_add(staker_rewards),
-                minimum_lamports,
-            );
+        let needs_adjustment = delegation_may_need_adjustment(
+            stake.delegation.stake,
+            new_delegation_with_rewards,
+            current_lamports.saturating_add(staker_rewards),
+            minimum_lamports,
+            status,
+        );
         // If `maybe_rewards.is_some()`, need to drive forward credits, even
         // if rewards are zero
         if needs_adjustment || maybe_rewards.is_some() {
@@ -179,7 +179,12 @@ pub(crate) fn delegation_may_need_adjustment(
     new_delegation_with_rewards: u64,
     lamports_with_rewards: u64,
     minimum_lamports: u64,
+    status: StakeActivationStatus,
 ) -> bool {
+    if status.effective == 0 && status.activating == 0 {
+        return false;
+    }
+
     let new_delegation = std::cmp::min(
         new_delegation_with_rewards,
         lamports_with_rewards.saturating_sub(minimum_lamports),

--- a/runtime/src/inflation_rewards/mod.rs
+++ b/runtime/src/inflation_rewards/mod.rs
@@ -6,7 +6,10 @@ use {
         CalculatedStakePoints, CalculationEnvironment, DelegatedVoteState,
         InflationPointCalculationEvent, SkippedReason, calculate_stake_points_and_credits,
     },
-    crate::{alpenglow_epoch_type::AlpenglowEpochType, stake_delegation::effective_stake},
+    crate::{
+        alpenglow_epoch_type::AlpenglowEpochType,
+        stake_delegation::{delegation_activation_status, effective_stake},
+    },
     solana_instruction::error::InstructionError,
     solana_stake_interface::{error::StakeError, state::Stake},
 };
@@ -105,7 +108,12 @@ fn redeem_stake_rewards<'a>(
         ));
     }
 
+    let rewarded_epoch = calculation_environment.rewarded_epoch;
+    let stake_history = calculation_environment.stake_history;
+    let new_rate_activation_epoch = calculation_environment.new_rate_activation_epoch;
+    let use_fixed_point_stake_math = calculation_environment.use_fixed_point_stake_math;
     let adjust_delegations_for_rent = calculation_environment.adjust_delegations_for_rent;
+
     let maybe_rewards = calculate_stake_rewards(
         stake,
         voter_commission_bps,
@@ -130,13 +138,24 @@ fn redeem_stake_rewards<'a>(
 
     let staker_rewards = maybe_rewards.map(|x| x.0).unwrap_or(0);
     if adjust_delegations_for_rent {
+        let has_activating_or_effective = {
+            let status = delegation_activation_status(
+                &stake.delegation,
+                rewarded_epoch,
+                stake_history,
+                new_rate_activation_epoch,
+                use_fixed_point_stake_math,
+            );
+            status.effective > 0 || status.activating > 0
+        };
         let new_delegation_with_rewards = stake.delegation.stake.saturating_add(staker_rewards);
-        let needs_adjustment = delegation_may_need_adjustment(
-            stake.delegation.stake,
-            new_delegation_with_rewards,
-            current_lamports.saturating_add(staker_rewards),
-            minimum_lamports,
-        );
+        let needs_adjustment = has_activating_or_effective
+            && delegation_may_need_adjustment(
+                stake.delegation.stake,
+                new_delegation_with_rewards,
+                current_lamports.saturating_add(staker_rewards),
+                minimum_lamports,
+            );
         // If `maybe_rewards.is_some()`, need to drive forward credits, even
         // if rewards are zero
         if needs_adjustment || maybe_rewards.is_some() {


### PR DESCRIPTION
#### Problem
`adjust_delegation_for_rent()` introduced by https://github.com/anza-xyz/feature-gate-tracker/issues/338 includes inactive stake accounts in partitioned epoch rewards (PER) if they meet the criteria for delegation adjustment, which would mean exactly the same inactive stakes must be in every validator's stakes cache for consensus. this is quite dangerous, especially since we have never required this to be true (stakes cache is only intended for reward-earning stake accounts, and hold inactive stakes purely as an optimization for deactivate/reactivate)

#### Summary of Changes
gate `delegation_may_need_adjustment()` on only active or activating stake accounts

#### Testing
`test_redeem_delegation_rewards_excludes_inactive_from_partition()` covers various cases