### PR TITLE
ag: fix startup replay rooting

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1735,7 +1735,6 @@ impl TowerError {
 #[derive(Debug)]
 pub enum ExternalRootSource {
     Tower(Slot),
-    VoteHistory(Slot),
     HardFork(Slot),
 }
 
@@ -1743,10 +1742,43 @@ impl ExternalRootSource {
     fn root(&self) -> Slot {
         match self {
             ExternalRootSource::Tower(slot) => *slot,
-            ExternalRootSource::VoteHistory(slot) => *slot,
             ExternalRootSource::HardFork(slot) => *slot,
         }
     }
+}
+
+/// Verifies that the slot ancestry of a vote-history root newer than the last blockstore root
+/// descends from it. This preserves the topology sanity check previously performed as part of
+/// reconciliation; it cannot distinguish competing blocks in the same slot.
+///
+/// Unlike [`reconcile_blockstore_roots_with_external_source`], this does not mark any slots as
+/// rooted. A vote-history root alone does not identify the block for its slot, so it must not be
+/// used to mutate blockstore roots.
+pub(crate) fn verify_blockstore_root_with_vote_history(
+    vote_history_root: Slot,
+    blockstore: &Blockstore,
+    last_blockstore_root: Slot,
+) {
+    if last_blockstore_root >= vote_history_root {
+        return;
+    }
+
+    for current in AncestorIterator::new_inclusive(vote_history_root, blockstore) {
+        match current.cmp(&last_blockstore_root) {
+            Ordering::Greater => continue,
+            Ordering::Equal => return,
+            Ordering::Less => panic!(
+                "last_blockstore_root({last_blockstore_root}) is skipped while traversing \
+                 blockstore (currently at {current}) from vote history root \
+                 ({vote_history_root})!?",
+            ),
+        }
+    }
+
+    warn!(
+        "Couldn't connect vote history root ({vote_history_root}) to blockstore root \
+         ({last_blockstore_root}); blockstore pruned or vote history moved into a new ledger?",
+    );
 }
 
 // Given an untimely crash, tower may have roots that are not reflected in blockstore,
@@ -3414,6 +3446,63 @@ pub mod test {
         )
         .unwrap();
         assert_eq!(blockstore.max_root(), 0);
+    }
+
+    #[test]
+    fn test_verify_blockstore_root_with_vote_history_does_not_mutate_roots() {
+        agave_logger::setup();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let (shreds, _) = make_slot_entries(1, 0, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        let (shreds, _) = make_slot_entries(4, 1, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        assert_eq!(blockstore.max_root(), 0);
+
+        verify_blockstore_root_with_vote_history(0, &blockstore, blockstore.max_root());
+        verify_blockstore_root_with_vote_history(4, &blockstore, blockstore.max_root());
+
+        assert_eq!(blockstore.max_root(), 0);
+        assert!(!blockstore.is_root(1));
+        assert!(!blockstore.is_root(4));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "last_blockstore_root(3) is skipped while traversing blockstore (currently at \
+                    1) from vote history root (4)!?"
+    )]
+    fn test_verify_blockstore_root_with_vote_history_panics_on_divergence() {
+        agave_logger::setup();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let (shreds, _) = make_slot_entries(1, 0, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        let (shreds, _) = make_slot_entries(3, 1, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        let (shreds, _) = make_slot_entries(4, 1, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        blockstore.set_roots(std::iter::once(&3)).unwrap();
+
+        verify_blockstore_root_with_vote_history(4, &blockstore, blockstore.max_root());
+    }
+
+    #[test]
+    fn test_verify_blockstore_root_with_vote_history_missing_root_does_not_mutate() {
+        agave_logger::setup();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+        let (shreds, _) = make_slot_entries(1, 0, 42);
+        blockstore.insert_shreds(shreds, false).unwrap();
+        assert_eq!(blockstore.max_root(), 0);
+
+        verify_blockstore_root_with_vote_history(4, &blockstore, blockstore.max_root());
+
+        assert_eq!(blockstore.max_root(), 0);
+        assert!(!blockstore.is_root(1));
     }
 
     #[test]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2588,14 +2588,6 @@ impl<'a> ProcessBlockStore<'a> {
         let vote_history = {
             let vote_history =
                 restore_vote_history(self.config, self.bank_forks, self.id, self.vote_account)?;
-            // reconciliation attempt 1 of 2 with vote history
-            reconcile_blockstore_roots_with_external_source(
-                ExternalRootSource::VoteHistory(vote_history.root()),
-                self.blockstore,
-                &mut self.original_blockstore_root,
-            )
-            .map_err(|err| format!("Failed to reconcile blockstore with vote history: {err:?}"))?;
-
             post_process_restored_vote_history(
                 vote_history,
                 self.id,
@@ -2609,7 +2601,7 @@ impl<'a> ProcessBlockStore<'a> {
             self.bank_forks.read().unwrap().root(),
         ) {
             // reconciliation attempt 2 of 2 with hard fork
-            // it is intentional that we do this second, as having the hard fork root < tower/vote_history root
+            // it is intentional that we do this second, as having the hard fork root < tower root
             // is invalid! This means we've hard forked and missed a finalized slot
             reconcile_blockstore_roots_with_external_source(
                 ExternalRootSource::HardFork(hard_fork_restart_slot),

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -14,6 +14,7 @@ use {
         consensus::{
             ExternalRootSource, Tower, reconcile_blockstore_roots_with_external_source,
             tower_storage::{NullTowerStorage, TowerStorage},
+            verify_blockstore_root_with_vote_history,
         },
         forwarding_stage::ForwardingClientConfig,
         repair::{
@@ -2588,6 +2589,11 @@ impl<'a> ProcessBlockStore<'a> {
         let vote_history = {
             let vote_history =
                 restore_vote_history(self.config, self.bank_forks, self.id, self.vote_account)?;
+            verify_blockstore_root_with_vote_history(
+                vote_history.root(),
+                self.blockstore,
+                self.original_blockstore_root,
+            );
             post_process_restored_vote_history(
                 vote_history,
                 self.id,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2093,6 +2093,7 @@ fn load_frozen_forks(
                     supermajority_root_from_vote_accounts(
                         bank.total_epoch_stake(),
                         &bank.vote_accounts(),
+                        &migration_status,
                     ).and_then(|supermajority_root| {
                         if supermajority_root > root {
                             // If there's a cluster confirmed root greater than our last
@@ -2239,6 +2240,7 @@ fn supermajority_root(roots: &[(Slot, u64)], total_epoch_stake: u64) -> Option<S
 fn supermajority_root_from_vote_accounts(
     total_epoch_stake: u64,
     vote_accounts: &VoteAccountsHashMap,
+    migration_status: &MigrationStatus,
 ) -> Option<Slot> {
     let mut roots_stakes: Vec<(Slot, u64)> = vote_accounts
         .values()
@@ -2254,8 +2256,11 @@ fn supermajority_root_from_vote_accounts(
     // Sort from greatest to smallest slot
     roots_stakes.sort_unstable_by_key(|a| cmp::Reverse(a.0));
 
-    // Find latest root
+    // Vote state identifies a root by slot only, so it can only be used to infer TowerBFT roots.
+    // In particular, reject the migration slot itself before the caller performs any rooting side
+    // effects.
     supermajority_root(&roots_stakes, total_epoch_stake)
+        .filter(|slot| migration_status.should_report_commitment_or_root(*slot))
 }
 
 /// Validates the chained block ID for a child slot against its parent.
@@ -4934,18 +4939,30 @@ pub mod tests {
         let total_stake = 10;
 
         // Supermajority root should be None
-        assert!(supermajority_root_from_vote_accounts(total_stake, &HashMap::default()).is_none());
+        let migration_status = MigrationStatus::default();
+        assert!(
+            supermajority_root_from_vote_accounts(
+                total_stake,
+                &HashMap::default(),
+                &migration_status,
+            )
+            .is_none()
+        );
 
         // Supermajority root should be None
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 1)];
         let accounts = convert_to_vote_accounts(roots_stakes);
-        assert!(supermajority_root_from_vote_accounts(total_stake, &accounts).is_none());
+        assert!(
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .is_none()
+        );
 
         // Supermajority root should be 4, has 7/10 of the stake
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 5)];
         let accounts = convert_to_vote_accounts(roots_stakes);
         assert_eq!(
-            supermajority_root_from_vote_accounts(total_stake, &accounts).unwrap(),
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .unwrap(),
             4
         );
 
@@ -4953,8 +4970,45 @@ pub mod tests {
         let roots_stakes = vec![(8, 1), (3, 1), (4, 1), (8, 6)];
         let accounts = convert_to_vote_accounts(roots_stakes);
         assert_eq!(
-            supermajority_root_from_vote_accounts(total_stake, &accounts).unwrap(),
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .unwrap(),
             8
+        );
+
+        // Vote-state roots do not identify an Alpenglow block. Once migration starts, only
+        // pre-migration roots may be inferred from vote accounts.
+        let migration_slot = migration_status.record_feature_activation(0);
+        let accounts = convert_to_vote_accounts(vec![(migration_slot - 1, total_stake)]);
+        assert_eq!(
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status),
+            Some(migration_slot - 1),
+        );
+        let accounts = convert_to_vote_accounts(vec![(migration_slot, total_stake)]);
+        assert!(
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .is_none()
+        );
+
+        // After the migrationary phase, no vote-account root may be inferred, including a root
+        // whose slot predates migration.
+        let genesis_block = Block {
+            slot: migration_slot - 1,
+            block_id: Hash::new_unique(),
+        };
+        migration_status.set_genesis_block(genesis_block);
+        migration_status.set_genesis_certificate(genesis_certificate(genesis_block));
+        assert!(migration_status.is_ready_to_enable());
+        let accounts = convert_to_vote_accounts(vec![(migration_slot - 1, total_stake)]);
+        assert!(
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .is_none()
+        );
+
+        migration_status.enable_alpenglow_during_startup();
+        assert!(migration_status.is_alpenglow_enabled());
+        assert!(
+            supermajority_root_from_vote_accounts(total_stake, &accounts, &migration_status)
+                .is_none()
         );
     }
 

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -87,7 +87,7 @@ pub(crate) struct EventHandler {
 
 struct LocalContext {
     pub(crate) my_pubkey: Pubkey,
-    pub(crate) genesis_slot: Slot,
+    pub(crate) genesis_block: Block,
     pub(crate) pending_blocks: PendingBlocks,
     pub(crate) finalized_blocks: BTreeSet<Block>,
     pub(crate) received_shred: BTreeSet<Slot>,
@@ -128,7 +128,7 @@ impl EventHandler {
             let _exit_on_drop = ExitOnDrop::new(validator_exit);
             let mut local_context = LocalContext {
                 my_pubkey: ctx.cluster_info.keypair().pubkey(),
-                genesis_slot: 0,
+                genesis_block: Block::default(),
                 pending_blocks: PendingBlocks::default(),
                 finalized_blocks: BTreeSet::default(),
                 received_shred: BTreeSet::default(),
@@ -142,7 +142,7 @@ impl EventHandler {
                 // Exited during migration
                 return Ok(());
             };
-            local_context.genesis_slot = genesis_block.slot;
+            local_context.genesis_block = genesis_block;
             let root_slot = vctx.sharable_banks.root().slot();
             info!(
                 "{}: Event loop starting genesis {genesis_block:?} root {root_slot}",
@@ -152,7 +152,7 @@ impl EventHandler {
             // Check for set identity
             if let Err(e) = Self::handle_set_identity(
                 &mut local_context.my_pubkey,
-                local_context.genesis_slot,
+                local_context.genesis_block,
                 &ctx,
                 &mut vctx,
             ) {
@@ -574,7 +574,7 @@ impl EventHandler {
                 info!("{}: SetIdentity", local_context.my_pubkey);
                 if let Err(e) = Self::handle_set_identity(
                     &mut local_context.my_pubkey,
-                    local_context.genesis_slot,
+                    local_context.genesis_block,
                     ctx,
                     vctx,
                 ) {
@@ -664,7 +664,7 @@ impl EventHandler {
 
     fn handle_set_identity(
         my_pubkey: &mut Pubkey,
-        genesis_slot: Slot,
+        genesis_block: Block,
         ctx: &SharedContext,
         vctx: &mut VotingContext,
     ) -> Result<(), VoteHistoryError> {
@@ -681,7 +681,7 @@ impl EventHandler {
             vctx.identity_keypair = new_identity;
             warn!("set-identity: from {my_old_pubkey} to {my_pubkey}");
         }
-        vctx.vote_history.initialize_genesis(genesis_slot);
+        vctx.vote_history.initialize_genesis(genesis_block);
         Ok(())
     }
 
@@ -1201,7 +1201,7 @@ mod tests {
         };
 
         let mut vote_history = VoteHistory::new(my_node_keypair.pubkey(), 0);
-        vote_history.initialize_genesis(0);
+        vote_history.initialize_genesis(Block::default());
         let voting_context = VotingContext {
             cluster_info: cluster_info.clone(),
             identity_keypair: Arc::new(my_node_keypair.insecure_clone()),
@@ -1227,7 +1227,7 @@ mod tests {
 
         let local_context = LocalContext {
             my_pubkey: my_node_keypair.pubkey(),
-            genesis_slot: 0,
+            genesis_block: Block::default(),
             pending_blocks: BTreeMap::new(),
             finalized_blocks: BTreeSet::new(),
             received_shred: BTreeSet::new(),
@@ -1828,10 +1828,14 @@ mod tests {
     fn test_try_skip_window_starts_after_unaligned_genesis() {
         let mut test_context = setup();
         let genesis_slot = 1;
+        let genesis_block = Block {
+            slot: genesis_slot,
+            block_id: Hash::new_unique(),
+        };
         test_context
             .voting_context
             .vote_history
-            .initialize_genesis(genesis_slot);
+            .initialize_genesis(genesis_block);
 
         test_context.send_timeout_event(2);
 
@@ -2375,7 +2379,7 @@ mod tests {
         vote_history_storage
             .store(&SavedVoteHistoryVersions::from(saved_vote_history))
             .unwrap();
-        old_vote_history.initialize_genesis(0);
+        old_vote_history.initialize_genesis(Block::default());
 
         test_context
             .cluster_info

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -98,15 +98,18 @@ impl VoteHistory {
         self.voted.contains(&slot)
     }
 
-    /// Initialize vote history at the Alpenglow genesis slot. The genesis vote
-    /// is cast and refreshed outside Votor during migration, so it is marked as
-    /// voted without being added to `votes_cast`.
-    pub fn initialize_genesis(&mut self, genesis_slot: Slot) {
-        if genesis_slot < self.root {
+    /// Initialize vote history at the Alpenglow genesis block. The genesis vote
+    /// is cast and refreshed outside Votor during migration, so its voted and
+    /// notarized state is initialized without adding it to `votes_cast`.
+    pub fn initialize_genesis(&mut self, genesis_block: Block) {
+        if genesis_block.slot < self.root {
             return;
         }
-        self.set_root(genesis_slot);
-        self.voted.insert(genesis_slot);
+        self.set_root(genesis_block.slot);
+        self.voted.insert(genesis_block.slot);
+        self.voted_notar
+            .insert(genesis_block.slot, genesis_block.block_id);
+        self.notarized_blocks.insert(genesis_block);
     }
 
     /// The block for which we voted notarize in slot `slot`
@@ -491,17 +494,30 @@ mod test {
     fn test_initialize_genesis() {
         let mut vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
         vote_history.add_vote(Vote::new_skip_vote(1));
-        vote_history.initialize_genesis(2);
-        vote_history.initialize_genesis(2);
+        let genesis_block = Block {
+            slot: 2,
+            block_id: Hash::new_unique(),
+        };
+        vote_history.initialize_genesis(genesis_block);
+        vote_history.initialize_genesis(genesis_block);
 
         assert_eq!(vote_history.root(), 2);
         assert!(vote_history.voted(2));
+        assert_eq!(vote_history.voted_notar(2), Some(genesis_block.block_id));
+        assert!(vote_history.is_block_notarized(&genesis_block));
         assert!(!vote_history.skipped(2));
         assert!(vote_history.votes_cast_since(0).is_empty());
 
-        vote_history.initialize_genesis(1);
+        let old_genesis_block = Block {
+            slot: 1,
+            block_id: Hash::new_unique(),
+        };
+        vote_history.initialize_genesis(old_genesis_block);
         assert_eq!(vote_history.root(), 2);
         assert!(vote_history.voted(2));
+        assert_eq!(vote_history.voted_notar(2), Some(genesis_block.block_id));
+        assert!(vote_history.is_block_notarized(&genesis_block));
+        assert!(!vote_history.is_block_notarized(&old_genesis_block));
     }
 
     #[test]

--- a/votor/src/vote_history.rs
+++ b/votor/src/vote_history.rs
@@ -105,6 +105,20 @@ impl VoteHistory {
         if genesis_block.slot < self.root {
             return;
         }
+        if let Some(block_id) = self.voted_notar.get(&genesis_block.slot) {
+            assert_eq!(
+                *block_id, genesis_block.block_id,
+                "genesis block does not match existing notarization vote for slot {}",
+                genesis_block.slot,
+            );
+        }
+        assert!(
+            self.notarized_blocks.iter().all(|block| {
+                block.slot != genesis_block.slot || block.block_id == genesis_block.block_id
+            }),
+            "genesis block does not match existing notarized block for slot {}",
+            genesis_block.slot,
+        );
         self.set_root(genesis_block.slot);
         self.voted.insert(genesis_block.slot);
         self.voted_notar
@@ -518,6 +532,40 @@ mod test {
         assert_eq!(vote_history.voted_notar(2), Some(genesis_block.block_id));
         assert!(vote_history.is_block_notarized(&genesis_block));
         assert!(!vote_history.is_block_notarized(&old_genesis_block));
+    }
+
+    #[test]
+    #[should_panic(expected = "genesis block does not match existing notarization vote")]
+    fn test_initialize_genesis_panics_on_voted_notar_mismatch() {
+        let mut vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
+        let genesis_block = Block {
+            slot: 2,
+            block_id: Hash::new_unique(),
+        };
+        vote_history
+            .voted_notar
+            .insert(genesis_block.slot, Hash::new_unique());
+
+        vote_history.initialize_genesis(genesis_block);
+    }
+
+    #[test]
+    #[should_panic(expected = "genesis block does not match existing notarized block")]
+    fn test_initialize_genesis_panics_on_notarized_block_mismatch() {
+        let mut vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
+        let genesis_block = Block {
+            slot: 2,
+            block_id: Hash::new_unique(),
+        };
+        vote_history
+            .voted_notar
+            .insert(genesis_block.slot, genesis_block.block_id);
+        vote_history.notarized_blocks.insert(Block {
+            slot: genesis_block.slot,
+            block_id: Hash::new_unique(),
+        });
+
+        vote_history.initialize_genesis(genesis_block);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
As noted by the bug bounty report.

During startup replay even in Alpenglow we root based on VoteAccount state. In alpenglow this vote account state is purely for rewards (doesn't contain the block id) and should not be used for rooting. This could lead to a LoA whereby the restarted validator roots the wrong block and doesn't progress.

#### Summary of Changes
Disable startup replay rooting via this path once we enter the migration period and onwards
Remove reconciliation between VoteHistory / blockstore, this is purely for efficiency not needed at all.
Fix the issue with startup vote history state by properly initializing the genesis block

#### Testing
Unit Test
