### PR TITLE
accounts-db: Renames variant to StorageLocation::AccountsFile

### DIFF
--- a/accounts-db/src/account_info.rs
+++ b/accounts-db/src/account_info.rs
@@ -1,4 +1,4 @@
-//! AccountInfo represents a reference to AccountSharedData in an AppendVec
+//! AccountInfo represents a reference to AccountSharedData in an AccountsFile
 //! AccountInfo is not persisted anywhere between program runs.
 //! AccountInfo is purely runtime state.
 //! Note that AccountInfo is saved to disk buckets during runtime, but disk buckets are recreated at startup.
@@ -12,27 +12,27 @@ use {
     modular_bitfield::prelude::*,
 };
 
-/// offset within an append vec to account data
+/// offset within an accounts file to account data
 pub type Offset = usize;
 
 /// specify where account data is located
 #[derive(Debug, PartialEq, Eq)]
 pub enum StorageLocation {
-    AppendVec(AccountsFileId, Offset),
+    AccountsFile(AccountsFileId, Offset),
 }
 
 impl StorageLocation {
     pub fn is_offset_equal(&self, other: &StorageLocation) -> bool {
         match self {
-            StorageLocation::AppendVec(_, offset) => match other {
-                StorageLocation::AppendVec(_, other_offset) => other_offset == offset,
+            StorageLocation::AccountsFile(_, offset) => match other {
+                StorageLocation::AccountsFile(_, other_offset) => other_offset == offset,
             },
         }
     }
     pub fn is_store_id_equal(&self, other: &StorageLocation) -> bool {
         match self {
-            StorageLocation::AppendVec(store_id, _) => match other {
-                StorageLocation::AppendVec(other_store_id, _) => other_store_id == store_id,
+            StorageLocation::AccountsFile(store_id, _) => match other {
+                StorageLocation::AccountsFile(other_store_id, _) => other_store_id == store_id,
             },
         }
     }
@@ -80,7 +80,7 @@ impl AccountInfo {
     pub fn new(storage_location: StorageLocation, is_zero_lamport: bool) -> Self {
         let mut packed_offset_and_flags = PackedOffsetAndFlags::default();
         let store_id = match storage_location {
-            StorageLocation::AppendVec(store_id, offset) => {
+            StorageLocation::AccountsFile(store_id, offset) => {
                 packed_offset_and_flags.set_offset_reduced(Self::get_reduced_offset(offset));
                 assert_eq!(
                     Self::reduced_offset_to_offset(packed_offset_and_flags.offset_reduced()),
@@ -114,7 +114,7 @@ impl AccountInfo {
     }
 
     pub fn storage_location(&self) -> StorageLocation {
-        StorageLocation::AppendVec(self.store_id, self.offset())
+        StorageLocation::AccountsFile(self.store_id, self.offset())
     }
 }
 
@@ -134,7 +134,7 @@ mod test {
             ALIGN_BOUNDARY_OFFSET,
             4 * ALIGN_BOUNDARY_OFFSET,
         ] {
-            let info = AccountInfo::new(StorageLocation::AppendVec(0, offset), true);
+            let info = AccountInfo::new(StorageLocation::AccountsFile(0, offset), true);
             assert!(info.offset() == offset);
         }
     }
@@ -143,6 +143,6 @@ mod test {
     #[should_panic(expected = "illegal offset")]
     fn test_alignment() {
         let offset = 1; // not aligned
-        AccountInfo::new(StorageLocation::AppendVec(0, offset), true);
+        AccountInfo::new(StorageLocation::AccountsFile(0, offset), true);
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -310,7 +310,7 @@ impl AccountFromStorage {
         let storage_id = 0;
         AccountFromStorage {
             index_info: AccountInfo::new(
-                StorageLocation::AppendVec(storage_id, offset),
+                StorageLocation::AccountsFile(storage_id, offset),
                 account.is_zero_lamport(),
             ),
             pubkey: *account.pubkey(),
@@ -2512,7 +2512,7 @@ impl AccountsDb {
                 let file_id = 0;
                 stored_accounts.push(AccountFromStorage {
                     index_info: AccountInfo::new(
-                        StorageLocation::AppendVec(file_id, offset),
+                        StorageLocation::AccountsFile(file_id, offset),
                         account.is_zero_lamport(),
                     ),
                     pubkey: *account.pubkey(),
@@ -3835,7 +3835,7 @@ impl AccountsDb {
         storage_location: &StorageLocation,
     ) -> LoadedAccountAccessor {
         match storage_location {
-            StorageLocation::AppendVec(store_id, offset) => {
+            StorageLocation::AccountsFile(store_id, offset) => {
                 let maybe_storage_entry = self
                     .storage
                     .get_account_storage_entry(slot, *store_id)
@@ -5478,7 +5478,7 @@ impl AccountsDb {
 
         for (i, offset) in stored_accounts_info.offsets.iter().enumerate() {
             infos.push(AccountInfo::new(
-                StorageLocation::AppendVec(store_id, *offset),
+                StorageLocation::AccountsFile(store_id, *offset),
                 accounts_and_meta_to_store.is_zero_lamport(i),
             ));
         }
@@ -5729,7 +5729,7 @@ impl AccountsDb {
                 keyed_account_infos.push((
                     *account.pubkey,
                     AccountInfo::new(
-                        StorageLocation::AppendVec(store_id, offset), // will never be cached
+                        StorageLocation::AccountsFile(store_id, offset), // will never be cached
                         is_account_zero_lamport,
                     ),
                 ));
@@ -5974,7 +5974,7 @@ impl AccountsDb {
                                 if *slot2 == slot {
                                     count += 1;
                                     let ai = AccountInfo::new(
-                                        StorageLocation::AppendVec(store_id, offset), // will never be cached
+                                        StorageLocation::AccountsFile(store_id, offset), // will never be cached
                                         account.is_zero_lamport(),
                                     );
                                     assert_eq!(&ai, account_info2);

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -181,7 +181,7 @@ pub(crate) fn append_single_account_with_default_hash(
 
     if let Some(index) = add_to_index {
         let account_info = AccountInfo::new(
-            StorageLocation::AppendVec(storage.id(), stored_accounts_info.offsets[0]),
+            StorageLocation::AccountsFile(storage.id(), stored_accounts_info.offsets[0]),
             account.lamports() == 0,
         );
         index.upsert(
@@ -3217,10 +3217,10 @@ fn test_delete_dependencies() {
     let key0 = Pubkey::new_from_array([0u8; 32]);
     let key1 = Pubkey::new_from_array([1u8; 32]);
     let key2 = Pubkey::new_from_array([2u8; 32]);
-    let info0 = AccountInfo::new(StorageLocation::AppendVec(0, 0), true);
-    let info1 = AccountInfo::new(StorageLocation::AppendVec(1, 0), true);
-    let info2 = AccountInfo::new(StorageLocation::AppendVec(2, 0), true);
-    let info3 = AccountInfo::new(StorageLocation::AppendVec(3, 0), true);
+    let info0 = AccountInfo::new(StorageLocation::AccountsFile(0, 0), true);
+    let info1 = AccountInfo::new(StorageLocation::AccountsFile(1, 0), true);
+    let info2 = AccountInfo::new(StorageLocation::AccountsFile(2, 0), true);
+    let info3 = AccountInfo::new(StorageLocation::AccountsFile(3, 0), true);
     let mut reclaims = ReclaimsSlotList::new();
     accounts_index.upsert(
         0,
@@ -5749,7 +5749,7 @@ fn test_filter_zero_lamport_clean_for_incremental_snapshots() {
     }
 
     let do_test = |test_params: TestParameters| {
-        let account_info = AccountInfo::new(StorageLocation::AppendVec(42, 128), true);
+        let account_info = AccountInfo::new(StorageLocation::AccountsFile(42, 128), true);
         let pubkey = solana_pubkey::new_rand();
         let mut key_set = HashSet::default();
         key_set.insert(pubkey);
@@ -6611,7 +6611,7 @@ fn populate_index(db: &AccountsDb, slots: Range<Slot>) {
             storage
                 .scan_accounts(&mut reader, |offset, account| {
                     let info = AccountInfo::new(
-                        StorageLocation::AppendVec(storage.id(), offset),
+                        StorageLocation::AccountsFile(storage.id(), offset),
                         account.is_zero_lamport(),
                     );
                     db.accounts_index.upsert(

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1192,7 +1192,7 @@ mod tests {
                         0,
                         0,
                         account.pubkey(),
-                        AccountInfo::new(StorageLocation::AppendVec(0, 0), false),
+                        AccountInfo::new(StorageLocation::AccountsFile(0, 0), false),
                         &mut ReclaimsSlotList::new(),
                         UpsertReclaim::IgnoreReclaims,
                     );
@@ -3628,7 +3628,10 @@ mod tests {
                             // non-empty slot list (but ignored) because slot_list = 1
                             let slot_list = vec![(
                                 slot,
-                                AccountInfo::new(StorageLocation::AppendVec(0, 0), lamports == 0),
+                                AccountInfo::new(
+                                    StorageLocation::AccountsFile(0, 0),
+                                    lamports == 0,
+                                ),
                             )];
                             alive_accounts.add(2, &account, &slot_list);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
@@ -3646,14 +3649,14 @@ mod tests {
                                 (
                                     slot,
                                     AccountInfo::new(
-                                        StorageLocation::AppendVec(0, 0),
+                                        StorageLocation::AccountsFile(0, 0),
                                         lamports == 0,
                                     ),
                                 ),
                                 (
                                     slot + 1,
                                     AccountInfo::new(
-                                        StorageLocation::AppendVec(0, 0),
+                                        StorageLocation::AccountsFile(0, 0),
                                         lamports == 0,
                                     ),
                                 ),
@@ -3674,14 +3677,14 @@ mod tests {
                                 (
                                     slot,
                                     AccountInfo::new(
-                                        StorageLocation::AppendVec(0, 0),
+                                        StorageLocation::AccountsFile(0, 0),
                                         lamports == 0,
                                     ),
                                 ),
                                 (
                                     slot - 1,
                                     AccountInfo::new(
-                                        StorageLocation::AppendVec(0, 0),
+                                        StorageLocation::AccountsFile(0, 0),
                                         lamports == 0,
                                     ),
                                 ),

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -602,7 +602,7 @@ mod tests {
                             let offset = 0; // does not matter
                             AccountFromStorage {
                                 index_info: AccountInfo::new(
-                                    StorageLocation::AppendVec(storage_id, offset),
+                                    StorageLocation::AccountsFile(storage_id, offset),
                                     account.is_zero_lamport(),
                                 ),
                                 data_len: account.data.len() as u64,
@@ -641,7 +641,7 @@ mod tests {
                             .zip(offsets.offsets.iter())
                             .for_each(|(account, offset)| {
                                 account.index_info = AccountInfo::new(
-                                    StorageLocation::AppendVec(0, *offset),
+                                    StorageLocation::AccountsFile(0, *offset),
                                     account.is_zero_lamport(),
                                 )
                             });
@@ -728,7 +728,7 @@ mod tests {
                     let offset = 0; // does not matter
                     AccountFromStorage {
                         index_info: AccountInfo::new(
-                            StorageLocation::AppendVec(storage_id, offset),
+                            StorageLocation::AccountsFile(storage_id, offset),
                             account.is_zero_lamport(),
                         ),
                         data_len: account.data.len() as u64,
@@ -768,7 +768,7 @@ mod tests {
                                         result.iter_mut().zip(offsets.offsets.iter()).for_each(
                                             |(account, offset)| {
                                                 account.index_info = AccountInfo::new(
-                                                    StorageLocation::AppendVec(0, *offset),
+                                                    StorageLocation::AccountsFile(0, *offset),
                                                     account.is_zero_lamport(),
                                                 )
                                             },
@@ -818,7 +818,7 @@ mod tests {
         let account = AccountSharedData::default();
         let account_from_storage = AccountFromStorage {
             index_info: AccountInfo::new(
-                StorageLocation::AppendVec(storage_id, offset),
+                StorageLocation::AccountsFile(storage_id, offset),
                 account.is_zero_lamport(),
             ),
             data_len: account.data().len() as u64,
@@ -856,7 +856,7 @@ mod tests {
         let accounts_db = AccountsDb::default_for_tests();
         let all_accounts: Vec<_> = iter::repeat_with(|| AccountFromStorage {
             index_info: AccountInfo::new(
-                StorageLocation::AppendVec(0, 0), // id and offset do not matter
+                StorageLocation::AccountsFile(0, 0), // id and offset do not matter
                 false,
             ),
             data_len: 0,
@@ -883,7 +883,7 @@ mod tests {
         let accounts_db = AccountsDb::default_for_tests();
         let all_accounts: Vec<_> = iter::repeat_with(|| AccountFromStorage {
             index_info: AccountInfo::new(
-                StorageLocation::AppendVec(0, 0), // id and offset do not matter
+                StorageLocation::AccountsFile(0, 0), // id and offset do not matter
                 false,
             ),
             data_len: 0,


### PR DESCRIPTION
#### Problem

Pretty minor, nothing actually functional. I end up looking for where AppendVec stuff is hard coded, and the `StorageLocation::AppendVec` variant always pops up. It's not strictly only for append vec, as it'll work with split storages as well.


#### Summary of Changes

Rename the variant.