### PR TITLE
ci(bump-version): auto-merge version bump PRs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -73,6 +73,7 @@ jobs:
           echo "target_branch=$target_branch" | tee -a $GITHUB_OUTPUT
 
       - name: Create PR
+        id: create-pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           NEW_VERSION: ${{ steps.process.outputs.new_version }}
@@ -84,7 +85,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Bump version to ${process.env.NEW_VERSION}`,
-              draft: true,
+              draft: false,
               head: `version-bump-${process.env.NEW_VERSION}`,
               base: process.env.TARGET_BRANCH
             })
@@ -94,4 +95,26 @@ jobs:
               repo: context.repo.repo,
               issue_number: pr.data.number,
               assignees: [context.actor],
+            })
+
+            core.setOutput('number', pr.data.number)
+
+      - name: Merge PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          NEW_VERSION: ${{ steps.process.outputs.new_version }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.number }}
+        with:
+          # the app is a ruleset bypass actor, GITHUB_TOKEN is not
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const pull_number = Number(process.env.PR_NUMBER)
+
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+              merge_method: 'squash',
+              commit_title: `Bump version to ${process.env.NEW_VERSION} (#${pull_number})`,
+              commit_message: '',
             })


### PR DESCRIPTION
#### Problem

The release workflow opens a version bump PR against `master` or a `v*` branch. Those PRs inherit the branch rulesets, so `v*` bumps need two approvals with at least one from `@anza-xyz/backport-reviewers`, and `master` bumps need an approval plus a merge queue trip. 

The diff for this version bump PR is generated by `cargo anza-xtask bump-version` and verified by that same command to touch nothing but version fields, so the reviews are a rubber stamp that parks a release chore on three specific people (and the SVM team on master).

#### Summary of Changes

- create the PR ready for review instead of as a draft, and export its number
- add a `Merge PR` step that squash merges using the app token; the `GITHUB_TOKEN` is not a bypass actor and would be rejected

Depends on anza-xyz/devops#2041, which makes `agave-version-bumper` a bypass actor on the `master` and `v[0-9]*` rulesets. That must land first or this merge step fails and leaves the PR open.

The same devops PR adds required reviewers to the `Version Bump` environment, so the run now pauses for approval from someone other than the dispatcher before it can mint the App token. The human checkpoint moves from PR review to dispatch.

#### Testing

Validated by the next `master` alpha bump, which should open and merge without a PR review. If the merge step fails the PR is left open and mergeable by hand, as today.

Fixes anza-xyz/devops#112
