### PR TITLE
Defer tombstoning zero lamport entries to clean

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -170,6 +170,7 @@ impl AccountStorageEntry {
 
     /// Insert offsets into the zero lamport single ref account offset set.
     /// Return the number of new offsets that were inserted.
+    #[cfg(test)]
     pub(crate) fn batch_insert_zero_lamport_single_ref_account_offsets(
         &self,
         offsets: &[Offset],

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -422,6 +422,8 @@ struct IndexGenerationAccumulator {
     /// The number of accounts in this slot that were skipped when generating the index as they
     /// were already marked obsolete in the account storage entry
     num_obsolete_accounts_skipped: u64,
+    /// The number of zero-lamport pubkeys found in this slot
+    num_zero_lamport_pubkeys: u64,
     slot_arena: IndexGenerationSlotArena,
 }
 impl IndexGenerationAccumulator {
@@ -439,6 +441,7 @@ impl IndexGenerationAccumulator {
             lt_hash_acc: batch::Accumulator::new(),
             capitalization: 0,
             num_obsolete_accounts_skipped: 0,
+            num_zero_lamport_pubkeys: 0,
             slot_arena: IndexGenerationSlotArena::default(),
         }
     }
@@ -458,6 +461,7 @@ impl IndexGenerationAccumulator {
             .checked_add(other.capitalization)
             .expect("capitalization cannot overflow");
         self.num_obsolete_accounts_skipped += other.num_obsolete_accounts_skipped;
+        self.num_zero_lamport_pubkeys += other.num_zero_lamport_pubkeys;
         self.storage_info.append(&mut other.storage_info);
     }
 }
@@ -468,14 +472,12 @@ impl IndexGenerationAccumulator {
 #[derive(Debug, Default)]
 struct IndexGenerationSlotArena {
     keyed_account_infos: Vec<(Pubkey, AccountInfo)>,
-    zero_lamport_offsets: Vec<usize>,
 }
 
 impl IndexGenerationSlotArena {
     /// Makes sure no actual items are stored in the allocated data structures
     fn ensure_empty(&mut self) {
         assert!(self.keyed_account_infos.is_empty(), "should be drained");
-        self.zero_lamport_offsets.clear();
     }
 }
 
@@ -513,6 +515,7 @@ struct GenerateIndexTimings {
     pub num_obsolete_accounts_marked: u64,
     pub num_slots_removed_as_obsolete: u64,
     pub num_obsolete_accounts_skipped: u64,
+    pub num_zero_lamport_pubkeys: u64,
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
@@ -593,6 +596,11 @@ impl GenerateIndexTimings {
             (
                 "num_obsolete_accounts_skipped",
                 self.num_obsolete_accounts_skipped,
+                i64
+            ),
+            (
+                "num_zero_lamport_pubkeys",
+                self.num_zero_lamport_pubkeys,
                 i64
             ),
         );
@@ -1959,6 +1967,9 @@ impl AccountsDb {
                                                     max_clean_root_inclusive,
                                                 );
                                             candidate_info.ref_count = ref_count;
+                                            // Even if the slot list length is 1, this may be
+                                            // reclaimable as it is a zero lamport account
+                                            should_collect_reclaims = true;
                                         } else {
                                             found_not_zero += 1;
                                         }
@@ -5661,7 +5672,7 @@ impl AccountsDb {
         let mut all_accounts_are_zero_lamports = true;
         accum.slot_arena.ensure_empty();
         let keyed_account_infos = &mut accum.slot_arena.keyed_account_infos;
-        let zero_lamport_offsets = &mut accum.slot_arena.zero_lamport_offsets;
+        let mut zero_lamport_pubkeys = Vec::new();
         // Batches this thread's account lt-hashes across all its storages; merged
         // into other accumulators in `accumulate`.
         let lt_hash_acc = &mut accum.lt_hash_acc;
@@ -5690,9 +5701,9 @@ impl AccountsDb {
                     accounts_data_len += data_len as u64;
                     all_accounts_are_zero_lamports = false;
                 } else {
-                    // All zero lamport accounts are obsolete or single ref by the end of index
-                    // generation. Store the offsets so they can be batch inserted later
-                    zero_lamport_offsets.push(offset);
+                    // Collect zero-lamport pubkeys so they can be added to `uncleaned_pubkeys`
+                    // after the scan, for clean to examine and remove.
+                    zero_lamport_pubkeys.push(*account.pubkey);
                 }
                 keyed_account_infos.push((
                     *account.pubkey,
@@ -5781,10 +5792,14 @@ impl AccountsDb {
             accum.storage_info.push((store_id, info));
         }
 
-        // Add all zero lamport accounts as zero lamport single refs to avoid having to revisit
-        // them later. This is safe as all zero lamport accounts will be single ref or obsolete
-        // by the end of index generation
-        storage.batch_insert_zero_lamport_single_ref_account_offsets(zero_lamport_offsets);
+        // Zero-lamport accounts stay alive in the index until clean removes them. Their storages
+        // are not otherwise dirty, so add the pubkeys into `uncleaned_pubkeys` for the first
+        // clean to examine them.
+        if !zero_lamport_pubkeys.is_empty() {
+            accum.num_zero_lamport_pubkeys += zero_lamport_pubkeys.len() as u64;
+            // Each slot has exactly one storage, so this is the only insert for `slot`.
+            self.uncleaned_pubkeys.insert(slot, zero_lamport_pubkeys);
+        }
 
         accum.num_accounts += insert_info.count as u64;
         accum.insert_time_us += insert_time_us;
@@ -6106,6 +6121,7 @@ impl AccountsDb {
         timings.mark_obsolete_accounts_us = mark_obsolete_accounts_time.as_us();
         timings.num_obsolete_accounts_marked = obsolete_account_stats.accounts_marked_obsolete;
         timings.num_slots_removed_as_obsolete = obsolete_account_stats.slots_removed;
+        timings.num_zero_lamport_pubkeys = total_accum.num_zero_lamport_pubkeys;
         total_time.stop();
         timings.total_time_us = total_time.as_us();
         timings.report(self.accounts_index.get_startup_stats());

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -144,6 +144,9 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     db.storage.insert(Arc::clone(&append_vec));
     assert!(!db.accounts_index.contains(&pubkey));
     let result = db.generate_index(None, false);
+
+    // The zero-lamport account stays alive in the index; its pubkey is added to
+    // `uncleaned_pubkeys` for clean to handle
     let slot_list_len = db.accounts_index.get_and_then(&pubkey, |entry| {
         (false, entry.unwrap().slot_list_lock_read_len())
     });
@@ -155,11 +158,17 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     assert_eq!(append_vec.accounts_count(), 1);
     assert_eq!(append_vec.count(), 1);
     assert_eq!(result.accounts_data_len, 0);
-    assert_eq!(1, append_vec.num_zero_lamport_single_ref_accounts());
+    assert_eq!(0, append_vec.num_zero_lamport_single_ref_accounts());
     assert_eq!(
-        0,
-        append_vec.alive_bytes_exclude_zero_lamport_single_ref_accounts()
+        db.uncleaned_pubkeys.get(&slot0).unwrap().value(),
+        &vec![pubkey]
     );
+
+    // Clean removes the account: the index entry is deleted, and the storage, now fully dead,
+    // is removed.
+    db.clean_accounts_for_tests();
+    assert!(!db.accounts_index.contains(&pubkey));
+    assert!(db.storage.get_slot_storage_entry(slot0).is_none());
 }
 
 pub(crate) fn append_single_account_with_default_hash(

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -936,7 +936,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             self.purge_older_root_entries(&mut slot_list, reclaims, max_clean_root_inclusive);
             let mut unref_count = (reclaims.len() - reclaims_start) as RefCount;
 
-            // If only a zero lamport single slot account remains, then reclaim it. It will be converted
+            // If only a zero lamport single ref account remains, then reclaim it. It will be converted
             // into a tombstone
             if entry.ref_count() == unref_count + 1
                 && let &[(slot, account_info)] = &*slot_list

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -936,12 +936,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             self.purge_older_root_entries(&mut slot_list, reclaims, max_clean_root_inclusive);
             let mut unref_count = (reclaims.len() - reclaims_start) as RefCount;
 
-            // If reclaiming leaves a single ref zero lamport account, it is safe to delete
-            // the account entirely and mark it as a tombstone. An untouched single-entry
-            // zero-lamport account stays on the classic zero-lamport purge path: its offset
-            // is already marked zero-lamport single-ref at flush or index generation.
-            if unref_count > 0
-                && entry.ref_count() == unref_count + 1
+            // If only a zero lamport single slot account remains, then reclaim it. It will be converted
+            // into a tombstone
+            if entry.ref_count() == unref_count + 1
                 && let &[(slot, account_info)] = &*slot_list
                 && account_info.is_zero_lamport()
             {

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -11,7 +11,6 @@ mod serde_snapshot_tests {
             snapshot_utils::StorageAndNextAccountsFileId,
         },
         agave_fs::{FileInfo, buffered_reader::FileBufRead as _, io_setup::IoSetupState},
-        log::info,
         rand::{Rng, rng},
         solana_account::{AccountSharedData, ReadableAccount},
         solana_accounts_db::{
@@ -704,38 +703,24 @@ mod serde_snapshot_tests {
         // So, prevent that from happening by introducing refcount
         ((current_slot - 1)..=current_slot).for_each(|slot| accounts.flush_root_write_cache(slot));
         accounts.clean_accounts_for_tests();
+
+        // Reconstruct the database from the snapshot to simulate a restore
         let accounts = reconstruct_accounts_db_via_serialization(
             &accounts,
             current_slot,
             ACCOUNTS_DB_CONFIG_FOR_TESTING,
         );
 
-        // Set snapshot to zero to avoid cleaning zero-lamport pubkey1
-        accounts.set_latest_full_snapshot_slot(0);
-        accounts.clean_accounts_for_tests();
-
-        info!("pubkey: {pubkey1}");
-        accounts.print_accounts_stats("pre_clean");
+        // At this point pubkey 1 has been restored as a zero lamport account
         accounts.assert_load_account(current_slot, pubkey1, zero_lamport);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);
 
-        // F: Finally, make Step A cleanable
-        current_slot += 1;
-        accounts.store_for_tests((current_slot, [(&pubkey2, &account)].as_slice()));
-        accounts.add_root(current_slot);
-
-        // Do clean
-        accounts.flush_root_write_cache(current_slot);
-
-        // Make zero-lamport pubkey1 cleanable by setting the latest snapshot slot
-        accounts.set_latest_full_snapshot_slot(current_slot);
+        // Regardless of the snapshot slot the zero-lamport pubkey1 is turned into a tombstone
+        // by clean
+        accounts.set_latest_full_snapshot_slot(0);
         accounts.clean_accounts_for_tests();
 
-        // 2nd clean needed to clean-up pubkey1
-        accounts.clean_accounts_for_tests();
-
-        // Ensure pubkey2 is cleaned from the index finally
         accounts.assert_not_load_account(current_slot, pubkey1);
         accounts.assert_load_account(current_slot, pubkey2, old_lamport);
         accounts.assert_load_account(current_slot, dummy_pubkey, dummy_lamport);


### PR DESCRIPTION
#### Problem
The last place zero lamport single ref accounts are inserted is during index generation. Removing them will clean-up a large amount of code

#### Summary of Changes
- Instead of inserting them as ZLSRs during index generation, add them to the uncleaned pubkey list and have clean remove them. 

One other option considered was adding them as tombstones during index generation. I don't see a lot of benefits vs this option though, and that option is higher touch and has more code during index generation. Handling it directly in index generation may be a better option in the future, but this is a lower touch change that allows us to remove a lot of dead code. 

The ideal time to make that change might be if we can make the entire slot list single slot only.

#### Testing
#### 25GB

Number of Entries

This shows the number of entries in the index across two restarts: Blue line is my validator, other lines are references.
The first start happens around 10:12. Without this code there are more index entries than the references as all the tombstones are revived into ZLSRS. 

Another restart occurs at ~10:28: They are immediately dispatched to clean and cleaned. 
<img width="1663" height="623" alt="image" src="https://github.com/user-attachments/assets/16f2d078-3aff-4f72-99fe-ce976190c8b8" />

Memory Usage

This one I found a little surprising, and was investigating for a while. It appears unrelated though. 
The total extra memory usage should be on the order of the number of pubkeys added to the unclean list*32 bytes. Through my testing I found the max was ~7m. Even assuming there are far worse cases, it should be on the order of 1GB. 

In my initial run:
The first restart doesn't have this code, while the second has this code. The peak looked about 10GB worse! 
<img width="1663" height="623" alt="image" src="https://github.com/user-attachments/assets/02be698e-d051-4ee7-b35d-48d637a3df96" />

On future runs though, it appears this is just random. Here's a series of restarts showing memory usage + the blue line which spikes on any restart that defers zero lamport entries to clean
<img width="1663" height="623" alt="image" src="https://github.com/user-attachments/assets/7a086f79-6245-42d8-a197-38c97d02968b" />

I spent some time debugging this. It looks like its the background flush thread during index generation. Sometimes it can keep up, sometimes it can't. I'm not sure what causes one vs the other. I tried emptying the accounts_index directory between restarts vs not, and didn't see a difference. This is probably worth looking into in the future, I would guess its something related to sequential writes vs random writes on the SSD itself (causing the run to run variation), but there should likely be some throttling (or a different way of generating the disk index) that avoids the memory spikes. 

#### In Mem
On In Mem there is no noticable memory spike:
<img width="1663" height="623" alt="image" src="https://github.com/user-attachments/assets/c51dd390-2ac6-4c07-86ac-3cdc840ee02a" />

Ran a bunch of times, difference in index generation time seemed within run to run variance

Clean
This definitely leads to a large clean spike after starting up, The worst case measured is 6s. This is after generate index is done and replay has started so I don't think its a problem
<img width="1663" height="623" alt="image" src="https://github.com/user-attachments/assets/e04706a4-c486-47fb-a31a-bc5e410faf24" />



Fixes #
