### PR TITLE
ci: bind bump-version level input via env before shell

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -60,10 +60,11 @@ jobs:
         id: process
         env:
           BASE_REF: ${{ github.ref }}
+          BUMP_LEVEL: ${{ inputs.level }}
         run: |
           old_version="$(toml get --raw Cargo.toml workspace.package.version)"
 
-          xtask bump-version ${{ inputs.level }}
+          xtask bump-version "$BUMP_LEVEL"
 
           new_version="$(toml get --raw Cargo.toml workspace.package.version)"
 


### PR DESCRIPTION
## Summary
- Bind `inputs.level` through `env: BUMP_LEVEL` before `xtask bump-version` in the Process shell step.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Version bump still applies the requested level (major/minor/patch/etc.) for trusted inputs


Made with [Cursor](https://cursor.com)