### PR TITLE
Sysvar test helpers: drop `SysvarSerialize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7501,7 +7501,9 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-id",
  "solana-transaction-context",
+ "wincode",
 ]
 
 [[package]]
@@ -10990,6 +10992,7 @@ dependencies = [
  "spl-token-interface",
  "test-case",
  "thiserror 2.0.19",
+ "wincode",
  "xxhash-rust",
 ]
 
@@ -11159,7 +11162,9 @@ dependencies = [
  "solana-system-interface 3.3.0",
  "solana-system-program",
  "solana-sysvar",
+ "solana-sysvar-id",
  "solana-transaction-context",
+ "wincode",
 ]
 
 [[package]]
@@ -11787,10 +11792,12 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-id",
  "solana-transaction-context",
  "solana-vote-interface",
  "solana-vote-program",
  "test-case",
+ "wincode",
 ]
 
 [[package]]

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -60,17 +60,20 @@ criterion = { workspace = true }
 rand = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
+solana-clock = { workspace = true, features = ["wincode"] }
 solana-epoch-rewards = { workspace = true }
-solana-epoch-schedule = { workspace = true }
+solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode"] }
 solana-slot-hashes = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
 solana-system-program = { workspace = true }
+solana-sysvar-id = { workspace = true }
 solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+wincode = { workspace = true }
 
 [[bench]]
 name = "serialization"

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1100,8 +1100,7 @@ mod tests {
         assert_matches::assert_matches,
         rand::Rng,
         solana_account::{
-            AccountSharedData, ReadableAccount, WritableAccount,
-            create_account_shared_data_for_test as create_account_for_test, state_traits::StateMut,
+            AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMut,
         },
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,
@@ -1115,8 +1114,26 @@ mod tests {
         solana_sbpf::program::{BuiltinFunctionDefinition, BuiltinProgram},
         solana_sdk_ids::{system_program, sysvar},
         solana_svm_type_overrides::sync::atomic::{AtomicU64, Ordering},
+        solana_sysvar_id::SysvarId,
         std::{fs::File, io::Read, ops::Range},
     };
+
+    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+    where
+        T: wincode::Serialize<Src = T> + SysvarId,
+    {
+        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+        let canonical_data_len = match T::id() {
+            sysvar::clock::ID => solana_clock::SIZE,
+            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
+            sysvar::rent::ID => solana_rent::SIZE,
+            id => panic!("unsupported sysvar: {id}"),
+        };
+        let required_data_len = canonical_data_len.max(serialized_len);
+        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+        account
+    }
 
     // 10 iterations is intentionally low: `mock_process_instruction` runs on a
     // single thread, so additional `shuttle::check_random` iterations validate
@@ -1767,8 +1784,8 @@ mod tests {
                 })
                 .unwrap();
             let spill_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
-            let rent_account = create_account_for_test(&rent);
-            let clock_account = create_account_for_test(&Clock {
+            let rent_account = create_sysvar_account(&rent);
+            let clock_account = create_sysvar_account(&Clock {
                 slot: SLOT.saturating_add(1),
                 ..Clock::default()
             });
@@ -2382,8 +2399,8 @@ mod tests {
                 0,
                 &system_program::id(),
             );
-            let rent_account = create_account_for_test(&rent);
-            let clock_account = create_account_for_test(&Clock {
+            let rent_account = create_sysvar_account(&rent);
+            let clock_account = create_sysvar_account(&Clock {
                 slot: SLOT,
                 ..Clock::default()
             });
@@ -3739,7 +3756,7 @@ mod tests {
                 programdata_address,
             })
             .unwrap();
-        let clock_account = create_account_for_test(&Clock {
+        let clock_account = create_sysvar_account(&Clock {
             slot: 1,
             ..Clock::default()
         });
@@ -3925,10 +3942,7 @@ mod tests {
                 (programdata_address, programdata_account),
                 (program_address, program_account),
                 (buffer_address, buffer_account),
-                (
-                    sysvar::rent::id(),
-                    create_account_for_test(&Rent::default()),
-                ),
+                (sysvar::rent::id(), create_sysvar_account(&Rent::default())),
                 (sysvar::clock::id(), clock_account),
                 (
                     system_program::id(),
@@ -4110,7 +4124,7 @@ mod tests {
     fn do_test_program_usage_count_on_upgrade() {
         let transaction_accounts = vec![(
             sysvar::epoch_schedule::id(),
-            create_account_for_test(&EpochSchedule::default()),
+            create_sysvar_account(&EpochSchedule::default()),
         )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();
@@ -4161,7 +4175,7 @@ mod tests {
     fn do_test_program_usage_count_on_non_upgrade() {
         let transaction_accounts = vec![(
             sysvar::epoch_schedule::id(),
-            create_account_for_test(&EpochSchedule::default()),
+            create_sysvar_account(&EpochSchedule::default()),
         )];
         with_mock_invoke_context!(invoke_context, transaction_context, transaction_accounts);
         let program_id = Pubkey::new_unique();

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -52,7 +52,10 @@ solana-sha256-hasher = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
 solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
+solana-sysvar = { workspace = true, features = ["wincode"] }
+solana-sysvar-id = { workspace = true }
 solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+wincode = { workspace = true }
 
 [[bench]]
 name = "system"

--- a/programs/system/benches/system.rs
+++ b/programs/system/benches/system.rs
@@ -2,7 +2,7 @@ use solana_program_runtime::solana_sbpf::program::BuiltinFunctionDefinition;
 #[allow(deprecated)]
 use {
     criterion::{Criterion, criterion_group, criterion_main},
-    solana_account::{self as account, AccountSharedData, WritableAccount},
+    solana_account::{AccountSharedData, WritableAccount},
     solana_hash::Hash,
     solana_instruction::AccountMeta,
     solana_nonce::{
@@ -14,14 +14,31 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{
         system_program,
-        sysvar::{recent_blockhashes, rent},
+        sysvar::{self, recent_blockhashes, rent},
     },
     solana_system_interface::instruction::SystemInstruction,
     solana_sysvar::recent_blockhashes::{IterItem, MAX_ENTRIES, RecentBlockhashes},
+    solana_sysvar_id::SysvarId,
 };
 
 const SEED: &str = "bench test";
 const ACCOUNT_BALANCE: u64 = u64::MAX / 4;
+
+fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+    let canonical_data_len = match T::id() {
+        sysvar::recent_blockhashes::ID => solana_sysvar::recent_blockhashes::SIZE,
+        sysvar::rent::ID => solana_rent::SIZE,
+        id => panic!("unsupported sysvar: {id}"),
+    };
+    let required_data_len = canonical_data_len.max(serialized_len);
+    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+    account
+}
 
 #[derive(Default)]
 struct TestSetup {
@@ -277,7 +294,7 @@ impl TestSetup {
             (nonce_address, nonce_account),
             (
                 blockhash_id,
-                account::create_account_shared_data_for_test(
+                create_sysvar_account(
                     // create a populated RecentBlockhashes sysvar account
                     &RecentBlockhashes::from_iter(vec![
                         IterItem(0u64, &Hash::default(), 0);
@@ -285,10 +302,7 @@ impl TestSetup {
                     ]),
                 ),
             ),
-            (
-                rent_id,
-                account::create_account_shared_data_for_test(&Rent::free()),
-            ),
+            (rent_id, create_sysvar_account(&Rent::free())),
         ];
 
         self.instruction_accounts = vec![
@@ -361,7 +375,7 @@ impl TestSetup {
             (nonce_address, nonce_account),
             (
                 blockhash_id,
-                account::create_account_shared_data_for_test(
+                create_sysvar_account(
                     // create a populated RecentBlockhashes sysvar account
                     &RecentBlockhashes::from_iter(vec![
                         IterItem(0u64, &Hash::default(), 0);
@@ -440,7 +454,7 @@ impl TestSetup {
             ),
             (
                 blockhash_id,
-                account::create_account_shared_data_for_test(
+                create_sysvar_account(
                     // create a populated RecentBlockhashes sysvar account
                     &RecentBlockhashes::from_iter(vec![
                         IterItem(0u64, &Hash::default(), 0);
@@ -448,10 +462,7 @@ impl TestSetup {
                     ]),
                 ),
             ),
-            (
-                rent_id,
-                account::create_account_shared_data_for_test(&Rent::free()),
-            ),
+            (rent_id, create_sysvar_account(&Rent::free())),
         ];
 
         self.instruction_accounts = vec![

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -578,10 +578,7 @@ mod tests {
     };
     #[allow(deprecated)]
     use {
-        solana_account::{
-            self as account, Account, AccountSharedData, DUMMY_INHERITABLE_ACCOUNT_FIELDS,
-            ReadableAccount, create_account_shared_data_with_fields, to_account,
-        },
+        solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
         solana_fee_calculator::FeeCalculator,
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction, error::InstructionError},
@@ -598,7 +595,25 @@ mod tests {
             recent_blockhashes::{IntoIterSorted, IterItem, MAX_ENTRIES, RecentBlockhashes},
             rent::Rent,
         },
+        solana_sysvar_id::SysvarId,
     };
+
+    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+    where
+        T: wincode::Serialize<Src = T> + SysvarId,
+    {
+        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+        let canonical_data_len = match T::id() {
+            sysvar::recent_blockhashes::ID => sysvar::recent_blockhashes::SIZE,
+            sysvar::rent::ID => solana_rent::SIZE,
+            id => panic!("unsupported sysvar: {id}"),
+        };
+        let required_data_len = canonical_data_len.max(serialized_len);
+        let mut account =
+            AccountSharedData::new(1, required_data_len, &solana_sdk_ids::sysvar::id());
+        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+        account
+    }
 
     impl From<Pubkey> for Address {
         fn from(address: Pubkey) -> Self {
@@ -637,16 +652,11 @@ mod tests {
     where
         I: IntoIterator<Item = IterItem<'a>>,
     {
-        let mut account = create_account_shared_data_with_fields::<RecentBlockhashes>(
-            &RecentBlockhashes::default(),
-            DUMMY_INHERITABLE_ACCOUNT_FIELDS,
-        );
         let sorted = BinaryHeap::from_iter(recent_blockhash_iter);
         let sorted_iter = IntoIterSorted::new(sorted);
         let recent_blockhash_iter = sorted_iter.take(MAX_ENTRIES);
         let recent_blockhashes: RecentBlockhashes = recent_blockhash_iter.collect();
-        to_account(&recent_blockhashes, &mut account);
-        account
+        create_sysvar_account(&recent_blockhashes)
     }
     fn create_default_recent_blockhashes_account() -> AccountSharedData {
         #[allow(deprecated)]
@@ -656,7 +666,7 @@ mod tests {
         ])
     }
     fn create_default_rent_account() -> AccountSharedData {
-        account::create_account_shared_data_for_test(&Rent::free())
+        create_sysvar_account(&Rent::free())
     }
 
     #[test]
@@ -1524,7 +1534,7 @@ mod tests {
                     if sysvar::recent_blockhashes::check_id(&meta.pubkey) {
                         create_default_recent_blockhashes_account()
                     } else if sysvar::rent::check_id(&meta.pubkey) {
-                        account::create_account_shared_data_for_test(&Rent::free())
+                        create_sysvar_account(&Rent::free())
                     } else {
                         AccountSharedData::new(0, 0, &Pubkey::new_unique())
                     },

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -62,19 +62,23 @@ agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-account = { workspace = true, features = ["bincode", "wincode"] }
-solana-clock = { workspace = true }
+solana-clock = { workspace = true, features = ["wincode"] }
+solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
 solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-rent = { workspace = true }
+solana-rent = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = "../system", features = ["agave-unstable-api"] }
+solana-sysvar-id = { workspace = true }
 solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
+wincode = { workspace = true }
 
 [[bench]]
 name = "vote_instructions"

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -1,7 +1,7 @@
 use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
     criterion::{BatchSize, Criterion, criterion_group, criterion_main},
-    solana_account::{Account, AccountSharedData, create_account_for_test},
+    solana_account::{Account, AccountSharedData, WritableAccount},
     solana_clock::{Clock, Slot},
     solana_hash::Hash,
     solana_instruction::AccountMeta,
@@ -12,6 +12,7 @@ use {
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{MAX_ENTRIES, SlotHashes},
+    solana_sysvar_id::SysvarId,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
@@ -22,6 +23,22 @@ use {
     },
     std::time::Duration,
 };
+
+fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+    let canonical_data_len = match T::id() {
+        sysvar::clock::ID => solana_clock::SIZE,
+        sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
+        id => panic!("unsupported sysvar: {id}"),
+    };
+    let required_data_len = canonical_data_len.max(serialized_len);
+    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+    account
+}
 
 fn create_accounts() -> (
     Slot,
@@ -75,12 +92,9 @@ fn create_accounts() -> (
         (vote_pubkey, AccountSharedData::from(vote_account)),
         (
             sysvar::slot_hashes::id(),
-            AccountSharedData::from(create_account_for_test(&slot_hashes)),
+            create_sysvar_account(&slot_hashes),
         ),
-        (
-            sysvar::clock::id(),
-            AccountSharedData::from(create_account_for_test(&clock)),
-        ),
+        (sysvar::clock::id(), create_sysvar_account(&clock)),
         (authority_pubkey, AccountSharedData::default()),
     ];
     let mut instruction_account_metas = (0..4)

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -2,7 +2,7 @@ use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
     bincode::serialize,
     criterion::{Criterion, criterion_group, criterion_main},
-    solana_account::{self as account, Account, AccountSharedData, create_account_for_test},
+    solana_account::{Account, AccountSharedData, WritableAccount},
     solana_clock::{Clock, Slot},
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
@@ -15,6 +15,7 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{sysvar, vote::id},
     solana_slot_hashes::{MAX_ENTRIES, SlotHashes},
+    solana_sysvar_id::SysvarId,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::{
@@ -30,12 +31,30 @@ use {
     },
 };
 
+fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+    let canonical_data_len = match T::id() {
+        sysvar::clock::ID => solana_clock::SIZE,
+        sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
+        sysvar::rent::ID => solana_rent::SIZE,
+        sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
+        id => panic!("unsupported sysvar: {id}"),
+    };
+    let required_data_len = canonical_data_len.max(serialized_len);
+    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+    account
+}
+
 fn create_default_rent_account() -> AccountSharedData {
-    account::create_account_shared_data_for_test(&Rent::free())
+    create_sysvar_account(&Rent::free())
 }
 
 fn create_default_clock_account() -> AccountSharedData {
-    account::create_account_shared_data_for_test(&Clock::default())
+    create_sysvar_account(&Clock::default())
 }
 
 fn create_accounts() -> (
@@ -90,12 +109,9 @@ fn create_accounts() -> (
         (vote_pubkey, AccountSharedData::from(vote_account)),
         (
             sysvar::slot_hashes::id(),
-            AccountSharedData::from(create_account_for_test(&slot_hashes)),
+            create_sysvar_account(&slot_hashes),
         ),
-        (
-            sysvar::clock::id(),
-            AccountSharedData::from(create_account_for_test(&clock)),
-        ),
+        (sysvar::clock::id(), create_sysvar_account(&clock)),
         (authority_pubkey, AccountSharedData::default()),
     ];
     let instruction_account_metas = vec![
@@ -247,7 +263,7 @@ impl BenchAuthorize {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let instruction_data = serialize(&VoteInstruction::Authorize(
             authorized_voter_pubkey,
             voter_with_bls(&vote_pubkey),
@@ -521,11 +537,11 @@ impl BenchUpdateCommission {
             // Add the sysvar accounts so they're in the cache for mock processing
             (
                 sysvar::clock::id(),
-                account::create_account_shared_data_for_test(&Clock::default()),
+                create_sysvar_account(&Clock::default()),
             ),
             (
                 sysvar::epoch_schedule::id(),
-                account::create_account_shared_data_for_test(&EpochSchedule::without_warmup()),
+                create_sysvar_account(&EpochSchedule::without_warmup()),
             ),
         ];
         let instruction_accounts = vec![
@@ -630,7 +646,7 @@ impl BenchAuthorizeChecked {
             100,
         );
         let clock_address = sysvar::clock::id();
-        let clock_account = account::create_account_shared_data_for_test(&Clock::default());
+        let clock_account = create_sysvar_account(&Clock::default());
         let authorized_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let new_authorized_account = AccountSharedData::new(0, 0, &Pubkey::new_unique());
         let transaction_accounts = vec![
@@ -778,7 +794,7 @@ impl BenchAuthorizeWithSeed {
             &node_pubkey,
             100,
         );
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -877,7 +893,7 @@ impl BenchAuthorizeCheckedWithSeed {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -946,7 +962,7 @@ impl BenchCompactUpdateVoteState {
         let vote = Vote::new(vec![1], Hash::default());
         let vote_state_update = VoteStateUpdate::from(vec![(1, 1)]);
         let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
-        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let slot_hashes_account = create_sysvar_account(&slot_hashes);
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: vote_pubkey,
@@ -1008,7 +1024,7 @@ impl BenchTowerSync {
         let (vote_pubkey, vote_account) = create_test_account();
         let vote = Vote::new(vec![1], Hash::default());
         let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
-        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let slot_hashes_account = create_sysvar_account(&slot_hashes);
         let instruction_accounts = vec![
             AccountMeta {
                 pubkey: vote_pubkey,

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -449,7 +449,7 @@ mod tests {
         },
         bincode::serialize,
         solana_account::{
-            self as account, Account, AccountSharedData, ReadableAccount, WritableAccount,
+            Account, AccountSharedData, ReadableAccount, WritableAccount,
             state_traits::StateMutWincode as _,
         },
         solana_clock::Clock,
@@ -467,6 +467,7 @@ mod tests {
         solana_slot_hashes::SlotHashes,
         solana_svm_feature_set::SVMFeatureSet,
         solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as SYSTEM_PROGRAM_COMPUTE_UNITS,
+        solana_sysvar_id::SysvarId,
         solana_vote_interface::{
             instruction::{CommissionKind, tower_sync, tower_sync_switch},
             state::{
@@ -477,6 +478,24 @@ mod tests {
         std::{cell::RefCell, collections::HashSet, str::FromStr, sync::Arc},
         test_case::test_matrix,
     };
+
+    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+    where
+        T: wincode::Serialize<Src = T> + SysvarId,
+    {
+        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+        let canonical_data_len = match T::id() {
+            sysvar::clock::ID => solana_clock::SIZE,
+            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
+            sysvar::rent::ID => solana_rent::SIZE,
+            sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
+            id => panic!("unsupported sysvar: {id}"),
+        };
+        let required_data_len = canonical_data_len.max(serialized_len);
+        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+        account
+    }
 
     fn vote_state_size_of() -> usize {
         VoteStateV4::size_of()
@@ -637,15 +656,13 @@ mod tests {
                 (
                     *pubkey,
                     if sysvar::clock::check_id(pubkey) {
-                        account::create_account_shared_data_for_test(&Clock::default())
+                        create_sysvar_account(&Clock::default())
                     } else if sysvar::epoch_schedule::check_id(pubkey) {
-                        account::create_account_shared_data_for_test(
-                            &EpochSchedule::without_warmup(),
-                        )
+                        create_sysvar_account(&EpochSchedule::without_warmup())
                     } else if sysvar::slot_hashes::check_id(pubkey) {
-                        account::create_account_shared_data_for_test(&SlotHashes::default())
+                        create_sysvar_account(&SlotHashes::default())
                     } else if sysvar::rent::check_id(pubkey) {
-                        account::create_account_shared_data_for_test(&Rent::free())
+                        create_sysvar_account(&Rent::free())
                     } else if *pubkey == invalid_vote_state_pubkey() {
                         AccountSharedData::from(Account {
                             owner: invalid_vote_state_pubkey(),
@@ -675,11 +692,11 @@ mod tests {
     }
 
     fn create_default_rent_account() -> AccountSharedData {
-        account::create_account_shared_data_for_test(&Rent::free())
+        create_sysvar_account(&Rent::free())
     }
 
     fn create_default_clock_account() -> AccountSharedData {
-        account::create_account_shared_data_for_test(&Clock::default())
+        create_sysvar_account(&Clock::default())
     }
 
     fn create_test_account() -> (Pubkey, AccountSharedData) {
@@ -1469,11 +1486,11 @@ mod tests {
             // Add the sysvar accounts so they're in the cache for mock processing
             (
                 sysvar::clock::id(),
-                account::create_account_shared_data_for_test(&Clock::default()),
+                create_sysvar_account(&Clock::default()),
             ),
             (
                 sysvar::epoch_schedule::id(),
-                account::create_account_shared_data_for_test(&EpochSchedule::without_warmup()),
+                create_sysvar_account(&EpochSchedule::without_warmup()),
             ),
         ];
         let mut instruction_accounts = vec![
@@ -1703,7 +1720,7 @@ mod tests {
         // Create a valid collector account: system-owned and rent-exempt.
         let new_collector_pubkey = Pubkey::new_unique();
         let rent = Rent::default();
-        let rent_sysvar_account = account::create_account_shared_data_for_test(&rent);
+        let rent_sysvar_account = create_sysvar_account(&rent);
         let collector_lamports = rent.minimum_balance(0);
         let new_collector_account =
             AccountSharedData::new(collector_lamports, 0, &solana_sdk_ids::system_program::id());
@@ -1863,10 +1880,7 @@ mod tests {
             get_commission_collector(&aliased_vote_account, CommissionKind::BlockRevenue);
         let aliased_transaction_accounts = vec![
             (vote_pubkey, aliased_vote_account),
-            (
-                sysvar::rent::id(),
-                account::create_account_shared_data_for_test(&rent),
-            ),
+            (sysvar::rent::id(), create_sysvar_account(&rent)),
         ];
         let aliased_instruction_accounts = vec![
             AccountMeta {
@@ -2138,7 +2152,7 @@ mod tests {
         let (vote_pubkey, vote_account) = create_test_account();
         let (vote, instruction_datas) = create_serialized_votes();
         let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
-        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let slot_hashes_account = create_sysvar_account(&slot_hashes);
         let mut instruction_accounts = vec![
             AccountMeta {
                 pubkey: vote_pubkey,
@@ -2210,7 +2224,7 @@ mod tests {
             // should fail, wrong hash
             transaction_accounts[1] = (
                 sysvar::slot_hashes::id(),
-                account::create_account_shared_data_for_test(&SlotHashes::new(&[(
+                create_sysvar_account(&SlotHashes::new(&[(
                     *vote.slots.last().unwrap(),
                     solana_sha256_hasher::hash(&[0u8]),
                 )])),
@@ -2226,7 +2240,7 @@ mod tests {
             // should fail, wrong slot
             transaction_accounts[1] = (
                 sysvar::slot_hashes::id(),
-                account::create_account_shared_data_for_test(&SlotHashes::new(&[(0, vote.hash)])),
+                create_sysvar_account(&SlotHashes::new(&[(0, vote.hash)])),
             );
             process_instruction(
                 features,
@@ -2239,7 +2253,7 @@ mod tests {
             // should fail, empty slot_hashes
             transaction_accounts[1] = (
                 sysvar::slot_hashes::id(),
-                account::create_account_shared_data_for_test(&SlotHashes::new(&[])),
+                create_sysvar_account(&SlotHashes::new(&[])),
             );
             process_instruction(
                 features,
@@ -2272,7 +2286,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let instruction_data = serialize(&VoteInstruction::Authorize(
             authorized_voter_pubkey,
             VoteAuthorize::Voter,
@@ -2386,7 +2400,7 @@ mod tests {
             leader_schedule_epoch: 4,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         transaction_accounts[1] = (sysvar::clock::id(), clock_account);
         process_instruction(
             features,
@@ -2401,7 +2415,7 @@ mod tests {
         // should fail, not signed by authorized voter
         let (vote, instruction_datas) = create_serialized_votes();
         let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
-        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let slot_hashes_account = create_sysvar_account(&slot_hashes);
         transaction_accounts.push((sysvar::slot_hashes::id(), slot_hashes_account));
         instruction_accounts.insert(
             1,
@@ -2456,7 +2470,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let (bls_pubkey, bls_proof_of_possession) =
             create_bls_pubkey_and_proof_of_possession(&vote_pubkey);
         let instruction_data = serialize(&VoteInstruction::Authorize(
@@ -2628,7 +2642,7 @@ mod tests {
             leader_schedule_epoch: 4,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         transaction_accounts[1] = (sysvar::clock::id(), clock_account);
         process_instruction_with_cu_check(
             features,
@@ -2644,7 +2658,7 @@ mod tests {
         // should fail, not signed by authorized voter
         let (vote, instruction_datas) = create_serialized_votes();
         let slot_hashes = SlotHashes::new(&[(*vote.slots.last().unwrap(), vote.hash)]);
-        let slot_hashes_account = account::create_account_shared_data_for_test(&slot_hashes);
+        let slot_hashes_account = create_sysvar_account(&slot_hashes);
         transaction_accounts.push((sysvar::slot_hashes::id(), slot_hashes_account));
         instruction_accounts.insert(
             1,
@@ -2698,7 +2712,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -2781,7 +2795,7 @@ mod tests {
         // Leader Schedule Epoch: 2
         //   Rotation schedules for target epoch 3
         //   BLS pubkey is set immediately
-        let clock_epoch_1 = account::create_account_shared_data_for_test(&Clock {
+        let clock_epoch_1 = create_sysvar_account(&Clock {
             epoch: 1,
             leader_schedule_epoch: 2,
             ..Clock::default()
@@ -2839,7 +2853,7 @@ mod tests {
         // Leader Schedule Epoch: 3
         //   Rotation schedules for target epoch 4
         //   BLS pubkey is set immediately
-        let clock_epoch_2 = account::create_account_shared_data_for_test(&Clock {
+        let clock_epoch_2 = create_sysvar_account(&Clock {
             epoch: 2,
             leader_schedule_epoch: 3,
             ..Clock::default()
@@ -3063,7 +3077,7 @@ mod tests {
             epoch: 3,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let rent_sysvar = Rent::default();
         let minimum_balance = rent_sysvar
             .minimum_balance(vote_account_with_epoch_credits_1.data().len())
@@ -3073,10 +3087,7 @@ mod tests {
             (vote_pubkey_1, vote_account_with_epoch_credits_1),
             (vote_pubkey_2, vote_account_with_epoch_credits_2),
             (sysvar::clock::id(), clock_account),
-            (
-                sysvar::rent::id(),
-                account::create_account_shared_data_for_test(&rent_sysvar),
-            ),
+            (sysvar::rent::id(), create_sysvar_account(&rent_sysvar)),
             (authorized_withdrawer_pubkey, AccountSharedData::default()),
         ];
         let mut instruction_accounts = vec![
@@ -3190,7 +3201,7 @@ mod tests {
         assert!(deinitialized_vote_account.data().iter().all(|&b| b == 0));
 
         // Authorize should fail on the deinitialized account.
-        let clock_account = account::create_account_shared_data_for_test(&Clock {
+        let clock_account = create_sysvar_account(&Clock {
             epoch: 100,
             ..Clock::default()
         });
@@ -3344,9 +3355,7 @@ mod tests {
                 (sysvar::clock::id(), create_default_clock_account()),
                 (
                     sysvar::epoch_schedule::id(),
-                    account::create_account_shared_data_for_test(
-                        &solana_epoch_schedule::EpochSchedule::without_warmup(),
-                    ),
+                    create_sysvar_account(&solana_epoch_schedule::EpochSchedule::without_warmup()),
                 ),
             ],
             vec![
@@ -3500,7 +3509,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -3624,7 +3633,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -3838,7 +3847,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -3992,7 +4001,7 @@ mod tests {
             leader_schedule_epoch: 2,
             ..Clock::default()
         };
-        let clock_account = account::create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account),
             (sysvar::clock::id(), clock_account),
@@ -4446,7 +4455,7 @@ mod tests {
             &default_authorized_pubkey,
         );
         let clock_address = sysvar::clock::id();
-        let clock_account = account::create_account_shared_data_for_test(&Clock::default());
+        let clock_account = create_sysvar_account(&Clock::default());
         let authorized_account = create_default_account();
         let new_authorized_account = create_default_account();
         let transaction_accounts = vec![
@@ -4721,11 +4730,11 @@ mod tests {
                 (authorized_withdrawer, AccountSharedData::default()),
                 (
                     sysvar::clock::id(),
-                    account::create_account_shared_data_for_test(&Clock::default()),
+                    create_sysvar_account(&Clock::default()),
                 ),
                 (
                     sysvar::epoch_schedule::id(),
-                    account::create_account_shared_data_for_test(&EpochSchedule::without_warmup()),
+                    create_sysvar_account(&EpochSchedule::without_warmup()),
                 ),
             ];
 
@@ -5253,7 +5262,7 @@ mod tests {
             },
         ];
 
-        let rent_account = account::create_account_shared_data_for_test(&rent_sysvar);
+        let rent_account = create_sysvar_account(&rent_sysvar);
         let transaction_accounts = vec![
             (vote_pubkey, vote_account.clone()),
             (authorized_withdrawer, AccountSharedData::default()),

--- a/runtime/src/conformance/block.rs
+++ b/runtime/src/conformance/block.rs
@@ -760,6 +760,7 @@ mod tests {
 
     use {
         super::{LEADER_SCHEDULE_HASH_SEED, execute_block, hash_epoch_leaders},
+        crate::sysvar_account::create_account,
         protosol::protos::{
             AcctState, BlockBank as ProtoBlockBank, BlockContext as ProtoBlockContext,
             BlockhashQueueEntry as ProtoBlockhashQueueEntry,
@@ -771,7 +772,7 @@ mod tests {
             SanitizedTransaction as ProtoSanitizedTransaction,
             TransactionMessage as ProtoTransactionMessage, VoteAccountVersion,
         },
-        solana_account::{Account, create_account_for_test},
+        solana_account::{Account, DUMMY_INHERITABLE_ACCOUNT_FIELDS},
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
@@ -783,9 +784,10 @@ mod tests {
         solana_stake_history::StakeHistory,
         solana_svm::conformance::account_state::account_to_proto,
         solana_sysvar::{
-            SysvarSerialize, epoch_rewards::EpochRewards, last_restart_slot::LastRestartSlot,
+            epoch_rewards::EpochRewards, last_restart_slot::LastRestartSlot,
             recent_blockhashes::RecentBlockhashes,
         },
+        solana_sysvar_id::SysvarId,
     };
 
     const PAYER: [u8; 32] = [0x11; 32];
@@ -812,8 +814,14 @@ mod tests {
         ))
     }
 
-    fn sysvar_account<T: SysvarSerialize>(pubkey: Pubkey, value: &T) -> AcctState {
-        account_to_proto((pubkey, create_account_for_test(value)))
+    fn sysvar_account<T>(pubkey: Pubkey, value: &T) -> AcctState
+    where
+        T: wincode::Serialize<Src = T> + SysvarId,
+    {
+        account_to_proto((
+            pubkey,
+            create_account(value, DUMMY_INHERITABLE_ACCOUNT_FIELDS).into(),
+        ))
     }
 
     fn block_sysvar_accounts(parent_slot: u64, epoch_schedule: &EpochSchedule) -> Vec<AcctState> {

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -164,11 +164,12 @@ solana-svm = { path = ".", features = ["agave-unstable-api", "dev-context-only-u
 solana-syscalls = { path = "../syscalls", features = ["agave-unstable-api"] }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
-solana-sysvar = { workspace = true }
+solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1398,7 +1398,7 @@ mod tests {
             rent_calculator::RENT_EXEMPT_RENT_EPOCH,
             rollback_accounts::RollbackAccounts,
         },
-        solana_account::{WritableAccount, create_account_shared_data_for_test},
+        solana_account::WritableAccount,
         solana_clock::Clock,
         solana_compute_budget_interface::ComputeBudgetInstruction,
         solana_epoch_schedule::EpochSchedule,
@@ -1421,12 +1421,31 @@ mod tests {
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
+        solana_sysvar_id::SysvarId,
         solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
     };
+
+    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+    where
+        T: wincode::Serialize<Src = T> + SysvarId,
+    {
+        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+        let canonical_data_len = match T::id() {
+            sysvar::clock::ID => solana_clock::SIZE,
+            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
+            sysvar::fees::ID => solana_sysvar::fees::SIZE,
+            sysvar::rent::ID => solana_rent::SIZE,
+            id => panic!("unsupported sysvar: {id}"),
+        };
+        let required_data_len = canonical_data_len.max(serialized_len);
+        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
+        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+        account
+    }
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))
@@ -1945,7 +1964,7 @@ mod tests {
             leader_schedule_epoch: 4,
             unix_timestamp: 5,
         };
-        let clock_account = create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         mock_bank
             .account_shared_data
             .write()
@@ -1953,7 +1972,7 @@ mod tests {
             .insert(sysvar::clock::id(), clock_account);
 
         let epoch_schedule = EpochSchedule::custom(64, 2, true);
-        let epoch_schedule_account = create_account_shared_data_for_test(&epoch_schedule);
+        let epoch_schedule_account = create_sysvar_account(&epoch_schedule);
         mock_bank
             .account_shared_data
             .write()
@@ -1965,7 +1984,7 @@ mod tests {
                 lamports_per_signature: 123,
             },
         };
-        let fees_account = create_account_shared_data_for_test(&fees);
+        let fees_account = create_sysvar_account(&fees);
         mock_bank
             .account_shared_data
             .write()
@@ -1973,7 +1992,7 @@ mod tests {
             .insert(sysvar::fees::id(), fees_account);
 
         let rent = Rent::default();
-        let rent_account = create_account_shared_data_for_test(&rent);
+        let rent_account = create_sysvar_account(&rent);
         mock_bank
             .account_shared_data
             .write()
@@ -2021,7 +2040,7 @@ mod tests {
             leader_schedule_epoch: 4,
             unix_timestamp: 5,
         };
-        let clock_account = create_account_shared_data_for_test(&clock);
+        let clock_account = create_sysvar_account(&clock);
         mock_bank
             .account_shared_data
             .write()
@@ -2029,7 +2048,7 @@ mod tests {
             .insert(sysvar::clock::id(), clock_account);
 
         let epoch_schedule = EpochSchedule::custom(64, 2, true);
-        let epoch_schedule_account = create_account_shared_data_for_test(&epoch_schedule);
+        let epoch_schedule_account = create_sysvar_account(&epoch_schedule);
         mock_bank
             .account_shared_data
             .write()
@@ -2041,7 +2060,7 @@ mod tests {
                 lamports_per_signature: 123,
             },
         };
-        let fees_account = create_account_shared_data_for_test(&fees);
+        let fees_account = create_sysvar_account(&fees);
         mock_bank
             .account_shared_data
             .write()
@@ -2049,7 +2068,7 @@ mod tests {
             .insert(sysvar::fees::id(), fees_account);
 
         let rent = Rent::default();
-        let rent_account = create_account_shared_data_for_test(&rent);
+        let rent_account = create_sysvar_account(&rent);
         mock_bank
             .account_shared_data
             .write()
@@ -2067,7 +2086,7 @@ mod tests {
             leader_schedule_epoch: 9,
             unix_timestamp: 10,
         };
-        let updated_clock_account = create_account_shared_data_for_test(&updated_clock);
+        let updated_clock_account = create_sysvar_account(&updated_clock);
         mock_bank
             .account_shared_data
             .write()


### PR DESCRIPTION
Finishes breaking down https://github.com/anza-xyz/agave/pull/12245 by replacing the remaining `solana-account` sysvar test helpers (dependent on SysvarSerialize) with local wincode helpers. 