### PR TITLE
refactor: switch to bincode-free solana-account API

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -97,7 +97,7 @@ shaq = { workspace = true }
 signal-hook = { workspace = true }
 slab = { workspace = true }
 smallvec = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-accounts-db = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-bincode = { workspace = true }
@@ -198,7 +198,7 @@ bencher = { workspace = true }
 bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
-solana-account = { workspace = true, features = ["wincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -44,7 +44,7 @@ use {
     arc_swap::ArcSwap,
     crossbeam_channel::{Receiver, bounded, unbounded},
     serde::{Deserialize, Serialize},
-    solana_account::ReadableAccount,
+    solana_account::{ReadableAccount, state_traits::StateMutWincode as _},
     solana_accounts_db::{
         accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
         accounts_update_notifier_interface::AccountsUpdateNotifier,
@@ -2079,10 +2079,7 @@ pub fn should_require_vote_history_file(
         return false;
     };
 
-    let Some(Ok(vote_state)) = bank
-        .get_account(vote_account)
-        .map(|acct| acct.deserialize_data())
-    else {
+    let Some(Ok(vote_state)) = bank.get_account(vote_account).map(|acct| acct.state()) else {
         // Must have a vote account
         return false;
     };
@@ -3218,7 +3215,7 @@ mod tests {
     fn test_should_require_vote_history_file() {
         use {
             agave_votor_messages::consensus_message::Block,
-            solana_account::{AccountSharedData, state_traits::StateMutWincode as _},
+            solana_account::AccountSharedData,
             solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
         };
 

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -38,7 +38,7 @@ itertools = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-accounts-db = { workspace = true }
 solana-client-traits = { workspace = true }
 solana-clock = { workspace = true }
@@ -73,7 +73,7 @@ solana-sdk-ids = { workspace = true }
 solana-shred-version = { workspace = true }
 solana-signer = { workspace = true }
 solana-slot-hashes = { workspace = true }
-solana-stake-interface = { workspace = true }
+solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-streamer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -10,7 +10,9 @@ use {
     agave_votor::vote_history_storage::FileVoteHistoryStorage,
     itertools::izip,
     log::*,
-    solana_account::{Account, AccountSharedData, ReadableAccount},
+    solana_account::{
+        Account, AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _,
+    },
     solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
     solana_clock::{DEFAULT_DEV_SLOTS_PER_EPOCH, DEFAULT_TICKS_PER_SLOT, Slot},
     solana_cluster_type::ClusterType,
@@ -1165,9 +1167,9 @@ impl LocalCluster {
                     (Some(stake_account), Some(vote_account)) => {
                         match (
                             stake_account
-                                .deserialize_data::<StakeStateV2>()
+                                .state()
                                 .ok()
-                                .and_then(|state| state.stake()),
+                                .and_then(|state: StakeStateV2| state.stake()),
                             VoteStateV4::deserialize(vote_account.data(), &vote_account_pubkey)
                                 .ok(),
                         ) {

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -43,7 +43,7 @@ solana-transaction-context = { workspace = true, features = ["bincode"] }
 [dev-dependencies]
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
+solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-hash = { workspace = true }
 solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -578,7 +578,10 @@ mod tests {
     };
     #[allow(deprecated)]
     use {
-        solana_account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
+        solana_account::{
+            Account, AccountSharedData, ReadableAccount, WritableAccount,
+            state_traits::StateMutWincode as _,
+        },
         solana_fee_calculator::FeeCalculator,
         solana_hash::Hash,
         solana_instruction::{AccountMeta, Instruction, error::InstructionError},
@@ -1975,10 +1978,8 @@ mod tests {
             &system_program::id(), // owner
         )
         .unwrap();
-        assert_eq!(
-            nonce_account.deserialize_data::<NonceVersions>().unwrap(),
-            versions
-        );
+        let stored: NonceVersions = nonce_account.state().unwrap();
+        assert_eq!(stored, versions);
         nonce_account
     }
 
@@ -2056,10 +2057,8 @@ mod tests {
         };
         let upgraded_nonce_account =
             NonceVersions::Current(Box::new(NonceState::Initialized(data)));
-        assert_eq!(
-            nonce_account.deserialize_data::<NonceVersions>().unwrap(),
-            upgraded_nonce_account
-        );
+        let stored: NonceVersions = nonce_account.state().unwrap();
+        assert_eq!(stored, upgraded_nonce_account);
         let accounts = process_instruction(
             &serialize(&SystemInstruction::UpgradeNonceAccount).unwrap(),
             vec![(nonce_address, nonce_account)],
@@ -2071,10 +2070,8 @@ mod tests {
             Err(InstructionError::InvalidArgument),
         );
         assert_eq!(accounts.len(), 1);
-        assert_eq!(
-            accounts[0].deserialize_data::<NonceVersions>().unwrap(),
-            upgraded_nonce_account
-        );
+        let stored: NonceVersions = accounts[0].state().unwrap();
+        assert_eq!(stored, upgraded_nonce_account);
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -1838,7 +1838,7 @@ mod tests {
                     &solana_vote_program::id(),
                 );
                 account
-                    .serialize_data(&VoteStateVersions::new_v4(vote_state))
+                    .set_state(&VoteStateVersions::new_v4(vote_state))
                     .unwrap();
                 bank.store_account(vote_address, &account);
             }
@@ -1854,9 +1854,7 @@ mod tests {
 
             let modify_vote_state = |modify_fn: &dyn Fn(&mut VoteStateV4)| {
                 let mut vote_account = bank.get_account(vote_address).unwrap();
-                let vote_state_versions = vote_account
-                    .deserialize_data::<VoteStateVersions>()
-                    .unwrap();
+                let vote_state_versions: VoteStateVersions = vote_account.state().unwrap();
                 let VoteStateVersions::V4(mut vote_state) = vote_state_versions else {
                     panic!("unexpected version");
                 };
@@ -1864,7 +1862,7 @@ mod tests {
                 modify_fn(&mut vote_state);
 
                 vote_account
-                    .serialize_data(&VoteStateVersions::V4(vote_state))
+                    .set_state(&VoteStateVersions::V4(vote_state))
                     .unwrap();
                 bank.store_account(vote_address, &vote_account);
             };
@@ -2727,10 +2725,8 @@ mod tests {
         assert_eq!(bank.epoch(), 1);
 
         let mut vote_account = bank.get_account(&vote_pubkey).unwrap();
-        let VoteStateVersions::V4(mut vote_state) = vote_account
-            .deserialize_data::<VoteStateVersions>()
-            .unwrap()
-        else {
+        let vote_state_versions: VoteStateVersions = vote_account.state().unwrap();
+        let VoteStateVersions::V4(mut vote_state) = vote_state_versions else {
             panic!("unexpected vote state version");
         };
         let last_credits = vote_state
@@ -2742,7 +2738,7 @@ mod tests {
             .epoch_credits
             .push((bank.epoch(), last_credits + 1_000_000, last_credits));
         vote_account
-            .serialize_data(&VoteStateVersions::V4(vote_state))
+            .set_state(&VoteStateVersions::V4(vote_state))
             .unwrap();
         bank.store_account(&vote_pubkey, &vote_account);
 
@@ -2830,10 +2826,8 @@ mod tests {
 
         let vote_pubkey = validator_keypairs[0].vote_keypair.pubkey();
         let mut vote_account = bank.get_account(&vote_pubkey).unwrap();
-        let VoteStateVersions::V4(mut vote_state) = vote_account
-            .deserialize_data::<VoteStateVersions>()
-            .unwrap()
-        else {
+        let vote_state_versions: VoteStateVersions = vote_account.state().unwrap();
+        let VoteStateVersions::V4(mut vote_state) = vote_state_versions else {
             panic!("unexpected vote state version");
         };
         let last_credits = vote_state
@@ -2845,7 +2839,7 @@ mod tests {
             .epoch_credits
             .push((bank.epoch(), last_credits + recorded_payout, last_credits));
         vote_account
-            .serialize_data(&VoteStateVersions::V4(vote_state))
+            .set_state(&VoteStateVersions::V4(vote_state))
             .unwrap();
         bank.store_account(&vote_pubkey, &vote_account);
 
@@ -4275,7 +4269,7 @@ mod tests {
                 &solana_vote_program::id(),
             );
             account
-                .serialize_data(&VoteStateVersions::new_v4(vote_state))
+                .set_state(&VoteStateVersions::new_v4(vote_state))
                 .unwrap();
             VoteAccount::try_from(account).unwrap()
         };

--- a/runtime/src/non_circulating_supply.rs
+++ b/runtime/src/non_circulating_supply.rs
@@ -1,7 +1,7 @@
 use {
     crate::bank::Bank,
     log::*,
-    solana_account::ReadableAccount,
+    solana_account::{ReadableAccount, state_traits::StateMutWincode as _},
     solana_accounts_db::{
         accounts_index::{AccountIndex, IndexKey},
         accounts_scan::ScanResult,
@@ -47,9 +47,7 @@ pub fn calculate_non_circulating_supply(bank: &Bank) -> ScanResult<NonCirculatin
     };
 
     for (pubkey, account) in stake_accounts.iter() {
-        let stake_account = account
-            .deserialize_data::<StakeStateV2>()
-            .unwrap_or_default();
+        let stake_account: StakeStateV2 = account.state().unwrap_or_default();
         match stake_account {
             StakeStateV2::Initialized(meta)
                 if (meta.lockup.is_in_force(&clock, None)

--- a/runtime/src/stakes.rs
+++ b/runtime/src/stakes.rs
@@ -812,7 +812,7 @@ pub(crate) mod tests {
         super::*,
         crate::{stake_delegation::effective_stake, stake_utils},
         rayon::ThreadPoolBuilder,
-        solana_account::WritableAccount,
+        solana_account::{WritableAccount, state_traits::StateMutWincode as _},
         solana_pubkey::Pubkey,
         solana_rent::Rent,
         solana_stake_interface::{self as stake, state::StakeStateV2},
@@ -904,11 +904,8 @@ pub(crate) mod tests {
 
             stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
             stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-            let stake = stake_account
-                .deserialize_data::<StakeStateV2>()
-                .unwrap()
-                .stake()
-                .unwrap();
+            let stake_state: StakeStateV2 = stake_account.state().unwrap();
+            let stake = stake_state.stake().unwrap();
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -939,11 +936,8 @@ pub(crate) mod tests {
             let mut stake_account =
                 create_stake_account(42, &vote_pubkey, &solana_pubkey::new_rand(), &rent);
             stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-            let stake = stake_account
-                .deserialize_data::<StakeStateV2>()
-                .unwrap()
-                .stake()
-                .unwrap();
+            let stake_state: StakeStateV2 = stake_account.state().unwrap();
+            let stake = stake_state.stake().unwrap();
             {
                 let stakes = stakes_cache.stakes();
                 let vote_accounts = stakes.vote_accounts();
@@ -1097,11 +1091,8 @@ pub(crate) mod tests {
         // delegates to vote_pubkey
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
 
-        let stake = stake_account
-            .deserialize_data::<StakeStateV2>()
-            .unwrap()
-            .stake()
-            .unwrap();
+        let stake_state: StakeStateV2 = stake_account.state().unwrap();
+        let stake = stake_state.stake().unwrap();
 
         {
             let stakes = stakes_cache.stakes();
@@ -1172,11 +1163,8 @@ pub(crate) mod tests {
 
         stakes_cache.check_and_store(&vote_pubkey, &vote_account, None, true);
         stakes_cache.check_and_store(&stake_pubkey, &stake_account, None, true);
-        let stake = stake_account
-            .deserialize_data::<StakeStateV2>()
-            .unwrap()
-            .stake()
-            .unwrap();
+        let stake_state: StakeStateV2 = stake_account.state().unwrap();
+        let stake = stake_state.stake().unwrap();
 
         let initial_expected_stake = {
             let stakes = stakes_cache.stakes();


### PR DESCRIPTION
Problem
`deserialize_data`/`serialize_data` are bincode-only inherent methods on `Account`/`AccountSharedData` with no wincode namesake. Unlike `new_data`, which will silently resolve to `StateMutWincode` the moment the inherent method disappears, these have to be rewritten by hand — so they block dropping `solana-account/bincode` from any crate that uses them.

#### Summary of changes
Migrate the 18 `deserialize_data`/`serialize_data` call sites to the wincode trait's `state()`/`set_state()`. Unlike `new_data`, these have no wincode namesake, so they can never resolve to the trait automatically and must be rewritten before any crate can drop `solana-account/bincode`.

- **`runtime`** 13 (`stakes.rs` 4, `calculation.rs` 8, `non_circulating_supply.rs` 1), **`programs/system`** 3, **`core`** 1, **`local-cluster`** 1.
- **`core`: `bincode` moves from `[dependencies]` to `[dev-dependencies]`.** This is the load-bearing change — `core`'s only production use was `validator.rs` `deserialize_data()`, migrated here; its 3 remaining `new_data` sites are all under `#[cfg(test)]`. Since `core` is a normal dependency of `local-cluster`, `agave-validator` and `accounts-cluster-bench`, this stops bincode propagating to all of them.
- **`local-cluster`: `bincode` dropped** (`["wincode"]` + `solana-stake-interface/wincode`) — its one `deserialize_data` is migrated here, leaving zero uses.
- `programs/system` gains `wincode` alongside `bincode` (its remaining uses are test-only `new_data`).

No functional change: wincode's encoding for `StakeStateV2`, `VoteStateVersions` and nonce `Versions` is byte-identical to bincode's. The error type changes from `bincode::Error` to `InstructionError`, absorbed by `.ok()`/`.unwrap()` at every site.

Side effect worth noting: retargeting `calculation.rs`'s test-module alias to the wincode trait also switches the pre-existing `.set_state()` calls in that module from bincode to wincode.

#### Testing
CI
