### PR TITLE
votor: Fixes remaining issues with sends on channels

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -2358,7 +2358,7 @@ pub mod test {
         // If we now set a root that causes slot 112 to be purged from BankForks, then
         // the switch proof will now fail since that validator's vote can no longer be
         // included in the switching proof
-        vote_simulator.set_root(44);
+        vote_simulator.set_root(&Pubkey::new_unique(), 44);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
         let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         assert_eq!(
@@ -3190,7 +3190,7 @@ pub mod test {
 
         // prepend tower restart!
         let mut slot_history = SlotHistory::default();
-        vote_simulator.set_root(replayed_root_slot);
+        vote_simulator.set_root(&Pubkey::new_unique(), replayed_root_slot);
         let ancestors = vote_simulator.bank_forks.read().unwrap().ancestors();
         let descendants = vote_simulator.bank_forks.read().unwrap().descendants();
         for slot in &[0, 1, 2, 43, replayed_root_slot] {

--- a/core/src/optimistic_confirmation_verifier.rs
+++ b/core/src/optimistic_confirmation_verifier.rs
@@ -139,8 +139,8 @@ impl OptimisticConfirmationVerifier {
 mod test {
     use {
         super::*, crate::vote_simulator::VoteSimulator, solana_leader_schedule::SlotLeader,
-        solana_ledger::get_tmp_ledger_path_auto_delete, solana_runtime::bank::Bank,
-        std::collections::HashMap, trees::tr,
+        solana_ledger::get_tmp_ledger_path_auto_delete, solana_pubkey::Pubkey,
+        solana_runtime::bank::Bank, std::collections::HashMap, trees::tr,
     };
 
     #[test]
@@ -274,7 +274,7 @@ mod test {
         );
 
         // Now set a root at slot 5, purging BankForks of slots < 5
-        vote_simulator.set_root(5);
+        vote_simulator.set_root(&Pubkey::new_unique(), 5);
 
         // Add a new bank 7 that descends from 6
         let bank6 = vote_simulator.bank_forks.read().unwrap().get(6).unwrap();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -5108,6 +5108,7 @@ impl ReplayStage {
     /// A wrapper around `root_utils::set_bank_forks_root` which additionally:
     /// - Executes `set_progress_and_tower_bft_root` to cleanup tower bft structs and the progress map
     pub fn handle_new_root(
+        my_pubkey: &Pubkey,
         new_root: Slot,
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
@@ -5119,6 +5120,7 @@ impl ReplayStage {
         tbft_structs: &mut TowerBFTStructures,
     ) {
         root_utils::set_bank_forks_root(
+            my_pubkey,
             new_root,
             bank_forks,
             snapshot_controller,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -555,6 +555,7 @@ fn test_handle_new_root() {
         epoch_slots_frozen_slots,
     };
     ReplayStage::handle_new_root(
+        &Pubkey::new_unique(),
         root,
         &bank_forks,
         &mut progress,
@@ -728,6 +729,7 @@ fn test_handle_new_root_ahead_of_highest_super_majority_root() {
         epoch_slots_frozen_slots: EpochSlotsFrozenSlots::default(),
     };
     ReplayStage::handle_new_root(
+        &Pubkey::new_unique(),
         root,
         &bank_forks,
         &mut progress,

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -240,15 +240,16 @@ impl VoteSimulator {
 
         let new_root = tower.record_bank_vote(&vote_bank);
         if let Some(new_root) = new_root {
-            self.set_root(new_root);
+            self.set_root(my_pubkey, new_root);
         }
 
         vec![]
     }
 
-    pub fn set_root(&mut self, new_root: Slot) {
+    pub fn set_root(&mut self, my_pubkey: &Pubkey, new_root: Slot) {
         let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
         ReplayStage::handle_new_root(
+            my_pubkey,
             new_root,
             &self.bank_forks,
             &mut self.progress,

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -17,6 +17,7 @@ use {
     solana_hash::Hash,
     solana_leader_schedule::SlotLeader,
     solana_ledger::genesis_utils::create_genesis_config,
+    solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
@@ -151,6 +152,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
             epoch_slots_frozen_slots,
         };
         ReplayStage::handle_new_root(
+            &Pubkey::new_unique(),
             root,
             &bank_forks,
             &mut progress,

--- a/votor/src/commitment.rs
+++ b/votor/src/commitment.rs
@@ -1,16 +1,9 @@
 use {
-    crossbeam_channel::{Sender, TrySendError},
-    solana_clock::Slot,
-    thiserror::Error,
+    crate::common::nonblocking_send, crossbeam_channel::Sender, solana_clock::Slot,
+    solana_pubkey::Pubkey,
 };
 
-#[derive(Debug, Error)]
-pub enum CommitmentError {
-    #[error("Failed to send commitment data, channel disconnected")]
-    ChannelDisconnected,
-}
-
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CommitmentType {
     /// Our node has voted notarize for the slot
     Notarize,
@@ -18,29 +11,25 @@ pub enum CommitmentType {
     Rooted,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CommitmentAggregationData {
     pub commitment_type: CommitmentType,
     pub slot: Slot,
 }
 
 pub fn update_commitment_cache(
+    my_pubkey: &Pubkey,
     commitment_type: CommitmentType,
     slot: Slot,
-    commitment_sender: &Sender<CommitmentAggregationData>,
-) -> Result<(), CommitmentError> {
-    match commitment_sender.try_send(CommitmentAggregationData {
+    sender: &Sender<CommitmentAggregationData>,
+) {
+    let msg = CommitmentAggregationData {
         commitment_type,
         slot,
-    }) {
-        Err(TrySendError::Disconnected(_)) => {
-            info!("commitment_sender has disconnected");
-            return Err(CommitmentError::ChannelDisconnected);
-        }
-        Err(TrySendError::Full(_)) => error!("commitment_sender is backed up, something is wrong"),
-        Ok(_) => (),
+    };
+    if let Err(channel_name) = nonblocking_send(my_pubkey, sender, msg, "commitment_sender") {
+        warn!("{my_pubkey}: channel \"{channel_name}\" disconnected");
     }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -52,8 +41,8 @@ mod tests {
         let (commitment_sender, commitment_receiver) = bounded(1024);
         let slot = 3;
         let commitment_type = CommitmentType::Notarize;
-        update_commitment_cache(commitment_type, slot, &commitment_sender)
-            .expect("Failed to send commitment data");
+        let my_pubkey = Pubkey::new_unique();
+        update_commitment_cache(&my_pubkey, commitment_type, slot, &commitment_sender);
         let received_data = commitment_receiver
             .try_recv()
             .expect("Failed to receive commitment data");
@@ -66,8 +55,7 @@ mod tests {
         );
         let slot = 5;
         let commitment_type = CommitmentType::Rooted;
-        update_commitment_cache(commitment_type, slot, &commitment_sender)
-            .expect("Failed to send commitment data");
+        update_commitment_cache(&my_pubkey, commitment_type, slot, &commitment_sender);
         let received_data = commitment_receiver
             .try_recv()
             .expect("Failed to receive commitment data");
@@ -78,10 +66,5 @@ mod tests {
                 slot,
             }
         );
-
-        // Close the channel and ensure the error is returned
-        drop(commitment_receiver);
-        let result = update_commitment_cache(CommitmentType::Notarize, 7, &commitment_sender);
-        assert!(matches!(result, Err(CommitmentError::ChannelDisconnected)));
     }
 }

--- a/votor/src/common.rs
+++ b/votor/src/common.rs
@@ -31,8 +31,9 @@ pub(crate) const DELTA_TIMEOUT: Duration = Duration::from_millis(400);
 /// Timeout for standstill detection mechanism.
 pub(crate) const DELTA_STANDSTILL: Duration = Duration::from_millis(10_000);
 
-/// Wrapper to do non-blocking send and drop msg if channel is full.  Returns Err(channel_name) on
-/// channel disconnect.
+/// Wrapper to do non-blocking send and drop msg if channel is full.
+/// Returns:
+/// - Err(channel_name) on channel disconnect.
 pub(crate) fn nonblocking_send<T>(
     my_pubkey: &Pubkey,
     sender: &Sender<T>,

--- a/votor/src/consensus_pool.rs
+++ b/votor/src/consensus_pool.rs
@@ -549,6 +549,10 @@ impl ConsensusPool {
         self.stats.maybe_report();
     }
 
+    pub(crate) fn do_report(&mut self) {
+        self.stats.do_report();
+    }
+
     pub(crate) fn get_certs_for_standstill(&self) -> Vec<Arc<Certificate>> {
         let highest_slot = match &self.highest_finalized_slot_cert {
             Some(c) => c.slot().slot(),

--- a/votor/src/consensus_pool/stats.rs
+++ b/votor/src/consensus_pool/stats.rs
@@ -153,7 +153,7 @@ impl ConsensusPoolStats {
     }
 
     /// Reports the certificate related statistics.
-    fn report(&self) {
+    pub(super) fn do_report(&self) {
         let Self {
             conflicting_votes,
             event_safe_to_notarize,
@@ -192,7 +192,7 @@ impl ConsensusPoolStats {
 
     pub(super) fn maybe_report(&mut self) {
         if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
-            self.report();
+            self.do_report();
             *self = Self::default();
         }
     }

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -9,7 +9,7 @@ mod stats;
 
 use {
     crate::{
-        common::DELTA_STANDSTILL,
+        common::{DELTA_STANDSTILL, blocking_send},
         consensus_pool::{
             ConsensusPool,
             parent_ready_tracker::{BlockProductionParent, ParentReady},
@@ -99,16 +99,80 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
 }
 
+impl ConsensusPoolContext {
+    fn new_consensus_pool(&self) -> ConsensusPool {
+        let initial_parent_ready = self.initial_parent_ready();
+        let root_bank = self.sharable_banks.root();
+        ConsensusPool::new(
+            self.cluster_info.clone(),
+            &root_bank,
+            self.generated_cert_types.clone(),
+            self.migration_status.clone(),
+            initial_parent_ready,
+        )
+    }
+
+    /// Finds the initial parent ready that we should use for instantiating the ConsensusPool or kicking off votor
+    /// The max of genesis block, root block, or the restored parent ready from vote history
+    fn initial_parent_ready(&self) -> ParentReady {
+        let root_bank = self.sharable_banks.root();
+        let root_block = root_block(&root_bank);
+        let genesis_block = self.migration_status.genesis_block();
+        Self::_initial_parent_ready(
+            genesis_block,
+            root_block,
+            self.vote_history_highest_parent_ready,
+        )
+    }
+
+    /// Pulled the implementation outside to enable testing.
+    fn _initial_parent_ready(
+        genesis_block: Option<Block>,
+        root_block: Block,
+        vote_history_highest_parent_ready: Option<(Slot, Block)>,
+    ) -> ParentReady {
+        let Some(genesis_block) = genesis_block else {
+            // Alpenglow is not yet enabled, start with just the root
+            return (root_block.slot.checked_add(1).unwrap(), root_block);
+        };
+
+        let initial_block = genesis_block.max(root_block);
+        let initial_parent_ready = (initial_block.slot.checked_add(1).unwrap(), initial_block);
+
+        if let Some(restored @ (restored_slot, _)) = vote_history_highest_parent_ready
+            && restored_slot > initial_parent_ready.0
+        {
+            restored
+        } else {
+            initial_parent_ready
+        }
+    }
+}
+
 pub(crate) struct ConsensusPoolService {
     t_consensus_pool_service: JoinHandle<()>,
 }
 
 impl ConsensusPoolService {
-    pub(crate) fn new(ctx: ConsensusPoolContext) -> Self {
+    pub(crate) fn new(mut ctx: ConsensusPoolContext) -> Self {
         let t_consensus_pool_service = Builder::new()
             .name("solVotorPoolSvc".to_string())
             .spawn(move || {
-                Self::main_loop(ctx);
+                // Unlike the other votor threads, consensus pool starts even before Alpenglow is enabled
+                // because it must track the genesis vote.
+                let mut consensus_pool = ctx.new_consensus_pool();
+                let mut stats = ConsensusPoolServiceStats::new();
+                if let Err(channel_name) =
+                    Self::main_loop(&mut ctx, &mut consensus_pool, &mut stats)
+                {
+                    info!(
+                        "{}: {channel_name} disconnected. Exiting",
+                        ctx.cluster_info.id()
+                    );
+                }
+                consensus_pool.do_report();
+                stats.do_report();
+                ctx.exit.store(true, Ordering::Relaxed);
                 info!("consensus pool service exited.");
             })
             .unwrap();
@@ -125,7 +189,7 @@ impl ConsensusPoolService {
         new_certificates_to_send: Vec<Arc<Certificate>>,
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         // If we have a new finalized slot, update the root and send new certificates
         if new_finalized_slot.is_some() {
             // Reset standstill timer
@@ -152,7 +216,7 @@ impl ConsensusPoolService {
         ctx: &ConsensusPoolContext,
         op: BLSOp,
         stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         let num_certs = Self::num_certificates(&op);
         if num_certs == 0 {
             return Ok(());
@@ -187,91 +251,34 @@ impl ConsensusPoolService {
         ctx: &ConsensusPoolContext,
         op: BLSOp,
         stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
+        let channel_name = "bls_sender";
         let num_certs = Self::num_certificates(&op);
-
         match ctx.bls_sender.try_send(op) {
             Ok(()) => {
                 stats.certificates_sent += num_certs;
                 Ok(())
             }
-            Err(TrySendError::Disconnected(_)) => Err(()),
             Err(TrySendError::Full(_)) => {
                 stats.certificates_dropped += num_certs;
-                warn!(
-                    "{}: channel is full, dropping {num_certs} certs",
-                    ctx.cluster_info.id()
-                );
+                let my_pubkey = ctx.cluster_info.id();
+                warn!("{my_pubkey}: channel \"{channel_name}\" is full, dropping msg");
                 Ok(())
             }
-        }
-    }
-
-    fn handle_channel_disconnected(ctx: &mut ConsensusPoolContext, channel_name: &str) {
-        info!(
-            "{}: {channel_name} disconnected. Exiting",
-            ctx.cluster_info.id()
-        );
-        ctx.exit.store(true, Ordering::Relaxed);
-    }
-
-    /// Finds the initial parent ready that we should use for instantiating the ConsensusPool or kicking off votor
-    /// The max of genesis block, root block, or the restored parent ready from vote history
-    fn initial_parent_ready(
-        genesis_block: Option<Block>,
-        root_block: Block,
-        vote_history_highest_parent_ready: Option<(Slot, Block)>,
-    ) -> ParentReady {
-        let Some(genesis_block) = genesis_block else {
-            // Alpenglow is not yet enabled, start with just the root
-            return (root_block.slot.checked_add(1).unwrap(), root_block);
-        };
-
-        let initial_block = genesis_block.max(root_block);
-        let initial_parent_ready = (initial_block.slot.checked_add(1).unwrap(), initial_block);
-
-        if let Some(restored @ (restored_slot, _)) = vote_history_highest_parent_ready
-            && restored_slot > initial_parent_ready.0
-        {
-            restored
-        } else {
-            initial_parent_ready
-        }
-    }
-
-    fn root_block(root_bank: &Bank) -> Block {
-        Block {
-            slot: root_bank.slot(),
-            block_id: root_bank
-                .block_id()
-                // Once SIMD-0333 is active we can hard unwrap here
-                .unwrap_or_default(),
+            Err(TrySendError::Disconnected(_)) => Err(channel_name),
         }
     }
 
     // Main loop for the consensus pool service
-    fn main_loop(mut ctx: ConsensusPoolContext) {
+    fn main_loop(
+        ctx: &mut ConsensusPoolContext,
+        consensus_pool: &mut ConsensusPool,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), &'static str> {
         let mut events = vec![];
         let root_bank = ctx.sharable_banks.root();
 
-        let initial_parent_ready = Self::initial_parent_ready(
-            ctx.migration_status.genesis_block(),
-            Self::root_block(&root_bank),
-            ctx.vote_history_highest_parent_ready,
-        );
-
-        // Unlike the other votor threads, consensus pool starts even before Alpenglow is enabled
-        // because it must track the genesis vote.
-        let mut consensus_pool = ConsensusPool::new(
-            ctx.cluster_info.clone(),
-            &root_bank,
-            ctx.generated_cert_types.clone(),
-            ctx.migration_status.clone(),
-            initial_parent_ready,
-        );
-
         info!("{}: Certificate pool loop starting", ctx.cluster_info.id());
-        let mut stats = ConsensusPoolServiceStats::new();
         let mut highest_parent_ready = root_bank.slot();
 
         // Standstill tracking
@@ -285,17 +292,12 @@ impl ConsensusPoolService {
 
         // Ingest votes into consensus pool and notify voting loop of new events
         while !ctx.exit.load(Ordering::Relaxed) {
-            let root_bank = ctx.sharable_banks.root();
             // Kick off parent ready event, this either happens:
             // - When we first migrate to alpenglow from TowerBFT - kick off with genesis block
             // - If we startup post alpenglow migration - kick off with root block
             // - If restored vote history is farther ahead, resume from its highest parent-ready
             if !kick_off_parent_ready && ctx.migration_status.is_alpenglow_enabled() {
-                let (slot, parent_block) = Self::initial_parent_ready(
-                    ctx.migration_status.genesis_block(),
-                    Self::root_block(&root_bank),
-                    ctx.vote_history_highest_parent_ready,
-                );
+                let (slot, parent_block) = ctx.initial_parent_ready();
                 events.push(VotorEvent::ParentReady { slot, parent_block });
                 kick_off_parent_ready = true;
                 // Intentionally do not increment `highest_parent_ready` in case
@@ -304,10 +306,10 @@ impl ConsensusPoolService {
 
             Self::add_produce_block_event(
                 &mut highest_parent_ready,
-                &consensus_pool,
-                &mut ctx,
+                consensus_pool,
+                ctx,
                 &mut events,
-                &mut stats,
+                stats,
             );
 
             if standstill_timer.elapsed() > DELTA_STANDSTILL {
@@ -324,37 +326,26 @@ impl ConsensusPoolService {
                 }
                 stats.standstill = true;
                 standstill_timer = Instant::now();
-                match Self::send_certificates(
-                    &ctx,
+                Self::send_certificates(
+                    ctx,
                     BLSOp::RefreshCertificates {
                         certificates: consensus_pool.get_certs_for_standstill(),
                     },
-                    &mut stats,
-                ) {
-                    Ok(()) => (),
-                    Err(()) => {
-                        return Self::handle_channel_disconnected(&mut ctx, "bls_sender channel");
-                    }
-                }
+                    stats,
+                )?;
             }
 
             // Process pending safe-to-notar blocks for intrawindow slots
-            if let Err(()) = Self::process_pending_safe_to_notar(
-                &ctx,
-                &mut consensus_pool,
+            Self::process_pending_safe_to_notar(
+                ctx,
+                consensus_pool,
                 &mut pending_safe_to_notar,
                 &mut events,
-                &mut stats,
-            ) {
-                return Self::handle_channel_disconnected(&mut ctx, "repair_event_sender channel");
-            }
-
-            if events
-                .drain(..)
-                .try_for_each(|event| ctx.event_sender.send(event))
-                .is_err()
-            {
-                return Self::handle_channel_disconnected(&mut ctx, "event_sender channel");
+                stats,
+            )?;
+            let my_pubkey = ctx.cluster_info.id();
+            for event in events.drain(..) {
+                blocking_send(&my_pubkey, &ctx.event_sender, event, "event_sender")?;
             }
 
             let wait_timeout = if pending_safe_to_notar.is_empty() {
@@ -365,19 +356,18 @@ impl ConsensusPoolService {
                 Duration::from_millis(20)
             };
 
-            if let Err(()) = Self::receive_msgs(
-                &mut ctx,
-                &mut consensus_pool,
+            Self::receive_msgs(
+                ctx,
+                consensus_pool,
                 &mut events,
                 &mut standstill_timer,
-                &mut stats,
+                stats,
                 wait_timeout,
-            ) {
-                return;
-            }
+            )?;
             stats.maybe_report();
             consensus_pool.maybe_report();
         }
+        Ok(())
     }
 
     /// Adds a vote to the consensus pool.
@@ -492,7 +482,7 @@ impl ConsensusPoolService {
         pending_safe_to_notar: &mut HashSet<Block>,
         events: &mut Vec<VotorEvent>,
         stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         // First, collect new pending blocks from the consensus pool and send them for repair
         for block in consensus_pool.take_pending_safe_to_notar() {
             if pending_safe_to_notar.contains(&block) {
@@ -513,7 +503,7 @@ impl ConsensusPoolService {
                     );
                     consensus_pool.add_to_pending_safe_to_notar(block);
                 }
-                Err(TrySendError::Disconnected(_)) => return Err(()),
+                Err(TrySendError::Disconnected(_)) => return Err("repair_event_sender"),
             }
         }
 
@@ -571,10 +561,9 @@ impl ConsensusPoolService {
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
         msg: Result<OwnMessage, RecvError>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         let Ok(first) = msg else {
-            Self::handle_channel_disconnected(ctx, "own_message_receiver channel");
-            return Err(());
+            return Err("own_message_receiver");
         };
 
         let mut received_messages: usize = 0;
@@ -626,10 +615,9 @@ impl ConsensusPoolService {
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
         msg: Result<SigVerifiedBatch, RecvError>,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         let Ok(first) = msg else {
-            Self::handle_channel_disconnected(ctx, "consensus_message_receiver channel");
-            return Err(());
+            return Err("consensus_message_receiver");
         };
 
         let mut received_batches: usize = 0;
@@ -681,7 +669,7 @@ impl ConsensusPoolService {
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
         wait_timeout: Duration,
-    ) -> Result<(), ()> {
+    ) -> Result<(), &'static str> {
         select_biased! {
             recv(ctx.own_message_receiver) -> msg => {
                 Self::receive_own_msgs(ctx, consensus_pool, events, standstill_timer, stats,  msg)
@@ -691,6 +679,16 @@ impl ConsensusPoolService {
             }
             default(wait_timeout) => Ok(()),
         }
+    }
+}
+
+fn root_block(root_bank: &Bank) -> Block {
+    Block {
+        slot: root_bank.slot(),
+        block_id: root_bank
+            .block_id()
+            // Once SIMD-0333 is active we can hard unwrap here
+            .unwrap_or_default(),
     }
 }
 
@@ -760,22 +758,9 @@ mod tests {
             let leader_schedule_cache =
                 Arc::new(LeaderScheduleCache::new_from_bank(&sharable_banks.root()));
 
-            let root_bank = sharable_banks.root();
             let cluster_info = get_cluster_info(my_keypair.insecure_clone());
-            let root_block = Block {
-                slot: root_bank.slot(),
-                block_id: root_bank.block_id().unwrap_or_default(),
-            };
-            let initial_parent_ready = (root_bank.slot().checked_add(1).unwrap(), root_block);
             let generated_cert_types = Arc::new(GeneratedCertTypes::default());
             let migration_status = Arc::new(MigrationStatus::post_migration_status());
-            let consensus_pool = ConsensusPool::new(
-                cluster_info.clone(),
-                &root_bank,
-                generated_cert_types.clone(),
-                migration_status.clone(),
-                initial_parent_ready,
-            );
             let (consensus_message_sender, consensus_message_receiver) = unbounded();
             let (own_message_sender, own_message_receiver) = unbounded();
             let (event_sender, event_receiver) = unbounded();
@@ -797,6 +782,7 @@ mod tests {
                 repair_event_sender,
                 highest_finalized: Arc::new(RwLock::new(None)),
             };
+            let consensus_pool = ctx.new_consensus_pool();
 
             TestContext {
                 consensus_pool,
@@ -1114,9 +1100,13 @@ mod tests {
             },
         );
         ctx.ctx.vote_history_highest_parent_ready = Some(restored_parent_ready);
+        let mut consensus_pool = ctx.ctx.new_consensus_pool();
         let exit = ctx.ctx.exit.clone();
 
-        let handle = thread::spawn(move || ConsensusPoolService::main_loop(ctx.ctx));
+        let handle = thread::spawn(move || {
+            let mut stats = ConsensusPoolServiceStats::new();
+            let _ = ConsensusPoolService::main_loop(&mut ctx.ctx, &mut consensus_pool, &mut stats);
+        });
 
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut saw_parent_ready = false;
@@ -1162,7 +1152,7 @@ mod tests {
             block_id: Hash::new_unique(),
         };
         assert_eq!(
-            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, None),
+            ConsensusPoolContext::_initial_parent_ready(genesis_block, root_block, None),
             (13, root_block)
         );
 
@@ -1174,7 +1164,7 @@ mod tests {
             },
         );
         assert_eq!(
-            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, Some(restored)),
+            ConsensusPoolContext::_initial_parent_ready(genesis_block, root_block, Some(restored)),
             restored
         );
 
@@ -1186,7 +1176,7 @@ mod tests {
             },
         );
         assert_eq!(
-            ConsensusPoolService::initial_parent_ready(genesis_block, root_block, Some(stale)),
+            ConsensusPoolContext::_initial_parent_ready(genesis_block, root_block, Some(stale)),
             (13, root_block)
         );
     }
@@ -1314,7 +1304,7 @@ mod tests {
             BLSOp::PushCertificates { certificates },
             &mut stats,
         );
-        assert_eq!(result.unwrap_err(), ());
+        result.unwrap_err();
     }
 
     #[test]

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -54,7 +54,7 @@ impl ConsensusPoolServiceStats {
         }
     }
 
-    fn report(&self) {
+    pub(super) fn do_report(&self) {
         let &Self {
             add_message_failed: Saturating(add_message_failed),
             certificates_sent: Saturating(certificates_sent),
@@ -132,7 +132,7 @@ impl ConsensusPoolServiceStats {
 
     pub(super) fn maybe_report(&mut self) {
         if self.last_request_time.elapsed() >= STATS_REPORT_INTERVAL {
-            self.report();
+            self.do_report();
             *self = Self::new();
         }
     }

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -752,10 +752,11 @@ impl EventHandler {
             votes.push(bls_op);
         }
         update_commitment_cache(
+            my_pubkey,
             CommitmentType::Notarize,
             slot,
             &voting_context.commitment_sender,
-        )?;
+        );
         pending_blocks.remove(&slot);
 
         Self::try_final(my_pubkey, Block { slot, block_id }, voting_context, votes)?;
@@ -1114,11 +1115,6 @@ mod tests {
         let (leader_window_info_sender, leader_window_info_receiver) = bounded(1024);
         let (repair_event_sender, repair_event_receiver) = bounded(1024);
         let latest_switch_request = LatestSwitchRequest::default();
-        let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
-            event_sender,
-            exit,
-            Arc::new(MigrationStatus::default()),
-        )));
 
         // Create 10 node validatorvotekeypairs vec
         let validator_keypairs = (0..10)
@@ -1146,6 +1142,12 @@ mod tests {
             Arc::new(my_node_keypair.insecure_clone()),
             SocketAddrSpace::Unspecified,
         ));
+        let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
+            cluster_info.clone(),
+            event_sender,
+            exit,
+            Arc::new(MigrationStatus::default()),
+        )));
         let blockstore = Arc::new(
             Blockstore::open_with_options(
                 &get_tmp_ledger_path!(),

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         commitment::{CommitmentType, update_commitment_cache},
+        common::nonblocking_send,
         event_handler::PendingBlocks,
         voting_utils::VotingContext,
         votor::SharedContext,
@@ -66,13 +67,12 @@ pub(crate) fn set_root(
         error!("failed to record optimistic slot in blockstore: slot={new_root_slot}: {e:?}");
     }
 
-    if let Err(err) = update_commitment_cache(
+    update_commitment_cache(
+        my_pubkey,
         CommitmentType::Rooted,
         new_root_slot,
         &vctx.commitment_sender,
-    ) {
-        warn!("failed to update Alpenglow rooted commitment for root {new_root_slot}: {err}");
-    }
+    );
 
     // It is critical to send the OC notification in order to keep compatibility with
     // the RPC API. Additionally the PrioritizationFeeCache relies on this notification
@@ -83,10 +83,17 @@ pub(crate) fn set_root(
             .dependency_tracker
             .as_ref()
             .map(|s| s.get_current_declared_work());
-        let _ = config.sender.send((
-            BankNotification::OptimisticallyConfirmed(new_root_slot, bank_hash),
-            dependency_work,
-        ));
+        if let Err(chanel_name) = nonblocking_send(
+            my_pubkey,
+            &config.sender,
+            (
+                BankNotification::OptimisticallyConfirmed(new_root_slot, bank_hash),
+                dependency_work,
+            ),
+            "bank_notification_sender",
+        ) {
+            info!("{my_pubkey}: channel {chanel_name} disconnected");
+        }
     }
 }
 
@@ -147,6 +154,7 @@ pub fn check_and_handle_new_root<CB>(
         .set_roots(rooted_slots.iter())
         .expect("Ledger set roots failed");
     set_bank_forks_root(
+        my_pubkey,
         new_root,
         bank_forks,
         snapshot_controller,
@@ -163,23 +171,30 @@ pub fn check_and_handle_new_root<CB>(
             .dependency_tracker
             .as_ref()
             .map(|s| s.get_current_declared_work());
-        sender
-            .sender
-            .send((BankNotification::NewRootBank(root_bank), dependency_work))
-            .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
-
+        if let Err(channel_name) = nonblocking_send(
+            my_pubkey,
+            &sender.sender,
+            (BankNotification::NewRootBank(root_bank), dependency_work),
+            "bank_notification_sender",
+        ) {
+            info!("{my_pubkey} channel {channel_name} disconnected");
+        }
         if let Some((new_chain, oldest_parent)) = rooted_slot_notifications {
             let dependency_work = sender
                 .dependency_tracker
                 .as_ref()
                 .map(|s| s.get_current_declared_work());
-            sender
-                .sender
-                .send((
+            if let Err(channel_name) = nonblocking_send(
+                my_pubkey,
+                &sender.sender,
+                (
                     BankNotification::NewRootedChain(new_chain, oldest_parent),
                     dependency_work,
-                ))
-                .unwrap_or_else(|err| warn!("bank_notification_sender failed: {err:?}"));
+                ),
+                "bank_notification_sender",
+            ) {
+                info!("{my_pubkey} channel {channel_name} disconnected");
+            }
         }
     }
     info!("{my_pubkey}: new root {new_root}");
@@ -190,6 +205,7 @@ pub fn check_and_handle_new_root<CB>(
 /// - Prune bank forks and drop the removed banks
 /// - Calls the callback for use in replay stage and tests
 pub fn set_bank_forks_root<CB>(
+    my_pubkey: &Pubkey,
     new_root: Slot,
     bank_forks: &RwLock<BankForks>,
     snapshot_controller: Option<&SnapshotController>,
@@ -217,10 +233,14 @@ pub fn set_bank_forks_root<CB>(
         highest_super_majority_root,
     );
 
-    drop_bank_sender
-        .send(removed_banks)
-        .unwrap_or_else(|err| warn!("bank drop failed: {err:?}"));
-
+    if let Err(channel_name) = nonblocking_send(
+        my_pubkey,
+        drop_bank_sender,
+        removed_banks,
+        "drop_bank_sender",
+    ) {
+        info!("{my_pubkey} channel {channel_name} disconnected");
+    }
     let r_bank_forks = bank_forks.read().unwrap();
     callback(&r_bank_forks);
 }

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -10,6 +10,7 @@ use {
     crossbeam_channel::Sender,
     parking_lot::RwLock as PlRwLock,
     solana_clock::Slot,
+    solana_gossip::cluster_info::ClusterInfo,
     std::{
         sync::{
             Arc,
@@ -30,6 +31,7 @@ pub(crate) struct TimerManager {
 
 impl TimerManager {
     pub(crate) fn new(
+        cluster_info: Arc<ClusterInfo>,
         event_sender: Sender<VotorEvent>,
         exit: Arc<AtomicBool>,
         migration_status: Arc<MigrationStatus>,
@@ -40,14 +42,20 @@ impl TimerManager {
             thread::spawn(move || {
                 let _ = migration_status.wait_for_migration_or_exit(exit.as_ref());
                 while !exit.load(Ordering::Relaxed) {
-                    let duration = match timers.write().progress(Instant::now()) {
-                        None => {
+                    let my_pubkey = cluster_info.id();
+                    let duration = match timers.write().progress(&my_pubkey, Instant::now()) {
+                        Err(channel_name) => {
+                            warn!("{my_pubkey}: {channel_name} disconnected. Exiting");
+                            exit.store(true, Ordering::Relaxed);
+                            break;
+                        }
+                        Ok(None) => {
                             // No active timers, sleep for an arbitrary amount.
                             // This should be smaller than the minimum amount
                             // of time any newly added timers would take to expire.
                             Duration::from_millis(100)
                         }
-                        Some(next_fire) => next_fire.duration_since(Instant::now()),
+                        Ok(Some(next_fire)) => next_fire.duration_since(Instant::now()),
                     };
                     thread::park_timeout(duration);
                 }
@@ -92,17 +100,20 @@ impl TimerManager {
 mod tests {
     use {
         super::*,
-        crate::event::VotorEvent,
+        crate::{event::VotorEvent, tests::get_cluster_info},
         crossbeam_channel::bounded,
         solana_clock::DEFAULT_MS_PER_SLOT,
+        solana_keypair::Keypair,
         std::{assert_matches, time::Duration},
     };
 
     #[test]
     fn test_timer_manager() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let (event_sender, event_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
         let timer_manager = TimerManager::new(
+            cluster_info,
             event_sender,
             exit.clone(),
             Arc::new(MigrationStatus::post_migration_status()),
@@ -149,9 +160,11 @@ mod tests {
 
     #[test]
     fn test_new_earlier_timer_wakes_sleeping_worker() {
+        let cluster_info = get_cluster_info(Keypair::new());
         let (event_sender, event_receiver) = bounded(1024);
         let exit = Arc::new(AtomicBool::new(false));
         let timer_manager = TimerManager::new(
+            cluster_info,
             event_sender,
             exit.clone(),
             Arc::new(MigrationStatus::post_migration_status()),

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -1,8 +1,9 @@
 use {
-    crate::{event::VotorEvent, timer_manager::stats::TimerManagerStats},
+    crate::{common::blocking_send, event::VotorEvent, timer_manager::stats::TimerManagerStats},
     crossbeam_channel::Sender,
     solana_clock::Slot,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
+    solana_pubkey::Pubkey,
     solana_runtime::leader_schedule_utils::last_of_consecutive_leader_slots,
     std::{
         cmp::Reverse,
@@ -230,7 +231,11 @@ impl Timers {
 
     /// Call to make progress on the timer states.  If there are still active
     /// timer states, returns when the earliest one might become ready.
-    pub(super) fn progress(&mut self, now: Instant) -> Option<Instant> {
+    pub(super) fn progress(
+        &mut self,
+        my_pubkey: &Pubkey,
+        now: Instant,
+    ) -> Result<Option<Instant>, &'static str> {
         assert_eq!(self.heap.len(), self.timers.len());
         let mut ret_timeout = None;
         loop {
@@ -247,7 +252,7 @@ impl Timers {
 
                     let mut timer = self.timers.remove(&slot).unwrap();
                     if let Some(event) = timer.progress(now) {
-                        self.event_sender.send(event).unwrap();
+                        blocking_send(my_pubkey, &self.event_sender, event, "event_sender")?;
                     }
                     if let Some(next_fire) = timer.next_fire() {
                         self.heap.push(Reverse((next_fire, slot)));
@@ -258,7 +263,7 @@ impl Timers {
                 }
             }
         }
-        ret_timeout
+        Ok(ret_timeout)
     }
 
     #[cfg(test)]
@@ -329,16 +334,17 @@ mod tests {
 
     #[test]
     fn timers_progress() {
+        let my_pubkey = Pubkey::new_unique();
         let one_micro = Duration::from_micros(1);
         let mut now = Instant::now();
         let (sender, receiver) = bounded(1024);
         let mut timers = Timers::new(one_micro, sender);
-        assert!(timers.progress(now).is_none());
+        assert!(timers.progress(&my_pubkey, now).unwrap().is_none());
         assert!(receiver.try_recv().unwrap_err().is_empty());
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
         timers.set_timeouts(0, now, None, delta_block, delta_block);
-        while timers.progress(now).is_some() {
+        while timers.progress(&my_pubkey, now).unwrap().is_some() {
             now = now.checked_add(one_micro).unwrap();
         }
         let mut events = receiver.try_iter().collect::<Vec<_>>();

--- a/votor/src/voting_utils.rs
+++ b/votor/src/voting_utils.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
-        commitment::{CommitmentAggregationData, CommitmentError},
+        commitment::CommitmentAggregationData,
+        common::{blocking_send, nonblocking_send},
         vote_history::{VoteHistory, VoteHistoryError},
         vote_history_storage::{SavedVoteHistory, SavedVoteHistoryVersions, VoteHistoryStorage},
         voting_service::BLSOp,
@@ -13,7 +14,7 @@ use {
         vote::Vote,
         wire::get_vote_payload_to_sign,
     },
-    crossbeam_channel::{SendError, Sender, TrySendError},
+    crossbeam_channel::Sender,
     solana_bls_signatures::{BlsError, keypair::Keypair as BLSKeypair},
     solana_clock::{Epoch, Slot},
     solana_gossip::cluster_info::ClusterInfo,
@@ -100,19 +101,10 @@ impl GenerateVoteTxResult {
 pub enum VoteError {
     #[error("Unable to generate bls vote message, transient error: {0:?}")]
     TransientError(Box<GenerateVoteTxResult>),
-
     #[error("Unable to generate bls vote message, configuration error: {0:?}")]
     InvalidConfig(Box<GenerateVoteTxResult>),
-
-    #[error("Unable to send to certificate pool")]
-    ConsensusPoolError(#[from] SendError<()>),
-
-    #[error("Channel to rewards container disconnected")]
-    RewardsChannelDisconnected,
-
-    #[error("Commitment sender error {0}")]
-    CommitmentSenderError(#[from] CommitmentError),
-
+    #[error("Channel \"{0}\" disconnected")]
+    ChannelDisconnected(&'static str),
     #[error("Saved vote history error {0}")]
     SavedVoteHistoryError(#[from] VoteHistoryError),
 }
@@ -329,11 +321,11 @@ pub(crate) fn create_and_send_own_vote_message(
         }
     };
 
-    let own_vote_msg = OwnMessage::Vote(vote_msg.clone());
-    context
-        .own_vote_sender
-        .send(own_vote_msg)
-        .map_err(|_| SendError(()))?;
+    let my_pubkey = &context.cluster_info.id();
+    let msg = OwnMessage::Vote(vote_msg.clone());
+    // TODO: this blocking send can lead to a deadlock.  We need to find a way to not block here.
+    blocking_send(my_pubkey, &context.own_vote_sender, msg, "own_vote_sender")
+        .map_err(VoteError::ChannelDisconnected)?;
 
     let root_slot = context.sharable_banks.root().slot();
     if rewards_wants_vote(
@@ -342,16 +334,14 @@ pub(crate) fn create_and_send_own_vote_message(
         root_slot,
         &vote_msg.vote,
     ) {
-        let reward_input = RewardInput::Own(vote_msg.clone());
-        match context.own_reward_sender.try_send(reward_input) {
-            Ok(()) => (),
-            Err(TrySendError::Full(_)) => {
-                warn!("Reward votes channel is full, dropping own vote {vote:?}");
-            }
-            Err(TrySendError::Disconnected(_)) => {
-                return Err(VoteError::RewardsChannelDisconnected);
-            }
-        }
+        let msg = RewardInput::Own(vote_msg.clone());
+        nonblocking_send(
+            my_pubkey,
+            &context.own_reward_sender,
+            msg,
+            "own_reward_sender",
+        )
+        .map_err(VoteError::ChannelDisconnected)?;
     }
     Ok(Some(vote_msg))
 }

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -220,6 +220,7 @@ impl Votor {
         };
 
         let timer_manager = Arc::new(PlRwLock::new(TimerManager::new(
+            cluster_info.clone(),
             event_sender.clone(),
             exit.clone(),
             migration_status.clone(),


### PR DESCRIPTION
#### Problem

See #11285 

Votor crate has some issues with sending on channels:
- we are using blocking sends in places where we should use nonblocking sends
- if some sends fail, we panic
- when we do block on a send, we do not emit a log msg indicating that that happened


#### Summary of Changes

Fixes the above issues and some related cleanups by using the recently introduced `blocking_send` and `nonblocking_send`.


#### Testing

Just CI

Fixes: #11285 