### PR TITLE
fix(clippy): fix arithmetic-side-effects for svm tests

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -113,8 +113,8 @@ fn program_cache_execution(threads: usize) {
                     &feature_set,
                     0,
                 );
-                let upcoming_environment =
-                    processor.program_runtime_environment_for_epoch(processor.epoch + 1);
+                let upcoming_environment = processor
+                    .program_runtime_environment_for_epoch(processor.epoch.saturating_add(1));
                 processor.prepare_one_program_for_upcoming_feature_set(
                     &account_loader,
                     false,


### PR DESCRIPTION
#### Problem

part of https://github.com/anza-xyz/agave/pull/14045

```
$ cargo clippy --all-targets --no-default-features --features shuttle-test --manifest-path svm/Cargo.toml

error: arithmetic operation that can potentially result in unexpected side-effects
   --> svm/tests/concurrent_tests.rs:117:69
    |
117 |                     processor.program_runtime_environment_for_epoch(processor.epoch + 1);
    |                                                                     ^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#arithmetic_side_effects
    = note: requested on the command line with `-D clippy::arithmetic-side-effects`
```


#### Summary of Changes

fix it