### PR TITLE
votor: account for group identity in base 3 certificates

### DIFF
--- a/votor/src/aggregate_accumulator.rs
+++ b/votor/src/aggregate_accumulator.rs
@@ -107,13 +107,28 @@ impl AggregateAccumulator {
         }))
     }
 
-    /// Builds a base3 [`Certificate`] from two accumulators.
+    /// Builds a [`Certificate`] from primary and fallback accumulators.
+    ///
+    /// Uses base3 encoding when the fallback partition is usable, and base2 encoding when only
+    /// the primary partition is usable.
     pub fn try_build_base3_cert(
         cert_type: CertificateType,
         total_stake: NonZero<u64>,
         primary: Option<&AggregateAccumulator>,
         fallback: &AggregateAccumulator,
     ) -> Result<Option<Certificate>, AggregateAccumulatorError> {
+        // Each non-empty base3 partition is verified against its own aggregate public key.
+        // Individually valid votes can still be chosen such that their signatures cancel to the
+        // identity within one partition, making any certificate containing that partition
+        // invalid. Treat an identity partition as absent and do not count its stake.
+        let primary = primary.filter(|accumulator| !accumulator.is_identity());
+        if fallback.is_identity() {
+            return match primary {
+                Some(primary) => primary.try_build_base2_cert(cert_type, total_stake),
+                None => Ok(None),
+            };
+        }
+
         let observed_fraction = Fraction::new(
             fallback
                 .stake()
@@ -168,5 +183,118 @@ impl AggregateAccumulator {
     /// Accessor for stake
     pub fn stake(&self) -> u64 {
         self.stake
+    }
+
+    fn is_identity(&self) -> bool {
+        self.signature == SignatureProjective::identity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_bls_signatures::Keypair as BlsKeypair,
+        solana_signer_store::{Decoded, decode},
+    };
+
+    const MAX_VALIDATORS: usize = 4;
+
+    fn new_accumulator(
+        ranks: &[usize],
+        stake: u64,
+        signature: SignatureProjective,
+    ) -> AggregateAccumulator {
+        let mut accumulator = AggregateAccumulator::new(MAX_VALIDATORS);
+        for &rank in ranks {
+            accumulator.ranks.set(rank, true);
+        }
+        accumulator.signature = signature;
+        accumulator.stake = stake;
+        accumulator
+    }
+
+    #[test]
+    fn test_base3_identity_fallback_uses_primary_base2() {
+        let cert_type = CertificateType::Skip(1);
+        let primary_signature = BlsKeypair::new().sign(b"primary");
+        let primary = new_accumulator(&[0, 1], 60, primary_signature);
+        let fallback = new_accumulator(&[2, 3], 2, SignatureProjective::identity());
+
+        let cert = AggregateAccumulator::try_build_base3_cert(
+            cert_type,
+            NonZero::new(100).unwrap(),
+            Some(&primary),
+            &fallback,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(cert.signature, BLSSignature::from(primary_signature));
+        let Decoded::Base2(ranks) = decode(&cert.bitmap, MAX_VALIDATORS).unwrap() else {
+            panic!("expected base2 encoding");
+        };
+        assert_eq!(ranks.count_ones(), 2);
+        assert!(ranks[0]);
+        assert!(ranks[1]);
+    }
+
+    #[test]
+    fn test_base3_identity_fallback_stake_is_ignored() {
+        let primary = new_accumulator(&[0, 1], 58, BlsKeypair::new().sign(b"primary"));
+        let fallback = new_accumulator(&[2, 3], 2, SignatureProjective::identity());
+
+        let cert = AggregateAccumulator::try_build_base3_cert(
+            CertificateType::Skip(1),
+            NonZero::new(100).unwrap(),
+            Some(&primary),
+            &fallback,
+        )
+        .unwrap();
+
+        assert!(cert.is_none());
+    }
+
+    #[test]
+    fn test_base3_identity_primary_uses_fallback_only() {
+        let fallback_signature = BlsKeypair::new().sign(b"fallback");
+        let primary = new_accumulator(&[0, 1], 2, SignatureProjective::identity());
+        let fallback = new_accumulator(&[2, 3], 60, fallback_signature);
+
+        let cert = AggregateAccumulator::try_build_base3_cert(
+            CertificateType::Skip(1),
+            NonZero::new(100).unwrap(),
+            Some(&primary),
+            &fallback,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(cert.signature, BLSSignature::from(fallback_signature));
+        let Decoded::Base3(primary_ranks, fallback_ranks) =
+            decode(&cert.bitmap, MAX_VALIDATORS).unwrap()
+        else {
+            panic!("expected base3 encoding");
+        };
+        assert_eq!(primary_ranks.count_ones(), 0);
+        assert_eq!(fallback_ranks.count_ones(), 2);
+        assert!(fallback_ranks[2]);
+        assert!(fallback_ranks[3]);
+    }
+
+    #[test]
+    fn test_base3_identity_primary_stake_is_ignored() {
+        let primary = new_accumulator(&[0, 1], 2, SignatureProjective::identity());
+        let fallback = new_accumulator(&[2, 3], 58, BlsKeypair::new().sign(b"fallback"));
+
+        let cert = AggregateAccumulator::try_build_base3_cert(
+            CertificateType::Skip(1),
+            NonZero::new(100).unwrap(),
+            Some(&primary),
+            &fallback,
+        )
+        .unwrap();
+
+        assert!(cert.is_none());
     }
 }


### PR DESCRIPTION
#### Problem
From bug bounty report, if the primary or fallback group in a base3 certificate corresponds to the identity, we still construct the certificate.

Similar to the fix we did for the rewards certificate we should ignore this group for construction.

#### Summary of Changes
If either the primary or fallback is identity, do not consider it for the stake fraction or certificate

#### Testing
Unit tests