### PR TITLE
civl: match shred ingest bound

### DIFF
--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -62,6 +62,8 @@ pub type DuplicateConfirmedSlotsSender = Sender<ThresholdConfirmedSlots>;
 pub type DuplicateConfirmedSlotsReceiver = Receiver<ThresholdConfirmedSlots>;
 
 const THRESHOLDS_TO_CHECK: [f64; 2] = [DUPLICATE_THRESHOLD, VOTE_THRESHOLD_SIZE];
+const MAX_VOTE_SLOT_DISTANCE_FROM_ROOT: Slot = 50_000;
+const MAX_VOTE_HASHES_PER_PUBKEY_PER_SLOT: u8 = 2;
 
 /// Notification channels and context threaded through the vote confirmation
 /// pipeline. Groups the senders used to communicate threshold crossings
@@ -83,6 +85,7 @@ pub struct SlotVoteTracker {
     // True if seen on gossip, false if only seen in replay.
     voted: HashMap<Pubkey, bool>,
     optimistic_votes_tracker: HashMap<Hash, VoteStakeTracker>,
+    num_optimistic_vote_hashes: HashMap<Pubkey, u8>,
     voted_slot_updates: Option<Vec<Pubkey>>,
     gossip_only_stake: u64,
 }
@@ -92,8 +95,29 @@ impl SlotVoteTracker {
         self.voted_slot_updates.take()
     }
 
-    fn get_or_insert_optimistic_votes_tracker(&mut self, hash: Hash) -> &mut VoteStakeTracker {
-        self.optimistic_votes_tracker.entry(hash).or_default()
+    fn add_optimistic_vote(
+        &mut self,
+        hash: Hash,
+        pubkey: Pubkey,
+        stake: u64,
+        total_epoch_stake: u64,
+    ) -> (Vec<bool>, bool) {
+        let num_vote_hashes = self.num_optimistic_vote_hashes.entry(pubkey).or_default();
+        if *num_vote_hashes >= MAX_VOTE_HASHES_PER_PUBKEY_PER_SLOT {
+            return (vec![false; THRESHOLDS_TO_CHECK.len()], false);
+        }
+
+        let result @ (_, is_new) = self
+            .optimistic_votes_tracker
+            .entry(hash)
+            .or_default()
+            .add_vote_pubkey(pubkey, stake, total_epoch_stake, &THRESHOLDS_TO_CHECK);
+
+        if is_new {
+            *num_vote_hashes += 1;
+        }
+
+        result
     }
     pub(crate) fn optimistic_votes_tracker(&self, hash: &Hash) -> Option<&VoteStakeTracker> {
         self.optimistic_votes_tracker.get(hash)
@@ -806,6 +830,13 @@ impl ClusterInfoVoteListener {
         let root = root_bank.slot();
         let vote_slots = vote.slots();
 
+        // Replay votes have already been executed and their slots validated.
+        // Reject gossip votes too far in the future
+        let max_vote_slot = root.saturating_add(MAX_VOTE_SLOT_DISTANCE_FROM_ROOT);
+        if is_gossip_vote && vote_slots.iter().any(|&slot| slot > max_vote_slot) {
+            return;
+        }
+
         let is_new_vote = Self::process_last_vote_for_optimistic_confirmation(
             vote_tracker,
             last_vote_slot,
@@ -976,9 +1007,7 @@ impl ClusterInfoVoteListener {
         // Insert vote and check for optimistic confirmation
         let mut w_slot_tracker = slot_tracker.write().unwrap();
 
-        w_slot_tracker
-            .get_or_insert_optimistic_votes_tracker(hash)
-            .add_vote_pubkey(pubkey, stake, total_epoch_stake, &THRESHOLDS_TO_CHECK)
+        w_slot_tracker.add_optimistic_vote(hash, pubkey, stake, total_epoch_stake)
     }
 
     fn sum_stake(sum: &mut u64, epoch_stakes: Option<&VersionedEpochStakes>, pubkey: &Pubkey) {


### PR DESCRIPTION
#### Problem
The shred ingest bound was recently tightened.
The vote ingest bound still uses the old values.

#### Summary of Changes
Tighten vote ingest as well.