### PR TITLE
Sets default incremental snapshot interval to 200 slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ still accepted for backwards compatibility but slated for full removal in the fu
 #### Changes
 * Turbine shred ingestion now rejects shreds more than half an epoch in the future (previously up to 2 full epochs ahead was accepted).
 * When XDP is enabled, gossip egress does not support private and loopback addresses. Operators running with `--allow-private-addr` must also pass `--no-xdp`.
+* The default incremental snapshot interval is now 200 slots.
 ### CLI
 #### Breaking
 #### Changes

--- a/snapshots/src/snapshot_config.rs
+++ b/snapshots/src/snapshot_config.rs
@@ -9,7 +9,7 @@ use {
 pub const DEFAULT_FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
     NonZeroU64::new(100_000).unwrap();
 pub const DEFAULT_INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS: NonZeroU64 =
-    NonZeroU64::new(100).unwrap();
+    NonZeroU64::new(200).unwrap();
 pub const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =
     NonZeroUsize::new(2).unwrap();
 pub const DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN: NonZeroUsize =


### PR DESCRIPTION
#### Problem

The incremental snapshot interval is too short.

1. At startup, Alessandro says we can replay 100 slots in ~5 seconds. The edge canaries at worst case take almost 5 seconds to create an incremental snapshot. So catch up ends up continuously taking snapshots and slowing down.

2. Slot times are reducing. We don't want to take snapshots more frequently just because slots are shorter.


#### Summary of Changes

Set the incremental snapshot interval to 200 (doubled from 100).

We'll want to bump the full snapshot interval too, but separately (likely when slot times have reduced). Maybe bump the incremental snapshot interval more too!


#### Testing

Ran 200 slot incremental snapshot interval on a node, all metrics look normal/expected.

There is one thing to note. With 400 ms slot times, increasing the snapshot interval to 200 slots results in ~80 seconds in between snapshots, vs the ~40 seconds today. In accounts background service (ABS), we flush the accounts write cache when handling a snapshot OR if we haven't flushed in the last 50 seconds. So before we'd only ever flush for snapshots, since 40 seconds is less than 50 seconds. Now (and only temporarily until slot times decrease), we flush first when hitting the 50 second timer. So the write cache ends up holding ~25 additional slots-worth of accounts. Note, this is the same amount as a node that has snapshots disabled, so it's a common use-case/amount.

We could increase the timer in ABS if we wanted, but I don't think we need to (or if we *do*, then can handle that in a subsequent PR). Just wanted to be explicit about this behavior change, and indicate it is both expected and safe/fine.