### PR TITLE
transaction types: prep for ALT relaxation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "5.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025bb5f7b6dd4a5545a9edd6ce42b896836b8dbc8600ad9f99de041bd65601ef"
+checksum = "e64c87da66381a05df06a264b42f8df59521d26be773b3d64efc008d27e96e8c"
 dependencies = [
  "bytes",
  "solana-hash 4.6.0",
@@ -1406,8 +1406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes 0.14.100",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -11029,9 +11029,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.3.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260eeb3e9542372a1b52710cd48e3b45802a2c4533205eaa286029e52f3785c3"
+checksum = "0afde938e0d3f06e87853e6e189396d67256e3b600675d867a47d066f8cebadb"
 dependencies = [
  "solana-hash 4.6.0",
  "solana-message",
@@ -12334,7 +12334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.3.
 agave-scheduler-bindings = "5.0.0"
 agave-scheduling-utils = { path = "scheduling-utils", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 agave-snapshots = { path = "snapshots", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
-agave-transaction-view = "5.1.0"
+agave-transaction-view = "6.0.0"
 agave-votor = { path = "votor", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 agave-votor-messages = { path = "votor-messages", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 agave-votor-transport = { path = "votor-transport", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
@@ -498,7 +498,7 @@ solana-svm-feature-set = { path = "svm-feature-set", version = "=4.3.0-alpha.3",
 solana-svm-log-collector = { path = "svm-log-collector", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-svm-measure = { path = "svm-measure", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-svm-timings = { path = "svm-timings", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
-solana-svm-transaction = "4.3.0"
+solana-svm-transaction = "5.0.0"
 solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-syscalls = { path = "syscalls", version = "=4.3.0-alpha.3", default-features = false, features = ["agave-unstable-api"] }
 solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -301,7 +301,10 @@ mod test {
         solana_keypair::Keypair,
         solana_message::{Message, v1::MAX_TRANSACTION_SIZE},
         solana_pubkey::Pubkey,
-        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_runtime_transaction::{
+            runtime_transaction::RuntimeTransaction,
+            transaction_with_meta::StaticTransactionWithMeta,
+        },
         solana_signer::Signer,
         solana_system_interface::instruction as system_instruction,
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -117,6 +117,14 @@ impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTrans
         unimplemented!("WritableKeysTransaction::num_write_locks")
     }
 
+    fn num_readonly_signed_static_accounts(&self) -> u8 {
+        unimplemented!("WritableKeysTransaction::num_readonly_signed_static_accounts")
+    }
+
+    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
+        unimplemented!("WritableKeysTransaction::num_readonly_unsigned_static_accounts")
+    }
+
     fn recent_blockhash(&self) -> &solana_hash::Hash {
         unimplemented!("WritableKeysTransaction::recent_blockhash")
     }
@@ -163,16 +171,9 @@ impl solana_svm_transaction::svm_message::SVMStaticMessage for WritableKeysTrans
     > {
         core::iter::empty()
     }
-}
 
-#[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
-    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
-        solana_message::AccountKeys::new(&self.writable_keys, None)
-    }
-
-    fn is_writable(&self, _index: usize) -> bool {
-        true
+    fn is_requested_writable(&self, _index: usize) -> bool {
+        unimplemented!("WritableKeysTransaction::is_requested_writable")
     }
 
     fn is_signer(&self, _index: usize) -> bool {
@@ -185,7 +186,18 @@ impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction
 }
 
 #[cfg(feature = "dev-context-only-utils")]
-impl solana_svm_transaction::svm_transaction::SVMTransaction for WritableKeysTransaction {
+impl solana_svm_transaction::svm_message::SVMMessage for WritableKeysTransaction {
+    fn account_keys(&self) -> solana_message::AccountKeys<'_> {
+        solana_message::AccountKeys::new(&self.writable_keys, None)
+    }
+
+    fn is_writable(&self, _index: usize) -> bool {
+        true
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
+impl solana_svm_transaction::svm_transaction::SVMStaticTransaction for WritableKeysTransaction {
     fn signature(&self) -> &solana_signature::Signature {
         unimplemented!("WritableKeysTransaction::signature")
     }
@@ -227,6 +239,19 @@ impl solana_runtime_transaction::transaction_meta::TransactionMeta for WritableK
 }
 
 #[cfg(feature = "dev-context-only-utils")]
+impl solana_runtime_transaction::transaction_with_meta::StaticTransactionWithMeta
+    for WritableKeysTransaction
+{
+    fn to_versioned_transaction(&self) -> solana_transaction::versioned::VersionedTransaction {
+        unimplemented!("WritableKeysTransaction::to_versioned_transaction")
+    }
+
+    fn serialized_size(&self) -> usize {
+        unimplemented!("WritableKeysTransaction::serialized_size")
+    }
+}
+
+#[cfg(feature = "dev-context-only-utils")]
 impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
     for WritableKeysTransaction
 {
@@ -235,14 +260,6 @@ impl solana_runtime_transaction::transaction_with_meta::TransactionWithMeta
         &self,
     ) -> std::borrow::Cow<'_, solana_transaction::sanitized::SanitizedTransaction> {
         unimplemented!("WritableKeysTransaction::as_sanitized_transaction");
-    }
-
-    fn to_versioned_transaction(&self) -> solana_transaction::versioned::VersionedTransaction {
-        unimplemented!("WritableKeysTransaction::to_versioned_transaction")
-    }
-
-    fn serialized_size(&self) -> usize {
-        unimplemented!("WritableKeysTransaction::serialized_size")
     }
 }
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "5.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025bb5f7b6dd4a5545a9edd6ce42b896836b8dbc8600ad9f99de041bd65601ef"
+checksum = "e64c87da66381a05df06a264b42f8df59521d26be773b3d64efc008d27e96e8c"
 dependencies = [
  "bytes",
  "solana-hash 4.6.0",
@@ -8691,9 +8691,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.3.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260eeb3e9542372a1b52710cd48e3b45802a2c4533205eaa286029e52f3785c3"
+checksum = "0afde938e0d3f06e87853e6e189396d67256e3b600675d867a47d066f8cebadb"
 dependencies = [
  "solana-hash 4.6.0",
  "solana-message",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -135,7 +135,7 @@ solana-svm-callback = { path = "../svm-callback", version = "=4.3.0-alpha.3", fe
 solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-svm-timings = { path = "../svm-timings", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
-solana-svm-transaction = "4.2.0"
+solana-svm-transaction = "5.0.0"
 solana-syscalls = { path = "../syscalls", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-system-interface = "3.2"
 solana-system-program = { path = "../programs/system", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "agave-transaction-view"
-version = "5.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025bb5f7b6dd4a5545a9edd6ce42b896836b8dbc8600ad9f99de041bd65601ef"
+checksum = "e64c87da66381a05df06a264b42f8df59521d26be773b3d64efc008d27e96e8c"
 dependencies = [
  "bytes",
  "solana-hash 4.6.0",
@@ -9613,9 +9613,9 @@ dependencies = [
 
 [[package]]
 name = "solana-svm-transaction"
-version = "4.3.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260eeb3e9542372a1b52710cd48e3b45802a2c4533205eaa286029e52f3785c3"
+checksum = "0afde938e0d3f06e87853e6e189396d67256e3b600675d867a47d066f8cebadb"
 dependencies = [
  "solana-hash 4.6.0",
  "solana-message",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -159,7 +159,7 @@ solana-stake-history = "=1.1.0"
 solana-svm = { path = "../../svm", version = "=4.3.0-alpha.3" }
 solana-svm-feature-set = { path = "../../svm-feature-set", version = "=4.3.0-alpha.3" }
 solana-svm-timings = { path = "../../svm-timings", version = "=4.3.0-alpha.3" }
-solana-svm-transaction = "=4.3.0"
+solana-svm-transaction = "=5.0.0"
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.3.0-alpha.3" }
 solana-system-interface = { version = "=3.3.0", features = ["bincode"] }
 solana-sysvar = "=4.2.0"

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -22,7 +22,7 @@ use {
         instruction::SVMInstruction,
         message_address_table_lookup::SVMMessageAddressTableLookup,
         svm_message::{SVMMessage, SVMStaticMessage},
-        svm_transaction::SVMTransaction,
+        svm_transaction::SVMStaticTransaction,
     },
     solana_transaction::{TransactionError, versioned::TransactionVersion},
 };
@@ -106,6 +106,14 @@ impl<T: SVMStaticMessage> SVMStaticMessage for RuntimeTransaction<T> {
         self.transaction.num_write_locks()
     }
 
+    fn num_readonly_signed_static_accounts(&self) -> u8 {
+        self.transaction.num_readonly_signed_static_accounts()
+    }
+
+    fn num_readonly_unsigned_static_accounts(&self) -> u8 {
+        self.transaction.num_readonly_unsigned_static_accounts()
+    }
+
     fn recent_blockhash(&self) -> &Hash {
         self.transaction.recent_blockhash()
     }
@@ -141,16 +149,6 @@ impl<T: SVMStaticMessage> SVMStaticMessage for RuntimeTransaction<T> {
     ) -> impl Iterator<Item = SVMMessageAddressTableLookup<'_>> {
         self.transaction.message_address_table_lookups()
     }
-}
-
-impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
-    fn account_keys(&self) -> AccountKeys<'_> {
-        self.transaction.account_keys()
-    }
-
-    fn is_writable(&self, index: usize) -> bool {
-        self.transaction.is_writable(index)
-    }
 
     fn is_signer(&self, index: usize) -> bool {
         self.transaction.is_signer(index)
@@ -161,7 +159,17 @@ impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
     }
 }
 
-impl<T: SVMTransaction> SVMTransaction for RuntimeTransaction<T> {
+impl<T: SVMMessage> SVMMessage for RuntimeTransaction<T> {
+    fn account_keys(&self) -> AccountKeys<'_> {
+        self.transaction.account_keys()
+    }
+
+    fn is_writable(&self, index: usize) -> bool {
+        self.transaction.is_writable(index)
+    }
+}
+
+impl<T: SVMStaticTransaction> SVMStaticTransaction for RuntimeTransaction<T> {
     fn signature(&self) -> &Signature {
         self.transaction.signature()
     }

--- a/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
+++ b/runtime-transaction/src/runtime_transaction/sdk_transactions.rs
@@ -5,7 +5,7 @@ use {
         transaction_meta::{
             CachedTransactionMeta, TransactionMeta, VersionedTransactionConfiguration,
         },
-        transaction_with_meta::TransactionWithMeta,
+        transaction_with_meta::{StaticTransactionWithMeta, TransactionWithMeta},
     },
     solana_message::{AddressLoader, TransactionSignatureDetails},
     solana_pubkey::Pubkey,
@@ -134,12 +134,7 @@ impl RuntimeTransaction<SanitizedTransaction> {
     }
 }
 
-impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
-    #[inline]
-    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
-        Cow::Borrowed(self)
-    }
-
+impl StaticTransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
     #[inline]
     fn to_versioned_transaction(&self) -> VersionedTransaction {
         self.transaction.to_versioned_transaction()
@@ -148,6 +143,13 @@ impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
     fn serialized_size(&self) -> usize {
         wincode::serialized_size(&self.to_versioned_transaction())
             .expect("versioned transaction serialization should succeed") as usize
+    }
+}
+
+impl TransactionWithMeta for RuntimeTransaction<SanitizedTransaction> {
+    #[inline]
+    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
+        Cow::Borrowed(self)
     }
 }
 

--- a/runtime-transaction/src/runtime_transaction/transaction_view.rs
+++ b/runtime-transaction/src/runtime_transaction/transaction_view.rs
@@ -6,7 +6,7 @@ use {
             CachedTransactionMeta, TransactionConfiguration, TransactionMeta,
             VersionedTransactionConfiguration,
         },
-        transaction_with_meta::TransactionWithMeta,
+        transaction_with_meta::{StaticTransactionWithMeta, TransactionWithMeta},
     },
     agave_transaction_view::{
         resolved_transaction_view::ResolvedTransactionView, transaction_data::TransactionData,
@@ -142,6 +142,94 @@ impl<D: TransactionData> RuntimeTransaction<ResolvedTransactionView<D>> {
     }
 }
 
+fn to_versioned_transaction<D: TransactionData>(
+    view: &SanitizedTransactionView<D>,
+) -> VersionedTransaction {
+    let header = MessageHeader {
+        num_required_signatures: view.num_required_signatures(),
+        num_readonly_signed_accounts: view.num_readonly_signed_static_accounts(),
+        num_readonly_unsigned_accounts: view.num_readonly_unsigned_static_accounts(),
+    };
+    let static_account_keys = view.static_account_keys().to_vec();
+    let recent_blockhash = *view.recent_blockhash();
+    let instructions = view
+        .instructions_iter()
+        .map(|ix| CompiledInstruction {
+            program_id_index: ix.program_id_index,
+            accounts: ix.accounts.to_vec(),
+            data: ix.data.to_vec(),
+        })
+        .collect();
+
+    let message = match view.version() {
+        TransactionVersion::Legacy => VersionedMessage::Legacy(solana_message::legacy::Message {
+            header,
+            account_keys: static_account_keys,
+            recent_blockhash,
+            instructions,
+        }),
+        TransactionVersion::V0 => VersionedMessage::V0(solana_message::v0::Message {
+            header,
+            account_keys: static_account_keys,
+            recent_blockhash,
+            instructions,
+            address_table_lookups: view
+                .address_table_lookup_iter()
+                .map(|atl| MessageAddressTableLookup {
+                    account_key: *atl.account_key,
+                    writable_indexes: atl.writable_indexes.to_vec(),
+                    readonly_indexes: atl.readonly_indexes.to_vec(),
+                })
+                .collect(),
+        }),
+        TransactionVersion::V1 => {
+            let config_view = view.transaction_config().expect("V1 must have config_view");
+            let config = solana_message::v1::TransactionConfig {
+                priority_fee: config_view.priority_fee_lamports(),
+                compute_unit_limit: config_view.compute_unit_limit(),
+                loaded_accounts_data_size_limit: config_view.loaded_accounts_data_size_limit(),
+                heap_size: config_view.requested_heap_size(),
+            };
+            VersionedMessage::V1(solana_message::v1::Message {
+                header,
+                config,
+                lifetime_specifier: recent_blockhash,
+                account_keys: static_account_keys,
+                instructions,
+            })
+        }
+    };
+
+    VersionedTransaction {
+        signatures: view.signatures().to_vec(),
+        message,
+    }
+}
+
+impl<D: TransactionData> StaticTransactionWithMeta
+    for RuntimeTransaction<SanitizedTransactionView<D>>
+{
+    fn to_versioned_transaction(&self) -> VersionedTransaction {
+        to_versioned_transaction(&self.transaction)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.transaction.data().len()
+    }
+}
+
+impl<D: TransactionData> StaticTransactionWithMeta
+    for RuntimeTransaction<ResolvedTransactionView<D>>
+{
+    fn to_versioned_transaction(&self) -> VersionedTransaction {
+        to_versioned_transaction(&self.transaction)
+    }
+
+    fn serialized_size(&self) -> usize {
+        self.transaction.data().len()
+    }
+}
+
 impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTransactionView<D>> {
     fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction> {
         let VersionedTransaction {
@@ -199,74 +287,6 @@ impl<D: TransactionData> TransactionWithMeta for RuntimeTransaction<ResolvedTran
             )
             .expect("transaction view is sanitized"),
         )
-    }
-
-    fn to_versioned_transaction(&self) -> VersionedTransaction {
-        let header = MessageHeader {
-            num_required_signatures: self.num_required_signatures(),
-            num_readonly_signed_accounts: self.num_readonly_signed_static_accounts(),
-            num_readonly_unsigned_accounts: self.num_readonly_unsigned_static_accounts(),
-        };
-        let static_account_keys = self.static_account_keys().to_vec();
-        let recent_blockhash = *self.recent_blockhash();
-        let instructions = self
-            .instructions_iter()
-            .map(|ix| CompiledInstruction {
-                program_id_index: ix.program_id_index,
-                accounts: ix.accounts.to_vec(),
-                data: ix.data.to_vec(),
-            })
-            .collect();
-
-        let message = match self.version() {
-            TransactionVersion::Legacy => {
-                VersionedMessage::Legacy(solana_message::legacy::Message {
-                    header,
-                    account_keys: static_account_keys,
-                    recent_blockhash,
-                    instructions,
-                })
-            }
-            TransactionVersion::V0 => VersionedMessage::V0(solana_message::v0::Message {
-                header,
-                account_keys: static_account_keys,
-                recent_blockhash,
-                instructions,
-                address_table_lookups: self
-                    .address_table_lookup_iter()
-                    .map(|atl| MessageAddressTableLookup {
-                        account_key: *atl.account_key,
-                        writable_indexes: atl.writable_indexes.to_vec(),
-                        readonly_indexes: atl.readonly_indexes.to_vec(),
-                    })
-                    .collect(),
-            }),
-            TransactionVersion::V1 => {
-                let config_view = self.transaction_config().expect("V1 must have config_view");
-                let config = solana_message::v1::TransactionConfig {
-                    priority_fee: config_view.priority_fee_lamports(),
-                    compute_unit_limit: config_view.compute_unit_limit(),
-                    loaded_accounts_data_size_limit: config_view.loaded_accounts_data_size_limit(),
-                    heap_size: config_view.requested_heap_size(),
-                };
-                VersionedMessage::V1(solana_message::v1::Message {
-                    header,
-                    config,
-                    lifetime_specifier: recent_blockhash,
-                    account_keys: static_account_keys,
-                    instructions,
-                })
-            }
-        };
-
-        VersionedTransaction {
-            signatures: self.signatures().to_vec(),
-            message,
-        }
-    }
-
-    fn serialized_size(&self) -> usize {
-        self.transaction.data().len()
     }
 }
 

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -1,15 +1,11 @@
 use {
     crate::transaction_meta::TransactionMeta,
-    solana_svm_transaction::svm_transaction::SVMTransaction,
+    solana_svm_transaction::svm_transaction::{SVMStaticTransaction, SVMTransaction},
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     std::borrow::Cow,
 };
 
-pub trait TransactionWithMeta: TransactionMeta + SVMTransaction {
-    /// Required to interact with geyser plugins.
-    /// This function should not be used except for interacting with geyser.
-    /// It may do numerous allocations that negatively impact performance.
-    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction>;
+pub trait StaticTransactionWithMeta: TransactionMeta + SVMStaticTransaction {
     /// Required to interact with several legacy interfaces that require
     /// `VersionedTransaction`. This should not be used unless necessary, as it
     /// performs numerous allocations that negatively impact performance.
@@ -18,4 +14,11 @@ pub trait TransactionWithMeta: TransactionMeta + SVMTransaction {
     /// Returns the serialized transaction size in bytes.
     /// Runtime metadata is not included.
     fn serialized_size(&self) -> usize;
+}
+
+pub trait TransactionWithMeta: StaticTransactionWithMeta + SVMTransaction {
+    /// Required to interact with geyser plugins.
+    /// This function should not be used except for interacting with geyser.
+    /// It may do numerous allocations that negatively impact performance.
+    fn as_sanitized_transaction(&self) -> Cow<'_, SanitizedTransaction>;
 }


### PR DESCRIPTION
#### Problem
to prepare for ALT relaxation, i landed breaking interface changes in https://github.com/anza-xyz/solana-sdk/pull/867 and https://github.com/anza-xyz/agave-sdk/pull/42 to move all viable static functionality off the resolved solana-svm-transaction traits onto the static traits. now we must update agave

#### Summary of Changes
most changes are mechanical conforming to the new interface. i also split `StaticTransactionWithMeta` off from `TransactionWithMeta`; the former now carries `to_versioned_transaction()` and `serialized_size()`, the latter carries only `as_sanitized_transaction()`, the expensive geyser conversion. i impl the new static trait for `SanitizedTransactionView` and its `RuntimeTransaction` wrapper

this is, again, a prepatory functional change that is good and correct even if no further progress is made on ALT relaxation, so im landing it speculatively. much more detail can be found in https://github.com/anza-xyz/solana-sdk/pull/867

but the general idea is relaxing all the trait constraints in `check_transactions.rs` should be pretty easy now and i think the view wrappers are suitable for our purposes in banking stage now. in the next pr i want to open a path to doing ALTs in avm and then in a pr after that actually do it