### PR TITLE
CI: run 2 staked nodes in localnet-sanity.sh

### DIFF
--- a/ci/localnet-sanity.sh
+++ b/ci/localnet-sanity.sh
@@ -81,6 +81,7 @@ nodes=(
     --no-restart \
     --dynamic-port-range 8200-8400
     --init-complete-file init-complete-node1.log \
+    --stake-sol 2 \
     --rpc-port 18899"
 )
 


### PR DESCRIPTION
#### Problem

When running single node as leader in the cluster, we can sometimes fail to add block ID about the block before we need it to produce next blocks. This is not a problem when there are multiple leaders in the cluster.
Context:
https://discord.com/channels/428295358100013066/439194979856809985/1533832947428233407
#### Summary of Changes

Make 2 nodes staked in the multinode CI script

#### Testing

CI (no prod code change)