### PR TITLE
fix(clippy): address manual-let-else lint in bpf loader

### DIFF
--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1181,9 +1181,8 @@ mod tests {
 
             // Consume the harness cell after Shuttle exits so extraction does
             // not call `shuttle::sync::Mutex::lock` outside the scheduler.
-            let mut result = match shuttle::sync::Arc::try_unwrap(result) {
-                Ok(result) => result,
-                Err(_) => panic!("shuttle test result still has outstanding references"),
+            let Ok(mut result) = shuttle::sync::Arc::try_unwrap(result) else {
+                panic!("shuttle test result still has outstanding references")
             };
             result
                 .get_mut()


### PR DESCRIPTION
#### Problem

part of https://github.com/anza-xyz/agave/pull/14045

```
$ cargo clippy --all-targets --no-default-features --features shuttle-test --manifest-path ./programs/bpf_loader/Cargo.toml
error: this could be rewritten as `let...else`
    --> programs/bpf_loader/src/lib.rs:1184:13
     |
1184 | /             let mut result = match shuttle::sync::Arc::try_unwrap(result) {
1185 | |                 Ok(result) => result,
1186 | |                 Err(_) => panic!("shuttle test result still has outstanding references"),
1187 | |             };
     | |______________^ help: consider writing: `let Ok(mut result) = shuttle::sync::Arc::try_unwrap(result) else { panic!("shuttle test result still has outstanding references") };`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#manual_let_else
     = note: requested on the command line with `-D clippy::manual-let-else`

error: could not compile `solana-bpf-loader-program` (lib test) due to 1 previous error
```

#### Summary of Changes

fix it

