### PR TITLE
Remove minimal index option

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -53,6 +53,12 @@ pub const BINS_FOR_TESTING: usize = 2; // we want > 1, but each bin is a few dis
 pub const BINS_FOR_BENCHMARKS: usize = 8192;
 // The unsafe is safe because we're using a fixed, known non-zero value
 pub const FLUSH_THREADS_TESTING: NonZeroUsize = NonZeroUsize::new(1).unwrap();
+pub const INDEX_LIMIT_THRESHOLD_FOR_TESTING: IndexLimit =
+    IndexLimit::Threshold(IndexLimitThreshold {
+        num_bytes: 1_000_000_000,
+        num_entries_overhead: 100,
+        num_entries_to_evict: 100,
+    });
 pub const ACCOUNTS_INDEX_CONFIG_FOR_TESTING: AccountsIndexConfig = AccountsIndexConfig {
     bins: Some(BINS_FOR_TESTING),
     num_flush_threads: Some(FLUSH_THREADS_TESTING),
@@ -140,9 +146,6 @@ pub trait DiskIndexValue:
 /// specification of how much memory the in-mem portion of account index can hold
 #[derive(Debug, Clone)]
 pub enum IndexLimit {
-    /// use disk index while keeping a minimal amount in-mem
-    /// deprecated in v4.1.0
-    Minimal,
     /// in-mem-only was specified, no disk index
     InMemOnly,
     /// evict from in-mem when usage exceeds threshold in bytes
@@ -1420,7 +1423,7 @@ mod tests {
 
         let mut config = ACCOUNTS_INDEX_CONFIG_FOR_TESTING;
         config.index_limit = if use_disk {
-            IndexLimit::Minimal
+            INDEX_LIMIT_THRESHOLD_FOR_TESTING
         } else {
             IndexLimit::InMemOnly
         };

--- a/accounts-db/src/accounts_index/bucket_map_holder.rs
+++ b/accounts-db/src/accounts_index/bucket_map_holder.rs
@@ -94,7 +94,7 @@ pub struct BucketMapHolder<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>>
     pub(crate) startup_stats: Arc<StartupStats>,
 
     /// Precomputed thresholds per bin for flushing and eviction
-    /// None for Minimal/InMemOnly, Some(threshold_entries_per_bin) for Threshold
+    /// None for InMemOnly, Some(threshold_entries_per_bin) for Threshold
     pub(super) threshold_entries_per_bin: Option<ThresholdEntriesPerBin>,
 
     /// If true, flush dirty entries to disk once `slot_list.len() == 1` and
@@ -146,7 +146,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
     }
 
     /// Calculate maximum evictions to perform for threshold-based flushing
-    /// Returns current_entries for Minimal disk index
     /// Returns the max_evictions for Threshold mode to bring count to the low water mark
     pub fn max_evictions_for_threshold(&self, current_entries: usize) -> NonZeroUsize {
         let evictions = match &self.threshold_entries_per_bin {
@@ -288,12 +287,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
 
         let disk = match config.index_limit {
             IndexLimit::InMemOnly => None,
-            IndexLimit::Minimal | IndexLimit::Threshold(_) => Some(BucketMap::new(bucket_config)),
+            IndexLimit::Threshold(_) => Some(BucketMap::new(bucket_config)),
         };
 
         // Compute threshold_entries once here
         let threshold_entries_per_bin = match &config.index_limit {
-            IndexLimit::InMemOnly | IndexLimit::Minimal => None,
+            IndexLimit::InMemOnly => None,
             IndexLimit::Threshold(threshold) => {
                 let limit_bytes = threshold.num_bytes;
                 let bytes_per_entry = InMemAccountsIndex::<T, U>::size_of_uninitialized()
@@ -331,21 +330,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> BucketMapHolder<T, U>
         // Write through is currently only used with a memory threshold, to ensure
         // the memory threshold is not exceeded
         let should_write_through = match config.index_limit {
-            IndexLimit::InMemOnly | IndexLimit::Minimal => false,
+            IndexLimit::InMemOnly => false,
             IndexLimit::Threshold(_) => true,
         };
 
         // The age interval, `age_ms`, varies depending on `config.index_limit`
         let age_ms = match config.index_limit {
-            IndexLimit::Minimal => {
-                // - 400 milliseconds was causing excessive disk iops due to
-                //   flushing the index to disk very often.
-                // - 4 seconds was tried and showed a large reduction in disk iops,
-                //   almost as good as when the disk index is entirely disabled!
-                //   But there were concerns about the in-mem index growth behavior.
-                // - 2 seconds is much faster, and does also reduce disk iops quite a lot.
-                2_000
-            }
             IndexLimit::InMemOnly => {
                 // the disk index is disabled, thus this value doesn't actually matter
                 2_000
@@ -551,8 +541,11 @@ pub struct ThresholdEntriesPerBin {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::accounts_index::IndexLimitThreshold, rayon::prelude::*,
-        std::time::Instant, test_case::test_case,
+        super::*,
+        crate::accounts_index::{INDEX_LIMIT_THRESHOLD_FOR_TESTING, IndexLimitThreshold},
+        rayon::prelude::*,
+        std::time::Instant,
+        test_case::test_case,
     };
 
     #[test]
@@ -648,7 +641,7 @@ mod tests {
     fn test_disk_index_enabled() {
         let bins = 1;
         let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Minimal,
+            index_limit: INDEX_LIMIT_THRESHOLD_FOR_TESTING,
             ..Default::default()
         };
         let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
@@ -685,21 +678,6 @@ mod tests {
         assert!(!test.should_evict_based_on_count(thresholds.high_water_mark - 1));
         assert!(!test.should_evict_based_on_count(thresholds.high_water_mark));
         assert!(test.should_evict_based_on_count(thresholds.high_water_mark + 1));
-    }
-
-    /// Ensure that should_evict_based_on_count() is always true when using IndexLimit::Minimal
-    #[test]
-    fn test_should_evict_based_on_count_minimal() {
-        let bins = 1;
-        let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Minimal,
-            ..Default::default()
-        };
-        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
-
-        assert!(test.should_evict_based_on_count(0));
-        assert!(test.should_evict_based_on_count(1000));
-        assert!(test.should_evict_based_on_count(usize::MAX));
     }
 
     /// Ensure that should_evict_based_on_count() is always false when using IndexLimit::InMemOnly
@@ -749,21 +727,6 @@ mod tests {
         assert!(!test.should_evict_based_on_free_entries(overhead + 1));
     }
 
-    /// Ensure that should_evict_based_on_free_entries() is always true when using IndexLimit::Minimal
-    #[test]
-    fn test_should_evict_based_on_free_entries_minimal() {
-        let bins = 1;
-        let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Minimal,
-            ..Default::default()
-        };
-        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
-
-        assert!(test.should_evict_based_on_free_entries(0));
-        assert!(test.should_evict_based_on_free_entries(1000));
-        assert!(test.should_evict_based_on_free_entries(usize::MAX));
-    }
-
     /// Ensure that should_evict_based_on_free_entries() is always false when using IndexLimit::InMemOnly
     #[test]
     fn test_should_evict_based_on_free_entries_in_mem_only() {
@@ -777,25 +740,6 @@ mod tests {
         assert!(!test.should_evict_based_on_free_entries(0));
         assert!(!test.should_evict_based_on_free_entries(1000));
         assert!(!test.should_evict_based_on_free_entries(usize::MAX));
-    }
-
-    #[test]
-    fn test_max_evictions_minimal() {
-        let bins = 1;
-        let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Minimal,
-            ..Default::default()
-        };
-        let test = BucketMapHolder::<u64, u64>::new(bins, &config, 1);
-
-        assert_eq!(
-            test.max_evictions_for_threshold(0),
-            NonZeroUsize::new(1).unwrap()
-        );
-        assert_eq!(
-            test.max_evictions_for_threshold(1000),
-            NonZeroUsize::new(1000).unwrap()
-        );
     }
 
     #[test_case(1; "bins=1")]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1077,9 +1077,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 
     /// Takes self's `startup_info` and writes it to disk and in-mem.
-    ///
-    /// If the configured memory limit is "minimal", nothing is writen to in-mem.
-    /// Otherwise write to in-mem (and respect the memory limit).
+    /// When in Threshold mode limit the insertions to the low water mark of the threshold.
     fn write_startup_info(&self) {
         let insert = std::mem::take(&mut *self.startup_info.insert.lock().unwrap());
         if insert.is_empty() {

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1014,82 +1014,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         current_age.wrapping_sub(entry.age()) <= ages_flushing_now
     }
 
-    /// Returns the value to write to disk, if `entry` can be flushed.
-    ///
-    /// To be flushed, `entry` must be dirty and regular.
-    /// ('regular' means ref count == 1 and slot list len == 1)
-    ///
-    /// If yes can be flushed, then `entry`'s dirty flag will be cleared.
-    /// If no cannot be flushed, then `entry`'s dirty flag will remain set.
-    fn try_make_entry_for_flush(
-        &self,
-        entry: &AccountMapEntry<T>,
-        current_age: Age,
-        ages_flushing_now: Age,
-    ) -> ShouldFlush<SlotListItem<T>> {
-        // Step 1: Perform the cheap checks on the entry
-        // Step 2: Clear the dirty flag
-        // Step 3: Perform all the checks on the entry.
-        // - If any fail, set the dirty flag again, update stats, and return None.
-        // Step 4: Extract the data to perform disk update outside the lock
-        //
-        // Race condition handling: If a parallel operation dirties the item again after scanning,
-        // then we will mark_dirty() and skip the disk update. The dirty flag will ensure the
-        // next flush picks up the item again. If the item becomes dirty during our disk write,
-        // that's ok - the dirty flag will be picked up on the next flush and prevent us from
-        // evicting the item from the cache.
-
-        if !Self::should_evict_based_on_age(current_age, entry, ages_flushing_now) {
-            // entry was bumped in age after initial scan for candidates
-            // do not flush now; will be handled in later passes (at later ages)
-            return ShouldFlush::No(ReasonToNotFlush::Age);
-        }
-
-        if entry.ref_count() != 1 {
-            // we only flush regular entries, i.e. ref count == 1
-            return ShouldFlush::No(ReasonToNotFlush::RefCount);
-        }
-
-        // assume we're going to flush this entry, so clear its dirty flag
-        let was_dirty = entry.clear_dirty();
-        if !was_dirty {
-            // entry is not dirty anymore, skip disk write
-            return ShouldFlush::No(ReasonToNotFlush::Clean);
-        }
-
-        // lock the slot list and then check *everything*
-        // if a check fails, do not flush, and set dirty flag again
-        let slot_list = entry.slot_list_read_lock();
-
-        // re-check the ref count after locking the slot list
-        if entry.ref_count() != 1 {
-            entry.mark_dirty();
-            return ShouldFlush::No(ReasonToNotFlush::RefCount);
-        }
-
-        if slot_list.len() != 1 {
-            // we only flush regular entries, i.e. slot list len == 1
-            entry.mark_dirty();
-            return ShouldFlush::No(ReasonToNotFlush::SlotListLen);
-        }
-
-        // SAFETY: We just checked that the slot list len is 1
-        let slot_list_elem = slot_list[0];
-
-        // entry is ready to be flushed
-        ShouldFlush::Yes(slot_list_elem)
-    }
-
-    /// Collect candidates to flush/evict from `iter` by checking age
+    /// Collect candidates to evict from `iter` by checking age
     /// Skip entries with ref_count != 1 since they will be rejected later anyway
-    fn gather_possible_flush_evict_candidates<'a>(
+    fn gather_possible_evict_candidates<'a>(
         iter: impl Iterator<Item = (&'a Pubkey, &'a Box<AccountMapEntry<T>>)>,
         current_age: Age,
-        ages_flushing_now: Age,
+        ages_evicting_now: Age,
         max_evictions: NonZeroUsize,
-        collect_flush_candidates: bool,
-    ) -> (CandidatesToFlush, CandidatesToEvict) {
-        let mut candidates_to_flush = Vec::new();
+    ) -> CandidatesToEvict {
         let mut rng = rng();
         // use reservoir sampling to select a bounded, roughly uniform subset
         let mut sampling_state = ReservoirState {
@@ -1098,52 +1030,44 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             max_samples: max_evictions,
         };
         for (k, v) in iter {
-            if !Self::should_evict_based_on_age(current_age, v, ages_flushing_now) {
-                // not planning to evict this item from memory within 'ages_flushing_now' ages
+            if !Self::should_evict_based_on_age(current_age, v, ages_evicting_now) {
+                // not planning to evict this item from memory within 'ages_evicting_now' ages
                 continue;
             }
 
             // Skip entries with ref_count != 1 early
-            // In 99% of cases, these will be rejected by try_make_entry_for_flush or evict_from_cache anyway
+            // In 99% of cases, these will be rejected by evict_from_cache anyway
             // Filtering here avoids unnecessary work and reduces write lock contention in evict_from_cache
             if v.ref_count() != 1 {
                 continue;
             }
 
-            if v.dirty() {
-                if collect_flush_candidates {
-                    candidates_to_flush.push(*k);
-                }
-            } else {
+            if !v.dirty() {
                 sampling_state.select(*k, &mut rng);
             }
         }
-        (
-            CandidatesToFlush(candidates_to_flush),
-            CandidatesToEvict(mem::take(&mut sampling_state.samples)),
-        )
+        CandidatesToEvict(mem::take(&mut sampling_state.samples))
     }
 
     /// scan loop
     /// holds read lock
-    /// Returns candidates to flush/evict now, pending further checks.
+    /// Returns candidates to evict now, pending further checks.
     /// Entries with ref_count != 1 are filtered out during scan
-    fn flush_scan(
+    fn evict_scan(
         &self,
         current_age: Age,
         _flush_guard: &FlushGuard,
-        ages_flushing_now: Age,
-    ) -> (CandidatesToFlush, CandidatesToEvict) {
+        ages_evicting_now: Age,
+    ) -> CandidatesToEvict {
         let (possible_evictions, m) = {
             let map = self.map_internal.read().unwrap();
-            let m = Measure::start("flush_scan"); // we don't care about lock time in this metric - bg threads can wait
+            let m = Measure::start("evict_scan"); // we don't care about lock time in this metric - bg threads can wait
             let max_evictions = self.storage.max_evictions_for_threshold(map.len());
-            let possible_evictions = Self::gather_possible_flush_evict_candidates(
+            let possible_evictions = Self::gather_possible_evict_candidates(
                 map.iter(),
                 current_age,
-                ages_flushing_now,
+                ages_evicting_now,
                 max_evictions,
-                !self.should_write_through,
             );
             (possible_evictions, m)
         };
@@ -1424,56 +1348,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         Self::update_stat(&self.stats().buckets_scanned, 1);
 
         // scan in-mem map for candidates to flush/evict
-        let (candidates_to_flush, candidates_to_evict) =
-            self.flush_scan(current_age, flush_guard, ages_flushing_now);
+        let candidates_to_evict = self.evict_scan(current_age, flush_guard, ages_flushing_now);
 
-        // write to disk outside in-mem map read lock
-        let disk = self.bucket.as_ref().unwrap();
-        let mut flush_stats = DiskFlushStats::new();
-
-        // Process each candidate to flush
-        // For each entry: lock map briefly, get entry, calculate disk value, release lock, then write to disk
-        let flush_update_measure = Measure::start("flush_update");
-        for key in candidates_to_flush.0 {
-            // Entry was dirty at scan time, need to write to disk
-            let lock_measure = Measure::start("flush_read_lock");
-            let map_read_guard = self.map_internal.read().unwrap();
-            let Some(entry) = map_read_guard.get(&key) else {
-                continue;
-            };
-
-            let mse = Measure::start("flush_should_evict");
-            let maybe_entry_for_flush =
-                self.try_make_entry_for_flush(entry, current_age, ages_flushing_now);
-            flush_stats.flush_should_evict_us += mse.end_as_us();
-
-            drop(map_read_guard);
-            flush_stats.flush_read_lock_us += lock_measure.end_as_us();
-
-            let (slot, account_info) = match maybe_entry_for_flush {
-                ShouldFlush::Yes(entry_for_flush) => entry_for_flush,
-                ShouldFlush::No(reason) => {
-                    match reason {
-                        ReasonToNotFlush::Clean => flush_stats.num_not_flushed_clean += 1,
-                        ReasonToNotFlush::Age => flush_stats.num_not_flushed_age += 1,
-                        ReasonToNotFlush::RefCount => flush_stats.num_not_flushed_ref_count += 1,
-                        ReasonToNotFlush::SlotListLen => {
-                            flush_stats.num_not_flushed_slot_list_len += 1
-                        }
-                    }
-                    continue;
-                }
-            };
-            let disk_entry = [(slot, account_info.into())];
-
-            // Now write to disk WITHOUT holding any locks
-            flush_stats.flush_grow_us += Self::write_to_disk(disk, &key, &disk_entry);
-            flush_stats.flush_entries_updated_on_disk_background += 1;
-        }
-        flush_stats.flush_update_us = flush_update_measure.end_as_us();
-        flush_stats.update_to_stats(self.stats());
-
-        let m = Measure::start("flush_evict");
+        let m = Measure::start("evict");
         self.evict_from_cache(&candidates_to_evict.0, current_age, ages_flushing_now);
         Self::update_time_stat(&self.stats().flush_evict_us, m);
 
@@ -1623,59 +1500,6 @@ impl ReservoirState {
     }
 }
 
-/// Statistics for disk flush operations
-#[derive(Debug, Default)]
-struct DiskFlushStats {
-    /// Time spent in flush update operation
-    flush_update_us: u64,
-    /// Time spent checking if entries should be evicted
-    flush_should_evict_us: u64,
-    /// Number of entries successfully written to disk by the background flush
-    flush_entries_updated_on_disk_background: u64,
-    /// Time spent growing disk storage
-    flush_grow_us: u64,
-    /// Time spent holding map_internal read lock
-    flush_read_lock_us: u64,
-    /// Number of entries not flushed because they were clean
-    num_not_flushed_clean: u64,
-    /// Number of entries not flushed because they weren't old enough
-    num_not_flushed_age: u64,
-    /// Number of entries not flushed because ref count != 1
-    num_not_flushed_ref_count: u64,
-    /// Number of entries not flushed because slot list len != 1
-    num_not_flushed_slot_list_len: u64,
-}
-
-impl DiskFlushStats {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn update_to_stats(&self, stats: &Stats) {
-        Self::update_stat(&stats.flush_update_us, self.flush_update_us);
-        Self::update_stat(&stats.flush_should_evict_us, self.flush_should_evict_us);
-        Self::update_stat(
-            &stats.flush_entries_updated_on_disk_background,
-            self.flush_entries_updated_on_disk_background,
-        );
-        Self::update_stat(&stats.flush_grow_us, self.flush_grow_us);
-        Self::update_stat(&stats.flush_read_lock_us, self.flush_read_lock_us);
-        Self::update_stat(&stats.held_in_mem.clean, self.num_not_flushed_clean);
-        Self::update_stat(&stats.held_in_mem.age, self.num_not_flushed_age);
-        Self::update_stat(&stats.held_in_mem.ref_count, self.num_not_flushed_ref_count);
-        Self::update_stat(
-            &stats.held_in_mem.slot_list_len,
-            self.num_not_flushed_slot_list_len,
-        );
-    }
-
-    fn update_stat(stat: &AtomicU64, value: u64) {
-        if value != 0 {
-            stat.fetch_add(value, Ordering::Relaxed);
-        }
-    }
-}
-
 /// An RAII implementation of a scoped lock for the `flushing_active` atomic flag in
 /// `InMemAccountsIndex`.  When this structure is dropped (falls out of scope), the flag will be
 /// cleared (set to false).
@@ -1705,42 +1529,11 @@ impl Drop for FlushGuard<'_> {
     }
 }
 
-/// Candidates in the in-mem index that may be flushed to disk, pending further checks.
-///
-/// Note, entries must be 'dirty' to be a candidate for flush.
-#[derive(Debug)]
-struct CandidatesToFlush(Vec<Pubkey>);
-
 /// Candidates in the in-mem index that may be evicted, pending further checks.
 ///
 /// Note, entries must be 'clean' to be a candidate for eviction.
 #[derive(Debug)]
 struct CandidatesToEvict(Vec<Pubkey>);
-
-/// Should an entry be flushed to disk?
-#[derive(Debug, Eq, PartialEq)]
-enum ShouldFlush<T> {
-    /// No, do not flush this entry to disk.
-    /// See inner `ReasonToNotFlush` for why.
-    No(ReasonToNotFlush),
-    /// Yes, flush this entry to disk.
-    Yes(T),
-}
-
-/// Why was an entry *not* flushed to disk?
-#[derive(Debug, Eq, PartialEq)]
-enum ReasonToNotFlush {
-    /// Only dirty entries are flushed to disk.
-    Clean,
-    /// This entry isn't old enough to flush yet.
-    Age,
-    /// return count was != 1
-    /// This account has versions in multiple storages, and will be cleaned/shrunk soon.
-    RefCount,
-    /// slot list len was != 1
-    /// This account has versions in multiple locations, and will be cleaned/shrunk soon.
-    SlotListLen,
-}
 
 #[cfg(test)]
 mod tests {
@@ -2053,100 +1846,6 @@ mod tests {
     }
 
     #[test]
-    fn test_gather_possible_flush_evict_candidates() {
-        const AGE_MAX: Age = 255;
-        let ref_count = 1;
-        // The values in the slot list elements do not matter.
-        // They are different so we can distinguish between 'dirty' and 'clean' for the test.
-        let slot_list_dirty = [(0xD1, 0xD2)];
-        let slot_list_clean = [(0xC3, 0xC4)];
-        let map_dirty: HashMap<_, _> = (0..=AGE_MAX)
-            .map(|age| {
-                let entry = Box::new(AccountMapEntry::new(
-                    SlotList::from(slot_list_dirty),
-                    ref_count,
-                    AccountMapEntryMeta::default(),
-                ));
-                entry.mark_dirty();
-                entry.set_age(age);
-                (Pubkey::new_unique(), entry)
-            })
-            .collect();
-        let map_clean: HashMap<_, _> = (0..=AGE_MAX)
-            .map(|age| {
-                let entry = Box::new(AccountMapEntry::new(
-                    SlotList::from(slot_list_clean),
-                    ref_count,
-                    AccountMapEntryMeta::default(),
-                ));
-                assert!(!entry.dirty());
-                entry.set_age(age);
-                (Pubkey::new_unique(), entry)
-            })
-            .collect();
-
-        for current_age in 0..=AGE_MAX {
-            for ages_flushing_now in 0..=AGE_MAX {
-                let (candidates_to_flush, candidates_to_evict) =
-                    InMemAccountsIndex::<u64, u64>::gather_possible_flush_evict_candidates(
-                        map_dirty.iter().chain(&map_clean),
-                        current_age,
-                        ages_flushing_now,
-                        NonZeroUsize::new(map_dirty.len() + map_clean.len()).unwrap(),
-                        true,
-                    );
-                // Verify that the number of entries selected for eviction matches the expected count.
-                // Test setup: map contains 256 dirty entries and 256 clean entries.
-                // Each with ages 0-255 (one entry per age value).
-                //
-                // gather_possible_flush_evict_candidates includes entries where:
-                //   current_age.wrapping_sub(entry.age) <= ages_flushing_now
-                // which is equivalent to:
-                //   entry.age >= current_age - ages_flushing_now (with wrapping)
-                //
-                // This selects entries in the age window [current_age - ages_flushing_now, current_age].
-                // The window size is (ages_flushing_now + 1) because both endpoints are inclusive.
-                //
-                // Example: If current_age=10 and ages_flushing_now=3, we select ages 7,8,9,10 = 4 entries.
-                assert_eq!(candidates_to_flush.0.len(), 1 + ages_flushing_now as usize);
-                assert_eq!(candidates_to_evict.0.len(), 1 + ages_flushing_now as usize);
-                candidates_to_flush.0.iter().for_each(|key| {
-                    let entry = map_dirty.get(key).unwrap();
-                    assert!(entry.dirty());
-                    assert_eq!(*entry.slot_list_read_lock(), slot_list_dirty);
-                    assert!(
-                        InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
-                            current_age,
-                            entry,
-                            ages_flushing_now,
-                        ),
-                        "current_age: {}, age: {}, ages_flushing_now: {}",
-                        current_age,
-                        entry.age(),
-                        ages_flushing_now
-                    );
-                });
-                candidates_to_evict.0.iter().for_each(|key| {
-                    let entry = map_clean.get(key).unwrap();
-                    assert!(!entry.dirty());
-                    assert_eq!(*entry.slot_list_read_lock(), slot_list_clean);
-                    assert!(
-                        InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
-                            current_age,
-                            entry,
-                            ages_flushing_now,
-                        ),
-                        "current_age: {}, age: {}, ages_flushing_now: {}",
-                        current_age,
-                        entry.age(),
-                        ages_flushing_now
-                    );
-                });
-            }
-        }
-    }
-
-    #[test]
     fn test_gather_possible_flush_and_evict_candidates_with_max_evictions() {
         let ref_count = 1;
         let current_age = 100;
@@ -2172,19 +1871,16 @@ mod tests {
             })
             .collect();
 
-        let (to_flush, to_evict) =
-            InMemAccountsIndex::<u64, u64>::gather_possible_flush_evict_candidates(
-                map.iter(),
-                current_age,
-                ages_flushing_now,
-                max_evictions,
-                true,
-            );
+        let to_evict = InMemAccountsIndex::<u64, u64>::gather_possible_evict_candidates(
+            map.iter(),
+            current_age,
+            ages_flushing_now,
+            max_evictions,
+        );
 
-        assert_eq!(to_flush.0.len(), 128);
         assert_eq!(to_evict.0.len(), max_evictions.get());
 
-        for key in to_flush.0.iter().chain(&to_evict.0) {
+        for key in to_evict.0.iter() {
             let entry = map.get(key).unwrap();
             assert_eq!(entry.ref_count(), ref_count);
             assert!(InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
@@ -2193,19 +1889,13 @@ mod tests {
                 ages_flushing_now,
             ));
         }
-
-        for key in &to_flush.0 {
-            assert!(map.get(key).unwrap().dirty());
-        }
         for key in &to_evict.0 {
             assert!(!map.get(key).unwrap().dirty());
         }
     }
 
-    /// With `collect_flush_candidates=false`, dirty entries should not appear in either
-    /// output list — not as flush candidates, and not as eviction candidates.
     #[test]
-    fn test_gather_possible_flush_evict_candidates_no_flush() {
+    fn test_gather_possible_evict_candidates_no_flush() {
         let accounts_index = new_disk_buckets_for_test::<u64>();
         let current_age = accounts_index.storage.current_age();
         let ages_flushing_now = accounts_index.num_ages_to_distribute_flushes;
@@ -2233,108 +1923,15 @@ mod tests {
             HashMap::from([(pubkey_clean, entry_clean), (pubkey_dirty, entry_dirty)]);
 
         let max_evictions = NonZeroUsize::new(map.len()).unwrap();
-        let (to_flush, to_evict) =
-            InMemAccountsIndex::<u64, u64>::gather_possible_flush_evict_candidates(
-                map.iter(),
-                current_age,
-                ages_flushing_now,
-                max_evictions,
-                false, // should_write_through mode: do not collect flush candidates
-            );
+        let to_evict = InMemAccountsIndex::<u64, u64>::gather_possible_evict_candidates(
+            map.iter(),
+            current_age,
+            ages_flushing_now,
+            max_evictions,
+        );
 
-        assert!(to_flush.0.is_empty());
         assert!(!to_evict.0.contains(&pubkey_dirty));
         assert!(to_evict.0.contains(&pubkey_clean));
-    }
-
-    #[test]
-    fn test_try_make_entry_for_flush() {
-        let bucket = new_for_test::<u64>();
-
-        // test: entry is ready for flush
-        {
-            let slot = 11;
-            let account_info = 22_u64; // <-- u64 means *not* cached
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(slot, account_info)]),
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-            entry.mark_dirty();
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(entry_for_flush, ShouldFlush::Yes((slot, account_info)));
-        }
-
-        // test: do not flush because not dirty
-        {
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(0, 0u64)]), // <-- u64 means *not* cached
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-            assert!(!entry.dirty());
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(entry_for_flush, ShouldFlush::No(ReasonToNotFlush::Clean),);
-        }
-
-        // test: do not flush due to age
-        {
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(0, 0u64)]), // <-- u64 means *not* cached
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 1, 0);
-            assert_eq!(entry_for_flush, ShouldFlush::No(ReasonToNotFlush::Age),);
-        }
-
-        // test: do not flush due to ref count
-        {
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(0, 0u64)]), // <-- u64 means *not* cached
-                /*ref count*/ 2,
-                AccountMapEntryMeta::default(),
-            );
-            entry.mark_dirty();
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(entry_for_flush, ShouldFlush::No(ReasonToNotFlush::RefCount),);
-        }
-
-        // test: do not flush due to slot list len, part 1
-        {
-            let entry = AccountMapEntry::new(
-                SlotList::new(), // <-- slot list is empty
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-            entry.mark_dirty();
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(
-                entry_for_flush,
-                ShouldFlush::No(ReasonToNotFlush::SlotListLen),
-            );
-        }
-
-        // test: do not flush due to slot list len, part 2
-        {
-            let entry = AccountMapEntry::new(
-                SlotList::from_iter([(0, 0u64), (1, 1)]), // <-- slot list has more than 1 item
-                /*ref count*/ 1,
-                AccountMapEntryMeta::default(),
-            );
-            entry.mark_dirty();
-
-            let entry_for_flush = bucket.try_make_entry_for_flush(&entry, 0, 0);
-            assert_eq!(
-                entry_for_flush,
-                ShouldFlush::No(ReasonToNotFlush::SlotListLen),
-            );
-        }
     }
 
     #[test]

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1556,8 +1556,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             stats.update_in_mem_capacity(capacity_pre, capacity_post);
         }
 
-        // Only Threshold mode cares about tombstone-driven capacity doublings; Minimal
-        // evicts everything each pass, so rebuilding every flush is wasted work.
+        // Only Threshold mode cares about tombstone-driven capacity doublings
         if evicted > 0 && self.storage.threshold_entries_per_bin.is_some() {
             self.reallocate_to_clear_tombstones();
         }
@@ -1748,8 +1747,9 @@ mod tests {
     use {
         super::*,
         crate::accounts_index::{
-            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig, BINS_FOR_TESTING, IndexLimit,
-            IndexLimitThreshold, bucket_map_holder::ThresholdEntriesPerBin,
+            ACCOUNTS_INDEX_CONFIG_FOR_TESTING, AccountsIndexConfig, BINS_FOR_TESTING,
+            INDEX_LIMIT_THRESHOLD_FOR_TESTING, IndexLimit, IndexLimitThreshold,
+            bucket_map_holder::ThresholdEntriesPerBin,
         },
         assert_matches::assert_matches,
         itertools::Itertools,
@@ -1769,7 +1769,7 @@ mod tests {
 
     fn new_disk_buckets_for_test<T: IndexValue>() -> InMemAccountsIndex<T, T> {
         let config = AccountsIndexConfig {
-            index_limit: IndexLimit::Minimal,
+            index_limit: INDEX_LIMIT_THRESHOLD_FOR_TESTING,
             ..Default::default()
         };
         let holder = Arc::new(BucketMapHolder::new(BINS_FOR_TESTING, &config, 1));
@@ -1916,13 +1916,13 @@ mod tests {
     }
 
     /// Populates `index` with four entries covering the age/dirty matrix, triggers a
-    /// background flush, then asserts the outcomes common to all flush modes:
+    /// background flush, then asserts:
     ///   - clean new: stays in memory, not on disk
     ///   - clean old: evicted from memory, not on disk
     ///   - dirty new: stays in memory, not on disk
     ///
     /// Returns `(pubkey_dirty_old, slot + 3, info + 3)` so the caller can assert the
-    /// mode-specific outcome for the old dirty entry (flushed vs. skipped).
+    /// outcome for the old dirty entry.
     fn flush_age_mixed_entries(
         accounts_index: &InMemAccountsIndex<u64, u64>,
     ) -> (Pubkey, Slot, u64) {
@@ -2018,33 +2018,6 @@ mod tests {
         assert!(accounts_index.load_from_disk(&pubkey_dirty_new).is_none());
 
         (pubkey_dirty_old, slot + 3, info + 3)
-    }
-
-    #[test]
-    fn test_flush_internal() {
-        let accounts_index = new_disk_buckets_for_test::<u64>();
-        let (pubkey_dirty_old, dirty_slot, dirty_info) = flush_age_mixed_entries(&accounts_index);
-
-        // old dirty entry should be flushed, and not evicted
-        let mut found_in_mem = None;
-        accounts_index.get_only_in_mem(&pubkey_dirty_old, false, |entry| {
-            found_in_mem = Some(entry.is_some());
-            let entry = entry.expect("entry should remain in memory");
-            assert!(!entry.dirty()); // flushing makes the entry clean
-
-            // also ensure that old dirty entry can be evicted next time
-            assert!(InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
-                accounts_index.storage.current_age(),
-                entry,
-                accounts_index.num_ages_to_distribute_flushes,
-            ));
-        });
-        assert_eq!(found_in_mem, Some(true));
-        let (slot_list, ref_count) = accounts_index
-            .load_from_disk(&pubkey_dirty_old)
-            .expect("entry should be written to disk");
-        assert_eq!(slot_list, SlotList::from([(dirty_slot, dirty_info)]));
-        assert_eq!(ref_count, 1);
     }
 
     /// With `should_write_through=true`, the background flush should evict old clean entries but
@@ -3242,42 +3215,6 @@ mod tests {
                 .num_hashmap_reallocates
                 .load(Ordering::Relaxed),
             1
-        );
-    }
-
-    /// Minimal mode evicts everything on every flush, so the per-pass HashMap
-    /// rebuild would be pure waste. Verify `evict_from_cache` skips it.
-    #[test]
-    fn test_reallocate_skipped_in_minimal_mode() {
-        let index = new_disk_buckets_for_test::<u64>();
-        assert!(index.storage.threshold_entries_per_bin.is_none());
-
-        let current_age = index.storage.current_age();
-        let pubkeys: Vec<_> = (0..100).map(|_| solana_pubkey::new_rand()).collect();
-        {
-            let mut map = index.map_internal.write().unwrap();
-            for pubkey in &pubkeys {
-                let entry = AccountMapEntry::new(
-                    SlotList::from([(/*slot*/ 0, /*info*/ 0)]),
-                    /*ref_count*/ 1,
-                    AccountMapEntryMeta::new_clean(&index.storage),
-                );
-                entry.set_age(current_age);
-                map.insert(*pubkey, Box::new(entry));
-            }
-        }
-
-        index.evict_from_cache(&pubkeys, current_age, /*ages_flushing_now*/ 0);
-
-        // All entries were evicted...
-        assert_eq!(index.map_internal.read().unwrap().len(), 0);
-        // ...but reallocate must not have run in Minimal mode.
-        assert_eq!(
-            index
-                .stats()
-                .num_hashmap_reallocates
-                .load(Ordering::Relaxed),
-            0
         );
     }
 }

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1071,7 +1071,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             );
             (possible_evictions, m)
         };
-        Self::update_time_stat(&self.stats().flush_scan_us, m);
+        Self::update_time_stat(&self.stats().evict_scan_us, m);
 
         possible_evictions
     }

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -1,6 +1,6 @@
 use {
     super::{
-        DiskIndexValue, IndexValue, SlotListItem,
+        DiskIndexValue, IndexValue,
         bucket_map_holder::{Age, AtomicAge, BucketMapHolder},
         in_mem_accounts_index::InMemAccountsIndex,
     },
@@ -18,16 +18,7 @@ use {
 const STATS_INTERVAL_MS: u64 = 10_000;
 
 #[derive(Debug, Default)]
-pub struct HeldInMemStats {
-    pub clean: AtomicU64,
-    pub age: AtomicU64,
-    pub ref_count: AtomicU64,
-    pub slot_list_len: AtomicU64,
-}
-
-#[derive(Debug, Default)]
 pub struct Stats {
-    pub held_in_mem: HeldInMemStats,
     pub get_mem_us: AtomicU64,
     pub gets_from_mem: AtomicU64,
     pub get_missing_us: AtomicU64,
@@ -52,21 +43,17 @@ pub struct Stats {
     pub count_in_mem: AtomicUsize,
     pub capacity_in_mem: AtomicUsize,
     pub flush_entries_updated_on_disk_immediate: AtomicU64,
-    pub flush_entries_updated_on_disk_background: AtomicU64,
     pub flush_entries_evicted_from_mem_immediate: AtomicU64,
     pub flush_entries_evicted_from_mem_background: AtomicU64,
     pub active_threads: AtomicU64,
     last_age: AtomicAge,
     last_ages_flushed: AtomicU64,
     pub flush_scan_us: AtomicU64,
-    pub flush_update_us: AtomicU64,
     pub flush_evict_us: AtomicU64,
     pub flush_grow_us: AtomicU64,
     last_was_startup: AtomicBool,
     last_time: AtomicInterval,
     bins: u64,
-    pub flush_should_evict_us: AtomicU64,
-    pub flush_read_lock_us: AtomicU64,
     pub num_hashmap_reallocates: AtomicU64,
     pub hashmap_reallocate_us: AtomicU64,
     pub evict_triggered_by_low_free_entries: AtomicU64,
@@ -260,11 +247,6 @@ impl Stats {
                     ),
                 );
             }
-            let held_in_mem_clean = self.held_in_mem.clean.swap(0, Ordering::Relaxed);
-            let held_in_mem_age = self.held_in_mem.age.swap(0, Ordering::Relaxed);
-            let held_in_mem_ref_count = self.held_in_mem.ref_count.swap(0, Ordering::Relaxed);
-            let held_in_mem_slot_list_len =
-                self.held_in_mem.slot_list_len.swap(0, Ordering::Relaxed);
             // If an entry is held in-mem due to ref count or slot list length,
             // then assume it has two slot list entries.
             // Since `approx_size_of_one_entry()` assumes 'regular' entries
@@ -276,20 +258,10 @@ impl Stats {
                 // (we ignore other hash map details, such as load factor)
                 capacity_in_mem * InMemAccountsIndex::<T, U>::size_of_uninitialized()
                 // each value in use we assume has a single entry in the slot list
-                + count_in_mem * InMemAccountsIndex::<T, U>::size_of_single_entry()
-                // and for entries held in mem due to ref count or slot list length, assume
-                // conservatively a slot list with two entries
-                + (held_in_mem_ref_count + held_in_mem_slot_list_len) as usize
-                    * size_of::<SlotListItem<T>>() // <-- size of one slot list entry
-                    * 2; // <-- and assume there are two entries
+                + count_in_mem * InMemAccountsIndex::<T, U>::size_of_single_entry();
             datapoint_info!(
                 datapoint_name,
                 ("estimate_mem_bytes", estimate_mem_bytes, i64),
-                (
-                    "flush_should_evict_us",
-                    self.flush_should_evict_us.swap(0, Ordering::Relaxed),
-                    i64
-                ),
                 ("count_in_mem", count_in_mem, i64),
                 ("capacity_in_mem", capacity_in_mem, i64),
                 ("count", self.total_count(), i64),
@@ -308,14 +280,6 @@ impl Stats {
                         thread_time_elapsed_ms
                     ),
                     f64
-                ),
-                ("num_not_flushed_clean", held_in_mem_clean, i64),
-                ("num_not_flushed_age", held_in_mem_age, i64),
-                ("num_not_flushed_ref_count", held_in_mem_ref_count, i64),
-                (
-                    "num_not_flushed_slot_list_len",
-                    held_in_mem_slot_list_len,
-                    i64
                 ),
                 ("min_in_bin_disk", disk_stats.0, i64),
                 ("max_in_bin_disk", disk_stats.1, i64),
@@ -415,11 +379,6 @@ impl Stats {
                     i64
                 ),
                 (
-                    "flush_update_us",
-                    self.flush_update_us.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "flush_grow_us",
                     self.flush_grow_us.swap(0, Ordering::Relaxed),
                     i64
@@ -427,11 +386,6 @@ impl Stats {
                 (
                     "flush_evict_us",
                     self.flush_evict_us.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "flush_read_lock_us",
-                    self.flush_read_lock_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -563,12 +517,6 @@ impl Stats {
                 (
                     "flush_entries_updated_on_disk_immediate",
                     self.flush_entries_updated_on_disk_immediate
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "flush_entries_updated_on_disk_background",
-                    self.flush_entries_updated_on_disk_background
                         .swap(0, Ordering::Relaxed),
                     i64
                 ),

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -48,7 +48,7 @@ pub struct Stats {
     pub active_threads: AtomicU64,
     last_age: AtomicAge,
     last_ages_flushed: AtomicU64,
-    pub flush_scan_us: AtomicU64,
+    pub evict_scan_us: AtomicU64,
     pub flush_evict_us: AtomicU64,
     pub flush_grow_us: AtomicU64,
     last_was_startup: AtomicBool,
@@ -374,8 +374,8 @@ impl Stats {
                     i64
                 ),
                 (
-                    "flush_scan_us",
-                    self.flush_scan_us.swap(0, Ordering::Relaxed),
+                    "evict_scan_us",
+                    self.evict_scan_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (


### PR DESCRIPTION
#### Problem
- MinimalIndex Option is now dead code

#### Summary of Changes
- Remove Minimal option
- Now that flush candidates are no longer created, remove flush candidate code
- Note: There is some renaming further up the stack that needs to be done, but this is enough for one PR 
- Best looked at as 4 individual commits. 

#### Testing


Fixes #
