### PR TITLE
test(accountsdb): use pub account interface instead of dcou feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6988,7 +6988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
 dependencies = [
  "bincode",
- "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -28,7 +28,7 @@ dev-context-only-utils = [
     "dep:solana-signer",
     "dep:solana-stake-interface",
     "dep:solana-vote-program",
-    "solana-account/dev-context-only-utils",
+    "solana-account/bincode",
     "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1930,10 +1930,10 @@ fn test_clean_old_with_both_normal_and_zero_lamport_accounts() {
 
     let mut normal_account = AccountSharedData::new(1, 0, AccountSharedData::default().owner());
     normal_account.set_owner(spl_generic_token::token::id());
-    normal_account.set_data(account_data_with_mint.clone());
+    normal_account.set_data_from_slice(&account_data_with_mint);
     let mut zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     zero_account.set_owner(spl_generic_token::token::id());
-    zero_account.set_data(account_data_with_mint);
+    zero_account.set_data_from_slice(&account_data_with_mint);
 
     //store an account
     accounts.store_for_tests((0, [(&pubkey1, &normal_account)].as_slice()));
@@ -2062,7 +2062,7 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
     account_data_with_mint[..PUBKEY_BYTES].clone_from_slice(&(mint_key.to_bytes()));
     account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
     let mut token_account = AccountSharedData::new(1, 0, &spl_generic_token::token::id());
-    token_account.set_data(account_data_with_mint);
+    token_account.set_data_from_slice(&account_data_with_mint);
 
     let zero_account = AccountSharedData::new(0, 0, &Pubkey::default());
 
@@ -3494,9 +3494,9 @@ fn test_flush_purged_zero_lamport_account_purges_secondary_index() {
     account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
 
     let mut live_account = AccountSharedData::new(1, 0, &spl_generic_token::token::id());
-    live_account.set_data(account_data_with_mint.clone());
+    live_account.set_data_from_slice(&account_data_with_mint);
     let mut zero_account = AccountSharedData::new(0, 0, &spl_generic_token::token::id());
-    zero_account.set_data(account_data_with_mint);
+    zero_account.set_data_from_slice(&account_data_with_mint);
 
     // Storing into the cache adds the secondary index entries for all three accounts
     accounts.store_for_tests((
@@ -3551,9 +3551,9 @@ fn test_clean_tombstone_purges_secondary_index() {
     account_data_with_mint[SPL_TOKEN_INITIALIZED_OFFSET] = 1;
 
     let mut live_account = AccountSharedData::new(1, 0, &spl_generic_token::token::id());
-    live_account.set_data(account_data_with_mint.clone());
+    live_account.set_data_from_slice(&account_data_with_mint);
     let mut zero_account = AccountSharedData::new(0, 0, &spl_generic_token::token::id());
-    zero_account.set_data(account_data_with_mint);
+    zero_account.set_data_from_slice(&account_data_with_mint);
 
     // Slot 1: nonzero version; slot 2: zero-lamport version. Flush without clean so the
     // slot 1 entry stays in the slot list for clean to reclaim
@@ -7248,7 +7248,7 @@ fn test_index_scan_accounts_excludes_roots_added_during_scan() {
             spl_generic_token::token::Account::get_packed_len(),
             &spl_generic_token::token::id(),
         );
-        acct.set_data(account_data.clone());
+        acct.set_data_from_slice(&account_data);
         acct
     };
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1451,7 +1451,9 @@ mod tests {
                             .map(|_| {
                                 let pk = solana_pubkey::new_rand();
                                 let mut account = account_template.clone();
-                                account.set_data((0..data_size).map(|x| (x % 256) as u8).collect());
+                                account.set_data_from_slice(
+                                    &(0..data_size).map(|x| (x % 256) as u8).collect::<Vec<_>>(),
+                                );
                                 data_size += 1;
                                 append_single_account_with_default_hash(
                                     storage,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1264,7 +1264,7 @@ mod tests {
             let data = std::iter::from_fn(|| Some(rng.random::<u8>()))
                 .take(data_len)
                 .collect::<Vec<_>>();
-            account.set_data(data);
+            account.set_data_from_slice(&data);
             (pubkey, account)
         };
 
@@ -1479,7 +1479,7 @@ mod tests {
             let owner = Pubkey::default();
             let data_len = 3_u64;
             let mut account = AccountSharedData::new(0, data_len as usize, &owner);
-            account.set_data(b"abc".to_vec());
+            account.set_data_from_slice(b"abc");
             let stored_meta = StoredMeta {
                 write_version: 0,
                 pubkey,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -5821,7 +5821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
 dependencies = [
  "bincode",
- "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5809,7 +5809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
 dependencies = [
  "bincode",
- "qualifier_attr",
  "serde",
  "serde_bytes",
  "serde_derive",


### PR DESCRIPTION
#### Problem
`solana-account` has `dev-only-context-utils` feature, whose only API change is to make `set_data` function public. It also pulls in `bincode` feature, which we should avoid going forward.

#### Summary of Changes
Switch to `set_data_from_slice` calls, which typically achieve the same goal. 

Note, there is a slight semantic difference (except for perf), but since it's only used in test, it should be ok:
* `set_data` gives the account exactly the Vec you hand it, capacity and all. 
* `set_data_from_slice` only ever reserves to grow; it never shrinks. 

#### Testing
CI

Fixes #