### PR TITLE
Add tombstones during index generation

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -169,6 +169,7 @@ impl AccountStorageEntry {
 
     /// Insert offsets into the zero lamport single ref account offset set.
     /// Return the number of new offsets that were inserted.
+    #[cfg(test)]
     pub(crate) fn batch_insert_zero_lamport_single_ref_account_offsets(
         &self,
         offsets: &[Offset],

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -422,10 +422,15 @@ struct IndexGenerationAccumulator {
     /// The number of accounts in this slot that were skipped when generating the index as they
     /// were already marked obsolete in the account storage entry
     num_obsolete_accounts_skipped: u64,
+    /// Pubkeys of the zero-lamport accounts encountered while scanning, grouped by index bin. After
+    /// older versions are resolved, those whose surviving entry is still a single-ref zero-lamport
+    /// are removed from the index and recorded as tombstones. Bucketing by bin as we accumulate
+    /// lets the tombstone pass consume the buckets directly, avoiding a second full-sized copy.
+    zero_lamport_pubkeys_by_bin: Vec<Vec<Pubkey>>,
     slot_arena: IndexGenerationSlotArena,
 }
 impl IndexGenerationAccumulator {
-    fn with_slots_capacity(num_slots: usize) -> Self {
+    fn with_slots_capacity(num_slots: usize, bins: usize) -> Self {
         Self {
             insert_time_us: 0,
             num_accounts: 0,
@@ -439,6 +444,7 @@ impl IndexGenerationAccumulator {
             lt_hash: LtHash::identity(),
             capitalization: 0,
             num_obsolete_accounts_skipped: 0,
+            zero_lamport_pubkeys_by_bin: vec![Vec::new(); bins],
             slot_arena: IndexGenerationSlotArena::default(),
         }
     }
@@ -458,6 +464,13 @@ impl IndexGenerationAccumulator {
             .checked_add(other.capitalization)
             .expect("capitalization cannot overflow");
         self.num_obsolete_accounts_skipped += other.num_obsolete_accounts_skipped;
+        for (pubkeys, mut other_pubkeys) in self
+            .zero_lamport_pubkeys_by_bin
+            .iter_mut()
+            .zip(other.zero_lamport_pubkeys_by_bin)
+        {
+            pubkeys.append(&mut other_pubkeys);
+        }
         self.storage_info.append(&mut other.storage_info);
     }
 }
@@ -468,14 +481,12 @@ impl IndexGenerationAccumulator {
 #[derive(Debug, Default)]
 struct IndexGenerationSlotArena {
     keyed_account_infos: Vec<(Pubkey, AccountInfo)>,
-    zero_lamport_offsets: Vec<usize>,
 }
 
 impl IndexGenerationSlotArena {
     /// Makes sure no actual items are stored in the allocated data structures
     fn ensure_empty(&mut self) {
         assert!(self.keyed_account_infos.is_empty(), "should be drained");
-        self.zero_lamport_offsets.clear();
     }
 }
 
@@ -513,6 +524,11 @@ struct GenerateIndexTimings {
     pub num_obsolete_accounts_marked: u64,
     pub num_slots_removed_as_obsolete: u64,
     pub num_obsolete_accounts_skipped: u64,
+    pub create_tombstones_us: u64,
+    /// Number of zero-lamport account versions collected during the scan and fed into the tombstone
+    /// pass (i.e. the candidate set, before single-ref filtering). Duplicates are included.
+    pub num_zero_lamport_pubkeys: u64,
+    pub num_tombstones_created: u64,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -595,6 +611,13 @@ impl GenerateIndexTimings {
                 self.num_obsolete_accounts_skipped,
                 i64
             ),
+            ("create_tombstones_us", self.create_tombstones_us, i64),
+            (
+                "num_zero_lamport_pubkeys",
+                self.num_zero_lamport_pubkeys,
+                i64
+            ),
+            ("num_tombstones_created", self.num_tombstones_created, i64),
         );
     }
 }
@@ -5714,7 +5737,7 @@ impl AccountsDb {
         let mut all_accounts_are_zero_lamports = true;
         accum.slot_arena.ensure_empty();
         let keyed_account_infos = &mut accum.slot_arena.keyed_account_infos;
-        let zero_lamport_offsets = &mut accum.slot_arena.zero_lamport_offsets;
+        let zero_lamport_pubkeys_by_bin = &mut accum.zero_lamport_pubkeys_by_bin;
 
         let geyser_notifier = self
             .accounts_update_notifier
@@ -5740,9 +5763,15 @@ impl AccountsDb {
                     accounts_data_len += data_len as u64;
                     all_accounts_are_zero_lamports = false;
                 } else {
-                    // All zero lamport accounts are obsolete or single ref by the end of index
-                    // generation. Store the offsets so they can be batch inserted later
-                    zero_lamport_offsets.push(offset);
+                    // Zero-lamport accounts become tombstones (removed from the index, retained in
+                    // storage) once their older versions are resolved. Collect their pubkeys,
+                    // grouped by index bin, so the tombstone pass after obsolete-marking can find
+                    // and remove the survivors.
+                    let bin = self
+                        .accounts_index
+                        .bin_calculator
+                        .bin_from_pubkey(account.pubkey);
+                    zero_lamport_pubkeys_by_bin[bin].push(*account.pubkey);
                 }
                 keyed_account_infos.push((
                     *account.pubkey,
@@ -5819,11 +5848,6 @@ impl AccountsDb {
             accum.storage_info.push((store_id, info));
         }
 
-        // Add all zero lamport accounts as zero lamport single refs to avoid having to revisit
-        // them later. This is safe as all zero lamport accounts will be single ref or obsolete
-        // by the end of index generation
-        storage.batch_insert_zero_lamport_single_ref_account_offsets(zero_lamport_offsets);
-
         accum.num_accounts += insert_info.count as u64;
         accum.insert_time_us += insert_time_us;
         accum.accounts_data_len += accounts_data_len;
@@ -5860,7 +5884,10 @@ impl AccountsDb {
 
         self.accounts_index.set_startup(Startup::Startup);
 
-        let mut total_accum = IndexGenerationAccumulator::with_slots_capacity(num_storages);
+        let mut total_accum = IndexGenerationAccumulator::with_slots_capacity(
+            num_storages,
+            self.accounts_index.bins(),
+        );
         let storages_orderer =
             AccountStoragesOrderer::with_random_order(&storages).into_concurrent_consumer();
         let exit_logger = AtomicBool::new(false);
@@ -5875,6 +5902,7 @@ impl AccountsDb {
                         .spawn_scoped(s, || {
                             let mut thread_accum = IndexGenerationAccumulator::with_slots_capacity(
                                 num_storages.div_ceil(num_threads),
+                                self.accounts_index.bins(),
                             );
                             let mut reader = append_vec::new_scan_accounts_reader();
                             for next_item in storages_orderer.iter() {
@@ -6142,6 +6170,22 @@ impl AccountsDb {
         timings.mark_obsolete_accounts_us = mark_obsolete_accounts_time.as_us();
         timings.num_obsolete_accounts_marked = obsolete_account_stats.accounts_marked_obsolete;
         timings.num_slots_removed_as_obsolete = obsolete_account_stats.slots_removed;
+
+        // Now that every older version has been obsolete-marked, each surviving zero-lamport
+        // account is a single-ref entry. Remove those from the index and record them as tombstones
+        // in their storages, so scans skip them and shrink counts them as dead.
+        timings.num_zero_lamport_pubkeys = total_accum
+            .zero_lamport_pubkeys_by_bin
+            .iter()
+            .map(Vec::len)
+            .sum::<usize>() as u64;
+        let mut create_tombstones_time = Measure::start("create_tombstones");
+        timings.num_tombstones_created = self.create_tombstones_at_startup(std::mem::take(
+            &mut total_accum.zero_lamport_pubkeys_by_bin,
+        ));
+        create_tombstones_time.stop();
+        timings.create_tombstones_us = create_tombstones_time.as_us();
+
         total_time.stop();
         timings.total_time_us = total_time.as_us();
         timings.report(self.accounts_index.get_startup_stats());
@@ -6217,6 +6261,32 @@ impl AccountsDb {
             })
             .sum();
         stats
+    }
+
+    /// Startup-only. Given the pubkeys of all zero-lamport accounts seen during index generation,
+    /// grouped by index bin, remove those whose surviving entry is still a single-ref zero-lamport
+    /// account from the index and record them as tombstones on their storages. Must run after older
+    /// versions have been obsolete-marked so that each surviving zero-lamport is genuinely
+    /// single-ref. Returns the number of tombstones created.
+    fn create_tombstones_at_startup(&self, zero_lamport_pubkeys_by_bin: Vec<Vec<Pubkey>>) -> u64 {
+        zero_lamport_pubkeys_by_bin
+            .par_iter()
+            .map(|pubkeys| {
+                let tombstones = self
+                    .accounts_index
+                    .create_zero_lamport_tombstones_by_bin(pubkeys);
+                for (slot, account_info) in &tombstones {
+                    if let Some(storage) = self
+                        .storage
+                        .get_account_storage_entry(*slot, account_info.store_id())
+                    {
+                        storage
+                            .batch_insert_tombstone_offsets(std::iter::once(account_info.offset()));
+                    }
+                }
+                tombstones.len() as u64
+            })
+            .sum()
     }
 
     /// Used during generate_index() to:

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -133,7 +133,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     assert!(!db.accounts_index.contains(&pubkey));
     let storage = db.get_storage_for_slot(slot0).unwrap();
     let mut reader = crate::append_vec::new_scan_accounts_reader();
-    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
+    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1, db.accounts_index.bins());
     db.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
 }
 
@@ -166,10 +166,10 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     db.storage.insert(Arc::clone(&append_vec));
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
-    let slot_list_len = db.accounts_index.get_and_then(&pubkey, |entry| {
-        (false, entry.unwrap().slot_list_lock_read_len())
-    });
-    assert_eq!(slot_list_len, 1);
+    // The single-ref zero-lamport account is turned into a tombstone: removed from the index
+    // entirely, but retained in its storage so an incremental snapshot still observes it.
+    assert!(!db.accounts_index.contains(&pubkey));
+    assert_eq!(append_vec.num_tombstones(), 1);
     assert_eq!(
         append_vec.alive_bytes(),
         AppendVec::calculate_stored_size(0),
@@ -177,6 +177,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     assert_eq!(append_vec.accounts_count(), 1);
     assert_eq!(append_vec.count(), 1);
     assert_eq!(result.accounts_data_len, 0);
+    // Tombstones are counted as dead zero-lamport single refs, so shrink still reclaims them.
     assert_eq!(1, append_vec.num_zero_lamport_single_ref_accounts());
     assert_eq!(
         0,
@@ -5449,7 +5450,8 @@ fn test_calculate_storage_count_and_alive_bytes() {
 
     let storage = accounts.storage.get_slot_storage_entry(slot0).unwrap();
     let mut reader = crate::append_vec::new_scan_accounts_reader();
-    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
+    let mut accum =
+        IndexGenerationAccumulator::with_slots_capacity(1, accounts.accounts_index.bins());
     accounts.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
     assert_eq!(accum.storage_info.len(), 1);
     for (slot, value) in accum.storage_info {
@@ -5468,7 +5470,8 @@ fn test_calculate_storage_count_and_alive_bytes_0_accounts() {
     // empty store
     let storage = accounts.create_store(0, 1);
     let mut reader = crate::append_vec::new_scan_accounts_reader();
-    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
+    let mut accum =
+        IndexGenerationAccumulator::with_slots_capacity(1, accounts.accounts_index.bins());
     accounts.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
     assert!(accum.storage_info.is_empty());
 }
@@ -5503,7 +5506,8 @@ fn test_calculate_storage_count_and_alive_bytes_2_accounts() {
         .write_accounts(&(slot0, &[(&keys[0], &account), (&keys[1], &account_big)][..]));
 
     let mut reader = crate::append_vec::new_scan_accounts_reader();
-    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
+    let mut accum =
+        IndexGenerationAccumulator::with_slots_capacity(1, accounts.accounts_index.bins());
     accounts.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
     assert_eq!(accum.storage_info.len(), 1);
     for (slot, value) in accum.storage_info {
@@ -5563,7 +5567,8 @@ fn test_calculate_storage_count_and_alive_bytes_obsolete_account(
         .mark_accounts_obsolete(accounts_to_mark_obsolete.iter().cloned(), slot0 + 1);
 
     let mut reader = crate::append_vec::new_scan_accounts_reader();
-    let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
+    let mut accum =
+        IndexGenerationAccumulator::with_slots_capacity(1, accounts.accounts_index.bins());
     accounts.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
     assert_eq!(
         accum.num_obsolete_accounts_skipped,

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -944,6 +944,25 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         }
         reclaims
     }
+
+    /// Startup-only. For a set of pubkeys that all fall in the same index bin, remove any whose
+    /// sole surviving entry is a zero-lamport account, turning them into tombstones (removed from
+    /// the index but retained in storage). Returns the `(slot, value)` of each removed survivor so
+    /// the caller can record the tombstone offsets on the owning storages.
+    pub fn create_zero_lamport_tombstones_by_bin(
+        &self,
+        pubkeys_by_bin: &[Pubkey],
+    ) -> Vec<(Slot, T)> {
+        let map = match pubkeys_by_bin.first() {
+            Some(pubkey) => self.get_bin(pubkey),
+            None => return Vec::new(),
+        };
+
+        pubkeys_by_bin
+            .iter()
+            .filter_map(|pubkey| map.take_single_ref_zero_lamport_tombstone_on_startup(pubkey))
+            .collect()
+    }
 }
 
 /// modes the system can be in

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -367,6 +367,49 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
     }
 
+    /// Startup-only. If `pubkey`'s sole surviving index entry is a zero-lamport account, remove it
+    /// from the index (in memory and on disk) and return its `(slot, value)` so the caller can
+    /// record the resulting tombstone offset. Returns `None` if the entry is absent (e.g. it was
+    /// already reclaimed as an obsolete older version) or its surviving version is not a single-ref
+    /// zero-lamport account (e.g. it was revived to non-zero). Unlike `delete`, this emits no
+    /// reclaim: the account stays alive in its storage as a tombstone.
+    pub(crate) fn take_single_ref_zero_lamport_tombstone_on_startup(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(Slot, T)> {
+        let mut map = self.map_internal.write().unwrap();
+        match map.entry(*pubkey) {
+            Entry::Occupied(occupied) => {
+                let tombstone = {
+                    let slot_list = occupied.get().slot_list_read_lock();
+                    (slot_list.len() == 1 && slot_list[0].1.is_zero_lamport()).then(|| slot_list[0])
+                };
+                if tombstone.is_some() {
+                    self.delete_disk_key(occupied.key());
+                    self.stats().dec_mem_count();
+                    self.stats().inc_delete();
+                    occupied.remove();
+                }
+                tombstone
+            }
+            Entry::Vacant(vacant) => {
+                // Disk-only entry (flushed to disk during startup): load it, and if its sole
+                // version is a zero-lamport account, delete it from disk.
+                let (slot_list, _ref_count) = self.load_from_disk(vacant.key())?;
+                if slot_list.len() != 1 {
+                    return None;
+                }
+                let (slot, disk_value) = slot_list.into_iter().next().unwrap();
+                let value: T = disk_value.into();
+                value.is_zero_lamport().then(|| {
+                    self.delete_disk_key(vacant.key());
+                    self.stats().inc_delete();
+                    (slot, value)
+                })
+            }
+        }
+    }
+
     // If the slot list for pubkey exists in the index and is empty, remove the index entry for pubkey and return true.
     // Return false otherwise.
     pub fn remove_if_slot_list_empty(&self, pubkey: Pubkey) -> bool {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -447,7 +447,9 @@ mod serde_snapshot_tests {
 
         accounts.print_accounts_stats("reconstructed");
 
-        accounts.assert_load_account(current_slot, pubkey, zero_lamport);
+        // The zero-lamport account is reconstructed as a tombstone: removed from the index (so it
+        // does not load) but retained in storage for incremental snapshots.
+        accounts.assert_not_load_account(current_slot, pubkey);
     }
 
     fn with_chained_zero_lamport_accounts<F>(f: F)
@@ -505,8 +507,8 @@ mod serde_snapshot_tests {
         accounts.print_accounts_stats("post_f");
 
         accounts.assert_load_account(current_slot, pubkey, some_lamport);
-        accounts.assert_load_account(current_slot, purged_pubkey1, 0);
-        accounts.assert_load_account(current_slot, purged_pubkey2, 0);
+        accounts.assert_not_load_account(current_slot, purged_pubkey1);
+        accounts.assert_not_load_account(current_slot, purged_pubkey2);
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
 
         let calculated_capitalization =
@@ -620,8 +622,8 @@ mod serde_snapshot_tests {
         accounts.print_count_and_status("after purge zero");
 
         accounts.assert_load_account(current_slot, pubkey, old_lamport);
-        accounts.assert_load_account(current_slot, purged_pubkey1, 0);
-        accounts.assert_load_account(current_slot, purged_pubkey2, 0);
+        accounts.assert_not_load_account(current_slot, purged_pubkey1);
+        accounts.assert_not_load_account(current_slot, purged_pubkey2);
     }
 
     #[test]
@@ -711,7 +713,9 @@ mod serde_snapshot_tests {
 
         info!("pubkey: {pubkey1}");
         accounts.print_accounts_stats("pre_clean");
-        accounts.assert_load_account(current_slot, pubkey1, zero_lamport);
+        // pubkey1 is reconstructed as a tombstone: removed from the index (so it does not load)
+        // but retained in storage, so the step-A version is not revived.
+        accounts.assert_not_load_account(current_slot, pubkey1);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
 


### PR DESCRIPTION
#### Problem
Zero lamport accounts take index space, while tombstones are free from an index perspective

#### Summary of Changes
- Add tombstones during index generation 

#### Testing
TIming. 
<img width="1685" height="573" alt="image" src="https://github.com/user-attachments/assets/e5f3a0c1-6adf-4c18-9ad0-6f5c609dca14" />

Memory
<img width="1685" height="573" alt="image" src="https://github.com/user-attachments/assets/41941306-05d9-4ea2-906b-35a0dfe044c1" />



Fixes #
