### PR TITLE
svm-conformance: add VM syscall runner

### DIFF
--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -23,6 +23,11 @@ name = "test_exec_vm_serialization"
 path = "src/bin/test_exec_vm_serialization.rs"
 required-features = ["cli", "ffi"]
 
+[[bin]]
+name = "test_exec_vm_syscall"
+path = "src/bin/test_exec_vm_syscall.rs"
+required-features = ["cli", "ffi"]
+
 [features]
 default = ["cli", "ffi"]
 agave-unstable-api = []

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -34,6 +34,7 @@ ffi = [
     "dep:protosol",
     "dep:solana-compute-budget",
     "dep:solana-program-runtime",
+    "dep:solana-pubkey",
     "dep:solana-svm",
     "dep:solana-syscalls",
     "solana-svm/conformance",
@@ -46,12 +47,12 @@ prost = { version = "0.11", optional = true }
 protosol = { version = "=10.1.0", optional = true }
 solana-compute-budget = { workspace = true, optional = true }
 solana-program-runtime = { workspace = true, optional = true }
+solana-pubkey = { workspace = true, optional = true }
 solana-svm = { workspace = true, optional = true }
 solana-syscalls = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
-solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 

--- a/svm-conformance/src/bin/test_exec_vm_syscall.rs
+++ b/svm-conformance/src/bin/test_exec_vm_syscall.rs
@@ -1,0 +1,48 @@
+use {clap::Parser, prost::Message, protosol::protos::SyscallFixture, std::path::PathBuf};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let Ok(fixture) = SyscallFixture::decode(&blob[..]) else {
+        println!("Failed to parse fixture.");
+        return false;
+    };
+
+    let Some(context) = fixture.input else {
+        println!("No context found.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+
+    let effects = solana_svm_conformance::syscall::execute_vm_syscall(context);
+
+    let ok = effects == expected;
+    if ok {
+        println!("OK: {input:?}");
+    } else {
+        println!("FAIL: {input:?}");
+        println!("Expected: {expected:?}");
+        println!("Actual: {effects:?}");
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -7,3 +7,5 @@
 pub mod elf_loader;
 #[cfg(feature = "ffi")]
 pub mod serialization;
+#[cfg(feature = "ffi")]
+pub mod syscall;

--- a/svm-conformance/src/syscall.rs
+++ b/svm-conformance/src/syscall.rs
@@ -1,17 +1,6 @@
 //! VM syscall conformance harness.
 
 use {
-    crate::conformance::{
-        callback::ConformanceCallback,
-        err::{UnpackedResult, unpack_stable_result},
-        instr::context::InstrContext,
-        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
-        serialization::{SerializedParameters, push_and_serialize_parameters},
-        setup::{
-            InvokeContextFields, compute_budget, prepare_invoke_context_fields, program_loader_key,
-            program_runtime_environments, sysvar_cache_from_accounts,
-        },
-    },
     prost::Message,
     protosol::protos::{
         InputDataRegion as ProtoInputDataRegion, SyscallContext as ProtoSyscallContext,
@@ -32,6 +21,17 @@ use {
         },
     },
     solana_pubkey::Pubkey,
+    solana_svm::conformance::{
+        callback::ConformanceCallback,
+        err::{UnpackedResult, unpack_stable_result},
+        instr::context::InstrContext,
+        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+        serialization::{SerializedParameters, push_and_serialize_parameters},
+        setup::{
+            InvokeContextFields, compute_budget, prepare_invoke_context_fields, program_loader_key,
+            program_runtime_environments, sysvar_cache_from_accounts,
+        },
+    },
     std::{ffi::c_int, sync::Arc},
 };
 

--- a/svm/src/conformance/err.rs
+++ b/svm/src/conformance/err.rs
@@ -32,7 +32,7 @@ pub fn serialized_error_code<T: serde::Serialize>(error: &T) -> u32 {
 }
 
 /// A VM `program_result` mapped into the fields a conformance fixture compares.
-pub(crate) struct UnpackedResult {
+pub struct UnpackedResult {
     /// Error number, or `0` on success.
     pub error: i64,
     /// Which error taxonomy `error` belongs to (`ERR_KIND_*`).
@@ -97,7 +97,7 @@ impl UnpackedResult {
 }
 
 /// Map a VM `program_result` to its [`UnpackedResult`].
-pub(crate) fn unpack_stable_result(program_result: StableResult<u64, EbpfError>) -> UnpackedResult {
+pub fn unpack_stable_result(program_result: StableResult<u64, EbpfError>) -> UnpackedResult {
     match program_result {
         StableResult::Ok(r0) => UnpackedResult::ok(r0),
         StableResult::Err(ebpf_err) => UnpackedResult::from_ebpf_err(ebpf_err),

--- a/svm/src/conformance/mod.rs
+++ b/svm/src/conformance/mod.rs
@@ -17,8 +17,6 @@ pub mod programs;
 #[cfg(feature = "conformance")]
 pub mod serialization;
 pub mod setup;
-#[cfg(feature = "conformance")]
-pub mod syscall;
 pub mod transaction_address_loader;
 pub mod transaction_meta;
 pub mod txn;


### PR DESCRIPTION
#### Problem

The `solana-svm-conformance` dev-bin now hosts the ELF loader and VM
serialization harnesses with their runners. The syscall harness still lives in
`solana-svm`'s `conformance` module, which carries protobuf and prost
dependencies the validator does not need in production, and it has no runner bin
for processing fixtures.

#### Summary of Changes

Move the VM syscall harness and its FFI binding
(`sol_compat_vm_syscall_execute_v1`) into `solana-svm-conformance`, then add the
`test_exec_vm_syscall` runner bin target.

#### Testing

Build the test vectors:

```
git clone https://github.com/firedancer-io/test-vectors.git
cd test-vectors
./scripts/package.sh
```

Build and run the conformance target:

```
cargo build --manifest-path dev-bins/Cargo.toml -p solana-svm-conformance
dev-bins/target/debug/test_exec_vm_syscall -- ~/test-vectors/syscall/fixtures/*.fix
```

Part of #13382