### PR TITLE
geyser: Introduce notify_update_parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ still accepted for backwards compatibility but slated for full removal in the fu
   `GeyserPlugin::block_footer_notifications_enabled`; plugins can opt in to receive the complete
   versioned Alpenglow block footer, slot, and bank ID in entry order independently of entry
   notifications.
+* Added `GeyserPlugin::notify_entry_update_parent` and
+  `GeyserPlugin::notify_deshred_update_parent` so plugins can discard earlier notifications after
+  an UpdateParent marker.
 ### SDK
 #### Breaking
 * solana-program-test: syscall getters (e.g. `Rent::get()`, `Clock::get()`) and `solana_sysvar::get_sysvar()` now return

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -26,7 +26,12 @@ use {
     },
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
-    solana_ledger::{blockstore::Blockstore, leader_schedule_cache::LeaderScheduleCache},
+    solana_ledger::{
+        blockstore::Blockstore,
+        entry_notifier_interface::EntryUpdateParentInfo,
+        entry_notifier_service::{EntryNotification, EntryNotifierSender},
+        leader_schedule_cache::LeaderScheduleCache,
+    },
     solana_measure::measure::Measure,
     solana_perf::packet::{BytesPacket, Meta, PacketBatch, bytes::Bytes},
     solana_poh::{
@@ -133,6 +138,7 @@ pub struct BlockCreationLoopConfig {
     // Notifiers
     pub banking_tracer: Arc<BankingTracer>,
     pub slot_status_notifier: Option<SlotStatusNotifier>,
+    pub entry_notification_sender: Option<EntryNotifierSender>,
 
     // Receivers / notifications from banking stage / replay / votor
     pub leader_window_info_receiver: Receiver<LeaderWindowInfo>,
@@ -167,6 +173,7 @@ struct LeaderContext {
     bank_forks_controller: Arc<dyn BankForksController>,
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
     slot_status_notifier: Option<SlotStatusNotifier>,
+    entry_notification_sender: Option<EntryNotifierSender>,
     banking_tracer: Arc<BankingTracer>,
     replay_highest_frozen: Arc<ReplayHighestFrozen>,
     reward_certs_requestor: CertsRequestor,
@@ -244,6 +251,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         rpc_subscriptions,
         banking_tracer,
         slot_status_notifier,
+        entry_notification_sender,
         record_receiver_receiver,
         leader_window_info_receiver,
         replay_highest_frozen,
@@ -296,6 +304,7 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         bank_forks_controller,
         rpc_subscriptions,
         slot_status_notifier,
+        entry_notification_sender,
         banking_tracer,
         replay_highest_frozen,
         reward_certs_requestor,
@@ -946,11 +955,23 @@ fn handle_parent_ready(
             old_parent_slot,
             new_parent_slot,
         ))?;
+    let cleared_bank_id = bank.bank_id();
     bank.wait_for_inflight_commits();
     ctx.bank_forks_controller
         .clear_bank(slot)
         .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
     ctx.poh_recorder.write().unwrap().clear_bank(true);
+
+    if let Some(sender) = &ctx.entry_notification_sender
+        && let Err(err) = sender.send(EntryNotification::UpdateParent(EntryUpdateParentInfo {
+            slot,
+            cleared_bank_id,
+            parent_slot: new_parent_slot,
+            parent_block_id: new_parent_hash,
+        }))
+    {
+        warn!("UpdateParent entry notification send failed: {err:?}");
+    }
 
     // Create the new bank before re-injecting transactions to avoid racing.
     let new_bank = start_leader_wait_for_parent_replay(
@@ -1563,6 +1584,7 @@ mod tests {
             bank_forks_controller,
             rpc_subscriptions: None,
             slot_status_notifier: None,
+            entry_notification_sender: None,
             banking_tracer: BankingTracer::new_disabled(),
             replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
             reward_certs_requestor,
@@ -1681,6 +1703,7 @@ mod tests {
             bank_forks_controller,
             rpc_subscriptions: None,
             slot_status_notifier: None,
+            entry_notification_sender: None,
             banking_tracer: BankingTracer::new_disabled(),
             replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
             reward_certs_requestor,
@@ -1756,6 +1779,7 @@ mod tests {
             bank_forks_controller,
             rpc_subscriptions: None,
             slot_status_notifier: None,
+            entry_notification_sender: None,
             banking_tracer: BankingTracer::new_disabled(),
             replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
             reward_certs_requestor,
@@ -1843,6 +1867,7 @@ mod tests {
         let (banking_stage_sender, banking_stage_receiver) = BankingTracer::channel_for_test();
         let bank_forks_controller = test_bank_forks_controller(bank_forks.clone());
         let (reward_certs_requestor, _receiver) = CertsRequestor::new();
+        let (entry_notification_sender, entry_notification_receiver) = bounded(1);
 
         let mut ctx = LeaderContext {
             exit,
@@ -1865,6 +1890,7 @@ mod tests {
             bank_forks_controller,
             rpc_subscriptions: None,
             slot_status_notifier: None,
+            entry_notification_sender: Some(entry_notification_sender),
             banking_tracer: BankingTracer::new_disabled(),
             replay_highest_frozen: Arc::new(ReplayHighestFrozen::default()),
             reward_certs_requestor,
@@ -1912,6 +1938,20 @@ mod tests {
 
         assert_eq!(new_bank.slot(), leader_slot);
         assert_eq!(new_bank.parent_slot(), new_parent_slot);
+        let EntryNotification::UpdateParent(update_parent) =
+            entry_notification_receiver.try_recv().unwrap()
+        else {
+            panic!("expected UpdateParent entry notification");
+        };
+        assert_eq!(
+            update_parent,
+            EntryUpdateParentInfo {
+                slot: leader_slot,
+                cleared_bank_id: optimistic_bank_id,
+                parent_slot: new_parent_slot,
+                parent_block_id: new_parent_hash,
+            }
+        );
         assert_eq!(
             ctx.bank_forks
                 .read()

--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -12,6 +12,7 @@ use {
     solana_entry::entry::Entry,
     solana_ledger::{
         blockstore::{Blockstore, CompletedDataSetInfo},
+        blockstore_meta::UpdateParentInfo,
         deshred_transaction_notifier_interface::{
             DeshredTransactionNotifier, DeshredTransactionNotifierArc,
         },
@@ -166,6 +167,22 @@ impl CompletedDataSetsService {
                 let completed_data_set_ending_shred_index_exclusive = indices.end;
                 match blockstore.get_entries_in_data_block(slot, indices, /*slot_meta:*/ None) {
                     Ok(entries) => {
+                        if let Some(notifier) = deshred_transaction_notifier
+                            && let Some(update_parent) = blockstore
+                                .meta(slot)
+                                .inspect_err(|err| {
+                                    warn!("failed to read slot meta for slot {slot}: {err:?}")
+                                })
+                                .ok()
+                                .flatten()
+                                .and_then(|slot_meta| {
+                                    UpdateParentInfo::from_slot_meta(slot, &slot_meta)
+                                })
+                            && update_parent.update_parent_fec_set_index
+                                == completed_data_set_starting_shred_index
+                        {
+                            notifier.notify_deshred_update_parent(&update_parent);
+                        }
                         Self::notify_deshred_transactions_for_completed_data_set(
                             slot,
                             completed_data_set_starting_shred_index,
@@ -298,14 +315,21 @@ pub mod test {
     use {
         super::*,
         crossbeam_channel::bounded,
-        solana_entry::entry::next_versioned_entry,
+        solana_entry::{
+            block_component::{
+                BlockComponent, BlockHeaderV1, UpdateParentV1, VersionedBlockMarker,
+            },
+            entry::next_versioned_entry,
+        },
         solana_genesis_config::GenesisConfig,
         solana_hash::Hash,
         solana_instruction::Instruction,
         solana_keypair::Keypair,
         solana_ledger::{
-            blockstore, blockstore::Blockstore, get_tmp_ledger_path_auto_delete,
-            shred::max_ticks_per_n_shreds,
+            blockstore,
+            blockstore::Blockstore,
+            get_tmp_ledger_path_auto_delete,
+            shred::{ProcessShredsStats, ReedSolomonCache, Shredder, max_ticks_per_n_shreds},
         },
         solana_message::{
             Message, VersionedMessage,
@@ -341,6 +365,7 @@ pub mod test {
     #[derive(Default)]
     struct TestDeshredTransactionNotifier {
         notifications: Mutex<Vec<DeshredNotification>>,
+        update_parents: Mutex<Vec<(u64, u32, u64, Hash)>>,
     }
 
     impl DeshredTransactionNotifier for TestDeshredTransactionNotifier {
@@ -370,6 +395,15 @@ pub mod test {
 
         fn alt_resolution_enabled(&self) -> bool {
             false
+        }
+
+        fn notify_deshred_update_parent(&self, update_parent: &UpdateParentInfo) {
+            self.update_parents.lock().unwrap().push((
+                update_parent.slot,
+                update_parent.update_parent_fec_set_index,
+                update_parent.parent_slot,
+                update_parent.parent_block_id,
+            ));
         }
     }
 
@@ -582,6 +616,89 @@ pub mod test {
             completed_data_set.indices.end
         );
         assert_eq!(max_slots.shred_insert.load(Ordering::Relaxed), 11);
+
+        // A stale notification after the slot is cleared must not panic or notify.
+        blockstore.clear_unconfirmed_slot(11);
+        sender.send(vec![completed_data_set]).unwrap();
+        CompletedDataSetsService::recv_completed_data_sets(
+            &receiver,
+            &blockstore,
+            Some(&rpc_subscriptions),
+            &notifier,
+            &max_slots,
+            &bank_forks,
+        )
+        .unwrap();
+        assert_eq!(test_notifier.notifications.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_recv_completed_data_sets_notifies_update_parent() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&GenesisConfig::default()));
+        let max_slots = Arc::new(MaxSlots::default());
+        let test_notifier = Arc::new(TestDeshredTransactionNotifier::default());
+        let notifier = Some(test_notifier.clone() as DeshredTransactionNotifierArc);
+        let (sender, receiver) = bounded(1);
+        let update_parent = UpdateParentInfo {
+            slot: 12,
+            update_parent_fec_set_index: 32,
+            parent_slot: 10,
+            parent_block_id: Hash::new_unique(),
+        };
+        let make_marker_shreds = |marker, shred_index| {
+            let component = BlockComponent::new_block_marker(marker);
+            Shredder::new(update_parent.slot, 11, 0, 0)
+                .unwrap()
+                .make_merkle_shreds_from_component(
+                    &Keypair::new(),
+                    &component,
+                    false,
+                    Hash::new_unique(),
+                    shred_index,
+                    shred_index,
+                    &ReedSolomonCache::default(),
+                    &mut ProcessShredsStats::default(),
+                )
+                .collect::<Vec<_>>()
+        };
+        let mut shreds = make_marker_shreds(
+            VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+                parent_slot: 11,
+                parent_block_id: Hash::new_unique(),
+            }),
+            0,
+        );
+        shreds.extend(make_marker_shreds(
+            VersionedBlockMarker::from_update_parent(UpdateParentV1 {
+                new_parent_slot: update_parent.parent_slot,
+                new_parent_block_id: update_parent.parent_block_id,
+            }),
+            update_parent.update_parent_fec_set_index,
+        ));
+        let completed_data_sets = blockstore.insert_shreds(shreds, true).unwrap();
+        sender.send(completed_data_sets).unwrap();
+
+        CompletedDataSetsService::recv_completed_data_sets(
+            &receiver,
+            &blockstore,
+            None,
+            &notifier,
+            &max_slots,
+            &bank_forks,
+        )
+        .unwrap();
+
+        assert_eq!(
+            *test_notifier.update_parents.lock().unwrap(),
+            vec![(
+                update_parent.slot,
+                update_parent.update_parent_fec_set_index,
+                update_parent.parent_slot,
+                update_parent.parent_block_id,
+            )]
+        );
     }
 
     #[test]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -977,6 +977,7 @@ impl ReplayStage {
                     &update_parent_receiver,
                     &replay_vote_sender,
                     migration_status.as_ref(),
+                    entry_notification_sender.as_ref(),
                 );
 
                 let mut generate_new_bank_forks_time =
@@ -1068,6 +1069,7 @@ impl ReplayStage {
                         &mut async_verification_freelist,
                         &replay_vote_sender,
                         migration_status.as_ref(),
+                        entry_notification_sender.as_ref(),
                     );
                     Self::alpenglow_handle_newly_frozen_banks(
                         &new_frozen_slots,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -44,6 +44,7 @@ use {
             BlockstoreError, UpdateParentSignal, entries_to_test_shreds, make_slot_entries,
         },
         create_new_tmp_ledger,
+        entry_notifier_service::EntryNotification,
         genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
         get_tmp_ledger_path, get_tmp_ledger_path_auto_delete,
         shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
@@ -1337,14 +1338,16 @@ fn test_abandon_invalidates() {
     );
 
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
-    let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+    let mut process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
         bank_forks.clone(),
         blockstore,
         replay_vote_sender,
     );
+    let (entry_notification_sender, entry_notification_receiver) = bounded(1);
+    process_active_banks_context.entry_notification_sender = Some(entry_notification_sender);
     let update_parent = VersionedUpdateParent::V1(solana_entry::block_component::UpdateParentV1 {
         new_parent_slot: 0,
-        new_parent_block_id: Hash::default(),
+        new_parent_block_id: parent_block_id,
     });
     let replay_result = ReplaySlotFromBlockstore {
         is_slot_dead: false,
@@ -1375,6 +1378,15 @@ fn test_abandon_invalidates() {
             replay_slot: slot,
         })
     );
+    let EntryNotification::UpdateParent(update_parent) =
+        entry_notification_receiver.try_recv().unwrap()
+    else {
+        panic!("expected UpdateParent entry notification");
+    };
+    assert_eq!(update_parent.slot, slot);
+    assert_eq!(update_parent.cleared_bank_id, bank.bank_id());
+    assert_eq!(update_parent.parent_slot, 0);
+    assert_eq!(update_parent.parent_block_id, parent_block_id);
 }
 
 // Given a shred and a fatal expected error, check that replaying that shred causes causes the fork to be
@@ -3092,6 +3104,7 @@ fn test_update_parent_restart() {
 
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let (entry_notification_sender, entry_notification_receiver) = bounded(1);
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3102,6 +3115,7 @@ fn test_update_parent_restart() {
         &rx,
         &replay_vote_sender,
         &post_migration_status_for_tests(),
+        Some(&entry_notification_sender),
     );
 
     assert!(progress.get(&4).is_none()); // cleared: 5 < 32
@@ -3114,6 +3128,16 @@ fn test_update_parent_restart() {
         })
     );
     assert!(replay_vote_receiver.try_recv().is_err());
+    let EntryNotification::UpdateParent(update_parent) =
+        entry_notification_receiver.try_recv().unwrap()
+    else {
+        panic!("expected UpdateParent entry notification");
+    };
+    let slot_meta = blockstore.meta(4).unwrap().unwrap();
+    assert_eq!(update_parent.slot, 4);
+    assert_eq!(update_parent.cleared_bank_id, cleared_bank_id);
+    assert_eq!(update_parent.parent_slot, slot_meta.parent_slot.unwrap());
+    assert_eq!(update_parent.parent_block_id, slot_meta.parent_block_id);
 }
 
 #[test]
@@ -3233,6 +3257,7 @@ fn test_update_parent_tower_gated() {
         &rx,
         &replay_vote_sender,
         &MigrationStatus::default(),
+        None,
     );
 
     assert!(progress.get(&slot).is_some());
@@ -3277,6 +3302,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
         &rx,
         &replay_vote_sender,
         &post_migration_status_for_tests(),
+        None,
     );
 
     assert!(progress.get(&slot).is_some());
@@ -3324,6 +3350,7 @@ fn test_update_parent_keeps_hard() {
         &rx,
         &replay_vote_sender,
         &post_migration_status_for_tests(),
+        None,
     );
 
     assert!(blockstore.is_dead(slot));
@@ -3544,6 +3571,7 @@ fn test_soft_dead_restarts() {
         &mut async_verification_freelist,
         &replay_vote_sender,
         &post_migration_status_for_tests(),
+        None,
     );
 
     assert!(!blockstore.is_dead(slot));
@@ -3587,6 +3615,7 @@ fn test_full_soft_dead_hardens() {
         &mut async_verification_freelist,
         &replay_vote_sender,
         &post_migration_status_for_tests(),
+        None,
     );
 
     assert!(blockstore.is_dead(slot));

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -17,8 +17,10 @@ use {
     solana_entry::block_component::VersionedUpdateParent,
     solana_ledger::{
         blockstore::{Blockstore, UpdateParentReceiver},
-        blockstore_meta::SlotMeta,
+        blockstore_meta::{SlotMeta, UpdateParentInfo},
         blockstore_processor::AsyncVerificationProgress,
+        entry_notifier_interface::EntryUpdateParentInfo,
+        entry_notifier_service::{EntryNotification, EntryNotifierSender},
     },
     solana_pubkey::Pubkey,
     solana_runtime::{
@@ -97,8 +99,20 @@ pub(super) fn child_bank_replay_start(
     ChildBankReplayStart::FromUpdateParent(num_shreds)
 }
 
+fn notify_entry_update_parent(
+    sender: Option<&EntryNotifierSender>,
+    update_parent: EntryUpdateParentInfo,
+) {
+    if let Some(sender) = sender
+        && let Err(err) = sender.send(EntryNotification::UpdateParent(update_parent))
+    {
+        warn!("UpdateParent entry notification send failed: {err:?}");
+    }
+}
+
 /// Clear an in-progress bank so the next replay iteration recreates it from
 /// the current UpdateParent parent and FEC-set offset recorded in `SlotMeta`.
+#[allow(clippy::too_many_arguments)]
 fn try_restart_slot_from_update_parent(
     my_pubkey: &Pubkey,
     blockstore: &Blockstore,
@@ -109,6 +123,7 @@ fn try_restart_slot_from_update_parent(
     replay_vote_sender: &ReplayVoteSender,
     migration_status: &MigrationStatus,
     source: &str,
+    entry_notification_sender: Option<&EntryNotifierSender>,
 ) -> bool {
     if !migration_status.should_allow_block_markers(slot) {
         return false;
@@ -163,10 +178,24 @@ fn try_restart_slot_from_update_parent(
         "{my_pubkey}: restarting slot {slot} from replay_fec_set_index {replay_fec_set_index} via \
          {source} (was at {current_num_shreds} shreds)",
     );
-    if let Some(bank) = bank {
+    let cleared_bank_id = bank.map(|bank| {
         send_invalid_bank(&bank, replay_vote_sender);
-    }
+        bank.bank_id()
+    });
     ReplayStage::clear_slots([slot], bank_forks, progress, async_verification_freelist);
+    if let Some(cleared_bank_id) = cleared_bank_id {
+        let update_parent = UpdateParentInfo::from_slot_meta(slot, &slot_meta)
+            .expect("UpdateParent metadata must include a parent slot");
+        notify_entry_update_parent(
+            entry_notification_sender,
+            EntryUpdateParentInfo {
+                slot,
+                cleared_bank_id,
+                parent_slot: update_parent.parent_slot,
+                parent_block_id: update_parent.parent_block_id,
+            },
+        );
+    }
     true
 }
 
@@ -175,6 +204,7 @@ fn try_restart_slot_from_update_parent(
 /// If an UpdateParent marker is now visible in SlotMeta, replay is restarted
 /// from the marker's FEC set. If the slot completes without a marker, the
 /// soft-dead state is promoted to a durable hard-dead slot.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn process_soft_dead_slots(
     my_pubkey: &Pubkey,
     blockstore: &Arc<Blockstore>,
@@ -185,6 +215,7 @@ pub(super) fn process_soft_dead_slots(
     async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     replay_vote_sender: &ReplayVoteSender,
     migration_status: &MigrationStatus,
+    entry_notification_sender: Option<&EntryNotifierSender>,
 ) {
     let soft_dead_slots = progress
         .iter()
@@ -222,6 +253,7 @@ pub(super) fn process_soft_dead_slots(
                 replay_vote_sender,
                 migration_status,
                 "soft-dead scan",
+                entry_notification_sender,
             );
             continue;
         }
@@ -268,6 +300,7 @@ pub(super) fn handle_update_parent_interrupts(
     update_parent_receiver: &UpdateParentReceiver,
     replay_vote_sender: &ReplayVoteSender,
     migration_status: &MigrationStatus,
+    entry_notification_sender: Option<&EntryNotifierSender>,
 ) {
     while let Ok(signal) = update_parent_receiver.try_recv() {
         try_restart_slot_from_update_parent(
@@ -280,6 +313,7 @@ pub(super) fn handle_update_parent_interrupts(
             replay_vote_sender,
             migration_status,
             "UpdateParent signal",
+            entry_notification_sender,
         );
     }
 }
@@ -306,8 +340,11 @@ pub(super) fn handle_abandoned_bank(
     // recreated with the correct parent by generate_new_bank_forks, which
     // reads slot meta to determine both the new parent and the correct
     // replay offset (replay_fec_set_index).
-    let new_parent_slot = match &update_parent {
-        VersionedUpdateParent::V1(x) => x.new_parent_slot,
+    let (new_parent_slot, new_parent_block_id) = match update_parent {
+        VersionedUpdateParent::V1(update_parent) => (
+            update_parent.new_parent_slot,
+            update_parent.new_parent_block_id,
+        ),
     };
 
     datapoint_info!(
@@ -360,5 +397,16 @@ pub(super) fn handle_abandoned_bank(
         bank_forks,
         progress,
         async_verification_freelist,
+    );
+    notify_entry_update_parent(
+        process_active_banks_context
+            .entry_notification_sender
+            .as_ref(),
+        EntryUpdateParentInfo {
+            slot: bank_slot,
+            cleared_bank_id: bank.bank_id(),
+            parent_slot: new_parent_slot,
+            parent_block_id: new_parent_block_id,
+        },
     );
 }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1527,6 +1527,9 @@ impl Validator {
         let (optimistic_parent_sender, optimistic_parent_receiver) = bounded(100);
 
         let banking_stage_sender_for_bcl = banking_tracer_channels.non_vote_sender.clone();
+        let entry_notification_sender = entry_notifier_service
+            .as_ref()
+            .map(|service| service.sender_cloned());
 
         let block_creation_loop_config = BlockCreationLoopConfig {
             exit: exit.clone(),
@@ -1539,6 +1542,7 @@ impl Validator {
             rpc_subscriptions: rpc_subscriptions.clone(),
             banking_tracer: banking_tracer.clone(),
             slot_status_notifier: slot_status_notifier.clone(),
+            entry_notification_sender: entry_notification_sender.clone(),
             leader_window_info_receiver,
             highest_parent_ready: highest_parent_ready.clone(),
             replay_highest_frozen: replay_highest_frozen.clone(),
@@ -1563,10 +1567,6 @@ impl Validator {
         let (verified_vote_sender, verified_vote_receiver) = unbounded();
         let (gossip_verified_vote_hash_sender, gossip_verified_vote_hash_receiver) = unbounded();
         let (duplicate_confirmed_slot_sender, duplicate_confirmed_slots_receiver) = unbounded();
-
-        let entry_notification_sender = entry_notifier_service
-            .as_ref()
-            .map(|service| service.sender_cloned());
 
         let serve_repair_service = ServeRepairService::new(
             serve_repair,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -297,6 +297,52 @@ pub enum ReplicaEntryInfoVersions<'a> {
     V0_0_2(&'a ReplicaEntryInfoV2<'a>),
 }
 
+/// Information about a bank cleared by an Alpenglow UpdateParent marker.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaEntryUpdateParentInfo<'a> {
+    /// The slot of the cleared bank.
+    pub slot: Slot,
+
+    /// The bank cleared after processing the UpdateParent marker.
+    pub cleared_bank_id: BankId,
+
+    /// The parent slot selected by the UpdateParent marker.
+    pub parent_slot: Slot,
+
+    /// The parent block ID selected by the UpdateParent marker.
+    pub parent_block_id: &'a Hash,
+}
+
+/// A wrapper to future-proof ReplicaEntryUpdateParentInfo handling.
+#[repr(u32)]
+pub enum ReplicaEntryUpdateParentInfoVersions<'a> {
+    V0_0_1(&'a ReplicaEntryUpdateParentInfo<'a>),
+}
+
+/// Information about an Alpenglow UpdateParent marker in the deshred stream.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaDeshredUpdateParentInfo<'a> {
+    /// The slot containing the UpdateParent marker.
+    pub slot: Slot,
+
+    /// The FEC set index of the UpdateParent marker.
+    pub update_parent_fec_set_index: u32,
+
+    /// The parent slot selected by the UpdateParent marker.
+    pub parent_slot: Slot,
+
+    /// The parent block ID selected by the UpdateParent marker.
+    pub parent_block_id: &'a Hash,
+}
+
+/// A wrapper to future-proof ReplicaDeshredUpdateParentInfo handling.
+#[repr(u32)]
+pub enum ReplicaDeshredUpdateParentInfoVersions<'a> {
+    V0_0_1(&'a ReplicaDeshredUpdateParentInfo<'a>),
+}
+
 /// Information about an Alpenglow block footer.
 #[derive(Clone, Debug)]
 #[repr(C)]
@@ -884,5 +930,27 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// that only need the raw transaction should leave this disabled.
     fn deshred_transaction_alt_resolution_enabled(&self) -> bool {
         false
+    }
+
+    /// Called when an Alpenglow UpdateParent marker clears a bank.
+    /// Entry notifications may race with this callback; plugins should use the
+    /// cleared bank ID to reconcile them. The replacement bank ID is reported
+    /// separately through `SlotStatus::CreatedBank`.
+    #[allow(unused_variables)]
+    fn notify_entry_update_parent(
+        &self,
+        update_parent: ReplicaEntryUpdateParentInfoVersions,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called before deshred transaction notifications from the completed data
+    /// set beginning at the UpdateParent FEC-set boundary.
+    #[allow(unused_variables)]
+    fn notify_deshred_update_parent(
+        &self,
+        update_parent: ReplicaDeshredUpdateParentInfoVersions,
+    ) -> Result<()> {
+        Ok(())
     }
 }

--- a/geyser-plugin-manager/src/deshred_transaction_notifier.rs
+++ b/geyser-plugin-manager/src/deshred_transaction_notifier.rs
@@ -3,11 +3,15 @@ use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaDeshredTransactionInfoV2, ReplicaDeshredTransactionInfoVersions,
+        ReplicaDeshredUpdateParentInfo, ReplicaDeshredUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::Slot,
-    solana_ledger::deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+    solana_ledger::{
+        blockstore_meta::UpdateParentInfo,
+        deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+    },
     solana_measure::measure::Measure,
     solana_message::v0::LoadedAddresses,
     solana_signature::Signature,
@@ -82,6 +86,28 @@ impl DeshredTransactionNotifier for DeshredTransactionNotifierImpl {
         self.plugin_manager
             .load()
             .deshred_transaction_alt_resolution_enabled()
+    }
+
+    fn notify_deshred_update_parent(&self, update_parent: &UpdateParentInfo) {
+        let plugin_manager = self.plugin_manager.load();
+        let update_parent_info = ReplicaDeshredUpdateParentInfo {
+            slot: update_parent.slot,
+            update_parent_fec_set_index: update_parent.update_parent_fec_set_index,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: &update_parent.parent_block_id,
+        };
+        for plugin in plugin_manager.plugins.iter() {
+            if plugin.deshred_transaction_notifications_enabled()
+                && let Err(err) = plugin.notify_deshred_update_parent(
+                    ReplicaDeshredUpdateParentInfoVersions::V0_0_1(&update_parent_info),
+                )
+            {
+                error!(
+                    "Failed to notify deshred UpdateParent, error: ({err}) to plugin {}",
+                    plugin.name()
+                );
+            }
+        }
     }
 }
 

--- a/geyser-plugin-manager/src/entry_notifier.rs
+++ b/geyser-plugin-manager/src/entry_notifier.rs
@@ -3,13 +3,14 @@ use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaBlockFooterInfo, ReplicaBlockFooterInfoVersions, ReplicaEntryInfoV2,
-        ReplicaEntryInfoVersions,
+        ReplicaEntryInfoVersions, ReplicaEntryUpdateParentInfo,
+        ReplicaEntryUpdateParentInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::{BankId, Slot},
     solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
-    solana_ledger::entry_notifier_interface::EntryNotifier,
+    solana_ledger::entry_notifier_interface::{EntryNotifier, EntryUpdateParentInfo},
     std::sync::Arc,
 };
 
@@ -87,6 +88,28 @@ impl EntryNotifier for EntryNotifierImpl {
             }
         }
     }
+
+    fn notify_entry_update_parent(&self, update_parent: &EntryUpdateParentInfo) {
+        let plugin_manager = self.plugin_manager.load();
+        let update_parent_info = ReplicaEntryUpdateParentInfo {
+            slot: update_parent.slot,
+            cleared_bank_id: update_parent.cleared_bank_id,
+            parent_slot: update_parent.parent_slot,
+            parent_block_id: &update_parent.parent_block_id,
+        };
+        for plugin in plugin_manager.plugins.iter() {
+            if plugin.entry_notifications_enabled()
+                && let Err(err) = plugin.notify_entry_update_parent(
+                    ReplicaEntryUpdateParentInfoVersions::V0_0_1(&update_parent_info),
+                )
+            {
+                error!(
+                    "Failed to notify entry UpdateParent, error: ({err}) to plugin {}",
+                    plugin.name()
+                );
+            }
+        }
+    }
 }
 
 impl EntryNotifierImpl {
@@ -125,6 +148,7 @@ mod tests {
     };
 
     type EntryUpdate = (Slot, BankId, usize, usize);
+    type EntryUpdateParent = (Slot, BankId, Slot, Hash);
     type BlockFooterUpdate = (Slot, BankId, VersionedBlockFooter);
 
     #[derive(Debug)]
@@ -132,6 +156,7 @@ mod tests {
         entry_notifications_enabled: bool,
         block_footer_notifications_enabled: bool,
         entry_updates: Arc<Mutex<Vec<EntryUpdate>>>,
+        update_parents: Arc<Mutex<Vec<EntryUpdateParent>>>,
         block_footer_updates: Arc<Mutex<Vec<BlockFooterUpdate>>>,
     }
 
@@ -171,6 +196,20 @@ mod tests {
             Ok(())
         }
 
+        fn notify_entry_update_parent(
+            &self,
+            update_parent: ReplicaEntryUpdateParentInfoVersions,
+        ) -> Result<()> {
+            let ReplicaEntryUpdateParentInfoVersions::V0_0_1(update_parent) = update_parent;
+            self.update_parents.lock().unwrap().push((
+                update_parent.slot,
+                update_parent.cleared_bank_id,
+                update_parent.parent_slot,
+                *update_parent.parent_block_id,
+            ));
+            Ok(())
+        }
+
         fn entry_notifications_enabled(&self) -> bool {
             self.entry_notifications_enabled
         }
@@ -194,10 +233,12 @@ mod tests {
     }
 
     #[test]
-    fn test_notify_entry_and_block_footer_independently() {
+    fn test_notify_entry_update_parent_and_block_footer_independently() {
         let entry_plugin_entry_updates = Arc::new(Mutex::new(Vec::new()));
+        let entry_plugin_update_parents = Arc::new(Mutex::new(Vec::new()));
         let entry_plugin_block_footer_updates = Arc::new(Mutex::new(Vec::new()));
         let block_footer_plugin_entry_updates = Arc::new(Mutex::new(Vec::new()));
+        let block_footer_plugin_update_parents = Arc::new(Mutex::new(Vec::new()));
         let block_footer_plugin_block_footer_updates = Arc::new(Mutex::new(Vec::new()));
         let plugin_manager = Arc::new(ArcSwap::from(Arc::new(GeyserPluginManager {
             plugins: vec![
@@ -205,12 +246,14 @@ mod tests {
                     entry_notifications_enabled: true,
                     block_footer_notifications_enabled: false,
                     entry_updates: entry_plugin_entry_updates.clone(),
+                    update_parents: entry_plugin_update_parents.clone(),
                     block_footer_updates: entry_plugin_block_footer_updates.clone(),
                 }),
                 loaded_test_plugin(TestEntryPlugin {
                     entry_notifications_enabled: false,
                     block_footer_notifications_enabled: true,
                     entry_updates: block_footer_plugin_entry_updates.clone(),
+                    update_parents: block_footer_plugin_update_parents.clone(),
                     block_footer_updates: block_footer_plugin_block_footer_updates.clone(),
                 }),
             ],
@@ -229,16 +272,33 @@ mod tests {
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
+        let parent_block_id = Hash::new_unique();
 
         notifier.notify_entry(42, 9, 3, &entry, 7);
+        notifier.notify_entry_update_parent(&EntryUpdateParentInfo {
+            slot: 42,
+            cleared_bank_id: 9,
+            parent_slot: 40,
+            parent_block_id,
+        });
         notifier.notify_block_footer(42, 9, &block_footer);
 
         assert_eq!(
             *entry_plugin_entry_updates.lock().unwrap(),
             vec![(42, 9, 3, 7)]
         );
+        assert_eq!(
+            *entry_plugin_update_parents.lock().unwrap(),
+            vec![(42, 9, 40, parent_block_id)]
+        );
         assert!(entry_plugin_block_footer_updates.lock().unwrap().is_empty());
         assert!(block_footer_plugin_entry_updates.lock().unwrap().is_empty());
+        assert!(
+            block_footer_plugin_update_parents
+                .lock()
+                .unwrap()
+                .is_empty()
+        );
         assert_eq!(
             *block_footer_plugin_block_footer_updates.lock().unwrap(),
             vec![(42, 9, block_footer)]

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -520,12 +520,16 @@ mod tests {
         },
         agave_geyser_plugin_interface::geyser_plugin_interface::{
             GeyserPlugin, ReplicaDeshredTransactionInfo, ReplicaDeshredTransactionInfoVersions,
-            Result as PluginResult,
+            ReplicaDeshredUpdateParentInfoVersions, Result as PluginResult,
         },
         arc_swap::ArcSwap,
         libloading::Library,
         solana_clock::Slot,
-        solana_ledger::deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+        solana_hash::Hash,
+        solana_ledger::{
+            blockstore_meta::UpdateParentInfo,
+            deshred_transaction_notifier_interface::DeshredTransactionNotifier,
+        },
         solana_message::{Instruction, Message, VersionedMessage, v0::LoadedAddresses},
         solana_pubkey::Pubkey,
         solana_signature::Signature,
@@ -613,12 +617,15 @@ mod tests {
         loaded_addresses: Option<LoadedAddresses>,
     }
 
+    type DeshredUpdateParent = (Slot, u32, Slot, Hash);
+
     #[derive(Clone, Debug)]
     struct DeshredTestPlugin {
         name: &'static str,
         enabled: bool,
         alt_resolution_enabled: bool,
         notifications: Arc<Mutex<Vec<RecordedDeshredNotification>>>,
+        update_parents: Arc<Mutex<Vec<DeshredUpdateParent>>>,
     }
 
     impl GeyserPlugin for DeshredTestPlugin {
@@ -653,6 +660,20 @@ mod tests {
 
         fn deshred_transaction_notifications_enabled(&self) -> bool {
             self.enabled
+        }
+
+        fn notify_deshred_update_parent(
+            &self,
+            update_parent: ReplicaDeshredUpdateParentInfoVersions,
+        ) -> PluginResult<()> {
+            let ReplicaDeshredUpdateParentInfoVersions::V0_0_1(update_parent) = update_parent;
+            self.update_parents.lock().unwrap().push((
+                update_parent.slot,
+                update_parent.update_parent_fec_set_index,
+                update_parent.parent_slot,
+                *update_parent.parent_block_id,
+            ));
+            Ok(())
         }
 
         fn deshred_transaction_alt_resolution_enabled(&self) -> bool {
@@ -776,6 +797,7 @@ mod tests {
                         enabled: false,
                         alt_resolution_enabled: false,
                         notifications: Arc::new(Mutex::new(Vec::new())),
+                        update_parents: Arc::new(Mutex::new(Vec::new())),
                     },
                     DUMMY_CONFIG,
                 )
@@ -792,6 +814,7 @@ mod tests {
                         enabled: true,
                         alt_resolution_enabled: false,
                         notifications: Arc::new(Mutex::new(Vec::new())),
+                        update_parents: Arc::new(Mutex::new(Vec::new())),
                     },
                     DUMMY_CONFIG,
                 )
@@ -805,6 +828,8 @@ mod tests {
     fn test_deshred_transaction_notifier_forwards_only_enabled_plugins() {
         let enabled_notifications = Arc::new(Mutex::new(Vec::new()));
         let disabled_notifications = Arc::new(Mutex::new(Vec::new()));
+        let enabled_update_parents = Arc::new(Mutex::new(Vec::new()));
+        let disabled_update_parents = Arc::new(Mutex::new(Vec::new()));
         let plugin_manager = Arc::new(ArcSwap::new(Arc::new(GeyserPluginManager {
             plugins: vec![
                 Arc::new(
@@ -814,6 +839,7 @@ mod tests {
                             enabled: true,
                             alt_resolution_enabled: false,
                             notifications: enabled_notifications.clone(),
+                            update_parents: enabled_update_parents.clone(),
                         },
                         DUMMY_CONFIG,
                     )
@@ -826,6 +852,7 @@ mod tests {
                             enabled: false,
                             alt_resolution_enabled: false,
                             notifications: disabled_notifications.clone(),
+                            update_parents: disabled_update_parents.clone(),
                         },
                         DUMMY_CONFIG,
                     )
@@ -846,6 +873,13 @@ mod tests {
             &transaction,
             Some(&loaded_addresses),
         );
+        let parent_block_id = Hash::new_unique();
+        notifier.notify_deshred_update_parent(&UpdateParentInfo {
+            slot: 11,
+            update_parent_fec_set_index: 32,
+            parent_slot: 9,
+            parent_block_id,
+        });
 
         let enabled_notifications = enabled_notifications.lock().unwrap().clone();
         assert_eq!(enabled_notifications.len(), 1);
@@ -869,6 +903,11 @@ mod tests {
             Some(loaded_addresses)
         );
         assert!(disabled_notifications.lock().unwrap().is_empty());
+        assert_eq!(
+            *enabled_update_parents.lock().unwrap(),
+            vec![(11, 32, 9, parent_block_id)]
+        );
+        assert!(disabled_update_parents.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -879,6 +918,7 @@ mod tests {
             enabled: true,
             alt_resolution_enabled: false,
             notifications: Arc::new(Mutex::new(Vec::new())),
+            update_parents: Arc::new(Mutex::new(Vec::new())),
         };
         let transaction = sample_transaction();
         let deshred_info = ReplicaDeshredTransactionInfo {
@@ -907,6 +947,7 @@ mod tests {
                         enabled: true,
                         alt_resolution_enabled: false,
                         notifications: Arc::new(Mutex::new(Vec::new())),
+                        update_parents: Arc::new(Mutex::new(Vec::new())),
                     },
                     DUMMY_CONFIG,
                 )
@@ -923,6 +964,7 @@ mod tests {
                         enabled: true,
                         alt_resolution_enabled: true,
                         notifications: Arc::new(Mutex::new(Vec::new())),
+                        update_parents: Arc::new(Mutex::new(Vec::new())),
                     },
                     DUMMY_CONFIG,
                 )

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -209,6 +209,27 @@ pub struct SlotMetaV3 {
 
 pub type SlotMeta = SlotMetaV3;
 
+#[derive(Debug, Eq, PartialEq)]
+pub struct UpdateParentInfo {
+    pub slot: Slot,
+    pub update_parent_fec_set_index: u32,
+    pub parent_slot: Slot,
+    pub parent_block_id: Hash,
+}
+
+impl UpdateParentInfo {
+    pub fn from_slot_meta(slot: Slot, slot_meta: &SlotMeta) -> Option<Self> {
+        Some(Self {
+            slot,
+            update_parent_fec_set_index: slot_meta
+                .has_update_parent()
+                .then_some(slot_meta.replay_fec_set_index)?,
+            parent_slot: slot_meta.parent_slot?,
+            parent_block_id: slot_meta.parent_block_id,
+        })
+    }
+}
+
 /// Lighter-weight version of [`SlotMeta`] containing just the set
 /// of fields needed for repair.
 ///

--- a/ledger/src/deshred_transaction_notifier_interface.rs
+++ b/ledger/src/deshred_transaction_notifier_interface.rs
@@ -1,5 +1,6 @@
 use {
-    solana_clock::Slot, solana_message::v0::LoadedAddresses, solana_signature::Signature,
+    crate::blockstore_meta::UpdateParentInfo, solana_clock::Slot,
+    solana_message::v0::LoadedAddresses, solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction, std::sync::Arc,
 };
 
@@ -23,6 +24,9 @@ pub trait DeshredTransactionNotifier {
 
     /// Whether any plugin has opted in to ALT resolution for deshred transactions.
     fn alt_resolution_enabled(&self) -> bool;
+
+    /// Notify that an UpdateParent marker replaced earlier same-slot data.
+    fn notify_deshred_update_parent(&self, _update_parent: &UpdateParentInfo) {}
 }
 
 pub type DeshredTransactionNotifierArc = Arc<dyn DeshredTransactionNotifier + Sync + Send>;

--- a/ledger/src/entry_notifier_interface.rs
+++ b/ledger/src/entry_notifier_interface.rs
@@ -1,8 +1,17 @@
 use {
     solana_clock::{BankId, Slot},
     solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
+    solana_hash::Hash,
     std::sync::Arc,
 };
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct EntryUpdateParentInfo {
+    pub slot: Slot,
+    pub cleared_bank_id: BankId,
+    pub parent_slot: Slot,
+    pub parent_block_id: Hash,
+}
 
 pub trait EntryNotifier {
     fn notify_entry(
@@ -13,6 +22,9 @@ pub trait EntryNotifier {
         entry: &EntrySummary,
         starting_transaction_index: usize,
     );
+
+    /// Notify an Alpenglow UpdateParent marker on the entry stream.
+    fn notify_entry_update_parent(&self, _update_parent: &EntryUpdateParentInfo) {}
 
     /// Notify an Alpenglow block footer.
     ///

--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -1,5 +1,5 @@
 use {
-    crate::entry_notifier_interface::EntryNotifierArc,
+    crate::entry_notifier_interface::{EntryNotifierArc, EntryUpdateParentInfo},
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
     solana_clock::{BankId, Slot},
     solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
@@ -26,6 +26,7 @@ pub enum EntryNotification {
         bank_id: BankId,
         block_footer: Box<VersionedBlockFooter>,
     },
+    UpdateParent(EntryUpdateParentInfo),
 }
 
 pub type EntryNotifierSender = Sender<EntryNotification>;
@@ -86,6 +87,9 @@ impl EntryNotifierService {
                 bank_id,
                 block_footer,
             } => entry_notifier.notify_block_footer(slot, bank_id, block_footer.as_ref()),
+            EntryNotification::UpdateParent(update_parent) => {
+                entry_notifier.notify_entry_update_parent(&update_parent)
+            }
         }
         Ok(())
     }
@@ -123,6 +127,7 @@ mod tests {
             bank_id: BankId,
             block_footer: Box<VersionedBlockFooter>,
         },
+        UpdateParent(Slot, BankId, Slot, Hash),
     }
 
     #[derive(Default)]
@@ -159,10 +164,19 @@ mod tests {
                 block_footer: Box::new(block_footer.clone()),
             });
         }
+
+        fn notify_entry_update_parent(&self, update_parent: &EntryUpdateParentInfo) {
+            self.events.lock().unwrap().push(TestEvent::UpdateParent(
+                update_parent.slot,
+                update_parent.cleared_bank_id,
+                update_parent.parent_slot,
+                update_parent.parent_block_id,
+            ));
+        }
     }
 
     #[test]
-    fn test_forwards_entry_and_block_footer_in_order() {
+    fn test_forwards_entry_notifications_in_order() {
         let (sender, receiver) = unbounded();
         let notifier = Arc::new(TestEntryNotifier::default());
         let block_footer = VersionedBlockFooter::V1(BlockFooterV1 {
@@ -173,6 +187,7 @@ mod tests {
             skip_reward_cert: None,
             notar_reward_cert: None,
         });
+        let parent_block_id = Hash::new_unique();
 
         sender
             .send(EntryNotification::Entry {
@@ -188,6 +203,14 @@ mod tests {
             })
             .unwrap();
         sender
+            .send(EntryNotification::UpdateParent(EntryUpdateParentInfo {
+                slot: 42,
+                cleared_bank_id: 9,
+                parent_slot: 40,
+                parent_block_id,
+            }))
+            .unwrap();
+        sender
             .send(EntryNotification::BlockFooter {
                 slot: 42,
                 bank_id: 9,
@@ -195,6 +218,7 @@ mod tests {
             })
             .unwrap();
 
+        EntryNotifierService::notify(&receiver, notifier.clone()).unwrap();
         EntryNotifierService::notify(&receiver, notifier.clone()).unwrap();
         EntryNotifierService::notify(&receiver, notifier.clone()).unwrap();
 
@@ -207,6 +231,7 @@ mod tests {
                     index: 3,
                     starting_transaction_index: 7,
                 },
+                TestEvent::UpdateParent(42, 9, 40, parent_block_id),
                 TestEvent::BlockFooter {
                     slot: 42,
                     bank_id: 9,


### PR DESCRIPTION
#### Problem
Geyser plugins may receive entry or deshred transaction notifications from before an UpdateParent marker, but currently have no way to reconcile them.

#### Summary of Changes
Adds `notify_update_parent` to the Geyser plugin interface and emits it through the entry and deshred transaction notification paths.

#### Testing
CI

Part of #13540 and #12885 