### PR TITLE
feat(accountsdb): use wincode (through StateMutWincode) for account serialization

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -28,7 +28,7 @@ dev-context-only-utils = [
     "dep:solana-signer",
     "dep:solana-stake-interface",
     "dep:solana-vote-program",
-    "solana-account/bincode",
+    "solana-account/wincode",
     "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [
@@ -85,7 +85,10 @@ solana-rent = { workspace = true, optional = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true, optional = true }
 solana-slot-hashes = { workspace = true }
-solana-stake-interface = { workspace = true, optional = true, features = ["serde"] }
+solana-stake-interface = { workspace = true, optional = true, features = [
+    "serde",
+    "wincode",
+] }
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = { workspace = true }

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -80,7 +80,7 @@ impl<'a> StorableAccounts<'a> for (Slot, &'a [StakeReward]) {
 #[cfg(feature = "dev-context-only-utils")]
 use {
     rand::Rng,
-    solana_account::{WritableAccount, state_traits::StateMut},
+    solana_account::{WritableAccount, state_traits::StateMutWincode as _},
     solana_clock::Epoch,
     solana_keypair::Keypair,
     solana_rent::Rent,


### PR DESCRIPTION
#### Problem
`solana-accounts-db` serializes stake state through `solana_account::state_traits::StateMut`, the bincode-backed trait. The wincode migration replaces it with `StateMutWincode`, added in `solana-account` 4.5.0 as a parallel trait with the same `state`/`set_state` surface so both codecs can coexist while crates move over one at a time.

#### Summary of changes
- `stake_rewards.rs` — `StateMut` → `StateMutWincode as _`. The only use is `set_state(&StakeStateV2::Stake(..))` in `create_stake_account`, behind `dev-context-only-utils`; the call site is unchanged.
- `Cargo.toml` — swap `"solana-account/bincode"` → `"solana-account/wincode"` in `dev-context-only-utils`, and add `wincode` to `solana-stake-interface` for `StakeStateV2`'s `SchemaRead`/`SchemaWrite` impls.

**`solana-account` now resolves to `default, serde, wincode` for this crate — bincode is gone**

No functional change: wincode's derived encoding for `StakeStateV2` is byte-identical to bincode's, and the affected code is dev-context-only test/bench support.