### PR TITLE
TimerManager: do not hold lock while doing a blocking send

### DIFF
--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -5,7 +5,10 @@ mod stats;
 mod timers;
 
 use {
-    crate::{common::DELTA_TIMEOUT, event::VotorEvent},
+    crate::{
+        common::{DELTA_TIMEOUT, blocking_send},
+        event::VotorEvent,
+    },
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     parking_lot::RwLock as PlRwLock,
@@ -36,26 +39,31 @@ impl TimerManager {
         exit: Arc<AtomicBool>,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
-        let timers = Arc::new(PlRwLock::new(Timers::new(DELTA_TIMEOUT, event_sender)));
+        let timers = Arc::new(PlRwLock::new(Timers::new(DELTA_TIMEOUT)));
         let handle = {
             let timers = Arc::clone(&timers);
             thread::spawn(move || {
                 let _ = migration_status.wait_for_migration_or_exit(exit.as_ref());
                 while !exit.load(Ordering::Relaxed) {
-                    let my_pubkey = cluster_info.id();
-                    let duration = match timers.write().progress(&my_pubkey, Instant::now()) {
-                        Err(channel_name) => {
+                    let (duration, events) = timers.write().progress(Instant::now());
+                    let my_pubkey = &cluster_info.id();
+                    for event in events {
+                        if let Err(channel_name) =
+                            blocking_send(my_pubkey, &event_sender, event, "votor_event_sender")
+                        {
                             warn!("{my_pubkey}: {channel_name} disconnected. Exiting");
                             exit.store(true, Ordering::Relaxed);
-                            break;
+                            return;
                         }
-                        Ok(None) => {
+                    }
+                    let duration = match duration {
+                        None => {
                             // No active timers, sleep for an arbitrary amount.
                             // This should be smaller than the minimum amount
                             // of time any newly added timers would take to expire.
                             Duration::from_millis(100)
                         }
-                        Ok(Some(next_fire)) => next_fire.duration_since(Instant::now()),
+                        Some(next_fire) => next_fire.duration_since(Instant::now()),
                     };
                     thread::park_timeout(duration);
                 }

--- a/votor/src/timer_manager/timers.rs
+++ b/votor/src/timer_manager/timers.rs
@@ -1,9 +1,7 @@
 use {
-    crate::{common::blocking_send, event::VotorEvent, timer_manager::stats::TimerManagerStats},
-    crossbeam_channel::Sender,
+    crate::{event::VotorEvent, timer_manager::stats::TimerManagerStats},
     solana_clock::Slot,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
-    solana_pubkey::Pubkey,
     solana_runtime::leader_schedule_utils::last_of_consecutive_leader_slots,
     std::{
         cmp::Reverse,
@@ -179,19 +177,16 @@ pub(super) struct Timers {
     timers: HashMap<Slot, TimerState>,
     /// A min heap based on the time the next timer state might be ready.
     heap: BinaryHeap<Reverse<(Instant, Slot)>>,
-    /// Channel to send events on.
-    event_sender: Sender<VotorEvent>,
     /// Stats for the timer manager.
     stats: TimerManagerStats,
 }
 
 impl Timers {
-    pub(super) fn new(delta_timeout: Duration, event_sender: Sender<VotorEvent>) -> Self {
+    pub(super) fn new(delta_timeout: Duration) -> Self {
         Self {
             delta_timeout,
             timers: HashMap::new(),
             heap: BinaryHeap::new(),
-            event_sender,
             stats: TimerManagerStats::new(),
         }
     }
@@ -231,12 +226,9 @@ impl Timers {
 
     /// Call to make progress on the timer states.  If there are still active
     /// timer states, returns when the earliest one might become ready.
-    pub(super) fn progress(
-        &mut self,
-        my_pubkey: &Pubkey,
-        now: Instant,
-    ) -> Result<Option<Instant>, &'static str> {
+    pub(super) fn progress(&mut self, now: Instant) -> (Option<Instant>, Vec<VotorEvent>) {
         assert_eq!(self.heap.len(), self.timers.len());
+        let mut ret_events = vec![];
         let mut ret_timeout = None;
         loop {
             assert_eq!(self.heap.len(), self.timers.len());
@@ -252,7 +244,7 @@ impl Timers {
 
                     let mut timer = self.timers.remove(&slot).unwrap();
                     if let Some(event) = timer.progress(now) {
-                        blocking_send(my_pubkey, &self.event_sender, event, "event_sender")?;
+                        ret_events.push(event);
                     }
                     if let Some(next_fire) = timer.next_fire() {
                         self.heap.push(Reverse((next_fire, slot)));
@@ -263,7 +255,7 @@ impl Timers {
                 }
             }
         }
-        Ok(ret_timeout)
+        (ret_timeout, ret_events)
     }
 
     #[cfg(test)]
@@ -279,10 +271,7 @@ impl Timers {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, crate::common::DELTA_TIMEOUT, crossbeam_channel::bounded,
-        solana_clock::DEFAULT_MS_PER_SLOT,
-    };
+    use {super::*, crate::common::DELTA_TIMEOUT, solana_clock::DEFAULT_MS_PER_SLOT};
 
     #[test]
     fn timer_state_machine() {
@@ -334,30 +323,34 @@ mod tests {
 
     #[test]
     fn timers_progress() {
-        let my_pubkey = Pubkey::new_unique();
         let one_micro = Duration::from_micros(1);
         let mut now = Instant::now();
-        let (sender, receiver) = bounded(1024);
-        let mut timers = Timers::new(one_micro, sender);
-        assert!(timers.progress(&my_pubkey, now).unwrap().is_none());
-        assert!(receiver.try_recv().unwrap_err().is_empty());
+        let mut timers = Timers::new(one_micro);
+        let (duration, events) = timers.progress(now);
+        assert!(duration.is_none());
+        assert!(events.is_empty());
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
 
         timers.set_timeouts(0, now, None, delta_block, delta_block);
-        while timers.progress(&my_pubkey, now).unwrap().is_some() {
-            now = now.checked_add(one_micro).unwrap();
-        }
-        let mut events = receiver.try_iter().collect::<Vec<_>>();
 
+        let mut all_events = vec![];
+        loop {
+            let (duration, mut events) = timers.progress(now);
+            all_events.append(&mut events);
+            now = now.checked_add(one_micro).unwrap();
+            if duration.is_none() {
+                break;
+            }
+        }
         assert!(matches!(
-            events.remove(0),
+            all_events.remove(0),
             VotorEvent::TimeoutCrashedLeader(0)
         ));
-        assert!(matches!(events.remove(0), VotorEvent::Timeout(0)));
-        assert!(matches!(events.remove(0), VotorEvent::Timeout(1)));
-        assert!(matches!(events.remove(0), VotorEvent::Timeout(2)));
-        assert!(matches!(events.remove(0), VotorEvent::Timeout(3)));
-        assert!(events.is_empty());
+        assert!(matches!(all_events.remove(0), VotorEvent::Timeout(0)));
+        assert!(matches!(all_events.remove(0), VotorEvent::Timeout(1)));
+        assert!(matches!(all_events.remove(0), VotorEvent::Timeout(2)));
+        assert!(matches!(all_events.remove(0), VotorEvent::Timeout(3)));
+        assert!(all_events.is_empty());
         let stats = timers.stats();
         assert_eq!(stats.set_timeout_count(), 1);
         assert_eq!(stats.set_timeout_succeed_count(), 1);


### PR DESCRIPTION
#### Problem

See: https://github.com/anza-xyz/agave/issues/14206.  Currently, we are doing a blocking send while holding a lock.  The main event handler loop can block on acquiring this lock.  If things are backed up, the votor can deadlock.


#### Summary of Changes

Does the blocking send after dropping the lock.


#### Testing

Just CI
