### PR TITLE
votor: bump prealloc limit for vote history

### DIFF
--- a/votor/src/vote_history_storage.rs
+++ b/votor/src/vote_history_storage.rs
@@ -16,6 +16,19 @@ use {
 
 pub type Result<T> = std::result::Result<T, VoteHistoryError>;
 
+// With four notarize-fallback certificates and a skip certificate per slot,
+// parent-ready sets grow quadratically. A 30,000-slot vote history can encode
+// to about 18.02 GB (16.78 GiB), including conservative local vote state.
+const VOTE_HISTORY_PREALLOCATION_SIZE_LIMIT: usize = 18 << 30;
+
+type VoteHistoryWincodeConfig =
+    wincode::config::Configuration<true, VOTE_HISTORY_PREALLOCATION_SIZE_LIMIT>;
+
+fn vote_history_wincode_config() -> VoteHistoryWincodeConfig {
+    wincode::config::Configuration::default()
+        .with_preallocation_size_limit::<VOTE_HISTORY_PREALLOCATION_SIZE_LIMIT>()
+}
+
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample, AbiEnumVisitor, StableAbi, StableAbiSample, Serialize, Deserialize),
@@ -40,7 +53,8 @@ impl SavedVoteHistoryVersions {
                 if !t.signature.verify(node_pubkey.as_ref(), &t.data) {
                     return Err(VoteHistoryError::InvalidSignature);
                 }
-                wincode::deserialize(&t.data).map(VoteHistoryVersions::Current)?
+                wincode::config::deserialize(&t.data, vote_history_wincode_config())
+                    .map(VoteHistoryVersions::Current)?
             }
         };
         let vote_history = vote_history.convert_to_current();
@@ -54,7 +68,7 @@ impl SavedVoteHistoryVersions {
     }
 
     fn serialize_into(&self, file: &mut File) -> Result<()> {
-        wincode::serialize_into(BufWriter::new(file), self)?;
+        wincode::config::serialize_into(BufWriter::new(file), self, vote_history_wincode_config())?;
         Ok(())
     }
 
@@ -104,7 +118,7 @@ impl SavedVoteHistory {
             )));
         }
 
-        let data = wincode::serialize(&vote_history)?;
+        let data = wincode::config::serialize(&vote_history, vote_history_wincode_config())?;
         let signature = keypair.sign_message(&data);
         Ok(Self {
             signature,
@@ -163,7 +177,8 @@ impl VoteHistoryStorage for FileVoteHistoryStorage {
         let file = File::open(&filename)?;
         let mut stream = BufReader::new(file);
 
-        let saved_vote_history: SavedVoteHistoryVersions = wincode::deserialize_from(&mut stream)?;
+        let saved_vote_history: SavedVoteHistoryVersions =
+            wincode::config::deserialize_from(&mut stream, vote_history_wincode_config())?;
         saved_vote_history.try_into_vote_history(node_pubkey)
     }
 
@@ -188,9 +203,107 @@ impl VoteHistoryStorage for FileVoteHistoryStorage {
 #[cfg(test)]
 mod test {
     use {
-        super::*, agave_votor_messages::vote::Vote, solana_keypair::Keypair, solana_signer::Signer,
+        super::*,
+        crate::common::MAX_NOTAR_FALLBACK_BLOCKS,
+        agave_votor_messages::{consensus_message::Block, vote::Vote},
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
+        solana_signer::Signer,
         tempfile::TempDir,
+        wincode::len::{BincodeLen, SeqLen},
     };
+
+    const MAX_SLOTS_WITHOUT_FINALIZATION: usize = 30_000;
+    const BINCODE_LEN_SIZE: usize = size_of::<u64>();
+    const SERIALIZED_BLOCK_SIZE: usize = size_of::<u64>() + size_of::<Hash>();
+    const FIXED_SIZE_EXCLUDING_PARENT_READY: usize = 104;
+    const GENESIS_STATE_SIZE: usize = 88;
+    // Notar + four NotarFallback votes + SkipFallback, including all indexes.
+    const MAX_LOCAL_VOTE_STATE_SIZE_PER_SLOT: usize = 450;
+
+    #[allow(clippy::arithmetic_side_effects)]
+    fn estimate_max_vote_history_size(slots: usize) -> usize {
+        let leader_window_size = NUM_CONSECUTIVE_LEADER_SLOTS.get();
+        assert!(slots.is_multiple_of(leader_window_size));
+
+        let num_leader_windows = slots / leader_window_size;
+        let nf_parent_occurrences = MAX_NOTAR_FALLBACK_BLOCKS
+            * (leader_window_size * num_leader_windows * (num_leader_windows + 1) / 2
+                - num_leader_windows);
+        // The root parent is present at each leader-window start and in the
+        // separate startup parent-ready entry.
+        let parent_occurrences = nf_parent_occurrences + num_leader_windows + 1;
+        let parent_ready_slots = num_leader_windows + 1;
+        let parent_ready_size = BINCODE_LEN_SIZE
+            + parent_ready_slots * (size_of::<u64>() + BINCODE_LEN_SIZE)
+            + parent_occurrences * SERIALIZED_BLOCK_SIZE;
+
+        FIXED_SIZE_EXCLUDING_PARENT_READY
+            + GENESIS_STATE_SIZE
+            + slots * MAX_LOCAL_VOTE_STATE_SIZE_PER_SLOT
+            + parent_ready_size
+    }
+
+    #[test]
+    fn test_vote_history_preallocation_limit_supports_30k_fallback_slots() {
+        assert_eq!(MAX_NOTAR_FALLBACK_BLOCKS, 4);
+        assert_eq!(SERIALIZED_BLOCK_SIZE, 40);
+        assert_eq!(wincode::serialized_size(&Block::default()).unwrap(), 40);
+
+        let estimated_size = estimate_max_vote_history_size(MAX_SLOTS_WITHOUT_FINALIZATION);
+        assert_eq!(estimated_size, 18_015_120_256);
+        assert!(estimated_size < VOTE_HISTORY_PREALLOCATION_SIZE_LIMIT);
+        assert!(
+            <BincodeLen as SeqLen<VoteHistoryWincodeConfig>>::prealloc_check::<u8>(estimated_size)
+                .is_ok()
+        );
+        assert!(
+            <BincodeLen as SeqLen<wincode::config::DefaultConfig>>::prealloc_check::<u8>(
+                estimated_size
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn test_file_vote_history_storage_30k_normal_slots_without_finalization() {
+        let tmp_dir = TempDir::new().unwrap();
+        let storage = FileVoteHistoryStorage::new(tmp_dir.path().to_path_buf());
+        let keypair = Keypair::new();
+        let mut vote_history = VoteHistory::new(keypair.pubkey(), 0);
+
+        // Use a linear 30,000-slot case for an end-to-end round trip; building
+        // the fallback case above would require about 18 GB of serialized data.
+        // The validator still casts a Finalize vote for each notarized block,
+        // but no finalization certificate advances the root.
+        for slot in 1..=MAX_SLOTS_WITHOUT_FINALIZATION as u64 {
+            let block = Block {
+                slot,
+                block_id: Hash::default(),
+            };
+            vote_history.add_vote(Vote::new_notarization_vote(block));
+            vote_history.add_block_notarized(block);
+            vote_history.add_vote(Vote::new_finalization_vote(slot));
+            if slot.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as u64) {
+                vote_history.add_parent_ready(
+                    slot,
+                    Block {
+                        slot: slot - 1,
+                        block_id: Hash::default(),
+                    },
+                );
+            }
+        }
+        let saved_vote_history = SavedVoteHistory::new(&vote_history, &keypair).unwrap();
+        assert!(saved_vote_history.data.len() > wincode::config::DEFAULT_PREALLOCATION_SIZE_LIMIT);
+        assert!(saved_vote_history.data.len() <= VOTE_HISTORY_PREALLOCATION_SIZE_LIMIT);
+
+        storage
+            .store(&SavedVoteHistoryVersions::from(saved_vote_history))
+            .unwrap();
+        assert_eq!(storage.load(&keypair.pubkey()).unwrap(), vote_history);
+    }
 
     #[test]
     fn test_file_vote_history_storage() {


### PR DESCRIPTION
#### Problem
As reported by the bug bounty:

Wincode has a prealloc limit of 4mb. In extreme standstill cases the vote history could exceed that.

#### Summary of Changes
Bump the limit to 18GB. Note this is wayyyy overprovisioned, it assumes 30k slots (longest we can go without a root in AG) where every single slot is equivocated and has 4 blocks certified in it.

This is just a limit, it doesn't actually pre allocate 18GB, it still uses the length of the underlying data which is usually very small

#### Testing
Unit test
