### PR TITLE
broadcast: blacklist the slot when skipping a window

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -143,6 +143,7 @@ impl StandardBroadcastRun {
         let Some(parent_bank) = bank.parent() else {
             // If our broadcast is quite backed up, the parent bank could have already been
             // pruned from BankForks by a newer window getting rooted
+            self.blacklist_broadcast_slot(bank.slot());
             return Err(Error::WindowSkipped(bank.slot()));
         };
         debug_assert!(parent_bank.is_frozen());
@@ -1222,6 +1223,102 @@ mod test {
         assert!(!standard_broadcast_run.is_broadcast_blacklisted(2));
         assert!(standard_broadcast_run.is_broadcast_blacklisted(3));
         assert!(standard_broadcast_run.is_broadcast_blacklisted(18));
+    }
+
+    #[test]
+    fn test_window_skipped_blacklists_descendants() {
+        let num_shreds_per_slot = 2;
+        let (
+            blockstore,
+            genesis_config,
+            _cluster_info,
+            parent_bank,
+            leader_keypair,
+            _socket,
+            _bank_forks,
+        ) = setup(num_shreds_per_slot);
+        let bank1 = new_child_bank(&parent_bank, 1);
+        let bank2 = Arc::new(Bank::new_from_parent(
+            bank1.clone(),
+            *bank1.leader(),
+            bank1.slot() + 1,
+        ));
+
+        // Rooting a bank squashes its parent. If broadcast is far enough behind, it can
+        // receive the bank after this has happened and before its block id was populated.
+        assert!(bank1.is_frozen());
+        assert!(bank1.block_id().is_none());
+        bank1.squash();
+        assert!(bank1.parent().is_none());
+
+        let (votor_event_sender, _votor_event_receiver) = bounded(1024);
+        let mut standard_broadcast_run = StandardBroadcastRun::new(
+            0,
+            Arc::new(MigrationStatus::default()),
+            votor_event_sender,
+            test_leader_schedule_cache(&bank1),
+        );
+        let (bsend, brecv) = bounded(1024);
+        let (ssend, srecv) = bounded(1024);
+        let ticks = create_ticks(1, 0, genesis_config.hash());
+        let receive_results = |bank: Arc<Bank>| ReceiveResults {
+            component: BlockComponent::EntryBatch(ticks.clone()),
+            last_tick_height: bank.tick_height() + ticks.len() as u64,
+            bank,
+        };
+
+        let err = standard_broadcast_run
+            .process_receive_results(
+                &leader_keypair,
+                &blockstore,
+                &ssend,
+                &bsend,
+                receive_results(bank1.clone()),
+                &mut ProcessShredsStats::default(),
+            )
+            .unwrap_err();
+        assert_matches!(err, Error::WindowSkipped(1));
+        assert!(standard_broadcast_run.is_broadcast_blacklisted(1));
+
+        // Further components for this window are drained without broadcasting.
+        standard_broadcast_run
+            .process_receive_results(
+                &leader_keypair,
+                &blockstore,
+                &ssend,
+                &bsend,
+                receive_results(bank1),
+                &mut ProcessShredsStats::default(),
+            )
+            .unwrap();
+
+        // The blacklist propagates to descendants, so bank2 never tries to read bank1's
+        // missing block id.
+        let err = standard_broadcast_run
+            .process_receive_results(
+                &leader_keypair,
+                &blockstore,
+                &ssend,
+                &bsend,
+                receive_results(bank2.clone()),
+                &mut ProcessShredsStats::default(),
+            )
+            .unwrap_err();
+        assert_matches!(err, Error::DuplicateSlotBroadcast(2));
+        assert!(standard_broadcast_run.is_broadcast_blacklisted(2));
+
+        standard_broadcast_run
+            .process_receive_results(
+                &leader_keypair,
+                &blockstore,
+                &ssend,
+                &bsend,
+                receive_results(bank2),
+                &mut ProcessShredsStats::default(),
+            )
+            .unwrap();
+        assert!(brecv.try_recv().is_err());
+        assert!(srecv.try_recv().is_err());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
On low node count clusters where the leader holds the majority of stake, broadcast can get backed up wrt replay.
This can lead to blocks being finalized that haven't yet been shredded or broadcast.

https://github.com/anza-xyz/agave/pull/14015 attempted to remedy this by skipping broadcast of the window if we were sufficiently backed up. It however did not properly blacklist the broadcast slot leading to descendants in the window running into the same issue.

Here are logs from a cluster where the leader holds 100% of the stake:
```

[2026-07-30T13:18:37.076372080Z INFO  solana_core::replay_stage] new fork:62 parent:61 (leader) root:30
[2026-07-30T13:18:37.162254013Z ERROR solana_turbine::broadcast_stage] run broadcaster error: WindowSkipped(29)
[2026-07-30T13:18:37.162382353Z ERROR solana_turbine::broadcast_stage] run broadcaster error: WindowSkipped(30)

thread 'solBroadcast' (109815) panicked at turbine/src/broadcast_stage/standard_broadcast_run.rs:151:14:
All banks frozen (including snapshot banks) must have a block id
stack backtrace:
```

Broadcast is ~30 slots behind replay which has already rooted slot `30`. When attempting to broadcast slots `29` and `30` we correctly skip broadcast, however we don't extend this to slot `31` which runs into the panic

#### Summary of Changes
Add the slot to the blacklist

#### Testing
Unit test


### Side note
we should probably figure out why shredding is so slow, this is all treating a symptom of a larger problem - broadcast cannot keep up with replay *in low node count clusters*. In larger clusters there is a large enough gap in non-leader time to drain the queue.

Looks like things have gotten worse here also because 200ms slots is active in the CI test