### PR TITLE
Moves conformance-specific test fns out of accounts-db

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6420,16 +6420,6 @@ impl AccountStorageEntry {
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
 #[cfg(feature = "dev-context-only-utils")]
 impl AccountsDb {
-    /// Create an AccountsDb tuned for short-lived, single-threaded test invocations.
-    pub fn new_for_tests_single_threaded() -> Self {
-        Self::new_with_config(
-            Vec::new(),
-            AccountsDbConfig::new_for_tests_single_threaded(),
-            None,
-            Arc::default(),
-        )
-    }
-
     pub fn default_for_tests() -> Self {
         Self::new_for_tests_with_config(Vec::new(), ACCOUNTS_DB_CONFIG_FOR_TESTING)
     }

--- a/accounts-db/src/accounts_db/accounts_db_config.rs
+++ b/accounts-db/src/accounts_db/accounts_db_config.rs
@@ -45,28 +45,6 @@ pub struct AccountsDbConfig {
     pub accounts_file_provider: AccountsFileProvider,
 }
 
-#[cfg(feature = "dev-context-only-utils")]
-impl AccountsDbConfig {
-    /// AccountsDb configuration optimized for short-lived, single-threaded test invocations.
-    pub fn new_for_tests_single_threaded() -> Self {
-        let single_thread = NonZeroUsize::new(1).unwrap();
-        Self {
-            index: Some(AccountsIndexConfig {
-                bins: Some(2),
-                num_flush_threads: Some(single_thread),
-                index_limit: crate::accounts_index::IndexLimit::InMemOnly,
-                ..AccountsIndexConfig::default()
-            }),
-            skip_initial_hash_calc: true,
-            num_background_threads: Some(single_thread),
-            num_foreground_threads: Some(single_thread),
-            exhaustively_verify_refcounts: false,
-            read_cache_num_shards: Some(2),
-            ..Self::default()
-        }
-    }
-}
-
 pub const ACCOUNTS_DB_CONFIG_FOR_TESTING: AccountsDbConfig = AccountsDbConfig {
     index: Some(ACCOUNTS_INDEX_CONFIG_FOR_TESTING),
     account_indexes: None,
@@ -108,23 +86,3 @@ pub const ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS: AccountsDbConfig = AccountsDbConfig
     num_foreground_threads: None,
     accounts_file_provider: AccountsFileProvider::AppendVec,
 };
-
-#[cfg(all(test, feature = "dev-context-only-utils"))]
-mod tests {
-    use {super::AccountsDbConfig, crate::accounts_index::IndexLimit};
-
-    #[test]
-    fn test_new_for_tests_single_threaded_config() {
-        let config = AccountsDbConfig::new_for_tests_single_threaded();
-        let index = config.index.unwrap();
-
-        assert_eq!(index.bins, Some(2));
-        assert_eq!(index.num_flush_threads.map(usize::from), Some(1));
-        assert!(matches!(index.index_limit, IndexLimit::InMemOnly));
-        assert!(config.skip_initial_hash_calc);
-        assert!(!config.exhaustively_verify_refcounts);
-        assert_eq!(config.read_cache_num_shards, Some(2));
-        assert_eq!(config.num_background_threads.map(usize::from), Some(1));
-        assert_eq!(config.num_foreground_threads.map(usize::from), Some(1));
-    }
-}

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -102,15 +102,6 @@ fn create_store_for_shrink_tests(
 }
 
 #[test]
-fn test_new_for_tests_single_threaded_uses_single_thread_pools() {
-    let accounts_db = AccountsDb::new_for_tests_single_threaded();
-
-    assert!(accounts_db.skip_initial_hash_calc);
-    assert_eq!(accounts_db.thread_pool_foreground.current_num_threads(), 1);
-    assert_eq!(accounts_db.thread_pool_background.current_num_threads(), 1);
-}
-
-#[test]
 #[should_panic(expected = "Accounts may only be stored once per slot:")]
 fn test_generate_index_duplicates_within_slot() {
     let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);

--- a/runtime/src/conformance/mod.rs
+++ b/runtime/src/conformance/mod.rs
@@ -20,13 +20,12 @@ use {
     solana_svm::conformance::account_state::account_from_proto,
 };
 use {
-    solana_accounts_db::{accounts::Accounts, accounts_db::AccountsDb},
-    std::sync::Arc,
+    solana_accounts_db::{
+        accounts::Accounts,
+        accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDb, AccountsDbConfig},
+    },
+    std::{num::NonZeroUsize, sync::Arc},
 };
-
-pub(crate) fn new_accounts_for_tests_single_threaded() -> Accounts {
-    Accounts::new(Arc::new(AccountsDb::new_for_tests_single_threaded()))
-}
 
 /// Parse the input accounts into keyed `AccountSharedData`, dropping zero-lamport
 /// accounts (treated as nonexistent).
@@ -65,5 +64,52 @@ pub(crate) fn fee_rate_governor_from_proto(
         min_lamports_per_signature: value.min_lamports_per_signature,
         max_lamports_per_signature: value.max_lamports_per_signature,
         burn_percent: value.burn_percent as u8,
+    }
+}
+
+pub(crate) fn new_accounts_for_tests_single_threaded() -> Accounts {
+    Accounts::new(Arc::new(AccountsDb::new_for_tests_with_config(
+        Vec::new(),
+        new_accounts_db_config_for_tests_single_threaded(),
+    )))
+}
+
+pub(crate) fn new_accounts_db_config_for_tests_single_threaded() -> AccountsDbConfig {
+    let single_thread = NonZeroUsize::new(1).unwrap();
+    AccountsDbConfig {
+        num_background_threads: Some(single_thread),
+        num_foreground_threads: Some(single_thread),
+        read_cache_num_shards: Some(2),
+        skip_initial_hash_calc: true,
+        ..ACCOUNTS_DB_CONFIG_FOR_TESTING
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, solana_accounts_db::accounts_index::IndexLimit};
+
+    #[test]
+    fn test_new_accounts_for_tests_single_threaded() {
+        let accounts = new_accounts_for_tests_single_threaded();
+        let accounts_db = &accounts.accounts_db;
+        assert!(accounts_db.skip_initial_hash_calc);
+        assert_eq!(accounts_db.thread_pool_foreground.current_num_threads(), 1);
+        assert_eq!(accounts_db.thread_pool_background.current_num_threads(), 1);
+    }
+
+    #[test]
+    fn test_new_accounts_db_config_for_tests_single_threaded_config() {
+        let one = NonZeroUsize::new(1).unwrap();
+        let config = new_accounts_db_config_for_tests_single_threaded();
+        let index = config.index.unwrap();
+        assert_eq!(index.bins, Some(2));
+        assert_eq!(index.num_flush_threads, Some(one));
+        assert!(matches!(index.index_limit, IndexLimit::InMemOnly));
+        assert!(config.skip_initial_hash_calc);
+        assert!(!config.exhaustively_verify_refcounts);
+        assert_eq!(config.read_cache_num_shards, Some(2));
+        assert_eq!(config.num_background_threads, Some(one));
+        assert_eq!(config.num_foreground_threads, Some(one));
     }
 }


### PR DESCRIPTION
#### Problem

PR https://github.com/anza-xyz/agave/pull/13910 added APIs to accounts-db that should not have been added. The new APIs are unnecessary because the desired behavior can be achieved already, without needing to add anything new.


#### Summary of Changes

Move the conformance-only helper fns into the conformance.rs file, and remove the APIs that were added in #13910.


#### Testing

Nothing additional.