### PR TITLE
votor-transport: allow unstaked participation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ still accepted for backwards compatibility but slated for full removal in the fu
   `CommitCancelled` errors in non-all-or-nothing batches. All-or-nothing batches continue to use
   `ALL_OR_NOTHING_BATCH_FAILURE`.
 * Using the deprecated value `minimal` for `--accounts-index-limit` now defaults to 25GB.
+* Unstaked nodes can now receive consensus messages via votor from any staked node.
+  Specify `--votor-peer-overrides <VALIDATOR IDENTITY>...` to additionally send votor
+  messages to identities outside the staked set.
 ### Geyser
 #### Deprecations
 * The legacy `GeyserPlugin` methods `update_account`, `notify_transaction`, `notify_entry`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "agave-votor",
  "agave-votor-transport",
  "agave-xdp",
+ "arc-swap",
  "assert_cmd",
  "assert_matches",
  "bytesize",

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -43,7 +43,7 @@ use {
         VerifiedVoterSlotsReceiver, VerifiedVoterSlotsSender, consensus_message::Block,
         metric_types::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
     },
-    agave_votor_transport::endpoint::QuicDatagramEndpoint,
+    agave_votor_transport::{PeerList, endpoint::QuicDatagramEndpoint},
     arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, Sender, bounded, unbounded},
     solana_client::connection_cache::ConnectionCache,
@@ -318,7 +318,10 @@ impl Tvu {
         // PeerListService populates the votor_peer_list channel immediately on startup,
         // so we can initialize the watch channel with a dummy value here.
         let (votor_peer_list_sender, votor_peer_list_receiver) =
-            watch::channel(Arc::new(HashMap::new()));
+            watch::channel(Arc::new(PeerList {
+                peers: HashMap::new(),
+                push_enabled: false,
+            }));
         let sharable_banks = bank_forks.read().unwrap().sharable_banks();
         let peer_list_service = PeerListService::new(
             cluster_info.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -44,6 +44,7 @@ use {
         metric_types::MAX_IN_FLIGHT_CONSENSUS_EVENTS,
     },
     agave_votor_transport::endpoint::QuicDatagramEndpoint,
+    arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, Sender, bounded, unbounded},
     solana_client::connection_cache::ConnectionCache,
     solana_clock::Slot,
@@ -84,7 +85,7 @@ use {
     solana_validator_exit::Exit,
     std::{
         collections::{HashMap, HashSet},
-        net::UdpSocket,
+        net::{SocketAddr, UdpSocket},
         num::NonZeroUsize,
         sync::{Arc, RwLock, atomic::AtomicBool},
         thread::{self, JoinHandle},
@@ -203,8 +204,8 @@ pub struct AlpenglowInitializationState {
     pub votor_server_sockets: Vec<UdpSocket>,
     // client socket for Alpenglow consensus traffic
     pub votor_client_socket: UdpSocket,
-    #[cfg(feature = "dev-context-only-utils")]
-    pub voting_service_test_override: Option<agave_votor::voting_service::VotingServiceOverride>,
+    // peers plugged into the votor peer_list regardless of stake
+    pub votor_peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
 }
 
 impl Tvu {
@@ -284,8 +285,7 @@ impl Tvu {
             key_notifiers,
             votor_server_sockets,
             votor_client_socket,
-            #[cfg(feature = "dev-context-only-utils")]
-            voting_service_test_override,
+            votor_peer_overrides,
             highest_finalized,
         } = votor_init;
 
@@ -324,8 +324,7 @@ impl Tvu {
             cluster_info.clone(),
             votor_peer_list_sender,
             sharable_banks.clone(),
-            #[cfg(feature = "dev-context-only-utils")]
-            voting_service_test_override,
+            votor_peer_overrides,
         );
         let (votor_egress, endpoint) = QuicDatagramEndpoint::spawn(
             &votor_rt_handle,
@@ -924,7 +923,7 @@ pub mod tests {
                     bind_to_localhost_unique().expect("bind votor server socket"),
                 ],
                 votor_client_socket: bind_to_localhost_unique().expect("bind votor client socket"),
-                voting_service_test_override: None,
+                votor_peer_overrides: Arc::default(),
                 highest_finalized: Arc::new(RwLock::new(None)),
                 bank_forks_controller,
                 bank_forks_controller_receiver,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -37,10 +37,10 @@ use {
     agave_votor::{
         vote_history::{VoteHistory, VoteHistoryError},
         vote_history_storage::{NullVoteHistoryStorage, VoteHistoryStorage},
-        voting_service::VotingServiceOverride,
     },
     agave_xdp::transmitter::{Transmitter, TransmitterBuilder},
     anyhow::{Result, anyhow},
+    arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, bounded, unbounded},
     serde::{Deserialize, Serialize},
     solana_account::ReadableAccount,
@@ -345,6 +345,11 @@ pub struct ValidatorConfig {
     pub known_validators: Option<HashSet<Pubkey>>, // None = trust all
     pub repair_validators: Option<HashSet<Pubkey>>, // None = repair from all
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
+    /// Peers plugged into the votor peer_list regardless of stake, admitting their
+    /// inbound connections and pushing consensus messages to them. Set by
+    /// `--votor-peer-overrides`.
+    /// `None` resolves the address from gossip, `Some` pins it.
+    pub votor_peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub should_check_duplicate_instance: bool,
     pub max_genesis_archive_unpacked_size: u64,
@@ -397,7 +402,6 @@ pub struct ValidatorConfig {
     pub tvu_shred_sigverify_threads: NonZeroUsize,
     pub tvu_bls_sigverify_threads: NonZeroUsize,
     pub delay_leader_block_for_pending_fork: bool,
-    pub voting_service_test_override: Option<VotingServiceOverride>,
     pub repair_handler_type: RepairHandlerType,
     // Thread niceness adjustment for snapshot packager service
     pub snapshot_packager_niceness_adj: i8,
@@ -430,6 +434,7 @@ impl ValidatorConfig {
             repair_validators: None,
             should_check_duplicate_instance: true,
             repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
+            votor_peer_overrides: Arc::default(),
             gossip_validators: None,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
             run_verification: true,
@@ -483,7 +488,6 @@ impl ValidatorConfig {
             tvu_shred_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             tvu_bls_sigverify_threads: NonZeroUsize::new(2).expect("2 is non-zero"),
             delay_leader_block_for_pending_fork: true,
-            voting_service_test_override: None,
             repair_handler_type: RepairHandlerType::default(),
             snapshot_packager_niceness_adj: 0,
         }
@@ -1668,8 +1672,7 @@ impl Validator {
                 key_notifiers: key_notifiers.clone(),
                 votor_server_sockets: node.sockets.votor_server,
                 votor_client_socket: node.sockets.quic_votor_client,
-                #[cfg(feature = "dev-context-only-utils")]
-                voting_service_test_override: config.voting_service_test_override.clone(),
+                votor_peer_overrides: config.votor_peer_overrides.clone(),
                 highest_finalized,
             },
             reward_aggregates_sender,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -346,8 +346,9 @@ pub struct ValidatorConfig {
     pub repair_validators: Option<HashSet<Pubkey>>, // None = repair from all
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     /// Peers plugged into the votor peer_list regardless of stake, admitting their
-    /// inbound connections and pushing consensus messages to them. Set by
-    /// `--votor-peer-overrides`.
+    /// inbound connections and (while this node is staked) pushing consensus
+    /// messages to them. Staked peers are admitted unconditionally, so this is
+    /// only needed for peers that hold no stake. Set by `--votor-peer-overrides`.
     /// `None` resolves the address from gossip, `Some` pins it.
     pub votor_peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -10,7 +10,10 @@ use {
         consensus_message::VoteMessage, unverified_vote_message::DecodedWireConsensusMessage,
         wire::VersionedWireConsensusMessage,
     },
-    agave_votor_transport::endpoint::{Datagram, QuicDatagramEndpoint},
+    agave_votor_transport::{
+        PeerList,
+        endpoint::{Datagram, QuicDatagramEndpoint},
+    },
     crossbeam_channel::{Receiver, bounded},
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
@@ -634,13 +637,16 @@ pub fn start_datagram_listener_for_alpenglow_votor(
         .build()
         .expect("tokio runtime");
     let (sender, receiver) = bounded(1024);
-    // Admit every peer from `admitted_peers`. The None address keeps the listener's
-    // outbound loop from connecting to them. Leak the sender so the channel stays open.
-    let peer_list = admitted_peers
+    // Admit every peer from `admitted_peers`. Pushing is off, so the listener's
+    // outbound loop never connects to them.
+    let peers = admitted_peers
         .iter()
         .map(|pubkey| (*pubkey, None))
         .collect::<HashMap<_, _>>();
-    let (peer_list_sender, peer_list_receiver) = tokio::sync::watch::channel(Arc::new(peer_list));
+    let (peer_list_sender, peer_list_receiver) = tokio::sync::watch::channel(Arc::new(PeerList {
+        peers,
+        push_enabled: false,
+    }));
     // We want the sender to stay alive so the endpoint does not exit prematurely.
     Box::leak(Box::new(peer_list_sender));
     let client_socket = bind_to_localhost_unique().expect("bind alpenglow client socket");

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -549,11 +549,10 @@ pub fn run_cluster_partition<C>(
     // alpenglow port override to SocketAddr which no one is listening on.
     let blackhole_socket = bind_to_localhost_unique().unwrap();
     let blackhole_addr: SocketAddr = blackhole_socket.local_addr().unwrap();
-    let new_override = HashMap::from_iter(
-        cluster_nodes
-            .iter()
-            .map(|node| (*node.pubkey(), Some(blackhole_addr))),
-    );
+    let new_override: HashMap<_, _> = cluster_nodes
+        .iter()
+        .map(|node| (*node.pubkey(), Some(blackhole_addr)))
+        .collect();
     alpenglow_port_override.store(Arc::new(new_override));
     sleep(partition_duration);
 

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -17,7 +17,6 @@ use {
         validator_configs::*,
     },
     agave_snapshots::{SnapshotInterval, snapshot_config::SnapshotConfig},
-    agave_votor::voting_service::VotingServiceOverride,
     arc_swap::ArcSwap,
     log::*,
     solana_account::AccountSharedData,
@@ -485,9 +484,7 @@ pub fn run_cluster_partition<C>(
     // Every validator's cache reads this same handle on each refresh.
     let alpenglow_port_override = Arc::new(ArcSwap::from_pointee(HashMap::new()));
     for config in &mut validator_configs {
-        config.voting_service_test_override = Some(VotingServiceOverride {
-            override_listeners: alpenglow_port_override.clone(),
-        });
+        config.votor_peer_overrides = alpenglow_port_override.clone();
     }
     let mut config = ClusterConfig {
         mint_lamports,
@@ -555,7 +552,7 @@ pub fn run_cluster_partition<C>(
     let new_override = HashMap::from_iter(
         cluster_nodes
             .iter()
-            .map(|node| (*node.pubkey(), blackhole_addr)),
+            .map(|node| (*node.pubkey(), Some(blackhole_addr))),
     );
     alpenglow_port_override.store(Arc::new(new_override));
     sleep(partition_duration);

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -83,7 +83,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         tvu_shred_sigverify_threads: config.tvu_shred_sigverify_threads,
         tvu_bls_sigverify_threads: config.tvu_bls_sigverify_threads,
         delay_leader_block_for_pending_fork: config.delay_leader_block_for_pending_fork,
-        voting_service_test_override: config.voting_service_test_override.clone(),
+        votor_peer_overrides: config.votor_peer_overrides.clone(),
         repair_handler_type: config.repair_handler_type.clone(),
         snapshot_packager_niceness_adj: config.snapshot_packager_niceness_adj,
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -4,7 +4,6 @@ use {
         SnapshotArchiveKind, SnapshotInterval, paths as snapshot_paths,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
     },
-    agave_votor::voting_service::VotingServiceOverride,
     agave_votor_messages::migration::MIGRATION_SLOT_OFFSET,
     arc_swap::ArcSwap,
     assert_matches::assert_matches,
@@ -6050,12 +6049,11 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
 
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.fixed_leader_schedule = Some(leader_schedule);
-    validator_config.voting_service_test_override = Some(VotingServiceOverride {
-        override_listeners: Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
+    validator_config.votor_peer_overrides =
+        Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
             listener_pubkey,
-            vote_listener_addr.local_addr().unwrap(),
-        )]))),
-    });
+            Some(vote_listener_addr.local_addr().unwrap()),
+        )])));
     validator_config.wait_for_supermajority = Some(0);
 
     // Cluster config
@@ -6233,12 +6231,11 @@ fn test_alpenglow_migration(
     let vote_listener_socket = bind_to_localhost_unique().unwrap();
     let vote_listener_addr = vote_listener_socket.try_clone().unwrap();
     let mut validator_config = ValidatorConfig::default_for_test();
-    validator_config.voting_service_test_override = Some(VotingServiceOverride {
-        override_listeners: Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
+    validator_config.votor_peer_overrides =
+        Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
             listener_keypair.pubkey(),
-            vote_listener_addr.local_addr().unwrap(),
-        )]))),
-    });
+            Some(vote_listener_addr.local_addr().unwrap()),
+        )])));
     validator_config.wait_for_supermajority = Some(0);
 
     let (leader_schedule, keys) = create_custom_leader_schedule_with_random_keys(leader_schedule);

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6049,11 +6049,10 @@ fn test_alpenglow_imbalanced_stakes_catchup() {
 
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.fixed_leader_schedule = Some(leader_schedule);
-    validator_config.votor_peer_overrides =
-        Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
-            listener_pubkey,
-            Some(vote_listener_addr.local_addr().unwrap()),
-        )])));
+    validator_config.votor_peer_overrides = Arc::new(ArcSwap::from_pointee(HashMap::from([(
+        listener_pubkey,
+        Some(vote_listener_addr.local_addr().unwrap()),
+    )])));
     validator_config.wait_for_supermajority = Some(0);
 
     // Cluster config
@@ -6231,11 +6230,10 @@ fn test_alpenglow_migration(
     let vote_listener_socket = bind_to_localhost_unique().unwrap();
     let vote_listener_addr = vote_listener_socket.try_clone().unwrap();
     let mut validator_config = ValidatorConfig::default_for_test();
-    validator_config.votor_peer_overrides =
-        Arc::new(ArcSwap::from_pointee(HashMap::from_iter([(
-            listener_keypair.pubkey(),
-            Some(vote_listener_addr.local_addr().unwrap()),
-        )])));
+    validator_config.votor_peer_overrides = Arc::new(ArcSwap::from_pointee(HashMap::from([(
+        listener_keypair.pubkey(),
+        Some(vote_listener_addr.local_addr().unwrap()),
+    )])));
     validator_config.wait_for_supermajority = Some(0);
 
     let (leader_schedule, keys) = create_custom_leader_schedule_with_random_keys(leader_schedule);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "agave-votor",
  "agave-votor-transport",
  "agave-xdp",
+ "arc-swap",
  "bytesize",
  "caps",
  "chrono",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -28,6 +28,7 @@ agave-snapshots = { workspace = true }
 agave-votor = { workspace = true }
 agave-votor-transport = { workspace = true }
 agave-xdp = { workspace = true }
+arc-swap = { workspace = true }
 bytesize = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 clap = { workspace = true }

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -808,6 +808,20 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .help("The number of QUIC endpoints used for the votor transport."),
     )
     .arg(
+        Arg::with_name("votor_peer_overrides")
+            .long("votor-peer-overrides")
+            .validator(is_pubkey)
+            .value_name("VALIDATOR IDENTITY")
+            .multiple(true)
+            .takes_value(true)
+            .hidden(hidden_unless_forced())
+            .help(
+                "A list of validator identities that this node admits into the votor transport \
+                 and pushes consensus messages to, regardless of their stake. Their addresses are \
+                 resolved from gossip. [default: staked validators only]",
+            ),
+    )
+    .arg(
         Arg::with_name("staked_nodes_overrides")
             .long("staked-nodes-overrides")
             .value_name("PATH")

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -817,8 +817,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .hidden(hidden_unless_forced())
             .help(
                 "A list of validator identities that this node admits into the votor transport \
-                 and pushes consensus messages to, regardless of their stake. Their addresses are \
-                 resolved from gossip. [default: staked validators only]",
+                 regardless of their stake, and pushes consensus messages to while this node is \
+                 itself staked. Their addresses are resolved from gossip. Staked validators are \
+                 always admitted, so this is only needed for peers that hold no stake. [default: \
+                 staked validators only]",
             ),
     )
     .arg(

--- a/validator/src/commands/run/args.rs
+++ b/validator/src/commands/run/args.rs
@@ -816,11 +816,10 @@ pub fn add_args<'a>(app: App<'a, 'a>, default_args: &'a DefaultArgs) -> App<'a, 
             .takes_value(true)
             .hidden(hidden_unless_forced())
             .help(
-                "A list of validator identities that this node admits into the votor transport \
-                 regardless of their stake, and pushes consensus messages to while this node is \
-                 itself staked. Their addresses are resolved from gossip. Staked validators are \
-                 always admitted, so this is only needed for peers that hold no stake. [default: \
-                 staked validators only]",
+                "A list of additional validator identities for this node to send votor consensus \
+                 messages to while staked. By default we only send consensus messages to staked \
+                 nodes, however an operator can use this flag to additionally send messages to an \
+                 unstaked RPC node for faster state. These identities are resolved from gossip.",
             ),
     )
     .arg(

--- a/validator/src/commands/run/execute.rs
+++ b/validator/src/commands/run/execute.rs
@@ -13,6 +13,7 @@ use {
     },
     agave_votor::vote_history_storage,
     agave_votor_transport::MAX_ENDPOINTS,
+    arc_swap::ArcSwap,
     bytesize::ByteSize,
     clap::{ArgMatches, crate_name, value_t, value_t_or_exit, values_t, values_t_or_exit},
     crossbeam_channel::unbounded,
@@ -489,6 +490,21 @@ pub fn execute(
         "gossip_validators",
         "--gossip-validator",
     )?;
+    let votor_peer_overrides = validators_set(
+        &identity_keypair.pubkey(),
+        matches,
+        "votor_peer_overrides",
+        "--votor-peer-overrides",
+    )?;
+    // Identities named on the command line carry no address: the peer list resolves
+    // them from gossip.
+    let votor_peer_overrides = Arc::new(ArcSwap::from_pointee(
+        votor_peer_overrides
+            .unwrap_or_default()
+            .into_iter()
+            .map(|identity| (identity, None))
+            .collect(),
+    ));
 
     if bind_addresses.len() > 1 {
         for (flag, msg) in [
@@ -795,6 +811,7 @@ pub fn execute(
         repair_validators,
         should_check_duplicate_instance: true,
         repair_whitelist,
+        votor_peer_overrides,
         repair_handler_type: RepairHandlerType::default(),
         gossip_validators,
         blockstore_cleanup_strategy,
@@ -877,7 +894,6 @@ pub fn execute(
             Arc::new(AtomicBool::new(false)),
         )]
         .into(),
-        voting_service_test_override: None,
         snapshot_packager_niceness_adj: value_t_or_exit!(
             matches,
             "snapshot_packager_niceness_adj",

--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -250,11 +250,13 @@ impl OutboundLoop {
     fn reconcile(&mut self) {
         debug!("OutboundLoop: running reconcile");
         let peer_list = self.peer_list_receiver.borrow().clone();
+        // With pushing off every peer we hold counts as departed.
+        let push_enabled = peer_list.push_enabled;
 
         // 1. Close connections for departed peers.
         let mut closed_not_in_peer_list = 0u64;
         self.peer_state.retain(|peer, state| {
-            if peer_list.contains_key(peer) {
+            if push_enabled && peer_list.peers.contains_key(peer) {
                 return true;
             }
             match state {
@@ -274,8 +276,12 @@ impl OutboundLoop {
             .connection_closed_not_in_peer_list
             .fetch_add(closed_not_in_peer_list, Ordering::Relaxed);
 
+        if !push_enabled {
+            return;
+        }
+
         // 2. Ensure a connection for every addressable peer.
-        for (peer, addr) in peer_list.iter() {
+        for (peer, addr) in peer_list.peers.iter() {
             if *peer == self.local_pubkey {
                 continue;
             }
@@ -409,6 +415,7 @@ impl OutboundLoop {
 mod tests {
     use {
         super::*,
+        crate::PeerList,
         solana_net_utils::sockets::unique_port_range_for_tests,
         std::net::Ipv4Addr,
         tokio::{sync::watch, time::sleep},
@@ -428,7 +435,10 @@ mod tests {
         let (_egress_tx, egress_rx) = mpsc::channel(1);
         let (_identity_tx, identity_rx) = watch::channel(Keypair::new());
         let (ack, _acks) = crossbeam_channel::unbounded();
-        let (_peer_list_tx, peer_list_rx) = watch::channel(Arc::new(HashMap::default()));
+        let (_peer_list_tx, peer_list_rx) = watch::channel(Arc::new(PeerList {
+            peers: HashMap::default(),
+            push_enabled: true,
+        }));
 
         let mut outbound = OutboundLoop::new(
             endpoint,

--- a/votor-transport/src/endpoint.rs
+++ b/votor-transport/src/endpoint.rs
@@ -68,8 +68,9 @@ impl QuicDatagramEndpoint {
     /// own port.
     /// Received datagrams flow into `inbound_datagrams`, per-peer receive rate is
     /// capped by `max_datagrams_per_second_per_peer`.
-    /// `peer_list` carries desired peer set: inbound closes connections to
-    /// peers no longer in the set, outbound connects to peers in it.
+    /// `peer_list` carries the desired peer set: inbound admits those peers and
+    /// closes connections to peers no longer in the set, outbound connects to
+    /// peers in it as long as the peer_list enables pushing.
     /// `cancel` controls when the endpoint should terminate.
     pub fn spawn(
         runtime: &Handle,
@@ -387,7 +388,7 @@ pub fn stub_ban_channel_for_tests(capacity: usize) -> (BanSender, mpsc::Receiver
 mod tests {
     use {
         super::{BanSender, Datagram, QuicDatagramEndpoint},
-        crate::{METRICS_INTERVAL, PeerListSender, transport::MAX_IDLE_TIMEOUT},
+        crate::{METRICS_INTERVAL, PeerList, PeerListSender, transport::MAX_IDLE_TIMEOUT},
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded},
         solana_keypair::{Keypair, Signer},
@@ -450,8 +451,19 @@ mod tests {
         }
 
         fn set_peer_list(&self, map: HashMap<Pubkey, Option<SocketAddr>>) {
+            self.set_peer_list_with_push(map, true);
+        }
+
+        fn set_peer_list_with_push(
+            &self,
+            peers: HashMap<Pubkey, Option<SocketAddr>>,
+            push_enabled: bool,
+        ) {
             self.peer_list_sender
-                .send(Arc::new(map))
+                .send(Arc::new(PeerList {
+                    peers,
+                    push_enabled,
+                }))
                 .expect("peer_list receiver alive");
         }
 
@@ -482,7 +494,10 @@ mod tests {
             // Ingress channel size mirrors prod (`solana_core::tvu`):
             // `MAX_ALPENGLOW_PACKET_NUM`.
             let (ingress_sender, ingress_receiver) = bounded(INGRESS_CAP);
-            let (peer_list_sender, peer_list_receiver) = watch::channel(Arc::new(peer_list));
+            let (peer_list_sender, peer_list_receiver) = watch::channel(Arc::new(PeerList {
+                peers: peer_list,
+                push_enabled: true,
+            }));
             let (egress, endpoint) = QuicDatagramEndpoint::spawn(
                 rt.handle(),
                 &keypair,
@@ -668,6 +683,60 @@ mod tests {
                 > 0,
             "unadmitted peer B's handshake should have been rejected (unauthorized)"
         );
+    }
+
+    #[test]
+    fn test_unstaked_client_push_flag_gates_outbound_connections() {
+        let rt = make_runtime_for_tests();
+        let client_keypair = Keypair::new();
+        let client_pubkey = client_keypair.pubkey();
+        let server = Node::spawn_node(
+            &rt,
+            Keypair::new(),
+            peer_list_with_unknown_addr(client_pubkey),
+            HIGH_PPS,
+        );
+        let client = Node::spawn_node(&rt, client_keypair, HashMap::new(), HIGH_PPS);
+        let peers = peer_list_of(server.pubkey(), server.addr);
+
+        client.set_peer_list_with_push(peers.clone(), false);
+        let while_disabled = Bytes::from_static(b"push-disabled");
+        assert_not_delivered(&client, &while_disabled, &server.ingress_receiver, 20);
+
+        // Same peer set, pushing enabled: the client now connects.
+        client.set_peer_list(peers.clone());
+        let while_enabled = Bytes::from_static(b"push-enabled");
+        send_until_received(&client, &while_enabled, &server.ingress_receiver, |d| {
+            (d.message == while_enabled).then_some(())
+        })
+        .expect("server never received a datagram once pushing was enabled");
+        drain_backlog(&server.ingress_receiver);
+
+        // Disabling it again tears the connection down.
+        client.set_peer_list_with_push(peers, false);
+        let after_disable = Bytes::from_static(b"push-disabled-again");
+        assert_not_delivered(&client, &after_disable, &server.ingress_receiver, 20);
+    }
+
+    #[test]
+    fn test_unstaked_server_admits_inbound_while_push_disabled() {
+        let rt = make_runtime_for_tests();
+        let client_keypair = Keypair::new();
+        let client_pubkey = client_keypair.pubkey();
+        let server = Node::spawn_node(&rt, Keypair::new(), HashMap::new(), HIGH_PPS);
+        server.set_peer_list_with_push(peer_list_with_unknown_addr(client_pubkey), false);
+        let client = Node::spawn_node(
+            &rt,
+            client_keypair,
+            peer_list_of(server.pubkey(), server.addr),
+            HIGH_PPS,
+        );
+
+        let payload = Bytes::from_static(b"inbound-while-push-disabled");
+        send_until_received(&client, &payload, &server.ingress_receiver, |d| {
+            (d.peer_pubkey == client_pubkey && d.message == payload).then_some(())
+        })
+        .expect("a non-pushing server must still admit its peers' datagrams");
     }
 
     /// Banning a peer closes its connections and blocks subsequent ones.

--- a/votor-transport/src/lib.rs
+++ b/votor-transport/src/lib.rs
@@ -15,12 +15,16 @@ use {
     tokio::sync::watch,
 };
 
-/// Snapshot of desired peers list. Peers we want to admit but cannot yet
-/// resolve to an address via gossip map to `None`.
-///
-/// Inbound admission uses membership only (the address is ignored).
+pub struct PeerList {
+    /// Peers with whom we are interested in communicating. Inbound admission
+    /// uses membership only, the address is only needed to push.
+    pub peers: HashMap<Pubkey, Option<SocketAddr>>,
+    /// Whether we open outbound connections.
+    pub push_enabled: bool,
+}
+
 /// Readers can clone the Arc and release the watch lock immediately.
-type PeerListSnapshot = Arc<HashMap<Pubkey, Option<SocketAddr>>>;
+type PeerListSnapshot = Arc<PeerList>;
 
 pub type PeerListSender = watch::Sender<PeerListSnapshot>;
 

--- a/votor-transport/src/server.rs
+++ b/votor-transport/src/server.rs
@@ -466,7 +466,7 @@ impl InboundLoop {
         let peer_list = peer_list_receiver.borrow().clone();
         let mut closed_not_in_peer_list = 0u64;
         for (peer, entry) in peer_state.iter() {
-            if entry.connections.is_empty() || peer_list.contains_key(peer) {
+            if entry.connections.is_empty() || peer_list.peers.contains_key(peer) {
                 continue;
             }
             let closed = entry
@@ -541,7 +541,7 @@ impl InboundLoop {
             return;
         }
 
-        if !self.peer_list_receiver.borrow().contains_key(&peer) {
+        if !self.peer_list_receiver.borrow().peers.contains_key(&peer) {
             debug!("Not admitted peer {peer} attempted a connection from {remote_addr}, rejected");
             close_codes::NOT_ADMITTED.close(&connection);
             record_server_error(&Error::NotAdmitted(peer), &self.stats);

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -1,7 +1,7 @@
 use {
     agave_bls_sigverify::bls_sigverifier::NUM_SLOTS_FOR_VERIFY,
     agave_votor_messages::reward_certificate::NUM_SLOTS_FOR_REWARD,
-    agave_votor_transport::PeerListSender,
+    agave_votor_transport::{PeerList, PeerListSender},
     arc_swap::ArcSwap,
     crossbeam_channel::{RecvTimeoutError, Sender, bounded},
     solana_gossip::cluster_info::ClusterInfo,
@@ -66,6 +66,10 @@ impl PeerListUpdater {
     ///
     /// Each peer's votor socket is resolved from gossip, unless an override pins it.
     /// Peers that have no address yet are added with `None`.
+    ///
+    /// Pushing is enabled only while this node is itself in the staked set: an
+    /// unstaked node still admits the set so it can follow consensus, but staked
+    /// peers would not admit it, so it must not dial out.
     pub fn refresh_peer_list(&self, cluster_info: &ClusterInfo, my_identity: &Pubkey) {
         let root = self.sharable_banks.root();
         let epoch_schedule = root.epoch_schedule();
@@ -98,31 +102,24 @@ impl PeerListUpdater {
             peers.extend(next.keys());
         }
 
+        let push_enabled = peers.contains(my_identity);
         let overrides = self.peer_overrides.load();
-
-        // Do not join the votor all2all mesh if this node is not marked as staked.
-        if !peers.contains(my_identity) {
-            peers.clear();
-            // An unstaked node without overrides has nobody to talk to.
-            if overrides.is_empty() {
-                // Empty peer_list means the transport neither connects nor admits peers.
-                self.peer_list_sender.send_replace(Arc::new(HashMap::new()));
-                return;
-            }
-        }
-
-        let peers = peers.iter().chain(overrides.keys());
-        let mut new_peer_list: HashMap<_, _> = cluster_info
-            .query_contact_infos(peers, |node| node.alpenglow())
+        let mut new_peers: HashMap<_, _> = cluster_info
+            .query_contact_infos(peers.iter().chain(overrides.keys()), |node| {
+                node.alpenglow()
+            })
             .into_iter()
             .map(|(pubkey, socket)| (pubkey, socket.flatten()))
             .collect();
         // An override that pins an address wins over whatever gossip resolved to.
         for (pubkey, socket) in overrides.iter().filter(|(_, socket)| socket.is_some()) {
-            new_peer_list.insert(*pubkey, *socket);
+            new_peers.insert(*pubkey, *socket);
         }
         // Publish the latest version - this neither blocks nor fails.
-        self.peer_list_sender.send_replace(Arc::new(new_peer_list));
+        self.peer_list_sender.send_replace(Arc::new(PeerList {
+            peers: new_peers,
+            push_enabled,
+        }));
     }
 }
 
@@ -333,12 +330,22 @@ mod tests {
         )
     }
 
-    /// An unstaked node publishes an empty peer_list, so the transport is idle.
+    /// A channel seeded the way `tvu` does it, before the first refresh lands.
+    fn empty_peer_list_channel() -> (PeerListSender, watch::Receiver<Arc<PeerList>>) {
+        watch::channel(Arc::new(PeerList {
+            peers: HashMap::new(),
+            push_enabled: false,
+        }))
+    }
+
+    /// An unstaked node admits the whole staked set but keeps its client off.
     #[test]
-    fn test_unstaked_peer_list_remains_empty() {
+    fn test_unstaked_node_admits_staked_set_without_pushing() {
         let slot_num = 12345000;
+        let num_nodes = 10;
         // A fully-staked set, none of whose identities is the local node below.
-        let (bank_forks, _, _) = create_bank_forks_and_cluster_info(10, 0, slot_num);
+        let (bank_forks, _, node_pubkeys) =
+            create_bank_forks_and_cluster_info(num_nodes, 0, slot_num);
 
         // Identity that is not staked.
         let unstaked_kp = Keypair::new();
@@ -348,10 +355,7 @@ mod tests {
             SocketAddrSpace::Unspecified,
         );
 
-        let (sender, receiver) = watch::channel(Arc::new(HashMap::from([(
-            Pubkey::new_unique(),
-            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8000)),
-        )])));
+        let (sender, receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             sender,
@@ -360,9 +364,15 @@ mod tests {
 
         svc.refresh_peer_list(&cluster_info, &cluster_info.id());
 
+        let snapshot = receiver.borrow().clone();
+        assert_eq!(
+            snapshot.peers.keys().copied().collect::<HashSet<_>>(),
+            node_pubkeys.iter().copied().collect::<HashSet<_>>(),
+            "an unstaked node admits the entire staked set"
+        );
         assert!(
-            receiver.borrow().is_empty(),
-            "unstaked node must publish an empty peer_list"
+            !snapshot.push_enabled,
+            "an unstaked node must not push anything"
         );
     }
 
@@ -375,7 +385,7 @@ mod tests {
         let (bank_forks, cluster_info, node_pubkeys) =
             create_bank_forks_and_cluster_info(num_nodes, num_zero_stake_nodes, slot_num);
 
-        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
@@ -385,17 +395,21 @@ mod tests {
         let unstaked = node_pubkeys[0];
         svc.refresh_peer_list(&cluster_info, &unstaked);
         assert!(
-            peerlist_receiver.borrow().is_empty(),
-            "unstaked node must publish an empty peer_list"
+            !peerlist_receiver.borrow().push_enabled,
+            "an unstaked identity must not push"
         );
 
-        // After assuming a staked identity: the peer_list should be populated immediately
+        // After assuming a staked identity: pushing is enabled immediately
         let staked = node_pubkeys[num_zero_stake_nodes];
         svc.refresh_peer_list(&cluster_info, &staked);
         let snapshot = peerlist_receiver.borrow().clone();
-        assert_eq!(snapshot.len(), num_nodes - num_zero_stake_nodes);
         assert!(
-            snapshot.values().all(|addr| addr.is_some()),
+            snapshot.push_enabled,
+            "a staked identity joins the mesh right away"
+        );
+        assert_eq!(snapshot.peers.len(), num_nodes - num_zero_stake_nodes);
+        assert!(
+            snapshot.peers.values().all(|addr| addr.is_some()),
             "every staked peer resolves to its gossip socket"
         );
     }
@@ -410,8 +424,8 @@ mod tests {
         ))
     }
 
-    /// The RPC-node side: an unstaked node listing staked identities admits exactly
-    /// those, and does not pull in the staked set.
+    /// The RPC-node side: an unstaked node admits the staked set plus its
+    /// overrides, and still does not push.
     #[test]
     fn test_overrides_admit_peers_on_unstaked_node() {
         let slot_num = 123456789;
@@ -421,29 +435,36 @@ mod tests {
         let (bank_forks, cluster_info, node_pubkeys) =
             create_bank_forks_and_cluster_info(num_nodes, num_zero_stake_nodes, slot_num);
 
-        let admitted = HashSet::from([
-            node_pubkeys[num_zero_stake_nodes],
-            node_pubkeys[num_zero_stake_nodes + 1],
-        ]);
-        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        // A zero-stake peer, which only an override can admit.
+        let overridden = node_pubkeys[1];
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
-            gossip_resolved_overrides(admitted.iter().copied()),
+            gossip_resolved_overrides([overridden]),
         );
 
         let unstaked = node_pubkeys[0];
         svc.refresh_peer_list(&cluster_info, &unstaked);
 
         let snapshot = peerlist_receiver.borrow().clone();
+        let expected: HashSet<_> = node_pubkeys[num_zero_stake_nodes..]
+            .iter()
+            .copied()
+            .chain([overridden])
+            .collect();
         assert_eq!(
-            snapshot.keys().copied().collect::<HashSet<_>>(),
-            admitted,
-            "an unstaked node admits its overrides and nothing else"
+            snapshot.peers.keys().copied().collect::<HashSet<_>>(),
+            expected,
+            "an unstaked node admits the staked set plus its overrides"
         );
         assert!(
-            snapshot.values().all(|addr| addr.is_some()),
-            "overridden peers resolve to their gossip sockets"
+            snapshot.peers.values().all(|addr| addr.is_some()),
+            "every admitted peer resolves to its gossip socket"
+        );
+        assert!(
+            !snapshot.push_enabled,
+            "overrides do not make an unstaked node push"
         );
     }
 
@@ -468,7 +489,7 @@ mod tests {
             cluster_info.id(),
             "redundant_peer must not be self"
         );
-        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
@@ -479,13 +500,22 @@ mod tests {
 
         let snapshot = peerlist_receiver.borrow().clone();
         assert_eq!(
-            snapshot.len(),
+            snapshot.peers.len(),
             num_nodes - num_zero_stake_nodes + 1,
             "the staked set gains exactly the one unstaked override"
         );
         assert!(
-            snapshot.get(&unstaked_peer).copied().flatten().is_some(),
+            snapshot
+                .peers
+                .get(&unstaked_peer)
+                .copied()
+                .flatten()
+                .is_some(),
             "an unstaked override is admitted and resolves to its gossip socket"
+        );
+        assert!(
+            snapshot.push_enabled,
+            "a staked node pushes to the peers it admits"
         );
     }
 
@@ -496,7 +526,7 @@ mod tests {
             create_bank_forks_and_cluster_info(10, 2, slot_num);
 
         let absent = Pubkey::new_unique();
-        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
@@ -507,7 +537,7 @@ mod tests {
 
         let snapshot = peerlist_receiver.borrow().clone();
         assert_eq!(
-            snapshot.get(&absent),
+            snapshot.peers.get(&absent),
             Some(&None),
             "an override absent from gossip is desired but has no address yet"
         );
@@ -522,7 +552,7 @@ mod tests {
 
         let staked_peer = node_pubkeys[num_zero_stake_nodes + 1];
         let pinned = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65001);
-        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let (peerlist_sender, peerlist_receiver) = empty_peer_list_channel();
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
@@ -536,7 +566,7 @@ mod tests {
 
         let snapshot = peerlist_receiver.borrow().clone();
         assert_eq!(
-            snapshot.get(&staked_peer),
+            snapshot.peers.get(&staked_peer),
             Some(&Some(pinned)),
             "a pinned address replaces the peer's gossip socket"
         );

--- a/votor/src/peer_list_updater.rs
+++ b/votor/src/peer_list_updater.rs
@@ -1,9 +1,8 @@
-#[cfg(feature = "dev-context-only-utils")]
-use {crate::voting_service::VotingServiceOverride, arc_swap::ArcSwap};
 use {
     agave_bls_sigverify::bls_sigverifier::NUM_SLOTS_FOR_VERIFY,
     agave_votor_messages::reward_certificate::NUM_SLOTS_FOR_REWARD,
     agave_votor_transport::PeerListSender,
+    arc_swap::ArcSwap,
     crossbeam_channel::{RecvTimeoutError, Sender, bounded},
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -34,36 +33,23 @@ pub struct PeerListUpdater {
     sharable_banks: SharableBanks,
     /// Publisher for the endpoint's peer_list snapshot.
     peer_list_sender: PeerListSender,
-    /// Live, shared override of the (pubkey -> socket) set
-    #[cfg(feature = "dev-context-only-utils")]
-    test_overrides: Arc<ArcSwap<HashMap<Pubkey, SocketAddr>>>,
+    /// Set of peers plugged into the peer_list regardless of stake.
+    /// `None` resolves the address from gossip like any other peer, `Some` forces it,
+    /// which local-cluster tests use to blackhole peers or point them at a spy listener.
+    peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
 }
 
 impl PeerListUpdater {
     pub fn new(
         sharable_banks: SharableBanks,
         peer_list_sender: PeerListSender,
-        #[cfg(feature = "dev-context-only-utils")] test_overrides: Arc<
-            ArcSwap<HashMap<Pubkey, SocketAddr>>,
-        >,
+        peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
     ) -> Self {
         Self {
             sharable_banks,
             peer_list_sender,
-            #[cfg(feature = "dev-context-only-utils")]
-            test_overrides,
+            peer_overrides,
         }
-    }
-
-    /// Augments the `peer_list` with test overrides (in DCOU builds only).
-    /// Does nothing in release builds.
-    fn apply_test_overrides(&self, peer_list: &mut HashMap<Pubkey, Option<SocketAddr>>) {
-        #[cfg(feature = "dev-context-only-utils")]
-        for (pubkey, socket) in self.test_overrides.load().iter() {
-            peer_list.insert(*pubkey, Some(*socket));
-        }
-        // Silences the unused `&mut` warning when the DCOU-only override loop is compiled out.
-        let _ = peer_list;
     }
 
     /// Publish the peer_list for the votor transport endpoint.
@@ -75,7 +61,10 @@ impl PeerListUpdater {
     /// - from `epoch(root_slot) + 1` when within [`NUM_SLOTS_FOR_VERIFY`] of the epoch end.
     ///   `NUM_SLOTS_FOR_VERIFY` is the furthest ahead of root a vote/cert is accepted.
     ///
-    /// Each peer's votor socket is resolved from gossip (or a test override).
+    /// Peer overrides join the set regardless of stake, which both admits their
+    /// inbound connections and makes us push to them.
+    ///
+    /// Each peer's votor socket is resolved from gossip, unless an override pins it.
     /// Peers that have no address yet are added with `None`.
     pub fn refresh_peer_list(&self, cluster_info: &ClusterInfo, my_identity: &Pubkey) {
         let root = self.sharable_banks.root();
@@ -87,7 +76,7 @@ impl PeerListUpdater {
             epoch_schedule.get_epoch(root.slot().saturating_sub(NUM_SLOTS_FOR_REWARD));
 
         // Only the pubkeys matter here; stake weights are unused.
-        let mut staked_nodes: HashSet<Pubkey> = root
+        let mut peers: HashSet<Pubkey> = root
             .epoch_staked_nodes(root_epoch)
             .expect("Root bank retains epoch_stakes for its own epoch")
             .keys()
@@ -99,30 +88,39 @@ impl PeerListUpdater {
         if root_epoch != trailing_epoch
             && let Some(nodes) = root.epoch_staked_nodes(trailing_epoch)
         {
-            staked_nodes.extend(nodes.keys());
+            peers.extend(nodes.keys());
         }
 
         // Near the epoch end, admit the upcoming epoch's set so new voters can connect in advance.
         let slots_in_epoch = epoch_schedule.get_slots_in_epoch(root_epoch);
         let near_end = slot_index >= slots_in_epoch.saturating_sub(NUM_SLOTS_FOR_VERIFY);
         if near_end && let Some(next) = root.epoch_staked_nodes(root_epoch.saturating_add(1)) {
-            staked_nodes.extend(next.keys());
+            peers.extend(next.keys());
         }
 
-        // Participate in votor only if this node is itself in the merged peer set.
-        // An unstaked node publishes an empty peer_list, so the transport neither
-        // connects to staked peers nor admits inbound connections.
-        if !staked_nodes.contains(my_identity) {
-            self.peer_list_sender.send_replace(Arc::new(HashMap::new()));
-            return;
+        let overrides = self.peer_overrides.load();
+
+        // Do not join the votor all2all mesh if this node is not marked as staked.
+        if !peers.contains(my_identity) {
+            peers.clear();
+            // An unstaked node without overrides has nobody to talk to.
+            if overrides.is_empty() {
+                // Empty peer_list means the transport neither connects nor admits peers.
+                self.peer_list_sender.send_replace(Arc::new(HashMap::new()));
+                return;
+            }
         }
 
-        let mut new_peer_list = cluster_info
-            .query_contact_infos(staked_nodes.iter(), |node| node.alpenglow())
+        let peers = peers.iter().chain(overrides.keys());
+        let mut new_peer_list: HashMap<_, _> = cluster_info
+            .query_contact_infos(peers, |node| node.alpenglow())
             .into_iter()
             .map(|(pubkey, socket)| (pubkey, socket.flatten()))
             .collect();
-        self.apply_test_overrides(&mut new_peer_list);
+        // An override that pins an address wins over whatever gossip resolved to.
+        for (pubkey, socket) in overrides.iter().filter(|(_, socket)| socket.is_some()) {
+            new_peer_list.insert(*pubkey, *socket);
+        }
         // Publish the latest version - this neither blocks nor fails.
         self.peer_list_sender.send_replace(Arc::new(new_peer_list));
     }
@@ -152,7 +150,7 @@ impl PeerListService {
         cluster_info: Arc<ClusterInfo>,
         peer_list: PeerListSender,
         sharable_banks: SharableBanks,
-        #[cfg(feature = "dev-context-only-utils")] test_override: Option<VotingServiceOverride>,
+        peer_overrides: Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>>,
     ) -> Self {
         let (key_updater_sender, key_updater_receiver) = bounded(16);
         let key_updater = Arc::new(PeerListKeyUpdater {
@@ -161,14 +159,8 @@ impl PeerListService {
         let thread_hdl = Builder::new()
             .name("solVotorPeerUpd".to_string())
             .spawn(move || {
-                let peer_list_updater = PeerListUpdater::new(
-                    sharable_banks,
-                    peer_list,
-                    #[cfg(feature = "dev-context-only-utils")]
-                    test_override
-                        .map(|v| v.override_listeners)
-                        .unwrap_or_default(),
-                );
+                let peer_list_updater =
+                    PeerListUpdater::new(sharable_banks, peer_list, peer_overrides);
 
                 info!("AlpenglowPeerListService has started");
                 let mut my_identity = cluster_info.id();
@@ -214,7 +206,6 @@ impl PeerListService {
 mod tests {
     use {
         super::*,
-        arc_swap::ArcSwap,
         rand::Rng,
         solana_gossip::{
             cluster_info::ClusterInfo, contact_info::ContactInfo, crds::GossipRoute,
@@ -364,7 +355,7 @@ mod tests {
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             sender,
-            Arc::new(ArcSwap::default()),
+            Arc::default(),
         );
 
         svc.refresh_peer_list(&cluster_info, &cluster_info.id());
@@ -388,7 +379,7 @@ mod tests {
         let svc = PeerListUpdater::new(
             bank_forks.read().unwrap().sharable_banks(),
             peerlist_sender,
-            Arc::new(ArcSwap::default()),
+            Arc::default(),
         );
 
         let unstaked = node_pubkeys[0];
@@ -406,6 +397,148 @@ mod tests {
         assert!(
             snapshot.values().all(|addr| addr.is_some()),
             "every staked peer resolves to its gossip socket"
+        );
+    }
+
+    /// Overrides whose address should be resolved from gossip, as
+    /// `--votor-peer-overrides` produces.
+    fn gossip_resolved_overrides(
+        peers: impl IntoIterator<Item = Pubkey>,
+    ) -> Arc<ArcSwap<HashMap<Pubkey, Option<SocketAddr>>>> {
+        Arc::new(ArcSwap::from_pointee(
+            peers.into_iter().map(|peer| (peer, None)).collect(),
+        ))
+    }
+
+    /// The RPC-node side: an unstaked node listing staked identities admits exactly
+    /// those, and does not pull in the staked set.
+    #[test]
+    fn test_overrides_admit_peers_on_unstaked_node() {
+        let slot_num = 123456789;
+        let num_nodes = 10;
+        let num_zero_stake_nodes = 2;
+
+        let (bank_forks, cluster_info, node_pubkeys) =
+            create_bank_forks_and_cluster_info(num_nodes, num_zero_stake_nodes, slot_num);
+
+        let admitted = HashSet::from([
+            node_pubkeys[num_zero_stake_nodes],
+            node_pubkeys[num_zero_stake_nodes + 1],
+        ]);
+        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let svc = PeerListUpdater::new(
+            bank_forks.read().unwrap().sharable_banks(),
+            peerlist_sender,
+            gossip_resolved_overrides(admitted.iter().copied()),
+        );
+
+        let unstaked = node_pubkeys[0];
+        svc.refresh_peer_list(&cluster_info, &unstaked);
+
+        let snapshot = peerlist_receiver.borrow().clone();
+        assert_eq!(
+            snapshot.keys().copied().collect::<HashSet<_>>(),
+            admitted,
+            "an unstaked node admits its overrides and nothing else"
+        );
+        assert!(
+            snapshot.values().all(|addr| addr.is_some()),
+            "overridden peers resolve to their gossip sockets"
+        );
+    }
+
+    /// The validator side: a staked node pushes to overridden peers that hold no stake,
+    /// on top of the full staked set.
+    #[test]
+    fn test_overrides_extend_staked_peer_list() {
+        let slot_num = 123456789;
+        let num_nodes = 10;
+        let num_zero_stake_nodes = 2;
+
+        let (bank_forks, cluster_info, node_pubkeys) =
+            create_bank_forks_and_cluster_info(num_nodes, num_zero_stake_nodes, slot_num);
+
+        // One zero-stake peer present in gossip, plus one staked peer that is already
+        // in the merged set and must not be double counted.
+        let unstaked_peer = node_pubkeys[0];
+        let staked = node_pubkeys[num_zero_stake_nodes];
+        let redundant_peer = node_pubkeys[num_zero_stake_nodes + 1];
+        assert_ne!(
+            redundant_peer,
+            cluster_info.id(),
+            "redundant_peer must not be self"
+        );
+        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let svc = PeerListUpdater::new(
+            bank_forks.read().unwrap().sharable_banks(),
+            peerlist_sender,
+            gossip_resolved_overrides([unstaked_peer, redundant_peer]),
+        );
+
+        svc.refresh_peer_list(&cluster_info, &staked);
+
+        let snapshot = peerlist_receiver.borrow().clone();
+        assert_eq!(
+            snapshot.len(),
+            num_nodes - num_zero_stake_nodes + 1,
+            "the staked set gains exactly the one unstaked override"
+        );
+        assert!(
+            snapshot.get(&unstaked_peer).copied().flatten().is_some(),
+            "an unstaked override is admitted and resolves to its gossip socket"
+        );
+    }
+
+    #[test]
+    fn test_override_missing_from_gossip_has_no_address() {
+        let slot_num = 123456789;
+        let (bank_forks, cluster_info, node_pubkeys) =
+            create_bank_forks_and_cluster_info(10, 2, slot_num);
+
+        let absent = Pubkey::new_unique();
+        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let svc = PeerListUpdater::new(
+            bank_forks.read().unwrap().sharable_banks(),
+            peerlist_sender,
+            gossip_resolved_overrides([absent]),
+        );
+
+        svc.refresh_peer_list(&cluster_info, &node_pubkeys[0]);
+
+        let snapshot = peerlist_receiver.borrow().clone();
+        assert_eq!(
+            snapshot.get(&absent),
+            Some(&None),
+            "an override absent from gossip is desired but has no address yet"
+        );
+    }
+
+    #[test]
+    fn test_override_chosen_address_overrides_gossip() {
+        let slot_num = 123456789;
+        let num_zero_stake_nodes = 2;
+        let (bank_forks, cluster_info, node_pubkeys) =
+            create_bank_forks_and_cluster_info(10, num_zero_stake_nodes, slot_num);
+
+        let staked_peer = node_pubkeys[num_zero_stake_nodes + 1];
+        let pinned = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 65001);
+        let (peerlist_sender, peerlist_receiver) = watch::channel(Arc::new(HashMap::new()));
+        let svc = PeerListUpdater::new(
+            bank_forks.read().unwrap().sharable_banks(),
+            peerlist_sender,
+            Arc::new(ArcSwap::from_pointee(HashMap::from([(
+                staked_peer,
+                Some(pinned),
+            )]))),
+        );
+
+        svc.refresh_peer_list(&cluster_info, &node_pubkeys[num_zero_stake_nodes]);
+
+        let snapshot = peerlist_receiver.borrow().clone();
+        assert_eq!(
+            snapshot.get(&staked_peer),
+            Some(&Some(pinned)),
+            "a pinned address replaces the peer's gossip socket"
         );
     }
 }

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -338,7 +338,7 @@ mod tests {
             vote::Vote,
         },
         agave_votor_transport::{
-            PeerListReceiver, PeerListSender,
+            PeerList, PeerListReceiver, PeerListSender,
             endpoint::{Datagram, QuicDatagramEndpoint},
         },
         arc_swap::ArcSwap,
@@ -605,16 +605,20 @@ mod tests {
         let client_kp = Keypair::new();
         let client_pubkey = client_kp.pubkey();
 
-        // Listener must admit the client; a `None` address keeps the listener's
-        // outbound loop from connecting to it.
-        let (_spy_peer_list_sender, spy_peer_list_receiver) =
-            watch::channel(Arc::new(HashMap::from([(client_pubkey, None)])));
+        // Listener must admit the client, but never pushes to it.
+        let (_spy_peer_list_sender, spy_peer_list_receiver) = watch::channel(Arc::new(PeerList {
+            peers: HashMap::from([(client_pubkey, None)]),
+            push_enabled: false,
+        }));
         let (endpoint, _egress, ingress_rx, listener_addr, rt) =
             spawn_endpoint(listener_kp, spy_peer_list_receiver);
 
-        // Seed the client's peer_list empty; create_voting_service installs a test
-        // override that injects the listener.
-        let (peer_list_sender, peer_list_receiver) = watch::channel(Arc::new(HashMap::new()));
+        // Seed the client's peer_list empty; create_voting_service installs an override
+        // that injects the listener.
+        let (peer_list_sender, peer_list_receiver) = watch::channel(Arc::new(PeerList {
+            peers: HashMap::new(),
+            push_enabled: false,
+        }));
         let (client_endpoint, egress, _client_ingress_rx, _client_addr, client_rt) =
             spawn_endpoint(client_kp, peer_list_receiver);
 

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -17,12 +17,6 @@ use {
     },
     tokio::sync::{mpsc, mpsc::error::TrySendError},
 };
-#[cfg(feature = "dev-context-only-utils")]
-use {
-    arc_swap::ArcSwap,
-    solana_pubkey::Pubkey,
-    std::{collections::HashMap, net::SocketAddr},
-};
 
 /// The maximum amount of packets per second we expect from an honest node
 pub const VOTOR_RATE_LIMIT_PPS: usize = 50;
@@ -172,14 +166,6 @@ impl StandstillRefreshQueue {
 
 pub struct VotingService {
     thread_hdl: JoinHandle<()>,
-}
-
-/// Test-only knob plumbed through [`ValidatorConfig`] so local-cluster tests can
-/// override the (pubkey -> socket) set used to address votor peers.
-#[derive(Clone)]
-pub struct VotingServiceOverride {
-    #[cfg(feature = "dev-context-only-utils")]
-    pub override_listeners: Arc<ArcSwap<HashMap<Pubkey, SocketAddr>>>,
 }
 
 impl VotingService {
@@ -355,6 +341,7 @@ mod tests {
             PeerListReceiver, PeerListSender,
             endpoint::{Datagram, QuicDatagramEndpoint},
         },
+        arc_swap::ArcSwap,
         bytes::Bytes,
         crossbeam_channel::{Receiver, bounded, unbounded},
         rand::Rng,
@@ -363,6 +350,7 @@ mod tests {
         solana_keypair::Keypair,
         solana_net_utils::{SocketAddrSpace, sockets::bind_to_localhost_unique},
         solana_perf::packet::packet_config,
+        solana_pubkey::Pubkey,
         solana_runtime::{
             bank::Bank,
             bank_forks::BankForks,
@@ -372,6 +360,7 @@ mod tests {
         },
         solana_signer::Signer,
         std::{
+            collections::HashMap,
             net::SocketAddr,
             num::NonZero,
             sync::{Arc, RwLock},
@@ -553,11 +542,10 @@ mod tests {
             cluster_info.clone(),
             peer_list,
             bank_forks.read().unwrap().sharable_banks(),
-            Some(VotingServiceOverride {
-                override_listeners: Arc::new(ArcSwap::from_pointee(HashMap::from_iter([
-                    spy_listener,
-                ]))),
-            }),
+            Arc::new(ArcSwap::from_pointee(HashMap::from([(
+                spy_listener.0,
+                Some(spy_listener.1),
+            )]))),
         );
         (
             VotingService::new(


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/issues/14301#issuecomment-5219402546

We need to allow unstaked nodes to get a feed of cert updates from staked ones during transition and for certain low-latency RPC functions.

#### Summary of Changes

* Repurposes the test-overrides to allow unstaked nodes to participate
* Adds optional --votor-peer-overrides  CLI argument to supply forward (should it be via admin RPC?). 
   * Arg can be given multiple times to add more nodes.
* Only staked node needs to add peers, unstaked admit all staked by default.

2 commits: first modifies votor logic for unstaked participation, second allows all unstaked to admit staked (per suggestion from @AshwinSekar).

#### Testing

CI + hacked multinode demo


