### PR TITLE
xdp: support per-module transmit queue subsets

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -40,7 +40,7 @@ use {
         vote_history_storage::{NullVoteHistoryStorage, VoteHistoryStorage},
         voting_service::VotingServiceOverride,
     },
-    agave_xdp::transmitter::{Transmitter, TransmitterBuilder},
+    agave_xdp::transmitter::{Transmitter, TransmitterBuilder, XdpSender},
     anyhow::{Result, anyhow},
     crossbeam_channel::{Receiver, bounded, unbounded},
     serde::{Deserialize, Serialize},
@@ -541,6 +541,38 @@ pub enum ValidatorStartProgress {
 pub struct XdpTransmitSetup {
     pub transmitter_builder: TransmitterBuilder,
     pub src_ip: Ipv4Addr,
+    pub modules: XdpModules,
+}
+
+/// Per-module XDP sender positions. `None` means the module uses OS sockets.
+///
+/// Positions index into the configured queue list (`XdpConfig::queues`), not into NIC hardware
+/// queue ids.
+#[derive(Clone, Debug)]
+pub struct XdpModules {
+    pub tpu: Option<Box<[usize]>>,
+    pub turbine: Option<Box<[usize]>>,
+    pub repair: Option<Box<[usize]>>,
+    pub gossip: Option<Box<[usize]>>,
+}
+
+impl XdpModules {
+    fn validate_sender_positions(&self, sender_count: usize) -> Result<()> {
+        for (module, positions) in [
+            ("tpu", &self.tpu),
+            ("turbine", &self.turbine),
+            ("repair", &self.repair),
+            ("gossip", &self.gossip),
+        ] {
+            let Some(positions) = positions else {
+                continue;
+            };
+            if let Err(err) = XdpSender::validate_subset_positions(positions, sender_count) {
+                return Err(anyhow!("invalid XDP sender positions for {module}: {err}"));
+            }
+        }
+        Ok(())
+    }
 }
 
 struct BlockstoreRootScan {
@@ -1414,6 +1446,7 @@ impl Validator {
         ) = if let Some(XdpTransmitSetup {
             transmitter_builder,
             src_ip,
+            modules,
         }) = xdp_transmit_setup
         {
             let turbine_src_port = node.sockets.retransmit_sockets[0]
@@ -1433,22 +1466,43 @@ impl Validator {
                 .expect("gossip socket should have local address")
                 .port();
 
+            modules.validate_sender_positions(transmitter_builder.sender_count())?;
             let (transmitter, sender) = transmitter_builder.build();
+
             (
                 Some(transmitter),
-                Some(PinnedXdpSender::new(
-                    sender.clone(),
-                    SocketAddrV4::new(src_ip, turbine_src_port),
-                )),
-                Some((sender.clone(), src_ip)),
-                Some(PinnedXdpSender::new(
-                    sender.clone(),
-                    SocketAddrV4::new(src_ip, repair_src_port),
-                )),
-                Some(PinnedXdpSender::new(
-                    sender,
-                    SocketAddrV4::new(src_ip, gossip_src_port),
-                )),
+                modules.turbine.map(|positions| {
+                    PinnedXdpSender::new(
+                        sender
+                            .subset(&positions)
+                            .expect("XDP sender positions were validated"),
+                        SocketAddrV4::new(src_ip, turbine_src_port),
+                    )
+                }),
+                modules.tpu.map(|positions| {
+                    (
+                        sender
+                            .subset(&positions)
+                            .expect("XDP sender positions were validated"),
+                        src_ip,
+                    )
+                }),
+                modules.repair.map(|positions| {
+                    PinnedXdpSender::new(
+                        sender
+                            .subset(&positions)
+                            .expect("XDP sender positions were validated"),
+                        SocketAddrV4::new(src_ip, repair_src_port),
+                    )
+                }),
+                modules.gossip.map(|positions| {
+                    PinnedXdpSender::new(
+                        sender
+                            .subset(&positions)
+                            .expect("XDP sender positions were validated"),
+                        SocketAddrV4::new(src_ip, gossip_src_port),
+                    )
+                }),
             )
         } else {
             (None, None, None, None, None)
@@ -3139,6 +3193,21 @@ mod tests {
         solana_vote_program::vote_state::{LandedVote, Lockout, VoteStateVersions},
         std::{fs::remove_dir_all, num::NonZeroU64, thread, time::Duration},
     };
+
+    #[test]
+    fn test_xdp_modules_validate_sender_positions_with_module_context() {
+        let modules = XdpModules {
+            tpu: Some([0].into()),
+            turbine: None,
+            repair: Some([1, 1].into()),
+            gossip: None,
+        };
+        let error = modules.validate_sender_positions(2).unwrap_err();
+        assert!(
+            error.to_string().contains("repair") && error.to_string().contains("is repeated"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[test]
     fn test_should_require_vote_history_file() {

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -371,7 +371,7 @@ pub fn execute(
             .map(|mut xdp_config| {
                 use {
                     agave_xdp::{device::NetworkDevice, interface_ipv4},
-                    solana_core::validator::XdpTransmitSetup,
+                    solana_core::validator::{XdpModules, XdpTransmitSetup},
                 };
 
                 let device = if let Some(interface) = xdp_config.interface.as_ref() {
@@ -393,11 +393,20 @@ pub fn execute(
                     ),
                     _ => panic!("IPv6 not supported"),
                 };
+                // Nothing can express per-module queue assignments yet, so every
+                // module transmits over the whole queue set.
+                let all_positions: Box<[usize]> = (0..xdp_config.queues.len()).collect();
                 (
                     XdpTransmitSetup {
                         transmitter_builder: TransmitterBuilder::new(xdp_config, exit.clone())
                             .expect("failed to create xdp transmitter"),
                         src_ip,
+                        modules: XdpModules {
+                            tpu: Some(all_positions.clone()),
+                            turbine: Some(all_positions.clone()),
+                            repair: Some(all_positions.clone()),
+                            gossip: Some(all_positions),
+                        },
                     },
                     XdpNetworkConfigReport {
                         zero_copy,
@@ -1400,6 +1409,9 @@ fn build_xdp_config(
     let cpus = if let Some(cpu_str) = xdp_cpu_cores {
         let parsed =
             parse_cpu_ranges(cpu_str).expect("clap validator already accepted this CPU list");
+        if parsed.is_empty() {
+            return Err(format!("--xdp-cpu-cores `{cpu_str}` selects no CPUs"));
+        }
         if let Some(poh_core) = poh_pinned_cpu_core
             && parsed.contains(&poh_core)
         {
@@ -1480,6 +1492,18 @@ mod xdp_tests {
         let matches = app.get_matches_from(vec!["agave-validator", "--no-xdp"]);
         let result = build_xdp_config(&matches, &Operation::Run, &single_ip_bind());
         assert!(result.unwrap().is_none(), "--no-xdp must disable XDP");
+    }
+
+    #[test]
+    fn test_empty_xdp_cpu_cores_is_error() {
+        let default_args = DefaultArgs::default();
+        let app = add_args(clap::App::new("agave-validator"), &default_args);
+        let matches = app.get_matches_from(vec!["agave-validator", "--xdp-cpu-cores", "5-3"]);
+        let result = build_xdp_config(&matches, &Operation::Run, &single_ip_bind());
+        assert!(
+            result.unwrap_err().contains("selects no CPUs"),
+            "empty XDP CPU core selection must produce an error"
+        );
     }
 
     #[test]

--- a/xdp/src/transmitter.rs
+++ b/xdp/src/transmitter.rs
@@ -5,6 +5,7 @@ use {
     bytes::Bytes,
     std::{
         error::Error,
+        io,
         net::{SocketAddr, SocketAddrV4},
         sync::{Arc, atomic::AtomicBool},
         thread,
@@ -244,6 +245,58 @@ impl AsRef<[SocketAddr]> for XdpAddrs {
 }
 
 impl XdpSender {
+    /// Validate positions for a sender subset before an `XdpSender` is available.
+    pub fn validate_subset_positions(
+        positions: &[usize],
+        sender_count: usize,
+    ) -> Result<(), io::Error> {
+        fn invalid_input(message: impl Into<String>) -> io::Error {
+            io::Error::new(io::ErrorKind::InvalidInput, message.into())
+        }
+
+        if positions.is_empty() {
+            return Err(invalid_input("XDP sender subset cannot be empty"));
+        }
+        if let Some(&position) = positions.iter().find(|&&position| position >= sender_count) {
+            return Err(invalid_input(format!(
+                "XDP sender subset position {position} is out of range for {sender_count} \
+                 configured XDP sender(s)"
+            )));
+        }
+        if let Some((_, &position)) = positions
+            .iter()
+            .enumerate()
+            .find(|(i, position)| positions[..*i].contains(position))
+        {
+            return Err(invalid_input(format!(
+                "XDP sender subset position {position} is repeated"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Return a sender restricted to `positions` in this sender's queue list, in the given order.
+    ///
+    /// `positions` must be non-empty and free of duplicates, and each element must be less than
+    /// `self.len()`. Position `i` of the returned sender maps to `positions[i]` of this one, so
+    /// the order determines which queue each `try_send` index lands on.
+    #[cfg(target_os = "linux")]
+    pub fn subset(&self, positions: &[usize]) -> Result<XdpSender, io::Error> {
+        Self::validate_subset_positions(positions, self.len())?;
+
+        Ok(XdpSender {
+            senders: positions.iter().map(|&i| self.senders[i].clone()).collect(),
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub fn subset(&self, _positions: &[usize]) -> Result<XdpSender, io::Error> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "XDP is only supported on Linux",
+        ))
+    }
+
     #[inline]
     pub fn try_send(
         &self,
@@ -449,6 +502,14 @@ impl TransmitterBuilder {
         })
     }
 
+    pub fn sender_count(&self) -> usize {
+        #[cfg(target_os = "linux")]
+        return self.tx_loops.len();
+
+        #[cfg(not(target_os = "linux"))]
+        0
+    }
+
     #[cfg(not(target_os = "linux"))]
     pub fn build(self) -> (Transmitter, XdpSender) {
         (Transmitter { threads: vec![] }, XdpSender {})
@@ -615,5 +676,61 @@ impl Drop for CapGuard {
             caps::drop(None, caps::CapSet::Effective, *capability)
                 .unwrap_or_else(|err| panic!("drop {capability:?} capability: {err}"));
         }
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use {
+        super::*,
+        crate::tx_loop::{Receiver, TryRecvError, TxReceiver},
+    };
+
+    /// The receivers are returned so they stay connected for the lifetime of the test.
+    fn sender_with_receivers(sender_count: usize) -> (XdpSender, Vec<TxReceiver<BytesTxPacket>>) {
+        let (senders, receivers) = (0..sender_count).map(|_| tx_loop::channel(1)).unzip();
+        (XdpSender { senders }, receivers)
+    }
+
+    fn packet() -> BytesTxPacket {
+        BytesTxPacket::new(
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1),
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 2)),
+            None,
+            Bytes::new(),
+        )
+    }
+
+    #[test]
+    fn subset_rejects_invalid_positions() {
+        let (sender, _receivers) = sender_with_receivers(2);
+        for (positions, expected) in [
+            (&[][..], "cannot be empty"),
+            (&[0, 2][..], "out of range"),
+            (&[1, 0, 1][..], "is repeated"),
+        ] {
+            let Err(error) = sender.subset(positions) else {
+                panic!("invalid subset {positions:?} must fail");
+            };
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(
+                error.to_string().contains(expected),
+                "unexpected error for {positions:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn subset_maps_positions_in_order() {
+        let (sender, receivers) = sender_with_receivers(3);
+        let subset = sender.subset(&[2, 0]).unwrap();
+        assert_eq!(subset.len(), 2);
+
+        subset.try_send(0, packet()).unwrap();
+        subset.try_send(1, packet()).unwrap();
+
+        assert!(receivers[2].try_recv().is_ok());
+        assert!(receivers[0].try_recv().is_ok());
+        assert!(matches!(receivers[1].try_recv(), Err(TryRecvError::Empty)));
     }
 }


### PR DESCRIPTION

#### Problem

All modules must currently use all available NIC queues for XDP tx. There's no way to separate different modules to use different NIC queues.

#### Summary of Changes

Add XdpSender::subset(positions), returning a sender restricted to a subset of the transmitter's per-queue TX workers, and add XdpModules to XdpTransmitSetup.

No functional change: nothing can express per-module assignments yet, so the validator passes every module the whole queue set. A follow-up adds a config file that assigns queues per module.

#### Testing

Starting validator with XDP enabled on dev box and verifying that there weren't any issues.
