### PR TITLE
cleanup: use wincode 0.6 adapters DefaultOnEmptyRead and DiscardSeq

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -15,7 +15,7 @@ use {
         fmt::{self, Debug, Display},
         ops::{Range, RangeBounds},
     },
-    wincode::{SchemaRead, SchemaWrite},
+    wincode::{SchemaRead, SchemaWrite, adapter::DefaultOnEmptyRead},
 };
 
 bitflags! {
@@ -196,14 +196,14 @@ pub struct SlotMetaV3 {
     ///
     /// Populated by the block header initially, then replaced if an UpdateParent
     /// marker changes the replay parent for this slot.
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Hash>")]
+    #[wincode(with = "DefaultOnEmptyRead<Hash>")]
     pub parent_block_id: Hash,
     /// Shred/FEC-set index where replay should start for this slot.
     ///
     /// A value of zero means replay starts from the block header. A non-zero
     /// value means an UpdateParent marker was observed and replay must skip the
     /// optimistic-parent prefix before this FEC set.
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u32>")]
+    #[wincode(with = "DefaultOnEmptyRead<u32>")]
     pub replay_fec_set_index: u32,
 }
 
@@ -253,11 +253,11 @@ pub struct SlotMetaRepair {
 mod wincode_compat {
     use {
         super::*,
-        std::{marker::PhantomData, mem::MaybeUninit},
+        std::mem::MaybeUninit,
         wincode::{
-            ReadError, ReadResult, WriteResult,
+            ReadResult, WriteResult,
             config::ConfigCore,
-            io::{ReadError as IoReadError, Reader, Writer},
+            io::{Reader, Writer},
         },
     };
 
@@ -286,49 +286,6 @@ mod wincode_compat {
 
         fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
             <Slot as SchemaWrite<C>>::write(writer, &src.unwrap_or(Slot::MAX))
-        }
-    }
-
-    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the
-    /// reader is exhausted (EOF). Useful for backward compatibility when
-    /// trailing fields are appended to persisted structs.
-    pub(crate) struct DefaultOnEmptyRead<T>(PhantomData<T>);
-
-    // TYPE_META intentionally left dynamic: decoding may read either 0 bytes
-    // (EOF fallback) or the full encoded representation.
-    unsafe impl<'de, C: ConfigCore, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaRead<'de, C>,
-        T::Dst: Default,
-    {
-        type Dst = T::Dst;
-
-        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-            match <T as SchemaRead<'de, C>>::read(reader, dst) {
-                Ok(()) => Ok(()),
-                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
-                    dst.write(Self::Dst::default());
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    unsafe impl<C: ConfigCore, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaWrite<C>,
-    {
-        type Src = T::Src;
-
-        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
-
-        fn size_of(src: &Self::Src) -> WriteResult<usize> {
-            <T as SchemaWrite<C>>::size_of(src)
-        }
-
-        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-            <T as SchemaWrite<C>>::write(writer, src)
         }
     }
 }

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -17,11 +17,10 @@ use {
     std::{
         collections::HashMap,
         fmt,
-        mem::MaybeUninit,
         num::NonZero,
         sync::{Arc, OnceLock},
     },
-    wincode::{ReadResult, SchemaRead, SchemaWrite, WriteResult, config::Config, io::Reader},
+    wincode::{SchemaRead, SchemaWrite, WriteResult, adapter::DiscardSeq, len::BincodeLen},
 };
 
 pub type NodeIdToVoteAccounts = HashMap<Pubkey, NodeVoteAccounts>;
@@ -506,41 +505,11 @@ pub(crate) struct DeserializableEpochStakes {
     vote_accounts: VoteAccounts,
     // Read-and-discarded (always empty); the serialize side writes it empty too.
     #[serde(deserialize_with = "deserialize_and_ignore_stake_delegations")]
-    #[wincode(with = "IgnoredStakeDelegations")]
+    #[wincode(with = "DiscardSeq<(Pubkey, Stake), BincodeLen>")]
     _stake_delegations: Vec<(Pubkey, Stake)>,
     _unused: u64,
     epoch: Epoch,
     stake_history: StakeHistory,
-}
-
-/// wincode `with` schema for the ignored stake delegations: reads and discards the wire's
-/// length-prefixed `Vec<(Pubkey, Stake)>`, yielding an empty `Vec`; writes it back through `Vec`
-/// (always empty, matching the serialize side).
-struct IgnoredStakeDelegations;
-
-unsafe impl<'de, C: Config> SchemaRead<'de, C> for IgnoredStakeDelegations {
-    type Dst = Vec<(Pubkey, Stake)>;
-
-    fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-        <Vec<(Pubkey, Stake)> as SchemaRead<'de, C>>::get(reader)?;
-        dst.write(Vec::new());
-        Ok(())
-    }
-}
-
-#[cfg(feature = "frozen-abi")]
-unsafe impl<C: Config> SchemaWrite<C> for IgnoredStakeDelegations {
-    type Src = Vec<(Pubkey, Stake)>;
-
-    const TYPE_META: wincode::TypeMeta = <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::TYPE_META;
-
-    fn size_of(src: &Self::Src) -> WriteResult<usize> {
-        <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::size_of(src)
-    }
-
-    fn write(writer: impl wincode::io::Writer, src: &Self::Src) -> WriteResult<()> {
-        <Vec<(Pubkey, Stake)> as SchemaWrite<C>>::write(writer, src)
-    }
 }
 
 impl From<DeserializableEpochStakes> for EpochStakes {

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -62,6 +62,7 @@ use {
     types::{SerdeAccountsLtHash, UnusedRentCollector},
     wincode::{
         ReadResult, SchemaRead, SchemaReadOwned, SchemaWrite, WriteResult,
+        adapter::DefaultOnEmptyRead,
         containers::FromIntoIterator,
         io::{Reader, std_write::WriteAdapter},
         len::BincodeLen,
@@ -84,61 +85,6 @@ pub(crate) use {
 
 const MAX_STREAM_SIZE: usize = 32 * 1024 * 1024 * 1024;
 type MaxStreamSizeConfig = wincode::config::Configuration<true, MAX_STREAM_SIZE>;
-
-/// wincode read helpers mirroring serde's `default_on_eof` for the snapshot read-path structs.
-mod wincode_compat {
-    use {
-        std::{marker::PhantomData, mem::MaybeUninit},
-        wincode::{
-            ReadError, ReadResult, SchemaRead, SchemaWrite, WriteResult,
-            config::Config,
-            io::{ReadError as IoReadError, Reader, Writer},
-        },
-    };
-
-    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the reader is
-    /// exhausted (EOF), for backward compatibility when new fields are appended to a struct.
-    /// Equivalent to `#[serde(deserialize_with = "default_on_eof")]`.
-    pub(super) struct DefaultOnEmptyRead<T>(PhantomData<T>);
-
-    // Note: TYPE_META is left dynamic, since during reading both 0-size or non-0-size reads are
-    // allowed, so trusted readers can't rely on encoding to be static sized.
-    unsafe impl<'de, C: Config, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaRead<'de, C>,
-        T::Dst: Default,
-    {
-        type Dst = T::Dst;
-
-        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-            match <T as SchemaRead<'de, C>>::read(reader, dst) {
-                Ok(()) => Ok(()),
-                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
-                    dst.write(Self::Dst::default());
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    unsafe impl<C: Config, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaWrite<C>,
-    {
-        type Src = T::Src;
-
-        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
-
-        fn size_of(src: &Self::Src) -> WriteResult<usize> {
-            <T as SchemaWrite<C>>::size_of(src)
-        }
-
-        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-            <T as SchemaWrite<C>>::write(writer, src)
-        }
-    }
-}
 
 /// A slot paired with its account storage entries, used as the `slot -> [entry]` map item on both
 /// the read path ([`AccountsDbFields`]) and the write ABI type [`SerializableAccountsDbForAbi`].
@@ -169,11 +115,11 @@ pub(crate) struct AccountsDbFields(
     BankHashInfo,
     /// all slots that were roots within the last epoch
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Vec<Slot>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Vec<Slot>>")]
     Vec<Slot>,
     /// slots that were roots within the last epoch for which we care about the hash value
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Vec<(Slot, Hash)>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Vec<(Slot, Hash)>>")]
     Vec<(Slot, Hash)>,
 );
 
@@ -483,20 +429,16 @@ where
 #[derive(Clone, Debug, Deserialize, SchemaRead)]
 struct ExtraFieldsToDeserialize {
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u64>")]
+    #[wincode(with = "DefaultOnEmptyRead<u64>")]
     lamports_per_signature: u64,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(
-        with = "wincode_compat::DefaultOnEmptyRead<Option<UnusedIncrementalSnapshotPersistence>>"
-    )]
+    #[wincode(with = "DefaultOnEmptyRead<Option<UnusedIncrementalSnapshotPersistence>>")]
     _unused_incremental_snapshot_persistence: Option<UnusedIncrementalSnapshotPersistence>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Hash>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Hash>>")]
     _unused_epoch_accounts_hash: Option<Hash>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(
-        with = "wincode_compat::DefaultOnEmptyRead<Vec<(u64, DeserializableVersionedEpochStakes)>>"
-    )]
+    #[wincode(with = "DefaultOnEmptyRead<Vec<(u64, DeserializableVersionedEpochStakes)>>")]
     // Match the serialize side's `HashMap<u64, VersionedEpochStakes>`, which samples `0..=1` entries.
     #[cfg_attr(
         feature = "frozen-abi",
@@ -505,10 +447,10 @@ struct ExtraFieldsToDeserialize {
     )]
     versioned_epoch_stakes: Vec<(u64, DeserializableVersionedEpochStakes)>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<SerdeAccountsLtHash>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<SerdeAccountsLtHash>>")]
     accounts_lt_hash: Option<SerdeAccountsLtHash>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Hash>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Hash>>")]
     block_id: Option<Hash>,
 }
 

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -14,64 +14,10 @@ use {
         InnerInstructions, Reward, RewardType, TransactionStatusMeta, TransactionTokenBalance,
     },
     std::str::FromStr,
-    wincode::ReadError,
+    wincode::{ReadError, adapter::DefaultOnEmptyRead},
 };
 
 pub mod convert;
-
-mod wincode_compat {
-    use {
-        std::{marker::PhantomData, mem::MaybeUninit},
-        wincode::{
-            ReadError, ReadResult, SchemaRead, SchemaWrite, WriteResult,
-            config::Config,
-            io::{ReadError as IoReadError, Reader, Writer},
-        },
-    };
-
-    /// Deserializes using `T` normally, but returns `T::Dst::default()` if the reader is
-    /// exhausted (EOF), for backward compatibility when new fields are appended
-    /// to a struct. Equivalent to `#[serde(deserialize_with = "default_on_eof")]`.
-    pub(super) struct DefaultOnEmptyRead<T>(PhantomData<T>);
-
-    // Note: TYPE_META is left dynamic, since during reading both 0-size or non-0-size reads are
-    // allowed, so trusted readers can't rely on encoding to be static sized.
-    unsafe impl<'de, C: Config, T> SchemaRead<'de, C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaRead<'de, C>,
-        T::Dst: Default,
-    {
-        type Dst = T::Dst;
-
-        fn read(reader: impl Reader<'de>, dst: &mut MaybeUninit<Self::Dst>) -> ReadResult<()> {
-            match <T as SchemaRead<'de, C>>::read(reader, dst) {
-                Ok(()) => Ok(()),
-                Err(ReadError::Io(IoReadError::ReadSizeLimit(_))) => {
-                    dst.write(Self::Dst::default());
-                    Ok(())
-                }
-                Err(e) => Err(e),
-            }
-        }
-    }
-
-    unsafe impl<C: Config, T> SchemaWrite<C> for DefaultOnEmptyRead<T>
-    where
-        T: SchemaWrite<C>,
-    {
-        type Src = T::Src;
-
-        const TYPE_META: wincode::TypeMeta = T::TYPE_META;
-
-        fn size_of(src: &Self::Src) -> WriteResult<usize> {
-            <T as SchemaWrite<C>>::size_of(src)
-        }
-
-        fn write(writer: impl Writer, src: &Self::Src) -> WriteResult<()> {
-            <T as SchemaWrite<C>>::write(writer, src)
-        }
-    }
-}
 
 pub type StoredExtendedRewards = Vec<StoredExtendedReward>;
 
@@ -80,16 +26,16 @@ pub struct StoredExtendedReward {
     pubkey: String,
     lamports: i64,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<u64>")]
+    #[wincode(with = "DefaultOnEmptyRead<u64>")]
     post_balance: u64,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<RewardType>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<RewardType>>")]
     reward_type: Option<RewardType>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u8>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<u8>>")]
     commission: Option<u8>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u16>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<u16>>")]
     commission_bps: Option<u16>,
 }
 
@@ -198,10 +144,10 @@ pub struct StoredTransactionTokenBalance {
     pub mint: String,
     pub ui_token_amount: StoredTokenAmount,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<String>")]
+    #[wincode(with = "DefaultOnEmptyRead<String>")]
     pub owner: String,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<String>")]
+    #[wincode(with = "DefaultOnEmptyRead<String>")]
     pub program_id: String,
 }
 
@@ -250,32 +196,28 @@ pub struct StoredTransactionStatusMeta {
     pub pre_balances: Vec<u64>,
     pub post_balances: Vec<u64>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<InnerInstructions>>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Vec<InnerInstructions>>>")]
     pub inner_instructions: Option<Vec<InnerInstructions>>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<String>>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Vec<String>>>")]
     pub log_messages: Option<Vec<String>>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(
-        with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>"
-    )]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>")]
     pub pre_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(
-        with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>"
-    )]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Vec<StoredTransactionTokenBalance>>>")]
     pub post_token_balances: Option<Vec<StoredTransactionTokenBalance>>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<Vec<StoredExtendedReward>>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<Vec<StoredExtendedReward>>>")]
     pub rewards: Option<Vec<StoredExtendedReward>>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<TransactionReturnData>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<TransactionReturnData>>")]
     pub return_data: Option<TransactionReturnData>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u64>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<u64>>")]
     pub compute_units_consumed: Option<u64>,
     #[serde(deserialize_with = "default_on_eof")]
-    #[wincode(with = "wincode_compat::DefaultOnEmptyRead<Option<u64>>")]
+    #[wincode(with = "DefaultOnEmptyRead<Option<u64>>")]
     pub cost_units: Option<u64>,
 }
 


### PR DESCRIPTION
#### Problem
New wincode version contains adapters that deduplicate code in agave and provide more efficient handling of discarding legacy byte data.

#### Summary of Changes

Replace hand-rolled wincode schemas with the adapters wincode 0.6 provides:

- drop the three local `DefaultOnEmptyRead` copies (runtime, ledger,
  storage-proto) in favour of `wincode::adapter::DefaultOnEmptyRead`
- `IgnoredStakeDelegations` -> `DiscardSeq`, which also skips the wire's
  stake delegations without allocating the discarded `Vec`

`OptionCompat` and `U32AsU64` stay hand-rolled: their conversions are
lossy/between foreign types, so `FromInto` does not apply.


#### Testing
CI / frozen-abi tests in particular

Fixes #