### PR TITLE
Fix - Insert `Unloaded` entry on deployment

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -287,7 +287,7 @@ fn load_program<'a>(
     // Allowing mut here, since it may be needed for jit compile, which is under a config flag
     #[allow(unused_mut)]
     let mut verified_executable = if is_elf {
-        let result = ProgramCacheEntry::new(
+        let result = ProgramCacheEntry::load(
             &loader_key,
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             slot,

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         invoke_context::InvokeContext,
         loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
-        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
+        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
     },
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
@@ -101,11 +101,11 @@ pub fn deploy_program(
         load_program_metrics.verify_code_us = verify_code_time.as_us();
     }
     // Insert but with program_runtime_environment
-    let program_cache_entry = ProgramCacheEntry::new_tombstone_or_unloaded(
+    let program_cache_entry = ProgramCacheEntry::new_unloaded(
         deployment_slot,
         ProgramCacheEntryOwner::try_from(loader_key)
             .map_err(|_| InstructionError::InvalidAccountData)?,
-        ProgramCacheEntryType::Unloaded(program_runtime_environment),
+        program_runtime_environment,
     );
     if let Some(old_entry) = program_cache_for_tx_batch.find(program_id) {
         program_cache_entry.stats.merge_from(&old_entry.stats);

--- a/program-runtime/src/deploy.rs
+++ b/program-runtime/src/deploy.rs
@@ -6,7 +6,7 @@ use {
     crate::{
         invoke_context::InvokeContext,
         loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment},
-        program_cache_entry::ProgramCacheEntry,
+        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
     },
     solana_clock::Slot,
     solana_instruction::error::InstructionError,
@@ -100,30 +100,21 @@ pub fn deploy_program(
         verify_code_time.stop();
         load_program_metrics.verify_code_us = verify_code_time.as_us();
     }
-    // Reload but with program_runtime_environment
-    let executor = unsafe {
-        // SAFETY: The executable has been verified just above.
-        ProgramCacheEntry::reload(
-            loader_key,
-            program_runtime_environment,
-            deployment_slot,
-            programdata,
-            #[cfg(feature = "metrics")]
-            load_program_metrics,
-        )
-    }
-    .map_err(|err| {
-        ic_logger_msg!(log_collector, "{}", err);
-        InstructionError::InvalidAccountData
-    })?;
+    // Insert but with program_runtime_environment
+    let program_cache_entry = ProgramCacheEntry::new_tombstone_or_unloaded(
+        deployment_slot,
+        ProgramCacheEntryOwner::try_from(loader_key)
+            .map_err(|_| InstructionError::InvalidAccountData)?,
+        ProgramCacheEntryType::Unloaded(program_runtime_environment),
+    );
     if let Some(old_entry) = program_cache_for_tx_batch.find(program_id) {
-        executor.stats.merge_from(&old_entry.stats);
+        program_cache_entry.stats.merge_from(&old_entry.stats);
     }
     #[cfg(feature = "metrics")]
     {
         load_program_metrics.program_id = program_id.to_string();
     }
-    program_cache_for_tx_batch.store_modified_entry(*program_id, Arc::new(executor));
+    program_cache_for_tx_batch.store_modified_entry(*program_id, Arc::new(program_cache_entry));
     Ok(())
 }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1063,17 +1063,16 @@ pub(crate) mod tests {
         })
     }
 
-    fn set_tombstone<FG: ForkGraph>(
+    fn set_failed_verification_tombstone<FG: ForkGraph>(
         cache: &mut ProgramCache<FG>,
         key: Pubkey,
         current_slot: Slot,
-        reason: ProgramCacheEntryType,
+        env: ProgramRuntimeEnvironment,
     ) -> Arc<ProgramCacheEntry> {
-        let env = get_mock_program_runtime_environment();
-        let program = Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
+        let program = Arc::new(ProgramCacheEntry::new_failed_verification_tombstone(
             current_slot,
             ProgramCacheEntryOwner::LoaderV2,
-            reason,
+            ProgramRuntimeEnvironment::clone(&env),
         ));
         cache.assign_program(&env, key, current_slot, program.clone());
         program
@@ -1133,11 +1132,11 @@ pub(crate) mod tests {
         // Add tombstones entries for program
         let env = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
         for slot in 21..31 {
-            set_tombstone(
+            set_failed_verification_tombstone(
                 cache,
                 program,
                 slot,
-                ProgramCacheEntryType::FailedVerification(env.clone()),
+                ProgramRuntimeEnvironment::clone(&env),
             );
         }
 
@@ -1431,12 +1430,10 @@ pub(crate) mod tests {
                         latest_access_slot: AtomicU64::new(deployment_slot),
                     }
                 } else {
-                    ProgramCacheEntry::new_tombstone_or_unloaded(
+                    ProgramCacheEntry::new_failed_verification_tombstone(
                         deployment_slot,
                         ProgramCacheEntryOwner::LoaderV2,
-                        ProgramCacheEntryType::FailedVerification(ProgramRuntimeEnvironment::from(
-                            BuiltinProgram::new_mock(),
-                        )), // Assign them different environments
+                        ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock()), // Assign them different environments
                     )
                 });
                 assert!(!cache.assign_program(&env, program_id, deployment_slot, entry));
@@ -1622,10 +1619,10 @@ pub(crate) mod tests {
     #[test]
     fn test_tombstone() {
         let env = get_mock_program_runtime_environment();
-        let tombstone = ProgramCacheEntry::new_tombstone_or_unloaded(
+        let tombstone = ProgramCacheEntry::new_failed_verification_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV2,
-            ProgramCacheEntryType::FailedVerification(env.clone()),
+            env.clone(),
         );
         assert_matches!(
             tombstone.program,
@@ -1635,11 +1632,8 @@ pub(crate) mod tests {
         assert_eq!(tombstone.deployment_slot, 0);
         assert_eq!(tombstone.effective_slot(), 0);
 
-        let tombstone = ProgramCacheEntry::new_tombstone_or_unloaded(
-            100,
-            ProgramCacheEntryOwner::LoaderV2,
-            ProgramCacheEntryType::Closed,
-        );
+        let tombstone =
+            ProgramCacheEntry::new_closed_tombstone(100, ProgramCacheEntryOwner::LoaderV2);
         assert_matches!(tombstone.program, ProgramCacheEntryType::Closed);
         assert!(tombstone.is_tombstone());
         assert_eq!(tombstone.deployment_slot, 100);
@@ -1647,12 +1641,7 @@ pub(crate) mod tests {
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);
         let program1 = Pubkey::new_unique();
-        let tombstone = set_tombstone(
-            &mut cache,
-            program1,
-            10,
-            ProgramCacheEntryType::FailedVerification(env.clone()),
-        );
+        let tombstone = set_failed_verification_tombstone(&mut cache, program1, 10, env.clone());
         let slot_versions = cache.get_slot_versions_for_tests(&program1);
         assert_eq!(slot_versions.len(), 1);
         assert!(slot_versions.first().unwrap().is_tombstone());
@@ -1666,12 +1655,7 @@ pub(crate) mod tests {
         assert_eq!(slot_versions.len(), 1);
         assert!(!slot_versions.first().unwrap().is_tombstone());
 
-        let tombstone = set_tombstone(
-            &mut cache,
-            program2,
-            60,
-            ProgramCacheEntryType::FailedVerification(env),
-        );
+        let tombstone = set_failed_verification_tombstone(&mut cache, program2, 60, env);
         let slot_versions = cache.get_slot_versions_for_tests(&program2);
         assert_eq!(slot_versions.len(), 2);
         assert!(!slot_versions.first().unwrap().is_tombstone());
@@ -2275,10 +2259,9 @@ pub(crate) mod tests {
             &env,
             program1,
             10,
-            Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
+            Arc::new(ProgramCacheEntry::new_closed_tombstone(
                 10,
                 ProgramCacheEntryOwner::LoaderV3,
-                ProgramCacheEntryType::Closed,
             )),
         );
         cache.assign_program(&env, program1, 20, new_test_entry(20));
@@ -2473,10 +2456,9 @@ pub(crate) mod tests {
     #[test]
     fn test_usable_entries_for_slot() {
         ProgramCache::<TestForkGraph>::new(0);
-        let tombstone = Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
+        let tombstone = Arc::new(ProgramCacheEntry::new_closed_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV2,
-            ProgramCacheEntryType::Closed,
         ));
 
         assert!(ProgramCache::<TestForkGraph>::matches_criteria(

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -445,11 +445,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 ProgramCacheEntryType::Builtin(_),
                                 ProgramCacheEntryType::Builtin(_),
                             )
-                            | (ProgramCacheEntryType::Closed, ProgramCacheEntryType::Loaded(_))
-                            | (
-                                ProgramCacheEntryType::Closed,
-                                ProgramCacheEntryType::FailedVerification(_),
-                            )
                             | (
                                 ProgramCacheEntryType::Unloaded(_),
                                 ProgramCacheEntryType::Loaded(_),
@@ -1465,6 +1460,7 @@ pub(crate) mod tests {
     #[test_matrix(
         (
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
+            ProgramCacheEntryType::Closed,
             new_loaded_entry(get_mock_program_runtime_environment()),
         ),
         (
@@ -1476,10 +1472,7 @@ pub(crate) mod tests {
         )
     )]
     #[test_matrix(
-        (
-            ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
-        ),
+        ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
         (
             ProgramCacheEntryType::Closed,
             ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
@@ -1527,10 +1520,7 @@ pub(crate) mod tests {
     }
 
     #[test_matrix(
-        (
-            ProgramCacheEntryType::Closed,
-            ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
-        ),
+        ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
         (
             new_loaded_entry(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -335,7 +335,7 @@ impl ProgramCacheForTxBatch {
                     // Found a program entry on the current fork, but it's not effective
                     // yet. It indicates that the program has delayed visibility. Return
                     // the tombstone to reflect that.
-                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
+                    Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded_with_stats(
                         entry.deployment_slot,
                         entry.account_owner,
                         ProgramCacheEntryType::DelayVisibility,
@@ -711,12 +711,14 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     // Found a program entry on the current fork, but it's not effective
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
-                                    Arc::new(ProgramCacheEntry::new_tombstone_with_stats(
-                                        entry.deployment_slot,
-                                        entry.account_owner,
-                                        ProgramCacheEntryType::DelayVisibility,
-                                        Arc::clone(&entry.stats),
-                                    ))
+                                    Arc::new(
+                                        ProgramCacheEntry::new_tombstone_or_unloaded_with_stats(
+                                            entry.deployment_slot,
+                                            entry.account_owner,
+                                            ProgramCacheEntryType::DelayVisibility,
+                                            Arc::clone(&entry.stats),
+                                        ),
+                                    )
                                 } else {
                                     continue;
                                 };
@@ -1076,7 +1078,7 @@ pub(crate) mod tests {
         reason: ProgramCacheEntryType,
     ) -> Arc<ProgramCacheEntry> {
         let env = get_mock_program_runtime_environment();
-        let program = Arc::new(ProgramCacheEntry::new_tombstone(
+        let program = Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
             current_slot,
             ProgramCacheEntryOwner::LoaderV2,
             reason,
@@ -1437,7 +1439,7 @@ pub(crate) mod tests {
                         latest_access_slot: AtomicU64::new(deployment_slot),
                     }
                 } else {
-                    ProgramCacheEntry::new_tombstone(
+                    ProgramCacheEntry::new_tombstone_or_unloaded(
                         deployment_slot,
                         ProgramCacheEntryOwner::LoaderV2,
                         ProgramCacheEntryType::FailedVerification(ProgramRuntimeEnvironment::from(
@@ -1621,7 +1623,7 @@ pub(crate) mod tests {
     #[test]
     fn test_tombstone() {
         let env = get_mock_program_runtime_environment();
-        let tombstone = ProgramCacheEntry::new_tombstone(
+        let tombstone = ProgramCacheEntry::new_tombstone_or_unloaded(
             0,
             ProgramCacheEntryOwner::LoaderV2,
             ProgramCacheEntryType::FailedVerification(env.clone()),
@@ -1634,7 +1636,7 @@ pub(crate) mod tests {
         assert_eq!(tombstone.deployment_slot, 0);
         assert_eq!(tombstone.effective_slot(), 0);
 
-        let tombstone = ProgramCacheEntry::new_tombstone(
+        let tombstone = ProgramCacheEntry::new_tombstone_or_unloaded(
             100,
             ProgramCacheEntryOwner::LoaderV2,
             ProgramCacheEntryType::Closed,
@@ -2274,7 +2276,7 @@ pub(crate) mod tests {
             &env,
             program1,
             10,
-            Arc::new(ProgramCacheEntry::new_tombstone(
+            Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
                 10,
                 ProgramCacheEntryOwner::LoaderV3,
                 ProgramCacheEntryType::Closed,
@@ -2472,7 +2474,7 @@ pub(crate) mod tests {
     #[test]
     fn test_usable_entries_for_slot() {
         ProgramCache::<TestForkGraph>::new(0);
-        let tombstone = Arc::new(ProgramCacheEntry::new_tombstone(
+        let tombstone = Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
             0,
             ProgramCacheEntryOwner::LoaderV2,
             ProgramCacheEntryType::Closed,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -445,6 +445,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                 ProgramCacheEntryType::Builtin(_),
                                 ProgramCacheEntryType::Builtin(_),
                             )
+                            | (ProgramCacheEntryType::Closed, ProgramCacheEntryType::Unloaded(_))
                             | (
                                 ProgramCacheEntryType::Unloaded(_),
                                 ProgramCacheEntryType::Loaded(_),
@@ -1460,13 +1461,21 @@ pub(crate) mod tests {
     #[test_matrix(
         (
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
-            ProgramCacheEntryType::Closed,
             new_loaded_entry(get_mock_program_runtime_environment()),
         ),
         (
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Closed,
             ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment()),
+            new_loaded_entry(get_mock_program_runtime_environment()),
+            ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
+        )
+    )]
+    #[test_matrix(
+        ProgramCacheEntryType::Closed,
+        (
+            ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
+            ProgramCacheEntryType::Closed,
             new_loaded_entry(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),
         )
@@ -1525,6 +1534,10 @@ pub(crate) mod tests {
             new_loaded_entry(get_mock_program_runtime_environment()),
             ProgramCacheEntryType::FailedVerification(get_mock_program_runtime_environment()),
         )
+    )]
+    #[test_case(
+        ProgramCacheEntryType::Closed,
+        ProgramCacheEntryType::Unloaded(get_mock_program_runtime_environment())
     )]
     #[test_case(
         ProgramCacheEntryType::Builtin(BuiltinProgram::new_mock()),

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -335,10 +335,9 @@ impl ProgramCacheForTxBatch {
                     // Found a program entry on the current fork, but it's not effective
                     // yet. It indicates that the program has delayed visibility. Return
                     // the tombstone to reflect that.
-                    Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded_with_stats(
+                    Arc::new(ProgramCacheEntry::new_delay_visibility_tombstone(
                         entry.deployment_slot,
                         entry.account_owner,
-                        ProgramCacheEntryType::DelayVisibility,
                         Arc::clone(&entry.stats),
                     ))
                 } else {
@@ -707,14 +706,11 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                     // Found a program entry on the current fork, but it's not effective
                                     // yet. It indicates that the program has delayed visibility. Return
                                     // the tombstone to reflect that.
-                                    Arc::new(
-                                        ProgramCacheEntry::new_tombstone_or_unloaded_with_stats(
-                                            entry.deployment_slot,
-                                            entry.account_owner,
-                                            ProgramCacheEntryType::DelayVisibility,
-                                            Arc::clone(&entry.stats),
-                                        ),
-                                    )
+                                    Arc::new(ProgramCacheEntry::new_delay_visibility_tombstone(
+                                        entry.deployment_slot,
+                                        entry.account_owner,
+                                        Arc::clone(&entry.stats),
+                                    ))
                                 } else {
                                     continue;
                                 };

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -240,6 +240,20 @@ impl ProgramCacheEntry {
         })
     }
 
+    pub fn new_unloaded(
+        deployment_slot: Slot,
+        account_owner: ProgramCacheEntryOwner,
+        program_runtime_environment: ProgramRuntimeEnvironment,
+    ) -> Self {
+        Self {
+            program: ProgramCacheEntryType::Unloaded(program_runtime_environment),
+            account_owner,
+            deployment_slot,
+            stats: Arc::default(),
+            latest_access_slot: AtomicU64::new(0),
+        }
+    }
+
     pub fn to_unloaded_in_env(&self, environment: ProgramRuntimeEnvironment) -> Option<Self> {
         match &self.program {
             ProgramCacheEntryType::Loaded(_)
@@ -279,36 +293,42 @@ impl ProgramCacheEntry {
         }
     }
 
-    pub fn new_tombstone_or_unloaded(
-        slot: Slot,
+    pub fn new_failed_verification_tombstone(
+        deployment_slot: Slot,
         account_owner: ProgramCacheEntryOwner,
-        reason: ProgramCacheEntryType,
+        program_runtime_environment: ProgramRuntimeEnvironment,
     ) -> Self {
-        debug_assert!(matches!(
-            reason,
-            ProgramCacheEntryType::FailedVerification(_)
-                | ProgramCacheEntryType::Closed
-                | ProgramCacheEntryType::DelayVisibility
-                | ProgramCacheEntryType::Unloaded(_)
-        ));
         Self {
-            program: reason,
+            program: ProgramCacheEntryType::FailedVerification(program_runtime_environment),
             account_owner,
-            deployment_slot: slot,
+            deployment_slot,
+            stats: Arc::default(),
+            latest_access_slot: AtomicU64::new(0),
+        }
+    }
+
+    pub fn new_closed_tombstone(
+        deployment_slot: Slot,
+        account_owner: ProgramCacheEntryOwner,
+    ) -> Self {
+        Self {
+            program: ProgramCacheEntryType::Closed,
+            account_owner,
+            deployment_slot,
             stats: Arc::default(),
             latest_access_slot: AtomicU64::new(0),
         }
     }
 
     pub fn new_delay_visibility_tombstone(
-        slot: Slot,
+        deployment_slot: Slot,
         account_owner: ProgramCacheEntryOwner,
         stats: Arc<ProgramStatistics>,
     ) -> Self {
         Self {
             program: ProgramCacheEntryType::DelayVisibility,
             account_owner,
-            deployment_slot: slot,
+            deployment_slot,
             stats,
             latest_access_slot: AtomicU64::new(0),
         }

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -208,7 +208,6 @@ impl ProgramCacheEntry {
             elf_bytes,
             #[cfg(feature = "metrics")]
             metrics,
-            false, /* reloading */
         )
     }
 
@@ -218,7 +217,6 @@ impl ProgramCacheEntry {
         deployment_slot: Slot,
         elf_bytes: &[u8],
         #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
-        reloading: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let entry_stats = ProgramStatistics::default();
         #[cfg(feature = "metrics")]
@@ -230,14 +228,12 @@ impl ProgramCacheEntry {
             metrics.load_elf_us = load_elf_time.end_as_us();
         }
 
-        if !reloading {
-            #[cfg(feature = "metrics")]
-            let verify_code_time = solana_svm_measure::measure::Measure::start("verify_code_time");
-            executable.verify::<RequisiteVerifier>()?;
-            #[cfg(feature = "metrics")]
-            {
-                metrics.verify_code_us = verify_code_time.end_as_us();
-            }
+        #[cfg(feature = "metrics")]
+        let verify_code_time = solana_svm_measure::measure::Measure::start("verify_code_time");
+        executable.verify::<RequisiteVerifier>()?;
+        #[cfg(feature = "metrics")]
+        {
+            metrics.verify_code_us = verify_code_time.end_as_us();
         }
 
         #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -74,7 +74,7 @@ impl From<ProgramCacheEntryOwner> for Pubkey {
     - Builtin => Builtin in TransactionBatchProcessor::add_builtin
 
     Un/re/deployment (with delay and cooldown):
-    - Empty / Closed => Loaded / FailedVerification in UpgradeableLoaderInstruction::DeployWithMaxDataLen
+    - Empty => Loaded / FailedVerification in UpgradeableLoaderInstruction::DeployWithMaxDataLen
     - Loaded / FailedVerification => Loaded in UpgradeableLoaderInstruction::Upgrade
     - Loaded / FailedVerification => Closed in UpgradeableLoaderInstruction::Close
 

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -108,9 +108,9 @@ pub enum ProgramCacheEntryType {
     Closed,
     /// Tombstone for programs which have recently been modified but the new version is not visible yet.
     DelayVisibility,
-    /// Successfully verified but not currently compiled.
+    /// Valid program account, but not relocated, verified or compiled.
     ///
-    /// It continues to track usage statistics even when the compiled executable of the program is evicted from memory.
+    /// It continues to track usage statistics even when the executable of the program is evicted from memory.
     Unloaded(ProgramRuntimeEnvironment),
     /// Verified program.
     ///
@@ -209,32 +209,6 @@ impl ProgramCacheEntry {
             #[cfg(feature = "metrics")]
             metrics,
             false, /* reloading */
-        )
-    }
-
-    /// Reloads a user program, *without* running the verifier.
-    ///
-    /// # Safety
-    ///
-    /// This method is unsafe since it assumes that the program has already been verified. Should
-    /// only be called when the program was previously verified and loaded in the cache, but was
-    /// unloaded due to inactivity. It should also be checked that the `program_runtime_environment`
-    /// hasn't changed since it was unloaded.
-    pub unsafe fn reload(
-        loader_key: &Pubkey,
-        program_runtime_environment: ProgramRuntimeEnvironment,
-        deployment_slot: Slot,
-        elf_bytes: &[u8],
-        #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::new_internal(
-            loader_key,
-            program_runtime_environment,
-            deployment_slot,
-            elf_bytes,
-            #[cfg(feature = "metrics")]
-            metrics,
-            true, /* reloading */
         )
     }
 

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -74,7 +74,7 @@ impl From<ProgramCacheEntryOwner> for Pubkey {
     - Builtin => Builtin in TransactionBatchProcessor::add_builtin
 
     Un/re/deployment (with delay and cooldown):
-    - Empty => Loaded / FailedVerification in UpgradeableLoaderInstruction::DeployWithMaxDataLen
+    - Empty / Closed => Unloaded in UpgradeableLoaderInstruction::DeployWithMaxDataLen
     - Loaded / FailedVerification => Loaded in UpgradeableLoaderInstruction::Upgrade
     - Loaded / FailedVerification => Closed in UpgradeableLoaderInstruction::Close
 

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -284,15 +284,6 @@ impl ProgramCacheEntry {
         account_owner: ProgramCacheEntryOwner,
         reason: ProgramCacheEntryType,
     ) -> Self {
-        Self::new_tombstone_or_unloaded_with_stats(slot, account_owner, reason, Arc::default())
-    }
-
-    pub fn new_tombstone_or_unloaded_with_stats(
-        slot: Slot,
-        account_owner: ProgramCacheEntryOwner,
-        reason: ProgramCacheEntryType,
-        stats: Arc<ProgramStatistics>,
-    ) -> Self {
         debug_assert!(matches!(
             reason,
             ProgramCacheEntryType::FailedVerification(_)
@@ -302,6 +293,20 @@ impl ProgramCacheEntry {
         ));
         Self {
             program: reason,
+            account_owner,
+            deployment_slot: slot,
+            stats: Arc::default(),
+            latest_access_slot: AtomicU64::new(0),
+        }
+    }
+
+    pub fn new_delay_visibility_tombstone(
+        slot: Slot,
+        account_owner: ProgramCacheEntryOwner,
+        stats: Arc<ProgramStatistics>,
+    ) -> Self {
+        Self {
+            program: ProgramCacheEntryType::DelayVisibility,
             account_owner,
             deployment_slot: slot,
             stats,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -194,7 +194,7 @@ impl PartialEq for ProgramCacheEntry {
 
 impl ProgramCacheEntry {
     /// Creates a loaded user program
-    pub fn new(
+    pub fn load(
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -193,25 +193,8 @@ impl PartialEq for ProgramCacheEntry {
 }
 
 impl ProgramCacheEntry {
-    /// Creates a new user program
+    /// Creates a loaded user program
     pub fn new(
-        loader_key: &Pubkey,
-        program_runtime_environment: ProgramRuntimeEnvironment,
-        deployment_slot: Slot,
-        elf_bytes: &[u8],
-        #[cfg(feature = "metrics")] metrics: &mut LoadProgramMetrics,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::new_internal(
-            loader_key,
-            program_runtime_environment,
-            deployment_slot,
-            elf_bytes,
-            #[cfg(feature = "metrics")]
-            metrics,
-        )
-    }
-
-    fn new_internal(
         loader_key: &Pubkey,
         program_runtime_environment: ProgramRuntimeEnvironment,
         deployment_slot: Slot,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -326,29 +326,34 @@ impl ProgramCacheEntry {
         }
     }
 
-    pub fn new_tombstone(
+    pub fn new_tombstone_or_unloaded(
         slot: Slot,
         account_owner: ProgramCacheEntryOwner,
         reason: ProgramCacheEntryType,
     ) -> Self {
-        Self::new_tombstone_with_stats(slot, account_owner, reason, Arc::default())
+        Self::new_tombstone_or_unloaded_with_stats(slot, account_owner, reason, Arc::default())
     }
 
-    pub fn new_tombstone_with_stats(
+    pub fn new_tombstone_or_unloaded_with_stats(
         slot: Slot,
         account_owner: ProgramCacheEntryOwner,
         reason: ProgramCacheEntryType,
         stats: Arc<ProgramStatistics>,
     ) -> Self {
-        let tombstone = Self {
+        debug_assert!(matches!(
+            reason,
+            ProgramCacheEntryType::FailedVerification(_)
+                | ProgramCacheEntryType::Closed
+                | ProgramCacheEntryType::DelayVisibility
+                | ProgramCacheEntryType::Unloaded(_)
+        ));
+        Self {
             program: reason,
             account_owner,
             deployment_slot: slot,
             stats,
             latest_access_slot: AtomicU64::new(0),
-        };
-        debug_assert!(tombstone.is_tombstone());
-        tombstone
+        }
     }
 
     pub fn is_tombstone(&self) -> bool {

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -766,10 +766,9 @@ fn process_loader_upgradeable_instruction(
                                 .program_cache_for_tx_batch
                                 .store_modified_entry(
                                     program_key,
-                                    Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
+                                    Arc::new(ProgramCacheEntry::new_closed_tombstone(
                                         clock.slot,
                                         ProgramCacheEntryOwner::LoaderV3,
-                                        ProgramCacheEntryType::Closed,
                                     )),
                                 );
                         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1075,7 +1075,7 @@ mod test_utils {
                     .data()
                     .get(programdata_data_offset.min(account.data().len())..)
                     .unwrap();
-                let loaded_program = ProgramCacheEntry::new(
+                let loaded_program = ProgramCacheEntry::load(
                     owner,
                     ProgramRuntimeEnvironment::clone(&program_runtime_environment),
                     0,

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -766,7 +766,7 @@ fn process_loader_upgradeable_instruction(
                                 .program_cache_for_tx_batch
                                 .store_modified_entry(
                                     program_key,
-                                    Arc::new(ProgramCacheEntry::new_tombstone(
+                                    Arc::new(ProgramCacheEntry::new_tombstone_or_unloaded(
                                         clock.slot,
                                         ProgramCacheEntryOwner::LoaderV3,
                                         ProgramCacheEntryType::Closed,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -763,13 +763,11 @@ pub(crate) mod tests {
                 .global_program_cache
                 .read()
                 .unwrap();
-            let entries = program_cache.get_flattened_entries();
+            let entries = program_cache.get_flattened_entries_for_tests();
             let target_entry = entries
                 .iter()
-                .find(|(program_id, _last_modification_slot, _entry)| {
-                    program_id == &self.target_program_address
-                })
-                .map(|(_program_id, _last_modification_slot, entry)| entry)
+                .rfind(|(program_id, _entry)| program_id == &self.target_program_address)
+                .map(|(_program_id, entry)| entry)
                 .unwrap();
 
             // The target program entry should be updated.
@@ -777,7 +775,10 @@ pub(crate) mod tests {
             assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
 
             // The target program entry should be a BPF program.
-            assert_matches!(target_entry.program, ProgramCacheEntryType::Loaded(..));
+            assert_matches!(
+                target_entry.program,
+                ProgramCacheEntryType::Unloaded(..) | ProgramCacheEntryType::Loaded(..)
+            );
         }
     }
 

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -135,7 +135,7 @@ pub fn add_program_to_program_cache(
     )
     .unwrap();
 
-    let entry = ProgramCacheEntry::new(
+    let entry = ProgramCacheEntry::load(
         loader_key,
         program_runtime_environment,
         0, // deployment_slot

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -121,7 +121,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             ))
         }
 
-        ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::new(
+        ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::load(
             program_account.owner(),
             ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
@@ -131,7 +131,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
         )
         .map_err(|_| (0, ProgramCacheEntryOwner::LoaderV1)),
 
-        ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => ProgramCacheEntry::new(
+        ProgramAccountLoadResult::ProgramOfLoaderV2(program_account) => ProgramCacheEntry::load(
             program_account.owner(),
             ProgramRuntimeEnvironment::clone(program_runtime_environment),
             0,
@@ -150,7 +150,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
             .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
             .ok_or(())
             .and_then(|programdata| {
-                ProgramCacheEntry::new(
+                ProgramCacheEntry::load(
                     program_account.owner(),
                     ProgramRuntimeEnvironment::clone(program_runtime_environment),
                     deployment_slot,
@@ -168,7 +168,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
                 .get(LoaderV4State::program_data_offset()..)
                 .ok_or(())
                 .and_then(|elf_bytes| {
-                    ProgramCacheEntry::new(
+                    ProgramCacheEntry::load(
                         &loader_v4::id(),
                         ProgramRuntimeEnvironment::clone(program_runtime_environment),
                         deployment_slot,
@@ -473,7 +473,7 @@ mod tests {
         let slot: Slot = 2;
         let environment = ProgramRuntimeEnvironment::from(BuiltinProgram::new_mock());
 
-        let result = ProgramCacheEntry::new(
+        let result = ProgramCacheEntry::load(
             &loader,
             ProgramRuntimeEnvironment::clone(&environment),
             slot,
@@ -577,7 +577,7 @@ mod tests {
         );
 
         let program_runtime_environment = get_mock_program_runtime_environment();
-        let expected = ProgramCacheEntry::new(
+        let expected = ProgramCacheEntry::load(
             account_data.owner(),
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,
@@ -667,7 +667,7 @@ mod tests {
             .set_data(data[UpgradeableLoaderState::size_of_programdata_metadata()..].to_vec());
 
         let program_runtime_environment = get_mock_program_runtime_environment();
-        let expected = ProgramCacheEntry::new(
+        let expected = ProgramCacheEntry::load(
             account_data.owner(),
             ProgramRuntimeEnvironment::clone(&program_runtime_environment),
             0,

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -113,9 +113,13 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
 
     let (load_result, last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
     let loaded_program = match load_result {
-        ProgramAccountLoadResult::InvalidAccountData(owner) => Ok(
-            ProgramCacheEntry::new_tombstone(current_slot, owner, ProgramCacheEntryType::Closed),
-        ),
+        ProgramAccountLoadResult::InvalidAccountData(owner) => {
+            Ok(ProgramCacheEntry::new_tombstone_or_unloaded(
+                current_slot,
+                owner,
+                ProgramCacheEntryType::Closed,
+            ))
+        }
 
         ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::new(
             program_account.owner(),
@@ -179,7 +183,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     }
     .unwrap_or_else(|(deployment_slot, owner)| {
         let env = ProgramRuntimeEnvironment::clone(program_runtime_environment);
-        ProgramCacheEntry::new_tombstone(
+        ProgramCacheEntry::new_tombstone_or_unloaded(
             deployment_slot,
             owner,
             ProgramCacheEntryType::FailedVerification(env),
@@ -517,7 +521,7 @@ mod tests {
             &mut ExecuteTimings::default(),
         );
 
-        let loaded_program = ProgramCacheEntry::new_tombstone(
+        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
             0, // Slot 0
             ProgramCacheEntryOwner::LoaderV3,
             ProgramCacheEntryType::FailedVerification(
@@ -547,7 +551,7 @@ mod tests {
             200,
             &mut ExecuteTimings::default(),
         );
-        let loaded_program = ProgramCacheEntry::new_tombstone(
+        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
             0,
             ProgramCacheEntryOwner::LoaderV2,
             ProgramCacheEntryType::FailedVerification(
@@ -623,7 +627,7 @@ mod tests {
             0,
             &mut ExecuteTimings::default(),
         );
-        let loaded_program = ProgramCacheEntry::new_tombstone(
+        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
             0,
             ProgramCacheEntryOwner::LoaderV3,
             ProgramCacheEntryType::FailedVerification(

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -11,7 +11,7 @@ use {
             ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
             ProgramToLoad,
         },
-        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType},
+        program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, loader_v4},
@@ -114,11 +114,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     let (load_result, last_modification_slot) = load_program_accounts(callbacks, pubkey)?;
     let loaded_program = match load_result {
         ProgramAccountLoadResult::InvalidAccountData(owner) => {
-            Ok(ProgramCacheEntry::new_tombstone_or_unloaded(
-                current_slot,
-                owner,
-                ProgramCacheEntryType::Closed,
-            ))
+            Ok(ProgramCacheEntry::new_closed_tombstone(current_slot, owner))
         }
 
         ProgramAccountLoadResult::ProgramOfLoaderV1(program_account) => ProgramCacheEntry::load(
@@ -183,11 +179,7 @@ pub fn load_program_with_pubkey<CB: TransactionProcessingCallback>(
     }
     .unwrap_or_else(|(deployment_slot, owner)| {
         let env = ProgramRuntimeEnvironment::clone(program_runtime_environment);
-        ProgramCacheEntry::new_tombstone_or_unloaded(
-            deployment_slot,
-            owner,
-            ProgramCacheEntryType::FailedVerification(env),
-        )
+        ProgramCacheEntry::new_failed_verification_tombstone(deployment_slot, owner, env)
     });
 
     #[cfg(feature = "metrics")]
@@ -308,6 +300,7 @@ mod tests {
                 BlockRelation, ForkGraph, ProgramRuntimeEnvironment,
                 get_mock_program_runtime_environment,
             },
+            program_cache_entry::ProgramCacheEntryType,
             solana_sbpf::program::BuiltinProgram,
         },
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader},
@@ -521,12 +514,10 @@ mod tests {
             &mut ExecuteTimings::default(),
         );
 
-        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
+        let loaded_program = ProgramCacheEntry::new_failed_verification_tombstone(
             0, // Slot 0
             ProgramCacheEntryOwner::LoaderV3,
-            ProgramCacheEntryType::FailedVerification(
-                batch_processor.program_runtime_environment_for_epoch(20),
-            ),
+            batch_processor.program_runtime_environment_for_epoch(20),
         );
         assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
     }
@@ -551,12 +542,10 @@ mod tests {
             200,
             &mut ExecuteTimings::default(),
         );
-        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
+        let loaded_program = ProgramCacheEntry::new_failed_verification_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV2,
-            ProgramCacheEntryType::FailedVerification(
-                batch_processor.program_runtime_environment_for_epoch(20),
-            ),
+            batch_processor.program_runtime_environment_for_epoch(20),
         );
         assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
 
@@ -627,12 +616,10 @@ mod tests {
             0,
             &mut ExecuteTimings::default(),
         );
-        let loaded_program = ProgramCacheEntry::new_tombstone_or_unloaded(
+        let loaded_program = ProgramCacheEntry::new_failed_verification_tombstone(
             0,
             ProgramCacheEntryOwner::LoaderV3,
-            ProgramCacheEntryType::FailedVerification(
-                batch_processor.program_runtime_environment_for_epoch(0),
-            ),
+            batch_processor.program_runtime_environment_for_epoch(0),
         );
         assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
 


### PR DESCRIPTION
#### Problem

Followup of https://github.com/anza-xyz/agave/pull/14204#discussion_r3689089738

This allows us to remove the `ProgramCacheEntry::reload()` path which skips the second verification on deployment and thus also not having to worry about the `Closed` => `FailedVerification` transition.

#### Summary of Changes

- Adds `ProgramCacheEntry::new_unloaded()` which allows `Unloaded` entries to be created directly without `ProgramCacheEntry::to_unloaded()`.
- Inserts an `Unloaded` entry instead of using `ProgramCacheEntry::reload()` in `deploy_program()`.
- Removes `ProgramCacheEntry::reload()`.
- Removes new_internal parameter from `ProgramCacheEntry::new_internal()`.
- Unifies `ProgramCacheEntry::new_internal()` and `ProgramCacheEntry::new()` into `ProgramCacheEntry::load()`.
- Disallows `Closed` => `Loaded` / `FailedVerification` transitions in `ProgramCache::assign_program()`.
- Allows `Closed` => `Unloaded` transitions in `ProgramCache::assign_program()`.
- Renames `ProgramCacheEntry::new_tombstone_or_unloaded_with_stats()` => `ProgramCacheEntry::new_delay_visibility_tombstone()`.
- Splits` ProgramCacheEntry::new_tombstone()` into `ProgramCacheEntry::new_failed_verification_tombstone()`, `ProgramCacheEntry::new_closed_tombstone()` and `ProgramCacheEntry::new_delay_visibility_tombstone()`.

#### Testing

- Adjusts `TestContext::run_program_checks()`.
- Adjusts `test_assign_program_failure()`.
- Adjusts `test_assign_program_success()`.