### PR TITLE
perf(program-runtime): Prune program cache entries in place, store them in `SmallVec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9657,6 +9657,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
+ "smallvec",
  "solana-account 4.3.1",
  "solana-account-info",
  "solana-clock",

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -39,6 +39,7 @@ log = { workspace = true }
 qualifier_attr = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
+smallvec = { workspace = true }
 solana-account = { workspace = true }
 solana-account-info = { workspace = true }
 solana-clock = { workspace = true }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -8,6 +8,7 @@ use {
         program_metrics::{EMA_SCALE, ProgramCacheStats},
     },
     log::error,
+    smallvec::SmallVec,
     solana_clock::{Epoch, Slot},
     solana_pubkey::Pubkey,
     solana_sbpf::program::BuiltinProgram,
@@ -21,6 +22,8 @@ use {
         sync::Weak,
     },
 };
+
+type ProgramCacheEntryVersions = SmallVec<[Arc<ProgramCacheEntry>; 2]>;
 
 #[repr(transparent)]
 #[derive(Clone, Debug)]
@@ -217,7 +220,7 @@ pub(crate) enum IndexImplementation {
         ///
         /// - the first level is for the address at which programs are deployed
         /// - the second level for the slot (and thus also fork), sorted by slot number.
-        entries: HashMap<Pubkey, Vec<Arc<ProgramCacheEntry>>>,
+        entries: HashMap<Pubkey, ProgramCacheEntryVersions>,
         /// The entries that are getting loaded and have not yet finished loading.
         ///
         /// The key is the program address, the value is a tuple of the slot in which the program is

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -520,44 +520,44 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     // Remove entries un/re/deployed on orphan forks
                     let mut first_ancestor_found = false;
                     let mut first_ancestor_env = None;
-                    *second_level = second_level
-                        .iter()
-                        .rev()
-                        .filter(|entry| {
-                            let relation =
-                                fork_graph.relationship(entry.deployment_slot, new_root_slot);
-                            if entry.deployment_slot >= new_root_slot {
-                                matches!(relation, BlockRelation::Equal | BlockRelation::Descendant)
-                            } else if matches!(relation, BlockRelation::Ancestor)
-                                || entry.deployment_slot <= self.latest_root_slot
-                            {
-                                if !first_ancestor_found {
-                                    first_ancestor_found = true;
-                                    first_ancestor_env = entry.program.get_environment();
-                                    return true;
-                                }
-                                // Do not prune the entry if the runtime environment of the entry is
-                                // different than the entry that was previously found (stored in
-                                // first_ancestor_env). Different environment indicates that this entry
-                                // might belong to an older epoch that had a different environment (e.g.
-                                // different feature set). Once the root moves to the new/current epoch,
-                                // the entry will get pruned. But, until then the entry might still be
-                                // getting used by an older slot.
-                                if let Some(entry_env) = entry.program.get_environment()
-                                    && let Some(env) = first_ancestor_env
-                                    && entry_env != env
-                                {
-                                    return true;
-                                }
-                                self.stats.prunes_orphan.fetch_add(1, Ordering::Relaxed);
-                                false
-                            } else {
-                                self.stats.prunes_orphan.fetch_add(1, Ordering::Relaxed);
-                                false
+                    // Scan newest to oldest while compacting in place, then restore the sort order.
+                    second_level.reverse();
+                    second_level.retain(|entry| {
+                        let relation =
+                            fork_graph.relationship(entry.deployment_slot, new_root_slot);
+                        if entry.deployment_slot >= new_root_slot {
+                            matches!(relation, BlockRelation::Equal | BlockRelation::Descendant)
+                        } else if matches!(relation, BlockRelation::Ancestor)
+                            || entry.deployment_slot <= self.latest_root_slot
+                        {
+                            if !first_ancestor_found {
+                                first_ancestor_found = true;
+                                first_ancestor_env = entry
+                                    .program
+                                    .get_environment()
+                                    .map(|environment| Arc::as_ptr(&environment.0));
+                                return true;
                             }
-                        })
-                        .cloned()
-                        .collect();
+                            // Do not prune the entry if the runtime environment of the entry is
+                            // different than the entry that was previously found (stored in
+                            // first_ancestor_env). Different environment indicates that this entry
+                            // might belong to an older epoch that had a different environment (e.g.
+                            // different feature set). Once the root moves to the new/current epoch,
+                            // the entry will get pruned. But, until then the entry might still be
+                            // getting used by an older slot.
+                            if let Some(entry_env) = entry.program.get_environment()
+                                && let Some(env) = first_ancestor_env
+                                && !std::ptr::eq(Arc::as_ptr(&entry_env.0), env)
+                            {
+                                return true;
+                            }
+                            self.stats.prunes_orphan.fetch_add(1, Ordering::Relaxed);
+                            false
+                        } else {
+                            self.stats.prunes_orphan.fetch_add(1, Ordering::Relaxed);
+                            false
+                        }
+                    });
                     second_level.reverse();
                     // Remove or adjust entries with outdated environment of previous feature set
                     if let Some(new_environment) = new_environment.as_ref() {


### PR DESCRIPTION
#### Problem

`ProgramCache::prune` rebuilt every program's slot-version vector using `filter().cloned().collect()`, allocating a new vector and updating `Arc` reference counts even when every entry was retained.

#### Summary of Changes

Reverse each version vector, retain entries in place while preserving the newest-to-oldest traversal semantics, then restore its sorted order. This adds two allocation-free linear reversals, but avoids allocating a new vector and cloning every retained `Arc`. The reversals are trivial for the common single-entry case.

Track the first ancestor environment by `Arc` identity to avoid additional cloning.

This removes allocation and `Arc` churn from the normal reroot path.

Use `SmallVec` with space for two program cache versions instead of `Vec`.

Most programs have only one cached version, while two versions can exist during runtime environment transitions. Keeping these entries inline avoids a heap allocation and pointer indirection in the common cases without increasing the collection's size. Additional versions continue to spill to the heap.

#### Testing

Profiles before:

<img width="3716" height="1411" alt="before" src="https://github.com/user-attachments/assets/3190c3be-85de-43d4-a961-7d07c0b5c5ac" />
<img width="1222" height="991" alt="before1" src="https://github.com/user-attachments/assets/e64fd146-cf59-42b7-b7a8-a60065bd72b9" />

After:

<img width="3711" height="1042" alt="after" src="https://github.com/user-attachments/assets/22f6168b-d90f-40ae-971d-4409d9671e90" />
<img width="931" height="827" alt="after1" src="https://github.com/user-attachments/assets/1bff7d3c-445a-4f11-9653-f307ff4e7a4c" />

