### PR TITLE
ag migration: account for test clusters with < 5000 slots per epoch

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -1067,6 +1067,15 @@ mod tests {
         assert!(!migration_status.is_full_alpenglow_epoch());
 
         let root_bank = make_root_bank_for_migration_status_test(
+            ff_activation_slot + MIGRATION_SLOT_OFFSET,
+            Some(ff_activation_slot),
+            Some(genesis_cert.clone()),
+        );
+        let migration_status = BankForks::initialize_migration_status(&root_bank);
+        assert!(migration_status.is_alpenglow_enabled());
+        assert!(!migration_status.is_full_alpenglow_epoch());
+
+        let root_bank = make_root_bank_for_migration_status_test(
             64,
             Some(ff_activation_slot),
             Some(genesis_cert),

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -393,7 +393,8 @@ impl MigrationStatus {
             }
             (Some(cert), Some(activation_slot)) => {
                 // Alpenglow is active, check if we're still in the mixed migration epoch
-                let migration_epoch = epoch_schedule.get_epoch(activation_slot);
+                let migration_epoch =
+                    epoch_schedule.get_epoch(activation_slot.saturating_add(MIGRATION_SLOT_OFFSET));
                 if root_epoch > migration_epoch {
                     MigrationPhase::FullAlpenglowEpoch {
                         full_alpenglow_epoch: migration_epoch.saturating_add(1),


### PR DESCRIPTION
#### Problem
We perform the AG migration 5000 slots into the epoch.

If the epoch has < 5000 slots the migration is deferred until the appropriate epoch, however we lose the tracking on which epoch was the migration epoch vs subsequent full ag epochs

#### Summary of Changes
Account for the fact that the migration epoch might be different from the activation epoch

#### Testing
Unit test

Fixes #14207
