### PR TITLE
ledger: skip repeated merkle root recompute in shred insert

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2817,7 +2817,7 @@ impl Blockstore {
 
         merkle_root_metas
             .entry((BlockLocation::Original, erasure_set))
-            .or_insert_with(||WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
+            .or_insert_with(|| WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
 
         if let HashMapEntry::Vacant(entry) =
             just_inserted_shreds.entry((BlockLocation::Original, shred.id()))
@@ -3055,7 +3055,7 @@ impl Blockstore {
         }
         merkle_root_metas
             .entry((location, erasure_set))
-            .or_insert_with(||WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
+            .or_insert_with(|| WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
         just_inserted_shreds.insert((location, shred.id()), shred);
         index_meta_working_set_entry.did_insert_occur = true;
         slot_meta_entry.did_insert_occur = true;

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2817,7 +2817,7 @@ impl Blockstore {
 
         merkle_root_metas
             .entry((BlockLocation::Original, erasure_set))
-            .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
+            .or_insert_with(||WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
 
         if let HashMapEntry::Vacant(entry) =
             just_inserted_shreds.entry((BlockLocation::Original, shred.id()))
@@ -3055,7 +3055,7 @@ impl Blockstore {
         }
         merkle_root_metas
             .entry((location, erasure_set))
-            .or_insert(WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
+            .or_insert_with(||WorkingEntry::Dirty(MerkleRootMeta::from_shred(&shred)));
         just_inserted_shreds.insert((location, shred.id()), shred);
         index_meta_working_set_entry.did_insert_occur = true;
         slot_meta_entry.did_insert_occur = true;


### PR DESCRIPTION
#### Problem

`check_insert_data_shred` and `check_insert_coding_shred` populate `merkle_root_metas` with `Entry::or_insert`, which evaluates its argument eagerly. `MerkleRootMeta::from_shred` recomputes the shred's merkle root, a sha256 over the full payload plus the proof walk, so every inserted shred pays for a value that is discarded for all but the first shred of each erasure set.

#### Summary of Changes

- Use `or_insert_with` at both `merkle_root_metas` sites so the merkle root is only computed when the entry is vacant. `MerkleRootMeta::from_shred` just a read, so the inserted value is unchanged.

#### Testing

CI
