### PR TITLE
refactor: program-runtime: decouple entry search from extract

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -697,9 +697,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     ) {
                                         break;
                                     }
-                                    if let ProgramCacheEntryType::Unloaded(_environment) =
-                                        &entry.program
-                                    {
+                                    if entry.program.is_unloaded() {
                                         break;
                                     }
                                     entry.clone()

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -694,10 +694,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     if !Self::matches_criteria(
                                         entry,
                                         &program_to_load.match_criteria,
-                                    ) {
-                                        break;
-                                    }
-                                    if entry.program.is_unloaded() {
+                                    ) || entry.program.is_unloaded()
+                                    {
                                         break;
                                     }
                                     entry.clone()

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -674,7 +674,20 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 );
                             if entry_in_same_branch {
                                 let entry_is_effective = batch_slot >= entry.effective_slot();
-                                let entry_to_return = if entry_is_effective {
+                                let entry_to_return = if !entry_is_effective {
+                                    if !entry.is_implicit_delay_visibility_tombstone(batch_slot) {
+                                        continue;
+                                    }
+                                    // Found a program entry on the current fork, but it's not effective
+                                    // yet. It indicates that the program has delayed visibility. Return
+                                    // the tombstone to reflect that.
+                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
+                                        entry.deployment_slot,
+                                        entry.account_owner,
+                                        ProgramCacheEntryType::DelayVisibility,
+                                        Arc::clone(&entry.stats),
+                                    ))
+                                } else {
                                     if !Self::matches_environment(
                                         entry,
                                         program_runtime_environment_for_execution,
@@ -699,18 +712,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                         break;
                                     }
                                     entry.clone()
-                                } else if entry.is_implicit_delay_visibility_tombstone(batch_slot) {
-                                    // Found a program entry on the current fork, but it's not effective
-                                    // yet. It indicates that the program has delayed visibility. Return
-                                    // the tombstone to reflect that.
-                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
-                                        entry.deployment_slot,
-                                        entry.account_owner,
-                                        ProgramCacheEntryType::DelayVisibility,
-                                        Arc::clone(&entry.stats),
-                                    ))
-                                } else {
-                                    continue;
                                 };
                                 entry_to_return.update_access_slot(batch_slot);
                                 if increment_usage_counter {

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -634,6 +634,63 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
+    /// Find the entry at `program_id` visible in `slot`.
+    #[allow(clippy::too_many_arguments)]
+    fn find_visible_entry<'a>(
+        entries: &'a HashMap<Pubkey, Vec<Arc<ProgramCacheEntry>>>,
+        locked_fork_graph: &FG,
+        latest_root_slot: Slot,
+        program_id: &Pubkey,
+        loader: ProgramCacheEntryOwner,
+        match_criteria: &ProgramCacheMatchCriteria,
+        slot: Slot,
+        program_runtime_environment_for_execution: &ProgramRuntimeEnvironment,
+    ) -> Option<&'a Arc<ProgramCacheEntry>> {
+        let second_level = entries.get(program_id)?;
+        let mut filter_by_deployment_slot = None;
+        for entry in second_level.iter().rev() {
+            let required_deployment_slot =
+                filter_by_deployment_slot.unwrap_or(entry.deployment_slot);
+            if required_deployment_slot != entry.deployment_slot || loader != entry.account_owner {
+                continue;
+            }
+            let entry_in_same_branch = entry.deployment_slot <= latest_root_slot
+                || matches!(
+                    locked_fork_graph.relationship(entry.deployment_slot, slot),
+                    BlockRelation::Equal | BlockRelation::Ancestor
+                );
+            if entry_in_same_branch {
+                let entry_is_effective = slot >= entry.effective_slot();
+                if !entry_is_effective {
+                    if !entry.is_implicit_delay_visibility_tombstone(slot) {
+                        continue;
+                    }
+                } else {
+                    if !Self::matches_environment(entry, program_runtime_environment_for_execution)
+                    {
+                        // We found an entry that would work, had its environment matched
+                        // the one we're planning to use for this slot.
+                        //
+                        // At this point we know that whatever the "current version" of
+                        // program is, it must have had a deployment slot equal to the
+                        // program we're looking at in this iteration. We just have to find
+                        // one with the correct environment and can skip entries for any
+                        // other deployment slot while searching further.
+                        filter_by_deployment_slot =
+                            filter_by_deployment_slot.or(Some(entry.deployment_slot));
+                        continue;
+                    }
+                    if !Self::matches_criteria(entry, match_criteria) || entry.program.is_unloaded()
+                    {
+                        break;
+                    }
+                }
+                return Some(entry);
+            }
+        }
+        None
+    }
+
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(
@@ -655,77 +712,37 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 loading_entries,
             } => {
                 search_for.retain(|program_to_load| {
-                    if let Some(second_level) = entries.get(program_to_load.program_id) {
-                        let mut filter_by_deployment_slot = None;
-                        for entry in second_level.iter().rev() {
-                            let required_deployment_slot =
-                                filter_by_deployment_slot.unwrap_or(entry.deployment_slot);
-                            if required_deployment_slot != entry.deployment_slot
-                                || program_to_load.loader != entry.account_owner
-                            {
-                                continue;
-                            }
-                            let entry_in_same_branch = entry.deployment_slot
-                                <= self.latest_root_slot
-                                || matches!(
-                                    locked_fork_graph
-                                        .relationship(entry.deployment_slot, batch_slot),
-                                    BlockRelation::Equal | BlockRelation::Ancestor
-                                );
-                            if entry_in_same_branch {
-                                let entry_is_effective = batch_slot >= entry.effective_slot();
-                                if !entry_is_effective {
-                                    if !entry.is_implicit_delay_visibility_tombstone(batch_slot) {
-                                        continue;
-                                    }
-                                } else {
-                                    if !Self::matches_environment(
-                                        entry,
-                                        program_runtime_environment_for_execution,
-                                    ) {
-                                        // We found an entry that would work, had its environment matched
-                                        // the one we're planning to use for this slot.
-                                        //
-                                        // At this point we know that whatever the "current version" of
-                                        // program is, it must have had a deployment slot equal to the
-                                        // program we're looking at in this iteration. We just have to find
-                                        // one with the correct environment and can skip entries for any
-                                        // other deployment slot while searching further.
-                                        filter_by_deployment_slot = filter_by_deployment_slot
-                                            .or(Some(entry.deployment_slot));
-                                        continue;
-                                    }
-                                    if !Self::matches_criteria(
-                                        entry,
-                                        &program_to_load.match_criteria,
-                                    ) || entry.program.is_unloaded()
-                                    {
-                                        break;
-                                    }
-                                }
-                                let entry_to_return = if entry_is_effective {
-                                    entry.clone()
-                                } else {
-                                    // Found a program entry on the current fork, but it's not effective
-                                    // yet. It indicates that the program has delayed visibility. Return
-                                    // the tombstone to reflect that.
-                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
-                                        entry.deployment_slot,
-                                        entry.account_owner,
-                                        ProgramCacheEntryType::DelayVisibility,
-                                        Arc::clone(&entry.stats),
-                                    ))
-                                };
-                                entry_to_return.update_access_slot(batch_slot);
-                                if increment_usage_counter {
-                                    entry_to_return.stats.uses.fetch_add(1, Ordering::Relaxed);
-                                }
-                                loaded_programs_for_tx_batch
-                                    .entries
-                                    .insert(*program_to_load.program_id, entry_to_return);
-                                return false;
-                            }
+                    if let Some(entry) = Self::find_visible_entry(
+                        entries,
+                        &locked_fork_graph,
+                        self.latest_root_slot,
+                        program_to_load.program_id,
+                        program_to_load.loader,
+                        &program_to_load.match_criteria,
+                        batch_slot,
+                        program_runtime_environment_for_execution,
+                    ) {
+                        let entry_to_return = if batch_slot >= entry.effective_slot() {
+                            entry.clone()
+                        } else {
+                            // Found a program entry on the current fork, but it's not effective
+                            // yet. It indicates that the program has delayed visibility. Return
+                            // the tombstone to reflect that.
+                            Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
+                                entry.deployment_slot,
+                                entry.account_owner,
+                                ProgramCacheEntryType::DelayVisibility,
+                                Arc::clone(&entry.stats),
+                            ))
+                        };
+                        entry_to_return.update_access_slot(batch_slot);
+                        if increment_usage_counter {
+                            entry_to_return.stats.uses.fetch_add(1, Ordering::Relaxed);
                         }
+                        loaded_programs_for_tx_batch
+                            .entries
+                            .insert(*program_to_load.program_id, entry_to_return);
+                        return false;
                     }
                     if cooperative_loading_task.is_none() {
                         let mut loading_entries = loading_entries.lock().unwrap();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -648,6 +648,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         let fork_graph = self.fork_graph.as_ref().unwrap().upgrade().unwrap();
         let locked_fork_graph = fork_graph.read().unwrap();
         let mut cooperative_loading_task = None;
+        let batch_slot = loaded_programs_for_tx_batch.slot;
         match &self.index {
             IndexImplementation::V1 {
                 entries,
@@ -667,15 +668,12 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             let entry_in_same_branch = entry.deployment_slot
                                 <= self.latest_root_slot
                                 || matches!(
-                                    locked_fork_graph.relationship(
-                                        entry.deployment_slot,
-                                        loaded_programs_for_tx_batch.slot
-                                    ),
+                                    locked_fork_graph
+                                        .relationship(entry.deployment_slot, batch_slot),
                                     BlockRelation::Equal | BlockRelation::Ancestor
                                 );
                             if entry_in_same_branch {
-                                let entry_is_effective =
-                                    loaded_programs_for_tx_batch.slot >= entry.effective_slot();
+                                let entry_is_effective = batch_slot >= entry.effective_slot();
                                 let entry_to_return = if entry_is_effective {
                                     if !Self::matches_environment(
                                         entry,
@@ -705,9 +703,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                         break;
                                     }
                                     entry.clone()
-                                } else if entry.is_implicit_delay_visibility_tombstone(
-                                    loaded_programs_for_tx_batch.slot,
-                                ) {
+                                } else if entry.is_implicit_delay_visibility_tombstone(batch_slot) {
                                     // Found a program entry on the current fork, but it's not effective
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
@@ -720,8 +716,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 } else {
                                     continue;
                                 };
-                                entry_to_return
-                                    .update_access_slot(loaded_programs_for_tx_batch.slot);
+                                entry_to_return.update_access_slot(batch_slot);
                                 if increment_usage_counter {
                                     entry_to_return.stats.uses.fetch_add(1, Ordering::Relaxed);
                                 }
@@ -736,10 +731,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         let mut loading_entries = loading_entries.lock().unwrap();
                         let entry = loading_entries.entry(*program_to_load.program_id);
                         if let Entry::Vacant(entry) = entry {
-                            entry.insert((
-                                loaded_programs_for_tx_batch.slot,
-                                thread::current().id(),
-                            ));
+                            entry.insert((batch_slot, thread::current().id()));
                             cooperative_loading_task = Some(*program_to_load.program_id);
                         }
                     }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -674,19 +674,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 );
                             if entry_in_same_branch {
                                 let entry_is_effective = batch_slot >= entry.effective_slot();
-                                let entry_to_return = if !entry_is_effective {
+                                if !entry_is_effective {
                                     if !entry.is_implicit_delay_visibility_tombstone(batch_slot) {
                                         continue;
                                     }
-                                    // Found a program entry on the current fork, but it's not effective
-                                    // yet. It indicates that the program has delayed visibility. Return
-                                    // the tombstone to reflect that.
-                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
-                                        entry.deployment_slot,
-                                        entry.account_owner,
-                                        ProgramCacheEntryType::DelayVisibility,
-                                        Arc::clone(&entry.stats),
-                                    ))
                                 } else {
                                     if !Self::matches_environment(
                                         entry,
@@ -711,7 +702,19 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     {
                                         break;
                                     }
+                                }
+                                let entry_to_return = if entry_is_effective {
                                     entry.clone()
+                                } else {
+                                    // Found a program entry on the current fork, but it's not effective
+                                    // yet. It indicates that the program has delayed visibility. Return
+                                    // the tombstone to reflect that.
+                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
+                                        entry.deployment_slot,
+                                        entry.account_owner,
+                                        ProgramCacheEntryType::DelayVisibility,
+                                        Arc::clone(&entry.stats),
+                                    ))
                                 };
                                 entry_to_return.update_access_slot(batch_slot);
                                 if increment_usage_counter {

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -148,6 +148,11 @@ impl ProgramCacheEntryType {
             _ => None,
         }
     }
+
+    /// Returns `true` if the program's binary has been evicted.
+    pub fn is_unloaded(&self) -> bool {
+        matches!(self, ProgramCacheEntryType::Unloaded(_))
+    }
 }
 
 /// Holds a program version at a specific address and on a specific slot / fork.

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -149,7 +149,7 @@ impl ProgramCacheEntryType {
         }
     }
 
-    /// Returns `true` if the program's binary has been evicted.
+    /// Returns `true` if this entry is in the `Unloaded` state (verified, but executable not currently resident/compiled).
     pub fn is_unloaded(&self) -> bool {
         matches!(self, ProgramCacheEntryType::Unloaded(_))
     }


### PR DESCRIPTION
#### Problem
We need to set the stage for #14306 by landing the initial refactoring in one dedicated PR to tidy up the diff on the behavioral change.

#### Summary of Changes
Refactor `ProgramCache::extract` so that searching/probing for a program cache entry in the slot versions is decoupled from `extract`, so that it may be used standalone.

The commits are intentionally tiny, since this function is extremely sensitive.

#### Testing
Purely a refactoring change. No behavioral change is included. Existing tests should catch any regressions.

