### PR TITLE
accounts-db: Updates test_generate_index_duplicates_within_slot()

### DIFF
--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -109,26 +109,18 @@ fn test_generate_index_duplicates_within_slot() {
 
     let pubkey = Pubkey::from([1; 32]);
 
-    let append_vec = db.create_store(slot0, 1000);
+    let store = db.create_store(slot0, 1000);
 
-    let mut account_small = AccountSharedData::default();
-    account_small.set_data(vec![1]);
-    account_small.set_lamports(1);
-    let mut account_big = AccountSharedData::default();
-    account_big.set_data(vec![5; 10]);
-    account_big.set_lamports(2);
-    assert_ne!(
-        AppendVec::calculate_stored_size(account_big.data().len()),
-        AppendVec::calculate_stored_size(account_small.data().len()),
-    );
+    let account_small = AccountSharedData::new(1, 1, &Pubkey::default());
+    let account_big = AccountSharedData::new(2, 10, &Pubkey::default());
     // same account twice with different data lens
     // Rules are the last one of each pubkey is the one that ends up in the index.
-    let data = vec![(&pubkey, &account_big), (&pubkey, &account_small)];
+    let data = [(&pubkey, &account_big), (&pubkey, &account_small)];
     let storable_accounts = (slot0, &data[..]);
 
-    // construct append vec with account to generate an index from
-    append_vec.accounts.write_accounts(&storable_accounts);
-    db.storage.insert(Arc::new(append_vec));
+    // construct store with account to generate an index from
+    store.accounts.write_accounts(&storable_accounts);
+    db.storage.insert(Arc::new(store));
 
     assert!(!db.accounts_index.contains(&pubkey));
     let storage = db.get_storage_for_slot(slot0).unwrap();

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -101,7 +101,10 @@ fn create_store_for_shrink_tests(
     (temp_dir, store)
 }
 
-fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool) {
+#[test]
+#[should_panic(expected = "Accounts may only be stored once per slot:")]
+fn test_generate_index_duplicates_within_slot() {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let slot0 = 0;
 
     let pubkey = Pubkey::from([1; 32]);
@@ -120,10 +123,7 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     );
     // same account twice with different data lens
     // Rules are the last one of each pubkey is the one that ends up in the index.
-    let mut data = vec![(&pubkey, &account_big), (&pubkey, &account_small)];
-    if reverse {
-        data = data.into_iter().rev().collect();
-    }
+    let data = vec![(&pubkey, &account_big), (&pubkey, &account_small)];
     let storable_accounts = (slot0, &data[..]);
 
     // construct append vec with account to generate an index from
@@ -135,20 +135,6 @@ fn run_generate_index_duplicates_within_slot_test(db: AccountsDb, reverse: bool)
     let mut reader = crate::append_vec::new_scan_accounts_reader();
     let mut accum = IndexGenerationAccumulator::with_slots_capacity(1);
     db.generate_index_for_slot(&mut reader, &mut accum, 0, &storage);
-}
-
-#[test]
-#[should_panic(expected = "Accounts may only be stored once per slot:")]
-fn test_generate_index_duplicates_within_slot() {
-    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    run_generate_index_duplicates_within_slot_test(db, false);
-}
-
-#[test]
-#[should_panic(expected = "Accounts may only be stored once per slot:")]
-fn test_generate_index_duplicates_within_slot_reverse() {
-    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    run_generate_index_duplicates_within_slot_test(db, true);
 }
 
 #[test]


### PR DESCRIPTION
#### Problem

`test_generate_index_duplicates_within_slot()` hard codes AppendVec when calculating the size of accounts.

This isn't a problem today, but we are working on adding another storage file format, and will be leveraging the AccountsFileProvider that is from the AccountsDbConfig and thus the AccountsDb instance. This test currently does not do that.


#### Summary of Changes

* First, we notice that test_generate_index_duplicates_within_slot() and test_generate_index_duplicates_within_slot_reverse() are duplicates. Remove `reverse`.
* Second, inline `run_generate_index_duplicates_within_slot()` into the test. This is the first commit.
* Update the test to not use hard coded AppendVec for calculating the stored size. In fact this assert isn't useful, so can simply remove it.