### PR TITLE
votor: add per-node vote credits lost metric

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -794,6 +794,7 @@ fn record_and_complete_block(
 
         BlockComponentProcessor::update_bank_with_footer_fields(
             &bank,
+            &ctx.my_pubkey,
             i64::try_from(footer.block_producer_time_nanos)
                 .expect("locally produced block timestamp must fit in i64"),
             None, // Banks we produce do not need the bank hash mismatch check

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,6 +76,7 @@ use {
         status_cache::{SlotDelta, StatusCache},
         sysvar_account::{create_account, create_account_with_bincode, from_account},
         transaction_batch::{OwnedOrBorrowed, TransactionBatch},
+        validated_reward_certificate::RewardCredit,
     },
     accounts_lt_hash::AccountsLtHashAsyncProgress,
     agave_bls_cert_verify::cert_verify::{self, Error as CertVerifyError},
@@ -704,6 +705,7 @@ impl PartialEq for Bank {
             accounts_lt_hash_async_progress: _,
             block_id,
             expected_bank_hash: _,
+            reward_credit: _,
             bank_hash_stats: _,
             epoch_rewards_calculation_cache: _,
             block_component_processor: _,
@@ -1054,6 +1056,11 @@ pub struct Bank {
     /// later when the bank is frozen.
     expected_bank_hash: RwLock<Option<Hash>>,
 
+    /// Whether this node was credited by the reward certificate in this block's footer.
+    /// Set when processing the footer, read by votor to report lost credits. Node-local
+    /// observability state; does not affect the bank hash.
+    reward_credit: RwLock<Option<RewardCredit>>,
+
     /// Accounts stats for computing the bank hash
     bank_hash_stats: AtomicBankHashStats,
 
@@ -1271,6 +1278,7 @@ impl Bank {
             accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
+            reward_credit: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
@@ -1538,6 +1546,7 @@ impl Bank {
             accounts_lt_hash_async_progress: AccountsLtHashAsyncProgress::new(),
             block_id: RwLock::new(None),
             expected_bank_hash: RwLock::new(None),
+            reward_credit: RwLock::new(None),
             bank_hash_stats: AtomicBankHashStats::default(),
             epoch_rewards_calculation_cache: parent.epoch_rewards_calculation_cache.clone(),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
@@ -2196,6 +2205,7 @@ impl Bank {
             bank_hash_stats: AtomicBankHashStats::new(&fields.bank_hash_stats),
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             expected_bank_hash: RwLock::new(None),
+            reward_credit: RwLock::new(None),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(false),
         };
@@ -3108,6 +3118,17 @@ impl Bank {
     /// Returns the expected bank hash if any.
     pub fn expected_bank_hash(&self) -> Option<Hash> {
         *self.expected_bank_hash.read().unwrap()
+    }
+
+    /// Record whether this node was credited by the reward certificate in this block's footer.
+    pub fn set_reward_credit(&self, reward_credit: RewardCredit) {
+        *self.reward_credit.write().unwrap() = Some(reward_credit);
+    }
+
+    /// Returns this node's reward-certificate outcome for this block, if a reward certificate
+    /// was present in the footer and our stake entry could be resolved.
+    pub fn reward_credit(&self) -> Option<RewardCredit> {
+        *self.reward_credit.read().unwrap()
     }
 
     // dangerous; don't use this; this is only needed for ledger-tool's special command

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -8,7 +8,9 @@ use {
         validated_block_finalization::{
             BlockFinalizationCertError, ValidatedBlockFinalizationCert,
         },
-        validated_reward_certificate::{Error as ValidatedRewardCertError, ValidatedRewardCert},
+        validated_reward_certificate::{
+            Error as ValidatedRewardCertError, RewardCredit, ValidatedRewardCert,
+        },
     },
     agave_votor_messages::{
         certificate::{CertSignature, Certificate, CertificateType, GenesisCert},
@@ -623,6 +625,7 @@ impl BlockComponentProcessor {
 
         Self::update_bank_with_footer_fields(
             &bank,
+            my_pubkey,
             block_producer_time_nanos,
             Some(bank_hash),
             reward_cert,
@@ -753,14 +756,42 @@ impl BlockComponentProcessor {
         (min_working_bank_time, max_working_bank_time)
     }
 
+    /// Record on `bank` whether our own vote account was credited by `cert`.
+    ///
+    /// The bitmap is keyed by vote account, so we resolve our identity through the rank map
+    /// for the rewarded slot. A node with no stake entry there (unstaked, or not yet in the
+    /// epoch's staked set) records nothing, so votor reports no loss for it.
+    fn record_reward_credit(bank: &Bank, my_pubkey: &Pubkey, cert: &ValidatedRewardCert) {
+        let reward_slot = cert.slot();
+        let Some(epoch_stakes) = bank.epoch_stakes_from_slot(reward_slot) else {
+            return;
+        };
+        let Some((_rank, entry)) = epoch_stakes
+            .bls_pubkey_to_rank_map()
+            .get_ranked_entry_for_node(my_pubkey)
+        else {
+            return;
+        };
+        bank.set_reward_credit(RewardCredit {
+            reward_slot,
+            credited: cert.validators().contains(&entry.vote_account_pubkey),
+        });
+    }
+
     pub fn update_bank_with_footer_fields(
         bank: &Bank,
+        my_pubkey: &Pubkey,
         block_producer_time_nanos: i64,
         bank_hash: Option<Hash>,
         reward_cert: Option<ValidatedRewardCert>,
         final_cert_input: Option<(&HashSet<Pubkey>, Slot)>,
     ) -> Result<(), BankFooterError> {
         bank.update_clock_from_footer(block_producer_time_nanos);
+        // Both the replay and the leader path land here, so recording our own outcome here
+        // keeps the credits-lost metric from treating our own blocks as missing a cert.
+        if let Some(cert) = &reward_cert {
+            Self::record_reward_credit(bank, my_pubkey, cert);
+        }
         calc_vote_rewards_update_vote_states(
             bank,
             reward_cert,
@@ -783,7 +814,10 @@ mod tests {
         crate::{
             bank::{Bank, SlotLeader},
             bank_forks::BankForks,
-            genesis_utils::{activate_all_features_alpenglow, create_genesis_config},
+            genesis_utils::{
+                ValidatorVoteKeypairs, activate_all_features_alpenglow, create_genesis_config,
+                create_genesis_config_with_alpenglow_vote_accounts,
+            },
         },
         rand::Rng,
         solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
@@ -795,6 +829,7 @@ mod tests {
             entry::Entry,
         },
         solana_hash::Hash,
+        solana_signer::Signer,
         std::{
             assert_matches,
             sync::{Arc, RwLock},
@@ -802,6 +837,64 @@ mod tests {
     };
 
     const DEFAULT_NS_PER_SLOT: u64 = DEFAULT_MS_PER_SLOT * 1_000_000;
+
+    /// The reward bitmap is keyed by vote account, so `record_reward_credit` has to resolve
+    /// our identity through the rank map before it can tell whether we were credited.
+    #[test]
+    fn test_record_reward_credit_resolves_own_vote_account() {
+        let validator_keypairs = (0..3)
+            .map(|_| ValidatorVoteKeypairs::new_rand())
+            .collect::<Vec<_>>();
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![100; validator_keypairs.len()],
+        );
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis.genesis_config);
+        let me = &validator_keypairs[0];
+        let my_identity = me.node_keypair.pubkey();
+        let my_vote_account = me.vote_keypair.pubkey();
+        let other_vote_account = validator_keypairs[1].vote_keypair.pubkey();
+        let reward_slot = bank.slot();
+
+        // Present in the bitmap.
+        BlockComponentProcessor::record_reward_credit(
+            &bank,
+            &my_identity,
+            &ValidatedRewardCert::new_for_tests(reward_slot, vec![my_vote_account]),
+        );
+        assert_eq!(
+            bank.reward_credit(),
+            Some(RewardCredit {
+                reward_slot,
+                credited: true
+            })
+        );
+
+        // Someone else is in the bitmap, we are not.
+        BlockComponentProcessor::record_reward_credit(
+            &bank,
+            &my_identity,
+            &ValidatedRewardCert::new_for_tests(reward_slot, vec![other_vote_account]),
+        );
+        assert_eq!(
+            bank.reward_credit(),
+            Some(RewardCredit {
+                reward_slot,
+                credited: false
+            })
+        );
+
+        // An identity with no stake entry records nothing, so it is never reported as a
+        // loss. Use a fresh bank so a stale value cannot masquerade as success.
+        let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis.genesis_config);
+        BlockComponentProcessor::record_reward_credit(
+            &bank,
+            &Pubkey::new_unique(),
+            &ValidatedRewardCert::new_for_tests(reward_slot, vec![my_vote_account]),
+        );
+        assert_eq!(bank.reward_credit(), None);
+    }
 
     fn create_test_bank() -> (Arc<Bank>, Arc<RwLock<BankForks>>) {
         let genesis_config_info = create_genesis_config(10_000);

--- a/runtime/src/validated_reward_certificate.rs
+++ b/runtime/src/validated_reward_certificate.rs
@@ -68,6 +68,19 @@ fn extract_slot(
     Ok(Some(slot))
 }
 
+/// Whether this node's vote account was credited by the reward certificate carried in a
+/// block footer. Recorded on the bank during footer processing so that votor can join it
+/// against its vote history and report credits that were lost in transit.
+///
+/// Node-local observability state only: it never affects the bank hash or consensus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RewardCredit {
+    /// The slot the reward certificate rewards, i.e. `bank.slot() - NUM_SLOTS_FOR_REWARD`.
+    pub reward_slot: Slot,
+    /// Whether our vote account appears in the certificate's bitmap.
+    pub credited: bool,
+}
+
 /// Struct built by validating incoming reward certs.
 #[derive(Debug, Clone)]
 pub struct ValidatedRewardCert {

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -22,7 +22,7 @@ use {
     },
     agave_votor_messages::{
         consensus_message::Block, metric_types::ConsensusMetricsEvent, migration::MigrationStatus,
-        vote::Vote,
+        reward_certificate::NUM_SLOTS_FOR_REWARD, vote::Vote,
     },
     crossbeam_channel::select,
     parking_lot::RwLock,
@@ -32,6 +32,7 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::{
         bank::Bank,
+        bank_forks::BankForks,
         leader_schedule_utils::{
             first_of_consecutive_leader_slots, last_of_consecutive_leader_slots, leader_slot_index,
         },
@@ -915,6 +916,67 @@ impl EventHandler {
     ///
     /// Additionally check if any of the finalized blocks is frozen with a bank hash mismatch.
     /// If so panic as it is unrecoverable.
+    /// Report vote credits lost on the slots that `new_root` newly finalizes.
+    ///
+    /// We earn a credit for slot S only if our vote account appears in the reward
+    /// certificate that the leader of `S + NUM_SLOTS_FOR_REWARD` puts in its block. The
+    /// runtime records whether we made it into that certificate on the bank that carried
+    /// it, so here we walk the newly rooted chain and join that against what we actually
+    /// voted for. Only rooted blocks are inspected, so an abandoned fork never reports a
+    /// loss.
+    fn report_lost_credits(
+        bank_forks: &BankForks,
+        vote_history: &VoteHistory,
+        old_root: Slot,
+        new_root: Slot,
+        stats: &mut EventHandlerStats,
+    ) {
+        // `voted` panics below the vote history root, and anything that old has been
+        // pruned, so treat it as not voted rather than reaching for it.
+        let voted = |slot: Slot| slot >= vote_history.root() && vote_history.voted(slot);
+
+        let mut next = bank_forks.get(new_root);
+        while let Some(bank) = next {
+            let slot = bank.slot();
+            if slot <= old_root {
+                break;
+            }
+            match bank.reward_credit() {
+                // We were in the rank map and the block carried a certificate, so this is
+                // the exact answer for that slot.
+                Some(credit) => {
+                    if !credit.credited && voted(credit.reward_slot) {
+                        stats.credits_lost_not_in_cert =
+                            stats.credits_lost_not_in_cert.saturating_add(1);
+                    }
+                }
+                // No certificate in the footer, or we hold no stake entry for the rewarded
+                // slot. In the latter case we would not have voted either, so the `voted`
+                // check keeps unstaked nodes out of this bucket.
+                None => {
+                    if let Some(reward_slot) = slot.checked_sub(NUM_SLOTS_FOR_REWARD)
+                        && voted(reward_slot)
+                    {
+                        stats.credits_lost_no_cert = stats.credits_lost_no_cert.saturating_add(1);
+                    }
+                }
+            }
+
+            // Slots skipped between this block and its parent produced no block at all, so
+            // the certificates they owed were never built. Clamp to `old_root`: anything at
+            // or below it was accounted for by an earlier root advance.
+            let parent_slot = bank.parent_slot();
+            for skipped in parent_slot.max(old_root).saturating_add(1)..slot {
+                if let Some(reward_slot) = skipped.checked_sub(NUM_SLOTS_FOR_REWARD)
+                    && voted(reward_slot)
+                {
+                    stats.credits_lost_no_block = stats.credits_lost_no_block.saturating_add(1);
+                }
+            }
+            next = bank_forks.get(parent_slot);
+        }
+    }
+
     fn check_rootable_blocks_and_bank_hash_mismatches(
         my_pubkey: &Pubkey,
         ctx: &SharedContext,
@@ -962,6 +1024,13 @@ impl EventHandler {
             // No rootable banks
             return;
         };
+        Self::report_lost_credits(
+            &bank_forks_r,
+            &vctx.vote_history,
+            old_root,
+            new_root.slot,
+            stats,
+        );
         drop(bank_forks_r);
         root_utils::set_root(
             my_pubkey,
@@ -1040,6 +1109,7 @@ mod tests {
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
             },
             installed_scheduler_pool::BankWithScheduler,
+            validated_reward_certificate::RewardCredit,
         },
         solana_streamer::evicting_sender::EvictingSender,
         std::{
@@ -2392,6 +2462,120 @@ mod tests {
         test_context.check_for_own_vote(&restored_vote);
         test_context.check_no_own_vote();
         assert!(test_context.bls_ops.is_empty());
+    }
+
+    /// Chain banks at `slots` off a fresh genesis, so `report_lost_credits` has a rooted
+    /// path to walk. Gaps in `slots` become skipped slots.
+    fn bank_forks_with_slots(slots: &[Slot]) -> Arc<RwLock<BankForks>> {
+        let validator_keypairs = (0..2)
+            .map(|_| ValidatorVoteKeypairs::new(Keypair::new(), Keypair::new(), Keypair::new()))
+            .collect::<Vec<_>>();
+        let genesis = create_genesis_config_with_alpenglow_vote_accounts(
+            1_000_000_000,
+            &validator_keypairs,
+            vec![100; validator_keypairs.len()],
+        );
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis.genesis_config));
+        let mut parent = bank_forks.read().unwrap().get(0).unwrap();
+        for &slot in slots {
+            let bank = Bank::new_from_parent(parent, SlotLeader::new_unique(), slot);
+            bank.freeze();
+            let mut w = bank_forks.write().unwrap();
+            w.insert(bank);
+            parent = w.get(slot).unwrap();
+        }
+        bank_forks
+    }
+
+    /// Each cause of a missing credit lands in its own bucket, and a slot we were
+    /// credited for lands in none.
+    #[test]
+    fn test_report_lost_credits_buckets_each_cause() {
+        // Bank slots reward `slot - NUM_SLOTS_FOR_REWARD`, so with the constant at 8 these
+        // banks cover rewarded slots 1, 2, 3 and 5. Slot 12 is absent, dropping rewarded
+        // slot 4 on the floor.
+        let bank_forks = bank_forks_with_slots(&[8, 9, 10, 11, 13]);
+        let bank_forks_r = bank_forks.read().unwrap();
+
+        bank_forks_r
+            .get(9)
+            .unwrap()
+            .set_reward_credit(RewardCredit {
+                reward_slot: 1,
+                credited: true,
+            });
+        bank_forks_r
+            .get(10)
+            .unwrap()
+            .set_reward_credit(RewardCredit {
+                reward_slot: 2,
+                credited: false,
+            });
+        // Bank 11 gets no reward credit at all: its footer carried no certificate.
+        bank_forks_r
+            .get(13)
+            .unwrap()
+            .set_reward_credit(RewardCredit {
+                reward_slot: 5,
+                credited: true,
+            });
+
+        let mut vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
+        for slot in 1..=5 {
+            vote_history.add_vote(Vote::new_skip_vote(slot));
+        }
+
+        let mut stats = EventHandlerStats::new();
+        EventHandler::report_lost_credits(&bank_forks_r, &vote_history, 8, 13, &mut stats);
+
+        assert_eq!(stats.credits_lost_not_in_cert, 1, "rewarded slot 2");
+        assert_eq!(stats.credits_lost_no_cert, 1, "rewarded slot 3");
+        assert_eq!(stats.credits_lost_no_block, 1, "rewarded slot 4");
+    }
+
+    /// Slots we never voted for are not losses, however the certificate turned out.
+    #[test]
+    fn test_report_lost_credits_ignores_slots_we_did_not_vote_for() {
+        let bank_forks = bank_forks_with_slots(&[8, 9, 10]);
+        let bank_forks_r = bank_forks.read().unwrap();
+        for (slot, reward_slot) in [(9, 1), (10, 2)] {
+            bank_forks_r
+                .get(slot)
+                .unwrap()
+                .set_reward_credit(RewardCredit {
+                    reward_slot,
+                    credited: false,
+                });
+        }
+
+        let vote_history = VoteHistory::new(Pubkey::new_unique(), 0);
+        let mut stats = EventHandlerStats::new();
+        EventHandler::report_lost_credits(&bank_forks_r, &vote_history, 8, 10, &mut stats);
+
+        assert_eq!(stats.credits_lost_not_in_cert, 0);
+        assert_eq!(stats.credits_lost_no_cert, 0);
+        assert_eq!(stats.credits_lost_no_block, 0);
+    }
+
+    /// Rewarded slots below the vote history root have been pruned. `VoteHistory::voted`
+    /// asserts on those, so they must be skipped rather than queried.
+    #[test]
+    fn test_report_lost_credits_below_vote_history_root() {
+        let bank_forks = bank_forks_with_slots(&[8, 9]);
+        let bank_forks_r = bank_forks.read().unwrap();
+        bank_forks_r
+            .get(9)
+            .unwrap()
+            .set_reward_credit(RewardCredit {
+                reward_slot: 1,
+                credited: false,
+            });
+
+        let vote_history = VoteHistory::new(Pubkey::new_unique(), 5);
+        let mut stats = EventHandlerStats::new();
+        EventHandler::report_lost_credits(&bank_forks_r, &vote_history, 8, 9, &mut stats);
+
+        assert_eq!(stats.credits_lost_not_in_cert, 0);
     }
 
     #[test]

--- a/votor/src/event_handler/stats.rs
+++ b/votor/src/event_handler/stats.rs
@@ -62,6 +62,20 @@ pub(crate) struct EventHandlerStats {
     // Number of times we updated the root.
     pub(crate) set_root_count: u16,
 
+    // Vote credits lost, bucketed by cause. A credit for slot S is earned only if our
+    // vote account is in the reward certificate carried by the block for
+    // S + NUM_SLOTS_FOR_REWARD. Each counter below covers slots we did vote for.
+    //
+    // The certificate was built and we are missing from it: our vote did not reach that
+    // leader in time. This is the only bucket that indicts our own vote delivery.
+    pub(crate) credits_lost_not_in_cert: u16,
+
+    // The block exists but carries no reward certificate, so nobody was credited.
+    pub(crate) credits_lost_no_cert: u16,
+
+    // The block was skipped, so the certificate it owed could never be produced.
+    pub(crate) credits_lost_no_block: u16,
+
     // Number of times we setup timeouts for a new leader window.
     pub(crate) timeout_set: u16,
 
@@ -133,6 +147,9 @@ impl EventHandlerStats {
             ignored: 0,
             leader_window_replaced: 0,
             set_root_count: 0,
+            credits_lost_not_in_cert: 0,
+            credits_lost_no_cert: 0,
+            credits_lost_no_block: 0,
             timeout_set: 0,
             receive_event_time_us: 0,
             send_votes_batch_time_us: 0,
@@ -220,6 +237,12 @@ impl EventHandlerStats {
             ),
             ("set_root_count", self.set_root_count as i64, i64),
             ("timeout_set", self.timeout_set as i64, i64),
+        );
+        datapoint_info!(
+            "votor_credits_lost",
+            ("not_in_cert", self.credits_lost_not_in_cert as i64, i64),
+            ("no_cert", self.credits_lost_no_cert as i64, i64),
+            ("no_block", self.credits_lost_no_block as i64, i64),
         );
         for (event, EventCountAndTime { count, time_us }) in &self.received_events_count_and_timing
         {


### PR DESCRIPTION
#### Problem

A credit for slot S is earned only if our vote account appears in the reward certificate that the leader of S + NUM_SLOTS_FOR_REWARD puts in its block. Nothing tracked whether that happened, so credits lost to a transport gap were invisible.

#### Summary of Changes

The runtime already enumerates the certificate's signers while BLS verifying it, so record there whether our own vote account was among them, resolving our identity through the rank map since the bitmap holds vote accounts. The hook sits in update_bank_with_footer_fields because both the replay and the leader path go through it.

votor joins that against its vote history once the block is rooted, so an abandoned fork never reports a loss, and emits votor_credits_lost split by cause: not_in_cert (our vote did not reach the leader), no_cert (the block carried none) and no_block (the slot was skipped). Only the first indicts our own vote delivery.