### PR TITLE
accounts-db: Updates test_shrink_zero_lamport_single_ref_account()

### DIFF
--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1352,12 +1352,10 @@ fn test_shrink_zero_lamport_single_ref_account() {
 
         // for testing, we need to cause shrink to think this will be productive.
         // The zero lamport account isn't dead, but it can become dead inside shrink.
-        accounts
-            .storage
-            .get_slot_storage_entry(slot)
-            .unwrap()
+        let storage = accounts.storage.get_slot_storage_entry(slot).unwrap();
+        storage
             .num_alive_bytes
-            .fetch_sub(AppendVec::calculate_stored_size(0), Ordering::Release);
+            .fetch_sub(storage.accounts.calculate_stored_size(0), Ordering::Release);
 
         if let Some(latest_full_snapshot_slot) = latest_full_snapshot_slot {
             accounts.set_latest_full_snapshot_slot(latest_full_snapshot_slot);


### PR DESCRIPTION
#### Problem

`test_shrink_zero_lamport_single_ref_account()` hard codes AppendVec when calculating the size of accounts.

This isn't a problem today, but we are working on adding another storage file format, and will be leveraging the AccountsFileProvider that is from the AccountsDbConfig and thus the AccountsDb instance. This test currently does not do that.


#### Summary of Changes

Ask the storage file for the stored size.