### PR TITLE
Fake future parent

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -441,6 +441,7 @@ pub struct ReplayStageConfig {
     pub banking_tracer: Arc<BankingTracer>,
     pub snapshot_controller: Option<Arc<SnapshotController>>,
     pub replay_highest_frozen: Arc<ReplayHighestFrozen>,
+    pub highest_parent_ready: Arc<RwLock<(Slot, Block)>>,
 }
 
 pub struct ReplaySenders {
@@ -761,6 +762,7 @@ impl ReplayStage {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
+            highest_parent_ready,
         } = config;
 
         let ReplaySenders {
@@ -806,7 +808,7 @@ impl ReplayStage {
         let mut identity_keypair = cluster_info.keypair().clone();
         let mut my_pubkey = identity_keypair.pubkey();
 
-        let mut highest_frozen_slot = bank_forks
+        let highest_frozen_slot = bank_forks
             .read()
             .unwrap()
             .highest_frozen_bank()
@@ -1083,8 +1085,8 @@ impl ReplayStage {
                         &leader_schedule_cache,
                         &optimistic_parent_sender,
                         &optimistic_parent_receiver,
+                        &highest_parent_ready,
                         &replay_highest_frozen,
-                        &mut highest_frozen_slot,
                     );
                     let mut process_switch_bank_events_time =
                         Measure::start("process_switch_bank_events_time");
@@ -1617,8 +1619,8 @@ impl ReplayStage {
         leader_schedule_cache: &LeaderScheduleCache,
         optimistic_parent_sender: &Sender<LeaderWindowInfo>,
         optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
+        highest_parent_ready: &RwLock<(Slot, Block)>,
         replay_highest_frozen: &ReplayHighestFrozen,
-        highest_frozen_slot: &mut Slot,
     ) {
         let flh_candidate_banks = {
             let bank_forks_r = bank_forks.read().unwrap();
@@ -1631,6 +1633,7 @@ impl ReplayStage {
                 })
                 .collect_vec()
         };
+        let highest_parent_ready_slot = highest_parent_ready.read().unwrap().0;
         for bank in flh_candidate_banks {
             Self::maybe_notify_of_optimistic_parent(
                 &bank,
@@ -1638,17 +1641,17 @@ impl ReplayStage {
                 leader_schedule_cache,
                 optimistic_parent_sender,
                 optimistic_parent_receiver,
+                highest_parent_ready_slot,
             );
         }
 
-        if let Some(highest) = new_frozen_slots.iter().max()
-            && *highest > *highest_frozen_slot
-        {
-            *highest_frozen_slot = *highest;
+        if let Some(highest) = new_frozen_slots.iter().max() {
             let mut l_highest_frozen = replay_highest_frozen.highest_frozen_slot.lock().unwrap();
-            // Let the block creation loop know about this new frozen slot
-            *l_highest_frozen = *highest;
-            replay_highest_frozen.freeze_notification.notify_one();
+            if *highest > *l_highest_frozen {
+                // Let the block creation loop know about this new frozen slot
+                *l_highest_frozen = *highest;
+                replay_highest_frozen.freeze_notification.notify_one();
+            }
         }
     }
 
@@ -4335,18 +4338,31 @@ impl ReplayStage {
         leader_schedule_cache: &LeaderScheduleCache,
         optimistic_parent_sender: &Sender<LeaderWindowInfo>,
         optimistic_parent_receiver: &Receiver<LeaderWindowInfo>,
+        highest_parent_ready_slot: Slot,
     ) {
         let next_slot = bank.slot().saturating_add(1);
+        if next_slot != first_of_consecutive_leader_slots(next_slot) {
+            return;
+        }
+
+        // Make sure we're not getting tricked into sending an optimistic parent for a
+        // leader window that is too far in the future.
+        let parent_window_start = first_of_consecutive_leader_slots(bank.slot());
+        if highest_parent_ready_slot < parent_window_start {
+            trace!(
+                "suppressing optimistic parent {} for window starting at {next_slot}: highest \
+                 ParentReady {highest_parent_ready_slot} is before parent window \
+                 {parent_window_start}",
+                bank.slot()
+            );
+            return;
+        }
 
         let is_next_leader = leader_schedule_cache
             .slot_leader_at(next_slot, Some(bank))
             .is_some_and(|leader| Self::leader_is_me(&leader.id, my_pubkey));
 
         if !is_next_leader {
-            return;
-        }
-
-        if next_slot != first_of_consecutive_leader_slots(next_slot) {
             return;
         }
 

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -32,6 +32,7 @@ use {
         },
         entry::{self, Entry},
     },
+    solana_epoch_schedule::EpochSchedule,
     solana_genesis_config as genesis_config,
     solana_gossip::{crds::Cursor, node::Node},
     solana_hash::Hash,
@@ -89,6 +90,55 @@ use {
 const NUM_CONSECUTIVE_LEADER_SLOTS: Slot = NUM_CONSECUTIVE_LEADER_SLOTS_NZ.get() as Slot;
 
 static_assertions::const_assert!(REFRESH_VOTE_BLOCKHEIGHT < solana_clock::MAX_PROCESSING_AGE);
+
+#[test]
+fn test_far_future_optimistic_parent_requires_parent_window_ready() {
+    let my_pubkey = Pubkey::new_unique();
+    let mut genesis = create_genesis_config_with_leader(10_000, &my_pubkey, 1_000);
+    genesis.genesis_config.epoch_schedule = EpochSchedule::without_warmup();
+    let root_bank = Bank::new_for_tests(&genesis.genesis_config);
+    root_bank.freeze();
+    let bank_forks = BankForks::new_rw_arc(root_bank);
+    let root_bank = bank_forks.read().unwrap().root_bank();
+    let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&root_bank);
+
+    let parent_slot = 65_531;
+    let parent_window_start = 65_528;
+    let parent_leader = leader_schedule_cache
+        .slot_leader_at(parent_slot, Some(&root_bank))
+        .unwrap();
+    let parent_bank =
+        Bank::new_from_parent_with_bank_forks(&bank_forks, root_bank, parent_leader, parent_slot);
+    let parent_block_id = Hash::new_unique();
+    parent_bank.set_block_id(Some(parent_block_id));
+    parent_bank.freeze();
+
+    let (sender, receiver) = bounded(1);
+    for highest_parent_ready_slot in [4, parent_window_start - 1] {
+        ReplayStage::maybe_notify_of_optimistic_parent(
+            &parent_bank,
+            &my_pubkey,
+            &leader_schedule_cache,
+            &sender,
+            &receiver,
+            highest_parent_ready_slot,
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    ReplayStage::maybe_notify_of_optimistic_parent(
+        &parent_bank,
+        &my_pubkey,
+        &leader_schedule_cache,
+        &sender,
+        &receiver,
+        parent_window_start,
+    );
+    let notification = receiver.try_recv().unwrap();
+    assert_eq!(notification.start_slot, 65_532);
+    assert_eq!(notification.parent_block.slot, parent_slot);
+    assert_eq!(notification.parent_block.block_id, parent_block_id);
+}
 
 impl ProcessActiveBanksContext {
     fn new_for_tests(

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -539,7 +539,7 @@ impl Tvu {
             commitment_sender: votor_commitment_sender,
             bank_notification_sender: bank_notification_sender.clone(),
             leader_window_info_sender,
-            highest_parent_ready,
+            highest_parent_ready: highest_parent_ready.clone(),
             event_sender: votor_event_sender.clone(),
             latest_switch_request: latest_switch_request.clone(),
             own_vote_sender: own_votes_sender.clone(),
@@ -611,6 +611,7 @@ impl Tvu {
             banking_tracer,
             snapshot_controller,
             replay_highest_frozen,
+            highest_parent_ready,
         };
 
         let voting_service = VotingService::new(


### PR DESCRIPTION
#### Problem

1. Some node submits a block that is 10s of thousands of slots into the future
2. We replay and freeze the block (assuming it is validly constructed)
3. Votor correctly waits for the correct skips to allow voting on this block, but FLH will start the next leader window w/o checking that the parent is current or certified
4. The next leader after the fake future slot waits for this parent block and potentially skips a bunch of leader spans while waiting.

#### Summary of Changes

1. share `highest_parent_ready` with `replay_stage` so it can be used to suppress `UpdateParent` notifications in `fn maybe_notify_of_optimistic_parent`
2. drop `highest_frozen_slot` param from `fn alpenglow_handle_newly_frozen_banks` and just grab it from the mutex when necessary. I think this is fine because we only acquire the lock every ~400ms (or soon 200ms). And the typical case is that we should be acquiring the lock to write the updated value anyways (we typically freeze in ascending slot order)

#### Testing
Added `test_far_future_optimistic_parent_requires_parent_window_ready` to cover the exact issue this is supposed to fix