### PR TITLE
refactor(transaction-status): Route token account lookups through a checked helper

### DIFF
--- a/transaction-status/src/parse_instruction.rs
+++ b/transaction-status/src/parse_instruction.rs
@@ -153,6 +153,23 @@ pub(crate) fn check_num_accounts(
     }
 }
 
+// Resolves the `position`th entry of an instruction's account list to its key,
+// returning a key-mismatch error instead of panicking when the position or the
+// resolved account index is out of range.
+pub(crate) fn account_key<'a>(
+    account_keys: &'a AccountKeys,
+    account_indexes: &[u8],
+    position: usize,
+    parsable_program: ParsableProgram,
+) -> Result<&'a Pubkey, ParseInstructionError> {
+    account_indexes
+        .get(position)
+        .and_then(|index| account_keys.get(*index as usize))
+        .ok_or(ParseInstructionError::InstructionKeyMismatch(
+            parsable_program,
+        ))
+}
+
 #[cfg(test)]
 mod test {
     use {super::*, serde_json::json};
@@ -238,5 +255,22 @@ mod test {
             })
             .is_err(),
         );
+    }
+
+    #[test]
+    fn test_account_key() {
+        let keys = [Pubkey::new_unique(), Pubkey::new_unique()];
+        let account_keys = AccountKeys::new(&keys, None);
+        let account_indexes = [1u8, 0];
+
+        // position -> account index -> key
+        assert_eq!(
+            account_key(&account_keys, &account_indexes, 0, ParsableProgram::SplToken).unwrap(),
+            &keys[1],
+        );
+        // position past the end of the instruction's account list
+        assert!(account_key(&account_keys, &account_indexes, 2, ParsableProgram::SplToken).is_err());
+        // account index that points past account_keys
+        assert!(account_key(&account_keys, &[9u8], 0, ParsableProgram::SplToken).is_err());
     }
 }

--- a/transaction-status/src/parse_token.rs
+++ b/transaction-status/src/parse_token.rs
@@ -1,6 +1,6 @@
 use {
     crate::parse_instruction::{
-        ParsableProgram, ParseInstructionError, ParsedInstructionEnum, check_num_accounts,
+        ParsableProgram, ParseInstructionError, ParsedInstructionEnum, account_key, check_num_accounts,
     },
     extension::{
         confidential_mint_burn::*, confidential_transfer::*, confidential_transfer_fee::*,
@@ -49,10 +49,10 @@ pub fn parse_token(
             } => {
                 check_num_token_accounts(&instruction.accounts, 2)?;
                 let mut value = json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     "decimals": decimals,
                     "mintAuthority": mint_authority.to_string(),
-                    "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "rentSysvar": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 if let COption::Some(freeze_authority) = freeze_authority {
@@ -73,7 +73,7 @@ pub fn parse_token(
             } => {
                 check_num_token_accounts(&instruction.accounts, 1)?;
                 let mut value = json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     "decimals": decimals,
                     "mintAuthority": mint_authority.to_string(),
                 });
@@ -94,10 +94,10 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeAccount".to_string(),
                     info: json!({
-                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                        "owner": account_keys[instruction.accounts[2] as usize].to_string(),
-                        "rentSysvar": account_keys[instruction.accounts[3] as usize].to_string(),
+                        "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
+                        "owner": account_key(account_keys, &instruction.accounts, 2, ParsableProgram::SplToken)?.to_string(),
+                        "rentSysvar": account_key(account_keys, &instruction.accounts, 3, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
@@ -106,10 +106,10 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeAccount2".to_string(),
                     info: json!({
-                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                         "owner": owner.to_string(),
-                        "rentSysvar": account_keys[instruction.accounts[2] as usize].to_string(),
+                        "rentSysvar": account_key(account_keys, &instruction.accounts, 2, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
@@ -118,23 +118,25 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeAccount3".to_string(),
                     info: json!({
-                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                         "owner": owner.to_string(),
                     }),
                 })
             }
             TokenInstruction::InitializeMultisig { m } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
-                let mut signers: Vec<String> = vec![];
-                for i in instruction.accounts[2..].iter() {
-                    signers.push(account_keys[*i as usize].to_string());
-                }
+                let signers: Vec<String> = instruction
+                    .accounts
+                    .iter()
+                    .skip(2)
+                    .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                    .collect();
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeMultisig".to_string(),
                     info: json!({
-                        "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "rentSysvar": account_keys[instruction.accounts[1] as usize].to_string(),
+                        "multisig": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                        "rentSysvar": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                         "signers": signers,
                         "m": m,
                     }),
@@ -142,14 +144,16 @@ pub fn parse_token(
             }
             TokenInstruction::InitializeMultisig2 { m } => {
                 check_num_token_accounts(&instruction.accounts, 2)?;
-                let mut signers: Vec<String> = vec![];
-                for i in instruction.accounts[1..].iter() {
-                    signers.push(account_keys[*i as usize].to_string());
-                }
+                let signers: Vec<String> = instruction
+                    .accounts
+                    .iter()
+                    .skip(1)
+                    .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                    .collect();
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeMultisig2".to_string(),
                     info: json!({
-                        "multisig": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "multisig": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                         "signers": signers,
                         "m": m,
                     }),
@@ -159,8 +163,8 @@ pub fn parse_token(
             TokenInstruction::Transfer { amount } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "destination": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "amount": amount.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -180,8 +184,8 @@ pub fn parse_token(
             TokenInstruction::Approve { amount } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "delegate": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "delegate": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "amount": amount.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -201,7 +205,7 @@ pub fn parse_token(
             TokenInstruction::Revoke => {
                 check_num_token_accounts(&instruction.accounts, 2)?;
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 parse_signers(
@@ -242,7 +246,7 @@ pub fn parse_token(
                     AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
                 };
                 let mut value = json!({
-                    owned: account_keys[instruction.accounts[0] as usize].to_string(),
+                    owned: account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     "authorityType": Into::<UiAuthorityType>::into(authority_type),
                     "newAuthority": map_coption_pubkey(new_authority),
                 });
@@ -263,8 +267,8 @@ pub fn parse_token(
             TokenInstruction::MintTo { amount } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "account": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "amount": amount.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -284,8 +288,8 @@ pub fn parse_token(
             TokenInstruction::Burn { amount } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "amount": amount.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -305,8 +309,8 @@ pub fn parse_token(
             TokenInstruction::CloseAccount => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "destination": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 parse_signers(
@@ -325,8 +329,8 @@ pub fn parse_token(
             TokenInstruction::FreezeAccount => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 parse_signers(
@@ -345,8 +349,8 @@ pub fn parse_token(
             TokenInstruction::ThawAccount => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 parse_signers(
@@ -366,9 +370,9 @@ pub fn parse_token(
                 check_num_token_accounts(&instruction.accounts, 4)?;
                 let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
+                    "destination": account_key(account_keys, &instruction.accounts, 2, ParsableProgram::SplToken)?.to_string(),
                     "tokenAmount": token_amount_to_ui_amount_v3(amount, &additional_data),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -389,9 +393,9 @@ pub fn parse_token(
                 check_num_token_accounts(&instruction.accounts, 4)?;
                 let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
-                    "delegate": account_keys[instruction.accounts[2] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
+                    "delegate": account_key(account_keys, &instruction.accounts, 2, ParsableProgram::SplToken)?.to_string(),
                     "tokenAmount": token_amount_to_ui_amount_v3(amount, &additional_data),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -412,8 +416,8 @@ pub fn parse_token(
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
                 let mut value = json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "account": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "tokenAmount": token_amount_to_ui_amount_v3(amount, &additional_data),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -434,8 +438,8 @@ pub fn parse_token(
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
                 let mut value = json!({
-                    "account": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "mint": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                     "tokenAmount": token_amount_to_ui_amount_v3(amount, &additional_data),
                 });
                 let map = value.as_object_mut().unwrap();
@@ -457,14 +461,14 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "syncNative".to_string(),
                     info: json!({
-                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
             TokenInstruction::GetAccountDataSize { extension_types } => {
                 check_num_token_accounts(&instruction.accounts, 1)?;
                 let mut value = json!({
-                    "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                    "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 if !extension_types.is_empty() {
@@ -488,7 +492,7 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeImmutableOwner".to_string(),
                     info: json!({
-                        "account": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "account": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
@@ -497,7 +501,7 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "amountToUiAmount".to_string(),
                     info: json!({
-                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                         "amount": amount.to_string(),
                     }),
                 })
@@ -507,7 +511,7 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "uiAmountToAmount".to_string(),
                     info: json!({
-                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                         "uiAmount": ui_amount,
                     }),
                 })
@@ -563,9 +567,9 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "createNativeMint".to_string(),
                     info: json!({
-                        "payer": account_keys[instruction.accounts[0] as usize].to_string(),
-                        "nativeMint": account_keys[instruction.accounts[1] as usize].to_string(),
-                        "systemProgram": account_keys[instruction.accounts[2] as usize].to_string(),
+                        "payer": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                        "nativeMint": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
+                        "systemProgram": account_key(account_keys, &instruction.accounts, 2, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
@@ -574,7 +578,7 @@ pub fn parse_token(
                 Ok(ParsedInstructionEnum {
                     instruction_type: "initializeNonTransferableMint".to_string(),
                     info: json!({
-                        "mint": account_keys[instruction.accounts[0] as usize].to_string(),
+                        "mint": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
                     }),
                 })
             }
@@ -636,8 +640,8 @@ pub fn parse_token(
             TokenInstruction::WithdrawExcessLamports => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "destination": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 parse_signers(
@@ -709,8 +713,8 @@ pub fn parse_token(
             TokenInstruction::UnwrapLamports { amount } => {
                 check_num_token_accounts(&instruction.accounts, 3)?;
                 let mut value = json!({
-                    "source": account_keys[instruction.accounts[0] as usize].to_string(),
-                    "destination": account_keys[instruction.accounts[1] as usize].to_string(),
+                    "source": account_key(account_keys, &instruction.accounts, 0, ParsableProgram::SplToken)?.to_string(),
+                    "destination": account_key(account_keys, &instruction.accounts, 1, ParsableProgram::SplToken)?.to_string(),
                 });
                 let map = value.as_object_mut().unwrap();
                 if let COption::Some(amount) = amount {
@@ -942,21 +946,21 @@ fn parse_signers(
     owner_field_name: &str,
     multisig_field_name: &str,
 ) {
+    let owner = accounts
+        .get(last_nonsigner_index)
+        .and_then(|i| account_keys.get(*i as usize));
     if accounts.len() > last_nonsigner_index + 1 {
-        let mut signers: Vec<String> = vec![];
-        for i in accounts[last_nonsigner_index + 1..].iter() {
-            signers.push(account_keys[*i as usize].to_string());
+        let signers: Vec<String> = accounts
+            .iter()
+            .skip(last_nonsigner_index + 1)
+            .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+            .collect();
+        if let Some(multisig) = owner {
+            map.insert(multisig_field_name.to_string(), json!(multisig.to_string()));
         }
-        map.insert(
-            multisig_field_name.to_string(),
-            json!(account_keys[accounts[last_nonsigner_index] as usize].to_string()),
-        );
         map.insert("signers".to_string(), json!(signers));
-    } else {
-        map.insert(
-            owner_field_name.to_string(),
-            json!(account_keys[accounts[last_nonsigner_index] as usize].to_string()),
-        );
+    } else if let Some(owner) = owner {
+        map.insert(owner_field_name.to_string(), json!(owner.to_string()));
     }
 }
 

--- a/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
+++ b/transaction-status/src/parse_token/extension/confidential_mint_burn.rs
@@ -21,7 +21,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "supplyElGamalPubkey": initialize_mint_data.supply_elgamal_pubkey.to_string(),
                 "decryptableSupply": initialize_mint_data.decryptable_supply.to_string(),
             });
@@ -37,7 +37,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "newDecryptableSupply": update_decryptable_supply.new_decryptable_supply.to_string(),
 
             });
@@ -62,7 +62,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "newSupplyElGamalPubkey": rotate_supply_data.new_supply_elgamal_pubkey.to_string(),
                 "proofInstructionOffset": rotate_supply_data.proof_instruction_offset,
 
@@ -74,12 +74,12 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                 if rotate_supply_data.proof_instruction_offset == 0 {
                     map.insert(
                         "proofContextStateAccount".to_string(),
-                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                        json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                     );
                 } else {
                     map.insert(
                         "instructionsSysvar".to_string(),
-                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                        json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                     );
                 }
             }
@@ -104,8 +104,8 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "destination": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "destination": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "newDecryptableSupply": mint_data.new_decryptable_supply.to_string(),
                 "equalityProofInstructionOffset": mint_data.equality_proof_instruction_offset,
                 "ciphertextValidityProofInstructionOffset": mint_data.ciphertext_validity_proof_instruction_offset,
@@ -121,7 +121,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -131,7 +131,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -140,7 +140,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "ciphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -149,7 +149,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -174,8 +174,8 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "destination": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "destination": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "newDecryptableAvailableBalance": burn_data.new_decryptable_available_balance.to_string(),
                 "equalityProofInstructionOffset": burn_data.equality_proof_instruction_offset,
                 "ciphertextValidityProofInstructionOffset": burn_data.ciphertext_validity_proof_instruction_offset,
@@ -191,7 +191,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -201,7 +201,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -210,7 +210,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "ciphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -219,7 +219,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -240,7 +240,7 @@ pub(in crate::parse_token) fn parse_confidential_mint_burn_instruction(
         ConfidentialMintBurnInstruction::ApplyPendingBurn => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             parse_signers(

--- a/transaction-status/src/parse_token/extension/confidential_transfer.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer.rs
@@ -22,7 +22,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "autoApproveNewAccounts": bool::from(initialize_mint_data.auto_approve_new_accounts),
                 "auditorElGamalPubkey": Option::<PodElGamalPubkey>::from(initialize_mint_data.auditor_elgamal_pubkey).map(|k| k.to_string()),
             });
@@ -42,8 +42,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
-                "confidentialTransferMintAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "confidentialTransferMintAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "autoApproveNewAccounts": bool::from(update_mint_data.auto_approve_new_accounts),
                 "auditorElGamalPubkey": Option::<PodElGamalPubkey>::from(update_mint_data.auditor_elgamal_pubkey).map(|k| k.to_string()),
             });
@@ -62,8 +62,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 .maximum_pending_balance_credit_counter
                 .into();
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "decryptableZeroBalance": format!("{}", configure_account_data.decryptable_zero_balance),
                 "maximumPendingBalanceCreditCounter": maximum_pending_balance_credit_counter,
                 "proofInstructionOffset": configure_account_data.proof_instruction_offset,
@@ -74,12 +74,12 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             if configure_account_data.proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string()),
                 );
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string()),
                 );
             }
 
@@ -101,9 +101,9 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: "approveConfidentialTransferAccount".to_string(),
                 info: json!({
-                    "account": account_keys[account_indexes[0] as usize].to_string(),
-                    "mint": account_keys[account_indexes[1] as usize].to_string(),
-                    "confidentialTransferAuditorAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                    "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                    "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                    "confidentialTransferAuditorAuthority": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 }),
             })
         }
@@ -115,7 +115,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 })?;
             let proof_instruction_offset: i8 = empty_account_data.proof_instruction_offset;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "proofInstructionOffset": proof_instruction_offset,
 
             });
@@ -124,12 +124,12 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             if proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[1] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string()),
                 );
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[1] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string()),
                 );
             }
 
@@ -154,8 +154,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             })?;
             let amount: u64 = deposit_data.amount.into();
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "amount": amount,
                 "decimals": deposit_data.decimals,
 
@@ -182,8 +182,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 })?;
             let amount: u64 = withdrawal_data.amount.into();
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "amount": amount,
                 "decimals": withdrawal_data.decimals,
                 "newDecryptableAvailableBalance": format!("{}", withdrawal_data.new_decryptable_available_balance),
@@ -200,7 +200,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -210,7 +210,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -220,7 +220,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -245,9 +245,9 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "destination": account_keys[account_indexes[2] as usize].to_string(),
+                "source": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "destination": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "newSourceDecryptableAvailableBalance": format!("{}", transfer_data.new_source_decryptable_available_balance),
                 "equalityProofInstructionOffset": transfer_data.equality_proof_instruction_offset,
                 "ciphertextValidityProofInstructionOffset": transfer_data.ciphertext_validity_proof_instruction_offset,
@@ -263,7 +263,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -273,7 +273,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -283,7 +283,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "ciphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -293,7 +293,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -327,9 +327,9 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 transfer_data.fee_ciphertext_validity_proof_instruction_offset;
             let range_proof_instruction_offset: i8 = transfer_data.range_proof_instruction_offset;
             let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "destination": account_keys[account_indexes[2] as usize].to_string(),
+                "source": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "destination": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "newSourceDecryptableAvailableBalance": format!("{}", transfer_data.new_source_decryptable_available_balance),
                 "equalityProofInstructionOffset": equality_proof_instruction_offset,
                 "transferAmountCiphertextValidityProofInstructionOffset": transfer_amount_ciphertext_validity_proof_instruction_offset,
@@ -349,7 +349,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -359,7 +359,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -368,7 +368,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "transferAmountCiphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -377,7 +377,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "feeSigmaProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -386,7 +386,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "feeCiphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -395,7 +395,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -423,7 +423,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
                 .expected_pending_balance_credit_counter
                 .into();
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "newDecryptableAvailableBalance": format!("{}", apply_pending_balance_data.new_decryptable_available_balance),
                 "expectedPendingBalanceCreditCounter": expected_pending_balance_credit_counter,
 
@@ -445,7 +445,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
         ConfidentialTransferInstruction::EnableConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
@@ -465,7 +465,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
         ConfidentialTransferInstruction::DisableConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
@@ -485,7 +485,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
         ConfidentialTransferInstruction::EnableNonConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
@@ -505,7 +505,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
         ConfidentialTransferInstruction::DisableNonConfidentialCredits => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
@@ -525,9 +525,9 @@ pub(in crate::parse_token) fn parse_confidential_transfer_instruction(
         ConfidentialTransferInstruction::ConfigureAccountWithRegistry => {
             check_num_token_accounts(account_indexes, 3)?;
             let value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "registry": account_keys[account_indexes[2] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "registry": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "configureConfidentialAccountWithRegistry".to_string(),

--- a/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/confidential_transfer_fee.rs
@@ -22,7 +22,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "withdrawWithheldAuthorityElGamalPubkey": Option::<PodElGamalPubkey>::from(transfer_fee_config.withdraw_withheld_authority_elgamal_pubkey).map(|k| k.to_string()),
             });
             let map = value.as_object_mut().unwrap();
@@ -42,8 +42,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
                 })?;
             let proof_instruction_offset: i8 = withdraw_withheld_data.proof_instruction_offset;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
-                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "feeRecipient": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "proofInstructionOffset": proof_instruction_offset,
                 "newDecryptableAvailableBalance": format!("{}", withdraw_withheld_data.new_decryptable_available_balance),
             });
@@ -53,12 +53,12 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
                 if proof_instruction_offset == 0 {
                     map.insert(
                         "proofContextStateAccount".to_string(),
-                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                        json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                     );
                 } else {
                     map.insert(
                         "instructionsSysvar".to_string(),
-                        json!(account_keys[account_indexes[offset] as usize].to_string()),
+                        json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                     );
                 }
                 offset += 1;
@@ -86,8 +86,8 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
             check_num_token_accounts(account_indexes, 4 + num_token_accounts as usize)?;
             let proof_instruction_offset: i8 = withdraw_withheld_data.proof_instruction_offset;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
-                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "feeRecipient": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "proofInstructionOffset": proof_instruction_offset,
                 "newDecryptableAvailableBalance": format!("{}", withdraw_withheld_data.new_decryptable_available_balance),
             });
@@ -98,18 +98,19 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
             if proof_instruction_offset == 0 {
                 map.insert(
                     "proofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string()),
                 );
             } else {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[2] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string()),
                 );
             }
-            let mut source_accounts: Vec<String> = vec![];
-            for i in account_indexes[first_source_account_index..].iter() {
-                source_accounts.push(account_keys[*i as usize].to_string());
-            }
+            let source_accounts: Vec<String> = account_indexes
+                .iter()
+                .skip(first_source_account_index)
+                .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                .collect();
             map.insert("sourceAccounts".to_string(), json!(source_accounts));
             parse_signers(
                 map,
@@ -128,14 +129,15 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
         ConfidentialTransferFeeInstruction::HarvestWithheldTokensToMint => {
             check_num_token_accounts(account_indexes, 1)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
-            let mut source_accounts: Vec<String> = vec![];
-            for i in account_indexes.iter().skip(1) {
-                source_accounts.push(account_keys[*i as usize].to_string());
-            }
+            let source_accounts: Vec<String> = account_indexes
+                .iter()
+                .skip(1)
+                .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                .collect();
             map.insert("sourceAccounts".to_string(), json!(source_accounts));
             Ok(ParsedInstructionEnum {
                 instruction_type: "harvestWithheldConfidentialTransferTokensToMint".to_string(),
@@ -145,7 +147,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
         ConfidentialTransferFeeInstruction::EnableHarvestToMint => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();
@@ -165,7 +167,7 @@ pub(in crate::parse_token) fn parse_confidential_transfer_fee_instruction(
         ConfidentialTransferFeeInstruction::DisableHarvestToMint => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
 
             });
             let map = value.as_object_mut().unwrap();

--- a/transaction-status/src/parse_token/extension/cpi_guard.rs
+++ b/transaction-status/src/parse_token/extension/cpi_guard.rs
@@ -19,7 +19,7 @@ pub(in crate::parse_token) fn parse_cpi_guard_instruction(
         CpiGuardInstruction::Disable => "disable",
     };
     let mut value = json!({
-        "account": account_keys[account_indexes[0] as usize].to_string(),
+        "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
     });
     let map = value.as_object_mut().unwrap();
     parse_signers(

--- a/transaction-status/src/parse_token/extension/default_account_state.rs
+++ b/transaction-status/src/parse_token/extension/default_account_state.rs
@@ -22,7 +22,7 @@ pub(in crate::parse_token) fn parse_default_account_state_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: format!("initialize{instruction_type}"),
                 info: json!({
-                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                     "accountState": convert_account_state(account_state),
                 }),
             })
@@ -30,7 +30,7 @@ pub(in crate::parse_token) fn parse_default_account_state_instruction(
         DefaultAccountStateInstruction::Update => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "accountState": convert_account_state(account_state),
             });
             let map = value.as_object_mut().unwrap();

--- a/transaction-status/src/parse_token/extension/group_member_pointer.rs
+++ b/transaction-status/src/parse_token/extension/group_member_pointer.rs
@@ -23,7 +23,7 @@ pub(in crate::parse_token) fn parse_group_member_pointer_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(authority) = Option::<Pubkey>::from(authority) {
@@ -47,7 +47,7 @@ pub(in crate::parse_token) fn parse_group_member_pointer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(member_address) = Option::<Pubkey>::from(member_address) {

--- a/transaction-status/src/parse_token/extension/group_pointer.rs
+++ b/transaction-status/src/parse_token/extension/group_pointer.rs
@@ -23,7 +23,7 @@ pub(in crate::parse_token) fn parse_group_pointer_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(authority) = Option::<Pubkey>::from(authority) {
@@ -44,7 +44,7 @@ pub(in crate::parse_token) fn parse_group_pointer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(group_address) = Option::<Pubkey>::from(group_address) {

--- a/transaction-status/src/parse_token/extension/interest_bearing_mint.rs
+++ b/transaction-status/src/parse_token/extension/interest_bearing_mint.rs
@@ -29,7 +29,7 @@ pub(in crate::parse_token) fn parse_interest_bearing_mint_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializeInterestBearingConfig".to_string(),
                 info: json!({
-                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                     "rateAuthority": rate_authority.map(|pubkey| pubkey.to_string()),
                     "rate": i16::from(rate),
                 }),
@@ -42,7 +42,7 @@ pub(in crate::parse_token) fn parse_interest_bearing_mint_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "newRate": i16::from(new_rate),
             });
             let map = value.as_object_mut().unwrap();

--- a/transaction-status/src/parse_token/extension/memo_transfer.rs
+++ b/transaction-status/src/parse_token/extension/memo_transfer.rs
@@ -19,7 +19,7 @@ pub(in crate::parse_token) fn parse_memo_transfer_instruction(
         RequiredMemoTransfersInstruction::Disable => "disable",
     };
     let mut value = json!({
-        "account": account_keys[account_indexes[0] as usize].to_string(),
+        "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
     });
     let map = value.as_object_mut().unwrap();
     parse_signers(

--- a/transaction-status/src/parse_token/extension/metadata_pointer.rs
+++ b/transaction-status/src/parse_token/extension/metadata_pointer.rs
@@ -23,7 +23,7 @@ pub(in crate::parse_token) fn parse_metadata_pointer_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(authority) = Option::<Pubkey>::from(authority) {
@@ -47,7 +47,7 @@ pub(in crate::parse_token) fn parse_metadata_pointer_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(metadata_address) = Option::<Pubkey>::from(metadata_address) {

--- a/transaction-status/src/parse_token/extension/mint_close_authority.rs
+++ b/transaction-status/src/parse_token/extension/mint_close_authority.rs
@@ -9,7 +9,7 @@ pub(in crate::parse_token) fn parse_initialize_mint_close_authority_instruction(
     Ok(ParsedInstructionEnum {
         instruction_type: "initializeMintCloseAuthority".to_string(),
         info: json!({
-            "mint": account_keys[account_indexes[0] as usize].to_string(),
+            "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             "newAuthority": map_coption_pubkey(close_authority),
         }),
     })

--- a/transaction-status/src/parse_token/extension/pausable.rs
+++ b/transaction-status/src/parse_token/extension/pausable.rs
@@ -24,7 +24,7 @@ pub(in crate::parse_token) fn parse_pausable_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializePausableConfig".to_string(),
                 info: json!({
-                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                     "authority": authority.map(|pubkey| pubkey.to_string()),
                 }),
             })
@@ -32,7 +32,7 @@ pub(in crate::parse_token) fn parse_pausable_instruction(
         PausableInstruction::Pause => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             parse_signers(
@@ -51,7 +51,7 @@ pub(in crate::parse_token) fn parse_pausable_instruction(
         PausableInstruction::Resume => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             parse_signers(

--- a/transaction-status/src/parse_token/extension/permanent_delegate.rs
+++ b/transaction-status/src/parse_token/extension/permanent_delegate.rs
@@ -9,7 +9,7 @@ pub(in crate::parse_token) fn parse_initialize_permanent_delegate_instruction(
     Ok(ParsedInstructionEnum {
         instruction_type: "initializePermanentDelegate".to_string(),
         info: json!({
-            "mint": account_keys[account_indexes[0] as usize].to_string(),
+            "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             "delegate": delegate.to_string(),
         }),
     })

--- a/transaction-status/src/parse_token/extension/permissioned_burn.rs
+++ b/transaction-status/src/parse_token/extension/permissioned_burn.rs
@@ -29,7 +29,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializePermissionedBurnConfig".to_string(),
                 info: json!({
-                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                     "authority": authority.to_string(),
                 }),
             })
@@ -41,9 +41,9 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "permissionedBurnAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "permissionedBurnAuthority": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "amount": u64::from(amount).to_string(),
             });
             let map = value.as_object_mut().unwrap();
@@ -68,9 +68,9 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
                 })?;
             let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "permissionedBurnAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "permissionedBurnAuthority": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "tokenAmount": token_amount_to_ui_amount_v3(u64::from(amount), &additional_data),
             });
             let map = value.as_object_mut().unwrap();
@@ -94,8 +94,8 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
                     ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
                 })?;
             let mut value = json!({
-                "account": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
+                "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "newDecryptableAvailableBalance": burn_data.new_decryptable_available_balance.to_string(),
                 "equalityProofInstructionOffset": burn_data.equality_proof_instruction_offset,
                 "ciphertextValidityProofInstructionOffset": burn_data.ciphertext_validity_proof_instruction_offset,
@@ -115,7 +115,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             if has_sysvar && offset < account_indexes.len().saturating_sub(2) {
                 map.insert(
                     "instructionsSysvar".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -125,7 +125,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             {
                 map.insert(
                     "equalityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -135,7 +135,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             {
                 map.insert(
                     "ciphertextValidityProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -145,7 +145,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             {
                 map.insert(
                     "rangeProofContextStateAccount".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }
@@ -153,7 +153,7 @@ pub(in crate::parse_token) fn parse_permissioned_burn_instruction(
             if offset < account_indexes.len().saturating_sub(1) {
                 map.insert(
                     "permissionedBurnAuthority".to_string(),
-                    json!(account_keys[account_indexes[offset] as usize].to_string()),
+                    json!(account_key(account_keys, account_indexes, offset, ParsableProgram::SplToken)?.to_string()),
                 );
                 offset += 1;
             }

--- a/transaction-status/src/parse_token/extension/reallocate.rs
+++ b/transaction-status/src/parse_token/extension/reallocate.rs
@@ -7,9 +7,9 @@ pub(in crate::parse_token) fn parse_reallocate_instruction(
 ) -> Result<ParsedInstructionEnum, ParseInstructionError> {
     check_num_token_accounts(account_indexes, 4)?;
     let mut value = json!({
-        "account": account_keys[account_indexes[0] as usize].to_string(),
-        "payer": account_keys[account_indexes[1] as usize].to_string(),
-        "systemProgram": account_keys[account_indexes[2] as usize].to_string(),
+        "account": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+        "payer": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+        "systemProgram": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
         "extensionTypes": extension_types.into_iter().map(UiExtensionType::from).collect::<Vec<_>>(),
     });
     let map = value.as_object_mut().unwrap();

--- a/transaction-status/src/parse_token/extension/scaled_ui_amount.rs
+++ b/transaction-status/src/parse_token/extension/scaled_ui_amount.rs
@@ -29,7 +29,7 @@ pub(in crate::parse_token) fn parse_scaled_ui_amount_instruction(
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializeScaledUiAmountConfig".to_string(),
                 info: json!({
-                    "mint": account_keys[account_indexes[0] as usize].to_string(),
+                    "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                     "authority": authority.map(|pubkey| pubkey.to_string()),
                     "multiplier": f64::from(multiplier).to_string(),
                 }),
@@ -44,7 +44,7 @@ pub(in crate::parse_token) fn parse_scaled_ui_amount_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "newMultiplier": f64::from(multiplier).to_string(),
                 "newMultiplierTimestamp": i64::from(effective_timestamp),
             });

--- a/transaction-status/src/parse_token/extension/token_group.rs
+++ b/transaction-status/src/parse_token/extension/token_group.rs
@@ -18,10 +18,10 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
                 update_authority,
             } = group;
             let value = json!({
-                "group": account_keys[account_indexes[0] as usize].to_string(),
+                "group": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "maxSize": u64::from(*max_size),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "mintAuthority": account_keys[account_indexes[2] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "mintAuthority": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "updateAuthority": Option::<Pubkey>::from(*update_authority).map(|v| v.to_string())
             });
             Ok(ParsedInstructionEnum {
@@ -33,9 +33,9 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
             check_num_token_accounts(account_indexes, 2)?;
             let UpdateGroupMaxSize { max_size } = update;
             let value = json!({
-                "group": account_keys[account_indexes[0] as usize].to_string(),
+                "group": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "maxSize": u64::from(*max_size),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "updateTokenGroupMaxSize".to_string(),
@@ -46,8 +46,8 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
             check_num_token_accounts(account_indexes, 2)?;
             let UpdateGroupAuthority { new_authority } = update;
             let value = json!({
-                "group": account_keys[account_indexes[0] as usize].to_string(),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "group": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "newAuthority": Option::<Pubkey>::from(*new_authority).map(|v| v.to_string())
             });
             Ok(ParsedInstructionEnum {
@@ -58,11 +58,11 @@ pub(in crate::parse_token) fn parse_token_group_instruction(
         TokenGroupInstruction::InitializeMember(_) => {
             check_num_token_accounts(account_indexes, 5)?;
             let value = json!({
-                "member": account_keys[account_indexes[0] as usize].to_string(),
-                "memberMint": account_keys[account_indexes[1] as usize].to_string(),
-                "memberMintAuthority": account_keys[account_indexes[2] as usize].to_string(),
-                "group": account_keys[account_indexes[3] as usize].to_string(),
-                "groupUpdateAuthority": account_keys[account_indexes[4] as usize].to_string(),
+                "member": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "memberMint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "memberMintAuthority": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
+                "group": account_key(account_keys, account_indexes, 3, ParsableProgram::SplToken)?.to_string(),
+                "groupUpdateAuthority": account_key(account_keys, account_indexes, 4, ParsableProgram::SplToken)?.to_string(),
             });
             Ok(ParsedInstructionEnum {
                 instruction_type: "initializeTokenGroupMember".to_string(),

--- a/transaction-status/src/parse_token/extension/token_metadata.rs
+++ b/transaction-status/src/parse_token/extension/token_metadata.rs
@@ -27,10 +27,10 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             check_num_token_accounts(account_indexes, 4)?;
             let Initialize { name, symbol, uri } = metadata;
             let value = json!({
-                "metadata": account_keys[account_indexes[0] as usize].to_string(),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
-                "mint": account_keys[account_indexes[2] as usize].to_string(),
-                "mintAuthority": account_keys[account_indexes[3] as usize].to_string(),
+                "metadata": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
+                "mintAuthority": account_key(account_keys, account_indexes, 3, ParsableProgram::SplToken)?.to_string(),
                 "name": name,
                 "symbol": symbol,
                 "uri": uri,
@@ -44,8 +44,8 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             check_num_token_accounts(account_indexes, 2)?;
             let UpdateField { field, value } = update;
             let value = json!({
-                "metadata": account_keys[account_indexes[0] as usize].to_string(),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "metadata": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "field": token_metadata_field_to_string(field),
                 "value": value,
             });
@@ -58,8 +58,8 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             check_num_token_accounts(account_indexes, 2)?;
             let RemoveKey { key, idempotent } = remove;
             let value = json!({
-                "metadata": account_keys[account_indexes[0] as usize].to_string(),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "metadata": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "key": key,
                 "idempotent": *idempotent,
             });
@@ -72,8 +72,8 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             check_num_token_accounts(account_indexes, 2)?;
             let UpdateAuthority { new_authority } = update;
             let value = json!({
-                "metadata": account_keys[account_indexes[0] as usize].to_string(),
-                "updateAuthority": account_keys[account_indexes[1] as usize].to_string(),
+                "metadata": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "updateAuthority": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
                 "newAuthority": Option::<Pubkey>::from(*new_authority).map(|v| v.to_string()),
             });
             Ok(ParsedInstructionEnum {
@@ -85,7 +85,7 @@ pub(in crate::parse_token) fn parse_token_metadata_instruction(
             check_num_token_accounts(account_indexes, 1)?;
             let Emit { start, end } = emit;
             let mut value = json!({
-                "metadata": account_keys[account_indexes[0] as usize].to_string(),
+                "metadata": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(start) = *start {

--- a/transaction-status/src/parse_token/extension/transfer_fee.rs
+++ b/transaction-status/src/parse_token/extension/transfer_fee.rs
@@ -19,7 +19,7 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
         } => {
             check_num_token_accounts(account_indexes, 1)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "transferFeeBasisPoints": transfer_fee_basis_points,
                 "maximumFee": maximum_fee,
             });
@@ -49,9 +49,9 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
             check_num_token_accounts(account_indexes, 4)?;
             let additional_data = SplTokenAdditionalDataV2::with_decimals(decimals);
             let mut value = json!({
-                "source": account_keys[account_indexes[0] as usize].to_string(),
-                "mint": account_keys[account_indexes[1] as usize].to_string(),
-                "destination": account_keys[account_indexes[2] as usize].to_string(),
+                "source": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "mint": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
+                "destination": account_key(account_keys, account_indexes, 2, ParsableProgram::SplToken)?.to_string(),
                 "tokenAmount": token_amount_to_ui_amount_v3(amount, &additional_data),
                 "feeAmount": token_amount_to_ui_amount_v3(fee, &additional_data),
             });
@@ -72,8 +72,8 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
         TransferFeeInstruction::WithdrawWithheldTokensFromMint => {
             check_num_token_accounts(account_indexes, 3)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
-                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "feeRecipient": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             parse_signers(
@@ -92,17 +92,18 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
         TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts } => {
             check_num_token_accounts(account_indexes, 3 + num_token_accounts as usize)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
-                "feeRecipient": account_keys[account_indexes[1] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
+                "feeRecipient": account_key(account_keys, account_indexes, 1, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
-            let mut source_accounts: Vec<String> = vec![];
             let first_source_account_index = account_indexes
                 .len()
                 .saturating_sub(num_token_accounts as usize);
-            for i in account_indexes[first_source_account_index..].iter() {
-                source_accounts.push(account_keys[*i as usize].to_string());
-            }
+            let source_accounts: Vec<String> = account_indexes
+                .iter()
+                .skip(first_source_account_index)
+                .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                .collect();
             map.insert("sourceAccounts".to_string(), json!(source_accounts));
             parse_signers(
                 map,
@@ -120,13 +121,14 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
         TransferFeeInstruction::HarvestWithheldTokensToMint => {
             check_num_token_accounts(account_indexes, 1)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
-            let mut source_accounts: Vec<String> = vec![];
-            for i in account_indexes.iter().skip(1) {
-                source_accounts.push(account_keys[*i as usize].to_string());
-            }
+            let source_accounts: Vec<String> = account_indexes
+                .iter()
+                .skip(1)
+                .filter_map(|i| account_keys.get(*i as usize).map(ToString::to_string))
+                .collect();
             map.insert("sourceAccounts".to_string(), json!(source_accounts));
             Ok(ParsedInstructionEnum {
                 instruction_type: "harvestWithheldTokensToMint".to_string(),
@@ -139,7 +141,7 @@ pub(in crate::parse_token) fn parse_transfer_fee_instruction(
         } => {
             check_num_token_accounts(account_indexes, 2)?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
                 "transferFeeBasisPoints": transfer_fee_basis_points,
                 "maximumFee": maximum_fee,
             });

--- a/transaction-status/src/parse_token/extension/transfer_hook.rs
+++ b/transaction-status/src/parse_token/extension/transfer_hook.rs
@@ -23,7 +23,7 @@ pub(in crate::parse_token) fn parse_transfer_hook_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(authority) = Option::<Pubkey>::from(authority) {
@@ -44,7 +44,7 @@ pub(in crate::parse_token) fn parse_transfer_hook_instruction(
                 ParseInstructionError::InstructionNotParsable(ParsableProgram::SplToken)
             })?;
             let mut value = json!({
-                "mint": account_keys[account_indexes[0] as usize].to_string(),
+                "mint": account_key(account_keys, account_indexes, 0, ParsableProgram::SplToken)?.to_string(),
             });
             let map = value.as_object_mut().unwrap();
             if let Some(program_id) = Option::<Pubkey>::from(program_id) {


### PR DESCRIPTION
Replaces the account_keys[account_indexes[i] as usize] index notation across the SPL Token instruction parser (parse_token plus its extensions) with a shared account_key helper that returns InstructionKeyMismatch, so each lookup is safe on its own instead of relying on the bounds guard at the top of parse_token being obvious at every call site.

note: This is a readability and defense in depth change, not actually a panic fix. parse_token already rejects any instruction whose max account index falls outside account_keys, so the old index notation could not actually panic. Making the accesses locally safe was the substance of the review feedback on the permissioned burn work (https://github.com/anza-xyz/agave/pull/14009). The variable length account lists (signers, source accounts) move to get and filter_map for the same reason.

Includes a unit test for the helper. Scope stays on the token parser: the other program parsers keep the existing pattern for now.
