### PR TITLE
chore(replay): use agave_transaction_view types for replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8845,6 +8845,7 @@ dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-transaction-view",
  "agave-votor-messages",
  "anyhow",
  "assert_matches",
@@ -10057,6 +10058,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "bytemuck",
+ "bytes",
  "criterion",
  "crossbeam-channel",
  "crossbeam-queue",
@@ -10188,6 +10190,7 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-transaction-view",
+ "bytes",
  "criterion",
  "rand 0.9.4",
  "solana-compute-budget",
@@ -11398,16 +11401,21 @@ dependencies = [
 name = "solana-unified-scheduler-logic"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "assert_matches",
+ "bytes",
  "solana-clock",
  "solana-hash 4.6.0",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
+ "solana-signature",
+ "solana-svm-transaction",
  "solana-transaction",
  "static_assertions",
  "test-case",
+ "wincode",
 ]
 
 [[package]]

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -324,9 +324,7 @@ mod tests {
         solana_keypair::Keypair,
         solana_message::Message,
         solana_perf::packet::Packet,
-        solana_runtime_transaction::{
-            runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
-        },
+        solana_runtime_transaction::sanitize_config::sanitize_config,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::{

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -22,7 +22,7 @@ use {
         bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
         installed_scheduler_pool::SchedulingContext,
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
     solana_svm_timings::ExecuteTimings,
     solana_system_transaction as system_transaction,
     solana_transaction_error::TransactionResult as Result,
@@ -92,7 +92,7 @@ fn test_scheduler_waited_by_drop_bank_service() {
     let root_hash = root_bank.hash();
     bank_forks.write().unwrap().insert(root_bank);
 
-    let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+    let tx = ReplayTransaction::from(system_transaction::transfer(
         &mint_keypair,
         &solana_pubkey::new_rand(),
         2,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6967,6 +6967,7 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-transaction-view",
  "agave-votor-messages",
  "anyhow",
  "assert_matches",
@@ -7778,6 +7779,7 @@ dependencies = [
  "agave-precompiles",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-transaction-view",
  "agave-votor-messages",
  "ahash 0.8.12",
  "arc-swap",
@@ -7787,6 +7789,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "bytemuck",
+ "bytes",
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -7905,6 +7908,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
+ "bytes",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.6.0",
@@ -8875,11 +8879,14 @@ dependencies = [
 name = "solana-unified-scheduler-logic"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "assert_matches",
+ "bytes",
  "solana-clock",
  "solana-hash 4.6.0",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
+ "solana-svm-transaction",
  "solana-transaction",
  "static_assertions",
 ]

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -37,10 +37,12 @@ agave-logger = { path = "../logger", version = "=4.4.0-alpha.0", features = ["ag
 agave-precompiles = { path = "../precompiles", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "../snapshots", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-transaction-view = "6.1.0"
 agave-votor = { path = "../votor", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
 assert_cmd = "2.2.2"
 bincode = "1.3.3"
+bytes = "1.12.1"
 chrono = { version = "0.4.42", default-features = false }
 clap = { version = "2.33.1", default-features = false, features = ["suggestions"] }
 crossbeam-channel = "0.5.16"

--- a/entry/benches/verify_signatures.rs
+++ b/entry/benches/verify_signatures.rs
@@ -1,43 +1,51 @@
 use {
     agave_reserved_account_keys::ReservedAccountKeys,
+    agave_transaction_view::transaction_view::{
+        SanitizedTransactionView, UnsanitizedTransactionView,
+    },
+    bytes::Bytes,
     criterion::{Criterion, Throughput, criterion_group, criterion_main},
-    solana_entry::entry::{Entry, UnverifiedSignatures, validate_and_hash_transactions},
+    solana_entry::entry::{
+        Entry, UnverifiedSignatures, entry_views_for_tests, validate_and_hash_transactions,
+    },
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_message::SimpleAddressLoader,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::{
+        runtime_transaction::{ReplayTransaction, RuntimeTransaction},
+        sanitize_config::sanitize_config,
+    },
     solana_signer::Signer,
     solana_system_transaction::transfer,
-    solana_transaction::{
-        sanitized::{MessageHash, SanitizedTransaction},
-        versioned::VersionedTransaction,
-    },
-    solana_transaction_error::TransactionResult as Result,
+    solana_transaction::sanitized::MessageHash,
+    solana_transaction_error::{TransactionError, TransactionResult as Result},
     std::hint::black_box,
 };
 
-fn build_unverified_signatures(num_transactions: usize) -> UnverifiedSignatures {
+fn build_unverified_signatures(num_transactions: usize) -> UnverifiedSignatures<Bytes> {
     let thread_pool = solana_entry::entry::thread_pool_for_benches();
     let hash = Hash::default();
     let keypair = Keypair::new();
     let transactions = (0..num_transactions)
         .map(|lamports| transfer(&keypair, &keypair.pubkey(), lamports as u64, hash))
         .collect();
-    let entries = vec![Entry::new(&hash, 0, transactions)];
+    let entries = entry_views_for_tests(vec![Entry::new(&hash, 0, transactions)]);
 
-    let validate_transaction = move |versioned_tx: VersionedTransaction,
-                                     message_bytes: &[u8]|
-          -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        RuntimeTransaction::try_create(
-            versioned_tx,
-            MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
-                message_bytes,
-            )),
-            None,
-            SimpleAddressLoader::Disabled,
-            &ReservedAccountKeys::empty_key_set(),
-        )
-    };
+    let validate_transaction =
+        move |unsanitized: UnsanitizedTransactionView<Bytes>| -> Result<ReplayTransaction> {
+            let sanitized = unsanitized
+                .sanitize(&sanitize_config())
+                .map_err(|_| TransactionError::SanitizeFailure)?;
+            let statically_loaded = RuntimeTransaction::<SanitizedTransactionView<Bytes>>::try_new(
+                sanitized,
+                MessageHash::Compute,
+                None,
+            )?;
+            ReplayTransaction::try_new(
+                statically_loaded,
+                None,
+                &ReservedAccountKeys::empty_key_set(),
+            )
+        };
 
     validate_and_hash_transactions(
         entries,

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -72,6 +72,32 @@ pub struct EntryView<D: TransactionData> {
     pub transactions: Vec<UnsanitizedTransactionView<D>>,
 }
 
+// for tests only, as this is an expensive operation and not needed in production.
+#[cfg(feature = "dev-context-only-utils")]
+impl<D> PartialEq for EntryView<D>
+where
+    D: PartialEq + TransactionData,
+{
+    fn eq(&self, other: &Self) -> bool {
+        let same_num_hashes = self.num_hashes == other.num_hashes;
+        let same_hash = self.hash == other.hash;
+        let same_transactions = || {
+            let same_len = self.transactions.len() == other.transactions.len();
+
+            if !same_len {
+                return false;
+            }
+
+            self.transactions
+                .iter()
+                .zip(other.transactions.iter())
+                .all(|(tx1, tx2)| tx1.data() == tx2.data())
+        };
+
+        same_num_hashes && same_hash && same_transactions()
+    }
+}
+
 impl<D> std::fmt::Debug for EntryView<D>
 where
     D: TransactionData,
@@ -207,12 +233,12 @@ pub enum EntryType<Tx: TransactionWithMeta> {
 }
 
 #[derive(Debug)]
-struct TxVerificationData {
+struct TxVerificationData<D: TransactionData> {
     is_simple_vote: bool,
     signatures: SmallVec<[Signature; 2]>,
     signer_pubkeys: SmallVec<[Address; 2]>,
     message_hash: Hash,
-    serialized_message: Vec<u8>,
+    transaction_view: UnsanitizedTransactionView<D>,
 }
 
 /// TODO: we will move this API into solana-sdk.
@@ -226,11 +252,14 @@ where
         .all(|(signature, pubkey, message)| signature.verify(pubkey.as_ref(), message))
 }
 
-pub struct UnverifiedSignatures {
-    signatures: Vec<TxVerificationData>,
+pub struct UnverifiedSignatures<D: TransactionData> {
+    signatures: Vec<TxVerificationData<D>>,
 }
 
-impl UnverifiedSignatures {
+impl<D> UnverifiedSignatures<D>
+where
+    D: TransactionData + Send + Sync,
+{
     fn with_capacity(capacity: usize) -> Self {
         Self {
             signatures: Vec::with_capacity(capacity),
@@ -239,7 +268,7 @@ impl UnverifiedSignatures {
 
     pub fn verify(&self) -> Result<()> {
         let verification_items = self.signatures.par_iter().flat_map_iter(|tx| {
-            let message = tx.serialized_message.as_slice();
+            let message = tx.transaction_view.message_data();
             let len = tx.signatures.len();
 
             (0..len).map(move |i| (&tx.signatures[i], &tx.signer_pubkeys[i], message))
@@ -261,7 +290,10 @@ impl UnverifiedSignatures {
                 .iter()
                 .zip(tx_signatures.signer_pubkeys.iter())
                 .all(|(signature, pubkey)| {
-                    signature.verify(pubkey.as_ref(), &tx_signatures.serialized_message)
+                    signature.verify(
+                        pubkey.as_ref(),
+                        tx_signatures.transaction_view.message_data(),
+                    )
                 })
             {
                 Ok(())
@@ -281,13 +313,12 @@ impl UnverifiedSignatures {
 
     pub fn verify_signatures(&self, index: usize) -> bool {
         let tx_data = &self.signatures[index];
+        let message = tx_data.transaction_view.message_data();
         tx_data
             .signatures
             .iter()
             .zip(&tx_data.signer_pubkeys)
-            .all(|(signature, pubkey)| {
-                signature.verify(pubkey.as_ref(), &tx_data.serialized_message)
-            })
+            .all(|(signature, pubkey)| signature.verify(pubkey.as_ref(), message))
     }
 
     pub fn vote_transaction_message_hash(&self, index: usize) -> Option<Hash> {
@@ -309,9 +340,9 @@ impl UnverifiedSignatures {
     }
 }
 
-pub struct ValidatedHashedTransactions<Tx: TransactionWithMeta> {
+pub struct ValidatedHashedTransactions<Tx: TransactionWithMeta, D: TransactionData> {
     pub entries: Vec<EntryType<Tx>>,
-    pub unverified_signatures: UnverifiedSignatures,
+    pub unverified_signatures: UnverifiedSignatures<D>,
 }
 
 impl Entry {
@@ -431,13 +462,14 @@ impl EntryVerificationState {
     }
 }
 
-fn validate_and_hash_entry_transactions<Tx: TransactionWithMeta, F>(
-    entry: Entry,
+fn validate_and_hash_entry_transactions<Tx: TransactionWithMeta, F, D>(
+    entry: EntryView<D>,
     verify: &F,
-    unverified_signatures: &mut UnverifiedSignatures,
+    unverified_signatures: &mut UnverifiedSignatures<D>,
 ) -> Result<EntryType<Tx>>
 where
-    F: Fn(VersionedTransaction, &[u8]) -> Result<Tx>,
+    F: Fn(UnsanitizedTransactionView<D>) -> Result<Tx>,
+    D: TransactionData + Clone,
 {
     if entry.transactions.is_empty() {
         return Ok(EntryType::Tick(entry.hash));
@@ -446,22 +478,21 @@ where
     let verified_transactions = entry
         .transactions
         .into_iter()
-        .map(|versioned_tx| {
-            let num_signers = usize::from(versioned_tx.message.header().num_required_signatures);
-            let static_account_keys = versioned_tx.message.static_account_keys();
+        .map(|transaction_view| {
+            let num_signers: usize = transaction_view.num_required_signatures().into();
+            let static_account_keys = transaction_view.static_account_keys();
             if static_account_keys.len() < num_signers {
                 return Err(TransactionError::SanitizeFailure);
             }
-            let signatures = versioned_tx.signatures.iter().copied().collect();
+            let signatures = transaction_view.signatures().iter().copied().collect();
             let signer_pubkeys = static_account_keys[..num_signers].iter().copied().collect();
-            let serialized_message = versioned_tx.message.serialize();
-            let verified_transaction = verify(versioned_tx, &serialized_message)?;
+            let verified_transaction = verify(transaction_view.clone())?;
             let message_hash = *verified_transaction.message_hash();
             unverified_signatures.signatures.push(TxVerificationData {
                 is_simple_vote: verified_transaction.is_simple_vote_transaction(),
                 signatures,
                 message_hash,
-                serialized_message,
+                transaction_view,
                 signer_pubkeys,
             });
 
@@ -475,14 +506,16 @@ where
 ///
 /// The function does NOT verify transaction signatures. The caller is expected to call
 /// `UnverifiedSignatures::verify()` on the returned `unverified_signatures`.
-pub fn validate_and_hash_transactions<Tx: TransactionWithMeta + Send + Sync, F>(
-    entries: Vec<Entry>,
+pub fn validate_and_hash_transactions<Tx, F, D>(
+    entries: Vec<EntryView<D>>,
     num_txs: usize,
     thread_pool: &ThreadPool,
     verify: F,
-) -> Result<ValidatedHashedTransactions<Tx>>
+) -> Result<ValidatedHashedTransactions<Tx, D>>
 where
-    F: Fn(VersionedTransaction, &[u8]) -> Result<Tx> + Send + Sync,
+    Tx: TransactionWithMeta + Send + Sync,
+    F: Fn(UnsanitizedTransactionView<D>) -> Result<Tx> + Send + Sync,
+    D: TransactionData + Clone + Send + Sync,
 {
     const PARALLEL_VERIFY_THRESHOLD: usize = 200;
     if num_txs < PARALLEL_VERIFY_THRESHOLD {
@@ -579,12 +612,6 @@ pub trait EntrySlice {
     fn verify_cpu(&self, start_hash: &Hash) -> EntryVerificationState;
     fn verify_cpu_generic(&self, start_hash: &Hash) -> EntryVerificationState;
     fn verify(&self, start_hash: &Hash, thread_pool: &ThreadPool) -> EntryVerificationState;
-    /// Checks that each entry tick has the correct number of hashes. Entry slices do not
-    /// necessarily end in a tick, so `tick_hash_count` is used to carry over the hash count
-    /// for the next entry slice.
-    fn verify_tick_hash_count(&self, tick_hash_count: &mut u64, hashes_per_tick: u64) -> bool;
-    /// Counts tick entries
-    fn tick_count(&self) -> u64;
 }
 
 impl EntrySlice for [Entry] {
@@ -602,7 +629,9 @@ impl EntrySlice for [Entry] {
         let verification_entries = entries_to_verification_data(self);
         verify_entries_cpu(&verification_entries, start_hash)
     }
+}
 
+impl EntrySliceTickCheck for [Entry] {
     fn verify_tick_hash_count(&self, tick_hash_count: &mut u64, hashes_per_tick: u64) -> bool {
         // When hashes_per_tick is 0, hashing is disabled.
         if hashes_per_tick == 0 {
@@ -632,8 +661,6 @@ impl EntrySlice for [Entry] {
         self.iter().filter(|e| e.is_tick()).count() as u64
     }
 }
-
-/// Additive counterpart to [`EntrySlice`]'s tick-checking methods, for [`EntryView`] slices.
 pub trait EntrySliceTickCheck {
     /// Checks that each entry tick has the correct number of hashes. Entry slices do not
     /// necessarily end in a tick, so `tick_hash_count` is used to carry over the hash count
@@ -732,29 +759,42 @@ pub fn thread_pool_for_benches() -> ThreadPool {
 mod tests {
     use {
         super::*,
+        crate::block_component::{BlockComponent, ParsedBlockComponent},
         agave_reserved_account_keys::ReservedAccountKeys,
+        agave_transaction_view::transaction_view::SanitizedTransactionView,
+        bytes::Bytes,
         rand::{Rng, rng},
         rayon::ThreadPoolBuilder,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_measure::measure::Measure,
         solana_message::{
-            MessageHeader, SimpleAddressLoader, VersionedMessage,
-            compiled_instruction::CompiledInstruction, v1,
+            MessageHeader, VersionedMessage, compiled_instruction::CompiledInstruction, v1,
         },
         solana_perf::test_tx::test_tx,
         solana_pubkey::Pubkey,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            runtime_transaction::{ReplayTransaction, RuntimeTransaction},
+            sanitize_config::sanitize_config,
+        },
         solana_sha256_hasher::hash,
         solana_signature::Signature,
         solana_signer::Signer,
         solana_system_transaction as system_transaction,
-        solana_transaction::{
-            sanitized::{MessageHash, SanitizedTransaction},
-            versioned::VersionedTransaction,
-        },
+        solana_transaction::{sanitized::MessageHash, versioned::VersionedTransaction},
         solana_transaction_error::TransactionResult as Result,
     };
+
+    fn entry_view_from_entry(entry: Entry) -> EntryView<Bytes> {
+        let component = BlockComponent::new_entry_batch(vec![entry]).unwrap();
+        let bytes = wincode::serialize(&component).unwrap();
+        let ParsedBlockComponent::EntryBatch(mut views) =
+            crate::block_component_parser::parse(bytes).unwrap()
+        else {
+            panic!("expected EntryBatch");
+        };
+        views.pop().unwrap()
+    }
 
     fn simple_v1_transaction_for_deserialization_tests() -> VersionedTransaction {
         VersionedTransaction {
@@ -797,10 +837,10 @@ mod tests {
     }
 
     fn test_verify_transactions<Tx: TransactionWithMeta + Send + Sync + 'static>(
-        entries: Vec<Entry>,
+        entries: Vec<EntryView<Bytes>>,
         skip_verification: bool,
         thread_pool: &ThreadPool,
-        verify: impl Fn(VersionedTransaction, &[u8]) -> Result<Tx> + Send + Sync,
+        verify: impl Fn(UnsanitizedTransactionView<Bytes>) -> Result<Tx> + Send + Sync,
     ) -> bool {
         let num_txs = entries.iter().map(|entry| entry.transactions.len()).sum();
         let txs = validate_and_hash_transactions(entries, num_txs, thread_pool, verify);
@@ -825,21 +865,24 @@ mod tests {
         let e1 = Entry::new(&zero, 0, vec![tx2, tx3]);
         assert!(e1.verify(&zero));
 
-        let es = vec![e0, e1];
+        let es = vec![entry_view_from_entry(e0), entry_view_from_entry(e1)];
         let thread_pool = ThreadPoolBuilder::new().build().unwrap();
 
         // Next, verify entry slice
         let verify_transaction = {
-            move |versioned_tx: VersionedTransaction,
-                  message_bytes: &[u8]|
-                  -> Result<RuntimeTransaction<SanitizedTransaction>> {
-                RuntimeTransaction::try_create(
-                    versioned_tx,
-                    MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
-                        message_bytes,
-                    )),
+            move |unsanitized: UnsanitizedTransactionView<Bytes>| -> Result<ReplayTransaction> {
+                let sanitized = unsanitized
+                    .sanitize(&sanitize_config())
+                    .map_err(|_| TransactionError::SanitizeFailure)?;
+                let statically_loaded =
+                    RuntimeTransaction::<SanitizedTransactionView<Bytes>>::try_new(
+                        sanitized,
+                        MessageHash::Compute,
+                        None,
+                    )?;
+                ReplayTransaction::try_new(
+                    statically_loaded,
                     None,
-                    SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             }
@@ -859,19 +902,22 @@ mod tests {
         let zero = Hash::default();
         let keypair = Keypair::new();
         let tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
-        let entries = vec![Entry::new(&zero, 0, vec![tx])];
+        let entries = vec![entry_view_from_entry(Entry::new(&zero, 0, vec![tx]))];
 
         let validate_and_hash_transaction =
-            move |versioned_tx: VersionedTransaction,
-                  message_bytes: &[u8]|
-                  -> Result<RuntimeTransaction<SanitizedTransaction>> {
-                RuntimeTransaction::try_create(
-                    versioned_tx,
-                    MessageHash::Precomputed(solana_message::VersionedMessage::hash_raw_message(
-                        message_bytes,
-                    )),
+            move |unsanitized: UnsanitizedTransactionView<Bytes>| -> Result<ReplayTransaction> {
+                let sanitized = unsanitized
+                    .sanitize(&sanitize_config())
+                    .map_err(|_| TransactionError::SanitizeFailure)?;
+                let statically_loaded =
+                    RuntimeTransaction::<SanitizedTransactionView<Bytes>>::try_new(
+                        sanitized,
+                        MessageHash::Compute,
+                        None,
+                    )?;
+                ReplayTransaction::try_new(
+                    statically_loaded,
                     None,
-                    SimpleAddressLoader::Disabled,
                     &ReservedAccountKeys::empty_key_set(),
                 )
             };
@@ -883,7 +929,7 @@ mod tests {
 
         let mut tx = system_transaction::transfer(&keypair, &keypair.pubkey(), 1, zero);
         tx.signatures[0] = solana_signature::Signature::default();
-        let entries = vec![Entry::new(&zero, 0, vec![tx])];
+        let entries = vec![entry_view_from_entry(Entry::new(&zero, 0, vec![tx]))];
         let txs =
             validate_and_hash_transactions(entries, 1, &thread_pool, validate_and_hash_transaction)
                 .expect("transaction validation and hashing must not verify signatures");

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -32,6 +32,7 @@ agave-unstable-api = []
 agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
+agave-transaction-view = { workspace = true }
 agave-votor-messages = { workspace = true }
 anyhow = { workspace = true }
 assert_matches = { workspace = true }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -31,6 +31,7 @@ use {
         migration::MigrationStatus, unverified_vote_message::UnverifiedCertificate,
     },
     assert_matches::{assert_matches, debug_assert_matches},
+    bytes::Bytes,
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
     dashmap::DashSet,
     itertools::Itertools,
@@ -45,11 +46,12 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_entry::{
         block_component::{
-            BlockComponent, VersionedBlockFooter, VersionedBlockHeader, VersionedBlockMarker,
-            VersionedUpdateParent, finalization_certificates_from_footer,
+            BlockComponent, ParsedBlockComponent, VersionedBlockFooter, VersionedBlockHeader,
+            VersionedBlockMarker, VersionedUpdateParent, finalization_certificates_from_footer,
             genesis_certificate_from_shred,
         },
-        entry::{Entry, create_ticks},
+        block_component_parser,
+        entry::{Entry, EntryView, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
     solana_hash::{HASH_BYTES, Hash},
@@ -58,14 +60,13 @@ use {
     solana_metrics::datapoint_error,
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, leader_schedule_utils::leader_slot_index},
+    solana_runtime_transaction::sanitize_config::sanitize_config,
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
+    solana_svm_transaction::svm_message::SVMMessage,
     solana_time_utils::timestamp,
-    solana_transaction::{
-        TransactionVerificationMode,
-        versioned::{VersionedTransaction, sanitized::SanitizedVersionedTransaction},
-    },
+    solana_transaction::{TransactionVerificationMode, versioned::VersionedTransaction},
     solana_transaction_status::{
         ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta, EntrySummary,
         RewardsAndNumPartitions, TransactionStatusMeta, TransactionWithStatusMeta,
@@ -4949,6 +4950,26 @@ impl Blockstore {
         Ok((entries, num_shreds, slot_meta.is_full()))
     }
 
+    /// Returns the entry-view vector for the slot starting with `shred_start_index`, the number
+    /// of shreds that comprise the entry vector, and whether the slot is full (consumed all
+    /// shreds).
+    pub fn get_slot_entry_views_with_shred_info(
+        &self,
+        slot: Slot,
+        start_index: u64,
+        allow_dead_slots: bool,
+    ) -> Result<(Vec<EntryView<Bytes>>, u64, bool)> {
+        let Some((completed_ranges, slot_meta, num_shreds)) =
+            self.get_slot_data_with_shred_info_common(slot, start_index, allow_dead_slots)?
+        else {
+            return Ok((vec![], 0, false));
+        };
+
+        let entries =
+            self.get_slot_entry_views_in_block(slot, &completed_ranges, Some(&slot_meta))?;
+        Ok((entries, num_shreds, slot_meta.is_full()))
+    }
+
     /// Returns the components vector for the slot starting with `shred_start_index`, the number of
     /// shreds that comprise the components vector, and whether the slot is full (consumed all
     /// shreds).
@@ -4966,6 +4987,24 @@ impl Blockstore {
 
         let components =
             self.get_slot_components_in_block(slot, &completed_ranges, Some(&slot_meta))?;
+        debug_assert_eq!(completed_ranges.len(), components.len());
+        Ok((components, completed_ranges, slot_meta.is_full()))
+    }
+
+    pub fn get_slot_component_views_with_shred_info(
+        &self,
+        slot: Slot,
+        start_index: u64,
+        allow_dead_slots: bool,
+    ) -> Result<(Vec<ParsedBlockComponent>, Vec<Range<u32>>, bool)> {
+        let Some((completed_ranges, slot_meta, _)) =
+            self.get_slot_data_with_shred_info_common(slot, start_index, allow_dead_slots)?
+        else {
+            return Ok((vec![], vec![], false));
+        };
+
+        let components =
+            self.get_slot_component_views_in_block(slot, &completed_ranges, Some(&slot_meta))?;
         debug_assert_eq!(completed_ranges.len(), components.len());
         Ok((components, completed_ranges, slot_meta.is_full()))
     }
@@ -4992,26 +5031,29 @@ impl Blockstore {
         (starting_slot..=ending_slot)
             .into_par_iter()
             .for_each(|slot| {
-                if let Ok(entries) = self.get_slot_entries(slot, 0) {
+                if let Ok((entries, _, _)) =
+                    self.get_slot_entry_views_with_shred_info(slot, 0, false)
+                {
                     entries.into_par_iter().for_each(|entry| {
                         entry.transactions.into_iter().for_each(|tx| {
-                            if let Some(lookups) = tx.message.address_table_lookups() {
-                                add_to_set(
-                                    &lookup_tables,
-                                    lookups.iter().map(|lookup| &lookup.account_key),
-                                );
-                            }
+                            add_to_set(
+                                &lookup_tables,
+                                tx.address_table_lookup_iter()
+                                    .map(|lookup| lookup.account_key),
+                            );
+
                             // Attempt to verify transaction and load addresses from the current bank,
                             // or manually scan the transaction for addresses if the transaction.
                             if let Ok(tx) = bank.verify_transaction(
                                 tx.clone(),
                                 TransactionVerificationMode::FullVerification,
                             ) {
-                                add_to_set(&result, tx.message().account_keys().iter());
+                                add_to_set(&result, tx.account_keys().iter());
                             } else {
-                                add_to_set(&result, tx.message.static_account_keys());
+                                add_to_set(&result, tx.static_account_keys());
 
-                                let tx = SanitizedVersionedTransaction::try_from(tx)
+                                let tx = tx
+                                    .sanitize(&sanitize_config())
                                     .expect("transaction failed to sanitize");
 
                                 let alt_scan_extensions = scan_transaction(&tx);
@@ -5171,6 +5213,29 @@ impl Blockstore {
         })
     }
 
+    fn get_slot_component_views_in_block(
+        &self,
+        slot: Slot,
+        completed_ranges: &CompletedRanges,
+        slot_meta: Option<&SlotMeta>,
+    ) -> Result<Vec<ParsedBlockComponent>> {
+        self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
+            let is_empty_entry_batch = BlockComponent::infer_is_empty_entry_batch(&payload);
+
+            block_component_parser::parse(payload)
+                .map(|component| vec![component])
+                .map_err(|error| {
+                    if is_empty_entry_batch {
+                        BlockstoreError::BlockAborted(slot)
+                    } else {
+                        BlockstoreError::InvalidShredData(format!(
+                            "could not reconstruct block component view: {error}"
+                        ))
+                    }
+                })
+        })
+    }
+
     /// Fetch the entries corresponding to all of the shred indices in `completed_ranges`.
     /// Block markers are skipped because they do not contain entries.
     fn get_slot_entries_in_block(
@@ -5191,6 +5256,32 @@ impl Blockstore {
                     } else {
                         BlockstoreError::InvalidShredData(format!(
                             "could not reconstruct block component: {e}"
+                        ))
+                    }
+                })
+        })
+    }
+
+    fn get_slot_entry_views_in_block(
+        &self,
+        slot: Slot,
+        completed_ranges: &CompletedRanges,
+        slot_meta: Option<&SlotMeta>,
+    ) -> Result<Vec<EntryView<Bytes>>> {
+        self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
+            let is_empty_entry_batch = BlockComponent::infer_is_empty_entry_batch(&payload);
+
+            block_component_parser::parse(payload)
+                .map(|component| match component {
+                    ParsedBlockComponent::BlockMarker(_) => vec![],
+                    ParsedBlockComponent::EntryBatch(entries) => entries,
+                })
+                .map_err(|error| {
+                    if is_empty_entry_batch {
+                        BlockstoreError::BlockAborted(slot)
+                    } else {
+                        BlockstoreError::InvalidShredData(format!(
+                            "could not reconstruct block component: {error}"
                         ))
                     }
                 })

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -460,13 +460,13 @@ impl Blockstore {
         }
 
         for slot in from_slot..=to_slot {
-            let mut slot_components =
-                self.get_slot_components_with_shred_info(slot, 0, /*allow_dead_slots:*/ true);
+            let mut slot_components = self
+                .get_slot_component_views_with_shred_info(slot, 0, /*allow_dead_slots:*/ true);
             if slot_components.is_err()
                 && let Ok(Some(slot_meta)) = self.meta(slot)
                 && slot_meta.has_update_parent()
             {
-                slot_components = self.get_slot_components_with_shred_info(
+                slot_components = self.get_slot_component_views_with_shred_info(
                     slot,
                     u64::from(slot_meta.replay_fec_set_index),
                     /*allow_dead_slots:*/ true,
@@ -478,10 +478,10 @@ impl Blockstore {
             let mut transaction_index = 0usize;
             for component in slot_components {
                 match component {
-                    BlockComponent::EntryBatch(entries) => {
+                    ParsedBlockComponent::EntryBatch(entries) => {
                         for transaction in entries.into_iter().flat_map(|entry| entry.transactions)
                         {
-                            if let Some(&signature) = transaction.signatures.first() {
+                            if let Some(&signature) = transaction.signatures().first() {
                                 self.transaction_status_cf
                                     .delete_in_batch(batch, (signature, slot));
                                 self.transaction_memos_cf
@@ -490,7 +490,7 @@ impl Blockstore {
                                 let meta = self.read_transaction_status((signature, slot))?;
                                 let loaded_addresses = meta.map(|meta| meta.loaded_addresses);
                                 let account_keys = AccountKeys::new(
-                                    transaction.message.static_account_keys(),
+                                    transaction.static_account_keys(),
                                     loaded_addresses.as_ref(),
                                 );
 
@@ -506,10 +506,10 @@ impl Blockstore {
                             transaction_index += 1;
                         }
                     }
-                    BlockComponent::BlockMarker(marker) if marker.is_update_parent() => {
+                    ParsedBlockComponent::BlockMarker(marker) if marker.is_update_parent() => {
                         transaction_index = 0;
                     }
-                    BlockComponent::BlockMarker(_) => {}
+                    ParsedBlockComponent::BlockMarker(_) => {}
                 }
             }
         }

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -13,7 +13,9 @@ use {
     },
     assert_matches::assert_matches,
     rand::{rng, seq::SliceRandom},
-    solana_entry::entry::next_entry_mut,
+    solana_entry::entry::{
+        entries_to_verification_data, entry_views_to_verification_data, next_entry_mut,
+    },
     solana_genesis_utils::{MAX_GENESIS_ARCHIVE_UNPACKED_SIZE, open_genesis_config},
     solana_hash::Hash,
     solana_message::{compiled_instruction::CompiledInstruction, v0::LoadedAddresses},
@@ -28,7 +30,7 @@ use {
     solana_transaction_context::transaction::TransactionReturnData,
     solana_transaction_error::TransactionError,
     solana_transaction_status::{InnerInstruction, InnerInstructions},
-    std::{cmp::Ordering, time::Duration},
+    std::{borrow::Cow, cmp::Ordering, time::Duration},
     test_case::{test_case, test_matrix},
 };
 
@@ -3071,9 +3073,12 @@ fn test_get_complete_block_with_block_markers() {
     blockstore.set_roots([parent_slot, slot].iter()).unwrap();
 
     let (slot_entries, num_shreds, is_full) = blockstore
-        .get_slot_entries_with_shred_info(slot, 0, false)
+        .get_slot_entry_views_with_shred_info(slot, 0, false)
         .unwrap();
-    assert_eq!(slot_entries, entries);
+    assert_eq!(
+        entry_views_to_verification_data(&slot_entries),
+        entries_to_verification_data(&entries)
+    );
     assert_eq!(num_shreds, u64::from(slot_end_index));
     assert!(is_full);
 
@@ -5692,7 +5697,7 @@ fn test_get_slot_entries_dead_slot_race() {
         std::thread::scope(|scope| {
             scope.spawn(|| {
                 while let Ok(slot) = slot_receiver.recv() {
-                    match blockstore.get_slot_entries_with_shred_info(slot, 0, false) {
+                    match blockstore.get_slot_entry_views_with_shred_info(slot, 0, false) {
                         Ok((_entries, _num_shreds, is_full)) => {
                             if is_full {
                                 signal_sender

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1,3 +1,5 @@
+#[cfg(any(test, feature = "dev-context-only-utils"))]
+use solana_entry::entry::{Entry, entry_views_for_tests};
 use {
     crate::{
         block_error::BlockError,
@@ -10,7 +12,11 @@ use {
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
     ExecuteTimingType::{NumExecuteBatches, TotalBatchesLen},
+    agave_transaction_view::{
+        transaction_data::TransactionData, transaction_view::UnsanitizedTransactionView,
+    },
     agave_votor_messages::{certificate::Certificate, migration::MigrationStatus},
+    bytes::Bytes,
     chrono_humanize::{Accuracy, HumanTime, Tense},
     crossbeam_channel::{Receiver, Sender},
     itertools::Itertools,
@@ -24,8 +30,11 @@ use {
     },
     solana_clock::{BankId, Slot},
     solana_entry::{
-        block_component::{BlockComponent, VersionedBlockMarker},
-        entry::{self, Entry, EntrySlice, EntryType, UnverifiedSignatures, create_ticks},
+        block_component::{ParsedBlockComponent, VersionedBlockMarker},
+        entry::{
+            self, EntrySliceTickCheck as _, EntryType, EntryView, UnverifiedSignatures,
+            create_ticks,
+        },
     },
     solana_genesis_config::GenesisConfig,
     solana_hash::Hash,
@@ -44,14 +53,11 @@ use {
         transaction_execution::TransactionStatusSender,
         vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
     solana_shred_version::compute_shred_version,
     solana_svm_timings::{ExecuteTimingType, ExecuteTimings, report_execute_timings},
     solana_svm_transaction::svm_message::SVMMessage,
-    solana_transaction::{
-        TransactionVerificationMode, sanitized::SanitizedTransaction,
-        versioned::VersionedTransaction,
-    },
+    solana_transaction::TransactionVerificationMode,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote::{vote_account::VoteAccountsHashMap, vote_parser::is_valid_vote_only_transaction},
     std::{
@@ -74,7 +80,7 @@ use {
 use {qualifier_attr::qualifiers, solana_runtime::bank::HashOverrides};
 
 struct ReplayEntry {
-    entry: EntryType<RuntimeTransaction<SanitizedTransaction>>,
+    entry: EntryType<ReplayTransaction>,
     starting_index: usize,
 }
 
@@ -140,6 +146,7 @@ impl ExecuteBatchesInternalMetrics {
 ///
 /// This method is for use testing against a single Bank, and assumes `Bank::transaction_count()`
 /// represents the number of transactions executed in this Bank
+#[cfg(feature = "dev-context-only-utils")]
 pub fn process_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> Result<()> {
     let result = schedule_entries_for_tests(bank, entries);
 
@@ -153,21 +160,17 @@ pub fn process_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) 
     result.and(wait_result)
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 fn schedule_entries_for_tests(bank: &BankWithScheduler, entries: Vec<Entry>) -> Result<()> {
     let validate_and_hash_transaction = {
         let bank = bank.clone_with_scheduler();
-        move |versioned_tx: VersionedTransaction,
-              serialized_message: &[u8]|
-              -> Result<RuntimeTransaction<SanitizedTransaction>> {
-            bank.verify_transaction_with_serialized_message(
-                versioned_tx,
-                serialized_message,
-                TransactionVerificationMode::HashOnly,
-            )
+        move |unsanitized: UnsanitizedTransactionView<Bytes>| {
+            bank.verify_transaction(unsanitized, TransactionVerificationMode::HashOnly)
         }
     };
 
     let num_txs = entries.iter().map(|entry| entry.transactions.len()).sum();
+    let entries = entry_views_for_tests(entries);
     let entry::ValidatedHashedTransactions {
         entries,
         unverified_signatures,
@@ -244,7 +247,7 @@ fn process_entries(bank: &BankWithScheduler, entries: Vec<ReplayEntry>) -> Resul
 /// Validate an entry's transactions before scheduling: each transaction's account
 /// locks (count and duplicates). Does not take account locks - the unified scheduler orders conflicts.
 fn validate_entry_transactions(
-    transactions: &[RuntimeTransaction<SanitizedTransaction>],
+    transactions: &[ReplayTransaction],
     tx_account_lock_limit: usize,
 ) -> Result<()> {
     for transaction in transactions {
@@ -504,9 +507,9 @@ pub fn process_blockstore_from_root(
 
 /// Verify that a segment of entries has the correct number of ticks and hashes
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-fn verify_ticks(
+fn verify_ticks<D: TransactionData>(
     bank: &Bank,
-    entries: &[Entry],
+    entries: &[EntryView<D>],
     slot_full: bool,
     tick_hash_count: &mut u64,
     migration_status: &MigrationStatus,
@@ -1066,7 +1069,7 @@ impl PohVerificationJob {
 }
 
 struct SignaturesVerificationJob {
-    signatures: Arc<VerificationBatch<UnverifiedSignatures>>,
+    signatures: Arc<VerificationBatch<UnverifiedSignatures<Bytes>>>,
     range: Range<usize>,
     slot: Slot,
     bank_id: BankId,
@@ -1217,7 +1220,7 @@ impl AsyncVerificationProgress {
     fn spawn_signature_verification(
         &mut self,
         worker_pool: &ReplayVerificationWorkerPool,
-        signatures: UnverifiedSignatures,
+        signatures: UnverifiedSignatures<Bytes>,
         slot: Slot,
         bank_id: BankId,
         replay_vote_sender: Option<ReplayVoteSender>,
@@ -1376,7 +1379,7 @@ pub fn confirm_slot(
     let (slot_components, completed_ranges, slot_full) = {
         let mut load_elapsed = Measure::start("load_elapsed");
         let load_result = blockstore
-            .get_slot_components_with_shred_info(slot, progress.num_shreds, allow_dead_slots)
+            .get_slot_component_views_with_shred_info(slot, progress.num_shreds, allow_dead_slots)
             .map_err(BlockstoreProcessorError::FailedToLoadEntries);
         load_elapsed.stop();
         if load_result.is_err() {
@@ -1419,7 +1422,7 @@ pub fn confirm_slot(
     // Find the index of the last EntryBatch in slot_components
     let last_entry_batch_index = slot_components
         .iter()
-        .rposition(|bc| matches!(bc, BlockComponent::EntryBatch(_)));
+        .rposition(|bc| matches!(bc, ParsedBlockComponent::EntryBatch(_)));
 
     for (ix, (completed_range, component)) in
         completed_ranges.iter().zip(slot_components).enumerate()
@@ -1428,7 +1431,7 @@ pub fn confirm_slot(
         let is_final = slot_full && ix == completed_ranges.len() - 1;
 
         match component {
-            BlockComponent::EntryBatch(entries) => {
+            ParsedBlockComponent::EntryBatch(entries) => {
                 let slot_full = slot_full && ix == last_entry_batch_index.unwrap();
 
                 // Skip block component validation for genesis block. Slot 0 is handled specially,
@@ -1456,7 +1459,7 @@ pub fn confirm_slot(
                     migration_status,
                 )?;
             }
-            BlockComponent::BlockMarker(marker) => {
+            ParsedBlockComponent::BlockMarker(marker) => {
                 let block_footer = match &marker {
                     VersionedBlockMarker::V1(marker) => marker.as_block_footer().cloned(),
                 };
@@ -1527,7 +1530,7 @@ pub fn confirm_slot(
 fn confirm_slot_entries(
     bank: &BankWithScheduler,
     replay_verification_worker_pool: &ReplayVerificationWorkerPool,
-    slot_entries_load_result: (Vec<Entry>, u64, bool),
+    slot_entries_load_result: (Vec<EntryView<Bytes>>, u64, bool),
     timing: &mut ConfirmationTiming,
     progress: &mut ConfirmationProgress,
     skip_verification: bool,
@@ -1612,7 +1615,7 @@ fn confirm_slot_entries(
     let last_entry_hash = entries.last().map(|e| e.hash);
     if !skip_verification {
         let start_hash = progress.last_entry;
-        let verify_entries = entry::entries_to_verification_data(&entries);
+        let verify_entries = entry::entry_views_to_verification_data(&entries);
         datapoint_debug!(
             "verify-batch-size",
             ("size", verify_entries.len() as i64, i64)
@@ -1629,12 +1632,8 @@ fn confirm_slot_entries(
 
     let validate_and_hash_transaction = {
         let bank = bank.clone_with_scheduler();
-        move |versioned_tx: VersionedTransaction, serialized_message: &[u8]| {
-            bank.verify_transaction_with_serialized_message(
-                versioned_tx,
-                serialized_message,
-                TransactionVerificationMode::HashOnly,
-            )
+        move |unsanitized: UnsanitizedTransactionView<Bytes>| {
+            bank.verify_transaction(unsanitized, TransactionVerificationMode::HashOnly)
         }
     };
 
@@ -2488,6 +2487,7 @@ pub mod tests {
             },
             shred::{ProcessShredsStats, ReedSolomonCache, Shred, Shredder},
         },
+        agave_transaction_view::transaction_view::SanitizedTransactionView,
         agave_votor_messages::{
             certificate::{CertSignature, GenesisCert},
             consensus_message::Block,
@@ -2526,10 +2526,11 @@ pub mod tests {
             },
             transaction_execution::TransactionStatusMessage,
         },
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_signer::Signer,
         solana_system_interface::error::SystemError,
         solana_system_transaction as system_transaction,
-        solana_transaction::Transaction,
+        solana_transaction::{Transaction, sanitized::MessageHash},
         solana_transaction_error::TransactionError,
         solana_unified_scheduler_pool::DefaultSchedulerPool,
         solana_vote::{vote_account::VoteAccount, vote_transaction},
@@ -5050,7 +5051,7 @@ pub mod tests {
         let result = confirm_slot_entries(
             &bank,
             &replay_verification_worker_pool,
-            (slot_entries, 0, slot_full),
+            (entry_views_for_tests(slot_entries), 0, slot_full),
             &mut ConfirmationTiming::default(),
             progress,
             false,
@@ -5084,7 +5085,7 @@ pub mod tests {
     fn create_test_transactions(
         mint_keypair: &Keypair,
         genesis_hash: &Hash,
-    ) -> Vec<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> Vec<ReplayTransaction> {
         let pubkey = solana_pubkey::new_rand();
         let keypair2 = Keypair::new();
         let pubkey2 = solana_pubkey::new_rand();
@@ -5092,19 +5093,19 @@ pub mod tests {
         let pubkey3 = solana_pubkey::new_rand();
 
         vec![
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            ReplayTransaction::from(system_transaction::transfer(
                 mint_keypair,
                 &pubkey,
                 1,
                 *genesis_hash,
             )),
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            ReplayTransaction::from(system_transaction::transfer(
                 &keypair2,
                 &pubkey2,
                 1,
                 *genesis_hash,
             )),
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            ReplayTransaction::from(system_transaction::transfer(
                 &keypair3,
                 &pubkey3,
                 1,
@@ -5310,13 +5311,25 @@ pub mod tests {
                     )
                     .unwrap();
                 let unverified_signatures = entry::validate_and_hash_transactions(
-                    vec![entry.clone()],
+                    entry_views_for_tests(vec![entry.clone()]),
                     num_items,
                     transaction_hash_verify_thread_pool(),
-                    |transaction, _| {
-                        Ok(RuntimeTransaction::from_transaction_for_tests(
-                            transaction.into_legacy_transaction().unwrap(),
-                        ))
+                    |unsanitized: UnsanitizedTransactionView<Bytes>| {
+                        let sanitized = unsanitized
+                            .sanitize(
+                                &solana_runtime_transaction::sanitize_config::sanitize_config(),
+                            )
+                            .map_err(|_| TransactionError::SanitizeFailure)?;
+                        let statically_loaded = RuntimeTransaction::<
+                            SanitizedTransactionView<Bytes>,
+                        >::try_new(
+                            sanitized, MessageHash::Compute, None
+                        )?;
+                        ReplayTransaction::try_new(
+                            statically_loaded,
+                            None,
+                            &agave_reserved_account_keys::ReservedAccountKeys::empty_key_set(),
+                        )
                     },
                 )
                 .unwrap()
@@ -6315,13 +6328,13 @@ pub mod tests {
         let payer = Keypair::new();
         let hash = Hash::new_unique();
         let txs = vec![
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            ReplayTransaction::from(system_transaction::transfer(
                 &payer,
                 &Pubkey::new_unique(),
                 1,
                 hash,
             )),
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            ReplayTransaction::from(system_transaction::transfer(
                 &payer,
                 &Pubkey::new_unique(),
                 1,
@@ -6333,14 +6346,12 @@ pub mod tests {
 
     #[test]
     fn test_validate_entry_transactions_too_many_locks() {
-        let txs = vec![RuntimeTransaction::from_transaction_for_tests(
-            system_transaction::transfer(
-                &Keypair::new(),
-                &Pubkey::new_unique(),
-                1,
-                Hash::new_unique(),
-            ),
-        )];
+        let txs = vec![ReplayTransaction::from(system_transaction::transfer(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            1,
+            Hash::new_unique(),
+        ))];
         // transfer touches >1 account; limit of 1 must reject
         assert_eq!(
             validate_entry_transactions(&txs, 1),
@@ -6368,9 +6379,11 @@ pub mod tests {
             recent_blockhash: Hash::new_unique(),
             instructions: vec![CompiledInstruction::new(2, &(), vec![0, 1])],
         };
-        let txs = vec![RuntimeTransaction::from_transaction_for_tests(
-            Transaction::new(&[&payer], message, Hash::new_unique()),
-        )];
+        let txs = vec![ReplayTransaction::from(Transaction::new(
+            &[&payer],
+            message,
+            Hash::new_unique(),
+        ))];
         assert_eq!(
             validate_entry_transactions(&txs, 10),
             Err(TransactionError::AccountLoadedTwice)

--- a/ledger/src/transaction_address_lookup_table_scanner.rs
+++ b/ledger/src/transaction_address_lookup_table_scanner.rs
@@ -1,10 +1,12 @@
 use {
     agave_reserved_account_keys::ReservedAccountKeys,
+    agave_transaction_view::{
+        transaction_data::TransactionData, transaction_view::SanitizedTransactionView,
+    },
     solana_address_lookup_table_interface::{
         self as address_lookup_table, instruction::ProgramInstruction,
     },
     solana_pubkey::Pubkey,
-    solana_transaction::versioned::sanitized::SanitizedVersionedTransaction,
     std::collections::HashSet,
     wincode::deserialize,
 };
@@ -17,16 +19,19 @@ pub struct ScannedLookupTableExtensions {
     pub accounts: Vec<Pubkey>, // empty if no extensions found
 }
 
-pub fn scan_transaction(
-    transaction: &SanitizedVersionedTransaction,
-) -> ScannedLookupTableExtensions {
+pub fn scan_transaction<D>(
+    transaction: &SanitizedTransactionView<D>,
+) -> ScannedLookupTableExtensions
+where
+    D: TransactionData,
+{
     // Accumulate accounts from account lookup table extension instructions
     let mut accounts = Vec::new();
     let mut no_user_programs = true;
-    for (program_id, instruction) in transaction.get_message().program_instructions_iter() {
+    for (program_id, instruction) in transaction.program_instructions_iter() {
         if address_lookup_table::program::check_id(program_id) {
             if let Ok(ProgramInstruction::ExtendLookupTable { new_addresses }) =
-                deserialize::<ProgramInstruction>(&instruction.data)
+                deserialize::<ProgramInstruction>(instruction.data)
             {
                 accounts.extend(new_addresses);
             }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7094,6 +7094,7 @@ dependencies = [
  "agave-feature-set",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-transaction-view",
  "agave-votor-messages",
  "anyhow",
  "assert_matches",
@@ -8014,6 +8015,7 @@ dependencies = [
  "agave-precompiles",
  "agave-reserved-account-keys",
  "agave-snapshots",
+ "agave-transaction-view",
  "agave-votor-messages",
  "ahash 0.8.12",
  "arc-swap",
@@ -8023,6 +8025,7 @@ dependencies = [
  "bincode",
  "bitvec",
  "bytemuck",
+ "bytes",
  "crossbeam-channel",
  "crossbeam-queue",
  "crossbeam-utils",
@@ -8141,6 +8144,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-transaction-view",
+ "bytes",
  "solana-compute-budget",
  "solana-compute-budget-instruction",
  "solana-hash 4.6.0",
@@ -9862,11 +9866,14 @@ dependencies = [
 name = "solana-unified-scheduler-logic"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-transaction-view",
  "assert_matches",
+ "bytes",
  "solana-clock",
  "solana-hash 4.6.0",
  "solana-pubkey 4.3.0",
  "solana-runtime-transaction",
+ "solana-svm-transaction",
  "solana-transaction",
  "static_assertions",
 ]

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -26,6 +26,7 @@ dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-ut
 [dependencies]
 agave-feature-set = { workspace = true }
 agave-transaction-view = { workspace = true }
+bytes = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true }
 solana-hash = { workspace = true }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -12,6 +12,8 @@
 use {
     crate::transaction_meta::{CachedTransactionMeta, TransactionConfiguration, TransactionMeta},
     agave_feature_set::FeatureSet,
+    agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
+    bytes::Bytes,
     core::ops::Deref,
     solana_compute_budget_instruction::compute_budget_instruction_details::*,
     solana_hash::Hash,
@@ -29,6 +31,8 @@ use {
 
 mod sdk_transactions;
 mod transaction_view;
+
+pub type ReplayTransaction = RuntimeTransaction<ResolvedTransactionView<Bytes>>;
 
 #[cfg_attr(feature = "dev-context-only-utils", derive(Clone))]
 #[derive(Debug)]

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -230,6 +230,34 @@ impl<D: TransactionData> StaticTransactionWithMeta
     }
 }
 
+#[cfg(feature = "dev-context-only-utils")]
+impl<D> From<solana_transaction::Transaction> for RuntimeTransaction<ResolvedTransactionView<D>>
+where
+    D: TransactionData + From<Vec<u8>>,
+{
+    fn from(transaction: solana_transaction::Transaction) -> Self {
+        let versioned_transaction = VersionedTransaction::from(transaction);
+        let data = D::from(wincode::serialize(&versioned_transaction).unwrap());
+        let sanitized_view = SanitizedTransactionView::try_new_sanitized(
+            data,
+            &crate::sanitize_config::sanitize_config(),
+        )
+        .expect("failed to create SanitizedTransactionView from Transaction");
+        let static_runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            sanitized_view,
+            MessageHash::Compute,
+            None,
+        )
+        .expect("failed to create RuntimeTransaction from Transaction");
+        RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+            static_runtime_tx,
+            None,
+            &HashSet::new(),
+        )
+        .expect("failed to create RuntimeTransaction from Transaction")
+    }
+}
+
 impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTransactionView<D>> {
     fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
         let VersionedTransaction {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -31,6 +31,7 @@ conformance = [
 dev-context-only-utils = [
     "agave-votor-messages/dev-context-only-utils",
     "solana-accounts-db/dev-context-only-utils",
+    "solana-entry/dev-context-only-utils",
     "solana-program-binaries",
     "solana-svm/dev-context-only-utils",
     "solana-runtime-transaction/dev-context-only-utils",
@@ -66,6 +67,7 @@ agave-fs = { workspace = true }
 agave-precompiles = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 agave-snapshots = { workspace = true }
+agave-transaction-view = { workspace = true }
 agave-votor-messages = { workspace = true }
 ahash = { workspace = true }
 arc-swap = { workspace = true }
@@ -75,6 +77,7 @@ base64 = { workspace = true }
 bincode = { workspace = true }
 bitvec = { workspace = true }
 bytemuck = { workspace = true }
+bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { workspace = true }
 crossbeam-utils = { workspace = true }
@@ -199,6 +202,7 @@ wincode = { workspace = true, features = ["smallvec"] }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 agave-transaction-view = { workspace = true }
 bitvec = { workspace = true }
+bytes = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 proptest = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -83,6 +83,12 @@ use {
     agave_precompiles::{get_precompile, get_precompiles, is_precompile},
     agave_reserved_account_keys::ReservedAccountKeys,
     agave_snapshots::snapshot_hash::SnapshotHash,
+    agave_transaction_view::{
+        resolved_transaction_view::ResolvedTransactionView,
+        transaction_data::TransactionData,
+        transaction_version::TransactionVersion,
+        transaction_view::{SanitizedTransactionView, UnsanitizedTransactionView},
+    },
     agave_votor_messages::{
         certificate::{CertSignature, Certificate, GenesisCert},
         migration::GENESIS_CERTIFICATE_ACCOUNT,
@@ -133,7 +139,7 @@ use {
     solana_lattice_hash::lt_hash::LtHash,
     solana_measure::{measure::Measure, measure_time, measure_us},
     solana_message::{
-        AccountKeys, SanitizedMessage, VersionedMessage, inner_instruction::InnerInstructions,
+        AccountKeys, SanitizedMessage, inner_instruction::InnerInstructions, v0::LoadedAddresses,
     },
     solana_packet::PACKET_DATA_SIZE,
     solana_precompile_error::PrecompileError,
@@ -183,12 +189,12 @@ use {
     solana_transaction::{
         Transaction, TransactionVerificationMode,
         sanitized::{MAX_TX_ACCOUNT_LOCKS, MessageHash, SanitizedTransaction},
-        versioned::{TransactionVersion, VersionedTransaction},
+        versioned::VersionedTransaction,
     },
     solana_transaction_context::{
         transaction::TransactionReturnData, transaction_accounts::KeyedAccountSharedData,
     },
-    solana_transaction_error::{TransactionError, TransactionResult as Result},
+    solana_transaction_error::{AddressLoaderError, TransactionError, TransactionResult as Result},
     solana_vote::{
         vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
         vote_parser,
@@ -5521,79 +5527,87 @@ impl Bank {
     }
 
     /// Verify the transaction signatures, hash and other metadata.
-    pub fn verify_transaction(
+    pub fn verify_transaction<D>(
         &self,
-        tx: VersionedTransaction,
+        tx: UnsanitizedTransactionView<D>,
         verification_mode: TransactionVerificationMode,
-    ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
-        // Discard v1 transactions until feature gate is activated.
-        if !self.feature_set.snapshot().enable_tx_v1
-            && tx.version() == TransactionVersion::Number(1)
-        {
-            return Err(TransactionError::UnsupportedVersion);
-        }
-
-        let serialized_message = tx.message.serialize();
-        self.verify_transaction_with_serialized_message(tx, &serialized_message, verification_mode)
-    }
-
-    /// Verify the transaction signatures, hash and other metadata, using the provided serialized
-    /// message.
-    ///
-    /// Verifying a transaction requires the serialized message to calculate the message hash. Use
-    /// this function if the message is already available. Note that the serialized message MUST
-    /// correspond to the transaction's message.
-    pub fn verify_transaction_with_serialized_message(
-        &self,
-        tx: VersionedTransaction,
-        serialized_message: &[u8],
-        verification_mode: TransactionVerificationMode,
-    ) -> Result<RuntimeTransaction<SanitizedTransaction>> {
+    ) -> Result<RuntimeTransaction<ResolvedTransactionView<D>>>
+    where
+        D: TransactionData,
+    {
         // Discard v1 transactions until feature gate is activated.
         let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
-        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
+        if !enable_tx_v1 && matches!(tx.version(), TransactionVersion::V1) {
             return Err(TransactionError::UnsupportedVersion);
         }
         let max_transaction_size = match tx.version() {
-            TransactionVersion::Number(1) if enable_tx_v1 => {
-                solana_message::v1::MAX_TRANSACTION_SIZE
-            }
+            TransactionVersion::V1 if enable_tx_v1 => solana_message::v1::MAX_TRANSACTION_SIZE,
             _ => PACKET_DATA_SIZE,
-        } as u64;
+        };
 
         // WARNING: Any pending features added here most likely must also be checked in
         //          `Bank::resanitize_transaction_minimally`.
         let sanitized_tx = {
-            let size =
-                wincode::serialized_size(&tx).map_err(|_| TransactionError::SanitizeFailure)?;
+            let size = tx.data().len();
             if size > max_transaction_size {
                 return Err(TransactionError::SanitizeFailure);
             }
 
             // SIMD-0160, check instruction limit before signature verification
-            if tx.message.instructions().len()
-                > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH
-            {
-                return Err(solana_transaction_error::TransactionError::SanitizeFailure);
+            let number_of_instructions: usize = tx.num_instructions().into();
+            if number_of_instructions > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH {
+                return Err(TransactionError::SanitizeFailure);
             }
 
-            let message_hash = if verification_mode == TransactionVerificationMode::FullVerification
-            {
-                tx.verify_and_hash_message()?
-            } else {
-                VersionedMessage::hash_raw_message(serialized_message)
+            if verification_mode == TransactionVerificationMode::FullVerification {
+                let message_data = tx.message_data();
+                let keys = tx.static_account_keys().iter();
+                let signatures = tx.signatures().iter();
+
+                for (key, signature) in keys.zip(signatures) {
+                    let valid_signature = signature.verify(key.as_ref(), message_data);
+                    if !valid_signature {
+                        return Err(TransactionError::SignatureFailure);
+                    }
+                }
             };
 
-            RuntimeTransaction::try_create(
-                tx,
-                MessageHash::Precomputed(message_hash),
+            let sanitized_tx = tx
+                .sanitize(&solana_runtime_transaction::sanitize_config::sanitize_config())
+                .map_err(|_| TransactionError::SanitizeFailure)?;
+
+            let sanitized_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+                sanitized_tx,
+                MessageHash::Compute,
                 None,
-                self,
+            )?;
+
+            let (loaded_addresses, _) = self.load_addresses_for_view(&sanitized_tx)?;
+
+            RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+                sanitized_tx,
+                loaded_addresses,
                 self.get_reserved_account_keys(),
             )
         }?;
 
         Ok(sanitized_tx)
+    }
+
+    /// Load addresses from ALTs (if necessary) and return the
+    /// [`LoadedAddresses`] with the minimum deactivation slot.
+    pub fn load_addresses_for_view<D: TransactionData>(
+        &self,
+        view: &SanitizedTransactionView<D>,
+    ) -> std::result::Result<(Option<LoadedAddresses>, Slot), AddressLoaderError> {
+        match view.version() {
+            TransactionVersion::Legacy | TransactionVersion::V1 => Ok((None, u64::MAX)),
+            TransactionVersion::V0 => self
+                .load_addresses_from_ref(view.address_table_lookup_iter())
+                .map(|(loaded_addresses, deactivation_slot)| {
+                    (Some(loaded_addresses), deactivation_slot)
+                }),
+        }
     }
 
     /// Checks if the transaction violates the bank's reserved keys.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -40,6 +40,7 @@ use {
     agave_snapshots::snapshot_config::SnapshotConfig,
     ahash::AHashMap,
     assert_matches::assert_matches,
+    bytes::Bytes,
     crossbeam_channel::{TrySendError, bounded},
     dashmap::DashMap,
     itertools::Itertools,
@@ -9566,6 +9567,18 @@ fn test_failed_compute_request_instruction() {
     assert_eq!(bank.signature_count(), 3);
 }
 
+fn transaction_view_from_versioned_transaction(
+    transaction: impl Into<VersionedTransaction>,
+) -> agave_transaction_view::result::Result<UnsanitizedTransactionView<Bytes>> {
+    let versioned_transaction = transaction.into();
+    let versioned_transaction_serialized_bytes =
+        wincode::serialize(&versioned_transaction).unwrap();
+
+    UnsanitizedTransactionView::try_new_unsanitized(Bytes::from(
+        versioned_transaction_serialized_bytes,
+    ))
+}
+
 #[test]
 fn test_verify_and_hash_transaction_sig_len() {
     let GenesisConfigInfo {
@@ -9582,46 +9595,25 @@ fn test_verify_and_hash_transaction_sig_len() {
     let from_pubkey = from_keypair.pubkey();
     let to_pubkey = to_keypair.pubkey();
 
-    enum TestCase {
-        AddSignature,
-        RemoveSignature,
-    }
+    let message = Message::new(
+        &[system_instruction::transfer(&from_pubkey, &to_pubkey, 1)],
+        Some(&from_pubkey),
+    );
+    let mut tx = Transaction::new(&[&from_keypair], message, recent_blockhash);
+    assert_eq!(tx.message.header.num_required_signatures, 1);
+    let signature = to_keypair.sign_message(&tx.message.serialize());
+    tx.signatures.push(signature);
 
-    let make_transaction = |case: TestCase| {
-        let message = Message::new(
-            &[system_instruction::transfer(&from_pubkey, &to_pubkey, 1)],
-            Some(&from_pubkey),
-        );
-        let mut tx = Transaction::new(&[&from_keypair], message, recent_blockhash);
-        assert_eq!(tx.message.header.num_required_signatures, 1);
-        match case {
-            TestCase::AddSignature => {
-                let signature = to_keypair.sign_message(&tx.message.serialize());
-                tx.signatures.push(signature);
-            }
-            TestCase::RemoveSignature => {
-                tx.signatures.remove(0);
-            }
-        }
-        tx
-    };
-
-    // Too few signatures: Sanitization failure
-    {
-        let tx = make_transaction(TestCase::RemoveSignature);
-        assert_matches!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure)
-        );
-    }
-    // Too many signatures: Sanitization failure
-    {
-        let tx = make_transaction(TestCase::AddSignature);
-        assert_matches!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
-            Err(TransactionError::SanitizeFailure)
-        );
-    }
+    // Too many signatures: Sanitization failure. A transaction with no signatures is rejected
+    // while constructing the transaction view, before it reaches Bank verification.
+    let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
+    assert_matches!(
+        bank.verify_transaction(
+            transaction_view,
+            TransactionVerificationMode::FullVerification
+        ),
+        Err(TransactionError::SanitizeFailure)
+    );
 }
 
 #[test]
@@ -9646,17 +9638,27 @@ fn test_verify_transactions_packet_data_size() {
     {
         let tx = make_transaction(5);
         assert!(bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64);
+
+        let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
         assert!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .is_ok(),
+            bank.verify_transaction(
+                transaction_view,
+                TransactionVerificationMode::FullVerification
+            )
+            .is_ok(),
         );
     }
     // Big transaction.
     {
         let tx = make_transaction(25);
         assert!(bincode::serialized_size(&tx).unwrap() > PACKET_DATA_SIZE as u64);
+
+        let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
         assert_matches!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            bank.verify_transaction(
+                transaction_view,
+                TransactionVerificationMode::FullVerification
+            ),
             Err(TransactionError::SanitizeFailure)
         );
     }
@@ -9664,10 +9666,15 @@ fn test_verify_transactions_packet_data_size() {
     // size exceeds packet data size.
     for size in 1..30 {
         let tx = make_transaction(size);
+        let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
+        let fits_in_packet = transaction_view.data().len() <= PACKET_DATA_SIZE;
         assert_eq!(
-            bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64,
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .is_ok(),
+            fits_in_packet,
+            bank.verify_transaction(
+                transaction_view,
+                TransactionVerificationMode::FullVerification
+            )
+            .is_ok()
         );
     }
 }
@@ -9714,21 +9721,33 @@ fn test_verify_transactions_tx_v1_size_gate_does_not_relax_legacy_or_v0() {
     };
 
     let legacy_tx = oversized_but_tx_v1_sized(&make_legacy_transaction);
+    let legacy_transaction_view = transaction_view_from_versioned_transaction(legacy_tx).unwrap();
     assert_matches!(
-        bank.verify_transaction(legacy_tx, TransactionVerificationMode::FullVerification),
+        bank.verify_transaction(
+            legacy_transaction_view,
+            TransactionVerificationMode::FullVerification
+        ),
         Err(TransactionError::SanitizeFailure)
     );
 
     let v0_tx = oversized_but_tx_v1_sized(&make_v0_transaction);
+    let v0_transaction_view = transaction_view_from_versioned_transaction(v0_tx).unwrap();
     assert_matches!(
-        bank.verify_transaction(v0_tx, TransactionVerificationMode::FullVerification),
+        bank.verify_transaction(
+            v0_transaction_view,
+            TransactionVerificationMode::FullVerification
+        ),
         Err(TransactionError::SanitizeFailure)
     );
 
     let v1_tx = oversized_but_tx_v1_sized(&make_v1_transaction);
+    let v1_transaction_view = transaction_view_from_versioned_transaction(v1_tx).unwrap();
     assert!(
-        bank.verify_transaction(v1_tx, TransactionVerificationMode::FullVerification)
-            .is_ok()
+        bank.verify_transaction(
+            v1_transaction_view,
+            TransactionVerificationMode::FullVerification
+        )
+        .is_ok()
     );
 }
 
@@ -9763,10 +9782,14 @@ fn test_verify_transactions_tx_v1_precompile_program_id_index_above_packet_limit
         }],
     );
     let tx = VersionedTransaction::try_new(VersionedMessage::V1(message), &[&keypair]).unwrap();
+    let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
 
     assert!(
-        bank.verify_transaction(tx, TransactionVerificationMode::FullVerification)
-            .is_ok()
+        bank.verify_transaction(
+            transaction_view,
+            TransactionVerificationMode::FullVerification
+        )
+        .is_ok()
     );
 }
 
@@ -9796,11 +9819,14 @@ fn test_verify_transactions_instruction_limit() {
         ixs,
     );
     let tx = Transaction::new(&[&keypair], message, recent_blockhash);
-
     assert!(bincode::serialized_size(&tx).unwrap() <= PACKET_DATA_SIZE as u64);
 
+    let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
     assert_matches!(
-        bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+        bank.verify_transaction(
+            transaction_view,
+            TransactionVerificationMode::FullVerification
+        ),
         Err(TransactionError::SanitizeFailure)
     );
 }
@@ -9832,9 +9858,13 @@ fn test_verify_transactions_accounts_limit() {
         vec![instruction],
     );
     let tx = Transaction::new(&[&keypair], message, recent_blockhash);
+    let transaction_view = transaction_view_from_versioned_transaction(tx).unwrap();
 
     assert_matches!(
-        bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+        bank.verify_transaction(
+            transaction_view,
+            TransactionVerificationMode::FullVerification
+        ),
         Err(TransactionError::SanitizeFailure)
     );
 }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -782,6 +782,7 @@ mod tests {
             },
         },
         agave_feature_set::FeatureSet,
+        agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
         agave_votor_messages::{
             certificate::{CertSignature, GenesisCert},
             consensus_message::Block,
@@ -800,7 +801,6 @@ mod tests {
         solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
         solana_sdk_ids::system_program,
         solana_signer::Signer,
-        solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
         solana_unified_scheduler_logic::OrderedTaskId,
         solana_vote_program::vote_state::BlockTimestamp,
@@ -832,7 +832,7 @@ mod tests {
 
         fn schedule_execution(
             &self,
-            _transaction: RuntimeTransaction<SanitizedTransaction>,
+            _transaction: RuntimeTransaction<ResolvedTransactionView<bytes::Bytes>>,
             _task_id: OrderedTaskId,
         ) -> ScheduleResult {
             Ok(())

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -10,6 +10,7 @@ use {
         },
         validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
     },
+    agave_transaction_view::transaction_data::TransactionData,
     agave_votor_messages::{
         certificate::{CertSignature, Certificate, CertificateType, GenesisCert},
         consensus_message::Block,
@@ -25,7 +26,7 @@ use {
             BlockFooterV1, BlockMarkerV1, GenesisCertBlockMarker, VersionedBlockFooter,
             VersionedBlockHeader, VersionedBlockMarker, VersionedUpdateParent,
         },
-        entry::Entry,
+        entry::EntryView,
     },
     solana_hash::Hash,
     solana_pubkey::Pubkey,
@@ -360,11 +361,11 @@ impl BlockComponentProcessor {
     /// Validates that a parent marker (header or update parent) has been processed
     /// before any entry batches. The terminal Alpenglow tick is the only entry
     /// batch allowed after the block footer.
-    pub fn on_entry_batch(
+    pub fn on_entry_batch<D: TransactionData>(
         &mut self,
         migration_status: &MigrationStatus,
         slot: Slot,
-        entries: &[Entry],
+        entries: &[EntryView<D>],
         is_final_component: bool,
     ) -> Result<(), BlockComponentProcessorError> {
         if !migration_status.should_allow_block_markers(slot) {
@@ -790,14 +791,12 @@ mod tests {
             bank_forks::BankForks,
             genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
         },
+        bytes::Bytes,
         rand::Rng,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         solana_clock::DEFAULT_MS_PER_SLOT,
-        solana_entry::{
-            block_component::{
-                BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
-            },
-            entry::Entry,
+        solana_entry::block_component::{
+            BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedUpdateParent,
         },
         solana_hash::Hash,
         std::{
@@ -885,8 +884,12 @@ mod tests {
         }
     }
 
-    fn alpentick(num_hashes: u64) -> [Entry; 1] {
-        [Entry::new(&Hash::default(), num_hashes, vec![])]
+    fn alpentick(num_hashes: u64) -> [EntryView<Bytes>; 1] {
+        [EntryView {
+            num_hashes,
+            hash: Hash::default(),
+            transactions: vec![],
+        }]
     }
 
     #[test]
@@ -895,7 +898,7 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
 
         // Try to process entry batch without header - should fail
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert!(matches!(
             result,
             Err(BlockComponentProcessorError::MissingParentMarker)
@@ -952,7 +955,7 @@ mod tests {
             )
             .unwrap();
         processor
-            .on_entry_batch(&migration_status, bank.slot(), &[], false)
+            .on_entry_batch::<Bytes>(&migration_status, bank.slot(), &[], false)
             .unwrap();
 
         let marker =
@@ -1363,7 +1366,7 @@ mod tests {
 
         // Process some entry batches (not full yet)
         processor
-            .on_entry_batch(&migration_status, 1, &[], false)
+            .on_entry_batch::<Bytes>(&migration_status, 1, &[], false)
             .unwrap();
 
         // Process footer with valid timestamp
@@ -1390,7 +1393,7 @@ mod tests {
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
 
         // Entry batch after footer should fail because the footer is terminal.
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert_matches!(
             result,
             Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
@@ -1407,20 +1410,20 @@ mod tests {
             .on_entry_batch(&migration_status, 1, &good_alpentick, true)
             .unwrap();
         assert_matches!(
-            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true),
+            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true,),
             Err(BlockComponentProcessorError::InvalidAlpentickPosition)
         );
 
         let mut processor = BlockComponentProcessor::default();
         assert_matches!(
-            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true),
+            processor.on_entry_batch(&migration_status, 1, &good_alpentick, true,),
             Err(BlockComponentProcessorError::MissingParentMarker)
         );
 
         let mut processor = processor_after_footer();
         let bad_alpentick = alpentick(2);
         assert_matches!(
-            processor.on_entry_batch(&migration_status, 1, &bad_alpentick, true),
+            processor.on_entry_batch(&migration_status, 1, &bad_alpentick, true,),
             Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
         );
 
@@ -1523,11 +1526,11 @@ mod tests {
         let mut processor = BlockComponentProcessor::default();
 
         // Processing entry batches pre-migration (without markers) should succeed
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert!(result.is_ok());
 
         // Even with slot full
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert!(result.is_ok());
     }
 
@@ -1558,7 +1561,7 @@ mod tests {
 
         // Process entry batches
         processor
-            .on_entry_batch(&migration_status, 1, &[], false)
+            .on_entry_batch::<Bytes>(&migration_status, 1, &[], false)
             .unwrap();
 
         // Calculate valid timestamp based on parent's time
@@ -1591,7 +1594,7 @@ mod tests {
         assert_eq!(bank.clock().unix_timestamp, expected_time_secs);
 
         // Entry batch after footer should fail because the footer is terminal.
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert_matches!(
             result,
             Err(BlockComponentProcessorError::EntryBatchAfterBlockFooter)
@@ -1672,7 +1675,7 @@ mod tests {
         let mut processor = processor_after_header();
 
         // Process entry batch with header but not full - should succeed even without footer
-        let result = processor.on_entry_batch(&migration_status, 1, &[], false);
+        let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert!(result.is_ok());
     }
 
@@ -2098,7 +2101,7 @@ mod tests {
             .unwrap();
 
         processor
-            .on_entry_batch(&migration_status, slot, &[], false)
+            .on_entry_batch::<Bytes>(&migration_status, slot, &[], false)
             .unwrap();
 
         let parent_time_nanos = parent.clock().unix_timestamp.saturating_mul(1_000_000_000);

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -25,13 +25,15 @@ use {
         stakes::{DeserializableDelegationStakes, SerdeStakesToStakeFormat, Stakes},
     },
     agave_feature_set::FeatureSet,
+    agave_transaction_view::transaction_view::UnsanitizedTransactionView,
+    bytes::Bytes,
     solana_account::AccountSharedData,
     solana_accounts_db::{ancestors::Ancestors, blockhash_queue::BlockhashQueue},
     solana_clock::{BankId, Clock, DEFAULT_TICKS_PER_SLOT, Epoch, MAX_PROCESSING_AGE},
     solana_epoch_schedule::EpochSchedule,
     solana_fee_calculator::FeeRateGovernor,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
     solana_sdk_ids::sysvar,
     solana_stake_interface::state::Stake,
     solana_svm::{
@@ -41,10 +43,7 @@ use {
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     solana_svm_timings::ExecuteTimings,
-    solana_transaction::{
-        TransactionVerificationMode, sanitized::SanitizedTransaction,
-        versioned::VersionedTransaction,
-    },
+    solana_transaction::{TransactionVerificationMode, versioned::VersionedTransaction},
     solana_transaction_error::TransactionError,
     solana_vote::vote_account::VoteAccounts,
     std::collections::HashMap,
@@ -61,6 +60,7 @@ use {
     },
     solana_instruction::error::InstructionError,
     solana_message::SanitizedMessage,
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     solana_signature::Signature,
     solana_svm::conformance::{
         account_state::account_to_proto, direct_mapping::direct_mapping_handle_cu_exhaustion,
@@ -86,7 +86,7 @@ pub enum BankTxnProcessingResult {
     /// processing result and transaction for effect extraction.
     Processed {
         result: TransactionProcessingResult,
-        runtime_transaction: Box<RuntimeTransaction<SanitizedTransaction>>,
+        runtime_transaction: Box<ReplayTransaction>,
     },
 }
 
@@ -158,8 +158,14 @@ pub fn execute_txn(
     let bank = Bank::new_for_txn_tests(bank_rc, bank_fields, feature_set, epoch_stakes);
     let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
+    let transaction_bytes = Bytes::from(wincode::serialize(&transaction).unwrap());
+    let Ok(transaction_view) = UnsanitizedTransactionView::try_new_unsanitized(transaction_bytes)
+    else {
+        return BankTxnProcessingResult::FailedVerification(TransactionError::SanitizeFailure);
+    };
+
     let runtime_transaction = match bank.verify_transaction(
-        transaction,
+        transaction_view,
         TransactionVerificationMode::HashAndVerifyPrecompiles,
     ) {
         Ok(tx) => tx,
@@ -455,7 +461,8 @@ pub fn execute_txn_proto(context: &ProtoTxnContext) -> ProtoTxnResult {
             runtime_transaction,
         } => (result, runtime_transaction),
     };
-    let sanitized_message = runtime_transaction.message();
+    let sanitized_transaction = runtime_transaction.as_sanitized_transaction();
+    let sanitized_message = sanitized_transaction.message();
 
     let mut txn_result = output_txn_result(&result, sanitized_message);
 
@@ -560,6 +567,7 @@ mod tests {
             v0::{self, MessageAddressTableLookup},
         },
         solana_pubkey::Pubkey,
+        solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
         solana_sdk_ids::{bpf_loader_upgradeable, native_loader, sysvar},
         solana_signature::Signature,
         solana_slot_hashes::SlotHashes,
@@ -733,14 +741,18 @@ mod tests {
             BankTxnProcessingResult::Processed {
                 result: Ok(ProcessedTransaction::Executed(executed_tx)),
                 runtime_transaction,
-            } => executed_tx
-                .loaded_transaction
-                .accounts
-                .iter()
-                .enumerate()
-                .filter(|(index, _)| runtime_transaction.message().is_writable(*index))
-                .find(|(_, (key, _))| key == pubkey)
-                .map(|(_, (_, account))| account.lamports()),
+            } => {
+                let sanitized_transaction = runtime_transaction.as_sanitized_transaction();
+                let sanitized_message = sanitized_transaction.message();
+                executed_tx
+                    .loaded_transaction
+                    .accounts
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| sanitized_message.is_writable(*index))
+                    .find(|(_, (key, _))| key == pubkey)
+                    .map(|(_, (_, account))| account.lamports())
+            }
             _ => None,
         }
     }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -25,9 +25,8 @@ use {
     log::*,
     solana_clock::Slot,
     solana_hash::Hash,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
     solana_svm_timings::ExecuteTimings,
-    solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_unified_scheduler_logic::OrderedTaskId,
     std::{
@@ -129,7 +128,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     /// having &mut.
     fn schedule_execution(
         &self,
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: ReplayTransaction,
         task_id: OrderedTaskId,
     ) -> ScheduleResult;
 
@@ -437,9 +436,7 @@ impl BankWithScheduler {
     /// wait_for_termination()-ed or the unified scheduler is disabled in the first place).
     pub fn schedule_transaction_executions(
         &self,
-        transaction_with_task_ids: impl ExactSizeIterator<
-            Item = (RuntimeTransaction<SanitizedTransaction>, OrderedTaskId),
-        >,
+        transaction_with_task_ids: impl ExactSizeIterator<Item = (ReplayTransaction, OrderedTaskId)>,
     ) -> Result<()> {
         trace!(
             "schedule_transaction_executions(): {} txs",
@@ -853,7 +850,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx0 = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -19,11 +19,14 @@ rustdoc-args = ["--cfg=docsrs"]
 agave-unstable-api = []
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 assert_matches = { workspace = true }
+bytes = { workspace = true }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-transaction = { workspace = true }
 static_assertions = { workspace = true }
 
@@ -32,7 +35,10 @@ solana-instruction = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-signature = { workspace = true }
+solana-transaction = { workspace = true, features = ["wincode"] }
 test-case = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -102,8 +102,10 @@ use {
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
-    solana_transaction::sanitized::SanitizedTransaction,
+    solana_runtime_transaction::{
+        runtime_transaction::ReplayTransaction, transaction_meta::TransactionMeta,
+    },
+    solana_svm_transaction::svm_message::SVMMessage,
     static_assertions::const_assert_eq,
     std::{
         cmp::Ordering,
@@ -443,7 +445,7 @@ mod utils {
 type LockResult = Result<(), ()>;
 const_assert_eq!(mem::size_of::<LockResult>(), 1);
 
-/// Something to be scheduled; usually a wrapper of [`SanitizedTransaction`].
+/// Something to be scheduled.
 pub type Task = Arc<TaskInner>;
 const_assert_eq!(mem::size_of::<Task>(), 8);
 
@@ -463,7 +465,7 @@ const_assert_eq!(mem::size_of::<BlockedUsageCountToken>(), 0);
 /// Internal scheduling data about a particular task.
 #[derive(Debug)]
 pub struct TaskInner {
-    transaction: RuntimeTransaction<SanitizedTransaction>,
+    transaction: ReplayTransaction,
     /// For block verification, the index of a transaction in ledger entries. Carrying this along
     /// with the transaction is needed to properly record the execution result of it.
     /// For block production, the priority of a transaction for reordering with
@@ -505,7 +507,7 @@ impl TaskInner {
         self.alt_invalidation_slot
     }
 
-    pub fn transaction(&self) -> &RuntimeTransaction<SanitizedTransaction> {
+    pub fn transaction(&self) -> &ReplayTransaction {
         &self.transaction
     }
 
@@ -563,7 +565,7 @@ impl TaskInner {
             })
     }
 
-    pub fn into_transaction(self: Task) -> RuntimeTransaction<SanitizedTransaction> {
+    pub fn into_transaction(self: Task) -> ReplayTransaction {
         Task::into_inner(self).unwrap().transaction
     }
 }
@@ -1275,7 +1277,7 @@ impl SchedulingStateMachine {
         }
     }
 
-    /// Creates a new task with [`RuntimeTransaction<SanitizedTransaction>`] with all of
+    /// Creates a new task with [`ReplayTransaction`] with all of
     /// its corresponding [`UsageQueue`]s preloaded.
     ///
     /// Closure (`usage_queue_loader`) is used to delegate the (possibly multi-threaded)
@@ -1289,7 +1291,7 @@ impl SchedulingStateMachine {
     /// after created, if `has_no_active_task()` is `true`. Also note that this is desired for
     /// separation of concern.
     pub fn create_task(
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: ReplayTransaction,
         task_id: OrderedTaskId,
         usage_queue_loader: &mut impl FnMut(Pubkey) -> UsageQueue,
     ) -> Task {
@@ -1304,7 +1306,7 @@ impl SchedulingStateMachine {
     }
 
     pub fn create_block_production_task(
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: ReplayTransaction,
         task_id: OrderedTaskId,
         consumed_block_size: BlockSize,
         sanitized_epoch: Epoch,
@@ -1322,7 +1324,7 @@ impl SchedulingStateMachine {
     }
 
     fn do_create_task(
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: ReplayTransaction,
         task_id: OrderedTaskId,
         consumed_block_size: BlockSize,
         sanitized_epoch: Epoch,
@@ -1359,14 +1361,13 @@ impl SchedulingStateMachine {
         // This redundancy is known. It was just left as-is out of abundance
         // of caution.
         let lock_contexts = transaction
-            .message()
             .account_keys()
             .iter()
             .enumerate()
             .map(|(task_id, address)| {
                 LockContext::new(
                     usage_queue_loader(*address),
-                    if transaction.message().is_writable(task_id) {
+                    if transaction.is_writable(task_id) {
                         RequestedUsage::Writable
                     } else {
                         RequestedUsage::Readonly
@@ -1508,10 +1509,21 @@ impl SchedulingStateMachine {
 mod tests {
     use {
         super::*,
+        agave_transaction_view::transaction_view::SanitizedTransactionView,
+        bytes::Bytes,
         solana_instruction::{AccountMeta, Instruction},
-        solana_message::Message,
+        solana_message::{AddressLookupTableAccount, Message, VersionedMessage, v0},
         solana_pubkey::Pubkey,
-        solana_transaction::{Transaction, sanitized::SanitizedTransaction},
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
+        },
+        solana_signature::Signature,
+        solana_svm_transaction::{
+            svm_message::SVMStaticMessage, svm_transaction::SVMStaticTransaction,
+        },
+        solana_transaction::{
+            Transaction, sanitized::MessageHash, versioned::VersionedTransaction,
+        },
         std::{
             cell::RefCell,
             collections::HashMap,
@@ -1521,22 +1533,24 @@ mod tests {
         test_case::test_matrix,
     };
 
-    fn simplest_transaction() -> RuntimeTransaction<SanitizedTransaction> {
-        let message = Message::new(&[], Some(&Pubkey::new_unique()));
-        let unsigned = Transaction::new_unsigned(message);
-        RuntimeTransaction::from_transaction_for_tests(unsigned)
+    fn simplest_transaction() -> ReplayTransaction {
+        simplest_transaction_with_payer(&Pubkey::new_unique())
     }
 
-    fn transaction_with_readonly_address(
-        address: Pubkey,
-    ) -> RuntimeTransaction<SanitizedTransaction> {
+    fn simplest_transaction_with_payer(payer: &Pubkey) -> ReplayTransaction {
+        let message = Message::new(&[], Some(payer));
+        let unsigned = Transaction::new_unsigned(message);
+        ReplayTransaction::from(unsigned)
+    }
+
+    fn transaction_with_readonly_address(address: Pubkey) -> ReplayTransaction {
         transaction_with_readonly_address_with_payer(address, &Pubkey::new_unique())
     }
 
     fn transaction_with_readonly_address_with_payer(
         address: Pubkey,
         payer: &Pubkey,
-    ) -> RuntimeTransaction<SanitizedTransaction> {
+    ) -> ReplayTransaction {
         let instruction = Instruction {
             program_id: Pubkey::default(),
             accounts: vec![AccountMeta::new_readonly(address, false)],
@@ -1544,19 +1558,17 @@ mod tests {
         };
         let message = Message::new(&[instruction], Some(payer));
         let unsigned = Transaction::new_unsigned(message);
-        RuntimeTransaction::from_transaction_for_tests(unsigned)
+        ReplayTransaction::from(unsigned)
     }
 
-    fn transaction_with_writable_address(
-        address: Pubkey,
-    ) -> RuntimeTransaction<SanitizedTransaction> {
+    fn transaction_with_writable_address(address: Pubkey) -> ReplayTransaction {
         transaction_with_writable_address_with_payer(address, &Pubkey::new_unique())
     }
 
     fn transaction_with_writable_address_with_payer(
         address: Pubkey,
         payer: &Pubkey,
-    ) -> RuntimeTransaction<SanitizedTransaction> {
+    ) -> ReplayTransaction {
         let instruction = Instruction {
             program_id: Pubkey::default(),
             accounts: vec![AccountMeta::new(address, false)],
@@ -1564,7 +1576,68 @@ mod tests {
         };
         let message = Message::new(&[instruction], Some(payer));
         let unsigned = Transaction::new_unsigned(message);
-        RuntimeTransaction::from_transaction_for_tests(unsigned)
+        ReplayTransaction::from(unsigned)
+    }
+
+    #[derive(Clone, Copy)]
+    enum LoadedAddressAccess {
+        Writable,
+        Readable,
+    }
+
+    /// Builds a v0 transaction whose only reference to `loaded_address` is through an address
+    /// lookup table, i.e. `loaded_address` never appears in `static_account_keys()`.
+    /// `RuntimeTransaction::from_transaction_view_for_tests` can't express this since it always
+    /// resolves with `loaded_addresses: None`, so this goes through the same
+    /// sanitize/statically-load/resolve pipeline by hand, providing the loaded address explicitly.
+    fn transaction_with_loaded_address_with_payer(
+        loaded_address: Pubkey,
+        payer: &Pubkey,
+        access: LoadedAddressAccess,
+    ) -> ReplayTransaction {
+        let instruction = Instruction {
+            program_id: Pubkey::default(),
+            accounts: vec![match access {
+                LoadedAddressAccess::Writable => AccountMeta::new(loaded_address, false),
+                LoadedAddressAccess::Readable => AccountMeta::new_readonly(loaded_address, false),
+            }],
+            data: vec![],
+        };
+        let message = v0::Message::try_compile(
+            payer,
+            &[instruction],
+            &[AddressLookupTableAccount {
+                key: Pubkey::new_unique(),
+                addresses: vec![loaded_address],
+            }],
+            Hash::default(),
+        )
+        .unwrap();
+        let versioned_transaction = VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V0(message),
+        };
+        let data: Bytes = Bytes::from(wincode::serialize(&versioned_transaction).unwrap());
+        let sanitized_view =
+            SanitizedTransactionView::try_new_sanitized(data, &sanitize_config()).unwrap();
+        let static_runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            sanitized_view,
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+        let loaded_addresses = match access {
+            LoadedAddressAccess::Writable => v0::LoadedAddresses {
+                writable: vec![loaded_address],
+                readonly: vec![],
+            },
+            LoadedAddressAccess::Readable => v0::LoadedAddresses {
+                writable: vec![],
+                readonly: vec![loaded_address],
+            },
+        };
+        ReplayTransaction::try_new(static_runtime_tx, Some(loaded_addresses), &HashSet::new())
+            .unwrap()
     }
 
     fn create_address_loader(
@@ -1583,7 +1656,7 @@ mod tests {
 
     #[test]
     fn test_scheduling_state_machine_creation() {
-        let state_machine = unsafe {
+        let state_machine: SchedulingStateMachine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling_for_test()
         };
         assert_eq!(state_machine.active_task_count(), 0);
@@ -1593,7 +1666,7 @@ mod tests {
 
     #[test]
     fn test_scheduling_state_machine_good_reinitialization() {
-        let mut state_machine = unsafe {
+        let mut state_machine: SchedulingStateMachine = unsafe {
             SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling_for_test()
         };
         state_machine.total_task_count.increment_self();
@@ -1702,6 +1775,150 @@ mod tests {
             Some(103)
         );
         state_machine.deschedule_task(&task3);
+        assert!(state_machine.has_no_active_task());
+    }
+
+    /// `do_create_task` must lock accounts resolved through an address lookup table, not just
+    /// `static_account_keys()`. task1 and task2 share `loaded_address` as their only common
+    /// writable account, resolved purely via each transaction's lookup table, so they must
+    /// conflict.
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_conflicting_tasks_sharing_only_a_loaded_address(capability: Capability) {
+        let loaded_address = Pubkey::new_unique();
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Writable,
+            ),
+            101,
+            address_loader,
+        );
+        let task2 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Writable,
+            ),
+            102,
+            address_loader,
+        );
+
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling_for_test()
+        };
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(state_machine.schedule_task(task2.clone()), None);
+
+        state_machine.deschedule_task(&task1);
+        assert_matches!(
+            state_machine
+                .schedule_next_unblocked_task()
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+        state_machine.deschedule_task(&task2);
+        assert!(state_machine.has_no_active_task());
+    }
+
+    /// task1 and task2 share `loaded_address` as a *readonly* lookup-table entry only, so they
+    /// must not conflict.
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_readonly_tasks_sharing_only_a_loaded_address_do_not_conflict(capability: Capability) {
+        let loaded_address = Pubkey::new_unique();
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Readable,
+            ),
+            101,
+            address_loader,
+        );
+        let task2 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Readable,
+            ),
+            102,
+            address_loader,
+        );
+
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling_for_test()
+        };
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(
+            state_machine
+                .schedule_task(task2.clone())
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+
+        state_machine.deschedule_task(&task1);
+        state_machine.deschedule_task(&task2);
+        assert!(state_machine.has_no_active_task());
+    }
+
+    /// task1 writes `loaded_address` via a lookup table; task2 only reads it via the same
+    /// lookup table. They must still conflict.
+    #[test_matrix([Capability::FifoQueueing, Capability::PriorityQueueing])]
+    fn test_writable_task_blocks_readonly_task_sharing_only_a_loaded_address(
+        capability: Capability,
+    ) {
+        let loaded_address = Pubkey::new_unique();
+        let address_loader = &mut create_address_loader(None, &capability);
+        let task1 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Writable,
+            ),
+            101,
+            address_loader,
+        );
+        let task2 = SchedulingStateMachine::create_task(
+            transaction_with_loaded_address_with_payer(
+                loaded_address,
+                &Pubkey::new_unique(),
+                LoadedAddressAccess::Readable,
+            ),
+            102,
+            address_loader,
+        );
+
+        let mut state_machine = unsafe {
+            SchedulingStateMachine::exclusively_initialize_current_thread_for_scheduling_for_test()
+        };
+        assert_matches!(
+            state_machine
+                .schedule_task(task1.clone())
+                .map(|t| t.task_id()),
+            Some(101)
+        );
+        assert_matches!(state_machine.schedule_task(task2.clone()), None);
+
+        state_machine.deschedule_task(&task1);
+        assert_matches!(
+            state_machine
+                .schedule_next_unblocked_task()
+                .map(|t| t.task_id()),
+            Some(102)
+        );
+        state_machine.deschedule_task(&task2);
         assert!(state_machine.has_no_active_task());
     }
 
@@ -2008,7 +2225,7 @@ mod tests {
             });
         // task2's fee payer should have been locked already even if task2 is blocked still via the
         // above the schedule_task(task2) call
-        let fee_payer = task2.transaction().message().fee_payer();
+        let fee_payer = task2.transaction().fee_payer();
         let usage_queue = usage_queues.get(fee_payer).unwrap();
         usage_queue
             .0

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -36,9 +36,8 @@ use {
         },
         vote_sender_types::{ReplayVoteSendType, ReplayVoteSender},
     },
-    solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+    solana_runtime_transaction::runtime_transaction::ReplayTransaction,
     solana_svm_timings::ExecuteTimings,
-    solana_transaction::sanitized::SanitizedTransaction,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_unified_scheduler_logic::{
         BlockSize, Capability, OrderedTaskId, SchedulingStateMachine, Task, UsageQueue,
@@ -1806,7 +1805,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
 
     fn schedule_execution(
         &self,
-        transaction: RuntimeTransaction<SanitizedTransaction>,
+        transaction: ReplayTransaction,
         task_id: OrderedTaskId,
     ) -> ScheduleResult {
         let task = SchedulingStateMachine::create_task(transaction, task_id, &mut |pubkey| {
@@ -1894,7 +1893,6 @@ mod tests {
         },
         solana_svm_timings::ExecuteTimingType,
         solana_system_transaction as system_transaction,
-        solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_error::TransactionError,
         std::{
             num::Saturating,
@@ -2242,25 +2240,23 @@ mod tests {
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
 
-        let tx_before_stale =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let tx_before_stale = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         bank.schedule_transaction_executions([(tx_before_stale, 0)].into_iter())
             .unwrap();
         sleepless_testing::at(TestCheckPoint::BeforeTimeoutListenerTriggered);
 
         sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
-        let tx_after_stale =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let tx_after_stale = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         bank.schedule_transaction_executions([(tx_after_stale, 1)].into_iter())
             .unwrap();
 
@@ -2360,26 +2356,24 @@ mod tests {
         let bank = BankWithScheduler::new(bank, Some(scheduler));
         pool.register_timeout_listener(bank.create_timeout_listener());
 
-        let tx_before_stale =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let tx_before_stale = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         bank.schedule_transaction_executions([(tx_before_stale, 0)].into_iter())
             .unwrap();
         sleepless_testing::at(TestCheckPoint::BeforeTimeoutListenerTriggered);
         sleepless_testing::at(TestCheckPoint::AfterSchedulerThreadAborted);
 
         sleepless_testing::at(TestCheckPoint::AfterTimeoutListenerTriggered);
-        let tx_after_stale =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let tx_after_stale = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         let result = bank.schedule_transaction_executions([(tx_after_stale, 1)].into_iter());
         assert_matches!(result, Err(TransactionError::AccountNotFound));
 
@@ -2441,26 +2435,24 @@ mod tests {
                 None, None, None, None, None,
             );
         let scheduler = pool.do_take_scheduler(SchedulingContext::new(bank.clone()));
-        let cancelled_transaction =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let cancelled_transaction = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         let bank = BankWithScheduler::new(bank, Some(Box::new(scheduler)));
         bank.schedule_transaction_executions([(cancelled_transaction, 0)].into_iter())
             .unwrap();
 
         sleepless_testing::at(TestCheckPoint::AfterSchedulerThreadAborted);
 
-        let transaction_after_abort =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let transaction_after_abort = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         assert_matches!(
             bank.schedule_transaction_executions([(transaction_after_abort, 1)].into_iter()),
             Err(TransactionError::CommitCancelled)
@@ -2488,7 +2480,7 @@ mod tests {
             ..
         } = create_genesis_config(10_000);
 
-        let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,
@@ -2598,7 +2590,7 @@ mod tests {
         const MAX_TASK_COUNT: OrderedTaskId = 100;
 
         for i in 0..MAX_TASK_COUNT {
-            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            let tx = ReplayTransaction::from(system_transaction::transfer(
                 &mint_keypair,
                 &solana_pubkey::new_rand(),
                 2,
@@ -2746,7 +2738,7 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx0 = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,
@@ -2802,7 +2794,7 @@ mod tests {
         let context = SchedulingContext::new(bank.clone());
         let scheduler = pool.take_scheduler(context).unwrap();
 
-        let bad_tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let bad_tx = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,
@@ -2813,13 +2805,12 @@ mod tests {
         sleepless_testing::at(TestCheckPoint::AfterTaskHandled);
         assert_eq!(bank.transaction_count(), 0);
 
-        let good_tx_after_bad_tx =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                3,
-                genesis_config.hash(),
-            ));
+        let good_tx_after_bad_tx = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            3,
+            genesis_config.hash(),
+        ));
         // make sure this tx is really a good one to execute.
         assert_matches!(
             bank.simulate_transaction_unchecked(&good_tx_after_bad_tx, false)
@@ -2931,7 +2922,7 @@ mod tests {
 
         for task_id in 0..TX_COUNT {
             // Use 2 non-conflicting txes to exercise the channel disconnected case as well.
-            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            let tx = ReplayTransaction::from(system_transaction::transfer(
                 &Keypair::new(),
                 &solana_pubkey::new_rand(),
                 1,
@@ -2999,7 +2990,7 @@ mod tests {
         let scheduler = pool.do_take_scheduler(context);
 
         for i in 0..10 {
-            let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+            let tx = ReplayTransaction::from(system_transaction::transfer(
                 &mint_keypair,
                 &solana_pubkey::new_rand(),
                 2,
@@ -3085,13 +3076,13 @@ mod tests {
         } = create_genesis_config_for_block_production(10_000);
 
         // tx0 and tx1 is definitely conflicting to write-lock the mint address
-        let tx0 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx0 = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,
             genesis_config.hash(),
         ));
-        let tx1 = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+        let tx1 = ReplayTransaction::from(system_transaction::transfer(
             &mint_keypair,
             &solana_pubkey::new_rand(),
             2,
@@ -3194,13 +3185,12 @@ mod tests {
         );
 
         // Create a dummy tx and two contexts
-        let dummy_tx =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let dummy_tx: ReplayTransaction = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         let context0 = &SchedulingContext::new(bank0.clone());
         let context1 = &SchedulingContext::new(bank1.clone());
 
@@ -3255,7 +3245,7 @@ mod tests {
 
         fn schedule_execution(
             &self,
-            transaction: RuntimeTransaction<SanitizedTransaction>,
+            transaction: ReplayTransaction,
             task_id: OrderedTaskId,
         ) -> ScheduleResult {
             let context = self.context().clone();
@@ -3384,13 +3374,12 @@ mod tests {
             mint_keypair,
             ..
         } = create_genesis_config(10_000);
-        let very_old_valid_tx =
-            RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
-                &mint_keypair,
-                &solana_pubkey::new_rand(),
-                2,
-                genesis_config.hash(),
-            ));
+        let very_old_valid_tx = ReplayTransaction::from(system_transaction::transfer(
+            &mint_keypair,
+            &solana_pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
         let bank = Bank::new_for_tests(&genesis_config);
         let (mut bank, _bank_forks) = setup_dummy_fork_graph(bank);
         for _ in 0..bank.max_processing_age() {
@@ -3482,9 +3471,9 @@ mod tests {
         );
         // mangle the transfer tx to try to lock fee_payer (= mint_keypair) address twice!
         tx.message.account_keys.push(tx.message.account_keys[0]);
-        let tx = RuntimeTransaction::from_transaction_for_tests(tx);
 
-        // this internally should call SanitizedTransaction::get_account_locks().
+        // this internally should call validate_account_locks() via
+        // Bank::prepare_unlocked_batch_from_single_tx().
         let result = &mut Ok(());
         let timings = &mut ExecuteTimings::default();
         let scheduling_context = &SchedulingContext::new(bank.clone());
@@ -3496,7 +3485,7 @@ mod tests {
             prioritization_fee_cache: None,
         };
 
-        let task = SchedulingStateMachine::create_task(tx, 0, &mut |_| {
+        let task = SchedulingStateMachine::create_task(ReplayTransaction::from(tx), 0, &mut |_| {
             UsageQueue::new(&Capability::FifoQueueing)
         });
         DefaultTaskHandler::handle(result, timings, scheduling_context, &task, handler_context);


### PR DESCRIPTION
#### Problem
See #14212 for in detail context. This PR builds on top of #14500

The main problem is that the code path for block-production mainly works with `transaction_view` types, whereas replay was using  `VersionedTransaction` type. Operating on two different types for transactions in block production and replay gives an increased chance of divergence in production and replay leading to non consensus.

#### Summary of Changes
- Replay code, starting from `blockstore_processor::confirm_slot` and down work exlusively on transaction views, instead of the previous `VersionedTransaction` types that required full deserialization.
- Updated code that previously interacted with `VersionedTransaction` to use the new APIs of `*TransactionViews<D>`

#### Testing
- Added unit test coverage to parsing function in  `entry/src/block_component_parser.rs`.
- Updated existing tests affected by API breakage of this migration to work with transaction views.

Fixes #14212
