### PR TITLE
bls-sigverify: verify batches of votes in parallel

### DIFF
--- a/bls-sigverify/src/bls_cert_sigverify.rs
+++ b/bls-sigverify/src/bls_cert_sigverify.rs
@@ -79,7 +79,7 @@ pub(super) fn verify_and_send_certificates(
         thread_pool,
     );
     stats.sig_verified_certs += messages.len() as u64;
-    send_certs_to_pool(messages, channel_to_pool, &mut stats)?;
+    send_certs_to_pool(messages, channel_to_pool, &mut stats.pool_sender)?;
 
     measure.stop();
     stats

--- a/bls-sigverify/src/bls_sigverifier.rs
+++ b/bls-sigverify/src/bls_sigverifier.rs
@@ -78,12 +78,32 @@ pub struct SigVerifierContext {
 }
 
 pub struct SigVerifierChannels {
-    pub packet_receiver: Receiver<Datagram>,
-    pub certificate_receiver: Receiver<(Slot, UnverifiedCertificate)>,
-    pub channel_to_repair: VerifiedVoterSlotsSender,
-    pub channel_to_reward: Sender<RewardInput>,
-    pub channel_to_pool: Sender<SigVerifiedBatch>,
-    pub channel_to_metrics: ConsensusMetricsEventSender,
+    pub(crate) packet_receiver: Receiver<Datagram>,
+    pub(crate) certificate_receiver: Receiver<(Slot, UnverifiedCertificate)>,
+    pub(crate) channel_to_repair: VerifiedVoterSlotsSender,
+    pub(crate) channel_to_reward: Sender<RewardInput>,
+    pub(crate) channel_to_pool: Sender<SigVerifiedBatch>,
+    pub(crate) channel_to_metrics: ConsensusMetricsEventSender,
+}
+
+impl SigVerifierChannels {
+    pub fn new(
+        packet_receiver: Receiver<Datagram>,
+        certificate_receiver: Receiver<(Slot, UnverifiedCertificate)>,
+        channel_to_repair: VerifiedVoterSlotsSender,
+        channel_to_reward: Sender<RewardInput>,
+        channel_to_pool: Sender<SigVerifiedBatch>,
+        channel_to_metrics: ConsensusMetricsEventSender,
+    ) -> Self {
+        Self {
+            packet_receiver,
+            certificate_receiver,
+            channel_to_repair,
+            channel_to_reward,
+            channel_to_pool,
+            channel_to_metrics,
+        }
+    }
 }
 
 /// Starts the BLS sigverifier service in its own dedicated thread.
@@ -639,14 +659,14 @@ mod tests {
                     num_threads: 4,
                     generated_cert_types: generated_cert_types.clone(),
                 },
-                SigVerifierChannels {
+                SigVerifierChannels::new(
                     packet_receiver,
                     certificate_receiver,
                     channel_to_repair,
                     channel_to_reward,
                     channel_to_pool,
                     channel_to_metrics,
-                },
+                ),
             );
             Self {
                 validator_keypairs,
@@ -822,8 +842,8 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(ctx.pool_receiver.try_iter().count(), 2);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 1);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 1);
         let received_verified_votes1 = ctx.repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes1,
@@ -857,8 +877,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
         let received_verified_votes2 = ctx.repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes2,
@@ -891,8 +911,8 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(ctx.pool_receiver.try_iter().count(), 1);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
         let received_verified_votes3 = ctx.repair_receiver.try_recv().unwrap();
         assert_eq!(
             received_verified_votes3,
@@ -909,8 +929,8 @@ mod tests {
 
         let datagrams = vec![datagram_from_bytes(Bytes::new(), Pubkey::new_unique())];
         ctx.verifier.verify_and_send_datagrams(datagrams).unwrap();
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 0);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 0);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
         assert_eq!(ctx.verifier.stats.num_malformed_pkts.0, 1);
 
         // Expect no messages since the packet was malformed
@@ -982,8 +1002,8 @@ mod tests {
         let datagrams =
             messages_to_datagrams(&msgs, ctx.verifier.cluster_info.my_shred_version() + 1);
         ctx.verifier.verify_and_send_datagrams(datagrams).unwrap();
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 0);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 0);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 0);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 0);
         assert_eq!(ctx.verifier.stats.num_malformed_pkts.0, 1);
     }
 
@@ -1056,7 +1076,7 @@ mod tests {
         assert_eq!(m2_recv, batch2);
         // pool_sent counts every message that made it onto the channel,
         // whether via try_send or the blocking fallback.
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 2);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 2);
     }
 
     #[test]
@@ -1183,13 +1203,16 @@ mod tests {
 
         ctx.verifier.verify_and_send_datagrams(packets).unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 2);
+        assert_eq!(batches.len(), 1);
         let total_votes_verified = batches
             .into_iter()
             .map(|batch| match batch {
                 SigVerifiedBatch::Votes(aggregates) => {
-                    assert_eq!(aggregates.len(), 1);
-                    aggregates[0].num_votes()
+                    assert_eq!(aggregates.len(), 2);
+                    aggregates
+                        .iter()
+                        .map(|aggregate| aggregate.num_votes())
+                        .sum::<usize>()
                 }
                 rest => panic!("unexpected type: {rest:?}"),
             })
@@ -1261,11 +1284,12 @@ mod tests {
 
         ctx.verifier.verify_and_send_datagrams(packets).unwrap();
         let batches = ctx.pool_receiver.try_iter().collect::<Vec<_>>();
-        assert_eq!(batches.len(), 2);
+        assert_eq!(batches.len(), 1);
         let total_votes_verified = batches
             .into_iter()
             .map(|batch| match batch {
                 SigVerifiedBatch::Votes(aggregates) => {
+                    assert_eq!(aggregates.len(), 3);
                     for aggregate in &aggregates {
                         if aggregate.vote() == &vote2
                             && *aggregate.ranks().get(invalid_rank as usize).unwrap()
@@ -1588,8 +1612,8 @@ mod tests {
                 assert_eq!(certs.len(), 1);
             }
         }
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 1);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 1);
     }
 
     #[test]
@@ -1621,10 +1645,10 @@ mod tests {
 
     #[test]
     fn test_verify_old_vote_and_cert() {
-        let (message_sender, message_receiver) = bounded(1024);
-        let (votes_for_repair_sender, _) = bounded(1024);
-        let (consensus_metrics_sender, _) = bounded(1024);
-        let (reward_votes_sender, _reward_votes_receiver) = bounded(1024);
+        let (channel_to_pool, pool_receiver) = bounded(1024);
+        let (channel_to_repair, _repair_receiver) = bounded(1024);
+        let (channel_to_metrics, _metrics_receiver) = bounded(1024);
+        let (channel_to_reward, _reward_receiver) = bounded(1024);
         let validator_keypairs = (0..10)
             .map(|_| ValidatorVoteKeypairs::new_rand())
             .collect::<Vec<_>>();
@@ -1666,14 +1690,14 @@ mod tests {
                 num_threads: 4,
                 generated_cert_types: Arc::new(GeneratedCertTypes::default()),
             },
-            SigVerifierChannels {
+            SigVerifierChannels::new(
                 packet_receiver,
                 certificate_receiver,
-                channel_to_repair: votes_for_repair_sender,
-                channel_to_reward: reward_votes_sender,
-                channel_to_pool: message_sender,
-                channel_to_metrics: consensus_metrics_sender,
-            },
+                channel_to_repair,
+                channel_to_reward,
+                channel_to_pool,
+                channel_to_metrics,
+            ),
         );
 
         let rank = 0;
@@ -1699,7 +1723,7 @@ mod tests {
         sig_verifier
             .verify_and_send_datagrams(datagrams_vote)
             .unwrap();
-        expect_no_receive(&message_receiver);
+        expect_no_receive(&pool_receiver);
         assert_eq!(sig_verifier.stats.num_old_votes_received.0, 1);
 
         let cert = test_create_base2_certificate(
@@ -1720,7 +1744,7 @@ mod tests {
         sig_verifier
             .verify_and_send_datagrams(datagrams_cert)
             .unwrap();
-        expect_no_receive(&message_receiver);
+        expect_no_receive(&pool_receiver);
         assert_eq!(sig_verifier.stats.num_old_certs_received.0, 1);
         assert_eq!(sig_verifier.stats.num_old_votes_received.0, 1);
     }
@@ -2123,9 +2147,9 @@ mod tests {
         ctx.verifier.verify_and_send_datagrams(datagrams).unwrap();
 
         assert_eq!(ctx.verifier.stats.vote_too_far_in_future.0, 1);
-        assert_eq!(ctx.verifier.stats.vote_stats.pool_sent.0, 1);
+        assert_eq!(ctx.verifier.stats.vote_stats.senders.pool_sender.sent.0, 1);
         assert_eq!(ctx.verifier.stats.cert_stats.too_far_in_future.0, 0);
-        assert_eq!(ctx.verifier.stats.cert_stats.pool_sent.0, 1);
+        assert_eq!(ctx.verifier.stats.cert_stats.pool_sender.sent.0, 1);
         assert_eq!(ctx.pool_receiver.try_iter().count(), 2);
         assert_eq!(
             ctx.repair_receiver.try_recv().unwrap(),

--- a/bls-sigverify/src/bls_vote_sigverify.rs
+++ b/bls-sigverify/src/bls_vote_sigverify.rs
@@ -7,7 +7,7 @@ use {
         bls_sigverifier::{BAN_TIMEOUT, SigVerifierChannels},
         errors::SigVerifyVoteError,
         rewards::rewards_wants_vote,
-        stats::SigVerifyVoteStats,
+        stats::{SigVerifyVoteStats, VoteSenderStats, VoteVerificationStats},
         utils::{
             send_sig_verified_batch_to_pool, send_votes_to_metrics, send_votes_to_repair,
             send_votes_to_rewards,
@@ -37,8 +37,43 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_pubkey::Pubkey,
     solana_runtime::{bank::Bank, epoch_stakes::BLSPubkeyToRankMap},
-    std::{collections::HashMap, num::NonZero, sync::Arc},
+    std::{
+        collections::{HashMap, hash_map::Entry},
+        num::NonZero,
+        sync::Arc,
+    },
 };
+
+#[derive(Default)]
+struct ProcessedVotes {
+    reward_msg: Vec<VoteAggregate>,
+    repair_msg: HashMap<Pubkey, Vec<Slot>>,
+    vote_aggregates_for_pool: Vec<VoteAggregate>,
+    metrics_msg: Vec<ConsensusMetricsEvent>,
+}
+
+impl ProcessedVotes {
+    fn merge(&mut self, other: Self) {
+        let Self {
+            mut reward_msg,
+            repair_msg,
+            mut vote_aggregates_for_pool,
+            mut metrics_msg,
+        } = other;
+        self.reward_msg.append(&mut reward_msg);
+        for (pubkey, mut slots) in repair_msg {
+            match self.repair_msg.entry(pubkey) {
+                Entry::Vacant(e) => {
+                    e.insert(slots);
+                }
+                Entry::Occupied(e) => e.into_mut().append(&mut slots),
+            }
+        }
+        self.vote_aggregates_for_pool
+            .append(&mut vote_aggregates_for_pool);
+        self.metrics_msg.append(&mut metrics_msg);
+    }
+}
 
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
 struct VerifiedVotePayload {
@@ -80,6 +115,38 @@ impl UnverifiedVotePayload {
     }
 }
 
+fn verify_vote_batch(
+    root_bank: &Bank,
+    cluster_info: &ClusterInfo,
+    leader_schedule: &LeaderScheduleCache,
+    ban_sender: &BanSender,
+    thread_pool: &ThreadPool,
+    rank_map_cache: &HashMap<Epoch, Arc<BLSPubkeyToRankMap>>,
+    vote_payload_to_sign: VotePayloadToSign,
+    unverified_votes: Vec<UnverifiedVotePayload>,
+) -> (u64, VoteVerificationStats, ProcessedVotes) {
+    let unverified_votes_len = unverified_votes.len() as u64;
+    let vote_slot = vote_payload_to_sign.slot();
+    let vote_epoch = root_bank.epoch_schedule().get_epoch(vote_slot);
+    let rank_map = rank_map_cache.get(&vote_epoch).unwrap();
+    let max_validators = rank_map.len();
+    let (verified_votes, vote_verification_stats) = verify_votes(
+        max_validators,
+        vote_payload_to_sign,
+        unverified_votes,
+        ban_sender,
+        thread_pool,
+    );
+
+    let processed_votes =
+        process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
+    (
+        unverified_votes_len,
+        vote_verification_stats,
+        processed_votes,
+    )
+}
+
 /// Verifies votes and sends the verified votes to the consensus pool; and sends the desired subset
 /// to rewards container and repair.
 ///
@@ -103,29 +170,57 @@ pub(super) fn verify_and_send_votes(
         .distinct_votes_stats
         .add_sample(unverified_votes.len() as u64);
 
-    for (vote_payload_to_sign, unverified_votes) in unverified_votes {
-        stats.votes_to_sig_verify += unverified_votes.len() as u64;
-        let vote_slot = vote_payload_to_sign.slot();
-        let vote_epoch = root_bank.epoch_schedule().get_epoch(vote_slot);
-        let rank_map = rank_map_cache.get(&vote_epoch).unwrap();
-        let max_validators = rank_map.len();
-        let verified_votes = verify_votes(
-            max_validators,
-            vote_payload_to_sign,
-            unverified_votes,
-            &mut stats,
-            ban_sender,
-            thread_pool,
-        );
-
-        let (sig_verified_batch, msgs_for_repair, msg_for_reward, msg_for_metrics) =
-            process_verified_votes(verified_votes, root_bank, cluster_info, leader_schedule);
-
-        send_sig_verified_batch_to_pool(sig_verified_batch, &channels.channel_to_pool, &mut stats)?;
-        send_votes_to_repair(msgs_for_repair, &channels.channel_to_repair, &mut stats)?;
-        send_votes_to_rewards(msg_for_reward, &channels.channel_to_reward, &mut stats)?;
-        send_votes_to_metrics(msg_for_metrics, &channels.channel_to_metrics, &mut stats)?;
-    }
+    let (total_votes, verification_stats, processed_votes) = thread_pool.install(|| {
+        unverified_votes
+            .into_par_iter()
+            .fold(
+                || {
+                    (
+                        0u64,
+                        VoteVerificationStats::default(),
+                        ProcessedVotes::default(),
+                    )
+                },
+                |(mut acc_total_votes, mut acc_verification_stats, mut acc_processed_votes),
+                 (vote_payload_to_sign, unverified_votes)| {
+                    let (unverified_votes_len, vote_verification_stats, processed_votes) =
+                        verify_vote_batch(
+                            root_bank,
+                            cluster_info,
+                            leader_schedule,
+                            ban_sender,
+                            thread_pool,
+                            rank_map_cache,
+                            vote_payload_to_sign,
+                            unverified_votes,
+                        );
+                    acc_total_votes = acc_total_votes.saturating_add(unverified_votes_len);
+                    acc_verification_stats.merge(vote_verification_stats);
+                    acc_processed_votes.merge(processed_votes);
+                    (acc_total_votes, acc_verification_stats, acc_processed_votes)
+                },
+            )
+            .reduce(
+                || {
+                    (
+                        0,
+                        VoteVerificationStats::default(),
+                        ProcessedVotes::default(),
+                    )
+                },
+                |mut left, right| {
+                    left.0 = left.0.saturating_add(right.0);
+                    left.1.merge(right.1);
+                    left.2.merge(right.2);
+                    left
+                },
+            )
+    });
+    let my_pubkey = &cluster_info.id();
+    let sender_stats = send_msgs(my_pubkey, channels, processed_votes)?;
+    stats.votes_to_sig_verify += total_votes;
+    stats.vote_verification_stats.merge(verification_stats);
+    stats.senders.merge(sender_stats);
 
     measure.stop();
     stats
@@ -160,12 +255,7 @@ fn process_verified_votes(
     root_bank: &Bank,
     cluster_info: &ClusterInfo,
     leader_schedule: &LeaderScheduleCache,
-) -> (
-    SigVerifiedBatch,
-    HashMap<Pubkey, Vec<Slot>>,
-    Vec<VoteAggregate>,
-    Vec<ConsensusMetricsEvent>,
-) {
+) -> ProcessedVotes {
     let mut votes_for_reward = Vec::with_capacity(verified_votes.len());
     let mut msgs_for_repair = HashMap::new();
     let mut vote_aggregates_for_pool = Vec::with_capacity(verified_votes.len());
@@ -197,13 +287,44 @@ fn process_verified_votes(
             (pubkey, slots)
         })
         .collect();
-    let sig_verified_batch = SigVerifiedBatch::Votes(vote_aggregates_for_pool);
-    (
-        sig_verified_batch,
-        msgs_for_repair,
-        votes_for_reward,
-        votes_for_metrics,
-    )
+    ProcessedVotes {
+        reward_msg: votes_for_reward,
+        repair_msg: msgs_for_repair,
+        vote_aggregates_for_pool,
+        metrics_msg: votes_for_metrics,
+    }
+}
+
+fn send_msgs(
+    my_pubkey: &Pubkey,
+    channels: &SigVerifierChannels,
+    processed_votes: ProcessedVotes,
+) -> Result<VoteSenderStats, SigVerifyVoteError> {
+    let mut sender_stats = VoteSenderStats::default();
+    send_sig_verified_batch_to_pool(
+        SigVerifiedBatch::Votes(processed_votes.vote_aggregates_for_pool),
+        &channels.channel_to_pool,
+        &mut sender_stats,
+    )?;
+    send_votes_to_repair(
+        my_pubkey,
+        processed_votes.repair_msg,
+        &channels.channel_to_repair,
+        &mut sender_stats,
+    );
+    send_votes_to_rewards(
+        my_pubkey,
+        processed_votes.reward_msg,
+        &channels.channel_to_reward,
+        &mut sender_stats,
+    );
+    send_votes_to_metrics(
+        my_pubkey,
+        processed_votes.metrics_msg,
+        &channels.channel_to_metrics,
+        &mut sender_stats,
+    );
+    Ok(sender_stats)
 }
 
 /// Sig verifies `unverified_votes` and returns a `Vec` of votes that passed verification.
@@ -211,12 +332,17 @@ fn verify_votes(
     max_validators: usize,
     vote_payload_to_sign: VotePayloadToSign,
     unverified_votes: Vec<UnverifiedVotePayload>,
-    stats: &mut SigVerifyVoteStats,
     ban_sender: &BanSender,
     thread_pool: &ThreadPool,
-) -> Vec<VerifiedVotePayload> {
+) -> (Vec<VerifiedVotePayload>, VoteVerificationStats) {
+    let mut stats = VoteVerificationStats::default();
     // Try optimistic verification - fast to verify, but cannot identify invalid votes
-    let res = verify_votes_optimistic(vote_payload_to_sign, &unverified_votes, stats, thread_pool);
+    let res = verify_votes_optimistic(
+        vote_payload_to_sign,
+        &unverified_votes,
+        &mut stats,
+        thread_pool,
+    );
 
     match res {
         Either::Left(signature) => {
@@ -234,10 +360,13 @@ fn verify_votes(
                 .into_iter()
                 .map(|v| v.sender_vote_account_pubkey)
                 .collect();
-            vec![VerifiedVotePayload {
-                vote_aggregate,
-                sender_vote_account_pubkeys,
-            }]
+            (
+                vec![VerifiedVotePayload {
+                    vote_aggregate,
+                    sender_vote_account_pubkeys,
+                }],
+                stats,
+            )
         }
         Either::Right(prepared_hash_msg) => {
             // Fallback to individual verification
@@ -259,7 +388,7 @@ fn verify_votes(
                 );
             }
             stats.fn_verify_individual_votes_stats.add_sample(time_us);
-            verified_votes
+            (verified_votes, stats)
         }
     }
 }
@@ -280,7 +409,7 @@ fn verify_votes(
 fn verify_votes_optimistic(
     vote_payload_to_sign: VotePayloadToSign,
     unverified_votes: &[UnverifiedVotePayload],
-    stats: &mut SigVerifyVoteStats,
+    stats: &mut VoteVerificationStats,
     thread_pool: &ThreadPool,
 ) -> Either<SignatureProjective, PreparedHashedMessage> {
     #[cfg(debug_assertions)]

--- a/bls-sigverify/src/errors.rs
+++ b/bls-sigverify/src/errors.rs
@@ -13,19 +13,13 @@ pub(super) enum SigVerifyError {
 #[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
 pub(super) enum SigVerifyVoteError {
-    #[error("channel to consensus pool disconnected")]
-    ConsensusPoolChannelDisconnected,
-    #[error("channel to rewards container disconnected")]
-    RewardsChannelDisconnected,
-    #[error("channel to repair disconnected")]
-    RepairChannelDisconnected,
-    #[error("channel to metrics disconnected")]
-    MetricsChannelDisconnected,
+    #[error("channel \"{0}\" disconnected")]
+    ChannelDisconnected(&'static str),
 }
 
 /// Different types of errors that sig verifying certs can fail with.
 #[derive(Debug, Error)]
 pub(super) enum SigVerifyCertError {
-    #[error("channel to consensus pool disconnected")]
-    ConsensusPoolChannelDisconnected,
+    #[error("channel \"{0}\" disconnected")]
+    ChannelDisconnected(&'static str),
 }

--- a/bls-sigverify/src/stats.rs
+++ b/bls-sigverify/src/stats.rs
@@ -199,7 +199,7 @@ impl SigVerifierStats {
 }
 
 /// Stats from sigverifying certs.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(super) struct SigVerifyCertStats {
     /// Number of certs [`verify_and_send_certificates`] attempted to verify the signature of.
     pub(super) certs_to_sig_verify: Saturating<u64>,
@@ -219,12 +219,7 @@ pub(super) struct SigVerifyCertStats {
     /// Number of times the cert was too far in the future and discarded.
     pub(super) too_far_in_future: Saturating<u64>,
 
-    /// How many messages are outstanding on the channel.
-    pub(super) pool_outstanding_msgs: Saturating<u64>,
-    /// Number of votes sent successfully over the channel to consensus pool.
-    pub(super) pool_sent: Saturating<u64>,
-    /// Number of times the channel to consensus pool was full and we resorted to blocking send.
-    pub(super) pool_channel_full: Saturating<u64>,
+    pub(super) pool_sender: SenderStats,
 
     /// Stats for [`verify_and_send_certificates`].
     pub(super) fn_verify_and_send_certs_stats: WelfordStats,
@@ -240,9 +235,7 @@ impl SigVerifyCertStats {
             banning_validator,
             certificate_verification_failed,
             too_far_in_future,
-            pool_outstanding_msgs,
-            pool_sent,
-            pool_channel_full,
+            pool_sender,
             fn_verify_and_send_certs_stats,
         } = other;
         self.certs_to_sig_verify += certs_to_sig_verify;
@@ -252,9 +245,7 @@ impl SigVerifyCertStats {
         self.banning_validator += banning_validator;
         self.certificate_verification_failed += certificate_verification_failed;
         self.too_far_in_future += too_far_in_future;
-        self.pool_outstanding_msgs += pool_outstanding_msgs;
-        self.pool_sent += pool_sent;
-        self.pool_channel_full += pool_channel_full;
+        self.pool_sender.merge(pool_sender);
         self.fn_verify_and_send_certs_stats
             .merge(fn_verify_and_send_certs_stats);
     }
@@ -268,12 +259,11 @@ impl SigVerifyCertStats {
             banning_validator,
             certificate_verification_failed,
             too_far_in_future,
-            pool_outstanding_msgs,
-            pool_sent,
-            pool_channel_full,
+            pool_sender,
             fn_verify_and_send_certs_stats,
         } = self;
 
+        pool_sender.report();
         datapoint_info!(
             "bls_cert_sigverify_stats",
             ("certs_to_sig_verify", certs_to_sig_verify.0, i64),
@@ -291,9 +281,6 @@ impl SigVerifyCertStats {
                 i64
             ),
             ("too_far_in_future", too_far_in_future.0, i64),
-            ("pool_outstanding_msgs", pool_outstanding_msgs.0, i64),
-            ("pool_sent", pool_sent.0, i64),
-            ("pool_channel_full", pool_channel_full.0, i64),
             (
                 "fn_verify_and_send_certs_count",
                 fn_verify_and_send_certs_stats.count(),
@@ -308,13 +295,25 @@ impl SigVerifyCertStats {
     }
 }
 
-/// Stats from sigverifying votes.
+impl Default for SigVerifyCertStats {
+    fn default() -> Self {
+        Self {
+            certs_to_sig_verify: Saturating(0),
+            sig_verified_certs: Saturating(0),
+            unnecessary_certs_verified: Saturating(0),
+            redundant_certs_skipped: Saturating(0),
+            banning_validator: Saturating(0),
+            certificate_verification_failed: Saturating(0),
+            too_far_in_future: Saturating(0),
+            pool_sender: new_cert_stats_pool_sender_stats(),
+            fn_verify_and_send_certs_stats: WelfordStats::default(),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-pub(super) struct SigVerifyVoteStats {
-    /// Number of votes [`verify_and_send_votes`] was requested to verify the signature of.
-    pub(super) votes_to_sig_verify: Saturating<u64>,
-
+pub(super) struct VoteVerificationStats {
     /// Number of times optimistic verification succeeded
     pub(super) optimistic_verification_succeeded: Saturating<u64>,
     /// Number of times optimistic verification failed
@@ -323,113 +322,48 @@ pub(super) struct SigVerifyVoteStats {
     pub(super) optimistic_batch: WelfordStats,
     /// Number of votes that were individually verified.
     pub(super) num_individual_verified: Saturating<u64>,
-
     /// Number of times we are banning a validator.
     pub(super) banning_validator: Saturating<u64>,
-
-    /// Number of votes sent successfully over the channel to metrics.
-    pub(super) metrics_sent: Saturating<u64>,
-    /// Number of times the channel to metrics was full.
-    pub(super) metrics_channel_full: Saturating<u64>,
-    /// Number of votes sent successfully over the channel to rewards.
-    pub(super) rewards_sent: Saturating<u64>,
-    /// Number of times the channel to rewards was full.
-    pub(super) rewards_channel_full: Saturating<u64>,
-    /// How many messages are outstanding on the channel.
-    pub(super) pool_outstanding_msgs: Saturating<u64>,
-    /// Number of votes sent successfully over the channel to consensus pool.
-    pub(super) pool_sent: Saturating<u64>,
-    /// Number of times the channel to consensus pool was full and we resorted to blocking send.
-    pub(super) pool_channel_full: Saturating<u64>,
-    /// Number of votes sent successfully over the channel to repair.
-    pub(super) repair_sent: Saturating<u64>,
-    /// Number of times the channel to repair was full.
-    pub(super) repair_channel_full: Saturating<u64>,
-
-    /// Stats for [`verify_and_send_votes`].
-    pub(super) fn_verify_and_send_votes_stats: WelfordStats,
     /// Stats for [`verify_votes_optimistic`].
     pub(super) fn_verify_votes_optimistic_stats: WelfordStats,
-
     /// Stats for [`verify_individual_votes`].
     pub(super) fn_verify_individual_votes_stats: WelfordStats,
-
-    /// Stats for number of distinct votes in batches.
-    pub(super) distinct_votes_stats: WelfordStats,
 }
 
-impl SigVerifyVoteStats {
+impl VoteVerificationStats {
     pub(super) fn merge(&mut self, other: Self) {
         let Self {
-            votes_to_sig_verify,
             optimistic_verification_succeeded,
             optimistic_verification_failed,
             optimistic_batch,
             num_individual_verified,
             banning_validator,
-            metrics_sent,
-            metrics_channel_full,
-            rewards_sent,
-            rewards_channel_full,
-            repair_sent,
-            repair_channel_full,
-            pool_outstanding_msgs,
-            pool_sent,
-            pool_channel_full,
-            fn_verify_and_send_votes_stats,
             fn_verify_votes_optimistic_stats,
             fn_verify_individual_votes_stats,
-            distinct_votes_stats,
         } = other;
-        self.votes_to_sig_verify += votes_to_sig_verify;
         self.optimistic_verification_succeeded += optimistic_verification_succeeded;
         self.optimistic_verification_failed += optimistic_verification_failed;
         self.optimistic_batch.merge(optimistic_batch);
         self.num_individual_verified += num_individual_verified;
         self.banning_validator += banning_validator;
-        self.metrics_sent += metrics_sent;
-        self.metrics_channel_full += metrics_channel_full;
-        self.rewards_sent += rewards_sent;
-        self.rewards_channel_full += rewards_channel_full;
-        self.repair_sent += repair_sent;
-        self.repair_channel_full += repair_channel_full;
-        self.pool_outstanding_msgs += pool_outstanding_msgs;
-        self.pool_sent += pool_sent;
-        self.pool_channel_full += pool_channel_full;
-        self.fn_verify_and_send_votes_stats
-            .merge(fn_verify_and_send_votes_stats);
         self.fn_verify_votes_optimistic_stats
             .merge(fn_verify_votes_optimistic_stats);
         self.fn_verify_individual_votes_stats
             .merge(fn_verify_individual_votes_stats);
-        self.distinct_votes_stats.merge(distinct_votes_stats);
     }
 
     pub(super) fn report(&self) {
         let Self {
-            votes_to_sig_verify,
             optimistic_verification_succeeded,
             optimistic_verification_failed,
             optimistic_batch,
             num_individual_verified,
             banning_validator,
-            metrics_sent,
-            metrics_channel_full,
-            rewards_sent,
-            rewards_channel_full,
-            repair_sent,
-            repair_channel_full,
-            pool_outstanding_msgs,
-            pool_sent,
-            pool_channel_full,
-            fn_verify_and_send_votes_stats,
             fn_verify_votes_optimistic_stats,
             fn_verify_individual_votes_stats,
-            distinct_votes_stats,
         } = self;
         datapoint_info!(
-            "bls_vote_sigverify_stats",
-            ("votes_to_sig_verify", votes_to_sig_verify.0, i64),
+            "bls_vote_sigverify_verification_stats",
             (
                 "optimistic_verification_succeeded",
                 optimistic_verification_succeeded.0,
@@ -448,25 +382,6 @@ impl SigVerifyVoteStats {
             ),
             ("num_individual_verified", num_individual_verified.0, i64),
             ("banning_validator", banning_validator.0, i64),
-            ("metrics_sent", metrics_sent.0, i64),
-            ("metrics_channel_full", metrics_channel_full.0, i64),
-            ("rewards_sent", rewards_sent.0, i64),
-            ("rewards_channel_full", rewards_channel_full.0, i64),
-            ("repair_sent", repair_sent.0, i64),
-            ("repair_channel_full", repair_channel_full.0, i64),
-            ("pool_outstanding_msgs", pool_outstanding_msgs.0, i64),
-            ("pool_sent", pool_sent.0, i64),
-            ("pool_channel_full", pool_channel_full.0, i64),
-            (
-                "fn_verify_and_send_votes_count",
-                fn_verify_and_send_votes_stats.count(),
-                i64
-            ),
-            (
-                "fn_verify_and_send_votes_mean",
-                fn_verify_and_send_votes_stats.mean().unwrap_or(0),
-                i64
-            ),
             (
                 "fn_verify_votes_optimistic_count",
                 fn_verify_votes_optimistic_stats.count(),
@@ -487,12 +402,161 @@ impl SigVerifyVoteStats {
                 fn_verify_individual_votes_stats.mean().unwrap_or(0),
                 i64
             ),
+        );
+    }
+}
+
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
+/// Stats from sigverifying votes.
+pub(super) struct SigVerifyVoteStats {
+    /// Number of votes [`verify_and_send_votes`] was requested to verify the signature of.
+    pub(super) votes_to_sig_verify: Saturating<u64>,
+    pub(super) senders: VoteSenderStats,
+    /// Stats for [`verify_and_send_votes`].
+    pub(super) fn_verify_and_send_votes_stats: WelfordStats,
+    /// Stats for number of distinct votes in batches.
+    pub(super) distinct_votes_stats: WelfordStats,
+    pub(super) vote_verification_stats: VoteVerificationStats,
+}
+
+impl SigVerifyVoteStats {
+    pub(super) fn merge(&mut self, other: Self) {
+        let Self {
+            votes_to_sig_verify,
+            fn_verify_and_send_votes_stats,
+            distinct_votes_stats,
+            senders,
+            vote_verification_stats,
+        } = other;
+        self.votes_to_sig_verify += votes_to_sig_verify;
+        self.fn_verify_and_send_votes_stats
+            .merge(fn_verify_and_send_votes_stats);
+        self.distinct_votes_stats.merge(distinct_votes_stats);
+        self.senders.merge(senders);
+        self.vote_verification_stats.merge(vote_verification_stats);
+    }
+
+    pub(super) fn report(&self) {
+        let Self {
+            votes_to_sig_verify,
+            fn_verify_and_send_votes_stats,
+            distinct_votes_stats,
+            senders,
+            vote_verification_stats,
+        } = self;
+        senders.report();
+        vote_verification_stats.report();
+        datapoint_info!(
+            "bls_vote_sigverify_stats",
+            ("votes_to_sig_verify", votes_to_sig_verify.0, i64),
+            (
+                "fn_verify_and_send_votes_count",
+                fn_verify_and_send_votes_stats.count(),
+                i64
+            ),
+            (
+                "fn_verify_and_send_votes_mean",
+                fn_verify_and_send_votes_stats.mean().unwrap_or(0),
+                i64
+            ),
             ("distinct_votes_count", distinct_votes_stats.count(), i64),
             (
                 "distinct_votes_mean",
                 distinct_votes_stats.mean().unwrap_or(0),
                 i64
             ),
+        );
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct VoteSenderStats {
+    pub(super) metrics_sender: SenderStats,
+    pub(super) rewards_sender: SenderStats,
+    pub(super) pool_sender: SenderStats,
+    pub(super) repair_sender: SenderStats,
+}
+
+impl VoteSenderStats {
+    pub(super) fn merge(&mut self, other: Self) {
+        let Self {
+            metrics_sender,
+            rewards_sender,
+            pool_sender,
+            repair_sender,
+        } = other;
+        self.metrics_sender.merge(metrics_sender);
+        self.rewards_sender.merge(rewards_sender);
+        self.pool_sender.merge(pool_sender);
+        self.repair_sender.merge(repair_sender);
+    }
+
+    pub(super) fn report(&self) {
+        let Self {
+            metrics_sender,
+            rewards_sender,
+            pool_sender,
+            repair_sender,
+        } = self;
+        metrics_sender.report();
+        rewards_sender.report();
+        pool_sender.report();
+        repair_sender.report();
+    }
+}
+
+impl Default for VoteSenderStats {
+    fn default() -> Self {
+        Self {
+            metrics_sender: SenderStats::new("bls_vote_sigverify_metrics_sender_stats"),
+            rewards_sender: SenderStats::new("bls_vote_sigverify_rewards_sender_stats"),
+            repair_sender: SenderStats::new("bls_vote_sigverify_repair_sender_stats"),
+            pool_sender: SenderStats::new("bls_vote_sigverify_pool_sender_stats"),
+        }
+    }
+}
+
+fn new_cert_stats_pool_sender_stats() -> SenderStats {
+    SenderStats::new("bls_cert_sigverify_pool_sender_stats")
+}
+
+#[derive(Debug)]
+pub(crate) struct SenderStats {
+    name: &'static str,
+    pub(super) sent: Saturating<u64>,
+    pub(super) channel_full: Saturating<u64>,
+}
+
+impl SenderStats {
+    pub(crate) fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            sent: Saturating(0),
+            channel_full: Saturating(0),
+        }
+    }
+
+    pub(super) fn merge(&mut self, other: Self) {
+        let Self {
+            sent,
+            channel_full,
+            name: _,
+        } = other;
+        self.sent += sent;
+        self.channel_full += channel_full;
+    }
+
+    pub(super) fn report(&self) {
+        let Self {
+            sent,
+            channel_full,
+            name,
+        } = self;
+        datapoint_info!(
+            name,
+            ("sent", sent.0, i64),
+            ("channel_full", channel_full.0, i64),
         );
     }
 }

--- a/bls-sigverify/src/utils.rs
+++ b/bls-sigverify/src/utils.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         errors::{SigVerifyCertError, SigVerifyVoteError},
         rewards::RewardInput,
-        stats::{SigVerifyCertStats, SigVerifyVoteStats},
+        stats::{SenderStats, VoteSenderStats},
     },
     agave_votor_messages::{
         VerifiedVoterSlotsSender,
@@ -10,52 +10,46 @@ use {
         sig_verified_messages::{SigVerifiedBatch, VoteAggregate},
     },
     crossbeam_channel::{Sender, TrySendError},
-    log::{error, info},
+    log::{error, info, warn},
     solana_clock::Slot,
     solana_pubkey::Pubkey,
-    std::{collections::HashMap, num::Saturating, time::Instant},
+    std::{collections::HashMap, time::Instant},
 };
 
 pub(super) fn send_votes_to_metrics(
+    my_pubkey: &Pubkey,
     votes: Vec<ConsensusMetricsEvent>,
     channel: &ConsensusMetricsEventSender,
-    stats: &mut SigVerifyVoteStats,
-) -> Result<(), SigVerifyVoteError> {
+    stats: &mut VoteSenderStats,
+) {
     let len = votes.len();
     let msg = (Instant::now(), votes);
     match channel.try_send(msg) {
-        Ok(()) => {
-            stats.metrics_sent += len as u64;
-            Ok(())
+        Ok(()) => stats.metrics_sender.sent += len as u64,
+        Err(TrySendError::Full(_)) => stats.metrics_sender.channel_full += 1,
+        Err(TrySendError::Disconnected(_)) => {
+            warn!("{my_pubkey}: channel \"channel_to_metrics\" disconnected");
         }
-        Err(TrySendError::Full(_)) => {
-            stats.metrics_channel_full += 1;
-            Ok(())
-        }
-        Err(TrySendError::Disconnected(_)) => Err(SigVerifyVoteError::MetricsChannelDisconnected),
     }
 }
 
 pub(super) fn send_votes_to_rewards(
+    my_pubkey: &Pubkey,
     votes: Vec<VoteAggregate>,
     channel: &Sender<RewardInput>,
-    stats: &mut SigVerifyVoteStats,
-) -> Result<(), SigVerifyVoteError> {
+    stats: &mut VoteSenderStats,
+) {
     if votes.is_empty() {
-        return Ok(());
+        return;
     }
     let len = votes.len();
     let msg = RewardInput::External(votes);
     match channel.try_send(msg) {
-        Ok(()) => {
-            stats.rewards_sent += len as u64;
-            Ok(())
+        Ok(()) => stats.rewards_sender.sent += len as u64,
+        Err(TrySendError::Full(_)) => stats.rewards_sender.channel_full += 1,
+        Err(TrySendError::Disconnected(_)) => {
+            warn!("{my_pubkey}: channel \"channel_to_rewards\" disconnected");
         }
-        Err(TrySendError::Full(_)) => {
-            stats.rewards_channel_full += 1;
-            Ok(())
-        }
-        Err(TrySendError::Disconnected(_)) => Err(SigVerifyVoteError::RewardsChannelDisconnected),
     }
 }
 
@@ -64,88 +58,85 @@ pub(super) fn send_votes_to_rewards(
 pub(super) fn send_sig_verified_batch_to_pool(
     batch: SigVerifiedBatch,
     channel: &Sender<SigVerifiedBatch>,
-    stats: &mut SigVerifyVoteStats,
+    stats: &mut VoteSenderStats,
 ) -> Result<(), SigVerifyVoteError> {
+    let channel_name = "channel_to_pool";
     if batch.is_empty() {
         return Ok(());
     }
     let len = batch.len();
     match channel.try_send(batch) {
         Ok(()) => {
-            stats.pool_sent += len as u64;
-            stats.pool_outstanding_msgs = Saturating(channel.len() as u64);
+            stats.pool_sender.sent += len as u64;
             Ok(())
         }
         Err(TrySendError::Full(msgs)) => {
-            stats.pool_channel_full += 1;
-            error!("votes channel to consensus pool is full.  Doing a blocking send.");
+            stats.pool_sender.channel_full += 1;
+            error!("channel \"{channel_name}\" is full.  Doing a blocking send.");
             match channel.send(msgs) {
                 Ok(()) => {
-                    info!("votes channel to consensus pool has space again");
-                    stats.pool_sent += len as u64;
+                    info!("channel \"{channel_name}\" has space again");
+                    stats.pool_sender.sent += len as u64;
                     Ok(())
                 }
-                Err(_) => Err(SigVerifyVoteError::ConsensusPoolChannelDisconnected),
+                Err(_) => Err(SigVerifyVoteError::ChannelDisconnected(channel_name)),
             }
         }
         Err(TrySendError::Disconnected(_)) => {
-            Err(SigVerifyVoteError::ConsensusPoolChannelDisconnected)
+            Err(SigVerifyVoteError::ChannelDisconnected(channel_name))
         }
     }
 }
 
 pub(super) fn send_votes_to_repair(
+    my_pubkey: &Pubkey,
     votes: HashMap<Pubkey, Vec<Slot>>,
     channel: &VerifiedVoterSlotsSender,
-    stats: &mut SigVerifyVoteStats,
-) -> Result<(), SigVerifyVoteError> {
+    stats: &mut VoteSenderStats,
+) {
     for (pubkey, slots) in votes {
         match channel.try_send((pubkey, slots)) {
-            Ok(()) => {
-                stats.repair_sent += 1;
-            }
-            Err(TrySendError::Full(_)) => {
-                stats.repair_channel_full += 1;
-            }
+            Ok(()) => stats.repair_sender.sent += 1,
+            Err(TrySendError::Full(_)) => stats.repair_sender.channel_full += 1,
             Err(TrySendError::Disconnected(_)) => {
-                return Err(SigVerifyVoteError::RepairChannelDisconnected);
+                warn!("{my_pubkey}: channel \"channel_to_repair\" disconnected");
+                return;
             }
         }
     }
-    Ok(())
 }
 
 /// Sends the `batch` to the consensus pool.  If the channel is bounded and full, then does a
 /// blocking send.
 pub(super) fn send_certs_to_pool(
     batch: SigVerifiedBatch,
-    channel_to_pool: &Sender<SigVerifiedBatch>,
-    stats: &mut SigVerifyCertStats,
+    channel: &Sender<SigVerifiedBatch>,
+    stats: &mut SenderStats,
 ) -> Result<(), SigVerifyCertError> {
+    let channel_name = "channel_to_pool";
     if batch.is_empty() {
         return Ok(());
     }
     let len = batch.len();
-    match channel_to_pool.try_send(batch) {
+    match channel.try_send(batch) {
         Ok(()) => {
-            stats.pool_sent += len as u64;
-            stats.pool_outstanding_msgs = Saturating(channel_to_pool.len() as u64);
+            stats.sent += len as u64;
             Ok(())
         }
         Err(TrySendError::Full(msgs)) => {
-            stats.pool_channel_full += 1;
-            error!("certs channel to consensus pool is full.  Doing a blocking send.");
-            match channel_to_pool.send(msgs) {
+            stats.channel_full += 1;
+            error!("channel \"{channel_name}\" is full.  Doing a blocking send.");
+            match channel.send(msgs) {
                 Ok(()) => {
-                    info!("certs channel to consensus pool has space again");
-                    stats.pool_sent += len as u64;
+                    info!("channel \"{channel_name}\" has space again");
+                    stats.sent += len as u64;
                     Ok(())
                 }
-                Err(_) => Err(SigVerifyCertError::ConsensusPoolChannelDisconnected),
+                Err(_) => Err(SigVerifyCertError::ChannelDisconnected(channel_name)),
             }
         }
         Err(TrySendError::Disconnected(_)) => {
-            Err(SigVerifyCertError::ConsensusPoolChannelDisconnected)
+            Err(SigVerifyCertError::ChannelDisconnected(channel_name))
         }
     }
 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -358,14 +358,14 @@ impl Tvu {
                 num_threads: tvu_config.bls_sigverify_threads.get(),
                 generated_cert_types: generated_cert_types.clone(),
             },
-            SigVerifierChannels {
-                packet_receiver: votor_ingress_receiver,
+            SigVerifierChannels::new(
+                votor_ingress_receiver,
                 certificate_receiver,
-                channel_to_repair: verified_voter_slots_sender,
-                channel_to_reward: reward_aggregates_sender.clone(),
-                channel_to_pool: consensus_message_sender,
-                channel_to_metrics: consensus_metrics_sender.clone(),
-            },
+                verified_voter_slots_sender,
+                reward_aggregates_sender.clone(),
+                consensus_message_sender,
+                consensus_metrics_sender.clone(),
+            ),
         );
 
         let (fetch_sender, fetch_receiver) = EvictingSender::new_bounded(SHRED_FETCH_CHANNEL_SIZE);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -70,11 +70,11 @@ pub(crate) enum PoolMessage {
 /// Maximum number of messages to process from a selected message channel before
 /// returning to channel selection. This keeps a continuously busy channel from
 /// starving the other consensus pool input channel.
-const MAX_MESSAGES_PER_RECEIVE: usize = 128;
+const MAX_MESSAGES_PER_RECEIVE: u64 = 128;
 
 /// Number of additional messages to drain from the selected message channel
 /// after receiving the first message.
-const ADDITIONAL_MESSAGES_PER_RECEIVE: usize = MAX_MESSAGES_PER_RECEIVE - 1;
+const ADDITIONAL_MESSAGES_PER_RECEIVE: u64 = MAX_MESSAGES_PER_RECEIVE - 1;
 
 /// Inputs for the consensus pool and consensus pool service
 pub(crate) struct ConsensusPoolContext {
@@ -567,14 +567,13 @@ impl ConsensusPoolService {
             return Err("own_vote_receiver");
         };
 
-        let mut received_messages: usize = 0;
+        let mut own_votes_received = 0u64;
         for msg in std::iter::once(first).chain(
             ctx.own_votes_receiver
                 .try_iter()
-                .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
+                .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
-            received_messages = received_messages.saturating_add(1);
-            stats.received_vote_aggregates += 1;
+            own_votes_received = own_votes_received.saturating_add(1);
             let pool_msg = PoolMessage::Votes(vec![PoolVote::Own(msg)]);
             let root_bank = ctx.sharable_banks.root();
             let (new_finalized_slot, new_certificates_to_send) = Self::add_pool_msg(
@@ -594,8 +593,8 @@ impl ConsensusPoolService {
                 stats,
             )?;
         }
-        stats.received_own_messages += received_messages;
-        if received_messages == MAX_MESSAGES_PER_RECEIVE {
+        stats.own_votes_received += own_votes_received;
+        if own_votes_received >= MAX_MESSAGES_PER_RECEIVE {
             stats.own_message_receive_limit_reached += 1;
         }
         Ok(())
@@ -613,14 +612,13 @@ impl ConsensusPoolService {
             return Err("footer_certs_receiver");
         };
 
-        let mut received_messages: usize = 0;
+        let mut footer_certs_received = 0u64;
         for certs in std::iter::once(first).chain(
             ctx.footer_certs_receiver
                 .try_iter()
-                .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
+                .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
-            received_messages = received_messages.saturating_add(1);
-            stats.received_certificates += certs.len();
+            footer_certs_received = footer_certs_received.saturating_add(1);
             let pool_msg = PoolMessage::Certificates(certs.to_vec());
             let root_bank = ctx.sharable_banks.root();
             let (new_finalized_slot, new_certificates_to_send) = Self::add_pool_msg(
@@ -640,8 +638,8 @@ impl ConsensusPoolService {
                 stats,
             )?;
         }
-        stats.received_own_messages += received_messages;
-        if received_messages == MAX_MESSAGES_PER_RECEIVE {
+        stats.footer_certs_received += footer_certs_received;
+        if footer_certs_received >= MAX_MESSAGES_PER_RECEIVE {
             stats.own_message_receive_limit_reached += 1;
         }
         Ok(())
@@ -659,20 +657,17 @@ impl ConsensusPoolService {
             return Err("consensus_message_receiver");
         };
 
-        let mut received_batches: usize = 0;
-        for batch in std::iter::once(first).chain(
-            ctx.consensus_message_receiver
-                .try_iter()
-                .take(ADDITIONAL_MESSAGES_PER_RECEIVE),
-        ) {
-            received_batches = received_batches.saturating_add(1);
+        let mut msgs_received = 0u64;
+        for batch in std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()) {
             let msg = match batch {
                 SigVerifiedBatch::Votes(votes) => {
-                    stats.received_vote_aggregates += votes.len();
+                    stats.vote_aggregates_received += votes.len() as u64;
+                    msgs_received = msgs_received.saturating_add(votes.len() as u64);
                     PoolMessage::Votes(votes.into_iter().map(PoolVote::External).collect())
                 }
                 SigVerifiedBatch::Certificates(certs) => {
-                    stats.received_certificates += certs.len();
+                    stats.certs_received += certs.len() as u64;
+                    msgs_received = msgs_received.saturating_add(certs.len() as u64);
                     PoolMessage::Certificates(certs)
                 }
             };
@@ -693,10 +688,10 @@ impl ConsensusPoolService {
                 standstill_timer,
                 stats,
             )?;
-        }
-        stats.received_consensus_message_batches += received_batches;
-        if received_batches == MAX_MESSAGES_PER_RECEIVE {
-            stats.consensus_message_batch_receive_limit_reached += 1;
+            if msgs_received >= MAX_MESSAGES_PER_RECEIVE {
+                stats.consensus_message_batch_receive_limit_reached += 1;
+                break;
+            }
         }
         Ok(())
     }
@@ -768,7 +763,7 @@ mod tests {
         ctx: ConsensusPoolContext,
         bls_receiver: Receiver<BLSOp>,
         consensus_message_sender: Sender<SigVerifiedBatch>,
-        _own_votes_sender: Sender<VoteMessage>,
+        own_votes_sender: Sender<VoteMessage>,
         footer_certs_sender: Sender<SmallVec<[Certificate; 2]>>,
         event_receiver: Receiver<VotorEvent>,
         _repair_event_receiver: Receiver<RepairEvent>,
@@ -835,7 +830,7 @@ mod tests {
                 ctx,
                 bls_receiver,
                 consensus_message_sender,
-                _own_votes_sender: own_votes_sender,
+                own_votes_sender,
                 footer_certs_sender,
                 event_receiver,
                 _repair_event_receiver: repair_event_receiver,
@@ -987,47 +982,141 @@ mod tests {
     }
 
     #[test]
-    fn test_receive_msgs_limits_consensus_batches_per_call() {
+    fn test_receive_own_votes_limits_messages_per_call() {
         let mut ctx = TestContext::default();
+        let vote = Vote::new_notarization_vote(Block {
+            slot: 1,
+            block_id: Hash::new_unique(),
+        });
+        let root_bank = ctx.ctx.sharable_banks.root();
+        let rank_map = root_bank.get_rank_map(vote.slot()).unwrap();
+        let stake = rank_map.get_pubkey_stake_entry(0).unwrap().stake;
+        let bls_keypair = BLSKeypair::derive_from_signer(
+            &ctx.validator_keypairs[0].vote_keypair,
+            BLS_KEYPAIR_DERIVE_SEED,
+        )
+        .unwrap();
+        let vote_message = VoteMessage {
+            vote,
+            signature: bls_keypair
+                .sign(&get_vote_payload_to_sign(
+                    vote,
+                    ctx.ctx.cluster_info.my_shred_version(),
+                ))
+                .into(),
+            rank: 0,
+            stake,
+        };
 
         for _ in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
+            ctx.own_votes_sender.send(vote_message.clone()).unwrap();
+        }
+
+        let mut events = vec![];
+        let mut standstill_timer = Instant::now();
+        let mut stats = ConsensusPoolServiceStats::new();
+        let msg = ctx.ctx.own_votes_receiver.recv();
+
+        ConsensusPoolService::receive_own_votes(
+            &mut ctx.ctx,
+            &mut ctx.consensus_pool,
+            &mut events,
+            &mut standstill_timer,
+            &mut stats,
+            msg,
+        )
+        .unwrap();
+
+        assert_eq!(ctx.ctx.own_votes_receiver.len(), 1);
+        assert_eq!(stats.own_votes_received.0, MAX_MESSAGES_PER_RECEIVE);
+        assert_eq!(stats.own_message_receive_limit_reached.0, 1);
+    }
+
+    #[test]
+    fn test_receive_consensus_msgs_limits_messages_per_call() {
+        let mut ctx = TestContext::default();
+
+        for slot in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
             ctx.consensus_message_sender
-                .send(SigVerifiedBatch::Votes(vec![]))
+                .send(SigVerifiedBatch::Certificates(vec![Certificate {
+                    cert_type: CertificateType::Skip(slot),
+                    signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                    bitmap: vec![],
+                }]))
                 .unwrap();
         }
 
         let mut events = vec![];
         let mut standstill_timer = Instant::now();
         let mut stats = ConsensusPoolServiceStats::new();
+        let msg = ctx.ctx.consensus_message_receiver.recv();
 
-        ConsensusPoolService::receive_msgs(
+        ConsensusPoolService::receive_consensus_msgs(
             &mut ctx.ctx,
             &mut ctx.consensus_pool,
             &mut events,
             &mut standstill_timer,
             &mut stats,
-            Duration::ZERO,
+            msg,
         )
         .unwrap();
 
         assert_eq!(ctx.ctx.consensus_message_receiver.len(), 1);
-        assert_eq!(stats.received_own_messages.0, 0);
-        assert_eq!(
-            stats.received_consensus_message_batches.0,
-            MAX_MESSAGES_PER_RECEIVE
-        );
-        assert_eq!(stats.own_message_receive_limit_reached.0, 0);
+        assert_eq!(stats.certs_received.0, MAX_MESSAGES_PER_RECEIVE);
         assert_eq!(stats.consensus_message_batch_receive_limit_reached.0, 1);
     }
 
     #[test]
-    fn test_receive_msgs_limits_own_messages_per_call() {
+    fn test_receive_consensus_msgs_stops_after_crossing_message_limit() {
+        for batch_sizes in [
+            vec![MAX_MESSAGES_PER_RECEIVE + 1, 1],
+            vec![MAX_MESSAGES_PER_RECEIVE - 28, 29, 1],
+        ] {
+            let mut ctx = TestContext::default();
+            let mut slot = 0;
+            for batch_size in batch_sizes {
+                let certs = (slot..slot + batch_size)
+                    .map(|slot| Certificate {
+                        cert_type: CertificateType::Skip(slot),
+                        signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                        bitmap: vec![],
+                    })
+                    .collect();
+                ctx.consensus_message_sender
+                    .send(SigVerifiedBatch::Certificates(certs))
+                    .unwrap();
+                slot += batch_size;
+            }
+
+            let mut events = vec![];
+            let mut standstill_timer = Instant::now();
+            let mut stats = ConsensusPoolServiceStats::new();
+            let msg = ctx.ctx.consensus_message_receiver.recv();
+
+            ConsensusPoolService::receive_consensus_msgs(
+                &mut ctx.ctx,
+                &mut ctx.consensus_pool,
+                &mut events,
+                &mut standstill_timer,
+                &mut stats,
+                msg,
+            )
+            .unwrap();
+
+            assert_eq!(ctx.ctx.consensus_message_receiver.len(), 1);
+            assert_eq!(stats.certs_received.0, MAX_MESSAGES_PER_RECEIVE + 1);
+            assert_eq!(stats.consensus_message_batch_receive_limit_reached.0, 1);
+        }
+    }
+
+    #[test]
+    fn test_receive_footer_certs_limits_messages_per_call() {
         let mut ctx = TestContext::default();
 
         for slot in 0..MAX_MESSAGES_PER_RECEIVE + 1 {
             ctx.footer_certs_sender
                 .send(smallvec![Certificate {
-                    cert_type: CertificateType::Skip(slot.try_into().unwrap()),
+                    cert_type: CertificateType::Skip(slot),
                     signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
                     bitmap: vec![],
                 }])
@@ -1038,21 +1127,21 @@ mod tests {
         let mut standstill_timer = Instant::now();
         let mut stats = ConsensusPoolServiceStats::new();
 
-        ConsensusPoolService::receive_msgs(
+        let msg = ctx.ctx.footer_certs_receiver.recv();
+
+        ConsensusPoolService::receive_footer_certs(
             &mut ctx.ctx,
             &mut ctx.consensus_pool,
             &mut events,
             &mut standstill_timer,
             &mut stats,
-            Duration::ZERO,
+            msg,
         )
         .unwrap();
 
         assert_eq!(ctx.ctx.footer_certs_receiver.len(), 1);
-        assert_eq!(stats.received_own_messages.0, MAX_MESSAGES_PER_RECEIVE);
-        assert_eq!(stats.received_consensus_message_batches.0, 0);
+        assert_eq!(stats.footer_certs_received.0, MAX_MESSAGES_PER_RECEIVE);
         assert_eq!(stats.own_message_receive_limit_reached.0, 1);
-        assert_eq!(stats.consensus_message_batch_receive_limit_reached.0, 0);
     }
 
     #[test]

--- a/votor/src/consensus_pool_service/stats.rs
+++ b/votor/src/consensus_pool_service/stats.rs
@@ -17,16 +17,17 @@ pub(super) struct ConsensusPoolServiceStats {
     pub(super) new_finalized_slot: Saturating<usize>,
     pub(super) parent_ready_missed_window: Saturating<usize>,
     pub(super) parent_ready_produce_window: Saturating<usize>,
-    pub(super) received_vote_aggregates: Saturating<usize>,
-    pub(super) received_own_messages: Saturating<usize>,
-    pub(super) received_consensus_message_batches: Saturating<usize>,
-    pub(super) own_message_receive_limit_reached: Saturating<usize>,
-    pub(super) consensus_message_batch_receive_limit_reached: Saturating<usize>,
-    pub(super) received_certificates: Saturating<usize>,
+    pub(super) own_votes_received: Saturating<u64>,
+    pub(super) footer_certs_received: Saturating<u64>,
+    pub(super) vote_aggregates_received: Saturating<u64>,
+    pub(super) certs_received: Saturating<u64>,
+    pub(super) own_message_receive_limit_reached: Saturating<u64>,
+    pub(super) consensus_message_batch_receive_limit_reached: Saturating<u64>,
     pub(super) standstill: bool,
     pub(super) prune_old_state_called: Saturating<usize>,
     pub(crate) pending_safe_to_notar_repair_sent: Saturating<usize>,
     pub(crate) pending_safe_to_notar_resolved: Saturating<usize>,
+
     last_request_time: Instant,
 }
 
@@ -40,12 +41,12 @@ impl ConsensusPoolServiceStats {
             new_finalized_slot: Saturating(0),
             parent_ready_missed_window: Saturating(0),
             parent_ready_produce_window: Saturating(0),
-            received_vote_aggregates: Saturating(0),
-            received_own_messages: Saturating(0),
-            received_consensus_message_batches: Saturating(0),
             own_message_receive_limit_reached: Saturating(0),
             consensus_message_batch_receive_limit_reached: Saturating(0),
-            received_certificates: Saturating(0),
+            own_votes_received: Saturating(0),
+            vote_aggregates_received: Saturating(0),
+            certs_received: Saturating(0),
+            footer_certs_received: Saturating(0),
             standstill: false,
             prune_old_state_called: Saturating(0),
             pending_safe_to_notar_repair_sent: Saturating(0),
@@ -56,75 +57,70 @@ impl ConsensusPoolServiceStats {
 
     pub(super) fn do_report(&self) {
         let &Self {
-            add_message_failed: Saturating(add_message_failed),
-            certificates_sent: Saturating(certificates_sent),
-            certificates_dropped: Saturating(certificates_dropped),
-            certificates_skipped_unstaked: Saturating(certificates_skipped_unstaked),
-            new_finalized_slot: Saturating(new_finalized_slot),
-            parent_ready_missed_window: Saturating(parent_ready_missed_window),
-            parent_ready_produce_window: Saturating(parent_ready_produce_window),
-            received_vote_aggregates: Saturating(received_vote_aggregates),
-            received_own_messages: Saturating(received_own_messages),
-            received_consensus_message_batches: Saturating(received_consensus_message_batches),
-            own_message_receive_limit_reached: Saturating(own_message_receive_limit_reached),
-            consensus_message_batch_receive_limit_reached:
-                Saturating(consensus_message_batch_receive_limit_reached),
-            received_certificates: Saturating(received_certificates),
+            add_message_failed,
+            certificates_sent,
+            certificates_dropped,
+            certificates_skipped_unstaked,
+            new_finalized_slot,
+            parent_ready_missed_window,
+            parent_ready_produce_window,
+            own_votes_received,
+            footer_certs_received,
+            vote_aggregates_received,
+            certs_received,
+            own_message_receive_limit_reached,
+            consensus_message_batch_receive_limit_reached,
             standstill,
-            prune_old_state_called: Saturating(prune_old_state_called),
-            pending_safe_to_notar_repair_sent: Saturating(pending_safe_to_notar_repair_sent),
-            pending_safe_to_notar_resolved: Saturating(pending_safe_to_notar_resolved),
+            prune_old_state_called,
+            pending_safe_to_notar_repair_sent,
+            pending_safe_to_notar_resolved,
             last_request_time: _,
         } = self;
         datapoint_info!(
             "consensus_pool_service",
-            ("add_message_failed", add_message_failed, i64),
-            ("certificates_sent", certificates_sent, i64),
-            ("certificates_dropped", certificates_dropped, i64),
+            ("add_message_failed", add_message_failed.0, i64),
+            ("certificates_sent", certificates_sent.0, i64),
+            ("certificates_dropped", certificates_dropped.0, i64),
             (
                 "certificates_skipped_unstaked",
-                certificates_skipped_unstaked,
+                certificates_skipped_unstaked.0,
                 i64
             ),
-            ("new_finalized_slot", new_finalized_slot, i64),
+            ("new_finalized_slot", new_finalized_slot.0, i64),
             (
                 "parent_ready_missed_window",
-                parent_ready_missed_window,
+                parent_ready_missed_window.0,
                 i64
             ),
             (
                 "parent_ready_produce_window",
-                parent_ready_produce_window,
+                parent_ready_produce_window.0,
                 i64
             ),
-            ("received_vote_aggregates", received_vote_aggregates, i64),
-            ("received_own_messages", received_own_messages, i64),
-            (
-                "received_consensus_message_batches",
-                received_consensus_message_batches,
-                i64
-            ),
+            ("vote_aggregates_received", vote_aggregates_received.0, i64),
+            ("own_votes_received", own_votes_received.0, i64),
+            ("certs_received", certs_received.0, i64),
             (
                 "own_message_receive_limit_reached",
-                own_message_receive_limit_reached,
+                own_message_receive_limit_reached.0,
                 i64
             ),
             (
                 "consensus_message_batch_receive_limit_reached",
-                consensus_message_batch_receive_limit_reached,
+                consensus_message_batch_receive_limit_reached.0,
                 i64
             ),
-            ("received_certificates", received_certificates, i64),
+            ("footer_certs_received", footer_certs_received.0, i64),
             ("in_standstill_bool", standstill, bool),
-            ("prune_old_state_called", prune_old_state_called, i64),
+            ("prune_old_state_called", prune_old_state_called.0, i64),
             (
                 "pending_safe_to_notar_repair_sent",
-                pending_safe_to_notar_repair_sent,
+                pending_safe_to_notar_repair_sent.0,
                 i64
             ),
             (
                 "pending_safe_to_notar_resolved",
-                pending_safe_to_notar_resolved,
+                pending_safe_to_notar_resolved.0,
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem

Chido and I did some more benchmarking of the master.  Chido has an attack where he simulates 1K validators sending votes to single machine.  When it hits the victim machine with 90-100K votes/sec, then bls-sigverify gets overwhelmed and starts to discard datagrams.

In particular, what we are observing is that:

-  `datagram_ingress_dropped_channel_full` is very high indicating that the bls sigverifier is not keeping up..
- Looking at the bls-sigverifier, we seem to be taking forever in verify_and_send_votes .  We never call verify_individual_votes and verify_votes_optimistic doesn't seem to be taking too long. .
- Further, we are seeing a lot of distinct votes which makes sense given the attack..
- So this seems to suggest that not running https://github.com/anza-xyz/agave/blob/c6e1b9bdc46fd07b2808d0ce600c348cc7d6f253/bls-sigverify/src/bls_vote_sigverify.rs#L106 is slowing us down.

<img width="753" height="456" alt="Screenshot from 2026-08-06 16-18-16" src="https://github.com/user-attachments/assets/59474cb1-d529-4044-9a7d-4dba0d3a285d" />


#### Summary of Changes

- Makes various changes to do the for loop in `verify_and_send_votes` in parallel.
- removes tracking out of outstanding msgs in stats.  There are a few corner cases in tracking this stat properly.  I removed it for now.  We can add it later if we really need it.


#### Testing

After the changes in this PR, we are still dropping datagrams but much fewer.

<img width="952" height="454" alt="Screenshot from 2026-08-07 13-15-38" src="https://github.com/user-attachments/assets/99752763-be2d-4138-b1b2-99f36eaf9c1d" />
