### PR TITLE
Perf - Reject invalid program accounts earlier

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -370,7 +370,6 @@ impl ProgramCacheForTxBatch {
 #[derive(Clone, PartialEq, Debug)]
 pub enum ProgramCacheMatchCriteria {
     DeployedOnOrAfterSlot(Slot),
-    Tombstone,
     NoCriteria,
 }
 
@@ -629,7 +628,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot) => {
                 program.deployment_slot >= *slot
             }
-            ProgramCacheMatchCriteria::Tombstone => program.is_tombstone(),
             ProgramCacheMatchCriteria::NoCriteria => true,
         }
     }
@@ -2485,11 +2483,6 @@ pub(crate) mod tests {
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &tombstone,
-            &ProgramCacheMatchCriteria::Tombstone
-        ));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &tombstone,
             &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
         ));
 
@@ -2503,11 +2496,6 @@ pub(crate) mod tests {
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &program,
             &ProgramCacheMatchCriteria::NoCriteria
-        ));
-
-        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::Tombstone
         ));
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
@@ -2525,11 +2513,6 @@ pub(crate) mod tests {
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(
             &program,
             &ProgramCacheMatchCriteria::NoCriteria
-        ));
-
-        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::Tombstone
         ));
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6464,13 +6464,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
             .read()
             .unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
-        assert_eq!(slot_versions.len(), 1);
-        assert_eq!(slot_versions[0].deployment_slot, bank.slot());
-        assert_eq!(slot_versions[0].effective_slot(), bank.slot());
-        assert!(matches!(
-            slot_versions[0].program,
-            ProgramCacheEntryType::Closed,
-        ));
+        assert!(slot_versions.is_empty());
     }
 
     // Test buffer invocation
@@ -6492,13 +6486,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
             .read()
             .unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&buffer_address);
-        assert_eq!(slot_versions.len(), 1);
-        assert_eq!(slot_versions[0].deployment_slot, bank.slot());
-        assert_eq!(slot_versions[0].effective_slot(), bank.slot());
-        assert!(matches!(
-            slot_versions[0].program,
-            ProgramCacheEntryType::Closed,
-        ));
+        assert!(slot_versions.is_empty());
     }
 
     // Test successful deploy

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -847,6 +847,27 @@ mod tests {
             );
         }
 
+        let programdata_address = Pubkey::new_unique();
+        let state = UpgradeableLoaderState::Program {
+            programdata_address,
+        };
+        let mut program = AccountSharedData::new(1, 1, &loader_ids[2]);
+        program.set_data(bincode::serialize(&state).unwrap());
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(program_ids[2], (program, 0));
+        let state = UpgradeableLoaderState::ProgramData {
+            slot: 0,
+            upgrade_authority_address: None,
+        };
+        let mut programdata = AccountSharedData::new(1, 1, &loader_ids[2]);
+        programdata.set_data(bincode::serialize(&state).unwrap());
+        mock_bank
+            .account_shared_data
+            .borrow_mut()
+            .insert(programdata_address, (programdata, 0));
+
         let tx = Transaction::new_with_compiled_instructions(
             &[&feepayer],
             &[program_ids[1], program_ids[2], loader_ids[2]],
@@ -907,7 +928,7 @@ mod tests {
                 ProgramToLoad {
                     program_id: &program_ids[2],
                     loader: ProgramCacheEntryOwner::LoaderV3,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
                     last_modification_slot: 0,
                 },
             ]

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -202,7 +202,13 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     loader: ProgramCacheEntryOwner,
 ) -> TransactionResult<Slot> {
     match loader {
-        ProgramCacheEntryOwner::LoaderV1 | ProgramCacheEntryOwner::LoaderV2 => Ok(0),
+        ProgramCacheEntryOwner::LoaderV1 | ProgramCacheEntryOwner::LoaderV2 => {
+            if program.data().is_empty() {
+                Err(TransactionError::ProgramAccountNotFound)
+            } else {
+                Ok(0)
+            }
+        }
         ProgramCacheEntryOwner::LoaderV3 => {
             if let Ok(UpgradeableLoaderState::Program {
                 programdata_address,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -230,8 +230,7 @@ pub(crate) fn get_program_deployment_slot<CB: TransactionProcessingCallback>(
     }
 }
 
-/// Appends to a set of executable program accounts (all accounts owned by any loader)
-/// for transactions with a valid blockhash or nonce.
+/// Returns the set of program accounts for a given batch of transactions.
 pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,
@@ -256,11 +255,12 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             } else {
                 continue;
             };
+            let Ok(deployment_slot) = get_program_deployment_slot(callbacks, &account, loader)
+            else {
+                continue;
+            };
             let match_criteria = if check_program_deployment_slot {
-                get_program_deployment_slot(callbacks, &account, loader)
-                    .map_or(ProgramCacheMatchCriteria::Tombstone, |slot| {
-                        ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot)
-                    })
+                ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot)
             } else {
                 ProgramCacheMatchCriteria::NoCriteria
             };
@@ -901,7 +901,7 @@ mod tests {
                 ProgramToLoad {
                     program_id: &program_ids[2],
                     loader: ProgramCacheEntryOwner::LoaderV3,
-                    match_criteria: ProgramCacheMatchCriteria::Tombstone,
+                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
                     last_modification_slot: 0,
                 },
             ]


### PR DESCRIPTION
#### Problem

We could already reject invalid program accounts earlier in `filter_executable_program_accounts()`. Thus, skip some work and avoid potential interactions with other threads in program loading.

#### Summary of Changes

- Stops loading missing entries if their program account can't be parsed.
- Stops loading empty loader-v1 and loader-v2 programs.
- Removes `ProgramCacheMatchCriteria::Tombstone`.

#### Testing

- Adjusts `test_filter_executable_program_accounts()`.
- Adjusts `test_bpf_loader_upgradeable_deploy_with_max_len()`.