### PR TITLE
SIMD-0599: remove inactive stakes, only cache effective/activating delegations

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -2634,7 +2634,7 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         ),
         (
             remove_inactive_stakes::id(),
-            "Remove inactive stakes from stake delegations",
+            "SIMD-0599: Remove inactive stakes from stake delegations",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -83,6 +83,7 @@ pub struct FeatureSnapshot {
     pub define_ltds_fee_only_semantics: bool,
     pub upgrade_bpf_stake_program_to_v5_1: bool,
     pub relax_fee_payer_constraint: bool,
+    pub remove_inactive_stakes: bool,
 }
 
 impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
@@ -186,6 +187,7 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             define_ltds_fee_only_semantics: is_active(&define_ltds_fee_only_semantics::ID),
             upgrade_bpf_stake_program_to_v5_1: is_active(&upgrade_bpf_stake_program_to_v5_1::ID),
             relax_fee_payer_constraint: is_active(&relax_fee_payer_constraint::ID),
+            remove_inactive_stakes: is_active(&remove_inactive_stakes::ID),
         }
     }
 }
@@ -1540,6 +1542,10 @@ pub mod double_disinflation_rate {
     pub const TAPER: f64 = 0.30;
 }
 
+pub mod remove_inactive_stakes {
+    solana_pubkey::declare_id!("RMsTKfD6hZnBhhNvgGBeKNrqCNkeoP3DYYxNtcuWtRg");
+}
+
 pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::new(|| {
     [
         (secp256k1_program_enabled::id(), "secp256k1 program"),
@@ -2625,6 +2631,10 @@ pub static FEATURE_NAMES: LazyLock<AHashMap<Pubkey, &'static str>> = LazyLock::n
         (
             double_disinflation_rate::id(),
             "SIMD-0550: Double disinflation rate",
+        ),
+        (
+            remove_inactive_stakes::id(),
+            "Remove inactive stakes from stake delegations",
         ),
         /*************** ADD NEW FEATURES HERE ***************/
         /***** ADD NEW FEATURE BOOL TO `FeatureSnapshot` *****/

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1736,7 +1736,7 @@ impl Bank {
 
     /// Whether a stored delegation with neither effective nor activating stake
     /// should be evicted from the stakes cache.
-    fn remove_inactive_stakes(&self) -> bool {
+    fn can_safely_remove_inactive_stakes(&self) -> bool {
         self.feature_set.snapshot().remove_inactive_stakes
             && matches!(self.epoch_reward_status, EpochRewardStatus::Inactive)
     }
@@ -1801,7 +1801,8 @@ impl Bank {
         ));
         debug_assert_eq!(reward_epoch_delegated_stakes.epoch, rewarded_epoch);
 
-        // Filter out inert delegations so they are not marked for rewards.
+        // Filter out inert delegations so they are not marked for rewards. This
+        // set is always empty when the `remove_inactive_stakes` feature is off.
         if !inert_stake_delegations.is_empty() {
             stake_delegations
                 .retain(|(stake_pubkey, _)| !inert_stake_delegations.contains(*stake_pubkey));
@@ -4813,7 +4814,7 @@ impl Bank {
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
-        let remove_inactive_stakes = self.remove_inactive_stakes();
+        let can_safely_remove_inactive_stakes = self.can_safely_remove_inactive_stakes();
 
         (0..accounts.len()).for_each(|i| {
             accounts.account(i, |account| {
@@ -4822,7 +4823,7 @@ impl Bank {
                     &account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                    remove_inactive_stakes,
+                    can_safely_remove_inactive_stakes,
                 )
             })
         });
@@ -5834,7 +5835,7 @@ impl Bank {
         debug_assert_eq!(txs.len(), processing_results.len());
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
-        let remove_inactive_stakes = self.remove_inactive_stakes();
+        let can_safely_remove_inactive_stakes = self.can_safely_remove_inactive_stakes();
         txs.iter()
             .zip(processing_results)
             .filter_map(|(tx, processing_result)| {
@@ -5861,7 +5862,7 @@ impl Bank {
                     account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                    remove_inactive_stakes,
+                    can_safely_remove_inactive_stakes,
                 );
             });
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1734,13 +1734,6 @@ impl Bank {
             .upgrade_bpf_stake_program_to_v5_1
     }
 
-    /// Whether a stored delegation with neither effective nor activating stake
-    /// should be evicted from the stakes cache.
-    fn can_safely_remove_inactive_stakes(&self) -> bool {
-        self.feature_set.snapshot().remove_inactive_stakes
-            && matches!(self.epoch_reward_status, EpochRewardStatus::Inactive)
-    }
-
     /// Get cached vote account state from the past few epochs so that some vote
     /// state configuration changes are delayed before being used in reward
     /// calculation.
@@ -4814,7 +4807,7 @@ impl Bank {
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
-        let can_safely_remove_inactive_stakes = self.can_safely_remove_inactive_stakes();
+        let remove_inactive_stakes = self.feature_set.snapshot().remove_inactive_stakes;
 
         (0..accounts.len()).for_each(|i| {
             accounts.account(i, |account| {
@@ -4823,7 +4816,7 @@ impl Bank {
                     &account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                    can_safely_remove_inactive_stakes,
+                    remove_inactive_stakes,
                 )
             })
         });
@@ -5835,7 +5828,7 @@ impl Bank {
         debug_assert_eq!(txs.len(), processing_results.len());
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
-        let can_safely_remove_inactive_stakes = self.can_safely_remove_inactive_stakes();
+        let remove_inactive_stakes = self.feature_set.snapshot().remove_inactive_stakes;
         txs.iter()
             .zip(processing_results)
             .filter_map(|(tx, processing_result)| {
@@ -5862,7 +5855,7 @@ impl Bank {
                     account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
-                    can_safely_remove_inactive_stakes,
+                    remove_inactive_stakes,
                 );
             });
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1197,6 +1197,10 @@ struct NewEpochBundle {
     unfiltered_distribution_vote_accounts: VoteAccounts,
     /// Current effective stake delegated to each vote account pubkey.
     delegated_stakes: DelegatedStakes,
+    /// Delegations that were inactive in the rewarded epoch and remain inactive
+    /// in the distribution epoch. These are evicted from the stakes cache when
+    /// `remove_inactive_stakes` is active.
+    inert_stake_delegations: HashSet<Pubkey>,
     /// Vote accounts computed from the stakes cache for the current
     /// (distribution) epoch *after* applying VAT filtering.
     filtered_distribution_vote_accounts: VoteAccounts,
@@ -1730,6 +1734,13 @@ impl Bank {
             .upgrade_bpf_stake_program_to_v5_1
     }
 
+    /// Whether a stored delegation with neither effective nor activating stake
+    /// should be evicted from the stakes cache.
+    fn remove_inactive_stakes(&self) -> bool {
+        self.feature_set.snapshot().remove_inactive_stakes
+            && matches!(self.epoch_reward_status, EpochRewardStatus::Inactive)
+    }
+
     /// Get cached vote account state from the past few epochs so that some vote
     /// state configuration changes are delayed before being used in reward
     /// calculation.
@@ -1770,13 +1781,14 @@ impl Bank {
         // update vote accounts with warmed up stakes before saving a
         // snapshot of stakes in epoch stakes
         let stakes = self.stakes_cache.stakes();
-        let stake_delegations = stakes.stake_delegations_vec();
+        let mut stake_delegations = stakes.stake_delegations_vec();
         let (
             (
                 stake_history,
                 unfiltered_distribution_vote_accounts,
                 delegated_stakes,
                 reward_epoch_delegated_stakes,
+                inert_stake_delegations,
             ),
             calculate_activated_stake_time_us,
         ) = measure_us!(stakes.calculate_activated_stake(
@@ -1785,8 +1797,15 @@ impl Bank {
             self.new_warmup_cooldown_rate_epoch(),
             &stake_delegations,
             self.use_fixed_point_stake_math(),
+            self.feature_set.snapshot().remove_inactive_stakes,
         ));
         debug_assert_eq!(reward_epoch_delegated_stakes.epoch, rewarded_epoch);
+
+        // Filter out inert delegations so they are not marked for rewards.
+        if !inert_stake_delegations.is_empty() {
+            stake_delegations
+                .retain(|(stake_pubkey, _)| !inert_stake_delegations.contains(*stake_pubkey));
+        }
 
         // Apply stake rewards and commission using the VAT-filtered distribution
         // vote-account snapshot.
@@ -1815,6 +1834,7 @@ impl Bank {
             stake_history,
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
+            inert_stake_delegations,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1844,6 +1864,7 @@ impl Bank {
             stake_history,
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
+            inert_stake_delegations,
             filtered_distribution_vote_accounts,
             rewards_calculation,
             calculate_activated_stake_time_us,
@@ -1860,6 +1881,7 @@ impl Bank {
             stake_history,
             unfiltered_distribution_vote_accounts,
             delegated_stakes,
+            &inert_stake_delegations,
         );
 
         // Save a snapshot of stakes for use in consensus and stake weighted networking
@@ -4791,6 +4813,7 @@ impl Bank {
         let mut m = Measure::start("stakes_cache.check_and_store");
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
+        let remove_inactive_stakes = self.remove_inactive_stakes();
 
         (0..accounts.len()).for_each(|i| {
             accounts.account(i, |account| {
@@ -4799,6 +4822,7 @@ impl Bank {
                     &account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
+                    remove_inactive_stakes,
                 )
             })
         });
@@ -5810,6 +5834,7 @@ impl Bank {
         debug_assert_eq!(txs.len(), processing_results.len());
         let new_warmup_cooldown_rate_epoch = self.new_warmup_cooldown_rate_epoch();
         let use_fixed_point_stake_math = self.use_fixed_point_stake_math();
+        let remove_inactive_stakes = self.remove_inactive_stakes();
         txs.iter()
             .zip(processing_results)
             .filter_map(|(tx, processing_result)| {
@@ -5836,6 +5861,7 @@ impl Bank {
                     account,
                     new_warmup_cooldown_rate_epoch,
                     use_fixed_point_stake_math,
+                    remove_inactive_stakes,
                 );
             });
     }

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -2219,6 +2219,113 @@ mod tests {
     }
 
     #[test]
+    fn test_inert_delegation_is_not_partitioned_for_rewards() {
+        let GenesisConfigInfo {
+            mut genesis_config,
+            voting_keypair,
+            ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        genesis_config.rent = Rent::default();
+        let genesis_vote_address = voting_keypair.pubkey();
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let feature_snapshot = bank.feature_set.snapshot();
+        assert!(feature_snapshot.remove_inactive_stakes);
+        assert!(feature_snapshot.relax_post_exec_min_balance_check);
+
+        // A delegation deactivated in the epoch it was activated in never has
+        // effective or activating stake, so the epoch boundary evicts it from
+        // the stakes cache. Its lamports leave no room for the rent-exempt
+        // reserve, which is what makes SIMD-0392 want to rewrite it at
+        // distribution time.
+        let delegation = LAMPORTS_PER_SOL;
+        let inert_stake_address = Pubkey::new_unique();
+        let mut inert_stake_account =
+            create_stake_account(delegation, delegation, &genesis_vote_address, 0);
+        let StakeStateV2::Stake(meta, mut stake, flags) = inert_stake_account.state().unwrap()
+        else {
+            panic!("expected a delegated stake account");
+        };
+        stake.delegation.deactivation_epoch = stake.delegation.activation_epoch;
+        inert_stake_account
+            .set_state(&StakeStateV2::Stake(meta, stake, flags))
+            .unwrap();
+
+        // Seed the cache directly. Once the feature is active, storing an inert
+        // delegation never puts it in the cache to begin with; the boundary
+        // sweep exists for delegations that were cached before activation, or
+        // that went inert while cached.
+        bank.store_account_without_stakes_cache(&inert_stake_address, &inert_stake_account);
+        bank.stakes_cache.check_and_store(
+            &inert_stake_address,
+            &inert_stake_account,
+            bank.new_warmup_cooldown_rate_epoch(),
+            bank.use_fixed_point_stake_math(),
+            false,
+        );
+        assert!(
+            bank.stakes_cache
+                .stakes()
+                .stake_delegations()
+                .contains_key(&inert_stake_address)
+        );
+
+        let bank = apply_epoch_operations(
+            bank,
+            bank_forks.as_ref(),
+            EpochOperations {
+                epoch: 0,
+                vote_operations: vec![(
+                    genesis_vote_address,
+                    VoteOperations {
+                        earned_credits: Some(1000),
+                        ..VoteOperations::default()
+                    },
+                )],
+            },
+        );
+
+        assert!(
+            !bank
+                .stakes_cache
+                .stakes()
+                .stake_delegations()
+                .contains_key(&inert_stake_address)
+        );
+        let EpochRewardStatus::Active(EpochRewardPhase::Calculation(status)) =
+            &bank.epoch_reward_status
+        else {
+            panic!("expected rewards pending distribution");
+        };
+        assert!(
+            !status
+                .all_stake_rewards
+                .enumerated_rewards_iter()
+                .any(|(_, reward)| reward.stake_pubkey == inert_stake_address),
+            "an evicted delegation must not be scheduled for distribution"
+        );
+
+        // Run the distribution block: the delegation is left alone rather than
+        // failing to resolve against the stakes cache.
+        let slot = bank.slot();
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            bank,
+            SlotLeader::new_unique(),
+            slot + 1,
+        );
+        let stake_account = bank.get_account(&inert_stake_address).unwrap();
+        let stake_state: StakeStateV2 = stake_account.state().unwrap();
+        assert_eq!(stake_state.stake().unwrap().delegation.stake, delegation);
+    }
+
+    #[test]
     fn test_calculate_stake_vote_rewards_genesis_vote_account() {
         let GenesisConfigInfo {
             mut genesis_config,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5854,7 +5854,7 @@ fn test_bank_hash_deterministic_with_stakes_cache() {
 
     assert_eq!(
         bank2.hash().to_string(),
-        "Bfv1qFoAHPB8QxxEpypMv9wpcLwMfHacWjM46oEEyH5",
+        "9agm2yVmnQmfwLy1jBV4kgf26Fk6q2gtJ2q9nWRTFs37",
     );
 }
 

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -679,9 +679,20 @@ impl Stakes<StakeAccount> {
             new_rate_activation_epoch,
             use_fixed_point_stake_math,
         );
-        // A delegation with neither effective nor activating stake cannot
-        // contribute stake, so there is no reason to keep tracking it.
+        let previous_activation_status = delegation_activation_status(
+            delegation,
+            self.epoch.saturating_sub(1),
+            &self.stake_history,
+            new_rate_activation_epoch,
+            use_fixed_point_stake_math,
+        );
+
+        // A delegation with neither effective nor activating stake in the past
+        // two epochs contributes no stake, and cannot receive rewards, so there
+        // is no reason to track it.
         if remove_inactive_stakes
+            && previous_activation_status.effective == 0
+            && previous_activation_status.activating == 0
             && activation_status.effective == 0
             && activation_status.activating == 0
         {

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -899,6 +899,7 @@ pub(crate) mod tests {
         solana_stake_interface::{self as stake, state::StakeStateV2},
         solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, VoteStateV4},
         solana_vote_program::vote_state,
+        test_case::test_case,
     };
 
     impl Stakes<Delegation> {
@@ -1340,5 +1341,46 @@ pub(crate) mod tests {
             assert!(vote_accounts.get(&vote_pubkey).is_some());
             assert_eq!(vote_accounts.get_delegated_stake(&vote_pubkey), 0);
         }
+    }
+
+    #[test_case(4, u64::MAX, true; "activating")]
+    #[test_case(0, u64::MAX, true; "active")]
+    #[test_case(0, 4, true; "deactivating")]
+    #[test_case(0, 3, true; "new_deactivated")]
+    #[test_case(0, 2, false; "old_deactivated")]
+    #[test_case(4, 4, false; "active/deactive")]
+    fn test_inert_delegation_is_removed_from_cache(
+        activation_epoch: Epoch,
+        deactivation_epoch: Epoch,
+        expect_cached: bool,
+    ) {
+        let stakes_cache = StakesCache::new(Stakes {
+            epoch: 4,
+            ..Stakes::default()
+        });
+        let rent = Rent::default();
+
+        let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
+            create_staked_node_accounts(10, &rent);
+        let StakeStateV2::Stake(meta, mut stake, flags) = stake_account.state().unwrap() else {
+            panic!("expected a delegated stake account");
+        };
+        stake.delegation.activation_epoch = activation_epoch;
+        stake.delegation.deactivation_epoch = deactivation_epoch;
+        stake_account
+            .set_state(&StakeStateV2::Stake(meta, stake, flags))
+            .unwrap();
+
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, true);
+        // Force insert the inactive stake in the cache
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
+        // Update with `remove_inactive_stakes = true` removes it
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, true);
+
+        let stakes = stakes_cache.stakes();
+        assert_eq!(
+            stakes.stake_delegations().contains_key(&stake_pubkey),
+            expect_cached
+        );
     }
 }

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -26,7 +26,7 @@ use {
     solana_vote::vote_account::{VoteAccount, VoteAccounts, VoteAccountsHashMap},
     solana_vote_interface::state::VoteStateVersions,
     std::{
-        collections::HashMap,
+        collections::{HashMap, HashSet},
         sync::{Arc, RwLock, RwLockReadGuard},
     },
     thiserror::Error,
@@ -90,6 +90,7 @@ impl StakesCache {
         account: &impl ReadableAccount,
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
+        remove_inactive_stakes: bool,
     ) {
         // TODO: If the account is already cached as a vote or stake account
         // but the owner changes, then this needs to evict the account from
@@ -149,6 +150,7 @@ impl StakesCache {
                         stake_account,
                         new_rate_activation_epoch,
                         use_fixed_point_stake_math,
+                        remove_inactive_stakes,
                     );
                 }
                 Err(_) => {
@@ -169,9 +171,16 @@ impl StakesCache {
         stake_history: StakeHistory,
         vote_accounts: VoteAccounts,
         delegated_stakes: DelegatedStakes,
+        inert_stake_delegations: &HashSet<Pubkey>,
     ) {
         let mut stakes = self.0.write().unwrap();
-        stakes.activate_epoch(next_epoch, stake_history, vote_accounts, delegated_stakes)
+        stakes.activate_epoch(
+            next_epoch,
+            stake_history,
+            vote_accounts,
+            delegated_stakes,
+            inert_stake_delegations,
+        )
     }
 
     pub(crate) fn refresh_delegated_stakes(
@@ -438,44 +447,70 @@ impl Stakes<StakeAccount> {
         new_rate_activation_epoch: Option<Epoch>,
         stake_delegations: &[(&Pubkey, &StakeAccount)],
         use_fixed_point_stake_math: bool,
+        remove_inactive_stakes: bool,
     ) -> (
         StakeHistory,
         VoteAccounts,
         DelegatedStakes,
         RewardEpochDelegatedStakes,
+        HashSet<Pubkey>,
     ) {
         // Wrap up the prev epoch by adding new stake history entry for the
         // prev epoch.
-        let (stake_history_entry, effective_delegated_stakes) = thread_pool.install(|| {
-            stake_delegations
-                .par_iter()
-                .fold(
-                    || (StakeActivationStatus::default(), HashMap::default()),
-                    |(acc, mut delegated_stakes), (_stake_pubkey, stake_account)| {
-                        let delegation = stake_account.delegation();
-                        let activation_status = delegation_activation_status(
-                            delegation,
-                            self.epoch,
-                            &self.stake_history,
-                            new_rate_activation_epoch,
-                            use_fixed_point_stake_math,
-                        );
-                        *delegated_stakes.entry(delegation.voter_pubkey).or_default() +=
-                            activation_status.effective;
-                        (acc + activation_status, delegated_stakes)
-                    },
-                )
-                .reduce(
-                    || (StakeActivationStatus::default(), HashMap::default()),
-                    |(activation_status_a, delegated_stakes_a),
-                     (activation_status_b, delegated_stakes_b)| {
-                        (
-                            activation_status_a + activation_status_b,
-                            merge_delegated_stakes(delegated_stakes_a, delegated_stakes_b),
-                        )
-                    },
-                )
-        });
+        let (stake_history_entry, effective_delegated_stakes, inert_stake_delegations) =
+            thread_pool.install(|| {
+                stake_delegations
+                    .par_iter()
+                    .fold(
+                        || {
+                            (
+                                StakeActivationStatus::default(),
+                                HashMap::default(),
+                                HashSet::default(),
+                            )
+                        },
+                        |(acc, mut delegated_stakes, mut inert_stake_delegations),
+                         (stake_pubkey, stake_account)| {
+                            let delegation = stake_account.delegation();
+                            let activation_status = delegation_activation_status(
+                                delegation,
+                                self.epoch,
+                                &self.stake_history,
+                                new_rate_activation_epoch,
+                                use_fixed_point_stake_math,
+                            );
+                            // A delegation with neither effective nor activating
+                            // stake can never contribute stake again, so it can
+                            // be dropped from the cache.
+                            if remove_inactive_stakes
+                                && activation_status.effective == 0
+                                && activation_status.activating == 0
+                            {
+                                inert_stake_delegations.insert(**stake_pubkey);
+                            }
+                            *delegated_stakes.entry(delegation.voter_pubkey).or_default() +=
+                                activation_status.effective;
+                            (acc + activation_status, delegated_stakes, inert_stake_delegations)
+                        },
+                    )
+                    .reduce(
+                        || {
+                            (
+                                StakeActivationStatus::default(),
+                                HashMap::default(),
+                                HashSet::default(),
+                            )
+                        },
+                        |(activation_status_a, delegated_stakes_a, inert_a),
+                         (activation_status_b, delegated_stakes_b, inert_b)| {
+                            (
+                                activation_status_a + activation_status_b,
+                                merge_delegated_stakes(delegated_stakes_a, delegated_stakes_b),
+                                merge_inert_stake_delegations(inert_a, inert_b),
+                            )
+                        },
+                    )
+            });
         let mut stake_history = self.stake_history.clone();
         stake_history.add(self.epoch, stake_history_entry);
         // Refresh the stake distribution of vote accounts for the next epoch,
@@ -498,6 +533,7 @@ impl Stakes<StakeAccount> {
             vote_accounts,
             delegated_stakes,
             reward_epoch_delegated_stakes,
+            inert_stake_delegations,
         )
     }
 
@@ -507,11 +543,19 @@ impl Stakes<StakeAccount> {
         stake_history: StakeHistory,
         vote_accounts: VoteAccounts,
         delegated_stakes: DelegatedStakes,
+        inert_stake_delegations: &HashSet<Pubkey>,
     ) {
         self.epoch = next_epoch;
         self.stake_history = stake_history;
         self.vote_accounts = vote_accounts;
         self.delegated_stakes = delegated_stakes;
+        // These delegations were inactive before `next_epoch`, so their zero
+        // contributions were already recorded in the previous epoch's stake
+        // history. They also contribute no stake to `delegated_stakes` or
+        // `vote_accounts`, so no further bookkeeping is needed here.
+        for stake_pubkey in inert_stake_delegations {
+            self.stake_delegations.remove(stake_pubkey);
+        }
     }
 
     fn calculate_delegated_stakes(
@@ -623,17 +667,32 @@ impl Stakes<StakeAccount> {
         stake_account: StakeAccount,
         new_rate_activation_epoch: Option<Epoch>,
         use_fixed_point_stake_math: bool,
+        remove_inactive_stakes: bool,
     ) {
         debug_assert_ne!(stake_account.lamports(), 0u64);
         let delegation = stake_account.delegation();
         let voter_pubkey = delegation.voter_pubkey;
-        let stake = delegation_effective_stake(
+        let activation_status = delegation_activation_status(
             delegation,
             self.epoch,
             &self.stake_history,
             new_rate_activation_epoch,
             use_fixed_point_stake_math,
         );
+        // A delegation with neither effective nor activating stake cannot
+        // contribute stake, so there is no reason to keep tracking it.
+        if remove_inactive_stakes
+            && activation_status.effective == 0
+            && activation_status.activating == 0
+        {
+            self.remove_stake_delegation(
+                &stake_pubkey,
+                new_rate_activation_epoch,
+                use_fixed_point_stake_math,
+            );
+            return;
+        }
+        let stake = activation_status.effective;
         match self.stake_delegations.insert(stake_pubkey, stake_account) {
             None => {
                 self.add_delegated_stake(voter_pubkey, stake);
@@ -751,6 +810,17 @@ fn merge_delegated_stakes(
         *stakes.entry(pubkey).or_default() += stake;
     }
     stakes
+}
+
+fn merge_inert_stake_delegations(
+    mut delegations: HashSet<Pubkey>,
+    other: HashSet<Pubkey>,
+) -> HashSet<Pubkey> {
+    if delegations.len() < other.len() {
+        return merge_inert_stake_delegations(other, delegations);
+    }
+    delegations.extend(other);
+    delegations
 }
 
 fn refresh_vote_accounts(
@@ -902,8 +972,8 @@ pub(crate) mod tests {
             let ((vote_pubkey, vote_account), (stake_pubkey, mut stake_account)) =
                 create_staked_node_accounts(10, &rent);
 
-            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
             let stake_state: StakeStateV2 = stake_account.state().unwrap();
             let stake = stake_state.stake().unwrap();
             {
@@ -919,7 +989,7 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(42);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -935,7 +1005,7 @@ pub(crate) mod tests {
             // activate more
             let mut stake_account =
                 create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand(), &rent);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
             let stake_state: StakeStateV2 = stake_account.state().unwrap();
             let stake = stake_state.stake().unwrap();
             {
@@ -951,7 +1021,7 @@ pub(crate) mod tests {
             }
 
             stake_account.set_lamports(0);
-            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+            stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -971,14 +1041,14 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
 
         let ((vote11_pubkey, vote11_account), (stake11_pubkey, stake11_account)) =
             create_staked_node_accounts(20, &rent);
 
-        stakes_cache.check_and_store(&vote11_pubkey, &vote11_account, None, true);
-        stakes_cache.check_and_store(&stake11_pubkey, &stake11_account, None, true);
+        stakes_cache.check_and_store(&vote11_pubkey, &vote11_account, None, true, false);
+        stakes_cache.check_and_store(&stake11_pubkey, &stake11_account, None, true, false);
 
         let vote11_node_pubkey = VoteStateV4::deserialize(vote11_account.data(), &vote11_pubkey)
             .unwrap()
@@ -1005,8 +1075,8 @@ pub(crate) mod tests {
         let ((vote_pubkey, mut vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1016,7 +1086,7 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(0);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1026,7 +1096,7 @@ pub(crate) mod tests {
         }
 
         vote_account.set_lamports(1);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1040,7 +1110,7 @@ pub(crate) mod tests {
         let mut pushed = vote_account.data().to_vec();
         pushed.push(0);
         vote_account.set_data_from_slice(&pushed);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1051,7 +1121,7 @@ pub(crate) mod tests {
 
         // Vote account uninitialized
         vote_account.set_data_from_slice(&vec![0; VoteStateV4::size_of()]);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1061,7 +1131,7 @@ pub(crate) mod tests {
         }
 
         vote_account.set_data_from_slice(&cache_data);
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1085,11 +1155,11 @@ pub(crate) mod tests {
         let ((vote_pubkey2, vote_account2), (_stake_pubkey2, stake_account2)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&vote_pubkey2, &vote_account2, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+        stakes_cache.check_and_store(&vote_pubkey2, &vote_account2, None, true, false);
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
 
         let stake_state: StakeStateV2 = stake_account.state().unwrap();
         let stake = stake_state.stake().unwrap();
@@ -1109,7 +1179,7 @@ pub(crate) mod tests {
         }
 
         // delegates to vote_pubkey2
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account2, None, true);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account2, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1139,11 +1209,11 @@ pub(crate) mod tests {
         let stake_pubkey2 = solana_pubkey::new_rand();
         let stake_account2 = create_stake_account(10, &vote_pubkey, &stake_pubkey2, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
 
         // delegates to vote_pubkey
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey2, &stake_account2, None, true);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
+        stakes_cache.check_and_store(&stake_pubkey2, &stake_account2, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1161,8 +1231,8 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
         let stake_state: StakeStateV2 = stake_account.state().unwrap();
         let stake = stake_state.stake().unwrap();
 
@@ -1180,7 +1250,13 @@ pub(crate) mod tests {
         }
         let thread_pool = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
         let next_epoch = 3;
-        let (stake_history, vote_accounts, delegated_stakes, effective_delegated_stakes) = {
+        let (
+            stake_history,
+            vote_accounts,
+            delegated_stakes,
+            effective_delegated_stakes,
+            inert_stake_delegations,
+        ) = {
             let stakes = stakes_cache.stakes();
             let stake_delegations = stakes.stake_delegations_vec();
             stakes.calculate_activated_stake(
@@ -1188,6 +1264,7 @@ pub(crate) mod tests {
                 &thread_pool,
                 None,
                 &stake_delegations,
+                true,
                 true,
             )
         };
@@ -1198,7 +1275,13 @@ pub(crate) mod tests {
                 .copied(),
             Some(initial_expected_stake)
         );
-        stakes_cache.activate_epoch(next_epoch, stake_history, vote_accounts, delegated_stakes);
+        stakes_cache.activate_epoch(
+            next_epoch,
+            stake_history,
+            vote_accounts,
+            delegated_stakes,
+            &inert_stake_delegations,
+        );
         {
             let stakes = stakes_cache.stakes();
             let vote_accounts = stakes.vote_accounts();
@@ -1222,8 +1305,8 @@ pub(crate) mod tests {
         let ((vote_pubkey, vote_account), (stake_pubkey, stake_account)) =
             create_staked_node_accounts(10, &rent);
 
-        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
-        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+        stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
+        stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
 
         {
             let stakes = stakes_cache.stakes();
@@ -1238,6 +1321,7 @@ pub(crate) mod tests {
             &AccountSharedData::new(1, 0, &stake::program::id()),
             None,
             true,
+            false,
         );
         {
             let stakes = stakes_cache.stakes();

--- a/runtime/src/stakes/serde_stakes.rs
+++ b/runtime/src/stakes/serde_stakes.rs
@@ -270,7 +270,7 @@ mod tests {
                 &node_pubkey,
                 rng.random_range(0..1_000_000), // lamports
             );
-            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
+            stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true, false);
             for _ in 0..rng.random_range(10usize..20) {
                 let stake_pubkey = solana_pubkey::new_rand();
                 let rent = Rent::free();
@@ -281,7 +281,7 @@ mod tests {
                     &rent,
                     rng.random_range(0..1_000_000), // lamports
                 );
-                stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
+                stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true, false);
             }
         }
         let stakes: Stakes<StakeAccount> = stakes_cache.stakes().clone();


### PR DESCRIPTION
#### Problem

The stakes cache contains inactive stakes, which do not contribute to the stake weight of validators.

#### Summary of Changes

Remove "inert" stakes (stakes that have been inactive for at least a full epoch) during epoch boundary calculation, and update the stakes cache to remove inactive stakes outside of the reward period.

#### Testing

New unit test.