### PR TITLE
block id repair: only compare the first 20 bytes of fec set roots

### DIFF
--- a/core/src/repair/block_id_repair_service.rs
+++ b/core/src/repair/block_id_repair_service.rs
@@ -644,6 +644,9 @@ impl BlockIdRepairService {
                 };
                 let start_index = fec_set_index;
                 let end_index = fec_set_index + DATA_SHREDS_PER_FEC_BLOCK as u32;
+                // The proof authenticates only the first 20 bytes of a leaf. Shred response
+                // verification compares that prefix, and the returned shred's leader
+                // signature authenticates its complete FEC-set root.
 
                 // Queue ShredForBlockId requests
                 state
@@ -1055,6 +1058,7 @@ impl BlockIdRepairService {
 mod tests {
     use {
         super::*,
+        crate::repair::request_response::RequestResponse as _,
         solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo, ping_pong::Ping},
         solana_hash::Hash,
         solana_keypair::{Keypair, Signer},
@@ -1246,7 +1250,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_fec_set_root_response() {
-        let fec_set_root = Hash::new_unique();
+        let fec_set_root = Hash::new_unique().into();
         let fec_set_proof = vec![2u8; SIZE_OF_MERKLE_PROOF_ENTRY * 3];
 
         let response = BlockIdRepairResponse::FecSetRoot {
@@ -1255,6 +1259,13 @@ mod tests {
         };
 
         let data = wincode::serialize(&response).unwrap();
+        assert_eq!(
+            data.len(),
+            std::mem::size_of::<u32>()
+                + SIZE_OF_MERKLE_PROOF_ENTRY
+                + std::mem::size_of::<u64>()
+                + fec_set_proof.len()
+        );
         let packet = make_packet(&data);
         let packet_data = packet.data(..).unwrap();
 
@@ -1327,7 +1338,7 @@ mod tests {
         let expired_shred_not_received = OutgoingMessage::Shred(ShredRepairType::ShredForBlockId {
             slot: 103,
             index: 5,
-            fec_set_merkle_root: Hash::new_unique(),
+            fec_set_merkle_root: Hash::new_unique().into(),
             block_id: Hash::new_unique(),
         });
         state
@@ -1349,7 +1360,7 @@ mod tests {
             OutgoingMessage::Shred(ShredRepairType::ShredForBlockId {
                 slot: received_slot,
                 index: received_shred_index,
-                fec_set_merkle_root: Hash::new_unique(),
+                fec_set_merkle_root: Hash::new_unique().into(),
                 block_id: received_block_id,
             });
         state
@@ -1360,7 +1371,7 @@ mod tests {
         let recent_shred = OutgoingMessage::Shred(ShredRepairType::ShredForBlockId {
             slot: 105,
             index: 15,
-            fec_set_merkle_root: Hash::new_unique(),
+            fec_set_merkle_root: Hash::new_unique().into(),
             block_id: Hash::new_unique(),
         });
         state.sent_requests.insert(recent_shred.clone(), now);
@@ -1483,7 +1494,7 @@ mod tests {
 
         // The FEC set root for fec_set_index=32 corresponds to leaf index 1 (32/32=1)
         let fec_set_leaf_index = fec_set_index as usize / DATA_SHREDS_PER_FEC_BLOCK;
-        let fec_set_root = fec_set_roots[fec_set_leaf_index];
+        let fec_set_root = fec_set_roots[fec_set_leaf_index].into();
         let fec_set_proof = proofs[fec_set_leaf_index].clone();
 
         // Create the request that would have been sent
@@ -1502,11 +1513,11 @@ mod tests {
             .sent_requests
             .insert(OutgoingMessage::Metadata(request), timestamp());
 
-        // Build the response
         let response = BlockIdRepairResponse::FecSetRoot {
             fec_set_root,
             fec_set_proof,
         };
+        assert!(request.verify_response(&response));
 
         // Serialize and create packet
         let data = serialize_response(&response, nonce);

--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -2,7 +2,7 @@ use {
     super::{
         malicious_repair_handler::{MaliciousRepairConfig, MaliciousRepairHandler},
         repair_response::repair_response_packet_from_bytes,
-        serve_repair::ServeRepair,
+        serve_repair::{FecSetRoot, ServeRepair},
         standard_repair_handler::StandardRepairHandler,
     },
     crate::repair::{
@@ -208,7 +208,7 @@ pub trait RepairHandler {
         let fec_set_proof = double_merkle_meta.get_fec_set_proof(proof_index)?.to_vec();
 
         let response = BlockIdRepairResponse::FecSetRoot {
-            fec_set_root,
+            fec_set_root: FecSetRoot::from(fec_set_root),
             fec_set_proof,
         };
         create_response_packet_batch(recycler, &response, from_addr, nonce, "run_fec_set_root")
@@ -420,7 +420,8 @@ mod tests {
                     fec_set_proof,
                 } => {
                     assert_eq!(
-                        fec_set_root, *expected_root,
+                        fec_set_root,
+                        FecSetRoot::from(*expected_root),
                         "FEC set root should match for index {fec_set_index}"
                     );
                     assert!(

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -105,6 +105,28 @@ const SIGNED_REPAIR_TIME_WINDOW: Duration = Duration::from_secs(60 * 10); // 10 
 #[cfg(test)]
 static_assertions::const_assert_eq!(MAX_ANCESTOR_RESPONSES, 30);
 
+/// The portion of an FEC-set Merkle root committed to by the double-Merkle tree.
+#[cfg_attr(
+    feature = "frozen-abi",
+    derive(AbiExample, StableAbi, StableAbiSample, Deserialize, Serialize)
+)]
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, SchemaRead, SchemaWrite)]
+pub struct FecSetRoot(merkle_tree::MerkleProofEntry);
+
+impl FecSetRoot {
+    /// Returns the authenticated bytes of the FEC-set root.
+    pub fn as_bytes(&self) -> &merkle_tree::MerkleProofEntry {
+        &self.0
+    }
+}
+
+impl From<Hash> for FecSetRoot {
+    fn from(root: Hash) -> Self {
+        Self(*merkle_tree::hash_as_merkle_proof_entry(&root))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum ShredRepairType {
     /// Requesting `MAX_ORPHAN_REPAIR_RESPONSES ` parent shreds
@@ -117,7 +139,7 @@ pub enum ShredRepairType {
     ShredForBlockId {
         slot: Slot,
         index: u32,
-        fec_set_merkle_root: Hash,
+        fec_set_merkle_root: FecSetRoot,
         // Double merkle block id
         block_id: Hash,
     },
@@ -178,7 +200,10 @@ impl RequestResponse for ShredRepairType {
                 shred_slot == *slot
                     && matches!(shred::layout::get_shred_type(shred), Ok(ShredType::Data))
                     && shred::layout::get_index(shred) == Some(*index)
-                    && get_merkle_root(shred) == Some(*fec_set_merkle_root)
+                    && get_merkle_root(shred).is_some_and(|root| {
+                        merkle_tree::hash_as_merkle_proof_entry(&root)
+                            == fec_set_merkle_root.as_bytes()
+                    })
             }
         }
     }
@@ -254,7 +279,7 @@ impl BlockIdRepairType {
     feature = "frozen-abi",
     derive(StableAbi, StableAbiSample, Deserialize, Serialize, PartialEq),
     frozen_abi(
-        abi_digest = "4UwjM1HevzQRxGkh6L9vXhf1db7y2ioQYTXRUaKZ4iNo",
+        abi_digest = "CfbU7jxf8EKXfJYEveg2StWVK8MYbLovaQZitXsHMYLz",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "eq_and_wire",
     )
@@ -268,7 +293,7 @@ pub enum BlockIdRepairResponse {
     },
 
     FecSetRoot {
-        fec_set_root: Hash,
+        fec_set_root: FecSetRoot,
         fec_set_proof: Vec<u8>,
     },
 
@@ -319,7 +344,7 @@ impl RequestResponse for BlockIdRepairType {
                     &fec_set_count.to_le_bytes(),
                 ]);
                 merkle_tree::verify_merkle_proof(
-                    parent_info_leaf,
+                    merkle_tree::hash_as_merkle_proof_entry(&parent_info_leaf),
                     *fec_set_count as usize,
                     parent_proof,
                     *block_id,
@@ -358,7 +383,7 @@ impl RequestResponse for BlockIdRepairType {
                     return false;
                 }
                 merkle_tree::verify_merkle_proof(
-                    *fec_set_root,
+                    fec_set_root.as_bytes(),
                     leaf_index,
                     fec_set_proof,
                     *block_id,
@@ -2006,6 +2031,7 @@ mod tests {
             get_tmp_ledger_path_auto_delete,
             shred::{
                 ProcessShredsStats, ReedSolomonCache, Shred, Shredder, max_ticks_per_n_shreds,
+                merkle_tree::hash_as_merkle_proof_entry,
             },
         },
         solana_net_utils::SocketAddrSpace,
@@ -3183,18 +3209,26 @@ mod tests {
         // ShredForBlockId
         let shred = new_test_data_shred(slot, index);
         let merkle_root = shred.merkle_root().expect("No more legacy shreds");
+        let mut poisoned_merkle_root = merkle_root.to_bytes();
+        poisoned_merkle_root[merkle_tree::SIZE_OF_MERKLE_PROOF_ENTRY] ^= 0xff;
+        let poisoned_merkle_root = Hash::new_from_array(poisoned_merkle_root);
+        assert_ne!(poisoned_merkle_root, merkle_root);
+        let fec_set_merkle_root = FecSetRoot::from(merkle_root);
+        assert_eq!(FecSetRoot::from(poisoned_merkle_root), fec_set_merkle_root);
         let request = ShredRepairType::ShredForBlockId {
             slot,
             index,
-            fec_set_merkle_root: merkle_root,
+            fec_set_merkle_root,
             block_id: Hash::new_unique(),
         };
         assert!(request.verify_response(shred.payload()));
-        // bad fec set root
+        // bad FEC-set root prefix
+        let mut bad_merkle_root = merkle_root.to_bytes();
+        bad_merkle_root[0] ^= 0xff;
         let request = ShredRepairType::ShredForBlockId {
             slot,
             index,
-            fec_set_merkle_root: Hash::new_unique(),
+            fec_set_merkle_root: Hash::new_from_array(bad_merkle_root).into(),
             block_id: Hash::new_unique(),
         };
         assert!(!request.verify_response(shred.payload()));
@@ -3328,7 +3362,7 @@ mod tests {
             fec_set_count: 1,
         };
         let response = BlockIdRepairResponse::FecSetRoot {
-            fec_set_root: block_id,
+            fec_set_root: block_id.into(),
             fec_set_proof: vec![],
         };
 
@@ -3358,7 +3392,13 @@ mod tests {
 
         // The generic verifier cannot distinguish an internal node from a leaf.
         assert!(
-            merkle_tree::verify_merkle_proof(internal_node, 0, &shortened_proof, block_id).is_ok()
+            merkle_tree::verify_merkle_proof(
+                hash_as_merkle_proof_entry(&internal_node),
+                0,
+                &shortened_proof,
+                block_id
+            )
+            .is_ok()
         );
 
         let request = BlockIdRepairType::FecSetRoot {
@@ -3368,12 +3408,12 @@ mod tests {
             fec_set_count: 2,
         };
         assert!(request.verify_response(&BlockIdRepairResponse::FecSetRoot {
-            fec_set_root: fec_set_roots[0],
+            fec_set_root: FecSetRoot::from(fec_set_roots[0]),
             fec_set_proof,
         }));
         assert!(
             !request.verify_response(&BlockIdRepairResponse::FecSetRoot {
-                fec_set_root: internal_node,
+                fec_set_root: FecSetRoot::from(internal_node),
                 fec_set_proof: shortened_proof,
             })
         );

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -5,7 +5,10 @@ use {
         shred::{
             ShredFlags, max_ticks_per_n_shreds,
             merkle::finish_erasure_batch_for_tests,
-            merkle_tree::{SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size, verify_merkle_proof},
+            merkle_tree::{
+                SIZE_OF_MERKLE_PROOF_ENTRY, get_proof_size, hash_as_merkle_proof_entry,
+                verify_merkle_proof,
+            },
         },
     },
     assert_matches::assert_matches,
@@ -6464,7 +6467,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     // FEC sets
     for (fec_set, root) in fec_set_roots.iter().enumerate() {
         verify_merkle_proof(
-            *root,
+            hash_as_merkle_proof_entry(root),
             fec_set,
             double_merkle_meta
                 .get_fec_set_proof(fec_set as u32)
@@ -6476,7 +6479,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
 
     // Parent info - final proof
     verify_merkle_proof(
-        parent_info_hash,
+        hash_as_merkle_proof_entry(&parent_info_hash),
         double_merkle_meta.fec_set_count as usize,
         double_merkle_meta.get_parent_info_proof().unwrap(),
         double_merkle_meta.double_merkle_root,

--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -19,6 +19,12 @@ pub(crate) const MERKLE_HASH_PREFIX_NODE: &[u8] = b"\x01SOLANA_MERKLE_SHREDS_NOD
 
 pub type MerkleProofEntry = [u8; 20];
 
+/// Borrows the prefix of a hash represented by a Merkle proof entry.
+#[inline]
+pub fn hash_as_merkle_proof_entry(hash: &Hash) -> &MerkleProofEntry {
+    <&MerkleProofEntry>::try_from(&hash.as_ref()[..SIZE_OF_MERKLE_PROOF_ENTRY]).unwrap()
+}
+
 /// A struct to track a given Merkle tree.
 pub struct MerkleTree {
     /// List of all the nodes in the tree.
@@ -91,9 +97,7 @@ impl MerkleTree {
                 offset += size;
                 size = (size + 1) >> 1;
                 index >>= 1;
-                let entry = &node.as_ref()[..SIZE_OF_MERKLE_PROOF_ENTRY];
-                let entry = <&MerkleProofEntry>::try_from(entry).unwrap();
-                Some(Ok(entry))
+                Some(Ok(hash_as_merkle_proof_entry(node)))
             } else if offset + 1 == self.nodes.len() {
                 None
             } else {
@@ -110,8 +114,9 @@ fn join_nodes<S: AsRef<[u8]>, T: AsRef<[u8]>>(node: S, other: T) -> Hash {
     hashv(&[MERKLE_HASH_PREFIX_NODE, node, other])
 }
 
-// Recovers root of the merkle tree from a leaf node
-// at the given index and the respective proof.
+// Recovers the root of the Merkle tree from a full leaf hash at the given index
+// and the respective proof. The full hash is required for a single-leaf tree,
+// where the proof is empty and the leaf itself is the root.
 pub fn get_merkle_root<'a, I>(index: usize, node: Hash, proof: I) -> Result<Hash, Error>
 where
     I: IntoIterator<Item = &'a MerkleProofEntry>,
@@ -131,20 +136,27 @@ where
         .ok_or(Error::InvalidMerkleProof)
 }
 
-/// Given a flattened merkle `proof` for `node` at `index`,
-/// verify the proof against merkle root `root`
+/// Given a non-empty flattened Merkle `proof` for `node` at `index`,
+/// verifies the proof against `expected_root`.
 pub fn verify_merkle_proof(
-    node: Hash,
+    node: &MerkleProofEntry,
     index: usize,
     proof: &[u8],
     expected_root: Hash,
 ) -> Result<(), Error> {
-    let proof = proof
-        .chunks(SIZE_OF_MERKLE_PROOF_ENTRY)
-        .map(<&MerkleProofEntry>::try_from)
-        .map(|entry| entry.map_err(|_| Error::InvalidMerkleProof))
-        .collect::<Result<Vec<_>, Error>>()?;
-    let merkle_root = get_merkle_root(index, node, proof)?;
+    let mut proof = proof.chunks_exact(SIZE_OF_MERKLE_PROOF_ENTRY);
+    if !proof.remainder().is_empty() {
+        return Err(Error::InvalidMerkleProof);
+    }
+    let other = proof.next().ok_or(Error::InvalidMerkleProof)?;
+    let other = <&MerkleProofEntry>::try_from(other).unwrap();
+    let parent = if index.is_multiple_of(2) {
+        join_nodes(node, other)
+    } else {
+        join_nodes(other, node)
+    };
+    let proof = proof.map(|entry| <&MerkleProofEntry>::try_from(entry).unwrap());
+    let merkle_root = get_merkle_root(index >> 1, parent, proof)?;
 
     (merkle_root == expected_root)
         .then_some(())
@@ -180,9 +192,41 @@ mod tests {
         let mut rng = rand::rng();
         let bytes: [u8; 32] = rng.random();
         let hash = Hash::from(bytes);
-        let entry = &hash.as_ref()[..SIZE_OF_MERKLE_PROOF_ENTRY];
-        let entry = MerkleProofEntry::try_from(entry).unwrap();
+        let entry = hash_as_merkle_proof_entry(&hash);
         assert_eq!(entry, &bytes[..SIZE_OF_MERKLE_PROOF_ENTRY]);
+    }
+
+    #[test]
+    fn test_verify_merkle_proof() {
+        let nodes = [Hash::new_unique(), Hash::new_unique()];
+        let tree = MerkleTree::try_new(nodes.iter().copied().map(Ok)).unwrap();
+        let expected_root = *tree.root();
+        for (index, node) in nodes.iter().enumerate() {
+            let proof: Vec<u8> = tree
+                .make_merkle_proof(index, nodes.len())
+                .flat_map(|entry| entry.unwrap().iter().copied())
+                .collect();
+            verify_merkle_proof(
+                hash_as_merkle_proof_entry(node),
+                index,
+                &proof,
+                expected_root,
+            )
+            .unwrap();
+            assert_matches!(
+                verify_merkle_proof(
+                    hash_as_merkle_proof_entry(node),
+                    index,
+                    &proof[..proof.len() - 1],
+                    expected_root,
+                ),
+                Err(Error::InvalidMerkleProof)
+            );
+        }
+        assert_matches!(
+            verify_merkle_proof(hash_as_merkle_proof_entry(&nodes[0]), 0, &[], expected_root,),
+            Err(Error::InvalidMerkleProof)
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
From a bug bounty report - only the first 20 bytes of the merkle root are used in the construction of the DMR.
We are comparing the full 32 bytes which is incorrect.

#### Summary of Changes
Only compare the first 20 bytes for acceptance criteria. This provides enough cyrptographic resistance.

#### Testing
Unit Tests