### PR TITLE
votor: avoid shutdown ownership deadlock

### DIFF
--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -32,6 +32,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
+        bank_forks::BankForks,
         leader_schedule_utils::{
             first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
         },
@@ -83,6 +84,10 @@ enum EventLoopError {
 
 pub(crate) struct EventHandler {
     t_event_handler: JoinHandle<()>,
+    // Keep BankForks teardown on the thread that owns and joins the event handler. If the event
+    // loop owns the last reference, BankForks drop glue can block this thread while Tvu::join is
+    // waiting for it to exit.
+    bank_forks_keepalive: Arc<std::sync::RwLock<BankForks>>,
 }
 
 struct LocalContext {
@@ -100,6 +105,7 @@ struct LocalContext {
 
 impl EventHandler {
     pub(crate) fn new(ctx: EventHandlerContext) -> Self {
+        let bank_forks_keepalive = ctx.shared_context.bank_forks.clone();
         let t_event_handler = Builder::new()
             .name("solVotorEvLoop".to_string())
             .spawn(move || {
@@ -109,7 +115,10 @@ impl EventHandler {
             })
             .unwrap();
 
-        Self { t_event_handler }
+        Self {
+            t_event_handler,
+            bank_forks_keepalive,
+        }
     }
 
     fn event_loop(context: EventHandlerContext) -> Result<(), EventLoopError> {
@@ -978,7 +987,11 @@ impl EventHandler {
     }
 
     pub(crate) fn join(self) -> thread::Result<()> {
-        self.t_event_handler.join()
+        let Self {
+            t_event_handler,
+            bank_forks_keepalive: _bank_forks_keepalive,
+        } = self;
+        t_event_handler.join()
     }
 }
 
@@ -1257,6 +1270,22 @@ mod tests {
             vote_history_storage,
             _vote_history_storage_dir: vote_history_storage_dir,
         }
+    }
+
+    #[test]
+    fn test_event_handler_keeps_bank_forks_alive_until_joined() {
+        let genesis = solana_runtime::genesis_utils::create_genesis_config(1);
+        let bank = Bank::new_for_tests(&genesis.genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let weak_bank_forks = Arc::downgrade(&bank_forks);
+        let event_handler = EventHandler {
+            t_event_handler: thread::spawn(|| {}),
+            bank_forks_keepalive: bank_forks,
+        };
+
+        assert!(weak_bank_forks.upgrade().is_some());
+        event_handler.join().unwrap();
+        assert!(weak_bank_forks.upgrade().is_none());
     }
 
     impl EventHandlerTestContext {

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -86,7 +86,6 @@ use {
         collections::HashMap,
         sync::{Arc, RwLock, atomic::AtomicBool},
         thread::{self, JoinHandle},
-        time::Duration,
     },
 };
 
@@ -303,22 +302,13 @@ impl Votor {
 
     pub fn join(self) -> thread::Result<()> {
         self.consensus_pool_service.join()?;
+        self.event_handler.join()?;
 
-        // Loop till we manage to unwrap the Arc and then we can join.
-        let mut timer_manager = self.timer_manager;
-        loop {
-            match Arc::try_unwrap(timer_manager) {
-                Ok(manager) => {
-                    manager.into_inner().join();
-                    break;
-                }
-                Err(m) => {
-                    timer_manager = m;
-                    thread::sleep(Duration::from_millis(1));
-                }
-            }
-        }
-        self.metrics.join()?;
-        self.event_handler.join()
+        // The event handler owns the only other TimerManager reference. Joining it first makes
+        // ownership deterministic and avoids waiting forever for a reference held by that thread.
+        let timer_manager = Arc::try_unwrap(self.timer_manager)
+            .unwrap_or_else(|_| panic!("event handler retained TimerManager after being joined"));
+        timer_manager.into_inner().join();
+        self.metrics.join()
     }
 }


### PR DESCRIPTION
#### Problem

During validator shutdown, `EventHandler::event_loop` consumes its context by value. When the loop returns, `SharedContext` is destroyed on the `solVotorEvLoop` thread. That context owns an `Arc<RwLock<BankForks>>`.

`Validator::join` drops its top-level `BankForks` reference before joining TVU services, so the event handler can own the last reference during teardown. Dropping that reference runs `BankForks` cleanup on `solVotorEvLoop`. The cleanup calls `SchedulerPool::uninstalled_from_bank_forks`, which waits for all scheduler-pool references before joining its cleaner thread. `Tvu::join` is simultaneously waiting for the event-handler thread, producing a circular shutdown wait.

There is a second ownership-ordering hazard in `Votor::join`. It previously retried `Arc::try_unwrap(timer_manager)` before joining the event handler, even though the event-handler context owns another timer-manager reference. If that thread had not finished, shutdown could spin indefinitely before reaching the join that would release the reference.

The related channel-deadlock changes in #14216, #14245, #14250, and #14283 address message delivery. The validator exit propagation added in #14389 makes thread termination more reliable, but it does not change where `BankForks` teardown runs or the timer-manager join order.

#### Summary of Changes

- Keep a `BankForks` reference in the `EventHandler` owner while the event-handler thread is running.
- Release that keepalive only after the event-handler thread has been joined, ensuring final `BankForks` teardown cannot execute in event-loop drop glue.
- Join the event handler before unwrapping and joining the timer manager.
- Replace the indefinite timer-manager ownership retry with a single ownership assertion after the event handler has released its reference.
- Add a regression test proving the event-handler owner keeps `BankForks` alive until join completes and releases it afterward.

This does not change scheduler-pool behavior, consensus message handling, or runtime behavior outside shutdown ownership.

#### Testing

- `cargo test -p agave-votor --features agave-unstable-api`
  - 131 passed
- `cargo clippy -p agave-votor --features agave-unstable-api --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `CI_BASE_BRANCH=master ./ci/test-sanity.sh`

Benchmarking is not applicable because the change adds one `Arc` clone during event-handler construction and otherwise affects shutdown ordering only.

Fixes #14333
