### PR TITLE
votor-transport: scale MAX_INCOMING with number of endpoints

### DIFF
--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -495,7 +495,7 @@ mod tests {
 
         let server_keypair = Keypair::new();
         let server = Endpoint::server(
-            new_server_config(&server_keypair, MAX_DATAGRAMS_PER_SECOND),
+            new_server_config(&server_keypair, MAX_DATAGRAMS_PER_SECOND, 1),
             SocketAddr::from((Ipv4Addr::LOCALHOST, ports.next().unwrap())),
         )
         .expect("bind server endpoint");

--- a/votor-transport/src/endpoint.rs
+++ b/votor-transport/src/endpoint.rs
@@ -101,7 +101,11 @@ impl QuicDatagramEndpoint {
         let key_updater = Arc::new(key_updater);
         let local_pubkey = keypair.pubkey();
 
-        let server_config = new_server_config(keypair, max_datagrams_per_second_per_peer);
+        // Queue and rate limits are global budgets that get split across the endpoints,
+        // so the config has to know how many there will be.
+        let num_endpoints = inbound_sockets.len();
+        let server_config =
+            new_server_config(keypair, max_datagrams_per_second_per_peer, num_endpoints);
         // Spawn a quinn endpoint for each socket.
         let (inbound_endpoints, mut outbound_endpoint) = {
             // Endpoint::new requires the runtime context.
@@ -150,7 +154,6 @@ impl QuicDatagramEndpoint {
             mpsc::channel(CONN_EVENT_CHANNEL_CAP);
         // To run multiple AcceptLoops per endpoint, we split the global handshake budget
         // evenly across all loops so the aggregate rate is constrained.
-        let num_endpoints = inbound_endpoints.len();
         let num_accept_loops = num_endpoints
             .checked_mul(HANDSHAKE_WORKERS_PER_ENDPOINT)
             .expect("HANDSHAKE_WORKERS_PER_ENDPOINT should be small");
@@ -163,7 +166,7 @@ impl QuicDatagramEndpoint {
         let rate_limiter = TokenBucket::new(
             handshake_burst,
             handshake_burst,
-            HANDSHAKE_GLOBAL_RATE / num_accept_loops as f64,
+            HANDSHAKE_GLOBAL_RATE as f64 / num_accept_loops as f64,
         );
         for endpoint in &inbound_endpoints {
             for _ in 0..HANDSHAKE_WORKERS_PER_ENDPOINT {

--- a/votor-transport/src/lib.rs
+++ b/votor-transport/src/lib.rs
@@ -64,9 +64,13 @@ pub const PEER_RATE_LIMIT_DOS_WINDOW: Duration = Duration::from_secs(10);
 
 /// Sustained rate at which we start inbound TLS handshakes (handshakes/second),
 /// consulted before `Endpoint::accept()` so it bounds when we begin handshake
-/// crypto at all. Sized to the validator set: the whole set may (re)connect at
-/// once after a coordinated restart and should be admitted within ~1 second.
-pub const HANDSHAKE_GLOBAL_RATE: f64 = MAX_ALPENGLOW_VOTE_ACCOUNTS as f64;
+/// crypto at all. Sized to the validator set, which may (re)connect all at once
+/// after a coordinated restart.
+///
+/// This is a ceiling, not a rate we sustain. Whenever attempts stop completing
+/// promptly [`MAX_INFLIGHT_HANDSHAKES`] may get saturated first, so the achievable
+/// rate is [`HANDSHAKE_DRAIN_RATE`]. Size queues from that constant, not this one.
+pub const HANDSHAKE_GLOBAL_RATE: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
 
 /// Burst of inbound handshakes tolerated above allowed rate before
 /// new attempts are shed. Chosen to align with 200ms at [`HANDSHAKE_GLOBAL_RATE`].
@@ -88,7 +92,26 @@ pub(crate) const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
 /// under sustained [`HANDSHAKE_GLOBAL_RATE`] load, so admission is governed by
 /// the rate limiter rather than by this cap.
 pub const MAX_INFLIGHT_HANDSHAKES: usize =
-    (HANDSHAKE_GLOBAL_RATE * HANDSHAKE_TIMEOUT.as_secs_f64()) as usize;
+    HANDSHAKE_GLOBAL_RATE * HANDSHAKE_TIMEOUT.as_millis() as usize / 1000;
+
+/// Rate at which the accept loops actually take connection attempts off the
+/// endpoints under sustained load, aggregated over all endpoints
+/// (handshakes/second).
+pub(crate) const HANDSHAKE_DRAIN_RATE: usize = {
+    let inflight_bound = MAX_INFLIGHT_HANDSHAKES * 1000 / (HANDSHAKE_TIMEOUT.as_millis() as usize);
+    if inflight_bound < HANDSHAKE_GLOBAL_RATE {
+        inflight_bound
+    } else {
+        HANDSHAKE_GLOBAL_RATE
+    }
+};
+
+/// Longest an inbound attempt that we are going to serve may sit queued inside
+/// quinn before an accept loop reaches it. This is what sizes quinn's `max_incoming`:
+/// a deeper queue does not admit more handshakes (the drain rate is fixed), it only
+/// adds latency to the attempts we do serve, so we keep it short and let the excess
+/// be shed by quinn.
+pub(crate) const MAX_INCOMING_DELAY: Duration = Duration::from_millis(1000);
 
 /// How often endpoint metrics are reported.
 pub(crate) const METRICS_INTERVAL: Duration = Duration::from_secs(1);

--- a/votor-transport/src/server.rs
+++ b/votor-transport/src/server.rs
@@ -396,7 +396,7 @@ impl InboundLoop {
                         break;
                     }
                     let keypair = identity_receiver.borrow_and_update().insecure_clone();
-                    let server_config = new_server_config(&keypair, self.max_datagrams_per_second_per_peer);
+                    let server_config = new_server_config(&keypair, self.max_datagrams_per_second_per_peer, self.endpoints.len());
                     for endpoint in &self.endpoints {
                         endpoint.set_server_config(Some(server_config.clone()));
                     }
@@ -605,16 +605,107 @@ mod tests {
     use {
         super::*,
         crate::{
-            ALPENGLOW_ALPN, HANDSHAKE_BURST, HANDSHAKE_GLOBAL_RATE, MAX_INFLIGHT_HANDSHAKES,
-            transport::new_client_config,
+            ALPENGLOW_ALPN, HANDSHAKE_BURST, HANDSHAKE_GLOBAL_RATE, MAX_ENDPOINTS,
+            MAX_INFLIGHT_HANDSHAKES,
+            transport::{compute_max_incoming, new_client_config, new_transport_config},
         },
-        quinn::{ClientConfig, crypto::rustls::QuicClientConfig},
+        quinn::{ClientConfig, IdleTimeout, crypto::rustls::QuicClientConfig},
         solana_keypair::Keypair,
         solana_net_utils::sockets::{bind_to_localhost_async, unique_port_range_for_tests},
         solana_tls_utils::{new_dummy_x509_certificate, tls_client_config_builder},
         std::{net::Ipv4Addr, time::Duration},
         tokio::{spawn, time::sleep},
     };
+
+    /// Connection attempts arriving at a server whose incoming queue is already
+    /// full must be dropped with no reply at all, and must not displace attempts
+    /// that are already queued.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn saturated_incoming_queue_drops_silently() {
+        // The largest supported endpoint count yields the smallest per-endpoint
+        // queue, so the test opens as few connections as it can get away with.
+        let queue_capacity = compute_max_incoming(MAX_ENDPOINTS);
+        let overflow_attempts = 8;
+
+        let mut ports = unique_port_range_for_tests(2);
+        let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, ports.next().unwrap()));
+        let server_kp = Keypair::new();
+        // Deliberately no AcceptLoop: nothing drains the queue, so it fills and stays full.
+        let server = Endpoint::server(
+            new_server_config(&server_kp, 50, MAX_ENDPOINTS),
+            server_addr,
+        )
+        .expect("bind server endpoint");
+
+        let client_kp = Keypair::new();
+        let mut client = Endpoint::client(SocketAddr::from((
+            Ipv4Addr::LOCALHOST,
+            ports.next().unwrap(),
+        )))
+        .expect("bind client endpoint");
+        let mut client_cfg = new_client_config(&client_kp, 50);
+        let mut transport = new_transport_config(50);
+        // We want to send Initial exactly once and never give up on it. With production
+        // timings a client retransmits after ~1s and abandons the attempt after
+        // MAX_IDLE_TIMEOUT, either of which could race the assertions below. So we
+        // configure the client to have insane RTT estimate and idle timeout.
+        transport
+            .initial_rtt(Duration::from_secs(30))
+            .max_idle_timeout(Some(
+                IdleTimeout::try_from(Duration::from_secs(30)).expect("30s fits IdleTimeout"),
+            ));
+        client_cfg.transport_config(Arc::new(transport));
+        client.set_default_client_config(client_cfg);
+
+        // Fill the queue. The endpoint driver sends each Initial without the
+        // `Connecting` being polled; we only need to keep them alive, since
+        // dropping one would close the attempt.
+        let _filling = (0..queue_capacity)
+            .map(|_| {
+                client
+                    .connect(server_addr, "votor")
+                    .expect("client connect to fill queue")
+            })
+            .collect::<Vec<_>>();
+        // Let the server's driver enqueue them. Nothing expires or retransmits
+        // while we wait, so this bound only has to beat scheduling delay.
+        sleep(Duration::from_secs(1)).await;
+
+        // These arrive at a saturated queue. Poll them so we can tell whether the
+        // server answered: a refusal resolves them, a silent drop leaves them pending.
+        let overflow = (0..overflow_attempts)
+            .map(|_| {
+                let connecting = client
+                    .connect(server_addr, "votor")
+                    .expect("client connect to overflow queue");
+                spawn(async move { connecting.await.map(|_| ()) })
+            })
+            .collect::<Vec<_>>();
+        sleep(Duration::from_secs(1)).await;
+        for (i, handle) in overflow.iter().enumerate() {
+            assert!(
+                !handle.is_finished(),
+                "overflow attempt {i} got a reply from a saturated server; excess Initials must \
+                 be dropped not refused",
+            );
+        }
+
+        // Exactly the attempts that fit should have been queued; the rest were
+        // dropped outright. `ignore()` frees the slot without answering the peer.
+        let mut queued = 0;
+        while let Ok(Some(incoming)) = timeout(Duration::from_millis(100), server.accept()).await {
+            incoming.ignore();
+            queued += 1;
+        }
+        assert_eq!(
+            queued, queue_capacity,
+            "server queued {queued} attempts but max_incoming is {queue_capacity}",
+        );
+
+        for handle in overflow {
+            handle.abort();
+        }
+    }
 
     /// A peer that completes the QUIC Initial but never finishes the handshake
     /// must not pin an in-flight slot indefinitely.
@@ -627,7 +718,7 @@ mod tests {
         // timeout lives). The control loop is not needed: the handshake never
         // completes, so no Accepted event is ever forwarded.
         let server_kp = Keypair::new();
-        let server_cfg = new_server_config(&server_kp, 50);
+        let server_cfg = new_server_config(&server_kp, 50, 1);
         let endpoint = Endpoint::server(server_cfg, server_addr).expect("bind server endpoint");
         let server_addr = endpoint.local_addr().expect("server local addr");
 
@@ -640,7 +731,11 @@ mod tests {
             events_sender,
             stats.clone(),
             cancel.clone(),
-            TokenBucket::new(HANDSHAKE_BURST, HANDSHAKE_BURST, HANDSHAKE_GLOBAL_RATE),
+            TokenBucket::new(
+                HANDSHAKE_BURST,
+                HANDSHAKE_BURST,
+                HANDSHAKE_GLOBAL_RATE as f64,
+            ),
             MAX_INFLIGHT_HANDSHAKES,
         );
         let loop_handle = spawn(accept.run());
@@ -703,7 +798,7 @@ mod tests {
         let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, ports.next().unwrap()));
 
         let server_kp = Keypair::new();
-        let server_cfg = new_server_config(&server_kp, 50);
+        let server_cfg = new_server_config(&server_kp, 50, 1);
         let server_endpoint =
             Endpoint::server(server_cfg, server_addr).expect("bind server endpoint");
 
@@ -715,7 +810,11 @@ mod tests {
             events_sender,
             stats.clone(),
             cancel.clone(),
-            TokenBucket::new(HANDSHAKE_BURST, HANDSHAKE_BURST, HANDSHAKE_GLOBAL_RATE),
+            TokenBucket::new(
+                HANDSHAKE_BURST,
+                HANDSHAKE_BURST,
+                HANDSHAKE_GLOBAL_RATE as f64,
+            ),
             MAX_INFLIGHT_HANDSHAKES,
         );
         let accept_loop_handle = spawn(accept.run());
@@ -784,7 +883,7 @@ mod tests {
         let server_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, ports.next().unwrap()));
 
         let server_kp = Keypair::new();
-        let server_cfg = new_server_config(&server_kp, 50);
+        let server_cfg = new_server_config(&server_kp, 50, 1);
         let endpoint = Endpoint::server(server_cfg, server_addr).expect("bind server endpoint");
 
         let (events_sender, mut events_receiver) = mpsc::channel(1);
@@ -795,7 +894,11 @@ mod tests {
             events_sender,
             stats.clone(),
             cancel.clone(),
-            TokenBucket::new(HANDSHAKE_BURST, HANDSHAKE_BURST, HANDSHAKE_GLOBAL_RATE),
+            TokenBucket::new(
+                HANDSHAKE_BURST,
+                HANDSHAKE_BURST,
+                HANDSHAKE_GLOBAL_RATE as f64,
+            ),
             MAX_INFLIGHT_HANDSHAKES,
         );
         let accept_loop_handle = spawn(accept.run());

--- a/votor-transport/src/transport.rs
+++ b/votor-transport/src/transport.rs
@@ -1,6 +1,6 @@
 //! Transport tuning constants for a votor-style workload.
 use {
-    crate::{ALPENGLOW_ALPN, MAX_ALPENGLOW_VOTE_ACCOUNTS},
+    crate::{ALPENGLOW_ALPN, HANDSHAKE_DRAIN_RATE, MAX_INCOMING_DELAY},
     quinn::{
         ClientConfig, IdleTimeout, ServerConfig, TransportConfig, VarInt,
         crypto::rustls::{QuicClientConfig, QuicServerConfig},
@@ -22,9 +22,14 @@ const KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(2);
 /// MTU used for all datagrams. Path-MTU discovery is disabled, so the initial
 /// and minimum MTU are the same; 1280 is the QUIC-spec floor.
 const DATAGRAM_MTU: u16 = 1280;
-/// Max number of buffered connection requests we will keep.
-/// Sized such that a cluster-wide simultaneous reconnect fits.
-const MAX_INCOMING: usize = MAX_ALPENGLOW_VOTE_ACCOUNTS;
+/// Max number of connection attempts quinn buffers *per endpoint* before it starts
+/// dropping Initials outright.
+#[allow(clippy::arithmetic_side_effects)]
+pub(crate) fn compute_max_incoming(num_endpoints: usize) -> usize {
+    debug_assert!(num_endpoints > 0, "an endpoint needs at least one socket");
+    let per_endpoint_rate = HANDSHAKE_DRAIN_RATE / num_endpoints;
+    (per_endpoint_rate * MAX_INCOMING_DELAY.as_millis() as usize / 1000).max(1)
+}
 
 /// Creates a new transport config for datagram mode.
 ///
@@ -54,6 +59,7 @@ pub(crate) fn new_transport_config(max_datagrams_per_second_per_peer: usize) -> 
 pub(crate) fn new_server_config(
     keypair: &Keypair,
     max_datagrams_per_second_per_peer: usize,
+    num_endpoints: usize,
 ) -> ServerConfig {
     let (cert, key) = new_dummy_x509_certificate(keypair);
     let mut tls = tls_server_config_builder()
@@ -65,8 +71,9 @@ pub(crate) fn new_server_config(
         .expect("TLS 1.3-only config yields an initial cipher suite");
     let mut cfg = ServerConfig::with_crypto(Arc::new(quic));
     cfg.incoming_buffer_size((DATAGRAM_MTU * 2) as u64);
-    cfg.incoming_buffer_size_total(MAX_INCOMING as u64 * DATAGRAM_MTU as u64);
-    cfg.max_incoming(MAX_INCOMING);
+    let max_incoming = compute_max_incoming(num_endpoints);
+    cfg.incoming_buffer_size_total(max_incoming as u64 * DATAGRAM_MTU as u64);
+    cfg.max_incoming(max_incoming);
     cfg.retry_token_lifetime(MAX_IDLE_TIMEOUT);
     cfg.transport_config(Arc::new(new_transport_config(
         max_datagrams_per_second_per_peer,
@@ -92,4 +99,50 @@ pub(crate) fn new_client_config(
         max_datagrams_per_second_per_peer,
     )));
     cfg
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::compute_max_incoming,
+        crate::{
+            HANDSHAKE_DRAIN_RATE, HANDSHAKE_GLOBAL_RATE, HANDSHAKE_WORKERS_PER_ENDPOINT,
+            MAX_ENDPOINTS, MAX_INCOMING_DELAY,
+        },
+    };
+
+    #[test]
+    fn max_incoming_splits_across_endpoints() {
+        // One endpoint owns the entire drain budget for one full delay window.
+        let total_buffered_handshakes = HANDSHAKE_DRAIN_RATE
+            .saturating_mul(MAX_INCOMING_DELAY.as_millis() as usize)
+            .saturating_div(1000);
+        assert_eq!(
+            compute_max_incoming(1),
+            total_buffered_handshakes,
+            "a lone endpoint should buffer MAX_INCOMING_DELAY worth of the HANDSHAKE_DRAIN_RATE \
+             drain budget",
+        );
+
+        for num_endpoints in 1..=MAX_ENDPOINTS {
+            let queue_length = compute_max_incoming(num_endpoints);
+
+            let even_share = total_buffered_handshakes as f32 / num_endpoints as f32;
+            assert!(
+                (queue_length as f32 - even_share).abs() < 2.0,
+                "each of {num_endpoints} should buffer ~{even_share} Initials, got {queue_length}",
+            );
+            assert!(even_share > 8.0, "sanity");
+
+            let num_accept_loops = num_endpoints.saturating_mul(HANDSHAKE_WORKERS_PER_ENDPOINT);
+            let per_loop_rate = HANDSHAKE_GLOBAL_RATE as f64 / num_accept_loops as f64;
+            let per_endpoint_rate = per_loop_rate * HANDSHAKE_WORKERS_PER_ENDPOINT as f64;
+            let delay_secs = queue_length as f64 / per_endpoint_rate;
+            assert!(
+                delay_secs <= MAX_INCOMING_DELAY.as_secs_f64(),
+                "with {num_endpoints} endpoints a queued attempt waits up to {delay_secs}s, over \
+                 the MAX_INCOMING_DELAY budget",
+            );
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

MAX_INCOMING was not adjusted to number of endpoints, adding unnecessary delays to legit connection attempts coming at the end of the queue when using more than 1 endpoint.
Part of https://github.com/anza-xyz/agave/issues/14301

#### Summary of Changes

Make its choice more principled and driven by number of endpoints rather than fixed (as drain rates are split among endpoints).

Basic idea is to pick max amount of TIME a handshake request can be buffered for, and derive buffer sizes from that rather than having it somewhat haphazardly picked by hand.

#### Testing

CI + new test

Flood testing shows response to excessive handshakes is unchanged by this.


