### PR TITLE
ClusterSlots: tighten slot support calculations

### DIFF
--- a/core/src/cluster_slots_service/slot_supporters.rs
+++ b/core/src/cluster_slots_service/slot_supporters.rs
@@ -48,7 +48,7 @@ impl SlotSupporters {
 
     #[inline]
     pub(crate) fn set_support_by_index(&self, index: usize, stake: Stake) {
-        let old = self.supporting_stakes[index].swap(stake, Ordering::Relaxed);
+        let old = self.supporting_stakes[index].fetch_max(stake, Ordering::Relaxed);
         if stake > old {
             self.total_support.fetch_add(stake - old, Ordering::Relaxed);
         }


### PR DESCRIPTION
#### Problem
SlotSupporters::set_support_by_index tracking of a node's per-slot support is suboptimal. ClusterSlots may stop refining its support map early, then repair peer weights are computed suboptimally.
 
#### Summary of Changes

Make the per-node value monotonic within a slot (once a node confirms, it stays confirmed). One-line change, behavior is unchanged in the steady state.

#### Testing

CI, run on mds1.



