### PR TITLE
core: prioritization considers bytes

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -11,7 +11,7 @@ use {
             consumer::Consumer, decision_maker::BufferedPacketsDecision, packet_bytes,
             scheduler_messages::MaxAge,
         },
-        transaction_priority::calculate_priority_and_cost,
+        transaction_priority::{TransactionPriorityResourceLimits, calculate_priority_and_cost},
     },
     agave_banking_stage_ingress_types::{BankingPacketBatch, BankingPacketReceiver},
     agave_transaction_view::{
@@ -93,8 +93,14 @@ pub(crate) fn precheck_transaction(
         .transaction_configuration(&working_bank.feature_set)
         .map_err(|_| IngressCheckError::PacketHandling(PacketHandlingError::ComputeBudget))?;
     let max_age = calculate_max_age(root_bank.epoch(), deactivation_slot, root_bank.slot());
-    let (priority, cost) =
-        calculate_priority_and_cost(working_bank, &view, &transaction_configuration);
+    let transaction_bytes = view.serialized_size() as u64;
+    let (priority, cost) = calculate_priority_and_cost(
+        working_bank,
+        &view,
+        &transaction_configuration,
+        transaction_bytes,
+        TransactionPriorityResourceLimits::for_bank(working_bank),
+    );
     let state = TransactionState::new(view, max_age, priority, cost);
 
     let mut error_counters = TransactionErrorMetrics::default();

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -2,7 +2,12 @@
 //! packets to a node that is or will be leader soon.
 
 use {
-    crate::next_leader::next_leaders,
+    crate::{
+        next_leader::next_leaders,
+        transaction_priority::{
+            TransactionPriorityResourceLimits, calculate_priority as calculate_transaction_priority,
+        },
+    },
     agave_banking_stage_ingress_types::BankingPacketBatch,
     agave_transaction_view::transaction_view::SanitizedTransactionView,
     async_trait::async_trait,
@@ -274,6 +279,7 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
         bank: &Bank,
     ) {
         let sanitize_config = sanitize_config();
+        let priority_resource_limits = TransactionPriorityResourceLimits::for_bank(bank);
         for packet in packet_batch
             .iter()
             .filter(|p| initial_packet_meta_filter(p.meta()))
@@ -305,7 +311,14 @@ impl<VoteClient: ForwardingClient, NonVoteClient: ForwardingClient>
                         .map_err(|_| ())
                     })
                     .ok()
-                    .and_then(|transaction| calculate_priority(&transaction, bank))
+                    .and_then(|transaction| {
+                        calculate_priority(
+                            &transaction,
+                            bank,
+                            packet_data.len() as u64,
+                            priority_resource_limits,
+                        )
+                    })
             else {
                 self.metrics.votes_dropped_on_receive += vote_count;
                 self.metrics.non_votes_dropped_on_receive += non_vote_count;
@@ -587,20 +600,19 @@ impl NotifyKeyUpdate for TpuClientNextClient {
 /// Calculate priority for a transaction:
 ///
 /// The priority is calculated as:
-/// P = R / (1 + C)
+/// P = R / (1 + C + B * L_C / L_B)
 /// where P is the priority, R is the reward,
-/// and C is the cost towards block-limits.
+/// C is the cost towards the block cost limit, B is the serialized transaction
+/// size, L_C is the block cost limit, and L_B is the block entry-bytes limit.
 ///
-/// Current minimum costs are on the order of several hundred,
-/// so the denominator is effectively C, and the +1 is simply
-/// to avoid any division by zero due to a bug - these costs
-/// are estimate by the cost-model and are not direct
-/// from user input. They should never be zero.
-/// Any difference in the prioritization is negligible for
-/// the current transaction costs.
+/// The +1 explicitly avoids division by zero. Giving the normalized resource
+/// terms equal weight means that consuming the same fraction of either block
+/// limit contributes the same amount to the denominator.
 fn calculate_priority(
     transaction: &RuntimeTransaction<SanitizedTransactionView<&[u8]>>,
     bank: &Bank,
+    transaction_bytes: u64,
+    resource_limits: TransactionPriorityResourceLimits,
 ) -> Option<u64> {
     let transaction_configuration = transaction
         .transaction_configuration(&bank.feature_set)
@@ -626,17 +638,12 @@ fn calculate_priority(
         &bank.feature_set,
     );
 
-    // We need a multiplier here to avoid rounding down too aggressively.
-    // For many transactions, the cost will be greater than the fees in terms of raw lamports.
-    // For the purposes of calculating prioritization, we multiply the fees by a large number so that
-    // the cost is a small fraction.
-    // An offset of 1 is used in the denominator to explicitly avoid division by zero.
-    const MULTIPLIER: u64 = 1_000_000;
-    Some(
-        MULTIPLIER
-            .saturating_mul(reward)
-            .wrapping_div(cost.sum().saturating_add(1)),
-    )
+    Some(calculate_transaction_priority(
+        reward,
+        cost.sum(),
+        transaction_bytes,
+        resource_limits,
+    ))
 }
 
 fn send_batch_if_full(

--- a/core/src/forwarding_stage.rs
+++ b/core/src/forwarding_stage.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         next_leader::next_leaders,
         transaction_priority::{
-            TransactionPriorityResourceLimits, calculate_priority as calculate_transaction_priority,
+            TransactionPriorityResourceLimits, calculate_priority_for_transaction,
         },
     },
     agave_banking_stage_ingress_types::BankingPacketBatch,
@@ -602,8 +602,10 @@ impl NotifyKeyUpdate for TpuClientNextClient {
 /// The priority is calculated as:
 /// P = R / (1 + C + B * L_C / L_B)
 /// where P is the priority, R is the reward,
-/// C is the cost towards the block cost limit, B is the serialized transaction
+/// C is the cost towards the block cost limit, B is the prioritized transaction
 /// size, L_C is the block cost limit, and L_B is the block entry-bytes limit.
+/// Once txv1 is enabled, B includes a 32-byte penalty for each pubkey loaded
+/// through an address lookup table.
 ///
 /// The +1 explicitly avoids division by zero. Giving the normalized resource
 /// terms equal weight means that consuming the same fraction of either block
@@ -638,7 +640,8 @@ fn calculate_priority(
         &bank.feature_set,
     );
 
-    Some(calculate_transaction_priority(
+    Some(calculate_priority_for_transaction(
+        transaction,
         reward,
         cost.sum(),
         transaction_bytes,

--- a/core/src/sigverify.rs
+++ b/core/src/sigverify.rs
@@ -4,8 +4,9 @@
 
 use {
     crate::{
-        banking_trace::BankingPacketSender, sigverify_stage::SigVerifyServiceError,
-        transaction_priority::calculate_priority_from_bytes,
+        banking_trace::BankingPacketSender,
+        sigverify_stage::SigVerifyServiceError,
+        transaction_priority::{TransactionPriorityResourceLimits, calculate_priority_from_bytes},
     },
     agave_banking_stage_ingress_types::{BankingPacketBatch, SchedulerPriorityFloor},
     crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
@@ -415,6 +416,7 @@ fn apply_priority_floor_to_batch(
     floor: u64,
     bank: &Bank,
 ) -> (usize, bool) {
+    let priority_resource_limits = TransactionPriorityResourceLimits::for_bank(bank);
     let mut dropped: usize = 0;
     let mut any_kept = false;
     for mut packet in batch.iter_mut() {
@@ -428,7 +430,7 @@ fn apply_priority_floor_to_batch(
             continue;
         };
         // Unparseable packets are kept and left for downstream rejection.
-        match calculate_priority_from_bytes(bank, data) {
+        match calculate_priority_from_bytes(bank, data, priority_resource_limits) {
             Some(priority) if priority <= floor => {
                 packet.meta_mut().set_discard(true);
                 dropped = dropped.saturating_add(1);

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -11,6 +11,57 @@ use {
     solana_transaction::sanitized::MessageHash,
 };
 
+/// Block resource limits used to normalize transaction cost and serialized
+/// bytes into a single priority score.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TransactionPriorityResourceLimits {
+    block_cost: u64,
+    block_bytes: u64,
+}
+
+impl TransactionPriorityResourceLimits {
+    pub(crate) fn for_bank(bank: &Bank) -> Self {
+        let block_cost = bank.read_cost_tracker().unwrap().get_block_limit();
+        let block_bytes = bank.max_entry_bytes_per_slot();
+        debug_assert!(block_cost > 0);
+        debug_assert!(block_bytes > 0);
+        Self {
+            block_cost,
+            block_bytes,
+        }
+    }
+}
+
+/// Calculate transaction priority from its reward and consumption of the two
+/// block-wide resources: cost-model units and serialized entry bytes.
+///
+/// Serialized bytes are converted to cost-model units using the ratio of the
+/// block limits. Cross multiplication retains the fractional byte cost instead
+/// of rounding it before calculating priority.
+pub(crate) fn calculate_priority(
+    reward: u64,
+    cost: u64,
+    transaction_bytes: u64,
+    resource_limits: TransactionPriorityResourceLimits,
+) -> u64 {
+    const MULTIPLIER: u64 = 1_000_000;
+
+    // This is equivalent to:
+    // reward * MULTIPLIER / (cost + 1 + transaction_bytes * block_cost / block_bytes)
+    let denominator = u128::from(cost.saturating_add(1))
+        .saturating_mul(u128::from(resource_limits.block_bytes))
+        .saturating_add(
+            u128::from(transaction_bytes).saturating_mul(u128::from(resource_limits.block_cost)),
+        );
+    let priority = u128::from(reward)
+        .saturating_mul(u128::from(MULTIPLIER))
+        .saturating_mul(u128::from(resource_limits.block_bytes))
+        .checked_div(denominator)
+        .unwrap_or(0);
+
+    priority.min(u128::from(u64::MAX)) as u64
+}
+
 /// Calculate priority and cost for a transaction:
 ///
 /// Cost is calculated through the `CostModel`,
@@ -18,21 +69,20 @@ use {
 /// blockspace to the highest bidder.
 ///
 /// The priority is calculated as:
-/// P = R / (1 + C)
+/// P = R / (1 + C + B * L_C / L_B)
 /// where P is the priority, R is the reward,
-/// and C is the cost towards block-limits.
+/// C is the cost towards the block cost limit, B is the serialized transaction
+/// size, L_C is the block cost limit, and L_B is the block entry-bytes limit.
 ///
-/// Current minimum costs are on the order of several hundred,
-/// so the denominator is effectively C, and the +1 is simply
-/// to avoid any division by zero due to a bug - these costs
-/// are calculated by the cost-model and are not direct
-/// from user input. They should never be zero.
-/// Any difference in the prioritization is negligible for
-/// the current transaction costs.
+/// The +1 explicitly avoids division by zero. Giving the normalized resource
+/// terms equal weight means that consuming the same fraction of either block
+/// limit contributes the same amount to the denominator.
 pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage>(
     bank: &Bank,
     transaction: &Tx,
     transaction_configuration: &TransactionConfiguration,
+    transaction_bytes: u64,
+    resource_limits: TransactionPriorityResourceLimits,
 ) -> (u64, u64) {
     let cost = CostModel::calculate_cost_for_executed_transaction(
         transaction,
@@ -51,16 +101,8 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
         .calculate_reward_and_burn_fee_details(&CollectorFeeDetails::from(fee_details))
         .get_deposit();
 
-    // We need a multiplier here to avoid rounding down too aggressively.
-    // For many transactions, the cost will be greater than the fees in terms of raw lamports.
-    // For the purposes of calculating prioritization, we multiply the fees by a large number so that
-    // the cost is a small fraction.
-    // An offset of 1 is used in the denominator to explicitly avoid division by zero.
-    const MULTIPLIER: u64 = 1_000_000;
     (
-        reward
-            .saturating_mul(MULTIPLIER)
-            .saturating_div(cost.saturating_add(1)),
+        calculate_priority(reward, cost, transaction_bytes, resource_limits),
         cost,
     )
 }
@@ -70,7 +112,11 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
 ///
 /// Returns `None` if the bytes don't parse as a valid transaction, in which
 /// case the caller should leave the packet to downstream stages to reject.
-pub(crate) fn calculate_priority_from_bytes(bank: &Bank, data: &[u8]) -> Option<u64> {
+pub(crate) fn calculate_priority_from_bytes(
+    bank: &Bank,
+    data: &[u8],
+    resource_limits: TransactionPriorityResourceLimits,
+) -> Option<u64> {
     let view = SanitizedTransactionView::try_new_sanitized(data, &sanitize_config()).ok()?;
     let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
         view,
@@ -81,8 +127,13 @@ pub(crate) fn calculate_priority_from_bytes(bank: &Bank, data: &[u8]) -> Option<
     let transaction_configuration = runtime_tx
         .transaction_configuration(&bank.feature_set)
         .ok()?;
-    let (priority, _cost) =
-        calculate_priority_and_cost(bank, &runtime_tx, &transaction_configuration);
+    let (priority, _cost) = calculate_priority_and_cost(
+        bank,
+        &runtime_tx,
+        &transaction_configuration,
+        data.len() as u64,
+        resource_limits,
+    );
 
     Some(priority)
 }
@@ -131,14 +182,20 @@ mod tests {
     }
 
     fn priority_from(bank: &Bank, bytes: &[u8]) -> u64 {
-        calculate_priority_from_bytes(bank, bytes).unwrap()
+        calculate_priority_from_bytes(
+            bank,
+            bytes,
+            TransactionPriorityResourceLimits::for_bank(bank),
+        )
+        .unwrap()
     }
 
     #[test]
     fn priority_from_bytes_returns_none_for_garbage() {
         let (bank, _) = test_bank();
-        assert!(calculate_priority_from_bytes(&bank, &[]).is_none());
-        assert!(calculate_priority_from_bytes(&bank, &[0u8; 32]).is_none());
+        let resource_limits = TransactionPriorityResourceLimits::for_bank(&bank);
+        assert!(calculate_priority_from_bytes(&bank, &[], resource_limits).is_none());
+        assert!(calculate_priority_from_bytes(&bank, &[0u8; 32], resource_limits).is_none());
     }
 
     #[test]
@@ -185,9 +242,57 @@ mod tests {
         let transaction_configuration = runtime_tx
             .transaction_configuration(&bank.feature_set)
             .unwrap();
-        let (from_typed, _cost) =
-            calculate_priority_and_cost(&bank, &runtime_tx, &transaction_configuration);
+        let (from_typed, _cost) = calculate_priority_and_cost(
+            &bank,
+            &runtime_tx,
+            &transaction_configuration,
+            bytes.len() as u64,
+            TransactionPriorityResourceLimits::for_bank(&bank),
+        );
 
         assert_eq!(from_bytes, from_typed);
+    }
+
+    #[test]
+    fn zero_bytes_matches_previous_priority_formula() {
+        let reward = 5_000;
+        let cost = 200_000;
+        let resource_limits = TransactionPriorityResourceLimits {
+            block_cost: 100_000_000,
+            block_bytes: 20 * 1024 * 1024,
+        };
+
+        assert_eq!(
+            calculate_priority(reward, cost, 0, resource_limits),
+            reward
+                .saturating_mul(1_000_000)
+                .saturating_div(cost.saturating_add(1))
+        );
+    }
+
+    #[test]
+    fn smaller_transaction_has_higher_priority() {
+        let resource_limits = TransactionPriorityResourceLimits {
+            block_cost: 100_000_000,
+            block_bytes: 20 * 1024 * 1024,
+        };
+        let smaller = calculate_priority(5_000, 20_000, 500, resource_limits);
+        let larger = calculate_priority(5_000, 20_000, 1_000, resource_limits);
+
+        assert!(smaller > larger);
+    }
+
+    #[test]
+    fn equal_resource_fractions_have_equal_weight() {
+        let resource_limits = TransactionPriorityResourceLimits {
+            block_cost: 1_000,
+            block_bytes: 100,
+        };
+
+        // cost + 1 consumes 1% of the cost limit, and one byte consumes 1%
+        // of the byte limit, so adding the byte halves the priority.
+        let cost_only = calculate_priority(1_000, 9, 0, resource_limits);
+        let cost_and_bytes = calculate_priority(1_000, 9, 1, resource_limits);
+        assert_eq!(cost_only, cost_and_bytes * 2);
     }
 }

--- a/core/src/transaction_priority.rs
+++ b/core/src/transaction_priority.rs
@@ -17,19 +17,45 @@ use {
 pub(crate) struct TransactionPriorityResourceLimits {
     block_cost: u64,
     block_bytes: u64,
+    penalize_alt_lookups: bool,
 }
 
 impl TransactionPriorityResourceLimits {
     pub(crate) fn for_bank(bank: &Bank) -> Self {
         let block_cost = bank.read_cost_tracker().unwrap().get_block_limit();
         let block_bytes = bank.max_entry_bytes_per_slot();
+        let penalize_alt_lookups = bank.feature_set.snapshot().enable_tx_v1;
         debug_assert!(block_cost > 0);
         debug_assert!(block_bytes > 0);
         Self {
             block_cost,
             block_bytes,
+            penalize_alt_lookups,
         }
     }
+}
+
+const ALT_LOOKUP_PUBKEY_BYTE_PENALTY: u64 = 32;
+
+fn prioritized_transaction_bytes<Tx: SVMStaticMessage>(
+    transaction: &Tx,
+    serialized_bytes: u64,
+    penalize_alt_lookups: bool,
+) -> u64 {
+    if !penalize_alt_lookups {
+        return serialized_bytes;
+    }
+
+    let num_looked_up_pubkeys =
+        transaction
+            .message_address_table_lookups()
+            .fold(0u64, |num_looked_up_pubkeys, lookup| {
+                num_looked_up_pubkeys
+                    .saturating_add(lookup.writable_indexes.len() as u64)
+                    .saturating_add(lookup.readonly_indexes.len() as u64)
+            });
+    serialized_bytes
+        .saturating_add(num_looked_up_pubkeys.saturating_mul(ALT_LOOKUP_PUBKEY_BYTE_PENALTY))
 }
 
 /// Calculate transaction priority from its reward and consumption of the two
@@ -38,20 +64,22 @@ impl TransactionPriorityResourceLimits {
 /// Serialized bytes are converted to cost-model units using the ratio of the
 /// block limits. Cross multiplication retains the fractional byte cost instead
 /// of rounding it before calculating priority.
-pub(crate) fn calculate_priority(
+/// This affects transaction ordering only; hard byte accounting continues to
+/// use the actual serialized transaction size.
+fn calculate_priority(
     reward: u64,
     cost: u64,
-    transaction_bytes: u64,
+    prioritized_bytes: u64,
     resource_limits: TransactionPriorityResourceLimits,
 ) -> u64 {
     const MULTIPLIER: u64 = 1_000_000;
 
     // This is equivalent to:
-    // reward * MULTIPLIER / (cost + 1 + transaction_bytes * block_cost / block_bytes)
+    // reward * MULTIPLIER / (cost + 1 + prioritized_bytes * block_cost / block_bytes)
     let denominator = u128::from(cost.saturating_add(1))
         .saturating_mul(u128::from(resource_limits.block_bytes))
         .saturating_add(
-            u128::from(transaction_bytes).saturating_mul(u128::from(resource_limits.block_cost)),
+            u128::from(prioritized_bytes).saturating_mul(u128::from(resource_limits.block_cost)),
         );
     let priority = u128::from(reward)
         .saturating_mul(u128::from(MULTIPLIER))
@@ -60,6 +88,21 @@ pub(crate) fn calculate_priority(
         .unwrap_or(0);
 
     priority.min(u128::from(u64::MAX)) as u64
+}
+
+pub(crate) fn calculate_priority_for_transaction<Tx: SVMStaticMessage>(
+    transaction: &Tx,
+    reward: u64,
+    cost: u64,
+    serialized_bytes: u64,
+    resource_limits: TransactionPriorityResourceLimits,
+) -> u64 {
+    let prioritized_bytes = prioritized_transaction_bytes(
+        transaction,
+        serialized_bytes,
+        resource_limits.penalize_alt_lookups,
+    );
+    calculate_priority(reward, cost, prioritized_bytes, resource_limits)
 }
 
 /// Calculate priority and cost for a transaction:
@@ -71,8 +114,10 @@ pub(crate) fn calculate_priority(
 /// The priority is calculated as:
 /// P = R / (1 + C + B * L_C / L_B)
 /// where P is the priority, R is the reward,
-/// C is the cost towards the block cost limit, B is the serialized transaction
+/// C is the cost towards the block cost limit, B is the prioritized transaction
 /// size, L_C is the block cost limit, and L_B is the block entry-bytes limit.
+/// Once txv1 is enabled, B includes a 32-byte penalty for each pubkey loaded
+/// through an address lookup table.
 ///
 /// The +1 explicitly avoids division by zero. Giving the normalized resource
 /// terms equal weight means that consuming the same fraction of either block
@@ -102,7 +147,13 @@ pub(crate) fn calculate_priority_and_cost<Tx: TransactionMeta + SVMStaticMessage
         .get_deposit();
 
     (
-        calculate_priority(reward, cost, transaction_bytes, resource_limits),
+        calculate_priority_for_transaction(
+            transaction,
+            reward,
+            cost,
+            transaction_bytes,
+            resource_limits,
+        ),
         cost,
     )
 }
@@ -142,11 +193,16 @@ pub(crate) fn calculate_priority_from_bytes(
 mod tests {
     use {
         super::*,
+        agave_transaction_view::resolved_transaction_view::ResolvedTransactionView,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_hash::Hash,
+        solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
-        solana_message::Message,
+        solana_message::{
+            AddressLookupTableAccount, Message, VersionedMessage,
+            v0::{self, LoadedAddresses},
+        },
         solana_pubkey::Pubkey,
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
@@ -178,7 +234,32 @@ mod tests {
         let prioritization = ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price);
         let message = Message::new(&[transfer, prioritization], Some(&mint.pubkey()));
         let tx = Transaction::new(&[mint], message, recent_blockhash);
-        bincode::serialize(&VersionedTransaction::from(tx)).unwrap()
+        wincode::serialize(&VersionedTransaction::from(tx)).unwrap()
+    }
+
+    fn make_v0_tx_bytes(mint: &Keypair, recent_blockhash: Hash) -> Vec<u8> {
+        let writable = Pubkey::new_unique();
+        let readonly = Pubkey::new_unique();
+        let instruction = Instruction::new_with_bytes(
+            Pubkey::new_unique(),
+            &[],
+            vec![
+                AccountMeta::new(writable, false),
+                AccountMeta::new_readonly(readonly, false),
+            ],
+        );
+        let message = v0::Message::try_compile(
+            &mint.pubkey(),
+            &[instruction],
+            &[AddressLookupTableAccount {
+                key: Pubkey::new_unique(),
+                addresses: vec![writable, readonly],
+            }],
+            recent_blockhash,
+        )
+        .unwrap();
+        let tx = VersionedTransaction::try_new(VersionedMessage::V0(message), &[mint]).unwrap();
+        wincode::serialize(&tx).unwrap()
     }
 
     fn priority_from(bank: &Bank, bytes: &[u8]) -> u64 {
@@ -260,6 +341,7 @@ mod tests {
         let resource_limits = TransactionPriorityResourceLimits {
             block_cost: 100_000_000,
             block_bytes: 20 * 1024 * 1024,
+            penalize_alt_lookups: false,
         };
 
         assert_eq!(
@@ -275,6 +357,7 @@ mod tests {
         let resource_limits = TransactionPriorityResourceLimits {
             block_cost: 100_000_000,
             block_bytes: 20 * 1024 * 1024,
+            penalize_alt_lookups: false,
         };
         let smaller = calculate_priority(5_000, 20_000, 500, resource_limits);
         let larger = calculate_priority(5_000, 20_000, 1_000, resource_limits);
@@ -287,6 +370,7 @@ mod tests {
         let resource_limits = TransactionPriorityResourceLimits {
             block_cost: 1_000,
             block_bytes: 100,
+            penalize_alt_lookups: false,
         };
 
         // cost + 1 consumes 1% of the cost limit, and one byte consumes 1%
@@ -294,5 +378,65 @@ mod tests {
         let cost_only = calculate_priority(1_000, 9, 0, resource_limits);
         let cost_and_bytes = calculate_priority(1_000, 9, 1, resource_limits);
         assert_eq!(cost_only, cost_and_bytes * 2);
+    }
+
+    #[test]
+    fn alt_lookup_byte_penalty_requires_tx_v1_feature() {
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair: mint,
+            ..
+        } = create_genesis_config(u64::MAX);
+        let mut bank = Bank::new_for_tests(&genesis_config);
+        let bytes = make_v0_tx_bytes(&mint, bank.last_blockhash());
+        let view =
+            SanitizedTransactionView::try_new_sanitized(&bytes[..], &sanitize_config()).unwrap();
+        let runtime_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
+            view,
+            MessageHash::Compute,
+            None,
+        )
+        .unwrap();
+        let serialized_bytes = bytes.len() as u64;
+
+        bank.deactivate_feature(&agave_feature_set::enable_tx_v1::id());
+        let resource_limits = TransactionPriorityResourceLimits::for_bank(&bank);
+        assert_eq!(
+            prioritized_transaction_bytes(
+                &runtime_tx,
+                serialized_bytes,
+                resource_limits.penalize_alt_lookups,
+            ),
+            serialized_bytes,
+        );
+
+        bank.activate_feature(&agave_feature_set::enable_tx_v1::id());
+        let resource_limits = TransactionPriorityResourceLimits::for_bank(&bank);
+        assert_eq!(
+            prioritized_transaction_bytes(
+                &runtime_tx,
+                serialized_bytes,
+                resource_limits.penalize_alt_lookups,
+            ),
+            serialized_bytes + 2 * ALT_LOOKUP_PUBKEY_BYTE_PENALTY,
+        );
+
+        let resolved_tx = RuntimeTransaction::<ResolvedTransactionView<_>>::try_new(
+            runtime_tx,
+            Some(LoadedAddresses {
+                writable: vec![Pubkey::new_unique()],
+                readonly: vec![Pubkey::new_unique()],
+            }),
+            bank.get_reserved_account_keys(),
+        )
+        .unwrap();
+        assert_eq!(
+            prioritized_transaction_bytes(
+                &resolved_tx,
+                serialized_bytes,
+                resource_limits.penalize_alt_lookups,
+            ),
+            serialized_bytes + 2 * ALT_LOOKUP_PUBKEY_BYTE_PENALTY,
+        );
     }
 }


### PR DESCRIPTION
#### Problem
- We are possibly going to make transactions even larger than 4k
- We do not consider txn size during prioritization, but we have a limit

#### Summary of Changes
- Make prioritization formula take into account the byte-size of transactions

#### Testing

Fixes #
