### PR TITLE
feat(svm): use wincode (through StateMutWincode) for account serialization

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -81,7 +81,7 @@ protosol = { workspace = true, optional = true }
 qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 shuttle = { workspace = true, optional = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
     "bincode",
     "bytemuck",
@@ -105,7 +105,7 @@ solana-instructions-sysvar = { workspace = true }
 solana-loader-v3-interface = { workspace = true, features = ["bincode"] }
 solana-loader-v4-interface = { workspace = true }
 solana-message = { workspace = true }
-solana-nonce = { workspace = true }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-poseidon = { workspace = true, optional = true }
 solana-precompile-error = { workspace = true, optional = true }

--- a/svm/src/nonce_info.rs
+++ b/svm/src/nonce_info.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use {
     qualifier_attr::qualifiers,
-    solana_account::state_traits::StateMut,
+    solana_account::state_traits::StateMutWincode as StateMut,
     solana_nonce::{
         state::{DurableNonce, State as NonceState},
         versions::Versions as NonceVersions,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -21,7 +21,7 @@ use {
         transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
     },
     log::debug,
-    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _},
     solana_clock::{Epoch, Slot},
     solana_hash::Hash,
     solana_instruction::TRANSACTION_LEVEL_STACK_HEIGHT,


### PR DESCRIPTION
#### Problem
`solana-svm` serializes durable nonce state through `solana_account::state_traits::StateMut`, which is the bincode-backed trait. The ongoing migration replaces bincode with wincode, and `solana-account` 4.5.0 introduces `StateMutWincode` — a parallel trait with the same `state`/`set_state` surface — precisely so the two codecs can coexist while callers move over one crate at a time. SVM is still on the bincode side.

#### Summary of changes
Switch SVM's two `StateMut` users to `StateMutWincode`:
- `transaction_processor.rs` — the durable nonce advance (`set_state(&NonceVersions::new(..))`) on the fee-payer validation path. Imported as `StateMutWincode as _`, so the `set_state` call site is unchanged.
- `nonce_info.rs` — `NonceInfo::try_advance_nonce` (`dev-context-only-utils` gated). Imported as `StateMutWincode as StateMut` so the `StateMut::<NonceVersions>::state(..)` turbofish is unchanged.
- `svm/Cargo.toml` — enable `wincode` on `solana-account` (for the trait) and on `solana-nonce` (for `Versions`' `SchemaRead`/`SchemaWrite` impls).

No functional change: wincode's derived encoding for `nonce::versions::Versions` is byte-identical to bincode's, so the on-chain nonce account layout is untouched.

Note: bincode feature stays activated on `solana-account`:
* `create_account_shared_data_for_test` depends on sysvar, which wincode trait doesn't support, a few other test functions do the same
* until bincode is deactivated, code calling `new_data` and `new_data_with_space` will still use inherent `Account::` functions being part of `bincode feature`