### PR TITLE
svm-conformance: add instruction runner

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8538,10 +8538,14 @@ dependencies = [
 name = "solana-svm-conformance"
 version = "4.3.0-alpha.2"
 dependencies = [
+ "agave-precompiles",
  "bincode",
  "clap 4.6.1",
  "prost 0.11.9",
  "protosol",
+ "serde",
+ "solana-account 4.3.1",
+ "solana-clock",
  "solana-compute-budget",
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
@@ -8549,6 +8553,8 @@ dependencies = [
  "solana-sdk-ids",
  "solana-svm",
  "solana-syscalls",
+ "solana-system-interface 3.2.0",
+ "solana-system-program",
 ]
 
 [[package]]

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -19,6 +19,11 @@ path = "src/bin/test_exec_elf_loader.rs"
 required-features = ["cli", "ffi"]
 
 [[bin]]
+name = "test_exec_instr"
+path = "src/bin/test_exec_instr.rs"
+required-features = ["cli", "ffi"]
+
+[[bin]]
 name = "test_exec_vm_serialization"
 path = "src/bin/test_exec_vm_serialization.rs"
 required-features = ["cli", "ffi"]

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -35,6 +35,7 @@ cli = ["dep:clap"]
 dev-context-only-utils = []
 dummy-for-ci-check = []
 ffi = [
+    "dep:agave-precompiles",
     "dep:prost",
     "dep:protosol",
     "dep:solana-compute-budget",
@@ -47,6 +48,7 @@ ffi = [
 frozen-abi = []
 
 [dependencies]
+agave-precompiles = { workspace = true, optional = true }
 clap = { version = "4.5.59", features = ["derive"], optional = true }
 prost = { version = "0.11", optional = true }
 protosol = { version = "=10.1.0", optional = true }
@@ -58,8 +60,13 @@ solana-syscalls = { workspace = true, optional = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
+serde = { workspace = true }
+solana-account = { workspace = true }
+solana-clock = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
+solana-system-interface = { workspace = true }
+solana-system-program = { workspace = true }
 
 [lints]
 workspace = true

--- a/svm-conformance/src/bin/test_exec_instr.rs
+++ b/svm-conformance/src/bin/test_exec_instr.rs
@@ -1,0 +1,48 @@
+use {clap::Parser, prost::Message, protosol::protos::InstrFixture, std::path::PathBuf};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let Ok(fixture) = InstrFixture::decode(&blob[..]) else {
+        println!("Failed to parse fixture.");
+        return false;
+    };
+
+    let Some(context) = fixture.input else {
+        println!("No context found.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+
+    let effects = solana_svm_conformance::instr::execute_instr_proto(context);
+
+    let ok = effects == expected;
+    if ok {
+        println!("OK: {input:?}");
+    } else {
+        println!("FAIL: {input:?}");
+        println!("Expected: {expected:?}");
+        println!("Actual: {effects:?}");
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/svm-conformance/src/instr.rs
+++ b/svm-conformance/src/instr.rs
@@ -1,0 +1,190 @@
+//! Instruction conformance harness.
+
+use {
+    agave_precompiles::is_precompile,
+    prost::Message,
+    protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
+    solana_svm::conformance::{
+        callback::ConformanceCallback,
+        direct_mapping::direct_mapping_handle_cu_exhaustion,
+        instr::{context::InstrContext, harness::execute_instr_with_callback},
+        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
+        setup::{compute_budget, program_runtime_environments, sysvar_cache_from_accounts},
+    },
+    std::ffi::c_int,
+};
+
+pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
+    let instr_context = InstrContext::from(input);
+
+    // When testing with protobuf, we fill the sysvar cache from input accounts.
+    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
+
+    // When testing with protobuf, we fill the program cache from input accounts.
+    let mut program_cache = {
+        let slot = sysvar_cache.get_clock().unwrap().slot;
+        let feature_set = &instr_context.feature_set;
+        let compute_budget = compute_budget(feature_set);
+        let environments = program_runtime_environments(feature_set, &compute_budget);
+
+        let mut cache = new_program_cache_with_builtins(slot);
+        fill_program_cache_from_accounts(
+            &mut cache,
+            environments.get_env_for_deployment(),
+            &instr_context.accounts,
+            slot,
+        );
+
+        cache
+    };
+
+    let mut effects = execute_instr_with_callback(
+        &instr_context,
+        &ConformanceCallback::default(),
+        &mut program_cache,
+        &sysvar_cache,
+    );
+
+    // Precompile verification failures surface as `Custom`, but Firedancer
+    // reports a custom error code of 0 for precompiles.
+    if effects.custom_err.is_some()
+        && is_precompile(&instr_context.instruction.program_id, |_| true)
+    {
+        effects.custom_err = Some(0);
+    }
+
+    // TODO: Firedancer's tooling compares resulting account contents even
+    // when execution fails, so the harness must report them. Account
+    // contents are not meaningful on error (partial writes can diverge based
+    // on timing, e.g. with direct mapping or builtins), so once the tooling
+    // supports it, the harness should skip the account comparison on error
+    // entirely, which would also make the CU-exhaustion workaround below
+    // unnecessary.
+    direct_mapping_handle_cu_exhaustion(
+        instr_context.feature_set.virtual_address_space_adjustments,
+        effects.cu_avail,
+        effects.result.is_some(),
+        effects
+            .resulting_accounts
+            .iter_mut()
+            .map(|(_, account)| &mut account.data),
+    );
+
+    effects.into()
+}
+
+/// # Safety
+///
+/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
+/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
+/// is updated to the number of bytes written.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_instr_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
+        return 0;
+    };
+    let instr_effects = execute_instr_proto(instr_context);
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = instr_effects.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe {
+        *out_psz = out_vec.len() as u64;
+    }
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, solana_account::Account, solana_pubkey::Pubkey,
+        solana_svm::conformance::programs::keyed_account_for_system_program,
+        solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as SYSTEM_TRANSFER_CUS,
+    };
+
+    const FROM_BASE_LAMPORTS: u64 = 5_000;
+    const TO_BASE_LAMPORTS: u64 = 1_000;
+
+    fn system_account_with_lamports(lamports: u64) -> Account {
+        Account {
+            lamports,
+            data: vec![],
+            owner: solana_sdk_ids::system_program::id(),
+            executable: false,
+            rent_epoch: u64::MAX,
+        }
+    }
+
+    fn proto_account(pubkey: Pubkey, account: Account) -> protosol::protos::AcctState {
+        protosol::protos::AcctState {
+            address: pubkey.to_bytes().to_vec(),
+            owner: account.owner.to_bytes().to_vec(),
+            lamports: account.lamports,
+            data: account.data,
+            executable: account.executable,
+        }
+    }
+
+    fn proto_sysvar_account<T: serde::Serialize>(
+        pubkey: Pubkey,
+        sysvar: &T,
+    ) -> protosol::protos::AcctState {
+        protosol::protos::AcctState {
+            address: pubkey.to_bytes().to_vec(),
+            owner: solana_sdk_ids::sysvar::id().to_bytes().to_vec(),
+            lamports: 1,
+            data: bincode::serialize(sysvar).unwrap(),
+            executable: false,
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "invariant violation: duplicate account load")]
+    fn test_duplicate_accounts_panic_with_invariant_violation() {
+        let from = Pubkey::new_unique();
+        let to = Pubkey::new_unique();
+        let duplicate = Pubkey::new_unique();
+        let instruction = solana_system_interface::instruction::transfer(&from, &to, 1);
+
+        execute_instr_proto(ProtoInstrContext {
+            program_id: solana_sdk_ids::system_program::id().to_bytes().to_vec(),
+            accounts: vec![
+                proto_account(from, system_account_with_lamports(FROM_BASE_LAMPORTS)),
+                proto_account(to, system_account_with_lamports(TO_BASE_LAMPORTS)),
+                proto_account(duplicate, system_account_with_lamports(1)),
+                proto_account(duplicate, system_account_with_lamports(1)),
+                proto_account(
+                    keyed_account_for_system_program().0,
+                    keyed_account_for_system_program().1,
+                ),
+                proto_sysvar_account(
+                    solana_sdk_ids::sysvar::clock::id(),
+                    &solana_clock::Clock::default(),
+                ),
+            ],
+            instr_accounts: vec![
+                protosol::protos::InstrAcct {
+                    index: 0,
+                    is_signer: true,
+                    is_writable: true,
+                },
+                protosol::protos::InstrAcct {
+                    index: 1,
+                    is_signer: false,
+                    is_writable: true,
+                },
+            ],
+            data: instruction.data,
+            cu_avail: SYSTEM_TRANSFER_CUS,
+            features: None,
+        });
+    }
+}

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -6,6 +6,8 @@
 #[cfg(feature = "ffi")]
 pub mod elf_loader;
 #[cfg(feature = "ffi")]
+pub mod instr;
+#[cfg(feature = "ffi")]
 pub mod serialization;
 #[cfg(feature = "ffi")]
 pub mod syscall;

--- a/svm/src/conformance/instr/harness.rs
+++ b/svm/src/conformance/instr/harness.rs
@@ -20,19 +20,6 @@ use {
     solana_svm_timings::ExecuteTimings,
     std::{collections::HashMap, rc::Rc},
 };
-#[cfg(feature = "conformance")]
-use {
-    crate::conformance::{
-        callback::ConformanceCallback,
-        direct_mapping::direct_mapping_handle_cu_exhaustion,
-        programs::{fill_program_cache_from_accounts, new_program_cache_with_builtins},
-        setup::sysvar_cache_from_accounts,
-    },
-    agave_precompiles::is_precompile,
-    prost::Message,
-    protosol::protos::{InstrContext as ProtoInstrContext, InstrEffects as ProtoInstrEffects},
-    std::ffi::c_int,
-};
 
 /// Execute a single instruction against the Solana VM with the default
 /// (no-precompile) callback.
@@ -152,96 +139,6 @@ pub fn execute_instr_with_callback<C: InvokeContextCallback>(
     }
 }
 
-#[cfg(feature = "conformance")]
-pub fn execute_instr_proto(input: ProtoInstrContext) -> ProtoInstrEffects {
-    let instr_context = InstrContext::from(input);
-
-    // When testing with protobuf, we fill the sysvar cache from input accounts.
-    let sysvar_cache = sysvar_cache_from_accounts(&instr_context.accounts);
-
-    // When testing with protobuf, we fill the program cache from input accounts.
-    let mut program_cache = {
-        let slot = sysvar_cache.get_clock().unwrap().slot;
-        let feature_set = &instr_context.feature_set;
-        let compute_budget = compute_budget(feature_set);
-        let environments = program_runtime_environments(feature_set, &compute_budget);
-
-        let mut cache = new_program_cache_with_builtins(slot);
-        fill_program_cache_from_accounts(
-            &mut cache,
-            environments.get_env_for_deployment(),
-            &instr_context.accounts,
-            slot,
-        );
-
-        cache
-    };
-
-    let mut effects = execute_instr_with_callback(
-        &instr_context,
-        &ConformanceCallback::default(),
-        &mut program_cache,
-        &sysvar_cache,
-    );
-
-    // Precompile verification failures surface as `Custom`, but Firedancer
-    // reports a custom error code of 0 for precompiles.
-    if effects.custom_err.is_some()
-        && is_precompile(&instr_context.instruction.program_id, |_| true)
-    {
-        effects.custom_err = Some(0);
-    }
-
-    // TODO: Firedancer's tooling compares resulting account contents even
-    // when execution fails, so the harness must report them. Account
-    // contents are not meaningful on error (partial writes can diverge based
-    // on timing, e.g. with direct mapping or builtins), so once the tooling
-    // supports it, the harness should skip the account comparison on error
-    // entirely, which would also make the CU-exhaustion workaround below
-    // unnecessary.
-    direct_mapping_handle_cu_exhaustion(
-        instr_context.feature_set.virtual_address_space_adjustments,
-        effects.cu_avail,
-        effects.result.is_some(),
-        effects
-            .resulting_accounts
-            .iter_mut()
-            .map(|(_, account)| &mut account.data),
-    );
-
-    effects.into()
-}
-
-/// # Safety
-///
-/// `in_ptr` must point to `in_sz` initialized bytes. `out_ptr` must point
-/// to a writable buffer of at least `*out_psz` bytes. On return, `*out_psz`
-/// is updated to the number of bytes written.
-#[cfg(feature = "conformance")]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn sol_compat_instr_execute_v1(
-    out_ptr: *mut u8,
-    out_psz: *mut u64,
-    in_ptr: *mut u8,
-    in_sz: u64,
-) -> c_int {
-    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
-    let Ok(instr_context) = ProtoInstrContext::decode(in_slice) else {
-        return 0;
-    };
-    let instr_effects = execute_instr_proto(instr_context);
-    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
-    let out_vec = instr_effects.encode_to_vec();
-    if out_vec.len() > out_slice.len() {
-        return 0;
-    }
-    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
-    unsafe {
-        *out_psz = out_vec.len() as u64;
-    }
-    1
-}
-
 #[cfg(test)]
 mod tests {
     use {
@@ -297,31 +194,6 @@ mod tests {
             }
         });
         sysvar_cache
-    }
-
-    #[cfg(feature = "conformance")]
-    fn proto_account(pubkey: Pubkey, account: Account) -> protosol::protos::AcctState {
-        protosol::protos::AcctState {
-            address: pubkey.to_bytes().to_vec(),
-            owner: account.owner.to_bytes().to_vec(),
-            lamports: account.lamports,
-            data: account.data,
-            executable: account.executable,
-        }
-    }
-
-    #[cfg(feature = "conformance")]
-    fn proto_sysvar_account<T: serde::Serialize>(
-        pubkey: Pubkey,
-        sysvar: &T,
-    ) -> protosol::protos::AcctState {
-        protosol::protos::AcctState {
-            address: pubkey.to_bytes().to_vec(),
-            owner: solana_sdk_ids::sysvar::id().to_bytes().to_vec(),
-            lamports: 1,
-            data: bincode::serialize(sysvar).unwrap(),
-            executable: false,
-        }
     }
 
     fn build_system_transfer_context(from: &Pubkey, to: &Pubkey, amount: u64) -> InstrContext {
@@ -425,48 +297,5 @@ mod tests {
         let effects = execute_instr(&context, &mut program_cache, &sysvar_cache);
         assert_eq!(effects.result, None);
         assert_eq!(effects.custom_err, None);
-    }
-
-    #[cfg(feature = "conformance")]
-    #[test]
-    #[should_panic(expected = "invariant violation: duplicate account load")]
-    fn test_duplicate_accounts_panic_with_invariant_violation() {
-        let from = Pubkey::new_unique();
-        let to = Pubkey::new_unique();
-        let duplicate = Pubkey::new_unique();
-        let instruction = solana_system_interface::instruction::transfer(&from, &to, 1);
-
-        execute_instr_proto(ProtoInstrContext {
-            program_id: solana_sdk_ids::system_program::id().to_bytes().to_vec(),
-            accounts: vec![
-                proto_account(from, system_account_with_lamports(FROM_BASE_LAMPORTS)),
-                proto_account(to, system_account_with_lamports(TO_BASE_LAMPORTS)),
-                proto_account(duplicate, system_account_with_lamports(1)),
-                proto_account(duplicate, system_account_with_lamports(1)),
-                proto_account(
-                    keyed_account_for_system_program().0,
-                    keyed_account_for_system_program().1,
-                ),
-                proto_sysvar_account(
-                    solana_sdk_ids::sysvar::clock::id(),
-                    &solana_clock::Clock::default(),
-                ),
-            ],
-            instr_accounts: vec![
-                protosol::protos::InstrAcct {
-                    index: 0,
-                    is_signer: true,
-                    is_writable: true,
-                },
-                protosol::protos::InstrAcct {
-                    index: 1,
-                    is_signer: false,
-                    is_writable: true,
-                },
-            ],
-            data: instruction.data,
-            cu_avail: SYSTEM_TRANSFER_CUS,
-            features: None,
-        });
     }
 }


### PR DESCRIPTION
#### Problem

The `solana-svm-conformance` dev-bin now hosts the ELF loader, VM serialization,
and VM syscall harnesses with their runners. The instruction harness has no
runner bin yet, and its FFI entrypoint still lives in `solana-svm`, which has no
`cdylib` target to expose it from.

#### Summary of Changes

Move only the FFI-gated surface — `execute_instr_proto` and
`sol_compat_instr_execute_v1` — into a new `instr` module in
`solana-svm-conformance`, then add the `test_exec_instr` runner bin target.

The harness itself stays in `solana-svm`: `InstrContext`, `InstrEffects`, their
protobuf conversions, and `execute_instr`/`execute_instr_with_callback` are all
unchanged, so existing Agave callers are unaffected and no support code has to
be dragged across.

#### Testing

Build the test vectors:

```
git clone https://github.com/firedancer-io/test-vectors.git
cd test-vectors
./scripts/package.sh
```

Build and run the conformance target:

```
cargo build --manifest-path dev-bins/Cargo.toml -p solana-svm-conformance
dev-bins/target/debug/test_exec_instr -- ~/test-vectors/instr/fixtures/*.fix
```

Part of #13382