### PR TITLE
rpc: Make Bigtable open failure a fatal error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Release channels have their own copy of this changelog:
 ## 4.3.0-Unreleased
 ### RPC
 #### Breaking
+* Failing to successfully establish a Bigtable connection will now result in a
+  fatal error when running with either `--enable-rpc-bigtable-ledger-storage` or
+  `--enable-bigtable-ledger-upload`. Previously, the error would be logged and
+  the process would continue without a Bigtable connection.
 #### Changes
 ### Validator
 #### Breaking

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -654,10 +654,9 @@ impl JsonRpcService {
                             bigtable_ledger_upload_service,
                         )
                     })
-                    .unwrap_or_else(|err| {
-                        error!("Failed to initialize BigTable ledger storage: {err:?}");
-                        (None, None)
-                    })
+                    .map_err(|err| {
+                        format!("Failed to initialize BigTable ledger storage: {err:?}")
+                    })?
             } else {
                 (None, None)
             };


### PR DESCRIPTION
#### Problem
The RPC service (JsonRpcService) attempts to open a connection to Bigtable conditionally during startup. If opening the connection fails, the error is logged but startup proceeds with Bigtable disabled.

#### Summary of Changes
This change promotes the error log to a fatal error; proceeding along without Bigtable when the operator specified it leads to confusion and it would be better to fail earlier and more loudly

#### Testing
Ran it on my node without variable set and confirmed the hard error:
```
[2026-08-06T06:01:15.574753892Z ERROR agave_validator] Failed to start validator: Failed to initialize BigTable ledger storage: BigTableError(AccessToken("GOOGLE_APPLICATION_CREDENTIALS environment variable not found"))
```
Related to https://github.com/anza-xyz/agave/issues/14157
