### PR TITLE
votor: fix bug where we can vote skip on the genesis block

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -85,6 +85,7 @@ pub(crate) struct EventHandler {
 
 struct LocalContext {
     pub(crate) my_pubkey: Pubkey,
+    pub(crate) genesis_slot: Slot,
     pub(crate) pending_blocks: PendingBlocks,
     pub(crate) finalized_blocks: BTreeSet<Block>,
     pub(crate) received_shred: BTreeSet<Slot>,
@@ -123,6 +124,7 @@ impl EventHandler {
         } = context;
         let mut local_context = LocalContext {
             my_pubkey: ctx.cluster_info.keypair().pubkey(),
+            genesis_slot: 0,
             pending_blocks: PendingBlocks::default(),
             finalized_blocks: BTreeSet::default(),
             received_shred: BTreeSet::default(),
@@ -136,6 +138,7 @@ impl EventHandler {
             // Exited during migration
             return Ok(());
         };
+        local_context.genesis_slot = genesis_block.slot;
         let root_slot = vctx.sharable_banks.root().slot();
         info!(
             "{}: Event loop starting genesis {genesis_block:?} root {root_slot}",
@@ -143,7 +146,12 @@ impl EventHandler {
         );
 
         // Check for set identity
-        if let Err(e) = Self::handle_set_identity(&mut local_context.my_pubkey, &ctx, &mut vctx) {
+        if let Err(e) = Self::handle_set_identity(
+            &mut local_context.my_pubkey,
+            local_context.genesis_slot,
+            &ctx,
+            &mut vctx,
+        ) {
             error!(
                 "Unable to load new vote history when attempting to change identity at startup \
                  from {} to {} on voting loop startup, Exiting: {}",
@@ -559,7 +567,12 @@ impl EventHandler {
             // Operator called set identity make sure that our keypair is updated for voting
             VotorEvent::SetIdentity => {
                 info!("{}: SetIdentity", local_context.my_pubkey);
-                if let Err(e) = Self::handle_set_identity(&mut local_context.my_pubkey, ctx, vctx) {
+                if let Err(e) = Self::handle_set_identity(
+                    &mut local_context.my_pubkey,
+                    local_context.genesis_slot,
+                    ctx,
+                    vctx,
+                ) {
                     error!(
                         "Unable to load new vote history when attempting to change identity from \
                          {} to {} in voting loop, Exiting: {}",
@@ -646,6 +659,7 @@ impl EventHandler {
 
     fn handle_set_identity(
         my_pubkey: &mut Pubkey,
+        genesis_slot: Slot,
         ctx: &SharedContext,
         vctx: &mut VotingContext,
     ) -> Result<(), VoteHistoryError> {
@@ -662,6 +676,7 @@ impl EventHandler {
             vctx.identity_keypair = new_identity;
             warn!("set-identity: from {my_old_pubkey} to {my_pubkey}");
         }
+        vctx.vote_history.initialize_genesis(genesis_slot);
         Ok(())
     }
 
@@ -843,10 +858,7 @@ impl EventHandler {
             .vote_history
             .root()
             .max(voting_context.sharable_banks.root().slot());
-        // No matter what happens, we should not vote skip for slot 0
-        let start = first_of_consecutive_leader_slots(slot)
-            .max(root_slot)
-            .max(1);
+        let start = first_of_consecutive_leader_slots(slot).max(root_slot);
         for s in start..=last_of_consecutive_leader_slots(slot) {
             if voting_context.vote_history.voted(s) {
                 continue;
@@ -1182,7 +1194,8 @@ mod tests {
             latest_switch_request,
         };
 
-        let vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
+        let mut vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
+        vote_history.initialize_genesis(0);
         let voting_context = VotingContext {
             cluster_info: cluster_info.clone(),
             identity_keypair: Arc::new(my_node_keypair.insecure_clone()),
@@ -1208,6 +1221,7 @@ mod tests {
 
         let local_context = LocalContext {
             my_pubkey: my_node_keypair.pubkey(),
+            genesis_slot: 0,
             pending_blocks: BTreeMap::new(),
             finalized_blocks: BTreeSet::new(),
             received_shred: BTreeSet::new(),
@@ -1805,6 +1819,30 @@ mod tests {
     }
 
     #[test]
+    fn test_try_skip_window_starts_after_unaligned_genesis() {
+        let mut test_context = setup();
+        let genesis_slot = 1;
+        test_context
+            .voting_context
+            .vote_history
+            .initialize_genesis(genesis_slot);
+
+        test_context.send_timeout_event(2);
+
+        assert!(test_context.voting_context.vote_history.voted(genesis_slot));
+        assert!(
+            !test_context
+                .voting_context
+                .vote_history
+                .skipped(genesis_slot)
+        );
+        test_context.check_for_vote(&Vote::new_skip_vote(2));
+        test_context.check_for_vote(&Vote::new_skip_vote(3));
+        assert!(test_context.bls_ops.is_empty());
+        test_context.check_no_own_vote();
+    }
+
+    #[test]
     fn test_received_safe_to_notar() {
         let mut test_context = setup();
 
@@ -2331,6 +2369,7 @@ mod tests {
         vote_history_storage
             .store(&SavedVoteHistoryVersions::from(saved_vote_history))
             .unwrap();
+        old_vote_history.initialize_genesis(0);
 
         test_context
             .cluster_info

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -98,6 +98,17 @@ impl VoteHistory {
         self.voted.contains(&slot)
     }
 
+    /// Initialize vote history at the Alpenglow genesis slot. The genesis vote
+    /// is cast and refreshed outside Votor during migration, so it is marked as
+    /// voted without being added to `votes_cast`.
+    pub fn initialize_genesis(&mut self, genesis_slot: Slot) {
+        if genesis_slot < self.root {
+            return;
+        }
+        self.set_root(genesis_slot);
+        self.voted.insert(genesis_slot);
+    }
+
     /// The block for which we voted notarize in slot `slot`
     pub fn voted_notar(&self, slot: Slot) -> Option<Hash> {
         assert!(slot >= self.root);
@@ -474,6 +485,23 @@ mod test {
         );
         // set_root doesn't automatically set its_over to true
         assert!(!vote_history.its_over(2));
+    }
+
+    #[test]
+    fn test_initialize_genesis() {
+        let mut vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
+        vote_history.add_vote(Vote::new_skip_vote(1));
+        vote_history.initialize_genesis(2);
+        vote_history.initialize_genesis(2);
+
+        assert_eq!(vote_history.root(), 2);
+        assert!(vote_history.voted(2));
+        assert!(!vote_history.skipped(2));
+        assert!(vote_history.votes_cast_since(0).is_empty());
+
+        vote_history.initialize_genesis(1);
+        assert_eq!(vote_history.root(), 2);
+        assert!(vote_history.voted(2));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
A bug bounty report pointed out that we could vote skip on the genesis block

#### Summary of Changes
Always set the genesis block as voted, so that we can never vote skip on it

#### Testing
Unit Test