### PR TITLE
fix(clippy): remove unnecessary mut from svm tests

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -42,13 +42,13 @@ mod mock_bank;
 const MAX_ITERATIONS: usize = 10_000;
 
 fn program_cache_execution(threads: usize) {
-    let mut mock_bank = MockBankCallback::default();
+    let mock_bank = MockBankCallback::default();
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
     let batch_processor = TransactionBatchProcessor::new(5, 5, Arc::downgrade(&fork_graph), None);
     let programs = [
-        deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
-        deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
-        deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
+        deploy_program("hello-solana".to_string(), 0, &mock_bank),
+        deploy_program("simple-transfer".to_string(), 0, &mock_bank),
+        deploy_program("clock-sysvar".to_string(), 0, &mock_bank),
     ];
 
     let ths: Vec<_> = (0..threads)


### PR DESCRIPTION
#### Problem

part of https://github.com/anza-xyz/agave/pull/14045

```
$ cargo clippy --all-targets --no-default-features --features shuttle-test --manifest-path svm/Cargo.toml

warning: the function `deploy_program` doesn't need a mutable reference
  --> svm/tests/concurrent_tests.rs:49:55
   |
49 |         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
   |                                                       ^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#unnecessary_mut_passed
   = note: `#[warn(clippy::unnecessary_mut_passed)]` on by default
help: remove this `mut`
   |
49 -         deploy_program("hello-solana".to_string(), 0, &mut mock_bank),
49 +         deploy_program("hello-solana".to_string(), 0, &mock_bank),
   |

warning: the function `deploy_program` doesn't need a mutable reference
  --> svm/tests/concurrent_tests.rs:50:58
   |
50 |         deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
   |                                                          ^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#unnecessary_mut_passed
help: remove this `mut`
   |
50 -         deploy_program("simple-transfer".to_string(), 0, &mut mock_bank),
50 +         deploy_program("simple-transfer".to_string(), 0, &mock_bank),
   |

warning: the function `deploy_program` doesn't need a mutable reference
  --> svm/tests/concurrent_tests.rs:51:55
   |
51 |         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
   |                                                       ^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#unnecessary_mut_passed
help: remove this `mut`
   |
51 -         deploy_program("clock-sysvar".to_string(), 0, &mut mock_bank),
51 +         deploy_program("clock-sysvar".to_string(), 0, &mock_bank),
   |
```

#### Summary of Changes

remove unnecessary mut