### PR TITLE
test-validator: Increase default blockstore retention

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -960,14 +960,9 @@ impl DefaultTestArgs {
             rpc_port: 8899.to_string(),
             faucet_port: FAUCET_PORT.to_string(),
             dynamic_port_range: format!("{}-{}", VALIDATOR_PORT_RANGE.0, VALIDATOR_PORT_RANGE.1),
-            // 10,000 was derived empirically by watching the size of the
-            // rocksdb/ directory self-limit itself to the 40-150MB range when
-            // running `solana-test-validator`
-            //
-            // This value was later updated to 20,000 when --limit-ledger-size
-            // was replaced with --limit-blockstore-size because the new method
-            // counts data AND coding shreds
-            limit_blockstore_size: 20_000.to_string(),
+            // See comments in ledger/src/blockstore_cleanup_service.rs for more
+            // details, but 800k shreds is approximately 1 GB of space
+            limit_blockstore_size: 800_000.to_string(),
             faucet_sol: (1_000_000.).to_string(),
             faucet_time_slice_secs: (faucet::TIME_SLICE).to_string(),
         }


### PR DESCRIPTION
#### Problem
solana-test-validator currently has a very small default blockstore retention of 20k shreds. Completely empty blocks created by the Agave scheduled are currently 224 data shreds (7 * 32 shreds); this value comes from a "timeout" that emits part of the block even if there have been on transactions to record.

#### Summary of Changes
So at ~450 data and coding shreds per slot, solana-test-validator would attempt to retain < 50 slots. This isn't very useful so bump the default limit to 800k shreds. This gives a history of > 1750 slots while keeping disk utilization around a 1 GB cap

#### Testing
Ran it real quick and confirmed that `BlockstoreCleanupService` didn't kick in 'til 800k shreds was hit
```
[... solana_ledger::blockstore_cleanup_service] Looking for Blockstore data to cleanup, latest root: 8941
[... solana_ledger::blockstore_cleanup_service] Blockstore has 1193972 total shreds in slots [6164, 8973]; 643782 data shreds, 550190 coding shreds
[... solana_ledger::blockstore_cleanup_service] Cleaned up Blockstore data older than slot 7093. purge_slots() took 35ms

[... solana_ledger::blockstore_cleanup_service] Looking for Blockstore data to cleanup, latest root: 9468
[... solana_ledger::blockstore_cleanup_service] Blockstore has 1233517 total shreds in slots [7094, 9499]; 643782 data shreds, 589735 coding shreds
[... solana_ledger::blockstore_cleanup_service] Cleaned up Blockstore data older than slot 7940. purge_slots() took 34ms

[... solana_ledger::blockstore_cleanup_service] Looking for Blockstore data to cleanup, latest root: 9994
[... solana_ledger::blockstore_cleanup_service] Blockstore has 789955 total shreds in slots [7941, 10025]; 367360 data shreds, 422595 coding shreds
```
There is a little "jaggedness" here since memtables are large in comparison to the limit (see https://github.com/anza-xyz/agave/issues/11762#issuecomment-4190174768) but I think fine to ignore now as it was a pre-existing problem and this is an improvement

Fixes https://github.com/anza-xyz/agave/issues/11762
