### PR TITLE
ci/run-sanity: Sets both full and incremental snapshot intervals

### DIFF
--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -22,7 +22,7 @@ rm -rf config/run/init-completed config/ledger
 # Also the banking_tracer thread needs some extra time to flush due to
 # unsynchronized and buffered IO.
 validator_timeout="${SOLANA_VALIDATOR_EXIT_TIMEOUT:-120}"
-SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 200 --enable-banking-trace $((1024 * 1024 * 1024))" \
+SOLANA_RUN_SH_VALIDATOR_ARGS="${SOLANA_RUN_SH_VALIDATOR_ARGS} --full-snapshot-interval-slots 200 --incremental-snapshot-interval-slots 100 --enable-banking-trace $((1024 * 1024 * 1024))" \
   SOLANA_VALIDATOR_EXIT_TIMEOUT="$validator_timeout" \
   timeout "$validator_timeout" ./scripts/run.sh &
 


### PR DESCRIPTION
#### Problem

Pulled out from https://github.com/anza-xyz/agave/pull/14350#discussion_r3722448588:

When bumping the incremental snapshot interval, CI localnet started failing. This is due to a now-invalid snapshot config.

The incremental snapshot interval *must* be less than the full snapshot interval. But bumping the default incremental interval to 200 meant this config was now invalid.

<details><summary>buildkite error log</summary>
<p>

from https://buildkite.com/anza/agave/builds/56767#019fd2ab-59ec-474d-b526-3cc146b8a689:

```
+ agave-validator --identity /solana/config/run/validator-identity.json --vote-account /solana/config/run/validator-vote-account.json --ledger /solana/config/ledger --gossip-port 8001 --full-rpc-api --rpc-port 8899 --rpc-faucet-address 127.0.0.1:9900 --log - --enable-rpc-transaction-history --enable-extended-tx-metadata-storage --init-complete-file /solana/config/run/init-completed --require-tower --no-wait-for-vote-to-start-leader --no-os-network-limits-test --no-xdp --full-snapshot-interval-slots 200 --enable-banking-trace 1073741824
[2026-08-05T16:09:12.428597882Z INFO  solana_faucet::faucet] Faucet started. Listening on: 0.0.0.0:9900
[2026-08-05T16:09:12.428652507Z INFO  solana_faucet::faucet] Faucet account address: 69TNJvVVEGakZM1BSfgq8QKuCwYNzE3YcugnNQBz2SZQ
[2026-08-05T16:09:12.433215067Z INFO  agave_validator::commands::run::execute] agave-validator 4.3.0-alpha.2 (src:05d029f9; feat:a7963ca3, client:Agave)
[2026-08-05T16:09:12.433254191Z INFO  agave_validator::commands::run::execute] Starting validator with: ArgsOs {
        inner: [
            "agave-validator",
            "--identity",
            "/solana/config/run/validator-identity.json",
            "--vote-account",
            "/solana/config/run/validator-vote-account.json",
            "--ledger",
            "/solana/config/ledger",
            "--gossip-port",
            "8001",
            "--full-rpc-api",
            "--rpc-port",
            "8899",
            "--rpc-faucet-address",
            "127.0.0.1:9900",
            "--log",
            "-",
            "--enable-rpc-transaction-history",
            "--enable-extended-tx-metadata-storage",
            "--init-complete-file",
            "/solana/config/run/init-completed",
            "--require-tower",
            "--no-wait-for-vote-to-start-leader",
            "--no-os-network-limits-test",
            "--no-xdp",
            "--full-snapshot-interval-slots",
            "200",
            "--enable-banking-trace",
            "1073741824",
        ],
    }
[2026-08-05T16:09:12.433807665Z INFO  solana_gossip::node] Bound all network sockets as follows: Sockets { gossip: [UdpSocket { addr: 0.0.0.0:8001, fd: 3 }], ip_echo: Some(TcpListener { addr: 0.0.0.0:8001, fd: 4 }), tvu: [UdpSocket { addr: 0.0.0.0:1488, fd: 5 }], tpu_vote: [UdpSocket { addr: 0.0.0.0:1491, fd: 8 }], broadcast: [UdpSocket { addr: 0.0.0.0:1496, fd: 24 }, UdpSocket { addr: 0.0.0.0:1496, fd: 25 }, UdpSocket { addr: 0.0.0.0:1496, fd: 26 }, UdpSocket { addr: 0.0.0.0:1496, fd: 27 }], repair: UdpSocket { addr: 0.0.0.0:1494, fd: 22 }, retransmit_sockets: [UdpSocket { addr: 0.0.0.0:1493, fd: 10 }, UdpSocket { addr: 0.0.0.0:1493, fd: 11 }, UdpSocket { addr: 0.0.0.0:1493, fd: 12 }, UdpSocket { addr: 0.0.0.0:1493, fd: 13 }, UdpSocket { addr: 0.0.0.0:1493, fd: 14 }, UdpSocket { addr: 0.0.0.0:1493, fd: 15 }, UdpSocket { addr: 0.0.0.0:1493, fd: 16 }, UdpSocket { addr: 0.0.0.0:1493, fd: 17 }, UdpSocket { addr: 0.0.0.0:1493, fd: 18 }, UdpSocket { addr: 0.0.0.0:1493, fd: 19 }, UdpSocket { addr: 0.0.0.0:1493, fd: 20 }, UdpSocket { addr: 0.0.0.0:1493, fd: 21 }], serve_repair: UdpSocket { addr: 0.0.0.0:1495, fd: 23 }, ancestor_hashes_requests: UdpSocket { addr: 0.0.0.0:1497, fd: 28 }, tpu_quic: [UdpSocket { addr: 0.0.0.0:1489, fd: 6 }], tpu_forwards_quic: [UdpSocket { addr: 0.0.0.0:1490, fd: 7 }], tpu_vote_quic: [UdpSocket { addr: 0.0.0.0:1492, fd: 9 }], block_id_repair: UdpSocket { addr: 0.0.0.0:1499, fd: 30 }, tpu_vote_forwarding_client: UdpSocket { addr: 0.0.0.0:1500, fd: 31 }, tpu_transaction_forwarding_clients: [UdpSocket { addr: 0.0.0.0:1501, fd: 32 }], votor_server: [UdpSocket { addr: 0.0.0.0:1498, fd: 29 }], quic_vote_client: UdpSocket { addr: 0.0.0.0:1502, fd: 33 }, quic_votor_client: UdpSocket { addr: 0.0.0.0:1503, fd: 34 }, rpc_sts_client: UdpSocket { addr: 0.0.0.0:1504, fd: 35 } }
[2026-08-05T16:09:12.433890058Z INFO  solana_perf] AVX detected
[2026-08-05T16:09:12.433894555Z INFO  solana_perf] AVX2 detected
[2026-08-05T16:09:12.434248113Z INFO  agave_validator::commands::run::execute] Snapshot configuration: full snapshot interval: 200 slots, incremental snapshot interval: 200 slots
[2026-08-05T16:09:12.434413681Z ERROR agave_validator] Failed to start validator: invalid snapshot configuration provided: snapshot intervals are incompatible. full snapshot interval MUST be larger than incremental snapshot interval (if enabled)
Validator command failed: invalid snapshot configuration provided: snapshot intervals are incompatible. full snapshot interval MUST be larger than incremental snapshot interval (if enabled)
```

</p>
</details> 


#### Summary of Changes

Simple fix, just specify the incremental interval is back to 100, like before.

This also future-proofs other default snapshot interval changes, since now both full and incremental snapshot intervals are specified here.


#### Testing

Nothing additional.