### PR TITLE
tpu-client-next: improve leader updater

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7764,7 +7764,6 @@ dependencies = [
  "arc-swap",
  "arrayvec",
  "assert_matches",
- "async-trait",
  "bencher",
  "bincode",
  "bitvec",
@@ -9937,7 +9936,6 @@ name = "solana-rpc-test"
 version = "4.4.0-alpha.0"
 dependencies = [
  "agave-logger",
- "async-trait",
  "bincode",
  "bs58",
  "crossbeam-channel",
@@ -10256,7 +10254,6 @@ name = "solana-send-transaction-service"
 version = "4.4.0-alpha.0"
 dependencies = [
  "agave-logger",
- "async-trait",
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
@@ -11099,6 +11096,7 @@ dependencies = [
  "crossbeam-channel",
  "futures 0.3.33",
  "futures-util",
+ "itertools 0.14.0",
  "log",
  "lru 0.18.2",
  "quinn",

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -3230,13 +3230,16 @@ async fn send_deploy_messages(
                 }
             }
 
-            // Holds the scheduler alive for the duration of the send.
-            let _tpu_client;
             let cancel_token = CancellationToken::new();
-            let transport = if use_rpc {
-                SendTransport::Rpc(config.send_transaction_config)
+            // Keep background TPU client tasks alive for the duration of the send.
+            let (transport, node_address_service, _tpu_client) = if use_rpc {
+                (
+                    SendTransport::Rpc(config.send_transaction_config),
+                    None,
+                    None,
+                )
             } else {
-                let node_address_service = WebsocketNodeAddressService::run(
+                let (provider, service) = WebsocketNodeAddressService::run(
                     rpc_client.clone(),
                     config.websocket_url.clone(),
                     LeaderTpuCacheServiceConfig::default(),
@@ -3246,20 +3249,22 @@ async fn send_deploy_messages(
 
                 let bind_socket = bind_to_unspecified()?;
 
-                let (transaction_sender, client) =
-                    ClientBuilder::new(Box::new(node_address_service))
-                        .cancel_token(cancel_token.clone())
-                        .bind_socket(bind_socket)
-                        .broadcaster(NonblockingBroadcaster)
-                        .build()
-                        .expect("Failed to build TPU client");
-                _tpu_client = client;
-                SendTransport::Tpu(transaction_sender)
+                let (transaction_sender, client) = ClientBuilder::new(Box::new(provider))
+                    .cancel_token(cancel_token.clone())
+                    .bind_socket(bind_socket)
+                    .broadcaster(NonblockingBroadcaster)
+                    .build()
+                    .expect("Failed to build TPU client");
+                (
+                    SendTransport::Tpu(transaction_sender),
+                    Some(service),
+                    Some(client),
+                )
             };
 
             let versioned_write_messages = write_messages.into_iter().map(VersionedMessage::Legacy);
 
-            let transaction_errors = send_and_confirm_transactions_in_parallel_v3(
+            let transaction_errors_result = send_and_confirm_transactions_in_parallel_v3(
                 rpc_client.clone(),
                 transport,
                 versioned_write_messages,
@@ -3273,10 +3278,19 @@ async fn send_deploy_messages(
                 },
             )
             .await
-            .map_err(|err| format!("Data writes to account failed: {err}"))?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+            .map_err(|err| format!("Data writes to account failed: {err}"));
+
+            cancel_token.cancel();
+            if let Some(node_address_service) = node_address_service
+                && let Err(err) = node_address_service.shutdown().await
+            {
+                error!("Failed to shut down WebSocket node address service: {err}");
+            }
+
+            let transaction_errors = transaction_errors_result?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
 
             if !transaction_errors.is_empty() {
                 for transaction_error in &transaction_errors {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -68,7 +68,6 @@ anyhow = { workspace = true }
 arc-swap = { workspace = true }
 arrayvec = { workspace = true }
 assert_matches = { workspace = true }
-async-trait = { workspace = true }
 bincode = { workspace = true }
 bitvec = { workspace = true }
 bytes = { workspace = true }

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -2,19 +2,21 @@
 //! packets to a node that is or will be leader soon.
 
 use {
-    crate::next_leader::next_leaders,
     agave_banking_stage_ingress_types::BankingPacketBatch,
     agave_transaction_view::transaction_view::SanitizedTransactionView,
-    async_trait::async_trait,
     crossbeam_channel::{Receiver, RecvTimeoutError},
     packet_container::PacketContainer,
+    smallvec::SmallVec,
+    solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
     solana_cost_model::cost_model::CostModel,
     solana_fee_structure::FeeDetails,
     solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol, node::NodeMultihoming},
     solana_keypair::Keypair,
+    solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_net_utils::{multihomed_sockets::BindIpAddrs, token_bucket::TokenBucket},
     solana_packet as packet,
     solana_poh::poh_recorder::PohRecorder,
+    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::{Bank, CollectorFeeDetails},
         bank_forks::SharableBanks,
@@ -102,22 +104,38 @@ impl ForwardAddressGetter {
         }
     }
 
-    /// Returns a list of forwarding addresses for non-vote transactions.
-    fn get_non_vote_forwarding_addresses(
-        &self,
-        max_count: u64,
-        protocol: Protocol,
-    ) -> Vec<SocketAddr> {
-        next_leaders(&self.cluster_info, &self.poh_recorder, max_count, |node| {
-            node.tpu_forwards(protocol)
-        })
+    /// Appends forwarding addresses for non-vote transactions to `leaders`.
+    fn non_vote_forwarding_addresses(&self, max_count: u64, leaders: &mut Vec<SocketAddr>) {
+        let mut leader_pubkeys = Vec::with_capacity(max_count as usize);
+        let recorder = self.poh_recorder.read().unwrap();
+        leader_pubkeys.extend((0..max_count).filter_map(|i| {
+            recorder.leader_after_n_slots(
+                FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET
+                    + i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64,
+            )
+        }));
+        drop(recorder);
+
+        leaders.extend(leader_pubkeys.iter().filter_map(|leader_pubkey| {
+            self.cluster_info
+                .lookup_contact_info(leader_pubkey, |node| node.tpu_forwards(Protocol::QUIC))?
+        }));
     }
 
-    /// Returns the TPU vote forwarding address of the next leader, if
-    /// available.
-    fn get_vote_forwarding_addresses(&self, max_count: u64) -> Vec<SocketAddr> {
-        next_leaders(&self.cluster_info, &self.poh_recorder, max_count, |node| {
-            node.tpu_vote(Protocol::UDP)
+    /// Returns the TPU vote forwarding address of the next leader, if available.
+    fn next_vote_forwarding_address(&self) -> Option<SocketAddr> {
+        let mut leader_pubkeys = SmallVec::<[Pubkey; NUM_LOOKAHEAD_LEADERS as usize]>::new();
+        let recorder = self.poh_recorder.read().unwrap();
+        leader_pubkeys.extend((0..NUM_LOOKAHEAD_LEADERS).filter_map(|i| {
+            recorder.leader_after_n_slots(
+                FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET
+                    + i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64,
+            )
+        }));
+        drop(recorder);
+        leader_pubkeys.into_iter().find_map(|leader_pubkey| {
+            self.cluster_info
+                .lookup_contact_info(&leader_pubkey, |node| node.tpu_vote(Protocol::UDP))?
         })
     }
 }
@@ -462,11 +480,8 @@ impl VoteClient {
         }
     }
 
-    fn get_next_valid_leader(&self) -> Option<SocketAddr> {
-        let node_addresses = self
-            .forward_address_getter
-            .get_vote_forwarding_addresses(NUM_LOOKAHEAD_LEADERS);
-        node_addresses.first().copied()
+    fn next_valid_leader(&self) -> Option<SocketAddr> {
+        self.forward_address_getter.next_vote_forwarding_address()
     }
 }
 
@@ -475,7 +490,7 @@ impl ForwardingClient for VoteClient {
         &self,
         wire_transactions: Vec<Vec<u8>>,
     ) -> Result<(), ForwardingClientError> {
-        let Some(current_address) = self.get_next_valid_leader() else {
+        let Some(current_address) = self.next_valid_leader() else {
             return Err(ForwardingClientError::LeaderContactMissing);
         };
         let batch_with_addresses = wire_transactions
@@ -486,13 +501,10 @@ impl ForwardingClient for VoteClient {
     }
 }
 
-#[async_trait]
 impl LeaderUpdater for ForwardAddressGetter {
-    fn next_leaders(&mut self, lookahead_slots: usize) -> Vec<SocketAddr> {
-        self.get_non_vote_forwarding_addresses(lookahead_slots as u64, Protocol::QUIC)
+    fn next_leaders(&mut self, lookahead_slots: usize, leaders: &mut Vec<SocketAddr>) {
+        self.non_vote_forwarding_addresses(lookahead_slots as u64, leaders);
     }
-
-    async fn stop(&mut self) {}
 }
 
 #[derive(Clone)]

--- a/core/src/next_leader.rs
+++ b/core/src/next_leader.rs
@@ -1,12 +1,6 @@
 use {
-    crate::banking_stage::LikeClusterInfo,
     itertools::Itertools,
-    solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
-    solana_gossip::{
-        cluster_info::ClusterInfo,
-        contact_info::{ContactInfoQuery, Protocol},
-    },
-    solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::Protocol},
     solana_poh::poh_recorder::PohRecorder,
     std::{net::SocketAddr, sync::RwLock},
 };
@@ -34,30 +28,5 @@ pub(crate) fn upcoming_leader_tpu_vote_sockets(
         })
         // dedup again since leaders could potentially share the same tpu vote socket
         .dedup()
-        .collect()
-}
-
-pub(crate) fn next_leaders(
-    cluster_info: &impl LikeClusterInfo,
-    poh_recorder: &RwLock<PohRecorder>,
-    max_count: u64,
-    port_selector: impl ContactInfoQuery<Option<SocketAddr>>,
-) -> Vec<SocketAddr> {
-    let recorder = poh_recorder.read().unwrap();
-    let leader_pubkeys: Vec<_> = (0..max_count)
-        .filter_map(|i| {
-            recorder.leader_after_n_slots(
-                FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET
-                    + i * NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64,
-            )
-        })
-        .collect();
-    drop(recorder);
-
-    leader_pubkeys
-        .iter()
-        .filter_map(|leader_pubkey| {
-            cluster_info.lookup_contact_info(leader_pubkey, &port_selector)?
-        })
         .collect()
 }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6165,7 +6165,6 @@ dependencies = [
  "arc-swap",
  "arrayvec",
  "assert_matches",
- "async-trait",
  "bincode",
  "bitvec",
  "bytes",
@@ -7958,7 +7957,6 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "4.4.0-alpha.0"
 dependencies = [
- "async-trait",
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
@@ -8607,6 +8605,7 @@ dependencies = [
  "bytes",
  "futures 0.3.33",
  "futures-util",
+ "itertools 0.14.0",
  "log",
  "lru 0.18.2",
  "quinn",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6257,7 +6257,6 @@ dependencies = [
  "arc-swap",
  "arrayvec",
  "assert_matches",
- "async-trait",
  "bincode",
  "bitvec",
  "bytes",
@@ -8922,7 +8921,6 @@ dependencies = [
 name = "solana-send-transaction-service"
 version = "4.4.0-alpha.0"
 dependencies = [
- "async-trait",
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
@@ -9594,6 +9592,7 @@ dependencies = [
  "bytes",
  "futures 0.3.33",
  "futures-util",
+ "itertools 0.14.0",
  "log",
  "lru 0.18.2",
  "quinn",

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -18,7 +18,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 agave-unstable-api = []
 
 [dependencies]
-async-trait = { workspace = true }
 bincode = { workspace = true }
 bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -47,6 +46,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/rpc-test/tests/rpc.rs
+++ b/rpc-test/tests/rpc.rs
@@ -1,5 +1,4 @@
 use {
-    async_trait::async_trait,
     bincode::serialize,
     crossbeam_channel::bounded,
     futures_util::StreamExt,
@@ -26,7 +25,7 @@ use {
     solana_system_transaction as system_transaction,
     solana_test_validator::TestValidator,
     solana_tpu_client_next::{
-        client_builder::ClientBuilder, leader_updater::LeaderUpdater,
+        client_builder::ClientBuilder, leader_updater::create_pinned_leader_updater,
         node_address_service::LeaderTpuCacheServiceConfig,
         websocket_node_address_service::WebsocketNodeAddressService,
     },
@@ -34,7 +33,6 @@ use {
     solana_transaction_status::TransactionStatus,
     std::{
         collections::HashSet,
-        net::SocketAddr,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -288,20 +286,6 @@ fn test_rpc_slot_updates() {
     }
 }
 
-/// LeaderUpdater for testing - returns a fixed TPU address
-struct TestLeaderUpdater {
-    address: SocketAddr,
-}
-
-#[async_trait]
-impl LeaderUpdater for TestLeaderUpdater {
-    fn next_leaders(&mut self, _lookahead_leaders: usize) -> Vec<SocketAddr> {
-        vec![self.address]
-    }
-
-    async fn stop(&mut self) {}
-}
-
 #[test]
 fn test_rpc_subscriptions() {
     agave_logger::setup();
@@ -443,9 +427,7 @@ fn test_rpc_subscriptions() {
     let bind_socket = sockets::bind_to_localhost_unique().unwrap();
     let tpu_address = *test_validator.tpu_quic();
 
-    let leader_updater = Box::new(TestLeaderUpdater {
-        address: tpu_address,
-    });
+    let leader_updater = create_pinned_leader_updater(tpu_address);
 
     let (transaction_sender, _client) = rt.block_on(async {
         ClientBuilder::new(leader_updater)
@@ -539,9 +521,7 @@ fn test_run_tpu_send_transaction() {
     let bind_socket = sockets::bind_to_localhost_unique().unwrap();
     let tpu_address = *test_validator.tpu_quic();
 
-    let leader_updater = Box::new(TestLeaderUpdater {
-        address: tpu_address,
-    });
+    let leader_updater = create_pinned_leader_updater(tpu_address);
 
     let (transaction_sender, _client) = rt.block_on(async {
         ClientBuilder::new(leader_updater)
@@ -583,7 +563,7 @@ fn test_node_address_service_slot_updates() {
     rt.block_on(async {
         let rpc_client = Arc::new(test_validator.get_async_rpc_client());
         let cancel = CancellationToken::new();
-        let mut service = WebsocketNodeAddressService::run(
+        let (provider, service) = WebsocketNodeAddressService::run(
             rpc_client,
             test_validator.rpc_pubsub_url(),
             LeaderTpuCacheServiceConfig::default(),
@@ -592,7 +572,7 @@ fn test_node_address_service_slot_updates() {
         .await
         .expect("WebsocketNodeAddressService should start");
 
-        let start_slot = service.current_slot();
+        let start_slot = provider.estimated_current_slot();
         let timeout = Duration::from_secs(5);
         let now = Instant::now();
         loop {
@@ -600,7 +580,7 @@ fn test_node_address_service_slot_updates() {
                 now.elapsed() < timeout,
                 "estimated slot did not advance within {timeout:?}"
             );
-            if service.current_slot() != start_slot {
+            if provider.estimated_current_slot() != start_slot {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(solana_clock::DEFAULT_MS_PER_SLOT)).await;

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -20,7 +20,6 @@ agave-unstable-api = []
 dev-context-only-utils = ["solana-net-utils"]
 
 [dependencies]
-async-trait = { workspace = true }
 crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/send-transaction-service/src/transaction_client.rs
+++ b/send-transaction-service/src/transaction_client.rs
@@ -1,6 +1,5 @@
 use {
     crate::{send_transaction_service_stats::SendTransactionServiceStats, tpu_info::TpuInfo},
-    async_trait::async_trait,
     log::warn,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
@@ -185,21 +184,24 @@ pub fn create_leader_updater<T: TpuInfoWithSendStatic>(
     })
 }
 
-#[async_trait]
 impl<T> LeaderUpdater for SendTransactionServiceLeaderUpdater<T>
 where
     T: TpuInfoWithSendStatic,
 {
-    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
-        let discovered_peers = self
+    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+        if let Some(tpu_peers) = &self.tpu_peers {
+            leaders.extend_from_slice(tpu_peers);
+        }
+
+        if let Some(discovered_peers) = self
             .leader_info_provider
             .get_leader_info()
             .map(|leader_info| leader_info.get_not_unique_leader_tpus(lookahead_leaders as u64))
             .filter(|addresses| !addresses.is_empty())
-            .unwrap_or_else(|| vec![&self.my_tpu_address]);
-        let mut all_peers = self.tpu_peers.clone().unwrap_or_default();
-        all_peers.extend(discovered_peers.into_iter().cloned());
-        all_peers
+        {
+            leaders.extend(discovered_peers.into_iter().copied());
+        } else {
+            leaders.push(self.my_tpu_address);
+        }
     }
-    async fn stop(&mut self) {}
 }

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -26,6 +26,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 quinn = { workspace = true }

--- a/tpu-client-next/src/connection_workers_scheduler.rs
+++ b/tpu-client-next/src/connection_workers_scheduler.rs
@@ -13,6 +13,7 @@ use {
         workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
     },
     async_trait::async_trait,
+    itertools::Itertools,
     quinn::{ClientConfig, Endpoint},
     solana_keypair::Keypair,
     std::{
@@ -233,6 +234,10 @@ impl ConnectionWorkersScheduler {
         // channel is dropped.
         let mut identity_updater_is_active = true;
 
+        let mut next_leaders = Vec::with_capacity(leaders_fanout.connect);
+        let mut connect_leaders = Vec::with_capacity(leaders_fanout.connect);
+        let mut send_leaders = Vec::with_capacity(leaders_fanout.send);
+
         loop {
             let transaction: WireTransaction = tokio::select! {
                 recv_res = transaction_receiver.recv() => match recv_res {
@@ -270,14 +275,14 @@ impl ConnectionWorkersScheduler {
                 }
             };
 
-            let connect_leaders = leader_updater.next_leaders(leaders_fanout.connect);
-            let send_leaders = extract_send_leaders(&connect_leaders, leaders_fanout.send);
+            next_leaders.clear();
+            leader_updater.next_leaders(leaders_fanout.connect, &mut next_leaders);
+            select_unique_leaders(&next_leaders, leaders_fanout.connect, &mut connect_leaders);
 
-            // add future leaders to the cache to hide the latency of opening
-            // the connection.
-            for peer in connect_leaders {
+            // add future leaders to the cache to hide the latency of opening the connection.
+            for peer in &connect_leaders {
                 if let Some(evicted_worker) = workers.ensure_worker(
-                    peer,
+                    *peer,
                     &endpoint,
                     worker_channel_size,
                     max_reconnect_attempts,
@@ -287,6 +292,8 @@ impl ConnectionWorkersScheduler {
                     shutdown_worker(evicted_worker);
                 }
             }
+
+            select_unique_leaders(&next_leaders, leaders_fanout.send, &mut send_leaders);
 
             if let Err(error) = broadcaster
                 .send_to_workers(&mut workers, &send_leaders, transaction)
@@ -300,7 +307,6 @@ impl ConnectionWorkersScheduler {
         workers.shutdown().await;
 
         endpoint.close(0u32.into(), b"Closing connection");
-        leader_updater.stop().await;
         if let Some(error) = last_error {
             return Err(error);
         }
@@ -359,23 +365,12 @@ impl WorkersBroadcaster for NonblockingBroadcaster {
     }
 }
 
-/// Extracts a list of unique leader addresses to which transactions will be sent.
-///
-/// This function selects up to `send_fanout` addresses from the `leaders` list, ensuring that
-/// only unique addresses are included while maintaining their original order.
-pub fn extract_send_leaders(leaders: &[SocketAddr], send_fanout: usize) -> Vec<SocketAddr> {
-    let send_count = send_fanout.min(leaders.len());
-    remove_duplicates(&leaders[..send_count])
-}
-
-/// Removes duplicate `SocketAddr` elements from the given slice while
-/// preserving their original order.
-fn remove_duplicates(input: &[SocketAddr]) -> Vec<SocketAddr> {
-    let mut res = Vec::with_capacity(input.len());
-    for address in input {
-        if !res.contains(address) {
-            res.push(*address);
-        }
-    }
-    res
+/// Replaces `selected_leaders` with unique TPU addresses from the first `max_leaders` candidates.
+fn select_unique_leaders(
+    leaders: &[SocketAddr],
+    max_leaders: usize,
+    selected_leaders: &mut Vec<SocketAddr>,
+) {
+    selected_leaders.clear();
+    selected_leaders.extend(leaders.iter().take(max_leaders).copied().unique());
 }

--- a/tpu-client-next/src/leader_updater.rs
+++ b/tpu-client-next/src/leader_updater.rs
@@ -3,9 +3,7 @@
 //! Currently, the main purpose of [`LeaderUpdater`] is to abstract over leader
 //! updates, hiding the details of how leaders are retrieved and which
 //! structures are used.
-
 use {
-    async_trait::async_trait,
     std::{fmt, net::SocketAddr},
     thiserror::Error,
 };
@@ -13,20 +11,18 @@ use {
 /// [`LeaderUpdater`] trait abstracts out functionality required for the
 /// [`ConnectionWorkersScheduler`](crate::ConnectionWorkersScheduler) to
 /// identify next leaders to send transactions to.
-#[async_trait]
 pub trait LeaderUpdater: Send {
-    /// Returns next leaders for the next `lookahead_leaders` starting from
-    /// current estimated slot.
+    /// Appends TPU addresses for upcoming leader windows to `leaders`.
     ///
-    /// Leaders are returned per [`NUM_CONSECUTIVE_LEADER_SLOTS`] to avoid unnecessary repetition.
+    /// `lookahead_leaders` controls how many scheduled leader windows are inspected but
+    /// implementation may append additional addresses on the leader-window boundary.
+    /// Implementations may return duplicate addresses. The scheduler is responsible for deriving
+    /// unique send and connect target sets from these ordered candidates.
     ///
     /// If the current leader estimation is incorrect and transactions are sent to
     /// only one estimated leader, there is a risk of losing all the transactions,
     /// depending on the forwarding policy.
-    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr>;
-
-    /// Stop [`LeaderUpdater`] and releases all associated resources.
-    async fn stop(&mut self);
+    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>);
 }
 
 /// Error type for [`LeaderUpdater`].
@@ -60,11 +56,8 @@ struct PinnedLeaderUpdater {
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-#[async_trait]
 impl LeaderUpdater for PinnedLeaderUpdater {
-    fn next_leaders(&mut self, _lookahead_leaders: usize) -> Vec<SocketAddr> {
-        self.address.clone()
+    fn next_leaders(&mut self, _lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+        leaders.extend_from_slice(&self.address);
     }
-
-    async fn stop(&mut self) {}
 }

--- a/tpu-client-next/src/node_address_service.rs
+++ b/tpu-client-next/src/node_address_service.rs
@@ -1,12 +1,16 @@
-//! This module provides [`NodeAddressService`] structure that implements [`LeaderUpdater`] trait to
-//! track upcoming leaders and maintains an up-to-date mapping of leader id to TPU socket address.
+//! This module provides [`NodeAddressService`] and [`NodeAddressProvider`] to track upcoming
+//! leaders and maintain an up-to-date mapping of leader id to TPU socket address.
+//!
+//! [`NodeAddressService`] owns the background tasks that update slot and leader TPU state.
+//! [`NodeAddressProvider`] is the cloneable read-side view returned by [`NodeAddressService::run`];
+//! it provides the current slot estimate and implements [`LeaderUpdater`].
 //!
 //! # Examples
 //!
-//! This example shows how to use [`NodeAddressService`] to implement [`LeaderUpdater`] using some
-//! custom slot update provider. Typically, it can be done with zero-cost abstraction as shown
-//! below. The case of `WebSocketNodeAddressService` requires, contrary, introducing task and
-//! channel due to specifics of the PubsubClient API implementation.
+//! This example shows how to use [`NodeAddressService`] with a custom slot update provider.
+//! Typically, it can be done with zero-cost abstraction as shown below. The case of
+//! `WebSocketNodeAddressService` requires a task and channel due to specifics of the PubsubClient
+//! API implementation.
 //!
 //! For the sake of the example, let's assume we have some custom slot updates that we receive by
 //! UDP.
@@ -16,6 +20,7 @@
 //!  use tokio::net::UdpSocket;
 //!
 //!  pub struct SlotUpdaterNodeAddressService {
+//!    provider: NodeAddressProvider,
 //!    service: NodeAddressService,
 //! }
 //!
@@ -30,9 +35,10 @@
 //!            .await
 //!            .map_err(|_e| NodeAddressServiceError::InitializationFailed)?;
 //!        let stream = Self::udp_slot_event_stream(socket);
-//!        let service = NodeAddressService::run(rpc_client, stream, config, cancel).await?;
+//!        let (provider, service) =
+//!            NodeAddressService::run(rpc_client, stream, config, cancel).await?;
 //!
-//!        Ok(Self { service })
+//!        Ok(Self { provider, service })
 //!    }
 //!
 //!    fn udp_slot_event_stream(socket: UdpSocket) -> impl Stream<Item = SlotEvent> + Send + 'static {
@@ -68,13 +74,11 @@
 use {
     crate::{
         leader_updater::LeaderUpdater,
-        logging::error,
         node_address_service::{
             leader_tpu_cache_service::{Error as LeaderTpuCacheServiceError, LeaderUpdateReceiver},
             slot_update_service::Error as SlotUpdateServiceError,
         },
     },
-    async_trait::async_trait,
     futures::StreamExt,
     solana_clock::Slot,
     std::{net::SocketAddr, sync::Arc},
@@ -98,12 +102,18 @@ pub use {
     slot_update_service::SlotUpdateService,
 };
 
-/// [`NodeAddressService`] is a convenience wrapper for [`SlotUpdateService`] and
-/// [`LeaderTpuCacheService`] to track upcoming leaders and maintains an up-to-date mapping of
-/// leader id to TPU socket address.
-pub struct NodeAddressService {
+/// Read-side view returned by [`NodeAddressService::run`].
+///
+/// This reader provides the estimated current slot and implements [`LeaderUpdater`] for scheduler
+/// consumers.
+#[derive(Clone)]
+pub struct NodeAddressProvider {
     leaders_receiver: LeaderUpdateReceiver,
     slot_receiver: SlotReceiver,
+}
+
+/// Background service that runs [`SlotUpdateService`] and [`LeaderTpuCacheService`].
+pub struct NodeAddressService {
     slot_update_service: SlotUpdateService,
     leader_cache_service: LeaderTpuCacheService,
 }
@@ -112,12 +122,10 @@ impl NodeAddressService {
     /// Run the [`NodeAddressService`].
     ///
     /// On success it starts [`SlotUpdateService`] together with [`LeaderTpuCacheService`] and
-    /// returns [`NodeAddressService`] instance which provides method to fetch next leaders. To run
-    /// mentioned services, it takes `cluster_info_provider` which abstracts access to information
-    /// about the cluster (see [`ClusterInfoProvider`]), `slot_update_stream` provides stream of
-    /// slot updates, `start_slot` is the initial slot to start from, `config` provides
-    /// configuration for the leader TPU cache service, and finally `cancel` is a cancellation token
-    /// to stop the service.
+    /// returns a [`NodeAddressProvider`] plus the [`NodeAddressService`] background service. To run
+    /// the services, it takes `cluster_info_provider` to access cluster information,
+    /// `slot_update_stream` to receive slot updates, `config` for leader TPU cache configuration,
+    /// and `cancel` to stop the service.
     ///
     /// On failure, it will return appropriate error.
     pub async fn run(
@@ -125,7 +133,7 @@ impl NodeAddressService {
         slot_update_stream: impl StreamExt<Item = SlotEvent> + Send + 'static,
         config: LeaderTpuCacheServiceConfig,
         cancel: CancellationToken,
-    ) -> Result<Self, NodeAddressServiceError> {
+    ) -> Result<(NodeAddressProvider, Self), NodeAddressServiceError> {
         let initial_slot = cluster_info_provider
             .initial_slot()
             .await
@@ -140,12 +148,16 @@ impl NodeAddressService {
         )
         .await?;
 
-        Ok(Self {
-            leaders_receiver,
-            slot_receiver,
-            slot_update_service,
-            leader_cache_service,
-        })
+        Ok((
+            NodeAddressProvider {
+                leaders_receiver,
+                slot_receiver,
+            },
+            Self {
+                slot_update_service,
+                leader_cache_service,
+            },
+        ))
     }
 
     pub async fn shutdown(&mut self) -> Result<(), NodeAddressServiceError> {
@@ -157,23 +169,19 @@ impl NodeAddressService {
         leader_cache_service_res?;
         Ok(())
     }
+}
 
+impl NodeAddressProvider {
     /// Returns the estimated current slot.
     pub fn estimated_current_slot(&self) -> Slot {
         self.slot_receiver.slot()
     }
 }
 
-#[async_trait]
-impl LeaderUpdater for NodeAddressService {
-    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
-        self.leaders_receiver.leaders(lookahead_leaders)
-    }
-
-    async fn stop(&mut self) {
-        if let Err(e) = self.shutdown().await {
-            error!("Failed to shutdown NodeAddressService: {e}");
-        }
+impl LeaderUpdater for NodeAddressProvider {
+    fn next_leaders(&mut self, lookahead_leaders: usize, leaders: &mut Vec<SocketAddr>) {
+        self.leaders_receiver
+            .next_leaders(lookahead_leaders, leaders);
     }
 }
 

--- a/tpu-client-next/src/node_address_service/leader_tpu_cache_service.rs
+++ b/tpu-client-next/src/node_address_service/leader_tpu_cache_service.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{
-        connection_workers_scheduler::extract_send_leaders,
         logging::{debug, error, info, warn},
         node_address_service::SlotReceiver,
     },
@@ -68,14 +67,18 @@ pub struct LeaderUpdateReceiver {
 }
 
 impl LeaderUpdateReceiver {
-    pub fn leaders(&self, lookahead_leaders: usize) -> Vec<SocketAddr> {
-        let NodesTpuInfo { leaders, extend } = self.receiver.borrow().clone();
-        let lookahead_leaders = if extend {
-            lookahead_leaders.saturating_add(1)
+    pub fn next_leaders(
+        &self,
+        num_lookahead_leaders: usize,
+        lookahead_leaders: &mut Vec<SocketAddr>,
+    ) {
+        let tpu_info = self.receiver.borrow();
+        let num_lookahead_leaders = if tpu_info.extend {
+            num_lookahead_leaders.saturating_add(1)
         } else {
-            lookahead_leaders
+            num_lookahead_leaders
         };
-        extract_send_leaders(&leaders, lookahead_leaders)
+        lookahead_leaders.extend(tpu_info.leaders.iter().take(num_lookahead_leaders).copied());
     }
 }
 
@@ -196,7 +199,10 @@ impl LeaderTpuCacheService {
                     );
                     let leaders = leader_sockets(current_slot, lookahead_leaders, &slot_leaders, &leader_tpu_map);
 
-                    if let Err(e) = leaders_sender.send(NodesTpuInfo { leaders, extend: config.lookahead_leaders != lookahead_leaders }) {
+                    if let Err(e) = leaders_sender.send(NodesTpuInfo {
+                        leaders,
+                        extend: config.lookahead_leaders != lookahead_leaders
+                    }) {
                         warn!("Unexpectedly dropped leaders_sender: {e}");
                         return Err(Error::ChannelClosed);
                     }

--- a/tpu-client-next/src/websocket_node_address_service.rs
+++ b/tpu-client-next/src/websocket_node_address_service.rs
@@ -2,20 +2,18 @@
 //! updates via WebSocket interface.
 use {
     crate::{
-        leader_updater::LeaderUpdater,
-        logging::{error, info},
+        logging::info,
         node_address_service::{
-            LeaderTpuCacheServiceConfig, NodeAddressService, NodeAddressServiceError, SlotEvent,
+            LeaderTpuCacheServiceConfig, NodeAddressProvider, NodeAddressService,
+            NodeAddressServiceError, SlotEvent,
         },
     },
-    async_trait::async_trait,
     futures::Stream,
     futures_util::stream::StreamExt,
-    solana_clock::Slot,
     solana_pubsub_client::nonblocking::pubsub_client::{PubsubClient, PubsubClientError},
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{client_error::Error as ClientError, response::SlotUpdate},
-    std::{net::SocketAddr, sync::Arc, time::Duration},
+    std::{sync::Arc, time::Duration},
     thiserror::Error,
     tokio::{
         sync::mpsc::{self, error::SendTimeoutError},
@@ -33,48 +31,34 @@ pub struct WebsocketNodeAddressService {
 }
 
 impl WebsocketNodeAddressService {
+    /// Run the [`WebsocketNodeAddressService`].
     pub async fn run(
         rpc_client: Arc<RpcClient>,
         websocket_url: String,
         config: LeaderTpuCacheServiceConfig,
         cancel: CancellationToken,
-    ) -> Result<Self, Error> {
+    ) -> Result<(NodeAddressProvider, Self), Error> {
         let (websocket_slot_event_stream, ws_task_handle) =
             websocket_slot_event_stream(websocket_url);
-        let service =
+        let (provider, service) =
             NodeAddressService::run(rpc_client, websocket_slot_event_stream, config, cancel)
                 .await?;
 
-        Ok(Self {
-            service,
-            ws_task_handle: Some(ws_task_handle),
-        })
+        Ok((
+            provider,
+            Self {
+                service,
+                ws_task_handle: Some(ws_task_handle),
+            },
+        ))
     }
 
-    pub async fn shutdown(&mut self) -> Result<(), Error> {
+    pub async fn shutdown(mut self) -> Result<(), Error> {
         self.service.shutdown().await?;
         if let Some(handle) = self.ws_task_handle.take() {
             handle.await??;
         }
         Ok(())
-    }
-
-    /// Returns the estimated current slot.
-    pub fn current_slot(&self) -> Slot {
-        self.service.estimated_current_slot()
-    }
-}
-
-#[async_trait]
-impl LeaderUpdater for WebsocketNodeAddressService {
-    fn next_leaders(&mut self, lookahead_leaders: usize) -> Vec<SocketAddr> {
-        self.service.next_leaders(lookahead_leaders)
-    }
-
-    async fn stop(&mut self) {
-        if let Err(e) = self.shutdown().await {
-            error!("Failed to shutdown WebsocketNodeAddressService: {e}");
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem

The API of NodeAddressService and related services for leader tracking is not very handy because receiver and handle of the background task are all in the same structure. This leads in particular to problems in transaction-bench when we want to run several schedulers and have to create many NodeAddressServices. 

#### Summary of Changes

Improves API of the tpu-client-next by rewriting leader-tracking code API. 
