### PR TITLE
Perf - Prunes tombstones and unloaded entries

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -509,8 +509,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     new_root_slot.saturating_sub(MAX_TOMBSTONE_AGE_IN_SLOTS);
                 entries.retain(|_id, second_level| {
                     // Clean up tombstones and unloaded entries
-                    if second_level.len() == 1 {
-                        let candidate = second_level.first().unwrap();
+                    if let [candidate] = &second_level[..] {
                         match candidate.program {
                             ProgramCacheEntryType::Builtin(_)
                             | ProgramCacheEntryType::Loaded(_) => {}

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -515,6 +515,7 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         && candidate.deployment_slot <= self.latest_root_slot
                         && candidate.latest_access_slot.load(Relaxed) < tombstone_slot_cutoff
                     {
+                        self.stats.prunes_stale.fetch_add(1, Ordering::Relaxed);
                         return false;
                     }
                     // Remove entries un/re/deployed on orphan forks

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1737,9 +1737,9 @@ pub(crate) mod tests {
                 None,
                 &fork_graph.read().unwrap(),
             );
-            // Test that exeeding latest_access_slot + MAX_TOMBSTONE_AGE_IN_SLOTS prunes
             let slot_versions = cache.get_slot_versions_for_tests(&program1);
             assert_eq!(slot_versions, std::slice::from_ref(entry));
+            // Test that exeeding latest_access_slot + MAX_TOMBSTONE_AGE_IN_SLOTS prunes
             cache.prune(
                 MAX_TOMBSTONE_AGE_IN_SLOTS
                     .saturating_add(entry.latest_access_slot.load(Ordering::Relaxed))

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -509,19 +509,13 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                     new_root_slot.saturating_sub(MAX_TOMBSTONE_AGE_IN_SLOTS);
                 entries.retain(|_id, second_level| {
                     // Clean up tombstones and unloaded entries
-                    if let [candidate] = &second_level[..] {
-                        match candidate.program {
-                            ProgramCacheEntryType::Builtin(_)
-                            | ProgramCacheEntryType::Loaded(_) => {}
-                            _ => {
-                                if candidate.deployment_slot <= self.latest_root_slot
-                                    && candidate.latest_access_slot.load(Relaxed)
-                                        < tombstone_slot_cutoff
-                                {
-                                    return false;
-                                }
-                            }
-                        }
+                    if let [candidate] = &second_level[..]
+                        && (matches!(candidate.program, ProgramCacheEntryType::Unloaded(_))
+                            || candidate.is_tombstone())
+                        && candidate.deployment_slot <= self.latest_root_slot
+                        && candidate.latest_access_slot.load(Relaxed) < tombstone_slot_cutoff
+                    {
+                        return false;
                     }
                     // Remove entries un/re/deployed on orphan forks
                     let mut first_ancestor_found = false;

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -18,7 +18,7 @@ use {
     },
     std::{
         collections::{HashMap, hash_map::Entry},
-        sync::Weak,
+        sync::{Weak, atomic::Ordering::Relaxed},
     },
 };
 
@@ -114,6 +114,7 @@ pub fn get_mock_program_runtime_environment() -> ProgramRuntimeEnvironment {
 }
 
 pub const MAX_LOADED_ENTRY_COUNT: usize = 1024;
+pub const MAX_TOMBSTONE_AGE_IN_SLOTS: u64 = 2250; // 15 Minutes at 400ms slot time
 
 /// A percentage, expected to be in the range `0..=100`.
 pub type Percent = u8;
@@ -504,6 +505,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     ) {
         match &mut self.index {
             IndexImplementation::V1 { entries, .. } => {
+                let tombstone_slot_cutoff =
+                    new_root_slot.saturating_sub(MAX_TOMBSTONE_AGE_IN_SLOTS);
                 entries.retain(|_id, second_level| {
                     // Clean up tombstones and unloaded entries
                     if second_level.len() == 1 {
@@ -512,7 +515,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                             ProgramCacheEntryType::Builtin(_)
                             | ProgramCacheEntryType::Loaded(_) => {}
                             _ => {
-                                if candidate.deployment_slot <= self.latest_root_slot {
+                                if candidate.deployment_slot <= self.latest_root_slot
+                                    && candidate.latest_access_slot.load(Relaxed)
+                                        < tombstone_slot_cutoff
+                                {
                                     return false;
                                 }
                             }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -504,7 +504,20 @@ impl<FG: ForkGraph> ProgramCache<FG> {
     ) {
         match &mut self.index {
             IndexImplementation::V1 { entries, .. } => {
-                for second_level in entries.values_mut() {
+                entries.retain(|_id, second_level| {
+                    // Clean up tombstones and unloaded entries
+                    if second_level.len() == 1 {
+                        let candidate = second_level.first().unwrap();
+                        match candidate.program {
+                            ProgramCacheEntryType::Builtin(_)
+                            | ProgramCacheEntryType::Loaded(_) => {}
+                            _ => {
+                                if candidate.deployment_slot <= self.latest_root_slot {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
                     // Remove entries un/re/deployed on orphan forks
                     let mut first_ancestor_found = false;
                     let mut first_ancestor_env = None;
@@ -559,7 +572,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         .cloned()
                         .collect();
                     second_level.reverse();
-                }
+                    true
+                });
             }
         }
         self.remove_programs_with_no_entries();

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -972,8 +972,9 @@ pub(crate) mod tests {
     use {
         crate::{
             loaded_programs::{
-                BlockRelation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
-                ProgramRuntimeEnvironment, ProgramToLoad, get_mock_program_runtime_environment,
+                BlockRelation, ForkGraph, MAX_TOMBSTONE_AGE_IN_SLOTS, Percent, ProgramCache,
+                ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramToLoad,
+                get_mock_program_runtime_environment,
             },
             program_cache_entry::{
                 ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
@@ -1694,6 +1695,42 @@ pub(crate) mod tests {
         assert!(cache.get_flattened_entries_for_tests().is_empty());
 
         cache.prune(10, None, &fork_graph.read().unwrap());
+        assert!(cache.get_flattened_entries_for_tests().is_empty());
+    }
+
+    #[test]
+    fn test_prune_tombstones() {
+        let mut cache = ProgramCache::<TestForkGraph>::new(0);
+        let env = get_mock_program_runtime_environment();
+        let fork_graph = Arc::new(RwLock::new(TestForkGraph {
+            relation: BlockRelation::Ancestor,
+        }));
+        cache.set_fork_graph(Arc::downgrade(&fork_graph));
+
+        let program1 = Pubkey::new_unique();
+        cache.assign_program(&env, program1, 10, new_test_entry(10));
+        cache.assign_program(
+            &env,
+            program1,
+            20,
+            Arc::new(ProgramCacheEntry::new_closed_tombstone(
+                20,
+                ProgramCacheEntryOwner::LoaderV3,
+            )),
+        );
+
+        cache.prune(100, None, &fork_graph.read().unwrap());
+        let slot_versions = cache.get_slot_versions_for_tests(&program1);
+        assert!(matches!(
+            &slot_versions.first().unwrap().program,
+            ProgramCacheEntryType::Closed,
+        ));
+
+        cache.prune(
+            MAX_TOMBSTONE_AGE_IN_SLOTS.saturating_add(1),
+            None,
+            &fork_graph.read().unwrap(),
+        );
         assert!(cache.get_flattened_entries_for_tests().is_empty());
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -18,7 +18,7 @@ use {
     },
     std::{
         collections::{HashMap, hash_map::Entry},
-        sync::{Weak, atomic::Ordering::Relaxed},
+        sync::Weak,
     },
 };
 
@@ -513,7 +513,8 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                         && (matches!(candidate.program, ProgramCacheEntryType::Unloaded(_))
                             || candidate.is_tombstone())
                         && candidate.deployment_slot <= self.latest_root_slot
-                        && candidate.latest_access_slot.load(Relaxed) < tombstone_slot_cutoff
+                        && candidate.latest_access_slot.load(Ordering::Relaxed)
+                            < tombstone_slot_cutoff
                     {
                         self.stats.prunes_stale.fetch_add(1, Ordering::Relaxed);
                         return false;
@@ -1719,33 +1720,35 @@ pub(crate) mod tests {
         for entry in &entries {
             let mut cache = ProgramCache::<TestForkGraph>::new(0);
             cache.set_fork_graph(Arc::downgrade(&fork_graph));
+            // Test that multiple entries prevent pruning
             cache.assign_program(&env, program1, 10, new_test_entry(10));
             cache.assign_program(&env, program1, entry.deployment_slot, Arc::clone(entry));
-            cache.prune(100, None, &fork_graph.read().unwrap());
+            cache.prune(
+                MAX_TOMBSTONE_AGE_IN_SLOTS,
+                None,
+                &fork_graph.read().unwrap(),
+            );
             let slot_versions = cache.get_slot_versions_for_tests(&program1);
             assert_eq!(slot_versions, std::slice::from_ref(entry));
+            // Test that latest_access_slot prevents pruning
+            cache.prune(
+                MAX_TOMBSTONE_AGE_IN_SLOTS
+                    .saturating_add(entry.latest_access_slot.load(Ordering::Relaxed)),
+                None,
+                &fork_graph.read().unwrap(),
+            );
+            // Test that exeeding latest_access_slot + MAX_TOMBSTONE_AGE_IN_SLOTS prunes
+            let slot_versions = cache.get_slot_versions_for_tests(&program1);
+            assert_eq!(slot_versions, std::slice::from_ref(entry));
+            cache.prune(
+                MAX_TOMBSTONE_AGE_IN_SLOTS
+                    .saturating_add(entry.latest_access_slot.load(Ordering::Relaxed))
+                    .saturating_add(1),
+                None,
+                &fork_graph.read().unwrap(),
+            );
+            assert!(cache.get_flattened_entries_for_tests().is_empty());
         }
-
-        let mut cache = ProgramCache::<TestForkGraph>::new(0);
-        cache.set_fork_graph(Arc::downgrade(&fork_graph));
-        cache.assign_program(
-            &env,
-            program1,
-            entries[0].deployment_slot,
-            Arc::clone(&entries[0]),
-        );
-        cache.prune(
-            MAX_TOMBSTONE_AGE_IN_SLOTS,
-            None,
-            &fork_graph.read().unwrap(),
-        );
-        assert!(!cache.get_flattened_entries_for_tests().is_empty());
-        cache.prune(
-            MAX_TOMBSTONE_AGE_IN_SLOTS.saturating_add(1),
-            None,
-            &fork_graph.read().unwrap(),
-        );
-        assert!(cache.get_flattened_entries_for_tests().is_empty());
     }
 
     #[test]

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1725,10 +1725,10 @@ pub(crate) mod tests {
             let mut cache = ProgramCache::<TestForkGraph>::new(0);
             cache.set_fork_graph(Arc::downgrade(&fork_graph));
             cache.assign_program(&env, program1, 10, new_test_entry(10));
-            cache.assign_program(&env, program1, entry.deployment_slot, Arc::clone(&entry));
+            cache.assign_program(&env, program1, entry.deployment_slot, Arc::clone(entry));
             cache.prune(100, None, &fork_graph.read().unwrap());
             let slot_versions = cache.get_slot_versions_for_tests(&program1);
-            assert_eq!(slot_versions, &[entry.clone()]);
+            assert_eq!(slot_versions, std::slice::from_ref(entry));
         }
 
         let mut cache = ProgramCache::<TestForkGraph>::new(0);

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1699,32 +1699,52 @@ pub(crate) mod tests {
 
     #[test]
     fn test_prune_tombstones() {
-        let mut cache = ProgramCache::<TestForkGraph>::new(0);
         let env = get_mock_program_runtime_environment();
         let fork_graph = Arc::new(RwLock::new(TestForkGraph {
             relation: BlockRelation::Ancestor,
         }));
-        cache.set_fork_graph(Arc::downgrade(&fork_graph));
 
         let program1 = Pubkey::new_unique();
-        cache.assign_program(&env, program1, 10, new_test_entry(10));
-        cache.assign_program(
-            &env,
-            program1,
-            20,
+        let entries = [
+            Arc::new(ProgramCacheEntry::new_unloaded(
+                20,
+                ProgramCacheEntryOwner::LoaderV3,
+                ProgramRuntimeEnvironment::clone(&env),
+            )),
             Arc::new(ProgramCacheEntry::new_closed_tombstone(
                 20,
                 ProgramCacheEntryOwner::LoaderV3,
             )),
+            Arc::new(ProgramCacheEntry::new_failed_verification_tombstone(
+                20,
+                ProgramCacheEntryOwner::LoaderV3,
+                ProgramRuntimeEnvironment::clone(&env),
+            )),
+        ];
+        for entry in &entries {
+            let mut cache = ProgramCache::<TestForkGraph>::new(0);
+            cache.set_fork_graph(Arc::downgrade(&fork_graph));
+            cache.assign_program(&env, program1, 10, new_test_entry(10));
+            cache.assign_program(&env, program1, entry.deployment_slot, Arc::clone(&entry));
+            cache.prune(100, None, &fork_graph.read().unwrap());
+            let slot_versions = cache.get_slot_versions_for_tests(&program1);
+            assert_eq!(slot_versions, &[entry.clone()]);
+        }
+
+        let mut cache = ProgramCache::<TestForkGraph>::new(0);
+        cache.set_fork_graph(Arc::downgrade(&fork_graph));
+        cache.assign_program(
+            &env,
+            program1,
+            entries[0].deployment_slot,
+            Arc::clone(&entries[0]),
         );
-
-        cache.prune(100, None, &fork_graph.read().unwrap());
-        let slot_versions = cache.get_slot_versions_for_tests(&program1);
-        assert!(matches!(
-            &slot_versions.first().unwrap().program,
-            ProgramCacheEntryType::Closed,
-        ));
-
+        cache.prune(
+            MAX_TOMBSTONE_AGE_IN_SLOTS,
+            None,
+            &fork_graph.read().unwrap(),
+        );
+        assert!(!cache.get_flattened_entries_for_tests().is_empty());
         cache.prune(
             MAX_TOMBSTONE_AGE_IN_SLOTS.saturating_add(1),
             None,

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -250,7 +250,7 @@ impl ProgramCacheEntry {
             account_owner,
             deployment_slot,
             stats: Arc::default(),
-            latest_access_slot: AtomicU64::new(0),
+            latest_access_slot: AtomicU64::new(deployment_slot),
         }
     }
 

--- a/program-runtime/src/program_metrics.rs
+++ b/program-runtime/src/program_metrics.rs
@@ -168,6 +168,8 @@ pub struct ProgramCacheStats {
     pub replacements: AtomicU64,
     /// a program was only used once before being unloaded
     pub one_hit_wonders: AtomicU64,
+    /// a program got pruned because it was unloaded for too long or a tombstone
+    pub prunes_stale: AtomicU64,
     /// a program became unreachable in the fork graph because of rerooting
     pub prunes_orphan: AtomicU64,
     /// a program got pruned because it was not recompiled for the next epoch
@@ -191,6 +193,7 @@ impl ProgramCacheStats {
         let lost_insertions = self.lost_insertions.load(Ordering::Relaxed);
         let replacements = self.replacements.load(Ordering::Relaxed);
         let one_hit_wonders = self.one_hit_wonders.load(Ordering::Relaxed);
+        let prunes_stale = self.prunes_stale.load(Ordering::Relaxed);
         let prunes_orphan = self.prunes_orphan.load(Ordering::Relaxed);
         let prunes_environment = self.prunes_environment.load(Ordering::Relaxed);
         let empty_entries = self.empty_entries.load(Ordering::Relaxed);
@@ -199,8 +202,8 @@ impl ProgramCacheStats {
             "Loaded Programs Cache Stats -- Hits: {hits}, Misses: {misses}, Evictions: \
              {evictions}, Reloads: {reloads}, Insertions: {insertions}, Lost-Insertions: \
              {lost_insertions}, Replacements: {replacements}, One-Hit-Wonders: {one_hit_wonders}, \
-             Prunes-Orphan: {prunes_orphan}, Prunes-Environment: {prunes_environment}, Empty: \
-             {empty_entries}, Water-Level: {water_level}"
+             Prunes-Stale: {prunes_stale}, Prunes-Orphan: {prunes_orphan}, Prunes-Environment: \
+             {prunes_environment}, Empty: {empty_entries}, Water-Level: {water_level}"
         );
 
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -235,6 +235,7 @@ pub(crate) fn report_loaded_programs_stats<T: ForkGraph>(cache: &ProgramCache<T>
     let lost_insertions = stats.lost_insertions.load(Ordering::Relaxed);
     let replacements = stats.replacements.load(Ordering::Relaxed);
     let one_hit_wonders = stats.one_hit_wonders.load(Ordering::Relaxed);
+    let prunes_stale = stats.prunes_stale.load(Ordering::Relaxed);
     let prunes_orphan = stats.prunes_orphan.load(Ordering::Relaxed);
     let prunes_environment = stats.prunes_environment.load(Ordering::Relaxed);
     let empty_entries = stats.empty_entries.load(Ordering::Relaxed);
@@ -250,6 +251,7 @@ pub(crate) fn report_loaded_programs_stats<T: ForkGraph>(cache: &ProgramCache<T>
         ("lost_insertions", lost_insertions, i64),
         ("replace_entry", replacements, i64),
         ("one_hit_wonders", one_hit_wonders, i64),
+        ("prunes_stale", prunes_stale, i64),
         ("prunes_orphan", prunes_orphan, i64),
         ("prunes_environment", prunes_environment, i64),
         ("empty_entries", empty_entries, i64),


### PR DESCRIPTION
#### Problem

Alternative to #14385 as eviction is only triggered when the number of loaded entries crosses the threshold, not the total number of entires.

#### Summary of Changes

Prunes tombstones and unloaded entries if we are sure that they are the only version of the program across all forks,
and if they were not used in a while.

#### Testing

- Adds `test_prune_tombstones()`.
- Replay against MNB for a day.