### PR TITLE
Speed up cluster_nodes

### DIFF
--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -56,6 +56,7 @@ use {
     self::traits::{Shred as _, ShredData as _},
     crate::shred::{merkle_tree::MerkleProofEntry, payload::PayloadMutGuard},
     bitflags::bitflags,
+    bytes::BufMut,
     itertools::Either,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     serde::{Deserialize, Serialize},
@@ -66,7 +67,7 @@ use {
     solana_entry::entry::{Entry, create_ticks},
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_sha256_hasher::hashv,
+    solana_sha256_hasher::Hasher,
     solana_signature::{SIGNATURE_BYTES, Signature},
     static_assertions::const_assert_eq,
     std::{fmt::Debug, mem::MaybeUninit, ops::Range},
@@ -335,13 +336,16 @@ impl ShredId {
 
     pub fn seed(&self, leader: &Pubkey) -> [u8; 32] {
         let ShredId(slot, index, shred_type) = self;
-        hashv(&[
-            &slot.to_le_bytes(),
-            &u8::from(*shred_type).to_le_bytes(),
-            &index.to_le_bytes(),
-            AsRef::<[u8]>::as_ref(leader),
-        ])
-        .to_bytes()
+        let mut bytes = [0u8; 8 + 1 + 4 + 32];
+        let mut cursor = bytes.as_mut_slice();
+        cursor.put_u64_le(*slot);
+        cursor.put_u8(u8::from(*shred_type));
+        cursor.put_u32_le(*index);
+        cursor.put_slice(leader.as_ref());
+        // One inlined update avoids hashv's wrapper and per-slice update overhead.
+        let mut hasher = Hasher::default();
+        hasher.hash(&bytes);
+        hasher.result().to_bytes()
     }
 }
 

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -269,6 +269,7 @@ impl ClusterNodes<BroadcastStage> {
         new_cluster_nodes(cluster_info, cluster_type, stakes, use_cha_cha_8)
     }
 
+    #[inline]
     pub(crate) fn get_broadcast_peer(&self, shred: &ShredId) -> Option<&ContactInfo> {
         let mut rng = TurbineRng::new_seeded(&self.pubkey, shred, self.use_cha_cha_8);
         let index = self.weighted_shuffle.first(&mut rng)?;

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -20,7 +20,7 @@ use {
     solana_ledger::shred::{ShredId, filter::check_feature_activation_from_bank},
     solana_native_token::LAMPORTS_PER_SOL,
     solana_net_utils::SocketAddrSpace,
-    solana_pubkey::Pubkey,
+    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_runtime::bank::Bank,
     solana_signer::Signer,
     solana_time_utils::timestamp,
@@ -54,6 +54,7 @@ pub enum Error {
 }
 
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 #[allow(clippy::large_enum_variant)]
 enum NodeId {
     // TVU node obtained through gossip (staked or not).
@@ -65,12 +66,14 @@ enum NodeId {
 // A lite version of gossip ContactInfo local to turbine where we only hold on
 // to a few necessary fields from gossip ContactInfo.
 #[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub(crate) struct ContactInfo {
     pubkey: Pubkey,
     wallclock: u64,
     tvu_udp: Option<SocketAddr>,
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct Node {
     node: NodeId,
     stake: u64,
@@ -82,20 +85,31 @@ pub struct ClusterNodes<T> {
     // sorted by (stake, pubkey) in descending order.
     nodes: Vec<Node>,
     // Reverse index from nodes pubkey to their index in self.nodes.
-    index: HashMap<Pubkey, /*index:*/ usize>,
+    index: HashMap<Pubkey, /*index:*/ usize, PubkeyHasherBuilder>,
     // Shuffles by weights = stakes
-    weighted_shuffle: WeightedShuffle,
+    weighted_shuffle: Arc<WeightedShuffle>,
     use_cha_cha_8: bool,
     _phantom: PhantomData<T>,
 }
 
-// Cache entries are wrapped in Arc<OnceLock<...>>, so that, when needed, only
-// one single thread initializes the entry for the epoch without holding a lock
-// on the entire cache.
-type LruCacheOnce<K, V> = RwLock<LruCache<K, Arc<OnceLock<V>>>>;
+// Epoch-stable broadcast routing state. Gossip contacts are refreshed
+// separately and mapped back to these indices.
+struct BroadcastTopology {
+    nodes: Box<[(Pubkey, /*stake:*/ u64)]>,
+    index: HashMap<Pubkey, /*index:*/ usize, PubkeyHasherBuilder>,
+    weighted_shuffle: Arc<WeightedShuffle>,
+}
+
+// Cache entries are wrapped in Arc, so that only one thread initializes an
+// entry without holding a lock on the entire cache. The topology outlives
+// contact refreshes and is shared by successive entries for the same epoch.
+struct CacheEntry<T> {
+    snapshot: OnceLock<(/*as of:*/ Instant, Arc<ClusterNodes<T>>)>,
+    topology: OnceLock<Option<Arc<BroadcastTopology>>>,
+}
 
 pub struct ClusterNodesCache<T> {
-    cache: LruCacheOnce<Epoch, (/*as of:*/ Instant, Arc<ClusterNodes<T>>)>,
+    cache: RwLock<LruCache<Epoch, Arc<CacheEntry<T>>>>,
     ttl: Duration, // Time to live.
 }
 
@@ -248,6 +262,9 @@ impl ClusterNodes<BroadcastStage> {
         stakes: &HashMap<Pubkey, u64>,
         use_cha_cha_8: bool,
     ) -> Self {
+        if let Some(topology) = BroadcastTopology::new(cluster_type, stakes, cluster_info.id()) {
+            return new_cluster_nodes_from_topology(&topology, cluster_info, use_cha_cha_8);
+        }
         new_cluster_nodes(cluster_info, cluster_type, stakes, use_cha_cha_8)
     }
 
@@ -274,7 +291,7 @@ impl ClusterNodes<RetransmitStage> {
             });
         }
         THREAD_LOCAL_WEIGHTED_SHUFFLE.with_borrow_mut(|weighted_shuffle| {
-            weighted_shuffle.clone_from(&self.weighted_shuffle);
+            weighted_shuffle.clone_from(self.weighted_shuffle.as_ref());
             if let Some(index) = self.index.get(slot_leader) {
                 weighted_shuffle.remove_index(*index);
             }
@@ -322,7 +339,7 @@ impl ClusterNodes<RetransmitStage> {
                 return Ok(None);
             }
         }
-        let mut weighted_shuffle = self.weighted_shuffle.clone();
+        let mut weighted_shuffle = self.weighted_shuffle.as_ref().clone();
         if let Some(index) = self.index.get(leader).copied() {
             weighted_shuffle.remove_index(index);
         }
@@ -347,7 +364,7 @@ pub fn new_cluster_nodes<T: 'static>(
 ) -> ClusterNodes<T> {
     let self_pubkey = cluster_info.id();
     let nodes = get_nodes(cluster_info, cluster_type, stakes);
-    let index: HashMap<_, _> = nodes
+    let index: HashMap<_, _, PubkeyHasherBuilder> = nodes
         .iter()
         .enumerate()
         .map(|(ix, node)| (*node.pubkey(), ix))
@@ -362,9 +379,89 @@ pub fn new_cluster_nodes<T: 'static>(
         pubkey: self_pubkey,
         nodes,
         index,
-        weighted_shuffle,
+        weighted_shuffle: Arc::new(weighted_shuffle),
         _phantom: PhantomData,
         use_cha_cha_8,
+    }
+}
+
+impl BroadcastTopology {
+    // Zero-weight peers can be selected only when no positive stake remains
+    // after removing the local node. Keep using the full constructor for that
+    // behavior and for development clusters.
+    fn new(
+        cluster_type: ClusterType,
+        stakes: &HashMap<Pubkey, u64>,
+        self_pubkey: Pubkey,
+    ) -> Option<Self> {
+        if cluster_type == ClusterType::Development {
+            return None;
+        }
+        let mut total_stake = 0u64;
+        let mut nodes = Vec::with_capacity(stakes.len());
+        for (&pubkey, &stake) in stakes {
+            if stake > 0 {
+                total_stake = total_stake.checked_add(stake)?;
+                nodes.push((pubkey, stake));
+            }
+        }
+        if total_stake <= stakes.get(&self_pubkey).copied().unwrap_or_default() {
+            return None;
+        }
+        nodes.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| b.0.cmp(&a.0)));
+        let index: HashMap<_, _, PubkeyHasherBuilder> = nodes
+            .iter()
+            .enumerate()
+            .map(|(index, (pubkey, _))| (*pubkey, index))
+            .collect();
+        let mut weighted_shuffle =
+            WeightedShuffle::new("cluster-nodes", nodes.iter().map(|(_, stake)| stake));
+        if let Some(index) = index.get(&self_pubkey) {
+            weighted_shuffle.remove_index(*index);
+        }
+        Some(Self {
+            nodes: nodes.into_boxed_slice(),
+            index,
+            weighted_shuffle: Arc::new(weighted_shuffle),
+        })
+    }
+}
+
+// Rebuilds only gossip-derived contact state while reusing the epoch-stable
+// ordering and weighted shuffle.
+fn new_cluster_nodes_from_topology<T>(
+    topology: &BroadcastTopology,
+    cluster_info: &ClusterInfo,
+    use_cha_cha_8: bool,
+) -> ClusterNodes<T> {
+    let gossip = cluster_info.tvu_peers(|node| ContactInfo::from(node));
+    let num_staked = topology.nodes.len();
+    let mut nodes = Vec::with_capacity(num_staked.max(gossip.len()).saturating_add(1));
+    nodes.extend(topology.nodes.iter().map(|&(pubkey, stake)| Node {
+        node: NodeId::from(pubkey),
+        stake,
+    }));
+    // ClusterInfo::tvu_peers excludes the local node.
+    let this_node = ContactInfo::from(&cluster_info.my_contact_info());
+    for node in gossip.into_iter().chain(std::iter::once(this_node)) {
+        if let Some(index) = topology.index.get(node.pubkey()) {
+            nodes[*index].node = NodeId::from(node);
+        } else {
+            nodes.push(Node {
+                node: NodeId::from(node),
+                stake: 0,
+            });
+        }
+    }
+    nodes[num_staked..].sort_unstable_by(|a, b| b.pubkey().cmp(a.pubkey()));
+    dedup_tvu_addrs(&mut nodes);
+    ClusterNodes {
+        pubkey: cluster_info.id(),
+        nodes,
+        index: HashMap::default(),
+        weighted_shuffle: Arc::clone(&topology.weighted_shuffle),
+        use_cha_cha_8,
+        _phantom: PhantomData,
     }
 }
 
@@ -440,20 +537,12 @@ fn cmp_nodes_stake(a: &Node, b: &Node) -> Ordering {
         })
 }
 
-/// If set > 1 it allows the nodes to run behind a NAT.
-/// This usecase is currently not supported.
-const MAX_NUM_NODES_PER_IP_ADDRESS: usize = 1;
-
 /// Dedups socket addresses so that if there are 2 nodes in the cluster with the
 /// same TVU socket-addr, we only send shreds to one of them.
 /// Additionally limits number of nodes at the same IP address to 1
 fn dedup_tvu_addrs(nodes: &mut Vec<Node>) {
     const TVU_PROTOCOLS: [Protocol; 1] = [Protocol::UDP];
-    let capacity = nodes.len().saturating_mul(2);
-    // Tracks (Protocol, SocketAddr) tuples already observed.
-    let mut addrs = HashSet::with_capacity(capacity);
-    // Maps IP addresses to number of nodes at that IP address.
-    let mut counts = HashMap::with_capacity(capacity);
+    let mut ips = HashSet::with_capacity(nodes.len());
     nodes.retain_mut(|node| {
         let node_stake = node.stake;
         let Some(node) = node.contact_info_mut() else {
@@ -466,11 +555,7 @@ fn dedup_tvu_addrs(nodes: &mut Vec<Node>) {
             let Some(addr) = node.tvu(protocol) else {
                 continue;
             };
-            let count: usize = *counts
-                .entry((protocol, addr.ip()))
-                .and_modify(|count| *count += 1)
-                .or_insert(1);
-            if !addrs.insert((protocol, addr)) || count > MAX_NUM_NODES_PER_IP_ADDRESS {
+            if !ips.insert(addr.ip()) {
                 // Remove the respective TVU address so that no more shreds are
                 // sent to this socket address.
                 node.remove_tvu_addr(protocol);
@@ -569,8 +654,8 @@ impl<T: 'static> ClusterNodesCache<T> {
         // or not expired yet. Discards the entry if it is already initialized
         // but also expired.
         let get_epoch_entry = |cache: &LruCache<Epoch, _>, epoch, ttl| {
-            let entry: &Arc<OnceLock<(Instant, _)>> = cache.get(&epoch)?;
-            let Some((asof, _)) = entry.get() else {
+            let entry: &Arc<CacheEntry<T>> = cache.get(&epoch)?;
+            let Some((asof, _)) = entry.snapshot.get() else {
                 return Some(entry.clone()); // not initialized yet
             };
             (asof.elapsed() < ttl).then(|| entry.clone())
@@ -589,35 +674,50 @@ impl<T: 'static> ClusterNodesCache<T> {
         );
         // Fall back to exclusive lock if there is a cache miss or the cached
         // entry has already expired.
-        let entry: Arc<OnceLock<_>> = entry.unwrap_or_else(|| {
+        let entry = entry.unwrap_or_else(|| {
             let mut cache = self.cache.write().unwrap();
             get_epoch_entry(&cache, epoch, self.ttl).unwrap_or_else(|| {
                 // Either a cache miss here or the existing entry has already
-                // expired. Upsert and return an uninitialized entry.
-                let entry = Arc::<OnceLock<_>>::default();
+                // expired. Reuse its epoch topology in a fresh entry.
+                let entry = Arc::new(CacheEntry {
+                    snapshot: OnceLock::new(),
+                    topology: cache
+                        .get(&epoch)
+                        .map_or_else(OnceLock::new, |entry| entry.topology.clone()),
+                });
                 cache.put(epoch, Arc::clone(&entry));
                 entry
             })
         });
         // Initialize if needed by only a single thread outside locks.
-        let (_, nodes) = entry.get_or_init(|| {
+        let (_, nodes) = entry.snapshot.get_or_init(|| {
             let epoch_staked_nodes = [root_bank, working_bank]
                 .iter()
-                .find_map(|bank| bank.epoch_staked_nodes(epoch))
-                .unwrap_or_else(|| {
+                .find_map(|bank| bank.epoch_staked_nodes(epoch));
+            let cluster_type = root_bank.cluster_type();
+            let nodes = if TypeId::of::<T>() == TypeId::of::<BroadcastStage>()
+                && let Some(epoch_staked_nodes) = &epoch_staked_nodes
+                && let Some(topology) = entry.topology.get_or_init(|| {
+                    BroadcastTopology::new(cluster_type, epoch_staked_nodes, cluster_info.id())
+                        .map(Arc::new)
+                }) {
+                new_cluster_nodes_from_topology::<T>(topology, cluster_info, use_cha_cha_8)
+            } else {
+                let epoch_staked_nodes = epoch_staked_nodes.unwrap_or_else(|| {
                     error!(
                         "ClusterNodesCache::get: unknown Bank::epoch_staked_nodes for epoch: \
                          {epoch}, slot: {shred_slot}"
                     );
                     inc_new_counter_error!("cluster_nodes-unknown_epoch_staked_nodes", 1);
-                    Arc::<HashMap<Pubkey, /*stake:*/ u64>>::default()
+                    Arc::default()
                 });
-            let nodes = new_cluster_nodes::<T>(
-                cluster_info,
-                root_bank.cluster_type(),
-                &epoch_staked_nodes,
-                use_cha_cha_8,
-            );
+                new_cluster_nodes::<T>(
+                    cluster_info,
+                    cluster_type,
+                    &epoch_staked_nodes,
+                    use_cha_cha_8,
+                )
+            };
             (Instant::now(), Arc::new(nodes))
         });
         nodes.clone()
@@ -724,7 +824,8 @@ mod tests {
         itertools::Itertools,
         rand::prelude::IndexedRandom as _,
         solana_hash::Hash as SolanaHash,
-        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, Shredder},
+        solana_ledger::shred::{ProcessShredsStats, ReedSolomonCache, ShredType, Shredder},
+        solana_runtime::genesis_utils::create_genesis_config_with_leader,
         std::{collections::VecDeque, fmt::Debug, hash::Hash},
         test_case::test_case,
     };
@@ -764,7 +865,7 @@ mod tests {
             .pop()
             .unwrap();
 
-        let mut weighted_shuffle = cluster_nodes.weighted_shuffle.clone();
+        let mut weighted_shuffle = cluster_nodes.weighted_shuffle.as_ref().clone();
         let mut chacha_rng = TurbineRng::new_seeded(&slot_leader, &shred.id(), use_cha_cha_8);
 
         let shuffled_nodes: Vec<&Node> = weighted_shuffle
@@ -868,8 +969,8 @@ mod tests {
     #[test_case(true)/*ChaCha8 */]
     #[test_case(false)/*ChaCha20 */]
     fn test_cluster_nodes_broadcast(use_cha_cha_8: bool) {
-        let mut rng = rand::rng();
-        let (nodes, stakes, cluster_info) = make_test_cluster(&mut rng, 1_000, None);
+        let mut rng = ChaCha8Rng::from_seed([7; 32]);
+        let (nodes, mut stakes, cluster_info) = make_test_cluster(&mut rng, 1_000, None);
         // ClusterInfo::tvu_peers excludes the node itself.
         assert_eq!(
             cluster_info.tvu_peers(GossipContactInfo::clone).len(),
@@ -908,6 +1009,89 @@ mod tests {
                 }
             }
         }
+        // The optimized constructor must preserve node ordering and peer selection.
+        cluster_info
+            .set_tvu_socket(SocketAddr::from(([10, 0, 0, 1], 8_001)))
+            .unwrap();
+        stakes.insert(*nodes[1].pubkey(), 1_000_000);
+        for self_stake in [0, 2_000_000] {
+            stakes.insert(cluster_info.id(), self_stake);
+            let expected = new_cluster_nodes::<BroadcastStage>(
+                &cluster_info,
+                ClusterType::MainnetBeta,
+                &stakes,
+                use_cha_cha_8,
+            );
+            let actual = ClusterNodes::<BroadcastStage>::new(
+                &cluster_info,
+                ClusterType::MainnetBeta,
+                &stakes,
+                use_cha_cha_8,
+            );
+
+            assert!(actual.index.is_empty());
+            assert_eq!(expected.nodes, actual.nodes);
+            for index in 0..1_000 {
+                let shred_type = [ShredType::Data, ShredType::Code][index as usize % 2];
+                let shred = ShredId::new(42, index, shred_type);
+                assert_eq!(
+                    expected.get_broadcast_peer(&shred),
+                    actual.get_broadcast_peer(&shred)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_broadcast_topology_fallback() {
+        let this_node = Pubkey::new_unique();
+        let peer = Pubkey::new_unique();
+        let mut stakes = HashMap::from([(this_node, 1)]);
+        assert!(BroadcastTopology::new(ClusterType::MainnetBeta, &stakes, this_node).is_none());
+        stakes.insert(peer, 1);
+        assert!(BroadcastTopology::new(ClusterType::Development, &stakes, this_node).is_none());
+        stakes.insert(this_node, u64::MAX);
+        assert!(BroadcastTopology::new(ClusterType::MainnetBeta, &stakes, this_node).is_none());
+    }
+
+    #[test]
+    fn test_cluster_nodes_cache_refreshes_broadcast_contacts() {
+        let validator = Pubkey::new_unique();
+        let mut genesis =
+            create_genesis_config_with_leader(10_000, &validator, LAMPORTS_PER_SOL).genesis_config;
+        genesis.cluster_type = ClusterType::MainnetBeta;
+        let bank = Bank::new_for_tests(&genesis);
+
+        let keypair = Arc::new(Keypair::new());
+        let now = timestamp();
+        let this_node = GossipContactInfo::new_localhost(&keypair.pubkey(), now);
+        let cluster_info = ClusterInfo::new(this_node, keypair, SocketAddrSpace::Unspecified);
+        let old_addr = SocketAddr::from(([10, 0, 0, 2], 8_001));
+        let mut node = GossipContactInfo::new_localhost(&validator, now);
+        node.set_tvu(Protocol::UDP, old_addr).unwrap();
+        cluster_info.insert_info(node.clone());
+
+        let cache = ClusterNodesCache::<BroadcastStage>::new(2, Duration::ZERO);
+        let before = cache.get(0, &bank, &bank, &cluster_info);
+        let new_addr = SocketAddr::from(([10, 0, 0, 3], 8_001));
+        node.set_wallclock(now.saturating_add(1));
+        node.set_tvu(Protocol::UDP, new_addr).unwrap();
+        cluster_info.insert_info(node);
+        let after = cache.get(0, &bank, &bank, &cluster_info);
+
+        assert!(!Arc::ptr_eq(&before, &after));
+        assert!(Arc::ptr_eq(
+            &before.weighted_shuffle,
+            &after.weighted_shuffle
+        ));
+        let shred = ShredId::new(0, 0, ShredType::Data);
+        let get_addr = |nodes: &ClusterNodes<BroadcastStage>| {
+            nodes
+                .get_broadcast_peer(&shred)
+                .and_then(|node| node.tvu_udp)
+        };
+        assert_eq!(get_addr(&before), Some(old_addr));
+        assert_eq!(get_addr(&after), Some(new_addr));
     }
 
     // Checks (1) computed retransmit children against expected children and
@@ -1145,5 +1329,35 @@ mod tests {
             assert!(unique_pubkeys.remove(node.pubkey()))
         }
         assert!(unique_pubkeys.is_empty());
+    }
+
+    #[test]
+    fn test_dedup_tvu_addrs_by_ip() {
+        let addr = |last_octet: u8, port: u16| SocketAddr::from(([127, 0, 0, last_octet], port));
+        let new_node = |stake, tvu_udp| Node {
+            node: NodeId::ContactInfo(ContactInfo {
+                pubkey: Pubkey::new_unique(),
+                wallclock: 0,
+                tvu_udp: Some(tvu_udp),
+            }),
+            stake,
+        };
+        // Nodes are ordered by descending stake before address deduplication.
+        let mut nodes = vec![
+            new_node(3, addr(1, 8001)),
+            new_node(2, addr(1, 8002)),
+            new_node(0, addr(1, 8003)),
+            new_node(0, addr(2, 8004)),
+        ];
+
+        dedup_tvu_addrs(&mut nodes);
+
+        assert_eq!(
+            nodes
+                .iter()
+                .map(|node| node.contact_info().unwrap().tvu_udp)
+                .collect::<Vec<_>>(),
+            [Some(addr(1, 8001)), None, Some(addr(2, 8004))]
+        );
     }
 }

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -95,6 +95,7 @@ pub struct ClusterNodes<T> {
 // Epoch-stable broadcast routing state. Gossip contacts are refreshed
 // separately and mapped back to these indices.
 struct BroadcastTopology {
+    self_pubkey: Pubkey,
     nodes: Box<[(Pubkey, /*stake:*/ u64)]>,
     index: HashMap<Pubkey, /*index:*/ usize, PubkeyHasherBuilder>,
     weighted_shuffle: Arc<WeightedShuffle>,
@@ -420,6 +421,7 @@ impl BroadcastTopology {
             weighted_shuffle.remove_index(*index);
         }
         Some(Self {
+            self_pubkey,
             nodes: nodes.into_boxed_slice(),
             index,
             weighted_shuffle: Arc::new(weighted_shuffle),
@@ -700,7 +702,9 @@ impl<T: 'static> ClusterNodesCache<T> {
                 && let Some(topology) = entry.topology.get_or_init(|| {
                     BroadcastTopology::new(cluster_type, epoch_staked_nodes, cluster_info.id())
                         .map(Arc::new)
-                }) {
+                })
+                && topology.self_pubkey == cluster_info.id()
+            {
                 new_cluster_nodes_from_topology::<T>(topology, cluster_info, use_cha_cha_8)
             } else {
                 let epoch_staked_nodes = epoch_staked_nodes.unwrap_or_else(|| {
@@ -1056,9 +1060,10 @@ mod tests {
 
     #[test]
     fn test_cluster_nodes_cache_refreshes_broadcast_contacts() {
-        let validator = Pubkey::new_unique();
+        let validator = Arc::new(Keypair::new());
         let mut genesis =
-            create_genesis_config_with_leader(10_000, &validator, LAMPORTS_PER_SOL).genesis_config;
+            create_genesis_config_with_leader(10_000, &validator.pubkey(), LAMPORTS_PER_SOL)
+                .genesis_config;
         genesis.cluster_type = ClusterType::MainnetBeta;
         let bank = Bank::new_for_tests(&genesis);
 
@@ -1067,7 +1072,7 @@ mod tests {
         let this_node = GossipContactInfo::new_localhost(&keypair.pubkey(), now);
         let cluster_info = ClusterInfo::new(this_node, keypair, SocketAddrSpace::Unspecified);
         let old_addr = SocketAddr::from(([10, 0, 0, 2], 8_001));
-        let mut node = GossipContactInfo::new_localhost(&validator, now);
+        let mut node = GossipContactInfo::new_localhost(&validator.pubkey(), now);
         node.set_tvu(Protocol::UDP, old_addr).unwrap();
         cluster_info.insert_info(node.clone());
 
@@ -1092,6 +1097,10 @@ mod tests {
         };
         assert_eq!(get_addr(&before), Some(old_addr));
         assert_eq!(get_addr(&after), Some(new_addr));
+
+        cluster_info.set_keypair(validator);
+        let after_identity_change = cache.get(0, &bank, &bank, &cluster_info);
+        assert_eq!(get_addr(&after_identity_change), None);
     }
 
     // Checks (1) computed retransmit children against expected children and

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -432,11 +432,15 @@ impl BroadcastTopology {
 
 // Rebuilds only gossip-derived contact state while reusing the epoch-stable
 // ordering and weighted shuffle.
-fn new_cluster_nodes_from_topology<T>(
+fn new_cluster_nodes_from_topology<T: 'static>(
     topology: &BroadcastTopology,
     cluster_info: &ClusterInfo,
     use_cha_cha_8: bool,
 ) -> ClusterNodes<T> {
+    assert!(
+        TypeId::of::<T>() == TypeId::of::<BroadcastStage>(),
+        "broadcast topology cannot construct ClusterNodes for a non-broadcast stage"
+    );
     let gossip = cluster_info.tvu_peers(|node| ContactInfo::from(node));
     let num_staked = topology.nodes.len();
     let mut nodes = Vec::with_capacity(num_staked.max(gossip.len()).saturating_add(1));

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -667,7 +667,15 @@ impl<T: 'static> ClusterNodesCache<T> {
         // Read from the cache with a shared lock.
         let entry = {
             let cache = self.cache.read().unwrap();
-            get_epoch_entry(&cache, epoch, self.ttl)
+            let entry = cache.get(&epoch);
+            if let Some((asof, nodes)) = entry.and_then(|entry| entry.snapshot.get())
+                && asof.elapsed() < self.ttl
+            {
+                return Arc::clone(nodes);
+            }
+            entry
+                .filter(|entry| entry.snapshot.get().is_none())
+                .cloned()
         };
         let use_cha_cha_8 = check_feature_activation_from_bank(
             &feature_set::switch_to_chacha8_turbine::ID,

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -85,7 +85,7 @@ pub struct ClusterNodes<T> {
     // sorted by (stake, pubkey) in descending order.
     nodes: Vec<Node>,
     // Reverse index from nodes pubkey to their index in self.nodes.
-    index: HashMap<Pubkey, /*index:*/ usize, PubkeyHasherBuilder>,
+    index: HashMap<Pubkey, /*index:*/ usize>,
     // Shuffles by weights = stakes
     weighted_shuffle: Arc<WeightedShuffle>,
     use_cha_cha_8: bool,
@@ -366,7 +366,7 @@ pub fn new_cluster_nodes<T: 'static>(
 ) -> ClusterNodes<T> {
     let self_pubkey = cluster_info.id();
     let nodes = get_nodes(cluster_info, cluster_type, stakes);
-    let index: HashMap<_, _, PubkeyHasherBuilder> = nodes
+    let index: HashMap<_, _> = nodes
         .iter()
         .enumerate()
         .map(|(ix, node)| (*node.pubkey(), ix))

--- a/turbine/src/cluster_nodes.rs
+++ b/turbine/src/cluster_nodes.rs
@@ -53,8 +53,7 @@ pub enum Error {
     Loopback { leader: Pubkey, shred: ShredId },
 }
 
-#[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 enum NodeId {
     // TVU node obtained through gossip (staked or not).
@@ -65,15 +64,15 @@ enum NodeId {
 
 // A lite version of gossip ContactInfo local to turbine where we only hold on
 // to a few necessary fields from gossip ContactInfo.
-#[derive(Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ContactInfo {
     pubkey: Pubkey,
     wallclock: u64,
     tvu_udp: Option<SocketAddr>,
 }
 
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(PartialEq)]
+#[cfg_attr(test, derive(Debug))]
 pub struct Node {
     node: NodeId,
     stake: u64,


### PR DESCRIPTION
Issue: Carryover from https://github.com/anza-xyz/agave/pull/13944/

## Summary

- cache epoch-stable broadcast ordering, pubkey indices, and `WeightedShuffle` state across contact refreshes
- rebuild only gossip-derived contact information when a broadcast cache entry expires
- construct cluster nodes without duplicate gossip/stake entries, skip the unused broadcast reverse index, and simplify TVU address deduplication
- retain the full constructor for development clusters and edge cases where zero-weight routing is required

## Rust Bench
(with jemalloc)
| Operation | `master` | This PR | Change |
|---|---:|---:|---:|
| `get_broadcast_peer()` | 102 ns | 102 ns | within noise |
| Warm `ClusterNodesCache::get()` | 37 ns | 37 ns | no regression |
| Full `ClusterNodes<BroadcastStage>::new()` | 1,410.9 us | 642.7 us | 54.4% faster / 2.20x |
| Expired/TTL `ClusterNodesCache::get()` | 1,329.5 us | 331.2 us | 75.1% faster / 4.01x |

## Mainnet live A/B

Complete machine-correct Influx history for Dublin since the baseline identity became active at `2026-08-06 06:41:28 UTC`, plus the Amsterdam optimized nine-hour window beginning at `2026-08-09 06:28:12 UTC`, using instrumented v4.2 branches:

- **baseline:** Dublin, [`eric/static-cluster-nodes-v4.2-baseline-metrics`](https://github.com/jito-foundation/jito-solana/tree/eric/static-cluster-nodes-v4.2-baseline-metrics), commit [`c841e0c3f1`](https://github.com/jito-foundation/jito-solana/commit/c841e0c3f179dea2b69660d1ac30b5f95ef27cd8); latest sample `2026-08-07 09:33:29 UTC`
- **optimized:** Amsterdam, [`eric/static-cluster-nodes-v4.2-metrics`](https://github.com/jito-foundation/jito-solana/tree/eric/static-cluster-nodes-v4.2-metrics), commit [`35bfc69cd1`](https://github.com/jito-foundation/jito-solana/commit/35bfc69cd13b48ccd8a9d006ded96cc8de278a05); samples from `2026-08-09 06:40:48 UTC` through `2026-08-09 15:03:21 UTC`
- both hosts: AMD EPYC 9474F, 48 cores / 96 threads, one socket and one NUMA node
- older baseline points are excluded because the same validator identity was previously running on Frankfurt
- older optimized points are excluded because Amsterdam retained the previous Tokyo Influx host ID

Hot-path timings are weighted means over the reported operation count. Percentiles are percentiles of the emitted 512-call or 16-call aggregate averages, not individual calls.

| Operation | Variant | Operations | Aggregate samples | Mean | p50 | p90 | p99 |
|---|---|---:|---:|---:|---:|---:|---:|
| `get_broadcast_peer()` | Dublin baseline | 40,448 | 79 | 258.1 ns | 259 ns | 278 ns | 311 ns |
| `get_broadcast_peer()` | Amsterdam optimized | 178,688 | 349 | 248.7 ns | 247 ns | 274 ns | 306 ns |
| Warm `ClusterNodesCache::get()` | Dublin baseline | 624 | 39 | 1,164.2 ns | 1,161 ns | 1,481 ns | 1,650 ns |
| Warm `ClusterNodesCache::get()` | Amsterdam optimized | 2,768 | 173 | 738.1 ns | 741 ns | 932 ns | 1,227 ns |

Cold and TTL reconstruction measurements:

| Comparison | Baseline mean | Events | Optimized mean | Events | Change |
|---|---:|---:|---:|---:|---:|
| Cold `ClusterNodesCache::get()` | 2,079.6 us | 4 | 1,021.5 us | 1 | **50.9% faster / 2.04x** |
| Initial constructor: full vs. `topology_new` | 2,595.5 us | 2 | 1,011.9 us | 1 | **61.0% faster / 2.57x** |
| Expired/TTL `ClusterNodesCache::get()` | 2,302.4 us | 2 | 1,040.8 us | 25 | **54.8% faster / 2.21x** |
| TTL constructor: full vs. `topology_refresh` | 2,287.8 us | 2 | 998.2 us | 25 | **56.4% faster / 2.29x** |

Optimized TTL distributions:

| Operation | Events | Mean | Min | p50 | p90 | p99 | Max |
|---|---:|---:|---:|---:|---:|---:|---:|
| `new_cluster_nodes / topology_refresh` | 25 | 998.2 us | 644.2 us | 1,059.5 us | 1,260.3 us | 1,337.2 us | 1,337.2 us |
| Expired `ClusterNodesCache::get()` | 25 | 1,040.8 us | 653.6 us | 1,120.7 us | 1,322.6 us | 1,358.0 us | 1,358.0 us |

The rare-path samples are unpaired events from each host. The baseline includes two directly observed TTL expirations, so no constructor proxy is used. The optimized cold and initial-constructor samples are retained from the previous machine-correct Amsterdam window because the nine-hour window had no process initialization. The two baseline initial-constructor events are the `full` samples timestamp-aligned with cold cache construction; the two TTL-constructor events are timestamp-aligned with cache expiration.

Across the nine-hour machine-correct hot-path set, optimized peer selection was **3.6% faster** and optimized warm cache get was **36.6% faster**. This remains a cross-host observation; the same-host jemalloc benchmark above remains the regression check (`102 ns` vs. `102 ns`, `37 ns` vs. `37 ns`).
