### PR TITLE
deps: opt out of bincode from solana-nonce-account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9407,15 +9407,14 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e156ad2cb96f9fae373cb6891b4e2b537f9edddc959041fa66a5ffa3a855b"
+checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
  "solana-account 4.5.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
- "wincode",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,7 +433,7 @@ solana-native-token = "3.0.0"
 solana-net-utils = { path = "net-utils", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "3.3.0"
-solana-nonce-account = "4.2.0"
+solana-nonce-account = { version = "4.3.0", default-features = false }
 solana-notifier = { path = "notifier", version = "=4.3.0-alpha.3", features = ["agave-unstable-api"] }
 solana-offchain-message = "3.0.0"
 solana-packet = "4.3.0"

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -62,6 +62,7 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -110,13 +110,14 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true, features = ["wincode"] }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -97,7 +97,7 @@ shaq = { workspace = true }
 signal-hook = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-accounts-db = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-bincode = { workspace = true }

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -1215,7 +1215,7 @@ checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -7441,15 +7441,14 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e156ad2cb96f9fae373cb6891b4e2b537f9edddc959041fa66a5ffa3a855b"
+checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
  "solana-account 4.5.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
- "wincode",
 ]
 
 [[package]]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -135,6 +135,7 @@ agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 bs58 = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-bls-signatures = { workspace = true }
 solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -38,7 +38,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-accounts-db = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -27,7 +27,7 @@ bincode = { workspace = true }
 chrono-humanize = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-address = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -58,7 +58,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7560,15 +7560,14 @@ dependencies = [
 
 [[package]]
 name = "solana-nonce-account"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e156ad2cb96f9fae373cb6891b4e2b537f9edddc959041fa66a5ffa3a855b"
+checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
  "solana-account 4.5.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
- "wincode",
 ]
 
 [[package]]

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -43,6 +43,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -61,7 +61,7 @@ solana-vote-interface = { workspace = true, features = ["bincode"] }
 agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-clock = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -111,6 +111,7 @@ wincode = { workspace = true }
 [dev-dependencies]
 agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
 serial_test = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-address-lookup-table-interface = { workspace = true }
 solana-client = { workspace = true }
 solana-cluster-type = { workspace = true }
@@ -120,7 +121,7 @@ solana-fee-structure = { workspace = true }
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-instruction = { workspace = true }
 solana-nonce = { workspace = true }
-solana-nonce-account = { workspace = true }
+solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-program-option = { workspace = true }
 solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -97,7 +97,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 shuttle = { workspace = true, optional = true }
 smallvec = { workspace = true, features = ["serde"] }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-account-decoder = { workspace = true }
 solana-account-info = { workspace = true }
 solana-accounts-db = { workspace = true }

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -41,7 +41,7 @@ tokio-util = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -81,7 +81,7 @@ protosol = { workspace = true, optional = true }
 qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 shuttle = { workspace = true, optional = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
     "bincode",
     "bytemuck",

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -65,6 +65,7 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -32,7 +32,7 @@ bincode = { workspace = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-accounts-db = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-cli-output = { workspace = true }


### PR DESCRIPTION
#### Problem
`solana-nonce-account` 4.2.0 declared its `solana-account` dependency as `features = ["bincode"]`, non-optionally. Because nearly every crate in the workspace reaches it, `solana-account/bincode` was enabled everywhere via feature unification — regardless of whether a given crate's code used bincode APIs. No agave crate declared the feature, so the dependency was invisible: unauditable, and impossible to remove from any crate no matter what its own manifest said.

#### Summary of Changes
Bump solana-nonce-account to 4.3.0, which no longer forces solana-account/bincode, and disable its default features at the workspace level.

Declare solana-account/bincode explicitly on the 15 crates whose code still uses bincode-only APIs (new_data, (de)serialize_data, the sysvar helpers, StateMut), on dev-dependencies where the use is test-only so it does not propagate downstream. cli and rpc gain an explicit wincode feature on solana-nonce-account, which they previously got via default.

No functional change; bincode is now an explicit per-crate opt-in rather than something every crate inherits.

#### Testing
CI
