### PR TITLE
migration: fix hashes per tick bug

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1004,7 +1004,7 @@ impl ReplayStage {
                     let r_bank_forks = bank_forks.read().unwrap();
                     (r_bank_forks.ancestors(), r_bank_forks.descendants())
                 };
-                let new_frozen_slots = Self::process_active_banks(
+                let mut new_frozen_slots = Self::process_active_banks(
                     cluster_info.my_shred_version(),
                     &process_active_banks_context,
                     &mut progress,
@@ -1043,6 +1043,8 @@ impl ReplayStage {
                         &mut ancestors,
                         &mut descendants,
                         &mut progress,
+                        &replay_highest_frozen,
+                        &mut new_frozen_slots,
                     );
                 }
 
@@ -1675,6 +1677,8 @@ impl ReplayStage {
         ancestors: &mut HashMap<Slot, HashSet<Slot>>,
         descendants: &mut HashMap<Slot, HashSet<Slot>>,
         progress: &mut ProgressMap,
+        replay_highest_frozen: &ReplayHighestFrozen,
+        new_frozen_slots: &mut Vec<Slot>,
     ) {
         let root_bank = bank_forks.read().unwrap().root_bank();
 
@@ -1734,6 +1738,13 @@ impl ReplayStage {
                 bank_forks,
                 blockstore,
             );
+        }
+
+        // Reset highest frozen to genesis
+        {
+            let mut l_highest_frozen = replay_highest_frozen.highest_frozen_slot.lock().unwrap();
+            *l_highest_frozen = genesis_block.slot;
+            new_frozen_slots.clear()
         }
 
         // Purge any partial slots greater than the genesis slot
@@ -3018,9 +3029,10 @@ impl ReplayStage {
         let mut w_replay_stats = replay_stats.write().unwrap();
         let mut w_replay_progress = replay_progress.write().unwrap();
         let tx_count_before = w_replay_progress.num_txs;
-        // All errors must lead to marking the slot as dead, otherwise,
-        // the `check_slot_agrees_with_cluster()` called by `replay_active_banks()`
-        // will break!
+        // All errors except an Alpenglow migration transition must lead to marking the slot as
+        // dead, otherwise `check_slot_agrees_with_cluster()` in `replay_active_banks()` will
+        // break. A migration transition is handled synchronously after replay results are
+        // processed; enabling Alpenglow purges this interrupted TowerBFT bank.
         blockstore_processor::confirm_slot(
             &process_active_banks_context.blockstore,
             bank,
@@ -3958,6 +3970,20 @@ impl ReplayStage {
                             tbft_structs.as_deref_mut(),
                         );
                         continue;
+                    }
+                    Err(BlockstoreProcessorError::BlockComponentProcessor(
+                        BlockComponentProcessorError::AlpenglowMigrationTransition,
+                    )) => {
+                        assert!(
+                            process_active_banks_context
+                                .migration_status
+                                .is_ready_to_enable()
+                        );
+                        info!(
+                            "Stopping replay of slot {bank_slot} to enable Alpenglow and rebuild \
+                             the bank"
+                        );
+                        return vec![];
                     }
                     Err(err) => {
                         mark_replay_dead_slot(

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -1368,6 +1368,83 @@ fn test_cmr_mismatch_hard_dead() {
 }
 
 #[test]
+fn test_alpenglow_migration_transition_does_not_mark_bank_dead() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0) / tr(1)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+
+    let slot = 1;
+    let bank = bank_forks.read().unwrap().get(slot).unwrap();
+    progress.insert(
+        slot,
+        ForkProgress::new(bank.last_blockhash(), Some(0), None, 0, 0, None),
+    );
+
+    let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
+    let process_active_banks_context = ProcessActiveBanksContext::new_for_tests(
+        bank_forks.clone(),
+        blockstore.clone(),
+        replay_vote_sender,
+    );
+    let genesis_block = Block {
+        slot: 0,
+        block_id: Hash::default(),
+    };
+    process_active_banks_context
+        .migration_status
+        .record_feature_activation(0);
+    process_active_banks_context
+        .migration_status
+        .set_genesis_block(genesis_block);
+    process_active_banks_context
+        .migration_status
+        .set_genesis_certificate(Arc::new(GenesisCert {
+            block: genesis_block,
+            signature: CertSignature {
+                signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+                bitmap: vec![],
+            },
+        }));
+    assert!(
+        process_active_banks_context
+            .migration_status
+            .is_ready_to_enable()
+    );
+
+    let replay_result = ReplaySlotFromBlockstore {
+        is_slot_dead: false,
+        bank_slot: slot,
+        replay_result: Some(Err(BlockstoreProcessorError::BlockComponentProcessor(
+            BlockComponentProcessorError::AlpenglowMigrationTransition,
+        ))),
+    };
+
+    ReplayStage::process_replay_results(
+        &process_active_banks_context,
+        &mut progress,
+        &mut Vec::new(),
+        &mut LatestValidatorVotesForFrozenBanks::default(),
+        &mut DuplicateSlotsToRepair::default(),
+        &mut PurgeRepairSlotCounter::default(),
+        None,
+        &[replay_result],
+        &Pubkey::new_unique(),
+    );
+
+    assert!(!blockstore.is_dead(slot));
+    assert!(progress.get(&slot).unwrap().dead_reason.is_none());
+    assert!(bank_forks.read().unwrap().get(slot).is_some());
+    assert!(replay_vote_receiver.try_recv().is_err());
+}
+
+#[test]
 fn test_abandon_invalidates() {
     let ReplayBlockstoreComponents {
         blockstore,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -293,6 +293,19 @@ pub enum BlockstoreProcessorError {
     BankHashMismatch(Slot, Hash, Hash),
 }
 
+impl BlockstoreProcessorError {
+    /// Returns whether replay stopped because a verified genesis certificate advanced the
+    /// migration to `ReadyToEnable`. This is control flow, not an invalid block.
+    pub fn is_alpenglow_migration_transition(&self) -> bool {
+        matches!(
+            self,
+            Self::BlockComponentProcessor(
+                BlockComponentProcessorError::AlpenglowMigrationTransition
+            )
+        )
+    }
+}
+
 /// Callback for accessing bank state after each slot is confirmed while
 /// processing the blockstore
 pub type ProcessSlotCallback = Arc<dyn Fn(&Bank) + Sync + Send>;
@@ -1469,7 +1482,11 @@ pub fn confirm_slot(
                             migration_status,
                         )
                         .inspect_err(|err| {
-                            if !matches!(err, BlockComponentProcessorError::AbandonedBank(_)) {
+                            if !matches!(
+                                err,
+                                BlockComponentProcessorError::AbandonedBank(_)
+                                    | BlockComponentProcessorError::AlpenglowMigrationTransition
+                            ) {
                                 warn!(
                                     "BlockComponentProcessor::on_marker() for slot {slot} failed \
                                      with {err}"
@@ -2048,15 +2065,12 @@ fn load_frozen_forks(
                 &migration_status,
             ) {
                 assert!(bank_forks.write().unwrap().remove(bank.slot()).is_some());
-                if opts.abort_on_invalid_block {
-                    return Err(error);
-                }
-
-                // If this block was the first alpenglow block and advanced the migration phase, we can enable alpenglow.
-                //
-                // This bank must have failed to freeze as it is an Alpenglow block being verified as a TowerBFT one.
-                // We are safe to cleanly transition to alpenglow here
-                if migration_status.is_ready_to_enable() {
+                if error.is_alpenglow_migration_transition() {
+                    assert!(migration_status.is_ready_to_enable());
+                    // This was the first Alpenglow block. Enable Alpenglow and replay it with
+                    // Alpenglow rules. Handle the transition even when `abort_on_invalid_block`
+                    // is set because the bank is not invalid; it was deliberately interrupted
+                    // while configured for TowerBFT.
                     let genesis_slot = migration_status.enable_alpenglow_during_startup();
 
                     // We need to clear pending_slots as it might contain Alpenglow blocks initialized as TowerBFT banks.
@@ -2071,6 +2085,11 @@ fn load_frozen_forks(
                         opts,
                         &migration_status,
                     )?;
+                    continue;
+                }
+
+                if opts.abort_on_invalid_block {
+                    return Err(error);
                 }
 
                 continue;
@@ -2380,8 +2399,12 @@ pub fn process_single_slot(
         migration_status,
     )
     .map_err(|err| {
-        warn!("slot {slot} failed to verify: {err}");
-        mark_dead_if_primary_access(blockstore, slot);
+        if err.is_alpenglow_migration_transition() {
+            info!("slot {slot} replay interrupted to enable Alpenglow");
+        } else {
+            warn!("slot {slot} failed to verify: {err}");
+            mark_dead_if_primary_access(blockstore, slot);
+        }
         err
     })?;
 

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -53,6 +53,8 @@ pub enum BlockComponentProcessorError {
     GenesisCertificateOnNonChild,
     #[error("GenesisCertificate was invalid and failed to verify")]
     GenesisCertificateFailedVerification,
+    #[error("Alpenglow migration became ready; aborting the TowerBFT bank")]
+    AlpenglowMigrationTransition,
     #[error("GenesisCertificate marker must immediately follow the block header")]
     GenesisCertificateOutOfOrder,
     #[error("FinalizationCertificate was invalid or failed to verify {0}")]
@@ -128,6 +130,7 @@ impl BlockComponentProcessorError {
             | BlockComponentProcessorError::MissingBlockFooter
             | BlockComponentProcessorError::MissingGenesisCertificateMarker
             | BlockComponentProcessorError::MultipleUpdateParents
+            | BlockComponentProcessorError::AlpenglowMigrationTransition
             | BlockComponentProcessorError::UpdateParentNotFirstInLeaderWindow(_) => false,
         }
     }
@@ -521,11 +524,11 @@ impl BlockComponentProcessor {
         }
 
         bank.set_alpenglow_genesis_certificate(&genesis_cert);
-        bank.set_hashes_per_tick(None);
         self.has_genesis_certificate_marker = true;
 
         if migration_status.is_alpenglow_enabled() {
             // We participated in the migration, nothing to do
+            bank.set_hashes_per_tick(None);
             return Ok(());
         }
 
@@ -544,7 +547,9 @@ impl BlockComponentProcessor {
         migration_status.set_genesis_certificate(Arc::new(genesis_cert));
         assert!(migration_status.is_ready_to_enable());
 
-        Ok(())
+        // This bank was created with TowerBFT tick configuration. Stop processing it immediately;
+        // replay will discard it, enable Alpenglow, and rebuild it with Alpenglow tick rules.
+        Err(BlockComponentProcessorError::AlpenglowMigrationTransition)
     }
 
     fn verify_genesis_certificate(
@@ -1048,12 +1053,49 @@ mod tests {
             bitmap: vec![],
         };
         let mut processor = processor_after_header();
+        bank.set_hashes_per_tick(Some(42));
+        assert!(bank.hashes_per_tick().is_some());
 
         processor
-            .on_genesis_cert_block_marker_leader(bank, genesis_marker, &migration_status)
+            .on_genesis_cert_block_marker_leader(bank.clone(), genesis_marker, &migration_status)
             .unwrap();
+        assert!(bank.hashes_per_tick().is_none());
         processor.stage = BlockComponentStage::Done;
         assert!(processor.on_final(&migration_status, 2, 1).is_ok());
+    }
+
+    #[test]
+    fn test_genesis_certificate_marker_aborts_tower_bank_during_migration() {
+        let migration_status = MigrationStatus::default();
+        migration_status.record_feature_activation(0);
+        let (genesis_bank, bank_forks) = create_test_bank();
+        let parent = create_child_bank(&bank_forks, &genesis_bank, 1);
+        let parent_block_id = Hash::new_unique();
+        parent.set_block_id(Some(parent_block_id));
+        let bank = create_child_bank(&bank_forks, &parent, 2);
+        let genesis_marker = GenesisCertBlockMarker {
+            slot: parent.slot(),
+            block_id: parent_block_id,
+            bls_signature: BLSSignature([0; BLS_SIGNATURE_AFFINE_SIZE]),
+            bitmap: vec![],
+        };
+        let mut processor = processor_after_header();
+        bank.set_hashes_per_tick(Some(42));
+        let tower_hashes_per_tick = bank.hashes_per_tick();
+        assert!(tower_hashes_per_tick.is_some());
+
+        assert_matches!(
+            processor.on_genesis_cert_block_marker_leader(
+                bank.clone(),
+                genesis_marker,
+                &migration_status,
+            ),
+            Err(BlockComponentProcessorError::AlpenglowMigrationTransition)
+        );
+
+        assert!(migration_status.is_ready_to_enable());
+        assert_eq!(bank.hashes_per_tick(), tower_hashes_per_tick);
+        assert!(bank.get_alpenglow_genesis_certificate().is_some());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
As found by the bug bounty report.

During the first alpenglow block we set the bank hashes_per_tick to None.
However weird timing games could cause this block to be viewed before the migration succeeds.
The block then can carry ticks with `u64::MAX` hashes stalling replay.

#### Summary of Changes
Instead only set the hashes_per_tick if alpenglow is already enabled.
If we're still in TowerBFT and get this block early, just abort it (similar to what we do in startup) and then retry as alpenglow.
This prevents the abuse

#### Testing
Unit test