### PR TITLE
votor: do not silently reset vote history on set-identity restore error

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -657,8 +657,19 @@ impl EventHandler {
         if *my_pubkey != new_pubkey || vctx.vote_history.node_pubkey != new_pubkey {
             let my_old_pubkey = vctx.vote_history.node_pubkey;
             *my_pubkey = new_pubkey;
-            vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)
-                .unwrap_or_else(|_| VoteHistory::new(new_pubkey, 0));
+            // A missing file is benign (e.g. a fresh identity that has never
+            // voted): start from an empty history. Any other error (corrupt,
+            // I/O, or signature mismatch) must NOT be silently collapsed into an
+            // empty history, which would drop equivocation protection for the
+            // new identity. Surface it instead, mirroring the startup
+            // require_vote_history guard; both callers already treat a returned
+            // error as a controlled exit.
+            vctx.vote_history =
+                match VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey) {
+                    Ok(vote_history) => vote_history,
+                    Err(e) if e.is_file_missing() => VoteHistory::new(new_pubkey, 0),
+                    Err(e) => return Err(e),
+                };
             vctx.identity_keypair = new_identity;
             warn!("set-identity: from {my_old_pubkey} to {my_pubkey}");
         }


### PR DESCRIPTION
### Problem

`handle_set_identity` (in `votor/src/event_handler.rs`) restores the new identity's vote history and, on **any** error, falls back to an empty history:

```rust
vctx.vote_history = VoteHistory::restore(ctx.vote_history_storage.as_ref(), my_pubkey)
    .unwrap_or_else(|_| VoteHistory::new(new_pubkey, 0));
```

A missing file is benign — a fresh identity that has never voted legitimately starts empty. But a **corrupt / I/O / signature-mismatch** error is collapsed into an empty history too, which drops equivocation protection for the new identity while the validator keeps voting.

The startup path already guards this: `require_vote_history` / `should_require_vote_history_file` (in `core/src/validator.rs`) halt rather than vote on an empty history when a vote-history file is expected. `handle_set_identity` had no equivalent.

### Change

Distinguish `is_file_missing()` (start from an empty history) from any other restore error, which is now propagated instead of swallowed. Both `handle_set_identity` callers already turn a returned error into a controlled exit (`EventLoopError::SetIdentityError`), so this reuses the existing halt path rather than introducing a new failure mode.

### Notes / discussion

This is a behavior change for set-identity when the on-disk vote history is **present but unreadable**: previously it silently continued with an empty history; now it exits. That matches the startup guard's intent (prefer halting over risking equivocation). Flagging explicitly in case the resilient/never-fail behavior was intentional — happy to gate it behind `require_vote_history` or adjust if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
