### PR TITLE
Remove test_clean_dead_slot_with_obsolete_accounts

### DIFF
--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1128,65 +1128,6 @@ fn test_clean_reclaim_marks_zero_lamport_single_ref() {
 }
 
 #[test]
-fn test_clean_dead_slot_with_obsolete_accounts() {
-    // This test is triggering a scenario in reclaim_accounts where the entire slot is reclaimed
-    // When an entire slot is reclaimed, it normally unrefs the pubkeys, while when individual
-    // accounts are reclaimed it does not unref the pubkeys
-
-    // Obsolete accounts are already unreffed so they should not be unreffed again
-
-    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-
-    let pubkey = solana_pubkey::new_rand();
-    let pubkey2 = solana_pubkey::new_rand();
-    let account = AccountSharedData::new(1, 1, AccountSharedData::default().owner());
-    let zero_lamport_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
-    accounts.set_latest_full_snapshot_slot(2);
-
-    // Store pubkey1 and pubkey2 in slot 0
-    accounts.store_for_tests((0, [(&pubkey, &account), (&pubkey2, &account)].as_slice()));
-
-    // Update pubkey1 and make pubkey2 a zero lamport account in slot 1
-    accounts.store_for_tests((
-        1,
-        [(&pubkey, &account), (&pubkey2, &zero_lamport_account)].as_slice(),
-    ));
-
-    // Update pubkey1 as in slot 2
-    accounts.store_for_tests((2, [(&pubkey, &account)].as_slice()));
-
-    // Flush the slots individually to avoid reclaims
-    accounts.add_root_and_flush_write_cache(0);
-    accounts.add_root_and_flush_write_cache(1);
-    accounts.add_root_and_flush_write_cache(2);
-
-    // Slot 1 should not be removed as it has the zero lamport account
-    assert!(accounts.storage.get_slot_storage_entry(1).is_some());
-    let slot = accounts.storage.get_slot_storage_entry(1).unwrap();
-
-    // Ensure that slot1 also still contains the obsolete account
-    assert_eq!(
-        slot.obsolete_accounts_read_lock()
-            .filter_obsolete_accounts(None)
-            .count(),
-        1
-    );
-
-    // Ref count for pubkey is 1 as the older version was marked obsolete
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey), 1);
-
-    // Clean, which will remove slot1
-    accounts.clean_accounts_for_tests();
-
-    assert!(accounts.storage.get_slot_storage_entry(0).is_none());
-    assert!(accounts.storage.get_slot_storage_entry(1).is_none());
-
-    // Ref count for pubkey should be 1. It was NOT decremented during clean_accounts_for_tests
-    // despite slot 1 being removed, because the account was already obsolete
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey), 1);
-}
-
-#[test]
 fn test_remove_zero_lamport_single_ref_accounts_after_shrink() {
     for pass in 0..3 {
         let accounts =


### PR DESCRIPTION
#### Problem
test_clean_dead_slot_with_obsolete_accounts verifies that clean_dead_slots doesn't unref accounts that are marked obsolete. 

Given that clean_dead_slot doesn't exist anymore, this is guaranteed. There are existing tests that cover the other parts of the test

#### Summary of Changes
- Remove the test

#### Testing


Fixes #
