### PR TITLE
Do not accept AG reward certs for tower slots

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -783,7 +783,7 @@ fn record_and_complete_block(
             validators,
         } = reward_certs;
         let reward_cert =
-            ValidatedRewardCert::try_new_for_leader(bank.slot(), &skip, &notar, validators)?;
+            ValidatedRewardCert::try_new_for_leader(&bank, &skip, &notar, validators)?;
         let guard = ctx.highest_finalized.read().unwrap();
         let footer = produce_block_footer(&bank, skip, notar, guard.as_ref());
         let final_cert_input = guard.as_ref().map(|c| c.vote_rewards_input());

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -17,7 +17,7 @@ use {
     agave_votor::event::LeaderWindowInfo,
     agave_votor_messages::{
         consensus_message::Block,
-        reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
+        reward_certificate::{NUM_SLOTS_FOR_REWARD, NotarRewardCertificate, SkipRewardCertificate},
     },
     crossbeam_channel::{Receiver, Sender, select_biased},
     solana_clock::Slot,
@@ -654,10 +654,20 @@ fn record_and_complete_block(
     block_timer: &mut Instant,
     block_timeout: Duration,
 ) -> Result<(), PohRecorderError> {
-    let reward_cert_request = ctx
-        .reward_certs_requestor
-        .request_reward_certs(ctx.my_pubkey, bank_slot)
-        .map_err(|()| PohRecorderError::ChannelDisconnected)?;
+    // Do not build reward certs for the first NUM_SLOTS_FOR_REWARD AG slots as the reward slots
+    // would be tower slots.
+    let reward_cert_request = if bank_slot
+        > ctx
+            .genesis_cert_block_marker
+            .slot
+            .saturating_add(NUM_SLOTS_FOR_REWARD)
+    {
+        ctx.reward_certs_requestor
+            .request_reward_certs(ctx.my_pubkey, bank_slot)
+            .map_err(|()| PohRecorderError::ChannelDisconnected)?
+    } else {
+        None
+    };
     let mut accumulated_txs = vec![];
     let mut records_shutdown = false;
     let window_has_moved_on = loop {

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -189,13 +189,16 @@ mod tests {
         crate::genesis_utils::{
             ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
         },
-        agave_votor_messages::consensus_message::VoteMessage,
+        agave_votor_messages::{
+            certificate::{CertSignature, GenesisCert},
+            consensus_message::VoteMessage,
+        },
         bitvec::vec::BitVec,
         rand::Rng,
         solana_bls_signatures::{
-            Keypair as BlsKeypair, Signature as BLSSignature,
-            SignatureCompressed as BlsSignatureCompressed, SignatureProjective,
-            pubkey::PubkeyCompressed as BLSPubkeyCompressed,
+            BLS_SIGNATURE_AFFINE_SIZE, BLS_SIGNATURE_COMPRESSED_SIZE, Keypair as BlsKeypair,
+            Signature as BLSSignature, SignatureCompressed as BlsSignatureCompressed,
+            SignatureProjective, pubkey::PubkeyCompressed as BLSPubkeyCompressed,
         },
         solana_hash::Hash,
         solana_leader_schedule::SlotLeader,
@@ -233,6 +236,60 @@ mod tests {
             BLSSignature::from(signature).try_into().unwrap(),
             encode_base2(&bitvec).unwrap(),
         )
+    }
+
+    #[test]
+    fn test_extract_slot_rejects_tower_slots() {
+        let migration_slot = 1;
+        let validator_keypairs = [ValidatorVoteKeypairs::new_rand()];
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![100],
+        );
+        let (root_bank, _bank_forks) =
+            Bank::new_for_tests(&genesis.genesis_config).wrap_with_bank_forks_for_tests();
+        let genesis_cert = GenesisCert {
+            block: Block {
+                slot: migration_slot,
+                block_id: Hash::default(),
+            },
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
+        };
+
+        for reward_slot in [migration_slot - 1, migration_slot, migration_slot + 1] {
+            let bank = Bank::new_from_parent(
+                root_bank.clone(),
+                SlotLeader::default(),
+                reward_slot + NUM_SLOTS_FOR_REWARD,
+            );
+            bank.set_alpenglow_genesis_certificate(&genesis_cert);
+            let skip = Some(
+                SkipRewardCertificate::try_new(
+                    reward_slot,
+                    BlsSignatureCompressed([0; BLS_SIGNATURE_COMPRESSED_SIZE]),
+                    vec![],
+                )
+                .unwrap(),
+            );
+
+            let result = extract_slot(&bank, &skip, &None);
+            if reward_slot <= migration_slot {
+                assert_eq!(
+                    result,
+                    Err(Error::InvalidSlotNumbers {
+                        current_slot: bank.slot(),
+                        notar_slot: None,
+                        skip_slot: Some(reward_slot),
+                    })
+                );
+            } else {
+                assert_eq!(result, Ok(Some(reward_slot)));
+            }
+        }
     }
 
     #[test]

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -39,10 +39,11 @@ pub enum Error {
 /// Returns Ok(None) if no certs were provided.
 /// Returns Error if the reward slot is invalid.
 fn extract_slot(
-    current_slot: Slot,
+    bank: &Bank,
     skip: &Option<SkipRewardCertificate>,
     notar: &Option<NotarRewardCertificate>,
 ) -> Result<Option<Slot>, Error> {
+    let current_slot = bank.slot();
     let slot = match (skip, notar) {
         (None, None) => return Ok(None),
         (Some(s), None) => s.slot,
@@ -58,9 +59,11 @@ fn extract_slot(
             s.slot
         }
     };
-    if slot.saturating_add(NUM_SLOTS_FOR_REWARD) != current_slot {
+    if slot.saturating_add(NUM_SLOTS_FOR_REWARD) != current_slot
+        || slot <= bank.get_alpenglow_migration_slot().unwrap_or(slot)
+    {
         return Err(Error::InvalidSlotNumbers {
-            current_slot,
+            current_slot: bank.slot(),
             notar_slot: notar.as_ref().map(|c| c.slot),
             skip_slot: skip.as_ref().map(|c| c.slot),
         });
@@ -85,7 +88,7 @@ impl ValidatedRewardCert {
         skip: &Option<SkipRewardCertificate>,
         notar: &Option<NotarRewardCertificate>,
     ) -> Result<Option<Self>, Error> {
-        let Some(reward_slot) = extract_slot(bank.slot(), skip, notar)? else {
+        let Some(reward_slot) = extract_slot(bank, skip, notar)? else {
             return Ok(None);
         };
         let rank_map = bank
@@ -143,12 +146,12 @@ impl ValidatedRewardCert {
     /// only needs the reward slot and validator set for bank reward
     /// calculation.
     pub fn try_new_for_leader(
-        current_slot: Slot,
+        bank: &Bank,
         skip: &Option<SkipRewardCertificate>,
         notar: &Option<NotarRewardCertificate>,
         validators: impl IntoIterator<Item = Pubkey>,
     ) -> Result<Option<Self>, Error> {
-        let Some(reward_slot) = extract_slot(current_slot, skip, notar)? else {
+        let Some(reward_slot) = extract_slot(bank, skip, notar)? else {
             return Ok(None);
         };
         let validators: HashSet<_> = validators.into_iter().collect();


### PR DESCRIPTION
#### Problem

As reported by the bug bounty report, it is possible for a malicious validator to claim AG rewards for the last remaining tower slots before migration to AG happens.


#### Summary of Changes

Validates that the slot in the reward cert is newer than the migration slot otherwise rejects the cert.


#### Testing

Unit test