### PR TITLE
fix(clippy): fix default-trait-access for svm tests

### DIFF
--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -5,7 +5,7 @@ use {
     assert_matches::assert_matches,
     mock_bank::MockBankCallback,
     shuttle::{
-        Runner,
+        Config, Runner,
         sync::{Arc, RwLock},
         thread,
     },
@@ -113,8 +113,8 @@ fn program_cache_execution(threads: usize) {
                     &feature_set,
                     0,
                 );
-                let upcoming_environment =
-                    processor.program_runtime_environment_for_epoch(processor.epoch + 1);
+                let upcoming_environment = processor
+                    .program_runtime_environment_for_epoch(processor.epoch.saturating_add(1));
                 processor.prepare_one_program_for_upcoming_feature_set(
                     &account_loader,
                     false,
@@ -164,7 +164,7 @@ fn test_program_cache_with_exhaustive_scheduler() {
     // Since this is not the case for the execution of jitted program, we can still run the test
     // but with decreased accuracy.
     let scheduler = shuttle::scheduler::DfsScheduler::new(Some(MAX_ITERATIONS), true);
-    let runner = Runner::new(scheduler, Default::default());
+    let runner = Runner::new(scheduler, Config::default());
     runner.run(move || program_cache_execution(4));
 }
 


### PR DESCRIPTION
#### Problem

part of https://github.com/anza-xyz/agave/pull/14045

```
$ cargo clippy --all-targets --no-default-features --features shuttle-test --manifest-path svm/Cargo.toml

error: calling `Config::default()` is more clear than this expression
   --> svm/tests/concurrent_tests.rs:167:41
    |
167 |     let runner = Runner::new(scheduler, Default::default());
    |                                         ^^^^^^^^^^^^^^^^^^ help: try: `Config::default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#default_trait_access
    = note: requested on the command line with `-D clippy::default-trait-access`
```

#### Summary of Changes

fix it