### PR TITLE
blockstore_processor: remove unnecessary checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8983,7 +8983,6 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-snapshots",
  "agave-votor-messages",
- "ahash 0.8.12",
  "anyhow",
  "assert_matches",
  "bitflags 2.13.1",

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -7120,7 +7120,6 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-snapshots",
  "agave-votor-messages",
- "ahash 0.8.12",
  "anyhow",
  "assert_matches",
  "bitflags 2.13.1",

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -33,7 +33,6 @@ agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
 agave-votor-messages = { workspace = true }
-ahash = { workspace = true }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }
 bitflags = { workspace = true }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -129,6 +129,41 @@ impl ExecuteBatchesInternalMetrics {
     }
 }
 
+struct EntryTransactionsValidator {
+    hashes: AHashSet<Hash>,
+    tx_account_lock_limit: usize,
+}
+
+impl EntryTransactionsValidator {
+    fn new(tx_account_lock_limit: usize) -> Self {
+        Self {
+            hashes: AHashSet::new(),
+            tx_account_lock_limit,
+        }
+    }
+
+    /// Validate an entry's transactions before scheduling: each transaction's account
+    /// locks (count and duplicates), and rejection of duplicate message hashes within
+    /// the entry. Does not take account locks - the unified scheduler orders conflicts.
+    /// Post-SIMD-83 the duplicate-message-hash check is what rejects an entry that
+    /// replays the same transaction twice (it no longer conflicts on locks).
+    fn validate(
+        &mut self,
+        transactions: &[RuntimeTransaction<SanitizedTransaction>],
+    ) -> Result<()> {
+        self.hashes.clear();
+
+        for transaction in transactions {
+            validate_account_locks(transaction.account_keys(), self.tx_account_lock_limit)?;
+            if !self.hashes.insert(*transaction.message_hash()) {
+                return Err(TransactionError::AlreadyProcessed);
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// Process an ordered list of entries and wait for their completed execution.
 /// 1. For each entry in order, up to a block-boundary `Tick`:
 ///    - `Transactions`: validate each transaction's account locks (and reject duplicate message
@@ -206,20 +241,8 @@ fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> 
 fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Result<()> {
     let mut tick_hashes = vec![];
 
-    let max_transactions_per_entry = entries
-        .iter()
-        .map(|replay_entry| {
-            let entry = &replay_entry.entry;
-
-            match entry {
-                EntryType::Tick(_) => 0,
-                EntryType::Transactions(transactions) => transactions.len(),
-            }
-        })
-        .max()
-        .unwrap_or(0); // AHashSet::with_capacity(0) does 0 allocation
-
-    let mut entry_message_hashes = AHashSet::with_capacity(max_transactions_per_entry);
+    let mut entry_transactions_validation =
+        EntryTransactionsValidator::new(bank.get_transaction_account_lock_limit());
 
     for ReplayEntry {
         entry,
@@ -251,11 +274,7 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                     "no scheduler installed for bank of slot {} during replay",
                     bank.slot()
                 );
-                validate_entry_transactions(
-                    &transactions,
-                    bank.get_transaction_account_lock_limit(),
-                    &mut entry_message_hashes,
-                )?;
+                entry_transactions_validation.validate(&transactions)?;
 
                 let indexes = starting_index..starting_index + transactions.len();
                 // Widening usize index to OrderedTaskId (= u128) won't ever fail.
@@ -268,28 +287,6 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
     for hash in tick_hashes {
         bank.register_tick(&hash);
     }
-    Ok(())
-}
-
-/// Validate an entry's transactions before scheduling: each transaction's account
-/// locks (count and duplicates), and rejection of duplicate message hashes within
-/// the entry. Does not take account locks - the unified scheduler orders conflicts.
-/// Post-SIMD-83 the duplicate-message-hash check is what rejects an entry that
-/// replays the same transaction twice (it no longer conflicts on locks).
-fn validate_entry_transactions(
-    transactions: &[RuntimeTransaction<SanitizedTransaction>],
-    tx_account_lock_limit: usize,
-    entry_message_hashes: &mut AHashSet<Hash>,
-) -> Result<()> {
-    entry_message_hashes.clear();
-
-    for transaction in transactions {
-        validate_account_locks(transaction.account_keys(), tx_account_lock_limit)?;
-        if !entry_message_hashes.insert(*transaction.message_hash()) {
-            return Err(TransactionError::AlreadyProcessed);
-        }
-    }
-
     Ok(())
 }
 
@@ -5963,10 +5960,7 @@ pub mod tests {
                 hash,
             )),
         ];
-        assert_eq!(
-            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
-            Ok(())
-        );
+        assert_eq!(EntryTransactionsValidator::new(10).validate(&txs), Ok(()));
     }
 
     #[test]
@@ -5981,7 +5975,7 @@ pub mod tests {
         )];
         // transfer touches >1 account; limit of 1 must reject
         assert_eq!(
-            validate_entry_transactions(&txs, 1, &mut AHashSet::new()),
+            EntryTransactionsValidator::new(1).validate(&txs),
             Err(TransactionError::TooManyAccountLocks)
         );
     }
@@ -6010,7 +6004,7 @@ pub mod tests {
             Transaction::new(&[&payer], message, Hash::new_unique()),
         )];
         assert_eq!(
-            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
+            EntryTransactionsValidator::new(10).validate(&txs),
             Err(TransactionError::AccountLoadedTwice)
         );
     }
@@ -6022,11 +6016,26 @@ pub mod tests {
             system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, Hash::new_unique()),
         )];
 
-        let mut entry_message_hashes = AHashSet::from_iter([*entry[0].message_hash()]);
-        assert_eq!(
-            validate_entry_transactions(&entry, 10, &mut entry_message_hashes),
-            Ok(())
-        );
+        let mut validator = EntryTransactionsValidator {
+            hashes: AHashSet::from_iter([*entry[0].message_hash()]),
+            tx_account_lock_limit: 10,
+        };
+        assert_eq!(validator.validate(&entry), Ok(()));
+    }
+
+    #[test]
+    fn test_validate_entry_transactions_same_entry_repeatedly() {
+        let payer = Keypair::new();
+        let entry = vec![RuntimeTransaction::from_transaction_for_tests(
+            system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, Hash::new_unique()),
+        )];
+
+        // One validator is reused for every entry in the slot, so a transaction that shows up
+        // again in a later entry must still be accepted.
+        let mut validator = EntryTransactionsValidator::new(10);
+        for _ in 0..3 {
+            assert_eq!(validator.validate(&entry), Ok(()));
+        }
     }
 
     #[test]
@@ -6039,7 +6048,7 @@ pub mod tests {
             RuntimeTransaction::from_transaction_for_tests(tx),
         ];
         assert_eq!(
-            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
+            EntryTransactionsValidator::new(10).validate(&txs),
             Err(TransactionError::AlreadyProcessed)
         );
     }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -219,7 +219,6 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                 }
             }
             EntryType::Transactions(transactions) => {
-
                 // Any bank replaying transactions must have a scheduler installed. Slot 0 -
                 // the only bank replayed before the scheduler pool is installed - is tick-only,
                 // so it never reaches here.
@@ -3754,19 +3753,9 @@ pub mod tests {
                 ),
             ],
         );
-        // should now be:
-        // keypair1=4
-        // keypair2=6
 
         let result = process_entries_for_tests_with_scheduler(&bank, vec![entry_1_to_2_twice]);
 
-        let balances = [
-            bank.get_balance(&keypair1.pubkey()),
-            bank.get_balance(&keypair2.pubkey()),
-        ];
-
-        // the first copy is committed before the second one fails
-        assert_eq!(balances, [4, 6]);
         assert_eq!(result, Err(TransactionError::AlreadyProcessed));
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -219,13 +219,6 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                 }
             }
             EntryType::Transactions(transactions) => {
-                // An entry carrying no transactions is a tick, enforced at the only place
-                // `EntryType` is built from an `Entry`
-                // (`solana_entry::entry::validate_and_hash_entry_transactions`).
-                debug_assert!(
-                    !transactions.is_empty(),
-                    "transaction entry with no transactions"
-                );
 
                 // Any bank replaying transactions must have a scheduler installed. Slot 0 -
                 // the only bank replayed before the scheduler pool is installed - is tick-only,
@@ -3740,11 +3733,9 @@ pub mod tests {
         assert_matches!(bank.transfer(5, &mint_keypair, &keypair1.pubkey()), Ok(_));
         assert_matches!(bank.transfer(5, &mint_keypair, &keypair2.pubkey()), Ok(_));
 
-        // one entry, two instances of the same transaction. this entry is invalid, but the
-        // duplicate no longer conflicts on account locks, so it is only caught by the status
-        // cache once the second copy executes - after the first has already been committed to
-        // this bank. Replay marks the slot dead on any error, so that intermediate state is
-        // discarded and never observable.
+        // The scheduler executes identical transactions sequentially. The first transfer commits,
+        // then the status cache rejects the second as already processed.
+
         let entry_1_to_2_twice = next_entry(
             &bank.last_blockhash(),
             1,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -9,7 +9,6 @@ use {
     },
     ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
     agave_votor_messages::{certificate::Certificate, migration::MigrationStatus},
-    ahash::AHashSet,
     chrono_humanize::{Accuracy, HumanTime, Tense},
     crossbeam_channel::{Receiver, Sender},
     itertools::Itertools,
@@ -129,41 +128,6 @@ impl ExecuteBatchesInternalMetrics {
     }
 }
 
-struct EntryTransactionsValidator {
-    hashes: AHashSet<Hash>,
-    tx_account_lock_limit: usize,
-}
-
-impl EntryTransactionsValidator {
-    fn new(tx_account_lock_limit: usize) -> Self {
-        Self {
-            hashes: AHashSet::new(),
-            tx_account_lock_limit,
-        }
-    }
-
-    /// Validate an entry's transactions before scheduling: each transaction's account
-    /// locks (count and duplicates), and rejection of duplicate message hashes within
-    /// the entry. Does not take account locks - the unified scheduler orders conflicts.
-    /// Post-SIMD-83 the duplicate-message-hash check is what rejects an entry that
-    /// replays the same transaction twice (it no longer conflicts on locks).
-    fn validate(
-        &mut self,
-        transactions: &[RuntimeTransaction<SanitizedTransaction>],
-    ) -> Result<()> {
-        self.hashes.clear();
-
-        for transaction in transactions {
-            validate_account_locks(transaction.account_keys(), self.tx_account_lock_limit)?;
-            if !self.hashes.insert(*transaction.message_hash()) {
-                return Err(TransactionError::AlreadyProcessed);
-            }
-        }
-
-        Ok(())
-    }
-}
-
 /// Process an ordered list of entries and wait for their completed execution.
 /// 1. For each entry in order, up to a block-boundary `Tick`:
 ///    - `Transactions`: validate each transaction's account locks (and reject duplicate message
@@ -241,9 +205,6 @@ fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> 
 fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Result<()> {
     let mut tick_hashes = vec![];
 
-    let mut entry_transactions_validation =
-        EntryTransactionsValidator::new(bank.get_transaction_account_lock_limit());
-
     for ReplayEntry {
         entry,
         starting_index,
@@ -274,7 +235,10 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                     "no scheduler installed for bank of slot {} during replay",
                     bank.slot()
                 );
-                entry_transactions_validation.validate(&transactions)?;
+                validate_entry_transactions(
+                    &transactions,
+                    bank.get_transaction_account_lock_limit(),
+                )?;
 
                 let indexes = starting_index..starting_index + transactions.len();
                 // Widening usize index to OrderedTaskId (= u128) won't ever fail.
@@ -287,6 +251,19 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
     for hash in tick_hashes {
         bank.register_tick(&hash);
     }
+    Ok(())
+}
+
+/// Validate an entry's transactions before scheduling: each transaction's account
+/// locks (count and duplicates). Does not take account locks - the unified scheduler orders conflicts.
+fn validate_entry_transactions(
+    transactions: &[RuntimeTransaction<SanitizedTransaction>],
+    tx_account_lock_limit: usize,
+) -> Result<()> {
+    for transaction in transactions {
+        validate_account_locks(transaction.account_keys(), tx_account_lock_limit)?;
+    }
+
     Ok(())
 }
 
@@ -3724,7 +3701,8 @@ pub mod tests {
         // keypair2=3
         // keypair3=3
 
-        // succeeds following simd83 locking, fails otherwise
+        // transactions within an entry may read/write and write/write the same accounts, so the
+        // colliding entry is valid and the scheduler orders the conflicts itself
         let result = process_entries_for_tests_with_scheduler(
             &bank,
             vec![
@@ -3762,9 +3740,11 @@ pub mod tests {
         assert_matches!(bank.transfer(5, &mint_keypair, &keypair1.pubkey()), Ok(_));
         assert_matches!(bank.transfer(5, &mint_keypair, &keypair2.pubkey()), Ok(_));
 
-        // one entry, two instances of the same transaction. this entry is invalid
-        // without simd83: due to lock conflicts
-        // with simd83: due to message hash duplication
+        // one entry, two instances of the same transaction. this entry is invalid, but the
+        // duplicate no longer conflicts on account locks, so it is only caught by the status
+        // cache once the second copy executes - after the first has already been committed to
+        // this bank. Replay marks the slot dead on any error, so that intermediate state is
+        // discarded and never observable.
         let entry_1_to_2_twice = next_entry(
             &bank.last_blockhash(),
             1,
@@ -3784,10 +3764,9 @@ pub mod tests {
             ],
         );
         // should now be:
-        // keypair1=5
-        // keypair2=5
+        // keypair1=4
+        // keypair2=6
 
-        // succeeds following simd83 locking, fails otherwise
         let result = process_entries_for_tests_with_scheduler(&bank, vec![entry_1_to_2_twice]);
 
         let balances = [
@@ -3795,7 +3774,8 @@ pub mod tests {
             bank.get_balance(&keypair2.pubkey()),
         ];
 
-        assert_eq!(balances, [5, 5]);
+        // the first copy is committed before the second one fails
+        assert_eq!(balances, [4, 6]);
         assert_eq!(result, Err(TransactionError::AlreadyProcessed));
     }
 
@@ -5960,7 +5940,7 @@ pub mod tests {
                 hash,
             )),
         ];
-        assert_eq!(EntryTransactionsValidator::new(10).validate(&txs), Ok(()));
+        assert_eq!(validate_entry_transactions(&txs, 10), Ok(()));
     }
 
     #[test]
@@ -5975,7 +5955,7 @@ pub mod tests {
         )];
         // transfer touches >1 account; limit of 1 must reject
         assert_eq!(
-            EntryTransactionsValidator::new(1).validate(&txs),
+            validate_entry_transactions(&txs, 1),
             Err(TransactionError::TooManyAccountLocks)
         );
     }
@@ -6004,52 +5984,8 @@ pub mod tests {
             Transaction::new(&[&payer], message, Hash::new_unique()),
         )];
         assert_eq!(
-            EntryTransactionsValidator::new(10).validate(&txs),
+            validate_entry_transactions(&txs, 10),
             Err(TransactionError::AccountLoadedTwice)
-        );
-    }
-
-    #[test]
-    fn test_validate_entry_transactions_clears_dirty_hash_set() {
-        let payer = Keypair::new();
-        let entry = vec![RuntimeTransaction::from_transaction_for_tests(
-            system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, Hash::new_unique()),
-        )];
-
-        let mut validator = EntryTransactionsValidator {
-            hashes: AHashSet::from_iter([*entry[0].message_hash()]),
-            tx_account_lock_limit: 10,
-        };
-        assert_eq!(validator.validate(&entry), Ok(()));
-    }
-
-    #[test]
-    fn test_validate_entry_transactions_same_entry_repeatedly() {
-        let payer = Keypair::new();
-        let entry = vec![RuntimeTransaction::from_transaction_for_tests(
-            system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, Hash::new_unique()),
-        )];
-
-        // One validator is reused for every entry in the slot, so a transaction that shows up
-        // again in a later entry must still be accepted.
-        let mut validator = EntryTransactionsValidator::new(10);
-        for _ in 0..3 {
-            assert_eq!(validator.validate(&entry), Ok(()));
-        }
-    }
-
-    #[test]
-    fn test_validate_entry_transactions_duplicate_message_hash() {
-        let payer = Keypair::new();
-        let hash = Hash::new_unique();
-        let tx = system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, hash);
-        let txs = vec![
-            RuntimeTransaction::from_transaction_for_tests(tx.clone()),
-            RuntimeTransaction::from_transaction_for_tests(tx),
-        ];
-        assert_eq!(
-            EntryTransactionsValidator::new(10).validate(&txs),
-            Err(TransactionError::AlreadyProcessed)
         );
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -206,6 +206,21 @@ fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> 
 fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Result<()> {
     let mut tick_hashes = vec![];
 
+    let max_transactions_per_entry = entries
+        .iter()
+        .map(|replay_entry| {
+            let entry = &replay_entry.entry;
+
+            match entry {
+                EntryType::Tick(_) => 0,
+                EntryType::Transactions(transactions) => transactions.len(),
+            }
+        })
+        .max()
+        .unwrap_or(0); // AHashSet::with_capacity(0) does 0 allocation
+
+    let mut entry_message_hashes = AHashSet::with_capacity(max_transactions_per_entry);
+
     for ReplayEntry {
         entry,
         starting_index,
@@ -220,9 +235,13 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                 }
             }
             EntryType::Transactions(transactions) => {
-                if transactions.is_empty() {
-                    continue;
-                }
+                // An entry carrying no transactions is a tick, enforced at the only place
+                // `EntryType` is built from an `Entry`
+                // (`solana_entry::entry::validate_and_hash_entry_transactions`).
+                debug_assert!(
+                    !transactions.is_empty(),
+                    "transaction entry with no transactions"
+                );
 
                 // Any bank replaying transactions must have a scheduler installed. Slot 0 -
                 // the only bank replayed before the scheduler pool is installed - is tick-only,
@@ -235,6 +254,7 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
                 validate_entry_transactions(
                     &transactions,
                     bank.get_transaction_account_lock_limit(),
+                    &mut entry_message_hashes,
                 )?;
 
                 let indexes = starting_index..starting_index + transactions.len();
@@ -259,12 +279,13 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
 fn validate_entry_transactions(
     transactions: &[RuntimeTransaction<SanitizedTransaction>],
     tx_account_lock_limit: usize,
+    entry_message_hashes: &mut AHashSet<Hash>,
 ) -> Result<()> {
-    let mut batch_message_hashes = AHashSet::with_capacity(transactions.len());
+    entry_message_hashes.clear();
 
     for transaction in transactions {
         validate_account_locks(transaction.account_keys(), tx_account_lock_limit)?;
-        if !batch_message_hashes.insert(transaction.message_hash()) {
+        if !entry_message_hashes.insert(*transaction.message_hash()) {
             return Err(TransactionError::AlreadyProcessed);
         }
     }
@@ -5942,7 +5963,10 @@ pub mod tests {
                 hash,
             )),
         ];
-        assert_eq!(validate_entry_transactions(&txs, 10), Ok(()));
+        assert_eq!(
+            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
+            Ok(())
+        );
     }
 
     #[test]
@@ -5957,7 +5981,7 @@ pub mod tests {
         )];
         // transfer touches >1 account; limit of 1 must reject
         assert_eq!(
-            validate_entry_transactions(&txs, 1),
+            validate_entry_transactions(&txs, 1, &mut AHashSet::new()),
             Err(TransactionError::TooManyAccountLocks)
         );
     }
@@ -5986,8 +6010,22 @@ pub mod tests {
             Transaction::new(&[&payer], message, Hash::new_unique()),
         )];
         assert_eq!(
-            validate_entry_transactions(&txs, 10),
+            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
             Err(TransactionError::AccountLoadedTwice)
+        );
+    }
+
+    #[test]
+    fn test_validate_entry_transactions_clears_dirty_hash_set() {
+        let payer = Keypair::new();
+        let entry = vec![RuntimeTransaction::from_transaction_for_tests(
+            system_transaction::transfer(&payer, &Pubkey::new_unique(), 1, Hash::new_unique()),
+        )];
+
+        let mut entry_message_hashes = AHashSet::from_iter([*entry[0].message_hash()]);
+        assert_eq!(
+            validate_entry_transactions(&entry, 10, &mut entry_message_hashes),
+            Ok(())
         );
     }
 
@@ -6001,7 +6039,7 @@ pub mod tests {
             RuntimeTransaction::from_transaction_for_tests(tx),
         ];
         assert_eq!(
-            validate_entry_transactions(&txs, 10),
+            validate_entry_transactions(&txs, 10, &mut AHashSet::new()),
             Err(TransactionError::AlreadyProcessed)
         );
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7238,7 +7238,6 @@ dependencies = [
  "agave-reserved-account-keys",
  "agave-snapshots",
  "agave-votor-messages",
- "ahash 0.8.12",
  "anyhow",
  "assert_matches",
  "bitflags 2.13.1",


### PR DESCRIPTION
#### Problem

Follow up to #14114, had [useless if guard](https://github.com/anza-xyz/agave/pull/14114#discussion_r3688076690). It also had allocation per item in replay entries. I think it is worth to replace it with one allocation per process_entries fn call. Also contributing guide https://github.com/anza-xyz/agave/blob/master/CONTRIBUTING.md#allocator-usage while does not specific one vs multiple allocations explicitly I believe it makes sense here to replace it with single allocation.


#### Summary of Changes

1. replace useless if check with debug_assert.
2. calculate capacity needed for hashset once and reuse the hashset.

Cost of this change is that fn `validate_entry_transactions` is no longer self-contained.

#### Testing
Added tests for new path and adjusted existing ones.

I have run all: 
```
./ci/test-sanity.sh
./ci/test-checks.sh
./ci/feature-check/test-feature.sh  
```

#### Fixes
Follow up to #14114

cc @apfitzge @DSharifi 