### PR TITLE
fix: test invariants not ahash stability

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -1584,17 +1584,21 @@ mod tests {
         bucket.batch_insert_non_duplicates(&[]);
     }
 
-    /// Ensure bucket_index_ix() produces stable results
+    /// Ensure bucket_index_ix() is deterministic for a given seed.
+    ///
+    /// `ahash` selects an implementation based on target features, so the exact
+    /// hash value is not portable across build configurations.
     #[test]
-    fn test_bucket_index_ix_is_stable() {
+    fn test_bucket_index_ix_is_deterministic() {
         const PUBKEY: Pubkey = Pubkey::new_from_array([0xC3; 32]);
         const RANDOM1: u64 = 0x18E7_9D0B_94D8_E428;
         const RANDOM2: u64 = 0x60AE_DA87_48E9_A887;
 
         let ix1 = Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM1);
-        assert_eq!(ix1, 0x0CAD_75DB_E472_9589);
+        assert_eq!(ix1, Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM1));
 
         let ix2 = Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM2);
+        assert_eq!(ix2, Bucket::<()>::bucket_index_ix(&PUBKEY, RANDOM2));
         assert_ne!(ix2, ix1);
     }
 }

--- a/perf/src/deduper.rs
+++ b/perf/src/deduper.rs
@@ -299,24 +299,17 @@ mod tests {
         assert_eq!(deduper.popcount.load(Ordering::Relaxed), 0);
     }
 
-    #[test_case([0xf9; 32],  3_199_997, 101_192,  51_414,  77, 101_083)]
-    #[test_case([0xdc; 32],  3_200_003, 101_192,  51_414,  64, 101_097)]
-    #[test_case([0xa5; 32],  6_399_971, 202_384, 102_828, 117, 202_257)]
-    #[test_case([0xdb; 32],  6_400_013, 202_386, 102_828, 135, 202_254)]
-    #[test_case([0xcd; 32], 12_799_987, 404_771, 205_655, 273, 404_521)]
-    #[test_case([0xc3; 32], 12_800_009, 404_771, 205_656, 283, 404_365)]
-    fn test_dedup_seeded(
-        seed: [u8; 32],
-        num_bits: u64,
-        capacity: u64,
-        num_packets: usize,
-        num_dups: usize,
-        popcount: u64,
-    ) {
+    #[test_case([0xf9; 32],  3_199_997,  51_414)]
+    #[test_case([0xdc; 32],  3_200_003,  51_414)]
+    #[test_case([0xa5; 32],  6_399_971, 102_828)]
+    #[test_case([0xdb; 32],  6_400_013, 102_828)]
+    #[test_case([0xcd; 32], 12_799_987, 205_655)]
+    #[test_case([0xc3; 32], 12_800_009, 205_656)]
+    fn test_dedup_seeded(seed: [u8; 32], num_bits: u64, num_packets: usize) {
         const FALSE_POSITIVE_RATE: f64 = 0.001;
         let mut rng = ChaChaRng::from_seed(seed);
         let deduper = Deduper::<2, [u8]>::new(&mut rng, num_bits);
-        assert_eq!(get_capacity::<2>(num_bits, FALSE_POSITIVE_RATE), capacity);
+        assert!((num_packets as u64) < get_capacity::<2>(num_bits, FALSE_POSITIVE_RATE));
         let mut packet = Packet::new([0u8; PACKET_DATA_SIZE], Meta::default());
         let mut dup_count = 0usize;
         for _ in 0..num_packets {
@@ -328,8 +321,14 @@ mod tests {
             }
             assert!(deduper.dedup(packet.data(..).unwrap()));
         }
-        assert_eq!(dup_count, num_dups);
-        assert_eq!(deduper.popcount.load(Ordering::Relaxed), popcount);
+        // `ahash` output varies with its target-specific implementation. Check
+        // distribution quality instead of pinning exact false-positive and bit
+        // counts to one build configuration.
+        assert!(dup_count < num_packets / 100);
+        let popcount = deduper.popcount.load(Ordering::Relaxed);
+        let max_popcount = 2 * (num_packets - dup_count) as u64;
+        assert!(popcount <= max_popcount);
+        assert!(popcount > max_popcount * 95 / 100);
         assert!(deduper.false_positive_rate() < FALSE_POSITIVE_RATE);
         assert!(!deduper.maybe_reset(
             &mut rng,


### PR DESCRIPTION
#### Problem
- ahash is NOT a stable hasher
- we test for stable ahash hashes
- if you run tests with something like AES enabled they break because ahash uses a different backend

#### Summary of Changes
- stop testing the stability of a documented unstable hasher and test for behavior

#### Testing
- tests pass with and without AES enabled

Fixes #
