### PR TITLE
loaderv3: test close programdata with read-only program

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -3837,6 +3837,34 @@ mod tests {
             accounts.first().unwrap().data().len()
         );
 
+        // Case: close a program account with a non-writable program account
+        process_instruction(
+            &loader_id,
+            &instruction,
+            vec![
+                (programdata_address, programdata_account.clone()),
+                (recipient_address, recipient_account.clone()),
+                (authority_address, authority_account.clone()),
+                (program_address, program_account.clone()),
+                (sysvar::clock::id(), clock_account.clone()),
+            ],
+            vec![
+                AccountMeta {
+                    pubkey: programdata_address,
+                    is_signer: false,
+                    is_writable: true,
+                },
+                recipient_meta.clone(),
+                authority_meta.clone(),
+                AccountMeta {
+                    pubkey: program_address,
+                    is_signer: false,
+                    is_writable: false,
+                },
+            ],
+            Err(InstructionError::InvalidArgument),
+        );
+
         // Case: close a program account
         let accounts = process_instruction(
             &loader_id,


### PR DESCRIPTION
#### Problem
loaderv3 doesnt have a test that closing programdata requires the program to be write-locked. since program closure may change with https://github.com/anza-xyz/agave/pull/9871, we should assert this

#### Summary of Changes
add this case to `test_bpf_loader_upgradeable_close()`
