### PR TITLE
votor-transport: add blackhole test

### DIFF
--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -14,6 +14,8 @@ pub(crate) mod test_port_allocator;
 #[cfg(not(any(target_os = "android", target_os = "windows")))]
 pub(crate) mod test_port_allocator;
 pub mod token_bucket;
+#[cfg(feature = "dev-context-only-utils")]
+pub mod udp_relay;
 
 #[cfg(feature = "dev-context-only-utils")]
 pub mod tooling_for_tests;

--- a/net-utils/src/udp_relay.rs
+++ b/net-utils/src/udp_relay.rs
@@ -1,0 +1,254 @@
+//! A UDP proxy for tests which need to emulate packet losses.
+use {
+    crate::sockets::bind_to_localhost_unique,
+    log::warn,
+    std::{
+        io::ErrorKind,
+        net::SocketAddr,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+        thread::{self, JoinHandle},
+        time::Duration,
+    },
+};
+
+/// Socket read timeout, i.e. how fast the relay threads notice `stop`.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Relay buffer size, large enough for any solana packet.
+const MAX_DATAGRAM_SIZE: usize = 1500;
+
+/// A UDP relay between a client and a server, either direction of which can be
+/// silently blackholed at runtime.
+///
+/// Point the client at `client_facing_address` instead of the server address.
+/// Datagrams are relayed both ways (if server replies).
+///
+/// The relay owns two sockets: a client-facing one, and one used for all
+/// traffic to the server. The client's address is learned from the first datagram
+/// it sends, so the client must send first.
+pub struct UdpRelay {
+    client_facing_address: SocketAddr,
+    drop_forward: Arc<AtomicBool>,
+    drop_reverse: Arc<AtomicBool>,
+    dropped_towards_server: Arc<AtomicU64>,
+    dropped_towards_client: Arc<AtomicU64>,
+    stop: Arc<AtomicBool>,
+    threads: Vec<JoinHandle<()>>,
+}
+
+impl UdpRelay {
+    /// Spawn a relay forwarding to `destination` on localhost.
+    pub fn spawn(destination: SocketAddr) -> UdpRelay {
+        let to_client = bind_to_localhost_unique().unwrap();
+        let to_server = bind_to_localhost_unique().unwrap();
+        let client_facing_address = to_client.local_addr().unwrap();
+        for socket in [&to_client, &to_server] {
+            socket
+                .set_read_timeout(Some(POLL_INTERVAL))
+                .expect("set read timeout");
+        }
+        let (to_client, to_server) = (Arc::new(to_client), Arc::new(to_server));
+        let drop_forward = Arc::new(AtomicBool::new(false));
+        let drop_reverse = Arc::new(AtomicBool::new(false));
+        let dropped_towards_server = Arc::new(AtomicU64::new(0));
+        let dropped_towards_client = Arc::new(AtomicU64::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        // Learned from the first datagram the client sends; the relay has no
+        // other way to know where to return the server's traffic.
+        let client_addr = Arc::new(Mutex::new(None));
+
+        let forward = {
+            let (to_client, to_server) = (Arc::clone(&to_client), Arc::clone(&to_server));
+            let drop_forward = Arc::clone(&drop_forward);
+            let dropped = Arc::clone(&dropped_towards_server);
+            let stop = Arc::clone(&stop);
+            let client_addr = Arc::clone(&client_addr);
+            thread::Builder::new()
+                .name("solRelayFwd".to_string())
+                .spawn(move || {
+                    let mut buf = [0u8; MAX_DATAGRAM_SIZE];
+                    while !stop.load(Ordering::Relaxed) {
+                        let (len, src) = match to_client.recv_from(&mut buf) {
+                            Ok(received) => received,
+                            Err(err) if err.kind() == ErrorKind::WouldBlock => continue,
+                            Err(e) => panic!("UDP relay cannot read from the client: {e}"),
+                        };
+                        assert!(
+                            len < MAX_DATAGRAM_SIZE,
+                            "datagram from the client filled the whole {MAX_DATAGRAM_SIZE} byte \
+                             buffer, so recv_from may have truncated it"
+                        );
+                        // Track the client even while dropping, so the return
+                        // path is ready the moment the direction reopens.
+                        *client_addr.lock().expect("client address mutex") = Some(src);
+                        if drop_forward.load(Ordering::Relaxed) {
+                            dropped.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        }
+                        if let Err(e) = to_server.send_to(&buf[..len], destination) {
+                            warn!("UDP relay failed to send to {destination}: {e}");
+                        }
+                    }
+                })
+                .unwrap()
+        };
+        let reverse = {
+            let drop_reverse = Arc::clone(&drop_reverse);
+            let dropped = Arc::clone(&dropped_towards_client);
+            let stop = Arc::clone(&stop);
+            let client_addr = Arc::clone(&client_addr);
+            thread::Builder::new()
+                .name("solRelayRev".to_string())
+                .spawn(move || {
+                    let mut buf = [0u8; MAX_DATAGRAM_SIZE];
+                    while !stop.load(Ordering::Relaxed) {
+                        let (len, _src) = match to_server.recv_from(&mut buf) {
+                            Ok(received) => received,
+                            Err(err) if err.kind() == ErrorKind::WouldBlock => continue,
+                            Err(e) => panic!("UDP relay cannot read from the server: {e}"),
+                        };
+                        assert!(
+                            len < MAX_DATAGRAM_SIZE,
+                            "datagram from the server filled the whole {MAX_DATAGRAM_SIZE} byte \
+                             buffer, so recv_from may have truncated it"
+                        );
+                        // Nowhere to send until the client has spoken once.
+                        let Some(dst) = *client_addr.lock().expect("client address mutex") else {
+                            continue;
+                        };
+                        if drop_reverse.load(Ordering::Relaxed) {
+                            dropped.fetch_add(1, Ordering::Relaxed);
+                            continue;
+                        }
+                        if let Err(e) = to_client.send_to(&buf[..len], dst) {
+                            warn!("UDP relay failed to send to {dst}: {e}");
+                        }
+                    }
+                })
+                .unwrap()
+        };
+
+        UdpRelay {
+            client_facing_address,
+            drop_forward,
+            drop_reverse,
+            dropped_towards_server,
+            dropped_towards_client,
+            stop,
+            threads: vec![forward, reverse],
+        }
+    }
+
+    pub fn client_facing_address(&self) -> SocketAddr {
+        self.client_facing_address
+    }
+
+    pub fn set_drop_towards_server(&self, drop: bool) {
+        self.drop_forward.store(drop, Ordering::Relaxed);
+    }
+
+    pub fn set_drop_towards_client(&self, drop: bool) {
+        self.drop_reverse.store(drop, Ordering::Relaxed);
+    }
+
+    /// Datagrams from the client discarded since spawn.
+    pub fn dropped_towards_server(&self) -> u64 {
+        self.dropped_towards_server.load(Ordering::Relaxed)
+    }
+
+    /// Datagrams from the server discarded since spawn.
+    pub fn dropped_towards_client(&self) -> u64 {
+        self.dropped_towards_client.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for UdpRelay {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        for thread in self.threads.drain(..) {
+            assert!(
+                thread.join().is_ok() || thread::panicking(),
+                "UDP relay thread panicked"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_udp_relay() {
+        const TIMEOUT: Duration = Duration::from_secs(1);
+        let server = bind_to_localhost_unique().expect("bind server socket");
+        let client = bind_to_localhost_unique().expect("bind client socket");
+        let server_addr = server.local_addr().expect("server local address");
+        let client_addr = client.local_addr().expect("client local address");
+        for socket in [&server, &client] {
+            socket
+                .set_read_timeout(Some(TIMEOUT))
+                .expect("set read timeout");
+        }
+        let relay = UdpRelay::spawn(server_addr);
+
+        // One round trip through the relay. The request teaches the relay where
+        // the client lives, so a reply can find its way back. Reports which of
+        // the two legs made it.
+        let mut buf = [0u8; 64];
+        let mut round_trip = |request: &[u8], reply: &[u8]| -> (bool, bool) {
+            client
+                .send_to(request, relay.client_facing_address())
+                .expect("client send");
+            let Ok((len, src)) = server.recv_from(&mut buf) else {
+                return (false, false);
+            };
+            assert_eq!(&buf[..len], request, "relay must not alter the payload");
+            assert_ne!(
+                src, client_addr,
+                "the server must see the relay as the source, not the client"
+            );
+            server.send_to(reply, src).expect("server reply");
+            let Ok((len, _src)) = client.recv_from(&mut buf) else {
+                return (true, false);
+            };
+            assert_eq!(&buf[..len], reply, "relay must not alter the payload");
+            (true, true)
+        };
+
+        assert_eq!(
+            round_trip(b"ping", b"pong"),
+            (true, true),
+            "an open relay must pass traffic both ways"
+        );
+        relay.set_drop_towards_client(true);
+        assert_eq!(
+            round_trip(b"request", b"dropped-reply"),
+            (true, false),
+            "only the direction towards the client must be blackholed"
+        );
+        relay.set_drop_towards_client(false);
+        relay.set_drop_towards_server(true);
+        assert_eq!(
+            round_trip(b"dropped-request", b"never-sent"),
+            (false, false),
+            "a blackholed direction towards the server must swallow the request"
+        );
+        relay.set_drop_towards_server(false);
+        assert_eq!(
+            round_trip(b"ping-again", b"pong-again"),
+            (true, true),
+            "traffic must resume once both directions are reopened"
+        );
+        assert_eq!(
+            (
+                relay.dropped_towards_server(),
+                relay.dropped_towards_client()
+            ),
+            (1, 1),
+            "exactly one datagram must have been dropped in each direction"
+        );
+    }
+}

--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -29,11 +29,11 @@ use {
 
 /// How often the outbound loop reconciles its connection table against the
 /// peer_list. Doubles as the retry interval for failed connects.
-const RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
+pub(crate) const RECONCILE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Upper bound on a single handshake attempt, enforced inside the connect task.
 /// Accommodates any plausible RTT with margin.
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const CLIENT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// State of a peer's entry in the outbound table.
 #[derive(Debug)]
@@ -78,7 +78,7 @@ async fn connect(
         }
         Ok(connection)
     };
-    match timeout(HANDSHAKE_TIMEOUT, attempt).await {
+    match timeout(CLIENT_HANDSHAKE_TIMEOUT, attempt).await {
         Ok(Ok(connection)) => Ok((peer, connection)),
         Ok(Err(e)) => {
             warn!("Connection attempt to ({peer}, {addr}) failed: {e:?}");
@@ -86,7 +86,10 @@ async fn connect(
             Err(peer)
         }
         Err(_elapsed) => {
-            warn!("Connection attempt to ({peer}, {addr}) timed out after {HANDSHAKE_TIMEOUT:?}");
+            warn!(
+                "Connection attempt to ({peer}, {addr}) timed out after \
+                 {CLIENT_HANDSHAKE_TIMEOUT:?}"
+            );
             stats.connect_failed.fetch_add(1, Ordering::Relaxed);
             Err(peer)
         }
@@ -264,7 +267,7 @@ impl OutboundLoop {
                     closed_not_in_peer_list = closed_not_in_peer_list.saturating_add(1);
                     false
                 }
-                // A Connecting entry resolves within HANDSHAKE_TIMEOUT through
+                // A Connecting entry resolves within CLIENT_HANDSHAKE_TIMEOUT through
                 // `handle_handshake_outcome` into an Established (at which point we can wipe it)
                 // or just gets removed there.
                 PeerState::Connecting => true,

--- a/votor-transport/src/endpoint.rs
+++ b/votor-transport/src/endpoint.rs
@@ -387,13 +387,21 @@ pub fn stub_ban_channel_for_tests(capacity: usize) -> (BanSender, mpsc::Receiver
 mod tests {
     use {
         super::{BanSender, Datagram, QuicDatagramEndpoint},
-        crate::{METRICS_INTERVAL, PeerListSender, transport::MAX_IDLE_TIMEOUT},
+        crate::{
+            METRICS_INTERVAL, PeerListSender,
+            client::{CLIENT_HANDSHAKE_TIMEOUT, RECONCILE_INTERVAL},
+            stats::ServerStats,
+            transport::{KEEP_ALIVE_INTERVAL, MAX_IDLE_TIMEOUT},
+        },
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded},
         solana_keypair::{Keypair, Signer},
-        solana_net_utils::sockets::{
-            SocketConfiguration, bind_more_with_config, bind_to, bind_to_localhost_unique,
-            unique_port_range_for_tests,
+        solana_net_utils::{
+            sockets::{
+                SocketConfiguration, bind_more_with_config, bind_to, bind_to_localhost_unique,
+                unique_port_range_for_tests,
+            },
+            udp_relay::UdpRelay,
         },
         solana_pubkey::Pubkey,
         solana_tls_utils::NotifyKeyUpdate,
@@ -517,16 +525,27 @@ mod tests {
         once((peer, None)).collect()
     }
 
-    /// Re-send `payload` until `cond` matches a received datagram or the delivery
-    /// window elapses.
+    /// Re-send `payload` until `cond` matches a received datagram or the default
+    /// delivery window elapses.
     fn send_until_received<T>(
         sender: &Node,
         payload: &Bytes,
         receiver: &Receiver<Datagram>,
+        cond: impl FnMut(&Datagram) -> Option<T>,
+    ) -> Result<T, ()> {
+        send_until_received_within(sender, payload, receiver, cond, Duration::from_secs(5))
+    }
+
+    /// [`send_until_received`] with an explicit delivery window.
+    fn send_until_received_within<T>(
+        sender: &Node,
+        payload: &Bytes,
+        receiver: &Receiver<Datagram>,
         mut cond: impl FnMut(&Datagram) -> Option<T>,
+        budget: Duration,
     ) -> Result<T, ()> {
         let start = Instant::now();
-        while start.elapsed() < Duration::from_secs(5) {
+        while start.elapsed() < budget {
             sender.send(payload);
             if let Ok(item) = receiver.recv_timeout(Duration::from_millis(100))
                 && let Some(t) = cond(&item)
@@ -558,6 +577,51 @@ mod tests {
             if let Ok(d) = receiver.recv_timeout(Duration::from_millis(150)) {
                 assert_ne!(&d.message, payload, "payload must not be delivered");
             }
+        }
+    }
+
+    /// Keep sending `payload` until deliveries dry up for `quiet` in a row,
+    /// panics if traffic was still arriving when `timeout` elapsed.
+    ///
+    /// `quiet` must sit well above the delivery latency of a healthy connection
+    /// (sub-millisecond on loopback) and below `MAX_IDLE_TIMEOUT`, so that a
+    /// gap this long can only mean the sender's connection is gone rather than
+    /// merely stalled.
+    fn wait_until_delivery_stops(
+        sender: &Node,
+        payload: &Bytes,
+        receiver: &Receiver<Datagram>,
+        quiet: Duration,
+        timeout: Duration,
+    ) {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            std::thread::sleep(Duration::from_millis(50));
+            sender.send(payload);
+            if receiver.recv_timeout(quiet).is_err() {
+                return;
+            }
+        }
+        panic!("Connection still live after timeout");
+    }
+
+    /// Server-side count of connections that went away, however they ended.
+    fn connections_reaped(stats: &ServerStats) -> u64 {
+        stats.connection_lost.load(Ordering::Relaxed)
+            + stats.connection_failed.load(Ordering::Relaxed)
+    }
+
+    /// Wait until the server has torn down at least one more connection than
+    /// `before`, panicking if it still holds the dead one after `timeout`.
+    /// See [`reap_timeout`] for how long that legitimately takes.
+    fn wait_for_reap(stats: &ServerStats, before: u64, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        while connections_reaped(stats) <= before {
+            assert!(
+                Instant::now() < deadline,
+                "server must reap the blackholed connection instead of holding it open"
+            );
+            std::thread::sleep(Duration::from_millis(50));
         }
     }
 
@@ -1310,6 +1374,239 @@ mod tests {
             (d.peer_pubkey == client_pubkey && d.message == after).then_some(())
         })
         .expect("client did not reconnect and resume delivery after server restart");
+    }
+
+    /// Worst-case time from reopening a blackholed direction to a datagram going across:
+    ///
+    /// - `MAX_IDLE_TIMEOUT`: the client may still believe the connection is up at
+    ///   the moment we reopen. Both peers run `KEEP_ALIVE_INTERVAL`, so while only
+    ///   the send path is broken the server's keep-alives keep resetting the
+    ///   client's idle timer until the server itself times out; only then does the
+    ///   client's own timer start running out.
+    /// - `CLIENT_HANDSHAKE_TIMEOUT`: a doomed attempt spawned just before we
+    ///   reopened holds the peer in `Connecting`.
+    /// - `RECONCILE_INTERVAL`: until the tick that spawns the next attempt.
+    /// - `CLIENT_HANDSHAKE_TIMEOUT` again: the attempt that has to succeed.
+    ///
+    /// Delivery itself then takes one send cycle, which the poll loop covers.
+    fn reconnect_timeout() -> Duration {
+        MAX_IDLE_TIMEOUT + CLIENT_HANDSHAKE_TIMEOUT * 2 + RECONCILE_INTERVAL
+    }
+
+    /// Worst-case time for the server to tear down a connection whose peer went silent,
+    /// measured from the last packet the server received:
+    /// idle timer expires MAX_IDLE_TIMEOUT later,
+    /// KEEP_ALIVE_INTERVAL its own keep-alive buys it (the idle timer is also restarted by
+    /// sending an ack-eliciting packet while none is outstanding). Doubled, because this
+    /// budget is only ever spent when the test is about to fail anyway.
+    fn reap_timeout() -> Duration {
+        (MAX_IDLE_TIMEOUT + KEEP_ALIVE_INTERVAL) * 2
+    }
+
+    /// Matches a datagram carrying exactly `payload` from `peer`.
+    fn datagram_from(peer: Pubkey, payload: Bytes) -> impl FnMut(&Datagram) -> Option<()> {
+        move |d: &Datagram| (d.peer_pubkey == peer && d.message == payload).then_some(())
+    }
+
+    /// A client and a server that can only reach each other through a relay,
+    /// either direction of which can be blackholed independently.
+    struct BlackholedPair {
+        client: Node,
+        server: Node,
+        blackhole: UdpRelay,
+        _rt: Runtime,
+    }
+
+    impl BlackholedPair {
+        /// Spawn the pair and establish the baseline: a single connection through
+        /// the relay, over which datagrams demonstrably arrive.
+        fn spawn() -> BlackholedPair {
+            let rt = make_runtime_for_tests();
+            let client_keypair = Keypair::new();
+            let client_pubkey = client_keypair.pubkey();
+            let server = Node::spawn_node(
+                &rt,
+                Keypair::new(),
+                peer_list_with_unknown_addr(client_pubkey),
+                HIGH_PPS,
+            );
+            // Counters must stay cumulative: these tests outlive several
+            // reporting ticks.
+            server
+                .endpoint
+                .server_stats
+                .report_frozen
+                .store(true, Ordering::Relaxed);
+
+            // The client can only reach the server through the relay. Delivery is
+            // asserted on peer_pubkey, never on peer_address: from the server's
+            // side every packet now originates at the relay's back socket.
+            let blackhole = UdpRelay::spawn(server.addr);
+            let client = Node::spawn_node(
+                &rt,
+                client_keypair,
+                peer_list_of(server.pubkey(), blackhole.client_facing_address()),
+                HIGH_PPS,
+            );
+
+            let probe = Bytes::from_static(b"pre-blackhole");
+            send_until_received(
+                &client,
+                &probe,
+                &server.ingress_receiver,
+                datagram_from(client_pubkey, probe.clone()),
+            )
+            .expect("server never received the pre-blackhole probe");
+            assert_eq!(
+                server
+                    .endpoint
+                    .server_stats
+                    .handshakes_completed
+                    .load(Ordering::Relaxed),
+                1,
+                "baseline must be a single established connection"
+            );
+            drain_backlog(&server.ingress_receiver);
+
+            BlackholedPair {
+                client,
+                blackhole,
+                server,
+                _rt: rt,
+            }
+        }
+
+        fn stats(&self) -> &ServerStats {
+            &self.server.endpoint.server_stats
+        }
+
+        /// Assert that `payload` cannot reach the server while the path is broken,
+        /// and that the relay is what caused it.
+        /// `dropped` chooses the metric to probe to confirm drop source.
+        fn assert_silenced(&self, payload: &Bytes, dropped: fn(&UdpRelay) -> u64) {
+            let dropped_before = dropped(&self.blackhole);
+            assert_not_delivered(&self.client, payload, &self.server.ingress_receiver, 10);
+            assert!(
+                dropped(&self.blackhole) > dropped_before,
+                "the relay, not a client that stopped sending, must be what silenced the path"
+            );
+        }
+
+        /// Broadcast `payload` until the server receives it.
+        fn expect_recovery(&self, payload: Bytes, context: &str) {
+            send_until_received_within(
+                &self.client,
+                &payload,
+                &self.server.ingress_receiver,
+                datagram_from(self.client.pubkey(), payload.clone()),
+                reconnect_timeout(),
+            )
+            .unwrap_or_else(|_| panic!("client must rebuild the connection: {context}"));
+        }
+
+        /// Recovery must have gone through a fresh handshake, and the server must
+        /// have treated it as the same peer coming back rather than a new one.
+        fn assert_reconnected(&self) {
+            assert!(
+                self.stats().handshakes_completed.load(Ordering::Relaxed) >= 2,
+                "recovery must go through a fresh handshake, not a surviving connection"
+            );
+            assert_eq!(
+                self.stats()
+                    .handshake_rejected_overload
+                    .load(Ordering::Relaxed),
+                0,
+                "reconnecting after a blackhole must not be refused for lack of slots"
+            );
+            assert_eq!(
+                self.stats().peak_unique_peers.load(Ordering::Relaxed),
+                1,
+                "every reconnect must land on the same peer entry"
+            );
+        }
+    }
+
+    /// Only server->client is lost: datagrams still reach the server and
+    /// `send_datagram` still returns Ok, so nothing but the idle timeout can tell
+    /// the client that its connection is sending to nowhere.
+    #[test]
+    fn test_client_recovers_from_return_path_blackhole() {
+        let pair = BlackholedPair::spawn();
+        let reaped_before = connections_reaped(pair.stats());
+
+        pair.blackhole.set_drop_towards_client(true);
+        let payload = Bytes::from_static(b"return-path-blackhole");
+        // The client only learns of the break when its idle timer expires, so
+        // silence must appear within MAX_IDLE_TIMEOUT plus the quiet window, and
+        // the budget leaves room for a slow CI machine on top of that.
+        wait_until_delivery_stops(
+            &pair.client,
+            &payload,
+            &pair.server.ingress_receiver,
+            Duration::from_secs(2),
+            MAX_IDLE_TIMEOUT * 3,
+        );
+        // Nothing may sneak through afterwards either: the handshake response
+        // travels the broken direction, so no reconnect can succeed yet. By now
+        // the client has no live connection left to send datagrams on, so what
+        // must keep being swallowed is the server's side of those doomed
+        // handshakes.
+        pair.assert_silenced(&payload, UdpRelay::dropped_towards_client);
+        wait_for_reap(pair.stats(), reaped_before, reap_timeout());
+
+        pair.blackhole.set_drop_towards_client(false);
+        pair.expect_recovery(
+            Bytes::from_static(b"after-return-path"),
+            "the return path is restored",
+        );
+        pair.assert_reconnected();
+    }
+
+    /// Both directions lose all packets: nothing arrives from the first packet onwards.
+    #[test]
+    fn test_client_recovers_from_symmetric_blackhole() {
+        let pair = BlackholedPair::spawn();
+        let reaped_before = connections_reaped(pair.stats());
+
+        pair.blackhole.set_drop_towards_server(true);
+        pair.blackhole.set_drop_towards_client(true);
+        pair.assert_silenced(
+            &Bytes::from_static(b"symmetric-blackhole"),
+            UdpRelay::dropped_towards_server,
+        );
+        wait_for_reap(pair.stats(), reaped_before, reap_timeout());
+
+        pair.blackhole.set_drop_towards_server(false);
+        pair.blackhole.set_drop_towards_client(false);
+        pair.expect_recovery(
+            Bytes::from_static(b"after-symmetric"),
+            "the path is restored",
+        );
+        pair.assert_reconnected();
+    }
+
+    /// Client->server packets are lost: the return path stays intact, so the client
+    /// keeps hearing from the server while everything it sends vanishes, its
+    /// reconnect attempts included, since the handshake's Initial packets travel
+    /// the broken direction.
+    #[test]
+    fn test_client_recovers_from_send_path_blackhole() {
+        let pair = BlackholedPair::spawn();
+        let reaped_before = connections_reaped(pair.stats());
+
+        pair.blackhole.set_drop_towards_server(true);
+        pair.assert_silenced(
+            &Bytes::from_static(b"send-path-blackhole"),
+            UdpRelay::dropped_towards_server,
+        );
+        wait_for_reap(pair.stats(), reaped_before, reap_timeout());
+
+        pair.blackhole.set_drop_towards_server(false);
+        pair.expect_recovery(
+            Bytes::from_static(b"after-send-path"),
+            "its send path is restored",
+        );
+        pair.assert_reconnected();
     }
 
     /// The client verifies the server's attested identity against the pubkey it

--- a/votor-transport/src/lib.rs
+++ b/votor-transport/src/lib.rs
@@ -85,7 +85,7 @@ pub const MAX_INFLIGHT_HANDSHAKES: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
 /// Hard timeout for an inbound handshake, enforced regardless of what
 /// the peer sends. ~1s suffices for a 300ms-RTT handshake with no packet
 /// loss, so we use 2s to have margin for losses & retransmits.
-pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const SERVER_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// How often endpoint metrics are reported.
 pub(crate) const METRICS_INTERVAL: Duration = Duration::from_secs(1);

--- a/votor-transport/src/server.rs
+++ b/votor-transport/src/server.rs
@@ -1,8 +1,8 @@
 //! Inbound (server) direction: we-accept, receive-only.
 use {
     crate::{
-        HANDSHAKE_TIMEOUT, MAX_INBOUND_CONNECTIONS_PER_PEER, METRICS_INTERVAL,
-        PEER_RATE_LIMIT_BURST_WINDOW, PEER_RATE_LIMIT_DOS_WINDOW, PeerListReceiver, close_codes,
+        MAX_INBOUND_CONNECTIONS_PER_PEER, METRICS_INTERVAL, PEER_RATE_LIMIT_BURST_WINDOW,
+        PEER_RATE_LIMIT_DOS_WINDOW, PeerListReceiver, SERVER_HANDSHAKE_TIMEOUT, close_codes,
         endpoint::{BanCommand, Datagram, KeyUpdateListener},
         error::Error,
         stats::{self, ServerStats, record_server_error},
@@ -180,7 +180,7 @@ async fn wait_for_complete_handshake(
     events_sender: mpsc::Sender<InboundConnectionEvent>,
     stats: Arc<ServerStats>,
 ) {
-    let connection = match timeout(HANDSHAKE_TIMEOUT, connecting).await {
+    let connection = match timeout(SERVER_HANDSHAKE_TIMEOUT, connecting).await {
         Ok(Ok(connection)) => {
             stats.handshakes_completed.fetch_add(1, Ordering::Relaxed);
             connection
@@ -674,8 +674,8 @@ mod tests {
         });
 
         // The loop should accept the Initial, start the handshake, then time it
-        // out after HANDSHAKE_TIMEOUT despite the client's retransmissions.
-        let deadline = HANDSHAKE_TIMEOUT + Duration::from_secs(3);
+        // out despite the client's retransmissions.
+        let deadline = SERVER_HANDSHAKE_TIMEOUT + Duration::from_secs(3);
         let mut waited = Duration::ZERO;
         let step = Duration::from_millis(100);
         while stats.handshake_timed_out.load(Ordering::Relaxed) == 0 && waited < deadline {
@@ -754,7 +754,9 @@ mod tests {
         // Poll until the server records the rejection.
         let mut waited = Duration::ZERO;
         let step = Duration::from_millis(100);
-        while stats.connection_failed.load(Ordering::Relaxed) == 0 && waited < HANDSHAKE_TIMEOUT {
+        while stats.connection_failed.load(Ordering::Relaxed) == 0
+            && waited < SERVER_HANDSHAKE_TIMEOUT
+        {
             sleep(step).await;
             waited += step;
         }
@@ -826,7 +828,7 @@ mod tests {
         };
         let mut waited = Duration::ZERO;
         let step = Duration::from_millis(100);
-        while recorded(&stats) == 0 && waited < HANDSHAKE_TIMEOUT {
+        while recorded(&stats) == 0 && waited < SERVER_HANDSHAKE_TIMEOUT {
             sleep(step).await;
             waited += step;
         }

--- a/votor-transport/src/transport.rs
+++ b/votor-transport/src/transport.rs
@@ -18,7 +18,7 @@ use {
 pub(crate) const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 /// QUIC keep-alive heartbeat. Must be << `MAX_IDLE_TIMEOUT` to avoid
 /// connections dying when no vote traffic is available.
-const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(2);
+pub(crate) const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(2);
 /// MTU used for all datagrams. Path-MTU discovery is disabled, so the initial
 /// and minimum MTU are the same; 1280 is the QUIC-spec floor.
 const DATAGRAM_MTU: u16 = 1280;


### PR DESCRIPTION
#### Problem

Votor-transport needed a test to confirm that state machine correctly resolves unidirectional packet loss, as well as "blackhole" events. 
Part of https://github.com/anza-xyz/agave/issues/14301
#### Summary of Changes

- Adds udp-relay primitive to net-utils to emulate unidirectional losses without requiring modificaitons to netfilter (for CI runs).
- Adds new blackhole tests to votor-transport.

#### Testing

CI (no prod logic changes)