### PR TITLE
Default Minimal index mode to threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ still accepted for backwards compatibility but slated for full removal in the fu
   that value for `--limit-blockstore-size`.
   * `--limit-blockstore-size` may occupy more disk footprint at steady state with current cluster
   activity; however, disk usage should be more stable during abnormal cluster activity.
+* Using the deprecated `minimal` for `--accounts-index-limit` now defaults to 25GB
 #### Changes
 * Validators running without `--full-rpc-api` and with snapshot generation disabled no longer
   store transaction signature keys in the status cache. Message hashes remain cached for duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ still accepted for backwards compatibility but slated for full removal in the fu
   that value for `--limit-blockstore-size`.
   * `--limit-blockstore-size` may occupy more disk footprint at steady state with current cluster
   activity; however, disk usage should be more stable during abnormal cluster activity.
-* Using the deprecated `minimal` for `--accounts-index-limit` now defaults to 25GB
 #### Changes
 * Validators running without `--full-rpc-api` and with snapshot generation disabled no longer
   store transaction signature keys in the status cache. Message hashes remain cached for duplicate
@@ -41,6 +40,7 @@ still accepted for backwards compatibility but slated for full removal in the fu
 * External scheduler execution responses now report `PARTIAL_BATCH_CANCELLED` for
   `CommitCancelled` errors in non-all-or-nothing batches. All-or-nothing batches continue to use
   `ALL_OR_NOTHING_BATCH_FAILURE`.
+* Using the deprecated `minimal` for `--accounts-index-limit` now defaults to 25GB
 ### Geyser
 #### Deprecations
 * The legacy `GeyserPlugin` methods `update_account`, `notify_transaction`, `notify_entry`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ still accepted for backwards compatibility but slated for full removal in the fu
 * External scheduler execution responses now report `PARTIAL_BATCH_CANCELLED` for
   `CommitCancelled` errors in non-all-or-nothing batches. All-or-nothing batches continue to use
   `ALL_OR_NOTHING_BATCH_FAILURE`.
-* Using the deprecated `minimal` for `--accounts-index-limit` now defaults to 25GB
+* Using the deprecated value `minimal` for `--accounts-index-limit` now defaults to 25GB.
 ### Geyser
 #### Deprecations
 * The legacy `GeyserPlugin` methods `update_account`, `notify_transaction`, `notify_entry`, and

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -40,7 +40,9 @@ use {
     },
 };
 pub use {
-    bucket_map_holder::{DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT},
+    bucket_map_holder::{
+        DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT, MINIMAL_THRESHOLD_NUM_BYTES,
+    },
     secondary::{
         AccountIndex, AccountSecondaryIndexes, AccountSecondaryIndexesIncludeExclude, IndexKey,
     },

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -48,6 +48,9 @@ pub const DEFAULT_NUM_ENTRIES_OVERHEAD: usize = 5_000;
 /// This value is used to compute the low watermark.
 pub const DEFAULT_NUM_ENTRIES_TO_EVICT: usize = 10_000;
 
+/// Byte threshold used when the deprecated `minimal` index limit is specified.
+pub const MINIMAL_THRESHOLD_NUM_BYTES: u64 = 25_000_000_000;
+
 pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> {
     pub disk: Option<BucketMap<(Slot, U)>>,
 

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -86,7 +86,7 @@ pub fn accounts_db_args<'a, 'b>() -> Box<[Arg<'a, 'b>]> {
                  index may use up to 50 GB of memory. The \"unlimited\" option keeps the entire \
                  accounts index in memory. All index entries that are not in memory are kept in \
                  the disk-backed index. The disk-backed index has lower performance; prefer \
-                 higher explicit limits here.",
+                 higher explicit limits here. \"minimal\" is deprecated and behaves as \"25GB\".",
             ),
         Arg::with_name("accounts_db_skip_shrink")
             .long("accounts-db-skip-shrink")
@@ -291,15 +291,16 @@ pub fn get_accounts_db_config(
         value_t!(arg_matches, "accounts_index_limit", String).unwrap_or_else(|err| err.exit());
     let index_limit = {
         enum CliIndexLimit {
-            // deprecated in v4.1.0
-            Minimal,
             Unlimited,
             Threshold(u64),
         }
         let cli_index_limit = match accounts_index_limit.as_str() {
             "minimal" => {
-                warn!("Using `minimal` for `--accounts-index-limit` is deprecated.");
-                CliIndexLimit::Minimal
+                warn!(
+                    "Using `minimal` for `--accounts-index-limit` is deprecated. Using 25GB \
+                     instead."
+                );
+                CliIndexLimit::Threshold(25_000_000_000)
             }
             "unlimited" => CliIndexLimit::Unlimited,
             "25GB" => CliIndexLimit::Threshold(25_000_000_000),
@@ -314,7 +315,6 @@ pub fn get_accounts_db_config(
             }
         };
         match cli_index_limit {
-            CliIndexLimit::Minimal => IndexLimit::Minimal,
             CliIndexLimit::Unlimited => IndexLimit::InMemOnly,
             CliIndexLimit::Threshold(num_bytes) => IndexLimit::Threshold(IndexLimitThreshold {
                 num_bytes,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -8,7 +8,7 @@ use {
         accounts_file::AccountsFileProvider,
         accounts_index::{
             AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT,
-            IndexLimit, IndexLimitThreshold, ScanFilter,
+            IndexLimit, IndexLimitThreshold, MINIMAL_THRESHOLD_NUM_BYTES, ScanFilter,
         },
         partitioned_rewards::PartitionedEpochRewardsConfig,
     },
@@ -300,7 +300,7 @@ pub fn get_accounts_db_config(
                     "Using `minimal` for `--accounts-index-limit` is deprecated. Using 25GB \
                      instead."
                 );
-                CliIndexLimit::Threshold(25_000_000_000)
+                CliIndexLimit::Threshold(MINIMAL_THRESHOLD_NUM_BYTES)
             }
             "unlimited" => CliIndexLimit::Unlimited,
             "25GB" => CliIndexLimit::Threshold(25_000_000_000),

--- a/runtime/src/bank/accounts_lt_hash.rs
+++ b/runtime/src/bank/accounts_lt_hash.rs
@@ -486,7 +486,11 @@ mod tests {
         ahash::HashSetExt as _,
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
-            accounts_index::{ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig, IndexLimit},
+            accounts_index::{
+                ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig,
+                DEFAULT_NUM_ENTRIES_OVERHEAD, DEFAULT_NUM_ENTRIES_TO_EVICT, IndexLimit,
+                IndexLimitThreshold,
+            },
         },
         solana_cluster_type::ClusterType,
         solana_fee_calculator::FeeRateGovernor,
@@ -781,9 +785,15 @@ mod tests {
         assert_eq!(expected_accounts_lt_hash, calculated_accounts_lt_hash);
     }
 
+    const INDEX_LIMIT_THRESHOLD: IndexLimit = IndexLimit::Threshold(IndexLimitThreshold {
+        num_bytes: 25_000_000_000,
+        num_entries_overhead: DEFAULT_NUM_ENTRIES_OVERHEAD,
+        num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
+    });
+
     #[test_matrix(
         [Features::None, Features::All],
-        [IndexLimit::Minimal, IndexLimit::InMemOnly]
+        [INDEX_LIMIT_THRESHOLD, IndexLimit::InMemOnly]
     )]
     fn test_verify_accounts_lt_hash_at_startup(
         features: Features,

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -1072,7 +1072,7 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
                  index may use up to 50 GB of memory. The \"unlimited\" option keeps the entire \
                  accounts index in memory. All index entries that are not in memory are kept in \
                  the disk-backed index. The disk-backed index has lower performance; prefer \
-                 higher explicit limits here.",
+                 higher explicit limits here. \"minimal\" is deprecated and behaves as \"25GB\".",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -23,7 +23,8 @@ use {
         accounts_file::AccountsFileProvider,
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndexConfig, DEFAULT_NUM_ENTRIES_OVERHEAD,
-            DEFAULT_NUM_ENTRIES_TO_EVICT, IndexLimit, IndexLimitThreshold, ScanFilter,
+            DEFAULT_NUM_ENTRIES_TO_EVICT, IndexLimit, IndexLimitThreshold,
+            MINIMAL_THRESHOLD_NUM_BYTES, ScanFilter,
         },
         partitioned_rewards::PartitionedEpochRewardsConfig,
         utils::{
@@ -566,44 +567,44 @@ pub fn execute(
 
     let accounts_index_limit =
         value_t!(matches, "accounts_index_limit", String).unwrap_or_else(|err| err.exit());
-    let index_limit = {
-        enum CliIndexLimit {
-            Unlimited,
-            Threshold(u64),
+    enum CliIndexLimit {
+        Unlimited,
+        Threshold(u64),
+    }
+    let cli_index_limit = match accounts_index_limit.as_str() {
+        "minimal" => {
+            warn!(
+                "Using `minimal` for `--accounts-index-limit` is deprecated. Using 25GB instead."
+            );
+            CliIndexLimit::Threshold(MINIMAL_THRESHOLD_NUM_BYTES)
         }
-        // Note: need to still handle --enable-accounts-disk-index until it is removed
-        let cli_index_limit = if matches.is_present("enable_accounts_disk_index") {
-            CliIndexLimit::Threshold(25_000_000_000)
-        } else {
-            match accounts_index_limit.as_str() {
-                "minimal" => {
-                    warn!(
-                        "Using `minimal` for `--accounts-index-limit` is deprecated. Using 25GB \
-                         instead."
-                    );
-                    CliIndexLimit::Threshold(25_000_000_000)
-                }
-                "unlimited" => CliIndexLimit::Unlimited,
-                "25GB" => CliIndexLimit::Threshold(25_000_000_000),
-                "50GB" => CliIndexLimit::Threshold(50_000_000_000),
-                "100GB" => CliIndexLimit::Threshold(100_000_000_000),
-                "200GB" => CliIndexLimit::Threshold(200_000_000_000),
-                "400GB" => CliIndexLimit::Threshold(400_000_000_000),
-                "800GB" => CliIndexLimit::Threshold(800_000_000_000),
-                x => {
-                    // clap will enforce only the above values are possible
-                    unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
-                }
-            }
-        };
-        match cli_index_limit {
-            CliIndexLimit::Unlimited => IndexLimit::InMemOnly,
-            CliIndexLimit::Threshold(num_bytes) => IndexLimit::Threshold(IndexLimitThreshold {
-                num_bytes,
-                num_entries_overhead: DEFAULT_NUM_ENTRIES_OVERHEAD,
-                num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
-            }),
+        "unlimited" => CliIndexLimit::Unlimited,
+        "25GB" => CliIndexLimit::Threshold(25_000_000_000),
+        "50GB" => CliIndexLimit::Threshold(50_000_000_000),
+        "100GB" => CliIndexLimit::Threshold(100_000_000_000),
+        "200GB" => CliIndexLimit::Threshold(200_000_000_000),
+        "400GB" => CliIndexLimit::Threshold(400_000_000_000),
+        "800GB" => CliIndexLimit::Threshold(800_000_000_000),
+        x => {
+            // clap will enforce only the above values are possible
+            unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
         }
+    };
+
+    // Note: need to still handle --enable-accounts-disk-index until it is removed
+    let cli_index_limit = if matches.is_present("enable_accounts_disk_index") {
+        CliIndexLimit::Threshold(MINIMAL_THRESHOLD_NUM_BYTES)
+    } else {
+        cli_index_limit
+    };
+
+    let index_limit = match cli_index_limit {
+        CliIndexLimit::Unlimited => IndexLimit::InMemOnly,
+        CliIndexLimit::Threshold(num_bytes) => IndexLimit::Threshold(IndexLimitThreshold {
+            num_bytes,
+            num_entries_overhead: DEFAULT_NUM_ENTRIES_OVERHEAD,
+            num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
+        }),
     };
 
     let mut accounts_index_config = AccountsIndexConfig {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -568,30 +568,35 @@ pub fn execute(
         value_t!(matches, "accounts_index_limit", String).unwrap_or_else(|err| err.exit());
     let index_limit = {
         enum CliIndexLimit {
-            // deprecated in v4.1.0
-            Minimal,
             Unlimited,
             Threshold(u64),
         }
-        let cli_index_limit = match accounts_index_limit.as_str() {
-            "minimal" => {
-                warn!("Using `minimal` for `--accounts-index-limit` is deprecated.");
-                CliIndexLimit::Minimal
-            }
-            "unlimited" => CliIndexLimit::Unlimited,
-            "25GB" => CliIndexLimit::Threshold(25_000_000_000),
-            "50GB" => CliIndexLimit::Threshold(50_000_000_000),
-            "100GB" => CliIndexLimit::Threshold(100_000_000_000),
-            "200GB" => CliIndexLimit::Threshold(200_000_000_000),
-            "400GB" => CliIndexLimit::Threshold(400_000_000_000),
-            "800GB" => CliIndexLimit::Threshold(800_000_000_000),
-            x => {
-                // clap will enforce only the above values are possible
-                unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
+        // Note: need to still handle --enable-accounts-disk-index until it is removed
+        let cli_index_limit = if matches.is_present("enable_accounts_disk_index") {
+            CliIndexLimit::Threshold(25_000_000_000)
+        } else {
+            match accounts_index_limit.as_str() {
+                "minimal" => {
+                    warn!(
+                        "Using `minimal` for `--accounts-index-limit` is deprecated. Using 25GB \
+                         instead."
+                    );
+                    CliIndexLimit::Threshold(25_000_000_000)
+                }
+                "unlimited" => CliIndexLimit::Unlimited,
+                "25GB" => CliIndexLimit::Threshold(25_000_000_000),
+                "50GB" => CliIndexLimit::Threshold(50_000_000_000),
+                "100GB" => CliIndexLimit::Threshold(100_000_000_000),
+                "200GB" => CliIndexLimit::Threshold(200_000_000_000),
+                "400GB" => CliIndexLimit::Threshold(400_000_000_000),
+                "800GB" => CliIndexLimit::Threshold(800_000_000_000),
+                x => {
+                    // clap will enforce only the above values are possible
+                    unreachable!("invalid value given to `--accounts-index-limit`: '{x}'")
+                }
             }
         };
         match cli_index_limit {
-            CliIndexLimit::Minimal => IndexLimit::Minimal,
             CliIndexLimit::Unlimited => IndexLimit::InMemOnly,
             CliIndexLimit::Threshold(num_bytes) => IndexLimit::Threshold(IndexLimitThreshold {
                 num_bytes,
@@ -599,12 +604,6 @@ pub fn execute(
                 num_entries_to_evict: DEFAULT_NUM_ENTRIES_TO_EVICT,
             }),
         }
-    };
-    // Note: need to still handle --enable-accounts-disk-index until it is removed
-    let index_limit = if matches.is_present("enable_accounts_disk_index") {
-        IndexLimit::Minimal
-    } else {
-        index_limit
     };
 
     let mut accounts_index_config = AccountsIndexConfig {


### PR DESCRIPTION
#### Problem
Minimal Index mode has been deprecated since v4.1. To reduce the potential bug surface, convert Minimal mode to use Threshold 25GB so the code can be deprecated

#### Summary of Changes
- Update long help of accounts_index_limit to cover what happens with minimal
- Updated both ledger and execute to use 25GB if Minimal is selected
- Changed lt_hash test to use threshold instead of minimal 
- Updated changelog

#### Testing
- Verified new warning is fired and accounts index boots with 25G mode when minimal is selected.

Fixes #
