### PR TITLE
gossip purge duration

### DIFF
--- a/core/src/epoch_specs.rs
+++ b/core/src/epoch_specs.rs
@@ -1,16 +1,12 @@
 use {
-    solana_clock::{DEFAULT_MS_PER_SLOT, Epoch},
+    solana_clock::Epoch,
     solana_epoch_schedule::EpochSchedule,
     solana_gossip::epoch_specs::EpochSpecs as EpochSpecsTrait,
     solana_pubkey::Pubkey,
-    solana_runtime::{
-        bank::Bank,
-        bank_forks::{BankForks, SharableBanks},
-    },
+    solana_runtime::bank_forks::{BankForks, SharableBanks},
     std::{
         collections::HashMap,
         sync::{Arc, RwLock},
-        time::Duration,
     },
 };
 
@@ -19,7 +15,6 @@ struct EpochSpecsCache {
     epoch: Epoch,
     epoch_schedule: EpochSchedule,
     current_epoch_staked_nodes: Arc<HashMap<Pubkey, u64>>,
-    epoch_duration: Duration,
     slots_in_epoch: u64,
 }
 
@@ -33,12 +28,6 @@ impl EpochSpecsTrait for EpochSpecs {
         let cache = &mut self.cache;
         Self::maybe_refresh_cache(cache, &self.sharable_banks);
         Arc::clone(&cache.current_epoch_staked_nodes)
-    }
-
-    fn epoch_duration(&mut self) -> Duration {
-        let cache = &mut self.cache;
-        Self::maybe_refresh_cache(cache, &self.sharable_banks);
-        cache.epoch_duration
     }
 
     fn epoch_slots(&mut self) -> u64 {
@@ -65,7 +54,6 @@ impl EpochSpecs {
         cache.epoch = root_bank.epoch();
         cache.epoch_schedule = root_bank.epoch_schedule().clone();
         cache.current_epoch_staked_nodes = root_bank.current_epoch_staked_nodes();
-        cache.epoch_duration = get_epoch_duration(&root_bank);
         cache.slots_in_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
     }
 }
@@ -83,18 +71,10 @@ impl From<Arc<RwLock<BankForks>>> for EpochSpecs {
                 epoch: root_bank.epoch(),
                 epoch_schedule: root_bank.epoch_schedule().clone(),
                 current_epoch_staked_nodes: root_bank.current_epoch_staked_nodes(),
-                epoch_duration: get_epoch_duration(&root_bank),
                 slots_in_epoch: root_bank.get_slots_in_epoch(root_bank.epoch()),
             },
         }
     }
-}
-
-fn get_epoch_duration(bank: &Bank) -> Duration {
-    let num_slots = bank.get_slots_in_epoch(bank.epoch());
-    // Gossip staked-CRDS timeout/purge intentionally follows the legacy
-    // default slot duration, not the runtime slot duration.
-    Duration::from_millis(num_slots.saturating_mul(DEFAULT_MS_PER_SLOT))
 }
 
 #[cfg(test)]
@@ -102,71 +82,10 @@ mod tests {
     use {
         super::*,
         solana_runtime::{
-            bank::SlotLeader,
+            bank::{Bank, SlotLeader},
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
         },
     };
-
-    #[test]
-    fn test_get_epoch_duration() {
-        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let (mut bank, bank_forks) =
-            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
-        let epoch = 0;
-        let num_slots = 32;
-        assert_eq!(bank.epoch(), epoch);
-        assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
-        assert_eq!(
-            get_epoch_duration(&bank),
-            Duration::from_millis(num_slots * DEFAULT_MS_PER_SLOT)
-        );
-        for slot in 1..32 {
-            bank = Bank::new_from_parent_with_bank_forks(
-                bank_forks.as_ref(),
-                bank,
-                SlotLeader::new_unique(),
-                slot,
-            );
-            assert_eq!(bank.epoch(), epoch);
-            assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
-            assert_eq!(
-                get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * DEFAULT_MS_PER_SLOT)
-            );
-        }
-        let epoch = 1;
-        let num_slots = 64;
-        for slot in 32..32 + num_slots {
-            bank = Bank::new_from_parent_with_bank_forks(
-                bank_forks.as_ref(),
-                bank,
-                SlotLeader::new_unique(),
-                slot,
-            );
-            assert_eq!(bank.epoch(), epoch);
-            assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
-            assert_eq!(
-                get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * DEFAULT_MS_PER_SLOT)
-            );
-        }
-        let epoch = 2;
-        let num_slots = 128;
-        for slot in 96..96 + num_slots {
-            bank = Bank::new_from_parent_with_bank_forks(
-                bank_forks.as_ref(),
-                bank,
-                SlotLeader::new_unique(),
-                slot,
-            );
-            assert_eq!(bank.epoch(), epoch);
-            assert_eq!(bank.get_slots_in_epoch(epoch), num_slots);
-            assert_eq!(
-                get_epoch_duration(&bank),
-                Duration::from_millis(num_slots * DEFAULT_MS_PER_SLOT)
-            );
-        }
-    }
 
     fn verify_epoch_specs(epoch_specs: &mut EpochSpecs, root_bank: &Bank) {
         assert_eq!(
@@ -178,7 +97,6 @@ mod tests {
         let cache = &epoch_specs.cache;
         assert_eq!(cache.epoch, root_bank.epoch());
         assert_eq!(cache.epoch_schedule, *root_bank.epoch_schedule());
-        assert_eq!(cache.epoch_duration, get_epoch_duration(root_bank));
         assert_eq!(
             cache.slots_in_epoch,
             root_bank.get_slots_in_epoch(root_bank.epoch())

--- a/gossip/benches/crds.rs
+++ b/gossip/benches/crds.rs
@@ -4,11 +4,13 @@ use {
     rayon::ThreadPoolBuilder,
     solana_gossip::{
         crds::{Crds, GossipRoute},
-        crds_gossip_pull::{CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CrdsTimeouts},
+        crds_gossip_pull::{
+            CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CRDS_GOSSIP_PURGE_DURATION, CrdsTimeouts,
+        },
         crds_value::CrdsValue,
     },
     solana_pubkey::Pubkey,
-    std::{collections::HashMap, time::Duration},
+    std::collections::HashMap,
 };
 
 fn bench_find_old_labels(c: &mut Criterion) {
@@ -28,7 +30,7 @@ fn bench_find_old_labels(c: &mut Criterion) {
     let timeouts = CrdsTimeouts::new(
         Pubkey::new_unique(),
         CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout
-        Duration::from_secs(48 * 3600),   // epoch_duration
+        CRDS_GOSSIP_PURGE_DURATION,
         &stakes,
     );
     c.bench_function("bench_find_old_labels", |b| {

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -23,8 +23,8 @@ use {
         crds_gossip::CrdsGossip,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
-            self, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CrdsFilter, CrdsTimeouts, ProcessPullStats,
-            PullRequest, get_max_bloom_filter_bytes,
+            self, CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CRDS_GOSSIP_PURGE_DURATION, CrdsFilter,
+            CrdsTimeouts, ProcessPullStats, PullRequest, get_max_bloom_filter_bytes,
         },
         crds_value::{CrdsValue, CrdsValueLabel},
         duplicate_shred::DuplicateShred,
@@ -47,7 +47,7 @@ use {
     itertools::{Either, Itertools},
     rand::{CryptoRng, Rng, prelude::IndexedMutRandom},
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
-    solana_clock::{DEFAULT_MS_PER_SLOT, DEFAULT_SLOTS_PER_EPOCH, Slot},
+    solana_clock::{DEFAULT_SLOTS_PER_EPOCH, Slot},
     solana_hash::Hash,
     solana_keypair::{Keypair, signable::Signable},
     solana_ledger::shred::Shred,
@@ -96,8 +96,6 @@ use {
     thiserror::Error,
 };
 
-const DEFAULT_EPOCH_DURATION: Duration =
-    Duration::from_millis(DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT);
 /// milliseconds we sleep for between gossip rounds
 pub const GOSSIP_SLEEP_MILLIS: u64 = 100;
 /// Interval between pull requests (in gossip rounds)
@@ -1469,16 +1467,11 @@ impl ClusterInfo {
             .all(|entrypoint| entrypoint.pubkey() != &Pubkey::default())
     }
 
-    fn handle_purge(
-        &self,
-        thread_pool: &ThreadPool,
-        epoch_duration: Duration,
-        stakes: &HashMap<Pubkey, u64>,
-    ) {
+    fn handle_purge(&self, thread_pool: &ThreadPool, stakes: &HashMap<Pubkey, u64>) {
         let self_pubkey = self.id();
         let timeouts = self
             .gossip
-            .make_timeouts(self_pubkey, stakes, epoch_duration);
+            .make_timeouts(self_pubkey, stakes, CRDS_GOSSIP_PURGE_DURATION);
         let num_purged = {
             let _st = ScopedTimer::from(&self.stats.purge);
             self.gossip
@@ -1570,11 +1563,7 @@ impl ClusterInfo {
                         // Make pull requests every PULL_REQUEST_PERIOD rounds
                         gossip_round % PULL_REQUEST_PERIOD == 0,
                     );
-                    let epoch_duration = epoch_specs
-                        .as_mut()
-                        .map(|es| es.epoch_duration())
-                        .unwrap_or(DEFAULT_EPOCH_DURATION);
-                    self.handle_purge(&thread_pool, epoch_duration, &stakes);
+                    self.handle_purge(&thread_pool, &stakes);
                     entrypoints_processed = entrypoints_processed || self.process_entrypoints();
                     //TODO: possibly tune this parameter
                     //we saw a deadlock passing an self.read().unwrap().timeout into sleep
@@ -1745,7 +1734,6 @@ impl ClusterInfo {
         mut requests: Vec<PullRequest>,
         stakes: &HashMap<Pubkey, u64>,
     ) -> RecycledPacketBatch {
-        const DEFAULT_EPOCH_DURATION_MS: u64 = DEFAULT_SLOTS_PER_EPOCH * DEFAULT_MS_PER_SLOT;
         let output_size_limit =
             self.update_data_budget(stakes.len()) / PULL_RESPONSE_MIN_SERIALIZED_SIZE;
         let mut packet_batch =
@@ -1782,7 +1770,7 @@ impl ClusterInfo {
         let get_score = |value: &CrdsValue| -> u64 {
             let age = now.saturating_sub(value.wallclock());
             // score CrdsValue: 2x score if staked; 2x score if ContactInfo
-            let score = DEFAULT_EPOCH_DURATION_MS
+            let score = (CRDS_GOSSIP_PURGE_DURATION.as_millis() as u64)
                 .saturating_sub(age)
                 .div(CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS)
                 .max(1);
@@ -1845,14 +1833,13 @@ impl ClusterInfo {
         &self,
         responses: Vec<CrdsValue>,
         stakes: &HashMap<Pubkey, u64>,
-        epoch_duration: Duration,
     ) {
         let _st = ScopedTimer::from(&self.stats.handle_batch_pull_responses_time);
         if !responses.is_empty() {
             let self_pubkey = self.id();
-            let timeouts = self
-                .gossip
-                .make_timeouts(self_pubkey, stakes, epoch_duration);
+            let timeouts =
+                self.gossip
+                    .make_timeouts(self_pubkey, stakes, CRDS_GOSSIP_PURGE_DURATION);
             self.handle_pull_response(responses, &timeouts);
         }
     }
@@ -2036,7 +2023,6 @@ impl ClusterInfo {
         recycler: &PacketBatchRecycler,
         response_sender: &impl ChannelSend<PacketBatch>,
         stakes: &HashMap<Pubkey, u64>,
-        epoch_duration: Duration,
         should_check_duplicate_instance: bool,
     ) -> Result<(), GossipError> {
         let _st = ScopedTimer::from(&self.stats.process_gossip_packets_time);
@@ -2157,7 +2143,7 @@ impl ClusterInfo {
             stakes,
             response_sender,
         );
-        self.handle_batch_pull_responses(pull_responses, stakes, epoch_duration);
+        self.handle_batch_pull_responses(pull_responses, stakes);
         self.trim_crds_table(CRDS_UNIQUE_PUBKEY_CAPACITY, stakes);
         self.handle_batch_pong_messages(pong_messages, Instant::now());
         self.handle_batch_pull_requests(pull_requests, recycler, stakes, response_sender);
@@ -2297,17 +2283,12 @@ impl ClusterInfo {
             .as_deref_mut()
             .map(|es| es.current_epoch_staked_nodes())
             .unwrap_or_default();
-        let epoch_duration = epoch_specs
-            .as_deref_mut()
-            .map(|es| es.epoch_duration())
-            .unwrap_or(DEFAULT_EPOCH_DURATION);
         self.process_packets(
             packet_buf,
             thread_pool,
             recycler,
             response_sender,
             &stakes,
-            epoch_duration,
             should_check_duplicate_instance,
         )?;
         packet_buf.clear();
@@ -2826,7 +2807,7 @@ mod tests {
         let timeouts = CrdsTimeouts::new(
             cluster_info.id(),
             CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout
-            Duration::from_secs(48 * 3600),   // epoch_duration
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
 

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -851,6 +851,7 @@ mod tests {
         super::*,
         crate::{
             crds_data::{Deprecated, LowestSlot, SnapshotHashes, new_rand_timestamp},
+            crds_gossip_pull::CRDS_GOSSIP_PURGE_DURATION,
             restart_crds_values::{RestartHeaviestFork, RestartLastVotedForkSlots},
         },
         rand::{Rng, rng},
@@ -1052,18 +1053,18 @@ mod tests {
         );
         let pubkey = Pubkey::new_unique();
         let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
-        let epoch_duration = Duration::from_secs(48 * 3600);
+        let purge_duration = CRDS_GOSSIP_PURGE_DURATION;
         let timeouts = CrdsTimeouts::new(
             pubkey,
             0u64, // default_timeout,
-            epoch_duration,
+            purge_duration,
             &stakes,
         );
         assert!(crds.find_old_labels(&thread_pool, 0, &timeouts).is_empty());
         let timeouts = CrdsTimeouts::new(
             pubkey,
             1u64, // default_timeout,
-            epoch_duration,
+            purge_duration,
             &stakes,
         );
         assert_eq!(
@@ -1073,7 +1074,7 @@ mod tests {
         let timeouts = CrdsTimeouts::new(
             pubkey,
             2u64, // default_timeout,
-            epoch_duration,
+            purge_duration,
             &stakes,
         );
         assert_eq!(
@@ -1090,8 +1091,8 @@ mod tests {
         let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            3,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            3, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert_eq!(
@@ -1103,7 +1104,7 @@ mod tests {
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                        // default_timeout
-            Duration::from_millis(1), // epoch_duration
+            Duration::from_millis(1), // purge_duration
             &stakes,
         );
         assert_eq!(
@@ -1112,23 +1113,23 @@ mod tests {
         );
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            3,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            3, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert!(crds.find_old_labels(&thread_pool, 2, &timeouts).is_empty());
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            1,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            1, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert!(crds.find_old_labels(&thread_pool, 2, &timeouts).is_empty());
         stakes.remove(&val.pubkey());
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            1,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            1, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert_eq!(
@@ -1149,8 +1150,8 @@ mod tests {
         let stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            1,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            1, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert_eq!(
@@ -1175,8 +1176,8 @@ mod tests {
         let mut stakes = HashMap::from([(Pubkey::new_unique(), 1u64)]);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            0,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            0, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         //now < timestamp
@@ -1186,8 +1187,8 @@ mod tests {
         stakes.insert(val.pubkey(), 1u64);
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
-            0,                              // default_timeout
-            Duration::from_secs(48 * 3600), // epoch_duration
+            0, // default_timeout
+            CRDS_GOSSIP_PURGE_DURATION,
             &stakes,
         );
         assert!(crds.find_old_labels(&thread_pool, 2, &timeouts).is_empty());
@@ -1195,7 +1196,7 @@ mod tests {
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             0,                        // default_timeout
-            Duration::from_millis(2), // epoch_duration
+            Duration::from_millis(2), // purge_duration
             &stakes,
         );
         assert!(crds.find_old_labels(&thread_pool, 2, &timeouts).is_empty());
@@ -1566,7 +1567,7 @@ mod tests {
         let timeouts = CrdsTimeouts::new(
             Pubkey::new_unique(),
             1,                        // default_timeout
-            Duration::from_millis(1), // epoch_duration
+            Duration::from_millis(1), // purge_duration
             &stakes,
         );
         assert_eq!(

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -287,9 +287,9 @@ impl CrdsGossip {
         &self,
         self_pubkey: Pubkey,
         stakes: &'a HashMap<Pubkey, u64>,
-        epoch_duration: Duration,
+        purge_duration: Duration,
     ) -> CrdsTimeouts<'a> {
-        self.pull.make_timeouts(self_pubkey, stakes, epoch_duration)
+        self.pull.make_timeouts(self_pubkey, stakes, purge_duration)
     }
 
     pub fn purge(

--- a/gossip/src/crds_gossip_pull.rs
+++ b/gossip/src/crds_gossip_pull.rs
@@ -52,6 +52,10 @@ use {
 };
 
 pub const CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS: u64 = 15000;
+/// How long staked CRDS values are retained before being purged.
+///
+/// This is fixed across clients and intentionally independent of slot and epoch duration.
+pub const CRDS_GOSSIP_PURGE_DURATION: Duration = Duration::from_secs(2 * 24 * 60 * 60);
 // Retention period of hashes of received outdated values.
 const FAILED_INSERTS_RETENTION_MS: u64 = 20_000;
 pub const FALSE_RATE: f64 = 0.1f64;
@@ -560,9 +564,9 @@ impl CrdsGossipPull {
         &self,
         self_pubkey: Pubkey,
         stakes: &'a HashMap<Pubkey, u64>,
-        epoch_duration: Duration,
+        purge_duration: Duration,
     ) -> CrdsTimeouts<'a> {
-        CrdsTimeouts::new(self_pubkey, self.crds_timeout, epoch_duration, stakes)
+        CrdsTimeouts::new(self_pubkey, self.crds_timeout, purge_duration, stakes)
     }
 
     /// Purge values from the crds that are older then `active_timeout`
@@ -592,10 +596,10 @@ impl<'a> CrdsTimeouts<'a> {
     pub fn new(
         pubkey: Pubkey,
         default_timeout: u64,
-        epoch_duration: Duration,
+        purge_duration: Duration,
         stakes: &'a HashMap<Pubkey, u64>,
     ) -> Self {
-        let extended_timeout = default_timeout.max(epoch_duration.as_millis() as u64);
+        let extended_timeout = default_timeout.max(purge_duration.as_millis() as u64);
         let default_timeout = if stakes.values().all(|&stake| stake == 0u64) {
             extended_timeout
         } else {

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -245,7 +245,6 @@ mod tests {
         },
         solana_signer::Signer,
         solana_time_utils::timestamp,
-        std::time::Duration,
     };
 
     fn create_duplicate_proof(
@@ -315,7 +314,6 @@ mod tests {
             .get_slots_in_epoch(0);
         let epoch_specs = TestEpochSpecs {
             staked_nodes: Arc::new(HashMap::new()),
-            epoch_duration: Duration::from_millis(slots_in_epoch * 400),
             slots_in_epoch,
         };
 
@@ -440,7 +438,6 @@ mod tests {
             .get_slots_in_epoch(0);
         let epoch_specs = TestEpochSpecs {
             staked_nodes: Arc::new(HashMap::new()),
-            epoch_duration: Duration::from_millis(slots_in_epoch * 400),
             slots_in_epoch,
         };
 

--- a/gossip/src/epoch_specs.rs
+++ b/gossip/src/epoch_specs.rs
@@ -1,11 +1,10 @@
 use {
     solana_pubkey::Pubkey,
-    std::{collections::HashMap, sync::Arc, time::Duration},
+    std::{collections::HashMap, sync::Arc},
 };
 
 pub trait EpochSpecs: Send + Sync {
     fn current_epoch_staked_nodes(&mut self) -> Arc<HashMap<Pubkey, /*stake:*/ u64>>;
-    fn epoch_duration(&mut self) -> Duration;
     fn epoch_slots(&mut self) -> u64;
     fn clone_box(&self) -> Box<dyn EpochSpecs>;
 }
@@ -15,16 +14,12 @@ pub trait EpochSpecs: Send + Sync {
 pub struct TestEpochSpecs {
     pub staked_nodes: Arc<HashMap<Pubkey, u64>>,
     pub slots_in_epoch: u64,
-    pub epoch_duration: Duration,
 }
 
 #[cfg(feature = "dev-context-only-utils")]
 impl EpochSpecs for TestEpochSpecs {
     fn current_epoch_staked_nodes(&mut self) -> Arc<HashMap<Pubkey, u64>> {
         Arc::clone(&self.staked_nodes)
-    }
-    fn epoch_duration(&mut self) -> Duration {
-        self.epoch_duration
     }
     fn epoch_slots(&mut self) -> u64 {
         self.slots_in_epoch

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -12,8 +12,8 @@ use {
         crds_gossip::*,
         crds_gossip_error::CrdsGossipError,
         crds_gossip_pull::{
-            CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CrdsTimeouts, ProcessPullStats, PullRequest,
-            SAMPLE_RATE,
+            CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, CRDS_GOSSIP_PURGE_DURATION, CrdsTimeouts,
+            ProcessPullStats, PullRequest, SAMPLE_RATE,
         },
         crds_gossip_push::CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS,
         crds_value::{CrdsValue, CrdsValueLabel},
@@ -611,7 +611,7 @@ fn network_run_pull(
                     let timeouts = CrdsTimeouts::new(
                         node.keypair.pubkey(),
                         CRDS_GOSSIP_PULL_CRDS_TIMEOUT_MS, // default_timeout
-                        Duration::from_secs(48 * 3600),   // epoch_duration
+                        CRDS_GOSSIP_PURGE_DURATION,
                         &stakes,
                     );
                     let (vers, vers_expired_timeout, failed_inserts) = node

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -317,7 +317,6 @@ pub fn cluster_info_scale() {
     let slots_in_epoch = root_bank.get_slots_in_epoch(root_bank.epoch());
     let epoch_specs: Box<dyn EpochSpecs> = Box::new(TestEpochSpecs {
         slots_in_epoch,
-        epoch_duration: Duration::from_millis(slots_in_epoch * 400),
         staked_nodes: root_bank.current_epoch_staked_nodes(),
     });
 


### PR DESCRIPTION
#### Problem
Gossip purge duration and scoring was historically attached to epoch duration, but it really doesn't have to be.

As part of the 200ms slot time changes, the decision was made to hold this purge interval constant at 2 days (not coupled to epoch duration). But the Agave code still derives this time using `DEFAULT_MS_PER_SLOT`.

I plan on changing `DEFAULT_MS_PER_SLOT` (part of `solana-clock`) to 200 at some point in the not too distant future so all of the client software and such can have correct slot time understanding. Without changing the gossip usage in Agave, we will change the purge duration when we update to the new `solana-clock`, which could cause a flurry of pull data due to mismatch between clients

#### Summary of Changes

1. Add new `CRDS_GOSSIP_PURGE_DURATION` constant (set to 2 days).
2. Delete `EpochSpecsCache::epoch_duration` and associated usage