### PR TITLE
conformance: programs, sbf tests (part 1)

### DIFF
--- a/program-binaries/src/lib.rs
+++ b/program-binaries/src/lib.rs
@@ -110,6 +110,7 @@ pub fn bpf_loader_upgradeable_program_accounts(
     program_id: &Pubkey,
     elf: &[u8],
     rent: &Rent,
+    upgrade_authority_address: Option<Pubkey>,
 ) -> [(Pubkey, Account); 2] {
     let programdata_address = get_program_data_address(program_id);
     let program_account = {
@@ -132,7 +133,7 @@ pub fn bpf_loader_upgradeable_program_accounts(
         let lamports = rent.minimum_balance(space);
         let mut data = bincode::serialize(&UpgradeableLoaderState::ProgramData {
             slot: 0,
-            upgrade_authority_address: Some(Pubkey::default()),
+            upgrade_authority_address,
         })
         .unwrap();
         data.extend_from_slice(elf);
@@ -156,8 +157,12 @@ pub fn spl_programs(rent: &Rent) -> Vec<(Pubkey, AccountSharedData)> {
         .flat_map(|(program_id, loader_id, elf)| {
             let mut accounts = vec![];
             if loader_id.eq(&solana_sdk_ids::bpf_loader_upgradeable::ID) {
-                for (key, account) in bpf_loader_upgradeable_program_accounts(program_id, elf, rent)
-                {
+                for (key, account) in bpf_loader_upgradeable_program_accounts(
+                    program_id,
+                    elf,
+                    rent,
+                    Some(Pubkey::default()),
+                ) {
                     accounts.push((key, AccountSharedData::from(account)));
                 }
             } else {
@@ -178,8 +183,12 @@ where
         .flat_map(|(program_id, feature_id, elf)| {
             let mut accounts = vec![];
             if feature_id.is_none() || feature_id.is_some_and(|f| is_feature_active(&f)) {
-                for (key, account) in bpf_loader_upgradeable_program_accounts(program_id, elf, rent)
-                {
+                for (key, account) in bpf_loader_upgradeable_program_accounts(
+                    program_id,
+                    elf,
+                    rent,
+                    Some(Pubkey::default()),
+                ) {
                     accounts.push((key, AccountSharedData::from(account)));
                 }
             }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -865,8 +865,12 @@ impl ProgramTest {
             panic!("Program file data not available for {program_name} ({program_id})")
         });
         let elf = read_file(program_file);
-        let program_accounts =
-            programs::bpf_loader_upgradeable_program_accounts(program_id, &elf, &Rent::default());
+        let program_accounts = programs::bpf_loader_upgradeable_program_accounts(
+            program_id,
+            &elf,
+            &Rent::default(),
+            Some(Pubkey::default()),
+        );
         for (address, account) in program_accounts {
             self.add_genesis_account(address, account);
         }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -50,7 +50,6 @@ use {
     solana_sdk_ids::sysvar::{self as sysvar, clock},
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
     solana_signer::Signer,
-    solana_svm::conformance::setup::sysvar_cache_from_accounts,
     solana_svm::{
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_processor::ExecutionRecordingConfig,
@@ -70,26 +69,30 @@ use {
     },
     test_case::test_matrix,
 };
-#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
-use {
-    agave_reserved_account_keys::ReservedAccountKeys,
-    solana_message::SanitizedMessage,
-    solana_svm::conformance::txn::{context::TxnContext, harness::execute_txn},
-};
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 use {
+    agave_reserved_account_keys::ReservedAccountKeys,
     solana_account::Account,
-    solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
+    solana_message::SanitizedMessage,
+    solana_program_runtime::sysvar_cache::SysvarCache,
     solana_sdk_ids::sysvar::rent,
     solana_svm::conformance::{
         instr::{context::InstrContext, harness::execute_instr},
         programs::{
             add_program_to_program_cache, keyed_account_for_bpf_loader_program,
-            keyed_account_for_bpf_loader_upgradeable_program, keyed_account_for_system_program,
-            new_program_cache_with_builtins,
+            keyed_account_for_system_program, new_program_cache_with_builtins,
         },
     },
     std::{fs::File, io::Read, path::PathBuf},
+};
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
+use {
+    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
+    solana_svm::conformance::{
+        programs::keyed_account_for_bpf_loader_upgradeable_program,
+        setup::sysvar_cache_from_accounts,
+        txn::{context::TxnContext, harness::execute_txn},
+    },
 };
 
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -10,13 +10,10 @@
 #[cfg(not(feature = "sbf_sanity_list"))]
 use solana_program_runtime::execution_budget::MAX_COMPUTE_UNIT_LIMIT;
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
-use solana_runtime::loader_utils::{
-    load_upgradeable_program_and_advance_slot, set_upgrade_authority, upgrade_program,
-};
+use solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
-    agave_reserved_account_keys::ReservedAccountKeys,
     borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
@@ -34,7 +31,7 @@ use {
     solana_loader_v3_interface::{
         instruction as loader_v3_instruction, state::UpgradeableLoaderState,
     },
-    solana_message::{Message, SanitizedMessage, inner_instruction::InnerInstruction},
+    solana_message::{Message, inner_instruction::InnerInstruction},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
@@ -53,6 +50,7 @@ use {
     solana_sdk_ids::sysvar::{self as sysvar, clock},
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable},
     solana_signer::Signer,
+    solana_svm::conformance::setup::sysvar_cache_from_accounts,
     solana_svm::{
         transaction_commit_result::{CommittedTransaction, TransactionCommitResult},
         transaction_processor::ExecutionRecordingConfig,
@@ -72,16 +70,23 @@ use {
     },
     test_case::test_matrix,
 };
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
+use {
+    agave_reserved_account_keys::ReservedAccountKeys,
+    solana_message::SanitizedMessage,
+    solana_svm::conformance::txn::{context::TxnContext, harness::execute_txn},
+};
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
 use {
     solana_account::Account,
-    solana_program_runtime::sysvar_cache::SysvarCache,
+    solana_program_runtime::{loaded_programs::ProgramCacheForTxBatch, sysvar_cache::SysvarCache},
     solana_sdk_ids::sysvar::rent,
     solana_svm::conformance::{
         instr::{context::InstrContext, harness::execute_instr},
         programs::{
             add_program_to_program_cache, keyed_account_for_bpf_loader_program,
-            keyed_account_for_system_program, new_program_cache_with_builtins,
+            keyed_account_for_bpf_loader_upgradeable_program, keyed_account_for_system_program,
+            new_program_cache_with_builtins,
         },
     },
     std::{fs::File, io::Read, path::PathBuf},
@@ -2421,63 +2426,207 @@ fn test_program_sbf_c_dup() {
 fn test_program_sbf_upgrade() {
     agave_logger::setup();
 
-    let GenesisConfigInfo {
-        genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config(50);
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank);
+    const UPGRADE_SLOT: u64 = 2;
+    const UPGRADE_EFFECTIVE_SLOT: u64 = 3;
 
-    // Deploy upgrade program
-    let authority_keypair = Keypair::new();
-    let (_bank, program_id) = load_upgradeable_program_and_advance_slot(
-        &mut bank_client,
-        &bank_forks,
-        &mint_keypair,
-        &authority_keypair,
-        "solana_sbf_rust_upgradeable",
+    let feature_set = FeatureSet::all_enabled();
+    let program_id = Pubkey::new_unique();
+    let program_elf = load_program_elf("solana_sbf_rust_upgradeable");
+    let mut program_cache = default_program_cache_with_program(
+        &program_id,
+        &program_elf,
+        &feature_set.runtime_features(),
     );
 
+    let new_authority_keypair = Keypair::new();
+    let mint_keypair = Keypair::new();
+    let authority_keypair = Keypair::new();
+
+    let (programdata_address, _) =
+        Pubkey::find_program_address(&[program_id.as_ref()], &bpf_loader_upgradeable::id());
+
+    let mut transaction_accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    let programdata_account = &mut transaction_accounts
+        .iter_mut()
+        .find(|(pubkey, _)| pubkey == &programdata_address)
+        .unwrap()
+        .1;
+    let programdata_state = bincode::serialize(&UpgradeableLoaderState::ProgramData {
+        slot: 0,
+        upgrade_authority_address: Some(authority_keypair.pubkey()),
+    })
+    .unwrap();
+    programdata_account.data[..programdata_state.len()].copy_from_slice(&programdata_state);
+
+    transaction_accounts.extend([
+        (
+            new_authority_keypair.pubkey(),
+            Account::new(0, 0, &system_program::id()),
+        ),
+        (
+            mint_keypair.pubkey(),
+            Account::new(50, 0, &system_program::id()),
+        ),
+        (
+            authority_keypair.pubkey(),
+            Account::new(0, 0, &system_program::id()),
+        ),
+        (
+            rent::id(),
+            Account {
+                lamports: 1,
+                data: bincode::serialize(&Rent::free()).unwrap(),
+                owner: sysvar::id(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        ),
+        (
+            clock::id(),
+            Account {
+                lamports: 1,
+                data: bincode::serialize(&solana_clock::Clock {
+                    slot: UPGRADE_SLOT,
+                    epoch_start_timestamp: 0,
+                    epoch: 0,
+                    leader_schedule_epoch: 0,
+                    unix_timestamp: 0,
+                })
+                .unwrap(),
+                owner: sysvar::id(),
+                executable: false,
+                rent_epoch: 0,
+            },
+        ),
+        keyed_account_for_bpf_loader_upgradeable_program(),
+    ]);
+
+    program_cache.set_slot_for_tests(UPGRADE_SLOT);
+    let sysvar_cache = default_sysvar_cache();
+    let execute_transaction = |accounts: Vec<(Pubkey, Account)>,
+                               instructions: &[Instruction],
+                               program_cache: &mut ProgramCacheForTxBatch,
+                               sysvar_cache: &SysvarCache| {
+        let sanitized_message = SanitizedMessage::try_from_legacy_message(
+            Message::new(instructions, Some(&mint_keypair.pubkey())),
+            &ReservedAccountKeys::empty_key_set(),
+        )
+        .unwrap();
+        let context = TxnContext::new_with_default_budget(
+            feature_set.clone(),
+            accounts,
+            sanitized_message,
+            None,
+        );
+        execute_txn(&context, program_cache, sysvar_cache)
+    };
+
     // Call upgradeable program
-    let mut instruction =
-        Instruction::new_with_bytes(program_id, &[0], vec![AccountMeta::new(clock::id(), false)]);
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
+    let instruction_accounts = vec![AccountMeta::new(clock::id(), false)];
+    let instruction = Instruction::new_with_bytes(program_id, &[0], instruction_accounts.clone());
     assert_eq!(
-        result.unwrap_err().unwrap(),
-        TransactionError::InstructionError(0, InstructionError::Custom(42))
+        execute_transaction(
+            transaction_accounts.clone(),
+            &[instruction],
+            &mut program_cache,
+            &sysvar_cache,
+        )
+        .status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(42),
+        )),
     );
 
     // Set authority
-    let new_authority_keypair = Keypair::new();
-    set_upgrade_authority(
-        &bank_client,
-        &mint_keypair,
+    let set_authority_instruction = loader_v3_instruction::set_upgrade_authority(
         &program_id,
-        &authority_keypair,
+        &authority_keypair.pubkey(),
         Some(&new_authority_keypair.pubkey()),
     );
 
-    // Upgrade program
-    let buffer_keypair = Keypair::new();
-    upgrade_program(
-        &bank_client,
-        &mint_keypair,
-        &buffer_keypair,
-        &program_id,
-        &new_authority_keypair,
-        "solana_sbf_rust_upgraded",
+    let effects = execute_transaction(
+        transaction_accounts.clone(),
+        &[set_authority_instruction],
+        &mut program_cache,
+        &sysvar_cache,
     );
-    bank_client
-        .advance_slot(1, &bank_forks, SlotLeader::default())
-        .expect("Failed to advance the slot");
+    assert_eq!(effects.status, Ok(()), "{:?}", effects.logs);
+    transaction_accounts = effects.resulting_accounts;
+
+    // Upgrade program
+    let upgraded_program_elf = load_program_elf("solana_sbf_rust_upgraded");
+    let mut buffer_data = bincode::serialize(&UpgradeableLoaderState::Buffer {
+        authority_address: Some(new_authority_keypair.pubkey()),
+    })
+    .unwrap();
+    buffer_data.extend_from_slice(&upgraded_program_elf);
+
+    let buffer_keypair = Keypair::new();
+    transaction_accounts.push((
+        buffer_keypair.pubkey(),
+        Account {
+            lamports: 1,
+            data: buffer_data,
+            owner: bpf_loader_upgradeable::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+    ));
+
+    let sysvar_cache = sysvar_cache_from_accounts(&transaction_accounts);
+
+    let upgrade_instruction = loader_v3_instruction::upgrade(
+        &program_id,
+        &buffer_keypair.pubkey(),
+        &new_authority_keypair.pubkey(),
+        &mint_keypair.pubkey(),
+    );
+
+    let effects = execute_transaction(
+        transaction_accounts.clone(),
+        &[upgrade_instruction],
+        &mut program_cache,
+        &sysvar_cache,
+    );
+    assert_eq!(effects.status, Ok(()), "{:?}", effects.logs);
+    transaction_accounts = effects.resulting_accounts;
+
+    let modified_programs = program_cache.drain_modified_entries();
+    assert!(modified_programs.contains_key(&program_id));
+
+    program_cache.merge(&modified_programs);
+    program_cache.set_slot_for_tests(UPGRADE_EFFECTIVE_SLOT);
+
+    let clock_account = &mut transaction_accounts
+        .iter_mut()
+        .find(|(pubkey, _)| pubkey == &clock::id())
+        .unwrap()
+        .1;
+    clock_account.data = bincode::serialize(&solana_clock::Clock {
+        slot: UPGRADE_EFFECTIVE_SLOT,
+        ..solana_clock::Clock::default()
+    })
+    .unwrap();
+    let sysvar_cache = sysvar_cache_from_accounts(&transaction_accounts);
 
     // Call upgraded program
-    instruction.data[0] += 1;
-    let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction.clone());
+    let effects = execute_transaction(
+        transaction_accounts,
+        &[Instruction::new_with_bytes(
+            program_id,
+            &[1],
+            instruction_accounts,
+        )],
+        &mut program_cache,
+        &sysvar_cache,
+    );
     assert_eq!(
-        result.unwrap_err().unwrap(),
-        TransactionError::InstructionError(0, InstructionError::Custom(43))
+        effects.status,
+        Err(TransactionError::InstructionError(
+            0,
+            InstructionError::Custom(43),
+        )),
     );
 }
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2584,7 +2584,6 @@ fn test_program_sbf_upgrade() {
             rent_epoch: 0,
         },
     ));
-
     let sysvar_cache = sysvar_cache_from_accounts(&transaction_accounts);
 
     let upgrade_instruction = loader_v3_instruction::upgrade(
@@ -2608,13 +2607,16 @@ fn test_program_sbf_upgrade() {
 
     program_cache.merge(&modified_programs);
     program_cache.set_slot_for_tests(UPGRADE_EFFECTIVE_SLOT);
+    add_program_to_program_cache(
+        &mut program_cache,
+        &program_id,
+        &bpf_loader_upgradeable::id(),
+        &upgraded_program_elf,
+        &feature_set.runtime_features(),
+    );
 
-    let clock_account = &mut transaction_accounts
-        .iter_mut()
-        .find(|(pubkey, _)| pubkey == &clock::id())
-        .unwrap()
-        .1;
-    clock_account.data = bincode::serialize(&solana_clock::Clock {
+    let clock_account = &mut transaction_accounts[6];
+    clock_account.1.data = bincode::serialize(&solana_clock::Clock {
         slot: UPGRADE_EFFECTIVE_SLOT,
         ..solana_clock::Clock::default()
     })

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -12,7 +12,7 @@ use solana_program_runtime::execution_budget::MAX_COMPUTE_UNIT_LIMIT;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
-    borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize},
+    borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_client_traits::SyncClient,
@@ -24,12 +24,12 @@ use {
     solana_fee_calculator::FeeRateGovernor,
     solana_fee_structure::{FeeBin, FeeStructure},
     solana_hash::Hash,
-    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
+    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_keypair::Keypair,
     solana_loader_v3_interface::{
         instruction as loader_v3_instruction, state::UpgradeableLoaderState,
     },
-    solana_message::{inner_instruction::InnerInstruction, Message},
+    solana_message::{Message, inner_instruction::InnerInstruction},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
@@ -37,9 +37,8 @@ use {
         bank_client::BankClient,
         bank_forks::BankForks,
         genesis_utils::{
-            bootstrap_validator_stake_lamports, create_genesis_config,
+            GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
-            GenesisConfigInfo,
         },
         loader_utils::{create_program, load_upgradeable_buffer},
     },
@@ -57,7 +56,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_svm_type_overrides::rand,
-    solana_system_interface::{program as system_program, MAX_PERMITTED_DATA_LENGTH},
+    solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, program as system_program},
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     std::{
@@ -86,6 +85,7 @@ use {
 };
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 use {
+    solana_clock::Clock,
     solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot,
     solana_svm::conformance::{
@@ -93,6 +93,7 @@ use {
         setup::sysvar_cache_from_accounts,
         txn::{context::TxnContext, harness::execute_txn},
     },
+    solana_sysvar::SysvarSerialize,
 };
 
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
@@ -233,6 +234,16 @@ fn bank_with_feature_deactivated(
         .unwrap()
         .insert(bank)
         .clone_without_scheduler()
+}
+
+#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
+fn sysvar_account<T: SysvarSerialize>(sysvar: &T) -> Account {
+    Account {
+        lamports: 1,
+        data: bincode::serialize(sysvar).unwrap(),
+        owner: sysvar::id(),
+        ..Account::default()
+    }
 }
 
 #[cfg(feature = "sbf_rust")]
@@ -767,17 +778,21 @@ fn test_return_data_and_log_data_syscall() {
 
         assert!(effects.result.is_none());
 
-        assert!(effects
-            .logs
-            .iter()
-            .any(|log| log == "Program data: AQID BAUG"));
+        assert!(
+            effects
+                .logs
+                .iter()
+                .any(|log| log == "Program data: AQID BAUG")
+        );
 
         assert_eq!(effects.return_data, vec![0x08, 0x01, 0x44]);
 
-        assert!(effects
-            .logs
-            .iter()
-            .any(|log| log == &format!("Program return: {} CAFE", program_id)));
+        assert!(
+            effects
+                .logs
+                .iter()
+                .any(|log| log == &format!("Program return: {} CAFE", program_id))
+        );
     }
 }
 
@@ -2482,32 +2497,13 @@ fn test_program_sbf_upgrade() {
             authority_keypair.pubkey(),
             Account::new(0, 0, &system_program::id()),
         ),
-        (
-            rent::id(),
-            Account {
-                lamports: 1,
-                data: bincode::serialize(&Rent::free()).unwrap(),
-                owner: sysvar::id(),
-                executable: false,
-                rent_epoch: 0,
-            },
-        ),
+        (rent::id(), sysvar_account(&Rent::free())),
         (
             clock::id(),
-            Account {
-                lamports: 1,
-                data: bincode::serialize(&solana_clock::Clock {
-                    slot: UPGRADE_SLOT,
-                    epoch_start_timestamp: 0,
-                    epoch: 0,
-                    leader_schedule_epoch: 0,
-                    unix_timestamp: 0,
-                })
-                .unwrap(),
-                owner: sysvar::id(),
-                executable: false,
-                rent_epoch: 0,
-            },
+            sysvar_account(&Clock {
+                slot: UPGRADE_SLOT,
+                ..Clock::default()
+            }),
         ),
         keyed_account_for_bpf_loader_upgradeable_program(),
     ]);
@@ -3924,9 +3920,11 @@ fn test_program_sbf_processed_inner_instruction() {
         &[instruction2, instruction1, instruction0],
         Some(&mint_keypair.pubkey()),
     );
-    assert!(bank_client
-        .send_and_confirm_message(&[&mint_keypair], message)
-        .is_ok());
+    assert!(
+        bank_client
+            .send_and_confirm_message(&[&mint_keypair], message)
+            .is_ok()
+    );
 }
 
 #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -12,7 +12,7 @@ use solana_program_runtime::execution_budget::MAX_COMPUTE_UNIT_LIMIT;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
-    borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec},
+    borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_client_traits::SyncClient,
@@ -24,12 +24,12 @@ use {
     solana_fee_calculator::FeeRateGovernor,
     solana_fee_structure::{FeeBin, FeeStructure},
     solana_hash::Hash,
-    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
+    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_keypair::Keypair,
     solana_loader_v3_interface::{
         instruction as loader_v3_instruction, state::UpgradeableLoaderState,
     },
-    solana_message::{Message, inner_instruction::InnerInstruction},
+    solana_message::{inner_instruction::InnerInstruction, Message},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
@@ -37,8 +37,9 @@ use {
         bank_client::BankClient,
         bank_forks::BankForks,
         genesis_utils::{
-            GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
+            bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
+            GenesisConfigInfo,
         },
         loader_utils::{create_program, load_upgradeable_buffer},
     },
@@ -56,7 +57,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_svm_type_overrides::rand,
-    solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, program as system_program},
+    solana_system_interface::{program as system_program, MAX_PERMITTED_DATA_LENGTH},
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     std::{
@@ -128,16 +129,11 @@ fn default_program_cache_with_program(
     program_cache
 }
 
-// If upgrade authority isn't provided, a default one would be used.
 fn upgradeable_program_accounts(
     program_id: &Pubkey,
     program_elf: &[u8],
     upgrade_authority_address: Option<Pubkey>,
 ) -> Vec<(Pubkey, Account)> {
-    let upgrade_authority_address = match upgrade_authority_address {
-        Some(_) => upgrade_authority_address,
-        None => Some(Pubkey::default()),
-    };
     solana_program_binaries::bpf_loader_upgradeable_program_accounts(
         program_id,
         program_elf,
@@ -333,7 +329,8 @@ fn test_program_sbf_sanity() {
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
 
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let mut accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
         accounts.extend([(pubkey1, Account::default()), (pubkey2, Account::default())]);
 
         let mut program_cache =
@@ -573,7 +570,8 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new(pubkey, false),
             AccountMeta::new(pubkey, false),
         ];
-        let program_accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let program_accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
 
         let mut execute = |data: &[u8]| {
             let mut accounts = program_accounts.clone();
@@ -625,7 +623,8 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new_readonly(pubkey, true),
             AccountMeta::new_readonly(program_id, false),
         ];
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let mut accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
         accounts.extend([
             (payer_pubkey, Account::new(100, 0, &Pubkey::default())),
             (payee_pubkey, Account::new(10, 1, &program_id)),
@@ -663,7 +662,8 @@ fn test_program_sbf_error_handling() {
 
         let pubkey1 = Pubkey::new_unique();
 
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let mut accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
         accounts.push((pubkey1, Account::default()));
 
         let mut program_cache =
@@ -749,7 +749,8 @@ fn test_return_data_and_log_data_syscall() {
         let feature_set = SVMFeatureSet::all_enabled();
 
         let pubkey = Pubkey::new_unique();
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let mut accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
         accounts.push((pubkey, Account::default()));
 
         let mut program_cache =
@@ -766,21 +767,17 @@ fn test_return_data_and_log_data_syscall() {
 
         assert!(effects.result.is_none());
 
-        assert!(
-            effects
-                .logs
-                .iter()
-                .any(|log| log == "Program data: AQID BAUG")
-        );
+        assert!(effects
+            .logs
+            .iter()
+            .any(|log| log == "Program data: AQID BAUG"));
 
         assert_eq!(effects.return_data, vec![0x08, 0x01, 0x44]);
 
-        assert!(
-            effects
-                .logs
-                .iter()
-                .any(|log| log == &format!("Program return: {} CAFE", program_id))
-        );
+        assert!(effects
+            .logs
+            .iter()
+            .any(|log| log == &format!("Program return: {} CAFE", program_id)));
     }
 }
 
@@ -1424,12 +1421,12 @@ fn test_program_sbf_program_id_spoofing() {
     accounts.extend(upgradeable_program_accounts(
         &malicious_swap_pubkey,
         &spoof1_elf,
-        None,
+        Some(Pubkey::default()),
     ));
     accounts.extend(upgradeable_program_accounts(
         &malicious_system_pubkey,
         &spoof1_system_elf,
-        None,
+        Some(Pubkey::default()),
     ));
     accounts.extend([
         (from_pubkey, Account::new(10, 0, &system_program::id())),
@@ -1489,11 +1486,12 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let mut accounts = upgradeable_program_accounts(&caller_pubkey, &caller_access_elf, None);
+    let mut accounts =
+        upgradeable_program_accounts(&caller_pubkey, &caller_access_elf, Some(Pubkey::default()));
     accounts.extend(upgradeable_program_accounts(
         &caller2_pubkey,
         &caller_access_elf,
-        None,
+        Some(Pubkey::default()),
     ));
 
     let mut program_cache = default_program_cache();
@@ -1541,7 +1539,7 @@ fn test_program_sbf_ro_modify() {
     accounts.extend(upgradeable_program_accounts(
         &program_id,
         &program_elf,
-        None,
+        Some(Pubkey::default()),
     ));
     accounts.push((test_pubkey, Account::new(10, 0, &system_program::id())));
 
@@ -1584,7 +1582,8 @@ fn test_program_sbf_call_depth() {
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
-    let program_accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+    let program_accounts =
+        upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
 
     let mut execute = |depth: usize| {
         let instruction = Instruction::new_with_bincode(program_id, &depth, vec![]);
@@ -1615,7 +1614,7 @@ fn test_program_sbf_compute_budget() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+    let accounts = upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
 
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -1693,7 +1692,8 @@ fn assert_instruction_count() {
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
 
         let account_pubkey = Pubkey::new_unique();
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+        let mut accounts =
+            upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
         accounts.push((account_pubkey, Account::new(0, 0, &program_id)));
 
         let instruction_accounts = vec![AccountMeta {
@@ -1818,7 +1818,7 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
     accounts.extend(upgradeable_program_accounts(
         &program_id,
         &program_elf,
-        None,
+        Some(Pubkey::default()),
     ));
 
     // The provided instruction data will be set to the return data.
@@ -2436,7 +2436,8 @@ fn test_program_sbf_c_dup() {
     ];
     let instruction = Instruction::new_with_bytes(program_id, &[4, 5, 6, 7], account_metas);
 
-    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+    let mut accounts =
+        upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
     accounts.push((account_address, account));
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
@@ -2758,7 +2759,8 @@ fn test_program_sbf_ro_account_modify() {
     let sysvar_cache = default_sysvar_cache();
 
     let argument_pubkey = Pubkey::new_unique();
-    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
+    let mut accounts =
+        upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default()));
     accounts.push((argument_pubkey, Account::new(42, 100, &program_id)));
 
     let account_metas = vec![
@@ -3922,11 +3924,9 @@ fn test_program_sbf_processed_inner_instruction() {
         &[instruction2, instruction1, instruction0],
         Some(&mint_keypair.pubkey()),
     );
-    assert!(
-        bank_client
-            .send_and_confirm_message(&[&mint_keypair], message)
-            .is_ok()
-    );
+    assert!(bank_client
+        .send_and_confirm_message(&[&mint_keypair], message)
+        .is_ok());
 }
 
 #[test]
@@ -4674,7 +4674,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
 
     let context = InstrContext {
         feature_set,
-        accounts: upgradeable_program_accounts(&program_id, &program_elf, None),
+        accounts: upgradeable_program_accounts(&program_id, &program_elf, Some(Pubkey::default())),
         instruction,
         cu_avail: 10_000,
     };
@@ -5752,7 +5752,7 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
     accounts.extend(upgradeable_program_accounts(
         &program_id,
         &program_elf,
-        None,
+        Some(Pubkey::default()),
     ));
 
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -9,8 +9,6 @@
 
 #[cfg(not(feature = "sbf_sanity_list"))]
 use solana_program_runtime::execution_budget::MAX_COMPUTE_UNIT_LIMIT;
-#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
-use solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
@@ -88,6 +86,7 @@ use {
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 use {
     solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
+    solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot,
     solana_svm::conformance::{
         programs::keyed_account_for_bpf_loader_upgradeable_program,
         setup::sysvar_cache_from_accounts,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -86,12 +86,10 @@ use {
 #[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
 use {
     solana_clock::Clock,
-    solana_program_runtime::loaded_programs::ProgramCacheForTxBatch,
     solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot,
     solana_svm::conformance::{
         programs::keyed_account_for_bpf_loader_upgradeable_program,
         setup::sysvar_cache_from_accounts,
-        txn::{context::TxnContext, harness::execute_txn},
     },
     solana_sysvar::SysvarSerialize,
 };
@@ -2481,10 +2479,10 @@ fn test_program_sbf_upgrade() {
     let mint_keypair = Keypair::new();
     let authority_keypair = Keypair::new();
 
-    let mut transaction_accounts =
+    let mut accounts =
         upgradeable_program_accounts(&program_id, &program_elf, Some(authority_keypair.pubkey()));
 
-    transaction_accounts.extend([
+    accounts.extend([
         (
             new_authority_keypair.pubkey(),
             Account::new(0, 0, &system_program::id()),
@@ -2510,56 +2508,32 @@ fn test_program_sbf_upgrade() {
 
     program_cache.set_slot_for_tests(UPGRADE_SLOT);
     let sysvar_cache = default_sysvar_cache();
-    let execute_transaction = |accounts: Vec<(Pubkey, Account)>,
-                               instructions: &[Instruction],
-                               program_cache: &mut ProgramCacheForTxBatch,
-                               sysvar_cache: &SysvarCache| {
-        let sanitized_message = SanitizedMessage::try_from_legacy_message(
-            Message::new(instructions, Some(&mint_keypair.pubkey())),
-            &ReservedAccountKeys::empty_key_set(),
-        )
-        .unwrap();
-        let context = TxnContext::new_with_default_budget(
-            feature_set.clone(),
-            accounts,
-            sanitized_message,
-            None,
-        );
-        execute_txn(&context, program_cache, sysvar_cache)
-    };
 
     // Call upgradeable program
     let instruction_accounts = vec![AccountMeta::new(clock::id(), false)];
     let instruction = Instruction::new_with_bytes(program_id, &[0], instruction_accounts.clone());
-    assert_eq!(
-        execute_transaction(
-            transaction_accounts.clone(),
-            &[instruction],
-            &mut program_cache,
-            &sysvar_cache,
-        )
-        .status,
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(42),
-        )),
+    let context = InstrContext::new_with_default_budget(
+        feature_set.runtime_features(),
+        accounts.clone(),
+        instruction,
     );
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
+    assert_eq!(effects.result, Some(InstructionError::Custom(42)));
 
     // Set authority
-    let set_authority_instruction = loader_v3_instruction::set_upgrade_authority(
+    let instruction = loader_v3_instruction::set_upgrade_authority(
         &program_id,
         &authority_keypair.pubkey(),
         Some(&new_authority_keypair.pubkey()),
     );
-
-    let effects = execute_transaction(
-        transaction_accounts.clone(),
-        &[set_authority_instruction],
-        &mut program_cache,
-        &sysvar_cache,
+    let context = InstrContext::new_with_default_budget(
+        feature_set.runtime_features(),
+        accounts,
+        instruction,
     );
-    assert_eq!(effects.status, Ok(()));
-    transaction_accounts = effects.resulting_accounts;
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
+    assert_eq!(effects.result, None);
+    accounts = effects.resulting_accounts;
 
     // Upgrade program
     let upgraded_program_elf = load_program_elf("solana_sbf_rust_upgraded");
@@ -2570,7 +2544,7 @@ fn test_program_sbf_upgrade() {
     buffer_data.extend_from_slice(&upgraded_program_elf);
 
     let buffer_keypair = Keypair::new();
-    transaction_accounts.push((
+    accounts.push((
         buffer_keypair.pubkey(),
         Account {
             lamports: 1,
@@ -2580,23 +2554,22 @@ fn test_program_sbf_upgrade() {
             rent_epoch: 0,
         },
     ));
-    let sysvar_cache = sysvar_cache_from_accounts(&transaction_accounts);
+    let sysvar_cache = sysvar_cache_from_accounts(&accounts);
 
-    let upgrade_instruction = loader_v3_instruction::upgrade(
+    let instruction = loader_v3_instruction::upgrade(
         &program_id,
         &buffer_keypair.pubkey(),
         &new_authority_keypair.pubkey(),
         &mint_keypair.pubkey(),
     );
-
-    let effects = execute_transaction(
-        transaction_accounts.clone(),
-        &[upgrade_instruction],
-        &mut program_cache,
-        &sysvar_cache,
+    let context = InstrContext::new_with_default_budget(
+        feature_set.runtime_features(),
+        accounts,
+        instruction,
     );
-    assert_eq!(effects.status, Ok(()));
-    transaction_accounts = effects.resulting_accounts;
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
+    assert_eq!(effects.result, None);
+    accounts = effects.resulting_accounts;
 
     let modified_programs = program_cache.drain_modified_entries();
     assert!(modified_programs.contains_key(&program_id));
@@ -2610,33 +2583,17 @@ fn test_program_sbf_upgrade() {
         &upgraded_program_elf,
         &feature_set.runtime_features(),
     );
-
-    let clock_account = &mut transaction_accounts[6];
-    clock_account.1.data = bincode::serialize(&solana_clock::Clock {
-        slot: UPGRADE_EFFECTIVE_SLOT,
-        ..solana_clock::Clock::default()
-    })
-    .unwrap();
-    let sysvar_cache = sysvar_cache_from_accounts(&transaction_accounts);
+    let sysvar_cache = sysvar_cache_from_accounts(&accounts);
 
     // Call upgraded program
-    let effects = execute_transaction(
-        transaction_accounts,
-        &[Instruction::new_with_bytes(
-            program_id,
-            &[1],
-            instruction_accounts,
-        )],
-        &mut program_cache,
-        &sysvar_cache,
+    let instruction = Instruction::new_with_bytes(program_id, &[1], instruction_accounts);
+    let context = InstrContext::new_with_default_budget(
+        feature_set.runtime_features(),
+        accounts,
+        instruction,
     );
-    assert_eq!(
-        effects.status,
-        Err(TransactionError::InstructionError(
-            0,
-            InstructionError::Custom(43),
-        )),
-    );
+    let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
+    assert_eq!(effects.result, Some(InstructionError::Custom(43)));
 }
 
 #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -14,7 +14,7 @@ use solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
-    borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec},
+    borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_client_traits::SyncClient,
@@ -26,12 +26,12 @@ use {
     solana_fee_calculator::FeeRateGovernor,
     solana_fee_structure::{FeeBin, FeeStructure},
     solana_hash::Hash,
-    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
+    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
     solana_keypair::Keypair,
     solana_loader_v3_interface::{
         instruction as loader_v3_instruction, state::UpgradeableLoaderState,
     },
-    solana_message::{Message, inner_instruction::InnerInstruction},
+    solana_message::{inner_instruction::InnerInstruction, Message},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
@@ -39,8 +39,9 @@ use {
         bank_client::BankClient,
         bank_forks::BankForks,
         genesis_utils::{
-            GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
+            bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
+            GenesisConfigInfo,
         },
         loader_utils::{create_program, load_upgradeable_buffer},
     },
@@ -58,7 +59,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_svm_type_overrides::rand,
-    solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, program as system_program},
+    solana_system_interface::{program as system_program, MAX_PERMITTED_DATA_LENGTH},
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     std::{
@@ -757,21 +758,17 @@ fn test_return_data_and_log_data_syscall() {
 
         assert!(effects.result.is_none());
 
-        assert!(
-            effects
-                .logs
-                .iter()
-                .any(|log| log == "Program data: AQID BAUG")
-        );
+        assert!(effects
+            .logs
+            .iter()
+            .any(|log| log == "Program data: AQID BAUG"));
 
         assert_eq!(effects.return_data, vec![0x08, 0x01, 0x44]);
 
-        assert!(
-            effects
-                .logs
-                .iter()
-                .any(|log| log == &format!("Program return: {} CAFE", program_id))
-        );
+        assert!(effects
+            .logs
+            .iter()
+            .any(|log| log == &format!("Program return: {} CAFE", program_id)));
     }
 }
 
@@ -2554,7 +2551,7 @@ fn test_program_sbf_upgrade() {
         &mut program_cache,
         &sysvar_cache,
     );
-    assert_eq!(effects.status, Ok(()), "{:?}", effects.logs);
+    assert_eq!(effects.status, Ok(()));
     transaction_accounts = effects.resulting_accounts;
 
     // Upgrade program
@@ -2592,7 +2589,7 @@ fn test_program_sbf_upgrade() {
         &mut program_cache,
         &sysvar_cache,
     );
-    assert_eq!(effects.status, Ok(()), "{:?}", effects.logs);
+    assert_eq!(effects.status, Ok(()));
     transaction_accounts = effects.resulting_accounts;
 
     let modified_programs = program_cache.drain_modified_entries();
@@ -3913,11 +3910,9 @@ fn test_program_sbf_processed_inner_instruction() {
         &[instruction2, instruction1, instruction0],
         Some(&mint_keypair.pubkey()),
     );
-    assert!(
-        bank_client
-            .send_and_confirm_message(&[&mint_keypair], message)
-            .is_ok()
-    );
+    assert!(bank_client
+        .send_and_confirm_message(&[&mint_keypair], message)
+        .is_ok());
 }
 
 #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -91,7 +91,6 @@ use {
         programs::keyed_account_for_bpf_loader_upgradeable_program,
         setup::sysvar_cache_from_accounts,
     },
-    solana_sysvar::SysvarSerialize,
 };
 
 #[cfg(any(feature = "sbf_c", feature = "sbf_rust"))]
@@ -232,16 +231,6 @@ fn bank_with_feature_deactivated(
         .unwrap()
         .insert(bank)
         .clone_without_scheduler()
-}
-
-#[cfg(all(feature = "sbf_rust", feature = "sbpf-v3"))]
-fn sysvar_account<T: SysvarSerialize>(sysvar: &T) -> Account {
-    Account {
-        lamports: 1,
-        data: bincode::serialize(sysvar).unwrap(),
-        owner: sysvar::id(),
-        ..Account::default()
-    }
 }
 
 #[cfg(feature = "sbf_rust")]
@@ -2495,13 +2484,21 @@ fn test_program_sbf_upgrade() {
             authority_keypair.pubkey(),
             Account::new(0, 0, &system_program::id()),
         ),
-        (rent::id(), sysvar_account(&Rent::free())),
+        (
+            rent::id(),
+            Account::new_data(1, &Rent::free(), &solana_sdk_ids::sysvar::id()).unwrap(),
+        ),
         (
             clock::id(),
-            sysvar_account(&Clock {
-                slot: UPGRADE_SLOT,
-                ..Clock::default()
-            }),
+            Account::new_data(
+                1,
+                &Clock {
+                    slot: UPGRADE_SLOT,
+                    ..Clock::default()
+                },
+                &solana_sdk_ids::sysvar::id(),
+            )
+            .unwrap(),
         ),
         keyed_account_for_bpf_loader_upgradeable_program(),
     ]);

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -14,7 +14,7 @@ use solana_runtime::loader_utils::load_upgradeable_program_and_advance_slot;
 #[cfg(feature = "sbf_rust")]
 use {
     agave_feature_set::{self as feature_set, FeatureSet},
-    borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize},
+    borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_client_traits::SyncClient,
@@ -26,12 +26,12 @@ use {
     solana_fee_calculator::FeeRateGovernor,
     solana_fee_structure::{FeeBin, FeeStructure},
     solana_hash::Hash,
-    solana_instruction::{error::InstructionError, AccountMeta, Instruction},
+    solana_instruction::{AccountMeta, Instruction, error::InstructionError},
     solana_keypair::Keypair,
     solana_loader_v3_interface::{
         instruction as loader_v3_instruction, state::UpgradeableLoaderState,
     },
-    solana_message::{inner_instruction::InnerInstruction, Message},
+    solana_message::{Message, inner_instruction::InnerInstruction},
     solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_runtime::{
@@ -39,9 +39,8 @@ use {
         bank_client::BankClient,
         bank_forks::BankForks,
         genesis_utils::{
-            bootstrap_validator_stake_lamports, create_genesis_config,
+            GenesisConfigInfo, bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader, create_genesis_config_with_leader_ex,
-            GenesisConfigInfo,
         },
         loader_utils::{create_program, load_upgradeable_buffer},
     },
@@ -59,7 +58,7 @@ use {
     solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::svm_message::SVMStaticMessage,
     solana_svm_type_overrides::rand,
-    solana_system_interface::{program as system_program, MAX_PERMITTED_DATA_LENGTH},
+    solana_system_interface::{MAX_PERMITTED_DATA_LENGTH, program as system_program},
     solana_transaction::Transaction,
     solana_transaction_error::TransactionError,
     std::{
@@ -130,11 +129,21 @@ fn default_program_cache_with_program(
     program_cache
 }
 
-fn upgradeable_program_accounts(program_id: &Pubkey, program_elf: &[u8]) -> Vec<(Pubkey, Account)> {
+// If upgrade authority isn't provided, a default one would be used.
+fn upgradeable_program_accounts(
+    program_id: &Pubkey,
+    program_elf: &[u8],
+    upgrade_authority_address: Option<Pubkey>,
+) -> Vec<(Pubkey, Account)> {
+    let upgrade_authority_address = match upgrade_authority_address {
+        Some(_) => upgrade_authority_address,
+        None => Some(Pubkey::default()),
+    };
     solana_program_binaries::bpf_loader_upgradeable_program_accounts(
         program_id,
         program_elf,
         &Rent::default(),
+        upgrade_authority_address,
     )
     .into()
 }
@@ -325,7 +334,7 @@ fn test_program_sbf_sanity() {
         ];
         let instruction = Instruction::new_with_bytes(program_id, &[1], account_metas);
 
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
         accounts.extend([(pubkey1, Account::default()), (pubkey2, Account::default())]);
 
         let mut program_cache =
@@ -565,7 +574,7 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new(pubkey, false),
             AccountMeta::new(pubkey, false),
         ];
-        let program_accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let program_accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
 
         let mut execute = |data: &[u8]| {
             let mut accounts = program_accounts.clone();
@@ -617,7 +626,7 @@ fn test_program_sbf_duplicate_accounts() {
             AccountMeta::new_readonly(pubkey, true),
             AccountMeta::new_readonly(program_id, false),
         ];
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
         accounts.extend([
             (payer_pubkey, Account::new(100, 0, &Pubkey::default())),
             (payee_pubkey, Account::new(10, 1, &program_id)),
@@ -655,7 +664,7 @@ fn test_program_sbf_error_handling() {
 
         let pubkey1 = Pubkey::new_unique();
 
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
         accounts.push((pubkey1, Account::default()));
 
         let mut program_cache =
@@ -741,7 +750,7 @@ fn test_return_data_and_log_data_syscall() {
         let feature_set = SVMFeatureSet::all_enabled();
 
         let pubkey = Pubkey::new_unique();
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
         accounts.push((pubkey, Account::default()));
 
         let mut program_cache =
@@ -758,17 +767,21 @@ fn test_return_data_and_log_data_syscall() {
 
         assert!(effects.result.is_none());
 
-        assert!(effects
-            .logs
-            .iter()
-            .any(|log| log == "Program data: AQID BAUG"));
+        assert!(
+            effects
+                .logs
+                .iter()
+                .any(|log| log == "Program data: AQID BAUG")
+        );
 
         assert_eq!(effects.return_data, vec![0x08, 0x01, 0x44]);
 
-        assert!(effects
-            .logs
-            .iter()
-            .any(|log| log == &format!("Program return: {} CAFE", program_id)));
+        assert!(
+            effects
+                .logs
+                .iter()
+                .any(|log| log == &format!("Program return: {} CAFE", program_id))
+        );
     }
 }
 
@@ -1412,10 +1425,12 @@ fn test_program_sbf_program_id_spoofing() {
     accounts.extend(upgradeable_program_accounts(
         &malicious_swap_pubkey,
         &spoof1_elf,
+        None,
     ));
     accounts.extend(upgradeable_program_accounts(
         &malicious_system_pubkey,
         &spoof1_system_elf,
+        None,
     ));
     accounts.extend([
         (from_pubkey, Account::new(10, 0, &system_program::id())),
@@ -1475,10 +1490,11 @@ fn test_program_sbf_caller_has_access_to_cpi_program() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let mut accounts = upgradeable_program_accounts(&caller_pubkey, &caller_access_elf);
+    let mut accounts = upgradeable_program_accounts(&caller_pubkey, &caller_access_elf, None);
     accounts.extend(upgradeable_program_accounts(
         &caller2_pubkey,
         &caller_access_elf,
+        None,
     ));
 
     let mut program_cache = default_program_cache();
@@ -1523,7 +1539,11 @@ fn test_program_sbf_ro_modify() {
 
     let test_pubkey = Pubkey::new_unique();
     let mut accounts = vec![keyed_account_for_system_program()];
-    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
+    accounts.extend(upgradeable_program_accounts(
+        &program_id,
+        &program_elf,
+        None,
+    ));
     accounts.push((test_pubkey, Account::new(10, 0, &system_program::id())));
 
     let mut program_cache =
@@ -1565,7 +1585,7 @@ fn test_program_sbf_call_depth() {
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
     let sysvar_cache = default_sysvar_cache();
-    let program_accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    let program_accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
 
     let mut execute = |depth: usize| {
         let instruction = Instruction::new_with_bincode(program_id, &depth, vec![]);
@@ -1596,7 +1616,7 @@ fn test_program_sbf_compute_budget() {
 
     let feature_set = SVMFeatureSet::all_enabled();
 
-    let accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    let accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
 
     let mut program_cache =
         default_program_cache_with_program(&program_id, &program_elf, &feature_set);
@@ -1674,7 +1694,7 @@ fn assert_instruction_count() {
             default_program_cache_with_program(&program_id, &program_elf, &feature_set);
 
         let account_pubkey = Pubkey::new_unique();
-        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+        let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
         accounts.push((account_pubkey, Account::new(0, 0, &program_id)));
 
         let instruction_accounts = vec![AccountMeta {
@@ -1796,7 +1816,11 @@ fn test_program_sbf_r2_instruction_data_pointer(num_accounts: usize, input_data_
         }
     }
 
-    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
+    accounts.extend(upgradeable_program_accounts(
+        &program_id,
+        &program_elf,
+        None,
+    ));
 
     // The provided instruction data will be set to the return data.
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
@@ -2413,7 +2437,7 @@ fn test_program_sbf_c_dup() {
     ];
     let instruction = Instruction::new_with_bytes(program_id, &[4, 5, 6, 7], account_metas);
 
-    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
     accounts.push((account_address, account));
     let context = InstrContext::new_with_default_budget(feature_set, accounts, instruction);
 
@@ -2442,21 +2466,8 @@ fn test_program_sbf_upgrade() {
     let mint_keypair = Keypair::new();
     let authority_keypair = Keypair::new();
 
-    let (programdata_address, _) =
-        Pubkey::find_program_address(&[program_id.as_ref()], &bpf_loader_upgradeable::id());
-
-    let mut transaction_accounts = upgradeable_program_accounts(&program_id, &program_elf);
-    let programdata_account = &mut transaction_accounts
-        .iter_mut()
-        .find(|(pubkey, _)| pubkey == &programdata_address)
-        .unwrap()
-        .1;
-    let programdata_state = bincode::serialize(&UpgradeableLoaderState::ProgramData {
-        slot: 0,
-        upgrade_authority_address: Some(authority_keypair.pubkey()),
-    })
-    .unwrap();
-    programdata_account.data[..programdata_state.len()].copy_from_slice(&programdata_state);
+    let mut transaction_accounts =
+        upgradeable_program_accounts(&program_id, &program_elf, Some(authority_keypair.pubkey()));
 
     transaction_accounts.extend([
         (
@@ -2746,7 +2757,7 @@ fn test_program_sbf_ro_account_modify() {
     let sysvar_cache = default_sysvar_cache();
 
     let argument_pubkey = Pubkey::new_unique();
-    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf);
+    let mut accounts = upgradeable_program_accounts(&program_id, &program_elf, None);
     accounts.push((argument_pubkey, Account::new(42, 100, &program_id)));
 
     let account_metas = vec![
@@ -3910,9 +3921,11 @@ fn test_program_sbf_processed_inner_instruction() {
         &[instruction2, instruction1, instruction0],
         Some(&mint_keypair.pubkey()),
     );
-    assert!(bank_client
-        .send_and_confirm_message(&[&mint_keypair], message)
-        .is_ok());
+    assert!(
+        bank_client
+            .send_and_confirm_message(&[&mint_keypair], message)
+            .is_ok()
+    );
 }
 
 #[test]
@@ -4660,7 +4673,7 @@ fn test_program_sbf_deplete_cost_meter_with_divide_by_zero() {
 
     let context = InstrContext {
         feature_set,
-        accounts: upgradeable_program_accounts(&program_id, &program_elf),
+        accounts: upgradeable_program_accounts(&program_id, &program_elf, None),
         instruction,
         cu_avail: 10_000,
     };
@@ -5735,7 +5748,11 @@ fn test_program_sbf_rust_direct_account_pointers(num_accounts: usize, input_data
         account_metas.push(AccountMeta::new(pubkey, false));
     }
 
-    accounts.extend(upgradeable_program_accounts(&program_id, &program_elf));
+    accounts.extend(upgradeable_program_accounts(
+        &program_id,
+        &program_elf,
+        None,
+    ));
 
     let input_data: Vec<u8> = (0..input_data_len).map(|i| (i % 256) as u8).collect();
 

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -59,7 +59,12 @@ pub fn create_program(bank: &Bank, loader_id: &Pubkey, name: &str) -> Pubkey {
     let rent = Rent::default();
     if bpf_loader_upgradeable::check_id(loader_id) {
         let [(_, program_account), (programdata_id, programdata_account)] =
-            bpf_loader_upgradeable_program_accounts(&program_id, &elf, &rent);
+            bpf_loader_upgradeable_program_accounts(
+                &program_id,
+                &elf,
+                &rent,
+                Some(Pubkey::default()),
+            );
         bank.store_account(&program_id, &AccountSharedData::from(program_account));
         bank.store_account(
             &programdata_id,

--- a/svm/src/conformance/setup.rs
+++ b/svm/src/conformance/setup.rs
@@ -225,7 +225,7 @@ pub(crate) fn recent_blockhash(sysvar_cache: &SysvarCache) -> (Hash, u64) {
 
 /// Build a sysvar cache populated from any sysvar accounts present in the
 /// input account set.
-#[cfg(any(feature = "conformance", test))]
+#[cfg(any(feature = "conformance", feature = "dev-context-only-utils", test))]
 pub fn sysvar_cache_from_accounts(accounts: &[(Pubkey, Account)]) -> SysvarCache {
     let mut cache = SysvarCache::default();
     cache.fill_missing_entries(|pubkey, set_sysvar| {


### PR DESCRIPTION
#### Description

First batch from https://github.com/anza-xyz/agave/issues/13386 https://github.com/anza-xyz/agave/pull/14036

#### Summary of Changes

- svm conformance setup function `sysvar_cache_from_accounts` got DCOU gate
- ported first test as example `test_program_sbf_upgrade`
- extended api of helpers `bpf_loader_upgradeable_program_accounts` and `upgradeable_program_accounts` to accept optional upgrade authority address
- fixed call sites of `bpf_loader_upgradeable_program_accounts` and  `upgradeable_program_accounts`

