### PR TITLE
votor-transport: make set_identity block until success

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -988,10 +988,27 @@ impl AdminRpcImpl {
                 }
             }
 
-            for (key, notifier) in &*post_init.notifies.read().unwrap() {
-                if let Err(err) = notifier.update_key(&identity_keypair) {
+            // Updaters block until the new key is in effect, so take a copy of the
+            // list instead of running them under the lock.
+            let notifiers = {
+                let notifies = post_init.notifies.read().unwrap();
+                notifies
+                    .into_iter()
+                    .map(|(key, notifier)| (key.clone(), Arc::clone(notifier)))
+                    .collect::<Vec<_>>()
+            };
+            // Bail out rather than switch identity on top of a network layer that
+            // may still be running under the old one. Updaters already run at this
+            // point keep the new key, so the operator must retry to converge.
+            for (key, notifier) in notifiers {
+                notifier.update_key(&identity_keypair).map_err(|err| {
                     error!("Error updating network layer keypair: {err} on {key:?}");
-                }
+                    jsonrpc_core::error::Error {
+                        code: ErrorCode::InternalError,
+                        message: format!("Failed to apply new identity to {key:?}: {err}"),
+                        data: None,
+                    }
+                })?;
             }
 
             let old_identity = post_init.cluster_info.id();
@@ -1375,6 +1392,10 @@ mod tests {
         meta: AdminRpcRequestMetadata,
         io: MetaIoHandler<AdminRpcRequestMetadata>,
         validator_ledger_path: PathBuf,
+        /// Kept alive for the lifetime of the test: `set_identity` reaches into
+        /// live network services, which are gone once the validator is dropped.
+        /// `Option` only so `Drop` can call the consuming `close()`.
+        validator: Option<Validator>,
     }
 
     impl TestValidatorWithAdminRpc {
@@ -1418,7 +1439,7 @@ mod tests {
                 rpc_to_plugin_manager_sender: None,
             };
 
-            let _validator = Validator::new(
+            let validator = Validator::new(
                 validator_node,
                 Arc::new(validator_keypair),
                 &validator_ledger_path,
@@ -1463,6 +1484,7 @@ mod tests {
                 meta,
                 io,
                 validator_ledger_path,
+                validator: Some(validator),
             }
         }
 
@@ -1473,6 +1495,10 @@ mod tests {
 
     impl Drop for TestValidatorWithAdminRpc {
         fn drop(&mut self) {
+            self.validator
+                .take()
+                .expect("validator is only taken here")
+                .close();
             remove_dir_all(self.validator_ledger_path.clone()).unwrap();
         }
     }

--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -2,6 +2,7 @@
 use {
     crate::{
         METRICS_INTERVAL, PeerListReceiver, close_codes,
+        endpoint::KeyUpdateListener,
         error::Error,
         stats::{self, ClientStats, record_client_error},
         transport::new_client_config,
@@ -19,7 +20,7 @@ use {
         time::Duration,
     },
     tokio::{
-        sync::{mpsc, watch},
+        sync::mpsc,
         task::JoinSet,
         time::{MissedTickBehavior, interval, timeout},
     },
@@ -91,7 +92,7 @@ pub(crate) struct OutboundLoop {
     local_pubkey: Pubkey,
     /// Channel for outbound messages to be broadcast
     egress_receiver: mpsc::Receiver<Bytes>,
-    identity_receiver: watch::Receiver<Keypair>,
+    key_updates: KeyUpdateListener,
     peer_list_receiver: PeerListReceiver,
     /// Per-peer send-only connection state.
     /// Size is limited to the peer_list size by reconcile task.
@@ -107,7 +108,7 @@ impl OutboundLoop {
         endpoint: Endpoint,
         local_pubkey: Pubkey,
         egress_receiver: mpsc::Receiver<Bytes>,
-        identity_receiver: watch::Receiver<Keypair>,
+        key_updates: KeyUpdateListener,
         peer_list_receiver: PeerListReceiver,
         cancel: CancellationToken,
         max_datagrams_per_second_per_peer: usize,
@@ -116,7 +117,7 @@ impl OutboundLoop {
             endpoint,
             local_pubkey,
             egress_receiver,
-            identity_receiver,
+            key_updates,
             peer_list_receiver,
             peer_state: HashMap::with_hasher(PubkeyHasherBuilder::default()),
             in_flight_handshakes: JoinSet::new(),
@@ -139,14 +140,14 @@ impl OutboundLoop {
         info!("Votor QUIC transport client ready.");
         loop {
             tokio::select! {
-                changed = self.identity_receiver.changed() => {
+                changed = self.key_updates.receiver.changed() => {
                     if changed.is_err() {
                         // Unreachable: endpoint holds the identity sender for this loop's lifetime.
                         error!("OutboundLoop: identity channel closed while running, exiting.");
                         debug_assert!(false, "identity channel closed while running");
                         break;
                     }
-                    let new_keypair = self.identity_receiver.borrow_and_update().insecure_clone();
+                    let new_keypair = self.key_updates.receiver.borrow_and_update().insecure_clone();
                     self.apply_identity_change(new_keypair);
                     self.reconcile();
                 }
@@ -222,6 +223,9 @@ impl OutboundLoop {
         self.stats
             .connection_closed_identity_changed
             .fetch_add(closed, Ordering::Relaxed);
+        // Never blocks, and a dropped ack only matters at shutdown, when the
+        // updater is gone anyway.
+        let _ = self.key_updates.ack.try_send(());
         info!(
             "outbound identity changed to {} ({} connection(s) closed)",
             self.local_pubkey, closed
@@ -385,8 +389,10 @@ impl OutboundLoop {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_net_utils::sockets::unique_port_range_for_tests, std::net::Ipv4Addr,
-        tokio::time::sleep,
+        super::*,
+        solana_net_utils::sockets::unique_port_range_for_tests,
+        std::net::Ipv4Addr,
+        tokio::{sync::watch, time::sleep},
     };
 
     /// Recreates an edge case when client identity changes while a peer is in `Connecting`
@@ -402,13 +408,17 @@ mod tests {
 
         let (_egress_tx, egress_rx) = mpsc::channel(1);
         let (_identity_tx, identity_rx) = watch::channel(Keypair::new());
+        let (ack, _acks) = crossbeam_channel::unbounded();
         let (_peer_list_tx, peer_list_rx) = watch::channel(Arc::new(HashMap::default()));
 
         let mut outbound = OutboundLoop::new(
             endpoint,
             old_pubkey,
             egress_rx,
-            identity_rx,
+            KeyUpdateListener {
+                receiver: identity_rx,
+                ack,
+            },
             peer_list_rx,
             CancellationToken::new(),
             50,

--- a/votor-transport/src/endpoint.rs
+++ b/votor-transport/src/endpoint.rs
@@ -11,7 +11,7 @@ use {
         transport::{new_client_config, new_server_config},
     },
     bytes::Bytes,
-    crossbeam_channel::Sender,
+    crossbeam_channel::{Receiver, Sender, bounded},
     log::{error, warn},
     qualifier_attr::qualifiers,
     quinn::{Endpoint, EndpointConfig, TokioRuntime},
@@ -21,7 +21,7 @@ use {
     solana_tls_utils::NotifyKeyUpdate,
     std::{
         net::{SocketAddr, UdpSocket},
-        sync::Arc,
+        sync::{Arc, Mutex, TryLockError},
         time::Duration,
     },
     tokio::{
@@ -50,7 +50,7 @@ pub struct QuicDatagramEndpoint {
     /// that tokio would otherwise swallow is surfaced.
     task_handles: JoinSet<()>,
     /// Identity rotation sender kept here so we control when the channel closes.
-    key_updater: Arc<KeyUpdater>,
+    key_updater: Arc<KeyUpdateNotifier>,
     ban_sender: BanSender,
     /// Inbound stats, exposed so integration tests can assert on them.
     #[cfg(any(test, feature = "dev-context-only-utils"))]
@@ -96,11 +96,9 @@ impl QuicDatagramEndpoint {
         let (egress_sender, egress_receiver) = mpsc::channel(egress_channel_capacity);
         let (ban_command_sender, ban_commands) = mpsc::channel(BAN_CHANNEL_CAPACITY);
         let ban_sender = BanSender(ban_command_sender);
-        // The dummy keypair here is never observed.
-        let (identity_sender, identity_receiver) = watch::channel(Keypair::new_from_array([0; 32]));
-        let key_updater = Arc::new(KeyUpdater {
-            sender: identity_sender,
-        });
+        let (key_updater, client_key_updates, server_key_updates) =
+            KeyUpdateNotifier::make_with_listeners();
+        let key_updater = Arc::new(key_updater);
         let local_pubkey = keypair.pubkey();
 
         let server_config = new_server_config(keypair, max_datagrams_per_second_per_peer);
@@ -139,7 +137,7 @@ impl QuicDatagramEndpoint {
             outbound_endpoint,
             local_pubkey,
             egress_receiver,
-            identity_receiver.clone(),
+            client_key_updates,
             peer_list.clone(),
             cancel.clone(),
             max_datagrams_per_second_per_peer,
@@ -189,7 +187,7 @@ impl QuicDatagramEndpoint {
             inbound_endpoints,
             inbound_events_sender,
             inbound_events_receiver,
-            identity_receiver,
+            server_key_updates,
             server_stats,
             cancel.clone(),
             max_datagrams_per_second_per_peer,
@@ -209,7 +207,7 @@ impl QuicDatagramEndpoint {
         Ok((egress_sender, endpoint))
     }
 
-    pub fn key_updater(&self) -> Arc<KeyUpdater> {
+    pub fn key_updater(&self) -> Arc<KeyUpdateNotifier> {
         self.key_updater.clone()
     }
 
@@ -268,21 +266,80 @@ impl Drop for QuicDatagramEndpoint {
     }
 }
 
-/// Handle for caller-driven identity rotation.
-pub struct KeyUpdater {
+pub struct KeyUpdateNotifier {
     sender: watch::Sender<Keypair>,
+    ack_sender: Sender<()>,
+    /// Both transport loops acknowledge here. Holding the lock ensures only one
+    /// update can be in progress at a time.
+    acks: Mutex<Receiver<()>>,
 }
 
-impl NotifyKeyUpdate for KeyUpdater {
+impl KeyUpdateNotifier {
+    /// Builds the notifier together with the listener for each transport loop.
+    /// The only place listeners are made, so we know there can be only 2.
+    pub(crate) fn make_with_listeners() -> (Self, KeyUpdateListener, KeyUpdateListener) {
+        // The initial value is never observed.
+        let (sender, _receiver) = watch::channel(Keypair::new_from_array([0; 32]));
+        // The bound is 2 because each loop acknowledges exactly once per update.
+        let (ack_sender, acks) = bounded(2);
+        let notifier = Self {
+            sender,
+            ack_sender,
+            acks: Mutex::new(acks),
+        };
+        let client_listener = KeyUpdateListener {
+            receiver: notifier.sender.subscribe(),
+            ack: notifier.ack_sender.clone(),
+        };
+        let server_listener = KeyUpdateListener {
+            receiver: notifier.sender.subscribe(),
+            ack: notifier.ack_sender.clone(),
+        };
+        (notifier, client_listener, server_listener)
+    }
+}
+
+impl NotifyKeyUpdate for KeyUpdateNotifier {
+    /// Publishes `keypair` to the transport loops and blocks until all have ack'd.
+    /// Outbound connections guaranteed to be gone when this returns.
+    ///
+    /// Rejects the update outright if an update is already in progress.
     fn update_key(&self, keypair: &Keypair) -> Result<(), Box<dyn std::error::Error>> {
-        let new_keypair = keypair.insecure_clone();
+        let acks = match self.acks.try_lock() {
+            Ok(acks) => acks,
+            Err(TryLockError::WouldBlock) => {
+                return Err("an identity update is already in progress".into());
+            }
+            // The validator aborts on panic, so nothing observes a poisoned lock.
+            // Never continue here, a stale ack would make the next update return
+            // before the transport has adopted it.
+            Err(TryLockError::Poisoned(err)) => {
+                unreachable!("ack receiver was poisoned while an update was in flight: {err}")
+            }
+        };
         self.sender
-            .send(new_keypair)
+            .send(keypair.insecure_clone())
             .map_err(|_| -> Box<dyn std::error::Error> {
                 "quic-datagram endpoint has shut down; identity update rejected".into()
             })?;
+        // Adopting takes milliseconds, so wait until we get acks. Channel is sized
+        // to exactly match number of listeners at construction.
+        for _ in 0..acks
+            .capacity()
+            .expect("ack channel is bounded to the number of listeners")
+        {
+            acks.recv()
+                .expect("ack channel cannot disconnect while the notifier holds a sender");
+        }
         Ok(())
     }
+}
+
+/// Bundles key update reception and ACK channels.
+/// These should only be constructed by KeyUpdateNotifier.
+pub(crate) struct KeyUpdateListener {
+    pub(crate) receiver: watch::Receiver<Keypair>,
+    pub(crate) ack: Sender<()>,
 }
 
 /// Command to temporarily ban a peer.
@@ -910,7 +967,6 @@ mod tests {
             .key_updater()
             .update_key(&keypair2)
             .expect("identity rotation accepted");
-        std::thread::sleep(Duration::from_millis(500));
 
         let payload2 = Bytes::from_static(b"under-K2");
         send_until_received(&client, &payload2, &server.ingress_receiver, |d| {
@@ -954,16 +1010,14 @@ mod tests {
             .key_updater()
             .update_key(&server_keypair2)
             .expect("server identity rotation must be accepted");
-        let evicted = wait_for_stat(
-            &server
+        // update_key returns only once the rotation has been applied.
+        assert!(
+            server
                 .endpoint
                 .server_stats
-                .connection_closed_identity_changed,
-            1,
-            METRICS_INTERVAL * 2,
-        );
-        assert!(
-            evicted > 0,
+                .connection_closed_identity_changed
+                .load(Ordering::Relaxed)
+                > 0,
             "server identity rotation must evict the inbound table"
         );
 
@@ -979,6 +1033,40 @@ mod tests {
             (d.message == payload2).then_some(())
         })
         .expect("server never received datagram under new identity");
+    }
+
+    /// Each id change waits for its own application, so back-to-back updates succeed.
+    #[test]
+    fn test_back_to_back_identity_updates() {
+        let rt = make_runtime_for_tests();
+        let client_keypair = Keypair::new();
+        let client_pubkey = client_keypair.pubkey();
+        let server = Node::spawn_node(
+            &rt,
+            Keypair::new(),
+            peer_list_with_unknown_addr(client_pubkey),
+            HIGH_PPS,
+        );
+        let client = Node::spawn_node(
+            &rt,
+            client_keypair,
+            peer_list_of(server.pubkey(), server.addr),
+            HIGH_PPS,
+        );
+
+        let payload = Bytes::from_static(b"pre-rotation");
+        send_until_received(&client, &payload, &server.ingress_receiver, |d| {
+            (d.message == payload).then_some(())
+        })
+        .expect("server never received datagram under original identity");
+
+        for _ in 0..3 {
+            server
+                .endpoint
+                .key_updater()
+                .update_key(&Keypair::new())
+                .expect("every rotation must be applied");
+        }
     }
 
     /// When a peer's address changes in the peer_list, the outbound

--- a/votor-transport/src/server.rs
+++ b/votor-transport/src/server.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         HANDSHAKE_TIMEOUT, MAX_INBOUND_CONNECTIONS_PER_PEER, METRICS_INTERVAL,
         PEER_RATE_LIMIT_BURST_WINDOW, PEER_RATE_LIMIT_DOS_WINDOW, PeerListReceiver, close_codes,
-        endpoint::{BanCommand, Datagram},
+        endpoint::{BanCommand, Datagram, KeyUpdateListener},
         error::Error,
         stats::{self, ServerStats, record_server_error},
         transport::new_server_config,
@@ -12,7 +12,7 @@ use {
     crossbeam_channel::{Sender, TrySendError},
     log::{debug, error, info, warn},
     quinn::{Connecting, Connection, Endpoint},
-    solana_keypair::{Keypair, Signer},
+    solana_keypair::Signer,
     solana_net_utils::{banlist::Banlist, token_bucket::TokenBucket},
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_tls_utils::get_remote_pubkey,
@@ -23,7 +23,7 @@ use {
         time::Duration,
     },
     tokio::{
-        sync::{mpsc, watch},
+        sync::mpsc,
         task::JoinSet,
         time::{Instant, MissedTickBehavior, interval, sleep, timeout},
     },
@@ -296,7 +296,7 @@ pub(crate) struct InboundLoop {
     /// Latest version of the admitted peer list.
     peer_list_receiver: PeerListReceiver,
     /// Identity-rotation notification channel.
-    identity_receiver: watch::Receiver<Keypair>,
+    key_updates: KeyUpdateListener,
     /// Endpoints that handle connections. On identity rotation we need to
     /// configure them with the updated TLS config.
     endpoints: Vec<Endpoint>,
@@ -327,7 +327,7 @@ impl InboundLoop {
         endpoints: Vec<Endpoint>,
         inbound_events_sender: mpsc::Sender<InboundConnectionEvent>,
         inbound_events_receiver: mpsc::Receiver<InboundConnectionEvent>,
-        identity_receiver: watch::Receiver<Keypair>,
+        key_updates: KeyUpdateListener,
         stats: Arc<ServerStats>,
         cancel: CancellationToken,
         max_datagrams_per_second_per_peer: usize,
@@ -343,7 +343,7 @@ impl InboundLoop {
             banlist: Banlist::default(),
             ban_receiver,
             peer_list_receiver,
-            identity_receiver,
+            key_updates,
             endpoints,
             peer_state: HashMap::with_hasher(PubkeyHasherBuilder::default()),
             connection_reader_tasks: JoinSet::new(),
@@ -371,7 +371,7 @@ impl InboundLoop {
         metrics.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         let mut peer_list_receiver = self.peer_list_receiver.clone();
-        let mut identity_receiver = self.identity_receiver.clone();
+        let mut identity_receiver = self.key_updates.receiver.clone();
 
         info!("Votor QUIC transport server ready.");
         loop {
@@ -405,6 +405,9 @@ impl InboundLoop {
                     let total_closed = self.close_all(close_codes::IDENTITY_CHANGED);
                     self.stats.connection_closed_identity_changed.fetch_add(total_closed, Ordering::Relaxed);
                     info!("InboundLoop: identity changed ({total_closed} connection(s) closed)");
+                    // Never blocks, and a dropped ack only matters at shutdown,
+                    // when the updater is gone anyway.
+                    let _ = self.key_updates.ack.try_send(());
                 }
                 // The admitted-peer set changed.
                 changed = peer_list_receiver.changed() => {
@@ -606,6 +609,7 @@ mod tests {
             transport::new_client_config,
         },
         quinn::{ClientConfig, crypto::rustls::QuicClientConfig},
+        solana_keypair::Keypair,
         solana_net_utils::sockets::{bind_to_localhost_async, unique_port_range_for_tests},
         solana_tls_utils::{new_dummy_x509_certificate, tls_client_config_builder},
         std::{net::Ipv4Addr, time::Duration},


### PR DESCRIPTION
#### Problem

set-identity does not wait for the transport to apply the new identity

it publishes the new key to asynchronous transport loops, then updates ClusterInfo. it can return before transport confirms that the new identity is active and old connections are cleared, so we could accidentally have a vote in flight that we should not.

    Ref: https://github.com/anza-xyz/agave/pull/13162#discussion_r3707091008

   Part of https://github.com/anza-xyz/agave/issues/14301

#### Summary of Changes

require the network layer to acknowledge completion before set-identity continues

Note: this does not enforce full clearing of all incoming connections. Worst case is we receive a few extra votes using old identity - not a problem.

#### Testing

CI (added new test).
