### PR TITLE
test(svm): use pub account interface instead of dcou feature

### DIFF
--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -58,7 +58,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-account = { workspace = true, features = ["dev-context-only-utils"] }
+solana-account = { workspace = true }
 solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1230,7 +1230,7 @@ mod tests {
         let rent = Rent::default();
         let mut program_account =
             AccountSharedData::new(rent.minimum_balance(elf.len()), 0, loader_id);
-        program_account.set_data(elf);
+        program_account.set_data_from_slice(&elf);
         program_account.set_executable(true);
         program_account
     }
@@ -1695,7 +1695,7 @@ mod tests {
     fn truncate_data(account: &mut AccountSharedData, len: usize) {
         let mut data = account.data().to_vec();
         data.truncate(len);
-        account.set_data(data);
+        account.set_data_from_slice(&data);
     }
 
     #[test]
@@ -4025,7 +4025,7 @@ mod tests {
             0..255,
             |bytes: &mut [u8]| {
                 let mut program_account = AccountSharedData::new(1, 0, &loader_id);
-                program_account.set_data(bytes.to_vec());
+                program_account.set_data_from_slice(bytes);
                 program_account.set_executable(true);
                 process_instruction(
                     &program_id,

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -142,7 +142,7 @@ assert_matches = { workspace = true }
 env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand = { workspace = true }
-solana-account = { workspace = true, features = ["dev-context-only-utils"] }
+solana-account = { workspace = true }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -369,7 +369,7 @@ mod tests {
         let state = UpgradeableLoaderState::Program {
             programdata_address: Pubkey::new_unique(),
         };
-        account_data.set_data(bincode::serialize(&state).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -381,7 +381,7 @@ mod tests {
             Some((ProgramAccountLoadResult::InvalidAccountData(_), _))
         ));
 
-        account_data.set_data(Vec::new());
+        account_data.set_data_from_slice(&[]);
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -429,7 +429,7 @@ mod tests {
         let state = UpgradeableLoaderState::Program {
             programdata_address: key2,
         };
-        account_data.set_data(bincode::serialize(&state).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -441,7 +441,7 @@ mod tests {
         };
         let mut account_data2 = AccountSharedData::default();
         account_data2.set_owner(bpf_loader_upgradeable::id());
-        account_data2.set_data(bincode::serialize(&state).unwrap());
+        account_data2.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -571,7 +571,7 @@ mod tests {
         assert_eq!(result.unwrap(), (Arc::new(loaded_program), 0));
 
         let buffer = load_test_program();
-        account_data.set_data(buffer);
+        account_data.set_data_from_slice(&buffer);
 
         mock_bank
             .account_shared_data
@@ -612,7 +612,7 @@ mod tests {
         let state = UpgradeableLoaderState::Program {
             programdata_address: key2,
         };
-        account_data.set_data(bincode::serialize(&state).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -623,7 +623,7 @@ mod tests {
             upgrade_authority_address: None,
         };
         let mut account_data2 = AccountSharedData::default();
-        account_data2.set_data(bincode::serialize(&state).unwrap());
+        account_data2.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -655,7 +655,7 @@ mod tests {
         ];
         header.append(&mut complement);
         header.append(&mut buffer);
-        account_data.set_data(header);
+        account_data.set_data_from_slice(&header);
 
         mock_bank
             .account_shared_data
@@ -670,9 +670,9 @@ mod tests {
             &mut ExecuteTimings::default(),
         );
 
-        let data = account_data.data();
+        let data = account_data.data().to_vec();
         account_data
-            .set_data(data[UpgradeableLoaderState::size_of_programdata_metadata()..].to_vec());
+            .set_data_from_slice(&data[UpgradeableLoaderState::size_of_programdata_metadata()..]);
 
         let program_runtime_environment = get_mock_program_runtime_environment();
         let expected = ProgramCacheEntry::load(
@@ -748,7 +748,7 @@ mod tests {
         let state = UpgradeableLoaderState::Program {
             programdata_address: Pubkey::new_unique(),
         };
-        account_data.set_data(bincode::serialize(&state).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -858,7 +858,7 @@ mod tests {
             programdata_address,
         };
         let mut program = AccountSharedData::new(1, 1, &loader_ids[2]);
-        program.set_data(bincode::serialize(&state).unwrap());
+        program.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()
@@ -868,7 +868,7 @@ mod tests {
             upgrade_authority_address: None,
         };
         let mut programdata = AccountSharedData::new(1, 1, &loader_ids[2]);
-        programdata.set_data(bincode::serialize(&state).unwrap());
+        programdata.set_data_from_slice(&bincode::serialize(&state).unwrap());
         mock_bank
             .account_shared_data
             .borrow_mut()

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -197,7 +197,7 @@ fn svm_concurrent() {
     let mut check_data = vec![Vec::new(); THREADS];
     let read_account = Pubkey::new_unique();
     let mut account_data = AccountSharedData::default();
-    account_data.set_data(AMOUNT.to_le_bytes().to_vec());
+    account_data.set_data_from_slice(&AMOUNT.to_le_bytes());
     account_data.set_rent_epoch(u64::MAX);
     account_data.set_lamports(1);
     mock_bank

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -146,7 +146,7 @@ impl MockBankCallback {
         };
 
         let mut account_data = AccountSharedData::default();
-        account_data.set_data(bincode::serialize(&clock).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&clock).unwrap());
         self.account_shared_data
             .write()
             .unwrap()
@@ -156,7 +156,7 @@ impl MockBankCallback {
         let rent = Rent::default();
 
         let mut account_data = AccountSharedData::default();
-        account_data.set_data(bincode::serialize(&rent).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&rent).unwrap());
         self.account_shared_data
             .write()
             .unwrap()
@@ -169,7 +169,7 @@ impl MockBankCallback {
         let recent_blockhashes = vec![BlockhashesEntry::default()];
 
         let mut account_data = AccountSharedData::default();
-        account_data.set_data(bincode::serialize(&recent_blockhashes).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&recent_blockhashes).unwrap());
         #[allow(deprecated)]
         self.account_shared_data
             .write()
@@ -180,7 +180,7 @@ impl MockBankCallback {
         let epoch_schedule = EpochSchedule::without_warmup();
 
         let mut account_data = AccountSharedData::default();
-        account_data.set_data(bincode::serialize(&epoch_schedule).unwrap());
+        account_data.set_data_from_slice(&bincode::serialize(&epoch_schedule).unwrap());
         self.account_shared_data
             .write()
             .unwrap()
@@ -236,7 +236,7 @@ pub fn deploy_program_with_upgrade_authority(
     account_data.set_lamports(rent.minimum_balance(buffer.len()));
     account_data.set_owner(solana_sdk_ids::bpf_loader_upgradeable::id());
     account_data.set_executable(true);
-    account_data.set_data(buffer);
+    account_data.set_data_from_slice(&buffer);
     mock_bank
         .account_shared_data
         .write()
@@ -261,7 +261,7 @@ pub fn deploy_program_with_upgrade_authority(
     header.append(&mut buffer);
     account_data.set_lamports(rent.minimum_balance(header.len()));
     account_data.set_owner(solana_sdk_ids::bpf_loader_upgradeable::id());
-    account_data.set_data(header);
+    account_data.set_data_from_slice(&header);
     mock_bank
         .account_shared_data
         .write()


### PR DESCRIPTION
#### Problem
`solana-account` has `dev-only-context-utils` feature, whose only API change is to make `set_data` function public. It also pulls in `bincode` feature, which we should avoid going forward.

#### Summary of Changes
Switch to `set_data_from_slice` calls, which typically achieve the same goal. 

Note, there is a slight semantic difference (except for perf), but since it's only used in test, it should be ok:
* `set_data` gives the account exactly the Vec you hand it, capacity and all. 
* `set_data_from_slice` only ever reserves to grow; it never shrinks. 

#### Testing
CI

Fixes #