### PR TITLE
core: guard Alpenglow commitment super-majority-root against regression

### DIFF
--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -196,9 +196,15 @@ impl AggregateCommitmentService {
             AlpenglowCommitmentType::Rooted => {
                 // There is no distinction of OC, root, or finalized in Alpengow commitment.
                 // Once votor selects a finalized bank as root, set all of these values.
+                // Guard highest_super_majority_root against regression, mirroring the
+                // monotonicity guard the tower path applies in update_commitment_cache
+                // below: a late or out-of-order Rooted update must never move the
+                // super-majority root backwards.
+                let highest_super_majority_root =
+                    max(slot, w_block_commitment_cache.highest_super_majority_root());
                 w_block_commitment_cache.set_highest_confirmed_slot(slot);
                 w_block_commitment_cache.set_root(slot);
-                w_block_commitment_cache.set_highest_super_majority_root(slot);
+                w_block_commitment_cache.set_highest_super_majority_root(highest_super_majority_root);
             }
         }
         w_block_commitment_cache.commitment_slots()


### PR DESCRIPTION
### Problem

`alpenglow_update_commitment_cache` (the Alpenglow commitment path in `core/src/commitment_service.rs`) sets `highest_super_majority_root` unconditionally on a `Rooted` update:

```rust
AlpenglowCommitmentType::Rooted => {
    w_block_commitment_cache.set_highest_confirmed_slot(slot);
    w_block_commitment_cache.set_root(slot);
    w_block_commitment_cache.set_highest_super_majority_root(slot);
}
```

The tower path in the same file (`update_commitment_cache`) clamps the same value with `max()` so it can never move backwards:

```rust
let highest_super_majority_root = max(
    new_block_commitment.highest_super_majority_root(),
    w_block_commitment_cache.highest_super_majority_root(),
);
```

The Alpenglow path is missing that monotonicity guard, so a late or out-of-order `Rooted` update could regress the super-majority root reported to RPC/consensus consumers.

### Change

Mirror the existing tower guard in the Alpenglow `Rooted` branch: clamp `highest_super_majority_root` with `max()` against its current value before writing.

### Impact / reachability

Defensive hardening. In practice votor emits `Rooted` updates monotonically, so the value should not regress today; this keeps the two commitment paths consistent and hardens the invariant against a late/out-of-order or future non-monotonic `Rooted`. No behavior change on the monotonic happy path. `max` is already imported in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
