### PR TITLE
UpdateParent boundary dead

### DIFF
--- a/core/src/consensus/progress_map.rs
+++ b/core/src/consensus/progress_map.rs
@@ -88,6 +88,9 @@ pub enum DeadSlotReason {
     /// Replay execution failed, but an `UpdateParent` marker could still make
     /// the failed prefix obsolete.
     ReplayFailureBeforeUpdateParent,
+    /// Replay rejected the `UpdateParent` marker exactly at its FEC-set
+    /// boundary. Restarting from the marker can discard the stale prefix state.
+    ReplayFailureAtUpdateParent(u64),
 }
 
 pub struct ForkProgress {

--- a/core/src/replay_stage/dead_slots.rs
+++ b/core/src/replay_stage/dead_slots.rs
@@ -23,6 +23,7 @@ use {
     solana_rpc_client_api::response::SlotUpdate,
     solana_runtime::{
         bank::Bank,
+        block_component_processor::BlockComponentProcessorError,
         vote_sender_types::{ReplayVoteMessage, ReplayVoteSender},
     },
     solana_time_utils::timestamp,
@@ -135,49 +136,69 @@ fn is_update_parent_recoverable_replay_error(err: &BlockstoreProcessorError) -> 
     }
 }
 
-/// Returns true when replay failed before the slot's final parent is known.
+/// Returns the recoverable dead-slot reason while the slot's final parent is
+/// not yet known.
 ///
 /// Fast leader handover may execute a prefix built on an optimistic parent. If
 /// a later `UpdateParent` marker can still make that prefix obsolete, the slot
 /// is only soft-dead in `ProgressMap`; blockstore/RPC are updated only after the
 /// marker proves recovery impossible.
-fn should_mark_soft_dead(
+///
+/// Returning `None` means the failure is not eligible for soft-dead recovery;
+/// `mark_replay_dead_slot` will therefore mark the slot hard-dead.
+fn soft_dead_reason(
     blockstore: &Blockstore,
     bank: &Bank,
     err: &BlockstoreProcessorError,
     progress: &ProgressMap,
     migration_status: &MigrationStatus,
-) -> bool {
+) -> Option<DeadSlotReason> {
     let slot = bank.slot();
     if !bank.feature_set.snapshot().alpenglow_fast_leader_handover
         || !migration_status.should_allow_block_markers(slot)
         || blockstore.is_dead(slot)
         || !is_update_parent_recoverable_replay_error(err)
     {
-        return false;
+        return None;
     }
 
-    let Some(fork_progress) = progress.get(&slot) else {
-        return false;
-    };
+    let fork_progress = progress.get(&slot)?;
     let replayed_shreds = fork_progress.replay_progress.read().unwrap().num_shreds;
-    let Some(slot_meta) = blockstore.meta(slot).ok().flatten() else {
-        return false;
-    };
+    let slot_meta = blockstore.meta(slot).ok().flatten()?;
 
     if slot_meta.has_update_parent() {
-        if replayed_shreds >= u64::from(slot_meta.replay_fec_set_index) {
-            // Execution error past update parent is hard-dead, because the
-            // marker can no longer make the replayed prefix obsolete.
-            return false;
+        let replay_fec_set_index = u64::from(slot_meta.replay_fec_set_index);
+        if replayed_shreds < replay_fec_set_index {
+            return Some(DeadSlotReason::ReplayFailureBeforeUpdateParent);
         }
+
+        // SpuriousUpdateParent is raised before the marker is consumed. At
+        // equality, replay therefore has not executed past the new-parent
+        // boundary and can safely restart from it. Other failures at the same
+        // boundary remain terminal.
+        if replayed_shreds == replay_fec_set_index
+            && matches!(
+                err,
+                BlockstoreProcessorError::BlockComponentProcessor(
+                    BlockComponentProcessorError::SpuriousUpdateParent
+                )
+            )
+        {
+            return Some(DeadSlotReason::ReplayFailureAtUpdateParent(
+                replay_fec_set_index,
+            ));
+        }
+
+        // Execution error at or past UpdateParent is otherwise hard-dead,
+        // because the marker can no longer make the replayed prefix obsolete.
+        None
     } else if slot_meta.is_full() {
         // The slot is complete and no `UpdateParent` marker was observed, so
         // the replay failure is terminal.
-        return false;
+        None
+    } else {
+        Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
     }
-
-    true
 }
 
 /// Mark a slot soft-dead after replay fails before a possible UpdateParent.
@@ -188,6 +209,7 @@ fn should_mark_soft_dead(
 fn mark_soft_dead_slot(
     bank: &Bank,
     err: &BlockstoreProcessorError,
+    reason: DeadSlotReason,
     progress: &mut ProgressMap,
     notifications: &DeadSlotNotifications,
 ) {
@@ -197,10 +219,7 @@ fn mark_soft_dead_slot(
         ("error", format!("error: {err:?}"), String),
         ("slot", slot, i64),
     );
-    progress
-        .get_mut(&slot)
-        .unwrap()
-        .mark_dead(DeadSlotReason::ReplayFailureBeforeUpdateParent);
+    progress.get_mut(&slot).unwrap().mark_dead(reason);
     send_invalid_bank(bank, &notifications.replay_vote_sender);
 }
 
@@ -345,14 +364,20 @@ pub(super) fn mark_replay_dead_slot(
     progress: &mut ProgressMap,
     dead_slot_context: &mut DeadSlotContext<'_>,
 ) {
-    if should_mark_soft_dead(
+    if let Some(reason) = soft_dead_reason(
         dead_slot_context.notifications.blockstore.as_ref(),
         bank,
         err,
         progress,
         dead_slot_context.migration_status,
     ) {
-        mark_soft_dead_slot(bank, err, progress, &dead_slot_context.notifications);
+        mark_soft_dead_slot(
+            bank,
+            err,
+            reason,
+            progress,
+            &dead_slot_context.notifications,
+        );
         return;
     }
 

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -3134,17 +3134,24 @@ fn test_update_parent_restart() {
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
 
     // Slot 4: 5 shreds, replay_fec_set_index=32; 5 < 32 so cleared.
-    // Slot 8: 40 shreds, replay_fec_set_index=32; 40 >= 32 so skipped.
-    for (slot, shreds) in [(4, 5), (8, 40)] {
+    // Slot 8: 40 shreds, replay_fec_set_index=32; 40 > 32 so skipped.
+    // Slot 12: 32 shreds, replay_fec_set_index=32, but no boundary replay
+    // failure; a late signal must not clear this healthy bank.
+    // Slot 16: 32 shreds and a boundary failure recorded for a different
+    // replay offset; stale failure state must not authorize this restart.
+    for (slot, shreds) in [(4, 5), (8, 40), (12, 32), (16, 32)] {
         let bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), slot);
         bank_forks.write().unwrap().insert(bank);
-        let p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+        let mut p = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
         p.replay_progress.write().unwrap().num_shreds = shreds;
+        if slot == 16 {
+            p.mark_dead(DeadSlotReason::ReplayFailureAtUpdateParent(64));
+        }
         progress.insert(slot, p);
     }
 
     let (tx, rx) = bounded(1024);
-    for slot in [4, 8] {
+    for slot in [4, 8, 12, 16] {
         let parent_block_id = Hash::new_unique();
         insert_update_parent_slot(
             &blockstore,
@@ -3174,7 +3181,9 @@ fn test_update_parent_restart() {
     );
 
     assert!(progress.get(&4).is_none()); // cleared: 5 < 32
-    assert!(progress.get(&8).is_some()); // skipped: 40 >= 32
+    assert!(progress.get(&8).is_some()); // skipped: 40 > 32
+    assert!(progress.get(&12).is_some()); // skipped: 32 == 32 without a replay failure
+    assert!(progress.get(&16).is_some()); // skipped: boundary failure was recorded for 64
     assert_eq!(
         replay_vote_receiver.try_recv(),
         Ok(ReplayVoteMessage::InvalidBank {
@@ -3522,6 +3531,109 @@ fn test_after_update_hard_dead() {
         progress.get(&slot).unwrap().dead_reason,
         Some(DeadSlotReason::Hard)
     ));
+}
+
+#[test_case(31, false; "before_update_parent_restarts")]
+#[test_case(32, false; "at_update_parent_restarts")]
+#[test_case(33, true; "after_update_parent_is_hard_dead")]
+fn test_spurious_update_parent_boundary(replayed_shreds: u64, should_be_hard: bool) {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+
+    let slot = 4;
+    let bank0 = bank_forks.read().unwrap().get(0).unwrap();
+    let bank = Bank::new_from_parent(bank0, SlotLeader::default(), slot);
+    let bank = bank_forks.write().unwrap().insert(bank);
+    let header = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+        parent_slot: 0,
+        parent_block_id: Hash::default(),
+    });
+    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
+        new_parent_slot: 0,
+        new_parent_block_id: Hash::default(),
+    });
+    let mut shreds = block_marker_shreds(slot, 0, header, 0);
+    shreds.retain(|shred| !shred.is_data() || shred.index() != 0);
+    shreds.extend(block_marker_shreds(slot, 0, update_parent, 32));
+    blockstore.insert_shreds(shreds, true).unwrap();
+    let meta = blockstore.meta(slot).unwrap().unwrap();
+    assert!(meta.has_update_parent());
+
+    let replay_fec_set_index = u64::from(meta.replay_fec_set_index);
+    assert_eq!(replay_fec_set_index, 32);
+    let p = ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None);
+    p.replay_progress.write().unwrap().num_shreds = replayed_shreds;
+    progress.insert(slot, p);
+
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (ancestor_hashes_replay_update_sender, _) = bounded(1024);
+    let mut duplicate_slots_to_repair = DuplicateSlotsToRepair::default();
+    let mut purge_repair_slot_counter = PurgeRepairSlotCounter::default();
+    let migration_status = post_migration_status_for_tests();
+    let mut dead_slot_context = dead_slot_context_for_tests(
+        blockstore.clone(),
+        replay_vote_sender.clone(),
+        &ancestor_hashes_replay_update_sender,
+        &mut duplicate_slots_to_repair,
+        &mut purge_repair_slot_counter,
+        None,
+        &migration_status,
+    );
+    mark_replay_dead_slot(
+        &bank,
+        &BlockstoreProcessorError::BlockComponentProcessor(
+            BlockComponentProcessorError::SpuriousUpdateParent,
+        ),
+        &mut progress,
+        &mut dead_slot_context,
+    );
+    drop(dead_slot_context);
+
+    if should_be_hard {
+        assert!(blockstore.is_dead(slot));
+        assert!(matches!(
+            progress.get(&slot).unwrap().dead_reason,
+            Some(DeadSlotReason::Hard)
+        ));
+        return;
+    }
+
+    assert!(!blockstore.is_dead(slot));
+    let expected_reason = if replayed_shreds < replay_fec_set_index {
+        DeadSlotReason::ReplayFailureBeforeUpdateParent
+    } else {
+        DeadSlotReason::ReplayFailureAtUpdateParent(replay_fec_set_index)
+    };
+    assert_eq!(
+        progress.get(&slot).unwrap().dead_reason.as_ref(),
+        Some(&expected_reason)
+    );
+
+    let mut async_verification_freelist = Vec::new();
+    process_soft_dead_slots(
+        &Pubkey::new_unique(),
+        &blockstore,
+        &bank_forks,
+        &None,
+        &None,
+        &mut progress,
+        &mut async_verification_freelist,
+        &replay_vote_sender,
+        &migration_status,
+        None,
+    );
+
+    assert!(!blockstore.is_dead(slot));
+    assert!(progress.get(&slot).is_none());
+    assert!(bank_forks.read().unwrap().get(slot).is_none());
 }
 
 #[test]

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -153,12 +153,15 @@ fn try_restart_slot_from_update_parent(
     }) {
         return false;
     }
-    if progress.get(&slot).is_some_and(|progress| {
-        progress.dead_reason.is_some()
-            && !matches!(
-                progress.dead_reason,
-                Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
-            )
+    let dead_reason = progress
+        .get(&slot)
+        .and_then(|progress| progress.dead_reason.clone());
+    if dead_reason.as_ref().is_some_and(|reason| {
+        !matches!(
+            reason,
+            DeadSlotReason::ReplayFailureBeforeUpdateParent
+                | DeadSlotReason::ReplayFailureAtUpdateParent(_)
+        )
     }) {
         return false;
     }
@@ -168,8 +171,15 @@ fn try_restart_slot_from_update_parent(
         .get(&slot)
         .map(|p| p.replay_progress.read().unwrap().num_shreds)
         .unwrap_or(0);
+    let failed_at_replay_fec_set_index = matches!(
+        dead_reason,
+        Some(DeadSlotReason::ReplayFailureAtUpdateParent(failed_index))
+            if failed_index == replay_fec_set_index
+    );
 
-    if current_num_shreds >= replay_fec_set_index {
+    if current_num_shreds > replay_fec_set_index
+        || (current_num_shreds == replay_fec_set_index && !failed_at_replay_fec_set_index)
+    {
         return false;
     }
 
@@ -222,7 +232,10 @@ pub(super) fn process_soft_dead_slots(
         .filter_map(|(&slot, progress)| {
             matches!(
                 progress.dead_reason,
-                Some(DeadSlotReason::ReplayFailureBeforeUpdateParent)
+                Some(
+                    DeadSlotReason::ReplayFailureBeforeUpdateParent
+                        | DeadSlotReason::ReplayFailureAtUpdateParent(_)
+                )
             )
             .then_some(slot)
         })


### PR DESCRIPTION
#### Problem
There is a corner case liveness issue related to FLH where we will mark a slot hard dead when replay has executed right up to the `UpdateParent` boundary. Other nodes that did not replay the prefix may be able to successfully start replay right at the `UpdateParent` marker and successfully freeze the block. This can diverge the cluster.

#### Summary of Changes

1. Add `DeadSlotReason::ReplayFailureAtUpdateParent` to differentiate this precise case so we can handle appropriately later
2. Have `soft_dead_reason` return a reason rather than just a bool so we can identify the case where we have failed right on the `UpdateParent` boundary. Also, only have this return soft dead when replayed shreds is right at the `UpdateParent` boundary if the error was `SpuriousUpdateParent`
3. Allow restarting in `fn try_restart_slot_from_update_parent` if we failed replay right at the `UpdateParent` marker

Note that simply changing the shred index checks in `fn try_restart_slot_from_update_parent` and `fn should_mark_soft_dead` from `>=` to `>` is insufficient because this could cause us to get into a retry/fail loop in the case there is some failure (e.g. invalid tranaction) immediately after the `UpdateParent` marker. Confirming the actual error was `SpuriousUpdateParent` is what solves this problem for this proposal

#### Testing
added `test_spurious_update_parent_boundary` for exercising cases where replay has executed before, right on, and after the UpdateParent marker boundary and ensures the proper dead marking is performed.