### PR TITLE
votor: adjust FirstShred modulo gate to account for unaligned migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "solana-frozen-abi",
  "solana-frozen-abi-macro",
  "solana-hash 4.5.0",
+ "solana-leader-schedule",
  "solana-pubkey 4.2.0",
  "solana-short-vec",
  "solana-signer-store",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "solana-clock",
  "solana-epoch-schedule",
  "solana-hash 4.5.0",
+ "solana-leader-schedule",
  "solana-pubkey 4.2.0",
  "solana-short-vec",
  "solana-signer-store",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "solana-clock",
  "solana-epoch-schedule",
  "solana-hash 4.5.0",
+ "solana-leader-schedule",
  "solana-pubkey 4.2.0",
  "solana-short-vec",
  "solana-signer-store",

--- a/turbine/src/retransmit_stage.rs
+++ b/turbine/src/retransmit_stage.rs
@@ -16,7 +16,6 @@ use {
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_ledger::{
         leader_schedule_cache::LeaderScheduleCache,
         shred::{self, ShredFlags, ShredId, ShredType},
@@ -923,9 +922,7 @@ fn notify_subscribers(
             .notify_first_shred_received(slot);
     }
 
-    if notifiers.migration_status.should_send_votor_event(slot)
-        && slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64)
-    {
+    if notifiers.migration_status.should_send_first_shred(slot) {
         match notifiers
             .votor_event_sender
             .try_send(VotorEvent::FirstShred(slot))
@@ -955,6 +952,7 @@ mod tests {
         solana_entry::entry::create_ticks,
         solana_hash::Hash,
         solana_keypair::Keypair,
+        solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
         solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
     };
 
@@ -1102,5 +1100,48 @@ mod tests {
            First time seeing shred Y w/ changed header (FEC Set index 3)=>Dup because common \
              header is unique but shred ID seen twice already"
         );
+    }
+
+    #[test]
+    fn test_notify_subscribers_sends_first_shred_after_genesis() {
+        let (votor_event_sender, votor_event_receiver) = crossbeam_channel::bounded(1);
+        let migration_status = Arc::new(MigrationStatus::post_migration_status());
+        let genesis_slot = migration_status.genesis_block().unwrap().slot;
+        let notifiers = RetransmitNotifiers {
+            rpc_subscriptions: None,
+            slot_status_notifier: None,
+            migration_status,
+            votor_event_sender,
+        };
+        let mut pending_first_shred_event = None;
+
+        let slot = genesis_slot.checked_add(1).unwrap();
+        assert!(!slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot));
+        notify_subscribers(
+            slot,
+            /*timestamp:*/ 0,
+            &notifiers,
+            &mut pending_first_shred_event,
+        );
+
+        assert!(matches!(
+            votor_event_receiver.try_recv(),
+            Ok(VotorEvent::FirstShred(received_slot)) if received_slot == slot
+        ));
+        assert!(pending_first_shred_event.is_none());
+
+        // Later unaligned slots do not need a FirstShred event.
+        let slot = slot.checked_add(1).unwrap();
+        assert!(!slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot));
+        notify_subscribers(
+            slot,
+            /*timestamp:*/ 0,
+            &notifiers,
+            &mut pending_first_shred_event,
+        );
+        assert!(matches!(
+            votor_event_receiver.try_recv(),
+            Err(TryRecvError::Empty)
+        ));
     }
 }

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -45,6 +45,7 @@ solana-frozen-abi-macro = { workspace = true, optional = true, features = [
     "frozen-abi",
 ] }
 solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode", "atomic"] }
+solana-leader-schedule = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-short-vec = { workspace = true, features = ["wincode"] }
 solana-signer-store = { workspace = true }

--- a/votor-messages/src/migration.rs
+++ b/votor-messages/src/migration.rs
@@ -54,6 +54,7 @@ use {
     solana_address::Address,
     solana_clock::{Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
+    solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_pubkey::Pubkey,
     std::{
         sync::{
@@ -260,6 +261,23 @@ impl MigrationPhase {
         self.is_alpenglow_block(slot)
     }
 
+    /// Should retransmit send a `FirstShred` event to Votor?
+    ///
+    /// Normally only the first slot in a leader window needs an event. The first
+    /// slot after the migration genesis is also included because the genesis
+    /// block is not guaranteed to end on a leader-window boundary.
+    fn should_send_first_shred(&self, slot: Slot) -> bool {
+        let is_first_slot_after_genesis = match self {
+            MigrationPhase::AlpenglowEnabled { genesis_cert } => {
+                genesis_cert.block.slot.checked_add(1) == Some(slot)
+            }
+            _ => false,
+        };
+        self.should_send_votor_event(slot)
+            && (slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot)
+                || is_first_slot_after_genesis)
+    }
+
     /// Should we respond to ancestor hashes repair requests  for this slot?
     fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool {
         // Same as epoch slots, while in the mixed migration epoch respond for tower bft slots
@@ -449,6 +467,7 @@ impl MigrationStatus {
     dispatch!(pub fn should_root_during_startup(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_publish_epoch_slots(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_send_votor_event(&self, slot: Slot) -> bool);
+    dispatch!(pub fn should_send_first_shred(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_respond_to_ancestor_hashes_requests(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_have_alpenglow_ticks(&self, slot: Slot) -> bool);
     dispatch!(pub fn should_allow_block_markers(&self, slot: Slot) -> bool);


### PR DESCRIPTION
#### Problem
Normally the first Alpenglow block will be the first slot of the leader window, but technically it doesn't need to be the case.

The `FirstShred` event is only emitted for first slots of the leader window, so if it's not aligned this could lead to the first Alpenglow leader being skipped.

#### Summary of Changes
Adjust the gate to allow for `genesis_block + 1` as well

#### Testing
Unit test

Fixes #13215 