### PR TITLE
feat: use wincode (through StateMutWincode) for account serialization

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -51,7 +51,7 @@ pretty-hex = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "rustls-tls-native-roots", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-account-decoder = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-bls-signatures = { workspace = true }

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     assert_matches::assert_matches,
-    solana_account::state_traits::StateMut,
+    solana_account::state_traits::StateMutWincode as _,
     solana_cli::{
         check_balance,
         cli::{CliCommand, CliConfig, process_command, request_and_confirm_airdrop},

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -134,7 +134,7 @@ solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
 solana-net-utils = { workspace = true }
-solana-nonce = { workspace = true }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-packet = { workspace = true }
 solana-perf = { workspace = true }
 solana-poh = { workspace = true }
@@ -198,7 +198,7 @@ bencher = { workspace = true }
 bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -746,7 +746,7 @@ mod tests {
         crate::banking_stage::tests::{create_slow_genesis_config, sanitize_transactions},
         agave_reserved_account_keys::ReservedAccountKeys,
         crossbeam_channel::bounded,
-        solana_account::{AccountSharedData, state_traits::StateMut},
+        solana_account::{AccountSharedData, state_traits::StateMutWincode as _},
         solana_address_lookup_table_interface::{
             self as address_lookup_table,
             state::{AddressLookupTable, LookupTableMeta},

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -327,7 +327,7 @@ impl AggregateCommitmentService {
 mod tests {
     use {
         super::*,
-        solana_account::{Account, ReadableAccount, state_traits::StateMut},
+        solana_account::{Account, ReadableAccount, state_traits::StateMutWincode as _},
         solana_leader_schedule::SlotLeader,
         solana_ledger::genesis_utils::{GenesisConfigInfo, create_genesis_config},
         solana_pubkey::Pubkey,

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -21,7 +21,7 @@ use {
     },
     crossbeam_channel::bounded,
     itertools::Itertools,
-    solana_account::{ReadableAccount, state_traits::StateMut},
+    solana_account::{ReadableAccount, state_traits::StateMutWincode as _},
     solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
     solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
     solana_client::connection_cache::ConnectionCache,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -3144,7 +3144,7 @@ mod tests {
     fn test_should_require_vote_history_file() {
         use {
             agave_votor_messages::consensus_message::Block,
-            solana_account::{AccountSharedData, state_traits::StateMut},
+            solana_account::{AccountSharedData, state_traits::StateMutWincode as _},
             solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         };
 

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
-solana-account = "4.3.1"
+solana-account = "4.5.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-bls-signatures = { version = "3.3.0", features = ["serde"] }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -41,7 +41,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-solana-account  = { workspace = true }
+solana-account  = { workspace = true, features = ["wincode"] }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
@@ -76,7 +76,7 @@ solana-sdk-ids = { workspace = true }
 solana-shred-version = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer-store = { workspace = true }
-solana-stake-interface = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-storage-bigtable = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -25,7 +25,9 @@ use {
     dashmap::DashMap,
     log::*,
     serde::Serialize,
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
+    solana_account::{
+        AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMutWincode as _,
+    },
     solana_clap_utils::{
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -27,7 +27,7 @@ bincode = { workspace = true }
 chrono-humanize = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-address = { workspace = true }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -11,7 +11,9 @@ use {
     chrono_humanize::{Accuracy, HumanTime, Tense},
     log::*,
     serde::Serialize,
-    solana_account::{Account, AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{
+        Account, AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _,
+    },
     solana_account_info::AccountInfo,
     solana_accounts_db::accounts_db::ACCOUNTS_DB_CONFIG_FOR_TESTING,
     solana_address::Address,

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -55,13 +55,13 @@ solana-sdk-ids = { workspace = true }
 solana-slot-hashes = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction-context = { workspace = true, features = ["bincode"] }
-solana-vote-interface = { workspace = true, features = ["bincode"] }
+solana-vote-interface = { workspace = true, features = ["bincode", "wincode"] }
 
 [dev-dependencies]
 agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-clock = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -450,7 +450,7 @@ mod tests {
         bincode::serialize,
         solana_account::{
             self as account, Account, AccountSharedData, ReadableAccount, WritableAccount,
-            state_traits::StateMut,
+            state_traits::StateMutWincode as _,
         },
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -50,7 +50,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 soketto = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-cli-output = { workspace = true }
@@ -120,7 +120,7 @@ solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction = { workspace = true }
-solana-nonce = { workspace = true }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-program-option = { workspace = true }
 solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
@@ -133,7 +133,7 @@ solana-send-transaction-service = { path = "../send-transaction-service", featur
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }
-solana-vote-interface = { workspace = true }
+solana-vote-interface = { workspace = true, features = ["wincode"] }
 symlink = { workspace = true }
 test-case = { workspace = true }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4600,7 +4600,7 @@ pub mod tests {
         jsonrpc_core::{ErrorCode, MetaIoHandler, Output, Response, Value, futures},
         jsonrpc_core_client::transports::local,
         serde::de::DeserializeOwned,
-        solana_account::{Account, state_traits::StateMut},
+        solana_account::{Account, state_traits::StateMutWincode as _},
         solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         solana_address_lookup_table_interface::{
             self as address_lookup_table,

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -351,7 +351,7 @@ pub(crate) mod tests {
         agave_reserved_account_keys::ReservedAccountKeys,
         crossbeam_channel::bounded,
         dashmap::DashMap,
-        solana_account::state_traits::StateMut,
+        solana_account::state_traits::StateMutWincode as _,
         solana_account_decoder::{
             parse_account_data::SplTokenAdditionalDataV2, parse_token::token_amount_to_ui_amount_v3,
         },

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -97,7 +97,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 shuttle = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["serde"] }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-account-decoder = { workspace = true }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }
@@ -142,7 +142,7 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-native-token = { workspace = true }
-solana-nonce = { workspace = true }
+solana-nonce = { workspace = true, features = ["wincode"] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-packet = { workspace = true }
 solana-poh-config = { workspace = true }
@@ -184,7 +184,7 @@ solana-transaction-status-client-types = { workspace = true }
 solana-unified-scheduler-logic = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
-solana-vote-interface = { workspace = true }
+solana-vote-interface = { workspace = true, features = ["wincode"] }
 solana-vote-program = { workspace = true }
 spl-generic-token = { workspace = true }
 static_assertions = { workspace = true }

--- a/runtime/benches/epoch_turnover.rs
+++ b/runtime/benches/epoch_turnover.rs
@@ -3,7 +3,9 @@
 use {
     criterion::{Criterion, criterion_group, criterion_main},
     itertools::iproduct,
-    solana_account::{Account, AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{
+        Account, AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _,
+    },
     solana_native_token::LAMPORTS_PER_SOL,
     solana_pubkey::Pubkey,
     solana_runtime::{

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7219,7 +7219,7 @@ pub mod test_utils {
     use {
         super::Bank,
         crate::installed_scheduler_pool::BankWithScheduler,
-        solana_account::{ReadableAccount, WritableAccount, state_traits::StateMut},
+        solana_account::{ReadableAccount, WritableAccount, state_traits::StateMutWincode as _},
         solana_instruction::error::LamportsError,
         solana_pubkey::Pubkey,
         solana_sha256_hasher::hashv,

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -359,7 +359,7 @@ mod tests {
             },
         },
         solana_account::{
-            AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
+            AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMutWincode as _,
         },
         solana_hash::Hash,
         solana_keypair::Keypair,

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -276,7 +276,7 @@ pub mod tests {
         super::*,
         crate::genesis_utils::{create_genesis_config, create_genesis_config_with_leader},
         agave_feature_set::FeatureSet,
-        solana_account::state_traits::StateMut,
+        solana_account::state_traits::StateMutWincode as _,
         solana_pubkey as pubkey,
         solana_rent::Rent,
         solana_signer::Signer,

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1260,7 +1260,7 @@ mod tests {
         rand::Rng,
         rayon::ThreadPoolBuilder,
         solana_account::{
-            AccountSharedData, ReadableAccount, accounts_equal, state_traits::StateMut,
+            AccountSharedData, ReadableAccount, accounts_equal, state_traits::StateMutWincode as _,
         },
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},

--- a/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/distribution.rs
@@ -13,7 +13,9 @@ use {
     },
     log::error,
     serde::{Deserialize, Serialize},
-    solana_account::{AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut},
+    solana_account::{
+        AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMutWincode as _,
+    },
     solana_accounts_db::stake_rewards::{StakeReward, StakeRewardInfo},
     solana_clock::Epoch,
     solana_measure::measure_us,

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -450,7 +450,7 @@ mod tests {
         },
         assert_matches::assert_matches,
         rand::Rng,
-        solana_account::{Account, state_traits::StateMut},
+        solana_account::{Account, state_traits::StateMutWincode as _},
         solana_accounts_db::{
             accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
             partitioned_rewards::PartitionedEpochRewardsConfig,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -47,7 +47,8 @@ use {
     rayon::{ThreadPool, ThreadPoolBuilder, iter::IntoParallelIterator},
     serde::{Deserialize, Serialize},
     solana_account::{
-        Account, AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
+        Account, AccountSharedData, ReadableAccount, WritableAccount,
+        state_traits::StateMutWincode as StateMut,
     },
     solana_account_info::MAX_PERMITTED_DATA_INCREASE,
     solana_accounts_db::{

--- a/runtime/src/genesis_utils.rs
+++ b/runtime/src/genesis_utils.rs
@@ -16,7 +16,9 @@ use {
     bincode::serialize,
     bitvec::vec::BitVec,
     log::*,
-    solana_account::{Account, AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{
+        Account, AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _,
+    },
     solana_bls_signatures::{
         BLS_SIGNATURE_AFFINE_SIZE, Pubkey as BLSPubkey, Signature as BLSSignature,
         keypair::Keypair as BLSKeypair, pubkey::PubkeyCompressed as BLSPubkeyCompressed,

--- a/runtime/src/stake_account.rs
+++ b/runtime/src/stake_account.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "dev-context-only-utils")]
 use qualifier_attr::qualifiers;
 use {
-    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _},
     solana_instruction::error::InstructionError,
     solana_pubkey::Pubkey,
     solana_stake_interface::{

--- a/runtime/src/stake_utils.rs
+++ b/runtime/src/stake_utils.rs
@@ -1,5 +1,5 @@
 use {
-    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMut},
+    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _},
     solana_clock::Epoch,
     solana_native_token::LAMPORTS_PER_SOL,
     solana_pubkey::Pubkey,


### PR DESCRIPTION
#### Problem
`StateMut` in `solana-account` is the bincode-backed serialization trait. The wincode migration needs these callers moved over, and `solana-account` 4.5.0 adds `StateMutWincode` — a parallel trait with the same `state`/`set_state` surface — so both codecs can coexist while crates migrate one at a time.

#### Summary of changes
Switch all non-svm `StateMut` users to `StateMutWincode`, covering `StakeStateV2`, `VoteStateVersions` and `nonce::versions::Versions`:

- **21 files, import lines only** — runtime (11), core (4), rpc (2), programs/vote, program-test, ledger-tool, cli tests. Imported as `StateMutWincode as _` where only method syntax is used, and as `StateMutWincode as StateMut` in `runtime/src/bank/tests.rs` where `StateMut::<Versions>::state(..)` turbofish call sites exist. No call site changed.
- **7 Cargo.toml** — enable `wincode` on `solana-account`, and on `solana-stake-interface` / `solana-vote-interface` / `solana-nonce` where each crate needs the state type's `SchemaRead`/`SchemaWrite` impls.

No functional change: wincode's derived encoding for these types is byte-identical to bincode's, so on-chain account layouts are untouched.

Note: bincode feature stays activated on solana-account:
* `create_account_shared_data_for_test` depends on sysvar, which wincode trait doesn't support, a few other test functions do the same
* until bincode is deactivated, code calling `new_data` and `new_data_with_space` will still use inherent `Account::` functions being part of bincode feature
