### PR TITLE
validator: remove deprecated --tpu-connection-pool-size cli argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release channels have their own copy of this changelog:
 * Loading a snapshot that contains an invalid vote account is now a hard error. Previously such
   accounts were silently dropped for compatibility with snapshots created before v2.1.0.
 * Banking trace is now disabled by default. To enable, provide `--enable-banking-trace <max bytes>`.
+* Previously deprecated `--tpu-connection-pool-size` has been removed. The connection pool size is fixed at the previous default of 1.
 #### Deprecations
 * `--disable-banking-trace` is now deprecated and a no-op (banking trace is disabled by
   default). The flag is still accepted for backward compatibility.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -584,8 +584,6 @@ struct TransactionHistoryServices {
 pub struct ValidatorTpuConfig {
     /// Controls if to use QUIC for sending TPU votes
     pub vote_use_quic: bool,
-    /// Controls the connection cache pool size
-    pub tpu_connection_pool_size: usize,
     /// QUIC server config for regular TPU
     pub tpu_quic_server_config: SwQosQuicStreamerConfig,
     /// QUIC server config for TPU forward
@@ -635,7 +633,6 @@ impl ValidatorTpuConfig {
 
         ValidatorTpuConfig {
             vote_use_quic: DEFAULT_VOTE_USE_QUIC,
-            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
@@ -747,7 +744,6 @@ impl Validator {
 
         let ValidatorTpuConfig {
             vote_use_quic,
-            tpu_connection_pool_size,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,
@@ -1179,7 +1175,7 @@ impl Validator {
         let vote_connection_cache = if vote_use_quic {
             let vote_connection_cache = ConnectionCache::new_with_client_options(
                 "connection_cache_vote_quic",
-                tpu_connection_pool_size,
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
                 Some(node.sockets.quic_vote_client),
                 Some((
                     &identity_keypair,
@@ -1196,7 +1192,7 @@ impl Validator {
         } else {
             Arc::new(ConnectionCache::with_udp(
                 "connection_cache_vote_udp",
-                tpu_connection_pool_size,
+                DEFAULT_TPU_CONNECTION_POOL_SIZE,
             ))
         };
 

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -504,7 +504,6 @@ pub fn run_cluster_partition<C>(
         skip_warmup_slots: true,
         additional_accounts,
         ticks_per_slot: ticks_per_slot.unwrap_or(DEFAULT_TICKS_PER_SLOT),
-        tpu_connection_pool_size: 2,
         ..ClusterConfig::default()
     };
 

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -54,7 +54,7 @@ use {
         state::{Authorized, Lockup, StakeStateV2},
     },
     solana_system_transaction as system_transaction,
-    solana_tpu_client::tpu_client::{DEFAULT_TPU_CONNECTION_POOL_SIZE, DEFAULT_VOTE_USE_QUIC},
+    solana_tpu_client::tpu_client::DEFAULT_VOTE_USE_QUIC,
     solana_transaction::Transaction,
     solana_transaction_error::TransportError,
     solana_vote_program::{
@@ -111,7 +111,6 @@ pub struct ClusterConfig {
     pub cluster_type: ClusterType,
     pub poh_config: PohConfig,
     pub additional_accounts: Vec<(Pubkey, AccountSharedData)>,
-    pub tpu_connection_pool_size: usize,
     pub vote_use_quic: bool,
 }
 
@@ -149,7 +148,6 @@ impl Default for ClusterConfig {
             poh_config: PohConfig::default(),
             skip_warmup_slots: false,
             additional_accounts: vec![],
-            tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             vote_use_quic: DEFAULT_VOTE_USE_QUIC,
         }
     }

--- a/tpu-client/src/tpu_client.rs
+++ b/tpu-client/src/tpu_client.rs
@@ -28,8 +28,7 @@ use {
 pub const DEFAULT_VOTE_USE_QUIC: bool = false;
 
 /// The default connection count is set to 1 -- it should
-/// be sufficient for most use cases. Validators can use
-/// --tpu-connection-pool-size to override this default value.
+/// be sufficient for most use cases.
 pub const DEFAULT_TPU_CONNECTION_POOL_SIZE: usize = 1;
 
 pub type Result<T> = std::result::Result<T, TpuSenderError>;

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -239,15 +239,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Keep this amount of shreds in root slots."),
         replaced_by: "limit-blockstore-size",
     );
-    add_arg!(
-        // deprecated in v4.0.0
-        Arg::with_name("tpu_connection_pool_size")
-            .long("tpu-connection-pool-size")
-            .takes_value(true)
-            .validator(is_parsable::<usize>)
-            .help("Controls the TPU connection pool size per remote address"),
-         usage_warning:"This parameter is misleading, avoid setting it",
-    );
     res
 }
 

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -69,7 +69,6 @@ use {
         nonblocking::{simple_qos::SimpleQosConfig, swqos::SwQosConfig},
         quic::{QuicStreamerConfig, SimpleQosQuicStreamerConfig, SwQosQuicStreamerConfig},
     },
-    solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
     solana_turbine::broadcast_stage::BroadcastStageType,
     solana_validator_exit::Exit,
     std::{
@@ -526,12 +525,6 @@ pub fn execute(
     let accounts_shrink_optimize_total_space =
         value_t_or_exit!(matches, "accounts_shrink_optimize_total_space", bool);
     let vote_use_quic = value_t_or_exit!(matches, "vote_use_quic", bool);
-
-    let tpu_connection_pool_size = matches
-        .value_of("tpu_connection_pool_size")
-        .unwrap_or("")
-        .parse()
-        .unwrap_or(DEFAULT_TPU_CONNECTION_POOL_SIZE);
 
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {
@@ -1127,7 +1120,6 @@ pub fn execute(
         run_args.socket_addr_space,
         ValidatorTpuConfig {
             vote_use_quic,
-            tpu_connection_pool_size,
             tpu_quic_server_config,
             tpu_fwd_quic_server_config,
             vote_quic_server_config,


### PR DESCRIPTION
#### Problem

Deprecated since 4.0.0. Can we remove already? that argument was probably not used by anyone ever.

#### Summary of Changes

rm deprecated code, changelog entry.

#### Testing

CI