### PR TITLE
Adds a AGENTS.md to help agents guess package names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository guidance for coding agents
+
+## Cargo package names
+
+This workspace contains both `agave-*` and `solana-*` packages. Do not infer a
+package name from its directory. The authoritative Cargo package name is the
+`name` field in the crate's `[package]` table.
+
+Before running a package-scoped Cargo command, verify the name in the manifest.


### PR DESCRIPTION
#### Problem

I see msgs like this on a regular basis when running clankers.

```
Ran cargo test -p solana-bls-sigverify
  └ error: package ID specification `solana-bls-sigverify` did not match any packages

• Explored
  └ Read Cargo.toml
    Search ^name\s*=|bls-sigverify in Cargo.toml

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

• The initial package selector was stale; this workspace names the crate agave-bls-sigverify.
```

#### Summary of Changes

Adds a AGENTS.md to help clankers guess the right names.  Hopefully speeding them up a little bit and reducing precious tokens usage.


#### Testing

Just a documentation change
