### PR TITLE
accounts-db: Updates create_storages_and_update_index() test helper

### DIFF
--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1,12 +1,12 @@
 use {
     super::*,
     crate::{
-        accounts_file::{AccountsFile, AccountsFileProvider},
+        accounts_file::AccountsFileProvider,
         accounts_index::{
             ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountIndex, AccountSecondaryIndexesIncludeExclude,
             AccountsIndexConfig, IndexLimit, IndexLimitThreshold, test_utils::*,
         },
-        append_vec::{AppendVec, STORE_META_OVERHEAD, test_utils::TempFile},
+        append_vec::{AppendVec, STORE_META_OVERHEAD},
     },
     itertools::Itertools as _,
     rand::{prelude::SliceRandom as _, rng},

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -218,34 +218,20 @@ pub(crate) fn append_single_account_with_default_hash(
 }
 
 fn sample_storage_with_entries_id(
-    tf: &TempFile,
+    accounts_db: &AccountsDb,
     slot: Slot,
     pubkey: &Pubkey,
-    id: AccountsFileId,
     mark_alive: bool,
     account_data_size: Option<u64>,
-) -> Arc<AccountStorageEntry> {
-    let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
-    let file_size = account_data_size.unwrap_or(123);
-    let size_aligned = AppendVec::calculate_stored_size(file_size as usize);
-    let mut storage = AccountStorageEntry::new(
-        &paths[0],
-        slot,
-        id,
-        size_aligned as u64,
-        AccountsFileProvider::AppendVec,
-    );
-    let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, (1024 * 1024).max(size_aligned)));
-    storage.accounts = av;
+) -> AccountStorageEntry {
+    let account_data_size = account_data_size.unwrap_or(48);
+    let file_size = account_data_size + 1_000_000;
+    let storage = accounts_db.create_store(slot, file_size);
 
-    let account = AccountSharedData::new(
-        1,
-        account_data_size.unwrap_or(48) as usize,
-        &Pubkey::default(),
-    );
+    let account = AccountSharedData::new(1, account_data_size as usize, &Pubkey::default());
     append_single_account_with_default_hash(&storage, pubkey, &account, mark_alive, None);
 
-    Arc::new(storage)
+    storage
 }
 
 #[test]
@@ -6563,21 +6549,11 @@ pub(crate) fn create_storages_and_update_index(
         return;
     }
 
-    let tf = crate::append_vec::test_utils::get_append_vec_path("create_storages_and_update_index");
-
-    let starting_id = db
-        .storage
-        .iter()
-        .map(|storage| storage.1.id())
-        .max()
-        .unwrap_or(999);
     for i in 0..num_slots {
-        let id = starting_id + (i as AccountsFileId);
-        let pubkey1 = solana_pubkey::new_rand();
+        let pubkey = solana_pubkey::new_rand();
         let slot = starting_slot + i as Slot;
-        let storage =
-            sample_storage_with_entries_id(&tf, slot, &pubkey1, id, alive, account_data_size);
-        db.storage.insert(Arc::clone(&storage));
+        let storage = sample_storage_with_entries_id(db, slot, &pubkey, alive, account_data_size);
+        db.storage.insert(Arc::new(storage));
     }
 
     let storage = db.get_storage_for_slot(starting_slot).unwrap();

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -217,20 +217,6 @@ pub(crate) fn append_single_account_with_default_hash(
     }
 }
 
-fn append_sample_data_to_storage(
-    storage: &AccountStorageEntry,
-    pubkey: &Pubkey,
-    mark_alive: bool,
-    account_data_size: Option<u64>,
-) {
-    let acc = AccountSharedData::new(
-        1,
-        account_data_size.unwrap_or(48) as usize,
-        AccountSharedData::default().owner(),
-    );
-    append_single_account_with_default_hash(storage, pubkey, &acc, mark_alive, None);
-}
-
 fn sample_storage_with_entries_id(
     tf: &TempFile,
     slot: Slot,
@@ -242,7 +228,7 @@ fn sample_storage_with_entries_id(
     let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
     let file_size = account_data_size.unwrap_or(123);
     let size_aligned = AppendVec::calculate_stored_size(file_size as usize);
-    let mut data = AccountStorageEntry::new(
+    let mut storage = AccountStorageEntry::new(
         &paths[0],
         slot,
         id,
@@ -250,11 +236,16 @@ fn sample_storage_with_entries_id(
         AccountsFileProvider::AppendVec,
     );
     let av = AccountsFile::AppendVec(AppendVec::new(&tf.path, (1024 * 1024).max(size_aligned)));
-    data.accounts = av;
+    storage.accounts = av;
 
-    let arc = Arc::new(data);
-    append_sample_data_to_storage(&arc, pubkey, mark_alive, account_data_size);
-    arc
+    let account = AccountSharedData::new(
+        1,
+        account_data_size.unwrap_or(48) as usize,
+        &Pubkey::default(),
+    );
+    append_single_account_with_default_hash(&storage, pubkey, &account, mark_alive, None);
+
+    Arc::new(storage)
 }
 
 #[test]

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -217,23 +217,6 @@ pub(crate) fn append_single_account_with_default_hash(
     }
 }
 
-fn sample_storage_with_entries_id(
-    accounts_db: &AccountsDb,
-    slot: Slot,
-    pubkey: &Pubkey,
-    mark_alive: bool,
-    account_data_size: Option<u64>,
-) -> AccountStorageEntry {
-    let account_data_size = account_data_size.unwrap_or(48);
-    let file_size = account_data_size + 1_000_000;
-    let storage = accounts_db.create_store(slot, file_size);
-
-    let account = AccountSharedData::new(1, account_data_size as usize, &Pubkey::default());
-    append_single_account_with_default_hash(&storage, pubkey, &account, mark_alive, None);
-
-    storage
-}
-
 #[test]
 fn test_accountsdb_add_root() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
@@ -6549,10 +6532,14 @@ pub(crate) fn create_storages_and_update_index(
         return;
     }
 
+    let account_data_size = account_data_size.unwrap_or(48);
+    let file_size = account_data_size + 1_000_000;
     for i in 0..num_slots {
-        let pubkey = solana_pubkey::new_rand();
         let slot = starting_slot + i as Slot;
-        let storage = sample_storage_with_entries_id(db, slot, &pubkey, alive, account_data_size);
+        let storage = db.create_store(slot, file_size);
+        let pubkey = solana_pubkey::new_rand();
+        let account = AccountSharedData::new(1, account_data_size as usize, &Pubkey::default());
+        append_single_account_with_default_hash(&storage, &pubkey, &account, alive, None);
         db.storage.insert(Arc::new(storage));
     }
 

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -231,17 +231,16 @@ fn append_sample_data_to_storage(
     append_single_account_with_default_hash(storage, pubkey, &acc, mark_alive, None);
 }
 
-fn sample_storage_with_entries_id_fill_percentage(
+fn sample_storage_with_entries_id(
     tf: &TempFile,
     slot: Slot,
     pubkey: &Pubkey,
     id: AccountsFileId,
     mark_alive: bool,
     account_data_size: Option<u64>,
-    fill_percentage: u64,
 ) -> Arc<AccountStorageEntry> {
     let (_temp_dirs, paths) = get_temp_accounts_paths(1).unwrap();
-    let file_size = account_data_size.unwrap_or(123) * 100 / fill_percentage;
+    let file_size = account_data_size.unwrap_or(123);
     let size_aligned = AppendVec::calculate_stored_size(file_size as usize);
     let mut data = AccountStorageEntry::new(
         &paths[0],
@@ -256,25 +255,6 @@ fn sample_storage_with_entries_id_fill_percentage(
     let arc = Arc::new(data);
     append_sample_data_to_storage(&arc, pubkey, mark_alive, account_data_size);
     arc
-}
-
-fn sample_storage_with_entries_id(
-    tf: &TempFile,
-    slot: Slot,
-    pubkey: &Pubkey,
-    id: AccountsFileId,
-    mark_alive: bool,
-    account_data_size: Option<u64>,
-) -> Arc<AccountStorageEntry> {
-    sample_storage_with_entries_id_fill_percentage(
-        tf,
-        slot,
-        pubkey,
-        id,
-        mark_alive,
-        account_data_size,
-        100,
-    )
 }
 
 #[test]

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -6563,7 +6563,6 @@ pub(crate) fn remove_account_for_tests(storage: &AccountStorageEntry, num_bytes:
 
 pub(crate) fn create_storages_and_update_index(
     db: &AccountsDb,
-    tf: Option<&TempFile>,
     starting_slot: Slot,
     num_slots: usize,
     alive: bool,
@@ -6573,10 +6572,7 @@ pub(crate) fn create_storages_and_update_index(
         return;
     }
 
-    let local_tf = (tf.is_none()).then(|| {
-        crate::append_vec::test_utils::get_append_vec_path("create_storages_and_update_index")
-    });
-    let tf = tf.unwrap_or_else(|| local_tf.as_ref().unwrap());
+    let tf = crate::append_vec::test_utils::get_append_vec_path("create_storages_and_update_index");
 
     let starting_id = db
         .storage
@@ -6589,7 +6585,7 @@ pub(crate) fn create_storages_and_update_index(
         let pubkey1 = solana_pubkey::new_rand();
         let slot = starting_slot + i as Slot;
         let storage =
-            sample_storage_with_entries_id(tf, slot, &pubkey1, id, alive, account_data_size);
+            sample_storage_with_entries_id(&tf, slot, &pubkey1, id, alive, account_data_size);
         db.storage.insert(Arc::clone(&storage));
     }
 
@@ -6615,7 +6611,7 @@ pub(crate) fn create_db_with_storages_and_index(
     // verify we create an ancient appendvec that has alive accounts and does not have dead accounts
 
     let slot1 = 1;
-    create_storages_and_update_index(&db, None, slot1, num_slots, alive, account_data_size);
+    create_storages_and_update_index(&db, slot1, num_slots, alive, account_data_size);
 
     let slot1 = slot1 as Slot;
     (db, slot1)

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3011,7 +3011,6 @@ mod tests {
                     create_db_with_storages_and_index(true /*alive*/, 1, data_sizes[1]);
                 create_storages_and_update_index(
                     &db,
-                    None,
                     slot1 + 1,
                     1,
                     true,
@@ -3512,7 +3511,7 @@ mod tests {
         let db = AccountsDb::default_for_tests();
         let initial_slot = 0;
         // create append vecs that we'll fill the recycler with when we pack them into 1 packed append vec
-        create_storages_and_update_index(&db, None, initial_slot, MAX_RECYCLE_STORES, true, None);
+        create_storages_and_update_index(&db, initial_slot, MAX_RECYCLE_STORES, true, None);
         let max_slot_inclusive = initial_slot + (MAX_RECYCLE_STORES as Slot) - 1;
         let range = initial_slot..(max_slot_inclusive + 1);
         // storages with Arc::strong_count > 1 cannot be pulled out of the
@@ -3530,7 +3529,7 @@ mod tests {
             let mut storages = vec![];
             // build an ancient append vec at slot 'ancient_slot'
             let ancient_slot = starting_slot;
-            create_storages_and_update_index(&db, None, ancient_slot, num_normal_slots, true, None);
+            create_storages_and_update_index(&db, ancient_slot, num_normal_slots, true, None);
             let max_slot_inclusive = ancient_slot + (num_normal_slots as Slot);
             let range = ancient_slot..(max_slot_inclusive + 1);
             storages.extend(
@@ -3561,7 +3560,7 @@ mod tests {
 
             // create a 2nd ancient append vec at 'next_slot'
             let next_slot = max_slot_inclusive + 1;
-            create_storages_and_update_index(&db, None, next_slot, num_normal_slots, true, None);
+            create_storages_and_update_index(&db, next_slot, num_normal_slots, true, None);
             let max_slot_inclusive = next_slot + (num_normal_slots as Slot);
             let range_all = ancient_slot..(max_slot_inclusive + 1);
             let range = next_slot..(max_slot_inclusive + 1);
@@ -3789,7 +3788,7 @@ mod tests {
         let (db, slot1) =
             create_db_with_storages_and_index(true /*alive*/, num_slots, Some(data_size));
         let non_ancient_slot = slot1 + (2 * tuning.max_ancient_slots) as u64;
-        create_storages_and_update_index(&db, None, non_ancient_slot, 1, true, Some(data_size));
+        create_storages_and_update_index(&db, non_ancient_slot, 1, true, Some(data_size));
         let mut slot_vec = (slot1..(slot1 + num_slots as Slot)).collect::<Vec<_>>();
         slot_vec.push(non_ancient_slot);
         for slot in &slot_vec {


### PR DESCRIPTION
#### Problem

The test helper fn, `create_storages_and_update_index()`, hard codes AppendVec when creating an account storage file.

This isn't a problem today, but we are working on adding another storage file format, and will be leveraging the AccountsFileProvider that is from the AccountsDbConfig and thus the AccountsDb instance. This fn currently does not do that.


#### Summary of Changes

Probably easiest to go commit by commit.

- inlines sample_storage_with_entries_id_fill_percentage()
- remove tf param from create_storages_and_update_index()
- inlines append_sample_data_to_storage()
- refactor create_storages_and_update_index(), sample_storage_with_entries_id()
- inlines sample_storage_with_entries_id()
- fixup imports

Now all tests that use `create_storages_and_update_index()` will respect the AccountsFileProvider from the AccountsDbConfig.