### PR TITLE
votor: robust exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-transaction",
+ "solana-validator-exit",
  "tempfile",
  "test-case",
  "thiserror 2.0.19",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -81,6 +81,7 @@ use {
     },
     solana_streamer::evicting_sender::EvictingSender,
     solana_turbine::{XdpSender as TurbineXdpSender, retransmit_stage::RetransmitStage},
+    solana_validator_exit::Exit,
     std::{
         collections::{HashMap, HashSet},
         net::UdpSocket,
@@ -195,6 +196,7 @@ pub struct AlpenglowInitializationState {
     pub votor_event_receiver: VotorEventReceiver,
 
     pub cancel: CancellationToken,
+    pub validator_exit: Arc<RwLock<Exit>>,
     pub key_notifiers: Arc<RwLock<KeyUpdaters>>,
 
     // server sockets for Alpenglow consensus traffic
@@ -278,6 +280,7 @@ impl Tvu {
             votor_event_sender,
             votor_event_receiver,
             cancel,
+            validator_exit,
             key_notifiers,
             votor_server_sockets,
             votor_client_socket,
@@ -518,6 +521,7 @@ impl Tvu {
 
         let votor_config = VotorConfig {
             exit: exit.clone(),
+            validator_exit,
             vote_account: *vote_account,
             wait_to_vote_slot,
             vote_history,
@@ -914,6 +918,7 @@ pub mod tests {
                 votor_event_sender,
                 votor_event_receiver,
                 cancel: CancellationToken::new(),
+                validator_exit: Arc::default(),
                 key_notifiers,
                 votor_server_sockets: vec![
                     bind_to_localhost_unique().expect("bind votor server socket"),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1668,6 +1668,7 @@ impl Validator {
                 votor_event_sender: votor_event_sender.clone(),
                 votor_event_receiver,
                 cancel: cancel.child_token(),
+                validator_exit: config.validator_exit.clone(),
                 key_notifiers: key_notifiers.clone(),
                 votor_server_sockets: node.sockets.votor_server,
                 votor_client_socket: node.sockets.quic_votor_client,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-transaction",
+ "solana-validator-exit",
  "thiserror 2.0.19",
  "tokio",
  "wincode",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-transaction",
+ "solana-validator-exit",
  "thiserror 2.0.19",
  "tokio",
  "wincode",

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -1144,7 +1144,7 @@ pub fn execute(
     }
     info!("Validator initialized");
     validator.listen_for_signals()?;
-    validator.join();
+    validator.close();
     info!("Validator exiting...");
 
     Ok(())

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -75,6 +75,7 @@ solana-streamer = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tls-utils = { workspace = true, features = ["agave-unstable-api"] }
 solana-transaction = { workspace = true }
+solana-validator-exit = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 wincode = { workspace = true, features = ["alloc"] }

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -16,6 +16,7 @@ use {
         },
         event::{LeaderWindowInfo, RepairEvent, RepairEventSender, VotorEvent, VotorEventSender},
         voting_service::BLSOp,
+        votor::ExitOnDrop,
     },
     agave_bls_sigverify::generated_cert_types::GeneratedCertTypes,
     agave_votor_messages::{
@@ -36,6 +37,7 @@ use {
         leader_schedule_utils::last_of_consecutive_leader_slots,
         validated_block_finalization::ValidatedBlockFinalizationCert,
     },
+    solana_validator_exit::Exit,
     stats::ConsensusPoolServiceStats,
     std::{
         collections::HashSet,
@@ -79,6 +81,7 @@ const ADDITIONAL_MESSAGES_PER_RECEIVE: usize = MAX_MESSAGES_PER_RECEIVE - 1;
 /// Inputs for the consensus pool and consensus pool service
 pub(crate) struct ConsensusPoolContext {
     pub(crate) exit: Arc<AtomicBool>,
+    pub(crate) validator_exit: Arc<RwLock<Exit>>,
     pub(crate) migration_status: Arc<MigrationStatus>,
     pub(crate) generated_cert_types: Arc<GeneratedCertTypes>,
 
@@ -159,6 +162,8 @@ impl ConsensusPoolService {
         let t_consensus_pool_service = Builder::new()
             .name("solVotorPoolSvc".to_string())
             .spawn(move || {
+                // Dropped before `ctx`, so the channel senders it owns outlive the shutdown.
+                let _exit_on_drop = ExitOnDrop::new(ctx.validator_exit.clone());
                 // Unlike the other votor threads, consensus pool starts even before Alpenglow is enabled
                 // because it must track the genesis vote.
                 let mut consensus_pool = ctx.new_consensus_pool();
@@ -173,7 +178,6 @@ impl ConsensusPoolService {
                 }
                 consensus_pool.do_report();
                 stats.do_report();
-                ctx.exit.store(true, Ordering::Relaxed);
                 info!("consensus pool service exited.");
             })
             .unwrap();
@@ -813,6 +817,7 @@ mod tests {
 
             let ctx = ConsensusPoolContext {
                 exit: Arc::new(AtomicBool::new(false)),
+                validator_exit: Arc::default(),
                 migration_status,
                 generated_cert_types,
                 cluster_info,

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -18,7 +18,7 @@ use {
             VoteError, VotingContext, create_and_send_own_vote_message,
             generate_refresh_vote_message, insert_vote_and_create_bls_message,
         },
-        votor::SharedContext,
+        votor::{ExitOnDrop, SharedContext},
     },
     agave_votor_messages::{
         consensus_message::Block, metric_types::ConsensusMetricsEvent, migration::MigrationStatus,
@@ -37,6 +37,7 @@ use {
         },
     },
     solana_signer::Signer,
+    solana_validator_exit::Exit,
     std::{
         collections::{BTreeMap, BTreeSet},
         sync::{
@@ -58,6 +59,7 @@ pub(crate) type PendingBlocks = BTreeMap<Slot, Vec<(Block, Block)>>;
 /// Inputs for the event handler thread
 pub(crate) struct EventHandlerContext {
     pub(crate) exit: Arc<AtomicBool>,
+    pub(crate) validator_exit: Arc<std::sync::RwLock<Exit>>,
     pub(crate) migration_status: Arc<MigrationStatus>,
 
     pub(crate) event_receiver: VotorEventReceiver,
@@ -98,13 +100,11 @@ struct LocalContext {
 
 impl EventHandler {
     pub(crate) fn new(ctx: EventHandlerContext) -> Self {
-        let exit = ctx.exit.clone();
         let t_event_handler = Builder::new()
             .name("solVotorEvLoop".to_string())
             .spawn(move || {
                 if let Err(e) = Self::event_loop(ctx) {
                     info!("Event loop exited: {e:?}. Shutting down");
-                    exit.store(true, Ordering::Relaxed);
                 }
             })
             .unwrap();
@@ -115,6 +115,7 @@ impl EventHandler {
     fn event_loop(context: EventHandlerContext) -> Result<(), EventLoopError> {
         let EventHandlerContext {
             exit,
+            validator_exit,
             migration_status,
             event_receiver,
             timer_manager,
@@ -122,101 +123,105 @@ impl EventHandler {
             voting_context: mut vctx,
             root_context: rctx,
         } = context;
-        let mut local_context = LocalContext {
-            my_pubkey: ctx.cluster_info.keypair().pubkey(),
-            genesis_slot: 0,
-            pending_blocks: PendingBlocks::default(),
-            finalized_blocks: BTreeSet::default(),
-            received_shred: BTreeSet::default(),
-            stats: EventHandlerStats::new(),
-            standstill_slot: None,
-        };
-
-        // Wait until migration has completed
-        info!("{}: Event loop initialized", local_context.my_pubkey);
-        let Some(genesis_block) = migration_status.wait_for_migration_or_exit(&exit) else {
-            // Exited during migration
-            return Ok(());
-        };
-        local_context.genesis_slot = genesis_block.slot;
-        let root_slot = vctx.sharable_banks.root().slot();
-        info!(
-            "{}: Event loop starting genesis {genesis_block:?} root {root_slot}",
-            local_context.my_pubkey
-        );
-
-        // Check for set identity
-        if let Err(e) = Self::handle_set_identity(
-            &mut local_context.my_pubkey,
-            local_context.genesis_slot,
-            &ctx,
-            &mut vctx,
-        ) {
-            error!(
-                "Unable to load new vote history when attempting to change identity at startup \
-                 from {} to {} on voting loop startup, Exiting: {}",
-                vctx.vote_history.node_pubkey,
-                ctx.cluster_info.id(),
-                e
-            );
-            return Err(EventLoopError::SetIdentityError(e));
-        }
-        Self::send_vote_history_to_consensus_pool(&local_context.my_pubkey, &mut vctx)?;
-
-        while !exit.load(Ordering::Relaxed) {
-            let mut receive_event_time = Measure::start("receive_event");
-            let event = select! {
-                recv(event_receiver) -> msg => {
-                    msg
-                },
-                default(Duration::from_secs(1))  => continue
+        {
+            // consumers have to observe the shutdown before they observe a closed channel.
+            let _exit_on_drop = ExitOnDrop::new(validator_exit);
+            let mut local_context = LocalContext {
+                my_pubkey: ctx.cluster_info.keypair().pubkey(),
+                genesis_slot: 0,
+                pending_blocks: PendingBlocks::default(),
+                finalized_blocks: BTreeSet::default(),
+                received_shred: BTreeSet::default(),
+                stats: EventHandlerStats::new(),
+                standstill_slot: None,
             };
-            let event =
-                event.map_err(|_| EventLoopError::ChannelDisconnected("votor_event_receiver"))?;
-            receive_event_time.stop();
-            local_context.stats.receive_event_time_us = local_context
-                .stats
-                .receive_event_time_us
-                .saturating_add(receive_event_time.as_us() as u32);
 
-            let root_bank = vctx.sharable_banks.root();
-            if event.should_ignore(root_bank.slot().max(vctx.vote_history.root())) {
-                local_context.stats.ignored = local_context.stats.ignored.saturating_add(1);
-                continue;
-            }
+            // Wait until migration has completed
+            info!("{}: Event loop initialized", local_context.my_pubkey);
+            let Some(genesis_block) = migration_status.wait_for_migration_or_exit(&exit) else {
+                // Exited during migration
+                return Ok(());
+            };
+            local_context.genesis_slot = genesis_block.slot;
+            let root_slot = vctx.sharable_banks.root().slot();
+            info!(
+                "{}: Event loop starting genesis {genesis_block:?} root {root_slot}",
+                local_context.my_pubkey
+            );
 
-            let mut event_processing_time = Measure::start("event_processing");
-            let stats_event = local_context.stats.handle_event_arrival(&event);
-            let votes = Self::handle_event(
-                event,
-                &timer_manager,
+            // Check for set identity
+            if let Err(e) = Self::handle_set_identity(
+                &mut local_context.my_pubkey,
+                local_context.genesis_slot,
                 &ctx,
                 &mut vctx,
-                &rctx,
-                &mut local_context,
-            )?;
-            event_processing_time.stop();
-            local_context
-                .stats
-                .incr_event_with_timing(stats_event, event_processing_time.as_us());
-
-            let mut send_votes_batch_time = Measure::start("send_votes_batch");
-            for vote in votes {
-                local_context.stats.incr_vote(&vote);
-                nonblocking_send(
-                    &local_context.my_pubkey,
-                    &vctx.bls_sender,
-                    vote,
-                    "bls_sender",
-                )
-                .map_err(EventLoopError::ChannelDisconnected)?;
+            ) {
+                error!(
+                    "Unable to load new vote history when attempting to change identity at \
+                     startup from {} to {} on voting loop startup, Exiting: {}",
+                    vctx.vote_history.node_pubkey,
+                    ctx.cluster_info.id(),
+                    e
+                );
+                return Err(EventLoopError::SetIdentityError(e));
             }
-            send_votes_batch_time.stop();
-            local_context.stats.send_votes_batch_time_us = local_context
-                .stats
-                .send_votes_batch_time_us
-                .saturating_add(send_votes_batch_time.as_us() as u32);
-            local_context.stats.maybe_report();
+            Self::send_vote_history_to_consensus_pool(&local_context.my_pubkey, &mut vctx)?;
+
+            while !exit.load(Ordering::Relaxed) {
+                let mut receive_event_time = Measure::start("receive_event");
+                let event = select! {
+                    recv(event_receiver) -> msg => {
+                        msg
+                    },
+                    default(Duration::from_secs(1))  => continue
+                };
+                let event = event
+                    .map_err(|_| EventLoopError::ChannelDisconnected("votor_event_receiver"))?;
+                receive_event_time.stop();
+                local_context.stats.receive_event_time_us = local_context
+                    .stats
+                    .receive_event_time_us
+                    .saturating_add(receive_event_time.as_us() as u32);
+
+                let root_bank = vctx.sharable_banks.root();
+                if event.should_ignore(root_bank.slot().max(vctx.vote_history.root())) {
+                    local_context.stats.ignored = local_context.stats.ignored.saturating_add(1);
+                    continue;
+                }
+
+                let mut event_processing_time = Measure::start("event_processing");
+                let stats_event = local_context.stats.handle_event_arrival(&event);
+                let votes = Self::handle_event(
+                    event,
+                    &timer_manager,
+                    &ctx,
+                    &mut vctx,
+                    &rctx,
+                    &mut local_context,
+                )?;
+                event_processing_time.stop();
+                local_context
+                    .stats
+                    .incr_event_with_timing(stats_event, event_processing_time.as_us());
+
+                let mut send_votes_batch_time = Measure::start("send_votes_batch");
+                for vote in votes {
+                    local_context.stats.incr_vote(&vote);
+                    nonblocking_send(
+                        &local_context.my_pubkey,
+                        &vctx.bls_sender,
+                        vote,
+                        "bls_sender",
+                    )
+                    .map_err(EventLoopError::ChannelDisconnected)?;
+                }
+                send_votes_batch_time.stop();
+                local_context.stats.send_votes_batch_time_us = local_context
+                    .stats
+                    .send_votes_batch_time_us
+                    .saturating_add(send_votes_batch_time.as_us() as u32);
+                local_context.stats.maybe_report();
+            }
         }
 
         Ok(())
@@ -1158,6 +1163,7 @@ mod tests {
             cluster_info.clone(),
             event_sender,
             exit,
+            Arc::default(),
             Arc::new(MigrationStatus::default()),
         )));
         let blockstore = Arc::new(

--- a/votor/src/timer_manager.rs
+++ b/votor/src/timer_manager.rs
@@ -8,15 +8,17 @@ use {
     crate::{
         common::{DELTA_TIMEOUT, blocking_send},
         event::VotorEvent,
+        votor::ExitOnDrop,
     },
     agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::Sender,
     parking_lot::RwLock as PlRwLock,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
+    solana_validator_exit::Exit,
     std::{
         sync::{
-            Arc,
+            Arc, RwLock,
             atomic::{AtomicBool, Ordering},
         },
         thread::{self, JoinHandle},
@@ -37,12 +39,16 @@ impl TimerManager {
         cluster_info: Arc<ClusterInfo>,
         event_sender: Sender<VotorEvent>,
         exit: Arc<AtomicBool>,
+        validator_exit: Arc<RwLock<Exit>>,
         migration_status: Arc<MigrationStatus>,
     ) -> Self {
         let timers = Arc::new(PlRwLock::new(Timers::new(DELTA_TIMEOUT)));
         let handle = {
             let timers = Arc::clone(&timers);
             thread::spawn(move || {
+                // Dropped before `event_sender`, so the shutdown runs while the
+                // event channel is still open.
+                let _exit_on_drop = ExitOnDrop::new(validator_exit);
                 let _ = migration_status.wait_for_migration_or_exit(exit.as_ref());
                 while !exit.load(Ordering::Relaxed) {
                     let (duration, events) = timers.write().progress(Instant::now());
@@ -52,7 +58,6 @@ impl TimerManager {
                             blocking_send(my_pubkey, &event_sender, event, "votor_event_sender")
                         {
                             warn!("{my_pubkey}: {channel_name} disconnected. Exiting");
-                            exit.store(true, Ordering::Relaxed);
                             return;
                         }
                     }
@@ -124,6 +129,7 @@ mod tests {
             cluster_info,
             event_sender,
             exit.clone(),
+            Arc::default(),
             Arc::new(MigrationStatus::post_migration_status()),
         );
         let delta_block = Duration::from_millis(DEFAULT_MS_PER_SLOT);
@@ -175,6 +181,7 @@ mod tests {
             cluster_info,
             event_sender,
             exit.clone(),
+            Arc::default(),
             Arc::new(MigrationStatus::post_migration_status()),
         );
 

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -81,6 +81,7 @@ use {
         validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     solana_streamer::evicting_sender::EvictingSender,
+    solana_validator_exit::Exit,
     std::{
         collections::HashMap,
         sync::{Arc, RwLock, atomic::AtomicBool},
@@ -89,9 +90,29 @@ use {
     },
 };
 
+/// Brings the whole validator down when a votor thread stops.
+pub(crate) struct ExitOnDrop {
+    validator_exit: Arc<RwLock<Exit>>,
+}
+
+impl ExitOnDrop {
+    pub(crate) fn new(validator_exit: Arc<RwLock<Exit>>) -> Self {
+        Self { validator_exit }
+    }
+}
+
+impl Drop for ExitOnDrop {
+    fn drop(&mut self) {
+        if let Ok(mut validator_exit) = self.validator_exit.write() {
+            validator_exit.exit();
+        }
+    }
+}
+
 /// Inputs to Votor
 pub struct VotorConfig {
     pub exit: Arc<AtomicBool>,
+    pub validator_exit: Arc<RwLock<Exit>>,
     // Validator config
     pub vote_account: Pubkey,
     pub wait_to_vote_slot: Option<Slot>,
@@ -152,6 +173,7 @@ impl Votor {
     pub fn new(config: VotorConfig) -> Self {
         let VotorConfig {
             exit,
+            validator_exit,
             vote_account,
             wait_to_vote_slot,
             vote_history,
@@ -227,11 +249,13 @@ impl Votor {
             cluster_info.clone(),
             event_sender.clone(),
             exit.clone(),
+            validator_exit.clone(),
             migration_status.clone(),
         )));
 
         let event_handler_context = EventHandlerContext {
             exit: exit.clone(),
+            validator_exit: validator_exit.clone(),
             migration_status: migration_status.clone(),
             event_receiver,
             timer_manager: Arc::clone(&timer_manager),
@@ -244,6 +268,7 @@ impl Votor {
 
         let consensus_pool_context = ConsensusPoolContext {
             exit: exit.clone(),
+            validator_exit,
             migration_status,
             generated_cert_types,
             cluster_info: cluster_info.clone(),


### PR DESCRIPTION
#### Problem

Votor Transport, Votor, or BLS sigverify can exit due to an unexpected channel closure or error while validator remains running.

Part of https://github.com/anza-xyz/agave/issues/14301

#### Summary of Changes

Ensure exit in the Votor/BLS sigverify signals exit via cancellation tokens as well and tears down the whole validator in a repeatable way.

#### Testing

CI