### PR TITLE
misc crates: drop `SysvarSerialize`

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "solana-core",
  "solana-cost-model",
  "solana-entry",
+ "solana-epoch-schedule",
  "solana-feature-gate-interface",
  "solana-genesis-config",
  "solana-genesis-utils",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -88,6 +88,7 @@ solana-connection-cache = { path = "../connection-cache", version = "=4.3.0-alph
 solana-core = { path = "../core", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-cost-model = { path = "../cost-model", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-entry = { path = "../entry", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
+solana-epoch-schedule = "3.3.0"
 solana-faucet = { path = "../faucet", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee-calculator = "3.2.2"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -88,7 +88,7 @@ solana-connection-cache = { path = "../connection-cache", version = "=4.3.0-alph
 solana-core = { path = "../core", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-cost-model = { path = "../cost-model", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-entry = { path = "../entry", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
-solana-epoch-schedule = "3.3.0"
+solana-epoch-schedule = "3.2.0"
 solana-faucet = { path = "../faucet", version = "=4.3.0-alpha.2", features = ["agave-unstable-api"] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee-calculator = "3.2.2"

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -51,7 +51,7 @@ solana-cluster-type = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
-solana-epoch-schedule = { version = "3.2.0", features = ["wincode"] }
+solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-feature-gate-interface = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -51,6 +51,7 @@ solana-cluster-type = { workspace = true }
 solana-core = { workspace = true, features = ["dev-context-only-utils"] }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
+solana-epoch-schedule = { version = "3.2.0", features = ["wincode"] }
 solana-feature-gate-interface = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
@@ -91,6 +92,7 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+wincode = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
@@ -102,7 +104,6 @@ signal-hook = { workspace = true }
 assert_cmd = { workspace = true }
 solana-bls-signatures = { workspace = true }
 tempfile = { workspace = true }
-wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -4,7 +4,7 @@ use {
     log::*,
     serde::{Deserialize, Serialize},
     serde_json::Result,
-    solana_account::{AccountSharedData, create_account_shared_data_for_test},
+    solana_account::{AccountSharedData, WritableAccount},
     solana_cli_output::{OutputFormat, QuietDisplay, VerboseDisplay},
     solana_clock::Slot,
     solana_ledger::blockstore_options::AccessType,
@@ -469,10 +469,14 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
         program_id, // ID of the loaded program. It can modify accounts with the same owner key
         AccountSharedData::new(0, 0, &loader_id),
     ));
-    transaction_accounts.push((
-        sysvar::epoch_schedule::id(),
-        create_account_shared_data_for_test(bank.epoch_schedule()),
-    ));
+    let mut epoch_schedule_account =
+        AccountSharedData::new(1, solana_epoch_schedule::SIZE, &sysvar::id());
+    wincode::serialize_into(
+        epoch_schedule_account.data_as_mut_slice(),
+        bank.epoch_schedule(),
+    )
+    .unwrap();
+    transaction_accounts.push((sysvar::epoch_schedule::id(), epoch_schedule_account));
     with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
 
     // Adding `DELAY_VISIBILITY_SLOT_OFFSET` to slots to accommodate for delay visibility of the program

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -22,7 +22,11 @@ name = "solana_program_runtime"
 [features]
 agave-unstable-api = []
 conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
-dev-context-only-utils = ["dep:qualifier_attr", "dep:solana-message"]
+dev-context-only-utils = [
+    "dep:qualifier_attr",
+    "dep:solana-message",
+    "solana-epoch-schedule/wincode",
+]
 dummy-for-ci-check = ["metrics"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 metrics = []

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1037,7 +1037,7 @@ pub fn mock_process_instruction_with_feature_set<
         .any(|(key, _)| *key == sysvar::epoch_schedule::id())
     {
         let mut account = AccountSharedData::new(1, solana_epoch_schedule::SIZE, &sysvar::id());
-        bincode::serialize_into(account.data_as_mut_slice(), &EpochSchedule::default()).unwrap();
+        wincode::serialize_into(account.data_as_mut_slice(), &EpochSchedule::default()).unwrap();
         accounts.push((sysvar::epoch_schedule::id(), account));
     }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -8979,6 +8979,7 @@ dependencies = [
  "solana-program-error",
  "solana-pubkey 4.2.0",
  "solana-sysvar",
+ "wincode",
 ]
 
 [[package]]
@@ -9009,7 +9010,6 @@ dependencies = [
 name = "solana-sbf-rust-sysvar"
 version = "4.3.0-alpha.2"
 dependencies = [
- "bincode",
  "solana-account-info",
  "solana-define-syscall 3.0.0",
  "solana-instruction",
@@ -9021,6 +9021,8 @@ dependencies = [
  "solana-sdk-ids",
  "solana-stake-history",
  "solana-sysvar",
+ "solana-sysvar-id",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -163,12 +163,14 @@ solana-svm-transaction = "=4.2.0"
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.3.0-alpha.2" }
 solana-system-interface = { version = "=3.2", features = ["bincode"] }
 solana-sysvar = "=4.1.0"
+solana-sysvar-id = "=3.1.0"
 solana-test-validator = { path = "../../test-validator", version = "=4.3.0-alpha.2" }
 solana-vote = { path = "../../vote", version = "=4.3.0-alpha.2" }
 solana-vote-interface = "6.0.3"
 solana-vote-program = { path = "../../programs/vote", version = "=4.3.0-alpha.2" }
 test-case = "3.3.1"
 thiserror = "2.0"
+wincode = { version = "0.5.5", default-features = false }
 
 [features]
 sbf_c = []

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -13,12 +13,13 @@ crate-type = ["cdylib"]
 
 [dependencies]
 solana-account-info = { workspace = true }
-solana-clock = { workspace = true }
+solana-clock = { workspace = true, features = ["wincode"] }
 solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sysvar = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/simulation/src/lib.rs
+++ b/programs/sbf/rust/simulation/src/lib.rs
@@ -4,15 +4,22 @@ use {
     solana_account_info::{AccountInfo, next_account_info},
     solana_clock::Clock,
     solana_msg::msg,
-    solana_program_error::ProgramResult,
+    solana_program_error::{ProgramError, ProgramResult},
     solana_pubkey::{Pubkey, declare_id},
-    solana_sysvar::{Sysvar, SysvarSerialize},
+    solana_sysvar::Sysvar,
     std::convert::TryInto,
 };
 
 declare_id!("Sim1jD5C35odT8mzctm8BWnjic8xW5xgeb5MbcbErTo");
 
 solana_program_entrypoint::entrypoint_no_alloc!(process_instruction);
+
+fn clock_from_account_info(account_info: &AccountInfo) -> Result<Clock, ProgramError> {
+    if !solana_sysvar::clock::check_id(account_info.unsigned_key()) {
+        return Err(ProgramError::InvalidArgument);
+    }
+    wincode::deserialize(&account_info.data.borrow()).map_err(|_| ProgramError::InvalidArgument)
+}
 
 pub fn process_instruction(
     _program_id: &Pubkey,
@@ -28,7 +35,7 @@ pub fn process_instruction(
     let slot: u64 = u64::from_le_bytes(data[data.len() - 8..].try_into().unwrap());
 
     let clock_from_cache = Clock::get().unwrap();
-    let clock_from_account = Clock::from_account_info(clock_account_info).unwrap();
+    let clock_from_account = clock_from_account_info(clock_account_info).unwrap();
 
     msg!("next_slot from slot history is {:?} ", slot);
     msg!("clock from cache is in slot {:?} ", clock_from_cache.slot);

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-bincode = { workspace = true }
 solana-account-info = { workspace = true }
 solana-define-syscall = { workspace = true }
 solana-instruction = { workspace = true }
@@ -23,7 +22,9 @@ solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-stake-history = { workspace = true }
-solana-sysvar = { workspace = true, features = ["bincode", "bytemuck"] }
+solana-sysvar = { workspace = true, features = ["bytemuck", "wincode"] }
+solana-sysvar-id = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -13,7 +13,7 @@ use {
     solana_stake_history::{StakeHistory, StakeHistoryGetEntry, sysvar::StakeHistorySysvar},
     solana_sysvar::{
         Sysvar, clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule,
-        rent::Rent, slot_hashes::PodSlotHashes,
+        rent::Rent, slot_hashes::PodSlotHashes, slot_history::SlotHistory,
     },
     solana_sysvar_id::SysvarId,
 };
@@ -194,9 +194,14 @@ pub fn process_instruction(
             {
                 msg!("SlotHashes identifier:");
                 sysvar::slot_hashes::id().log();
-                // Syscall `sol_get_sysvar`.
-                let pod_slot_hashes = PodSlotHashes::fetch()?;
-                assert!(pod_slot_hashes.get(/* slot */ &0)?.is_some());
+                // Account deserialization is unsupported.
+                // Inspecting first entry and comparing with the syscall value.
+                assert_eq!(accounts[7].data_len(), solana_sysvar::slot_hashes::SIZE);
+                let data = accounts[7].data.borrow();
+                let account_slot = u64::from_le_bytes(data[8..16].try_into().unwrap());
+                let account_hash = &data[16..48];
+                let syscall_hash = PodSlotHashes::fetch()?.get(&account_slot)?.unwrap();
+                assert_eq!(syscall_hash.as_ref(), account_hash);
             }
 
             Ok(())

--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -12,31 +12,39 @@ use {
     solana_sdk_ids::sysvar,
     solana_stake_history::{StakeHistory, StakeHistoryGetEntry, sysvar::StakeHistorySysvar},
     solana_sysvar::{
-        Sysvar, SysvarSerialize,
-        clock::Clock,
-        epoch_rewards::EpochRewards,
-        epoch_schedule::EpochSchedule,
-        rent::Rent,
-        slot_hashes::{PodSlotHashes, SlotHashes},
-        slot_history::SlotHistory,
+        Sysvar, clock::Clock, epoch_rewards::EpochRewards, epoch_schedule::EpochSchedule,
+        rent::Rent, slot_hashes::PodSlotHashes,
     },
+    solana_sysvar_id::SysvarId,
 };
 
-fn sol_get_sysvar<T>() -> Result<T, ProgramError>
+fn from_account_info<T>(account_info: &AccountInfo) -> Result<T, ProgramError>
 where
-    T: SysvarSerialize,
+    T: wincode::DeserializeOwned<Dst = T> + SysvarId,
+{
+    if !T::check_id(account_info.unsigned_key()) {
+        return Err(ProgramError::InvalidArgument);
+    }
+    wincode::deserialize(&account_info.data.borrow()).map_err(|_| ProgramError::InvalidArgument)
+}
+
+fn sol_get_sysvar<T>(data_len: usize) -> Result<T, ProgramError>
+where
+    T: wincode::DeserializeOwned<Dst = T> + SysvarId,
 {
     #[cfg(target_os = "solana")]
     {
-        let len = T::size_of();
-        let mut data = vec![0; len];
+        let mut data = vec![0; data_len];
 
-        solana_sysvar::get_sysvar(&mut data, &T::id(), 0, len as u64)?;
+        solana_sysvar::get_sysvar(&mut data, &T::id(), 0, data_len as u64)?;
 
-        bincode::deserialize(&data).map_err(|_| ProgramError::InvalidArgument)
+        wincode::deserialize(&data).map_err(|_| ProgramError::InvalidArgument)
     }
     #[cfg(not(target_os = "solana"))]
-    Err(ProgramError::UnsupportedSysvar)
+    {
+        let _ = data_len;
+        Err(ProgramError::UnsupportedSysvar)
+    }
 }
 
 solana_program_entrypoint::entrypoint_no_alloc!(process_instruction);
@@ -58,12 +66,12 @@ pub fn process_instruction(
             {
                 msg!("Clock identifier:");
                 sysvar::clock::id().log();
-                let clock = Clock::from_account_info(&accounts[2]).unwrap();
+                let clock = from_account_info::<Clock>(&accounts[2]).unwrap();
                 assert_ne!(clock, Clock::default());
                 let got_clock = Clock::get()?;
                 assert_eq!(clock, got_clock);
                 // Syscall `sol_get_sysvar`.
-                let sgs_clock = sol_get_sysvar::<Clock>()?;
+                let sgs_clock = sol_get_sysvar::<Clock>(solana_sysvar::clock::SIZE)?;
                 assert_eq!(clock, sgs_clock);
             }
 
@@ -71,11 +79,12 @@ pub fn process_instruction(
             {
                 msg!("EpochRewards identifier:");
                 sysvar::epoch_rewards::id().log();
-                let epoch_rewards = EpochRewards::from_account_info(&accounts[10]).unwrap();
+                let epoch_rewards = from_account_info::<EpochRewards>(&accounts[10]).unwrap();
                 let got_epoch_rewards = EpochRewards::get()?;
                 assert_eq!(epoch_rewards, got_epoch_rewards);
                 // Syscall `sol_get_sysvar`.
-                let sgs_epoch_rewards = sol_get_sysvar::<EpochRewards>()?;
+                let sgs_epoch_rewards =
+                    sol_get_sysvar::<EpochRewards>(solana_sysvar::epoch_rewards::SIZE)?;
                 assert_eq!(epoch_rewards, sgs_epoch_rewards);
             }
 
@@ -83,12 +92,13 @@ pub fn process_instruction(
             {
                 msg!("EpochSchedule identifier:");
                 sysvar::epoch_schedule::id().log();
-                let epoch_schedule = EpochSchedule::from_account_info(&accounts[3]).unwrap();
+                let epoch_schedule = from_account_info::<EpochSchedule>(&accounts[3]).unwrap();
                 assert_eq!(epoch_schedule, EpochSchedule::default());
                 let got_epoch_schedule = EpochSchedule::get()?;
                 assert_eq!(epoch_schedule, got_epoch_schedule);
                 // Syscall `sol_get_sysvar`.
-                let sgs_epoch_schedule = sol_get_sysvar::<EpochSchedule>()?;
+                let sgs_epoch_schedule =
+                    sol_get_sysvar::<EpochSchedule>(solana_sysvar::epoch_schedule::SIZE)?;
                 assert_eq!(epoch_schedule, sgs_epoch_schedule);
             }
 
@@ -98,7 +108,7 @@ pub fn process_instruction(
                 msg!("RecentBlockhashes identifier:");
                 sysvar::recent_blockhashes::id().log();
                 let recent_blockhashes =
-                    RecentBlockhashes::from_account_info(&accounts[5]).unwrap();
+                    from_account_info::<RecentBlockhashes>(&accounts[5]).unwrap();
                 assert_ne!(recent_blockhashes, RecentBlockhashes::default());
             }
 
@@ -106,22 +116,13 @@ pub fn process_instruction(
             {
                 msg!("Rent identifier:");
                 sysvar::rent::id().log();
-                let rent = Rent::from_account_info(&accounts[6]).unwrap();
+                let rent = from_account_info::<Rent>(&accounts[6]).unwrap();
                 let got_rent = Rent::get()?;
                 assert_eq!(rent, got_rent);
                 // Syscall `sol_get_sysvar`.
-                let sgs_rent = sol_get_sysvar::<Rent>()?;
+                let sgs_rent = sol_get_sysvar::<Rent>(solana_sysvar::rent::SIZE)?;
                 assert_eq!(rent, sgs_rent);
             }
-
-            // Slot History
-            // (Not fixed-size, but also not supported)
-            msg!("SlotHistory identifier:");
-            sysvar::slot_history::id().log();
-            assert_eq!(
-                Err(ProgramError::UnsupportedSysvar),
-                SlotHistory::from_account_info(&accounts[8])
-            );
 
             Ok(())
         }
@@ -162,14 +163,7 @@ pub fn process_instruction(
             {
                 msg!("StakeHistory identifier:");
                 sysvar::stake_history::id().log();
-                let _: StakeHistory =
-                    if sysvar::stake_history::check_id(accounts[9].unsigned_key()) {
-                        bincode::deserialize(&accounts[9].data.borrow())
-                            .map_err(|_| ProgramError::InvalidArgument)
-                    } else {
-                        Err(ProgramError::InvalidArgument)
-                    }
-                    .unwrap();
+                let _ = from_account_info::<StakeHistory>(&accounts[9]).unwrap();
                 // Syscall `sol_get_sysvar`.
                 let stake_history_sysvar = StakeHistorySysvar(1);
                 assert!(stake_history_sysvar.get_entry(0).is_some());
@@ -182,10 +176,6 @@ pub fn process_instruction(
             {
                 msg!("SlotHashes identifier:");
                 sysvar::slot_hashes::id().log();
-                assert_eq!(
-                    Err(ProgramError::UnsupportedSysvar),
-                    SlotHashes::from_account_info(&accounts[7])
-                );
                 // Syscall `sol_get_sysvar`.
                 let pod_slot_hashes = PodSlotHashes::fetch()?;
                 assert!(pod_slot_hashes.get(/* slot */ &0)?.is_some());

--- a/programs/sbf/rust/sysvar/src/lib.rs
+++ b/programs/sbf/rust/sysvar/src/lib.rs
@@ -124,6 +124,24 @@ pub fn process_instruction(
                 assert_eq!(rent, sgs_rent);
             }
 
+            // Slot History
+            {
+                msg!("SlotHistory identifier:");
+                sysvar::slot_history::id().log();
+                // SlotHistory exceeds the default SBF heap, so inspecting without deserializing.
+                // Its final `u64` field is `next_slot`.
+                assert_eq!(accounts[8].data_len(), solana_sysvar::slot_history::SIZE);
+                let data = accounts[8].data.borrow();
+                let next_slot = u64::from_le_bytes(*data.last_chunk().unwrap());
+                assert_eq!(next_slot, Clock::get()?.slot);
+                // Slot History is not stored in the runtime sysvar cache, so syscall
+                // `sol_get_sysvar` does not support it.
+                assert_eq!(
+                    Err(ProgramError::UnsupportedSysvar),
+                    sol_get_sysvar::<SlotHistory>(1)
+                );
+            }
+
             Ok(())
         }
         Some(&1) => {


### PR DESCRIPTION
Removes the last bit of direct SysvarSerialize usage. Next is remaining test helpers.

Continuing to break down https://github.com/anza-xyz/agave/pull/12245. Progresses https://github.com/anza-xyz/agave/issues/10672.

