### PR TITLE
streamer: evict QUIC connections from peers that lost their stake

### DIFF
--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -1,7 +1,10 @@
 use {
-    crate::nonblocking::quic::{ClientConnectionTracker, ConnectionPeerType},
+    crate::{
+        nonblocking::quic::{ClientConnectionTracker, ConnectionPeerType, get_pubkey_stake},
+        streamer::StakedNodes,
+    },
     quinn::Connection,
-    std::future::Future,
+    std::{future::Future, sync::RwLock},
     tokio_util::sync::CancellationToken,
 };
 
@@ -13,12 +16,36 @@ pub(crate) trait ConnectionContext: Clone + Send + Sync {
     fn remote_pubkey(&self) -> Option<solana_pubkey::Pubkey>;
 }
 
+pub(crate) fn has_sufficient_stake<C: ConnectionContext>(
+    context: &C,
+    staked_nodes: &RwLock<StakedNodes>,
+) -> bool {
+    let ConnectionPeerType::Staked(cached_stake) = context.peer_type() else {
+        return true;
+    };
+    context.remote_pubkey().is_some_and(|pubkey| {
+        get_pubkey_stake(&pubkey, staked_nodes).is_some_and(|(stake, _total_stake)| {
+            // Keep the connection as long as the peer retains at least half of the stake
+            // cached at handshake. This catches de-staking (no stake left) and large
+            // reductions, while tolerating organic drift (epoch rewards, routine delegator
+            // churn) so healthy staked connections are never recycled; a stale cache can
+            // thus over-grant at most 2x. Increases never evict: a peer can reconnect to
+            // claim its higher weight.
+            stake.saturating_mul(2) >= cached_stake
+        })
+    })
+}
+
 /// A trait to manage QoS for connections. This includes
 /// 1) deriving the ConnectionContext for a connection
 /// 2) managing connection caching and connection limits, stream limits
 pub(crate) trait QosController<C: ConnectionContext> {
     /// Build the ConnectionContext for a connection
     fn build_connection_context(&self, connection: &Connection) -> C;
+
+    /// Returns whether the peer still retains enough stake relative to the value cached in
+    /// the connection context, i.e. whether the connection may stay alive.
+    fn has_sufficient_stake(&self, context: &C) -> bool;
 
     /// Try to add a new connection to the connection table. This is an async operation that
     /// returns a Future. If successful, the Future resolves to Some containing a CancellationToken.
@@ -67,3 +94,66 @@ pub(crate) struct NullStreamerCounter;
 
 #[cfg(test)]
 impl OpaqueStreamerCounter for NullStreamerCounter {}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_pubkey::Pubkey,
+        std::{collections::HashMap, sync::Arc},
+    };
+
+    #[derive(Clone)]
+    struct TestConnectionContext {
+        peer_type: ConnectionPeerType,
+        remote_pubkey: Option<Pubkey>,
+    }
+
+    impl ConnectionContext for TestConnectionContext {
+        fn peer_type(&self) -> ConnectionPeerType {
+            self.peer_type
+        }
+
+        fn remote_pubkey(&self) -> Option<Pubkey> {
+            self.remote_pubkey
+        }
+    }
+
+    fn set_stakes(staked_nodes: &RwLock<StakedNodes>, stakes: HashMap<Pubkey, u64>) {
+        *staked_nodes.write().unwrap() = StakedNodes::new(Arc::new(stakes), HashMap::new());
+    }
+
+    #[test]
+    fn test_has_sufficient_stake() {
+        let pubkey = Pubkey::new_unique();
+        let staked_nodes = RwLock::new(StakedNodes::new(
+            Arc::new(HashMap::from([(pubkey, 100)])),
+            HashMap::new(),
+        ));
+        let context = TestConnectionContext {
+            peer_type: ConnectionPeerType::Staked(100),
+            remote_pubkey: Some(pubkey),
+        };
+        let unstaked_context = TestConnectionContext {
+            peer_type: ConnectionPeerType::Unstaked,
+            remote_pubkey: None,
+        };
+
+        // Stake unchanged.
+        assert!(has_sufficient_stake(&context, &staked_nodes));
+        // Stake increases never evict.
+        set_stakes(&staked_nodes, HashMap::from([(pubkey, 1_000)]));
+        assert!(has_sufficient_stake(&context, &staked_nodes));
+        // Reduction down to exactly half of the cached stake is tolerated.
+        set_stakes(&staked_nodes, HashMap::from([(pubkey, 50)]));
+        assert!(has_sufficient_stake(&context, &staked_nodes));
+        // Reduction below half of the cached stake evicts.
+        set_stakes(&staked_nodes, HashMap::from([(pubkey, 49)]));
+        assert!(!has_sufficient_stake(&context, &staked_nodes));
+        // Full de-staking evicts.
+        set_stakes(&staked_nodes, HashMap::new());
+        assert!(!has_sufficient_stake(&context, &staked_nodes));
+        // Unstaked connections are never evicted by this check.
+        assert!(has_sufficient_stake(&unstaked_context, &staked_nodes));
+    }
+}

--- a/streamer/src/nonblocking/qos.rs
+++ b/streamer/src/nonblocking/qos.rs
@@ -139,21 +139,33 @@ mod tests {
             remote_pubkey: None,
         };
 
-        // Stake unchanged.
-        assert!(has_sufficient_stake(&context, &staked_nodes));
-        // Stake increases never evict.
+        assert!(
+            has_sufficient_stake(&context, &staked_nodes),
+            "unchanged stake should keep the connection"
+        );
         set_stakes(&staked_nodes, HashMap::from([(pubkey, 1_000)]));
-        assert!(has_sufficient_stake(&context, &staked_nodes));
-        // Reduction down to exactly half of the cached stake is tolerated.
+        assert!(
+            has_sufficient_stake(&context, &staked_nodes),
+            "increased stake should keep the connection"
+        );
         set_stakes(&staked_nodes, HashMap::from([(pubkey, 50)]));
-        assert!(has_sufficient_stake(&context, &staked_nodes));
-        // Reduction below half of the cached stake evicts.
+        assert!(
+            has_sufficient_stake(&context, &staked_nodes),
+            "stake at half of the cached value should keep the connection"
+        );
         set_stakes(&staked_nodes, HashMap::from([(pubkey, 49)]));
-        assert!(!has_sufficient_stake(&context, &staked_nodes));
-        // Full de-staking evicts.
+        assert!(
+            !has_sufficient_stake(&context, &staked_nodes),
+            "stake below half of the cached value should evict the connection"
+        );
         set_stakes(&staked_nodes, HashMap::new());
-        assert!(!has_sufficient_stake(&context, &staked_nodes));
-        // Unstaked connections are never evicted by this check.
-        assert!(has_sufficient_stake(&unstaked_context, &staked_nodes));
+        assert!(
+            !has_sufficient_stake(&context, &staked_nodes),
+            "full de-staking should evict the connection"
+        );
+        assert!(
+            has_sufficient_stake(&unstaked_context, &staked_nodes),
+            "unstaked connections should not be evicted by stake revalidation"
+        );
     }
 }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -46,7 +46,7 @@ use {
         // introduce any other awaits while holding the RwLock.
         select,
         task::JoinHandle,
-        time::timeout,
+        time::{sleep, timeout},
     },
     tokio_util::{sync::CancellationToken, task::TaskTracker},
 };
@@ -78,6 +78,10 @@ const MAX_CONNECTION_BURST: u64 = 1000;
 /// Timeout for connection handshake. Timer starts once we get Initial from the
 /// peer, and is canceled when we get a Handshake packet from them.
 const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+
+// Bounds for the randomized interval between checks for stale cached stake.
+const MIN_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const MAX_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// Absolute max RTT to allow for a legitimate connection.
 /// Enough to cover any non-malicious link on Earth.
@@ -419,11 +423,24 @@ pub fn get_connection_stake(
 ) -> Option<(Pubkey, u64, u64)> {
     let pubkey = get_remote_pubkey(connection)?;
     debug!("Peer public key is {pubkey:?}");
+    let (stake, total_stake) = get_pubkey_stake(&pubkey, staked_nodes)?;
+    Some((pubkey, stake, total_stake))
+}
+
+pub(crate) fn get_pubkey_stake(
+    pubkey: &Pubkey,
+    staked_nodes: &RwLock<StakedNodes>,
+) -> Option<(u64, u64)> {
     let staked_nodes = staked_nodes.read().unwrap();
     Some((
-        pubkey,
-        staked_nodes.get_node_stake(&pubkey)?,
+        staked_nodes.get_node_stake(pubkey)?,
         staked_nodes.total_stake(),
+    ))
+}
+
+fn stake_revalidation_interval() -> Duration {
+    Duration::from_secs(rng().random_range(
+        MIN_STAKE_REVALIDATION_INTERVAL.as_secs()..=MAX_STAKE_REVALIDATION_INTERVAL.as_secs(),
     ))
 }
 
@@ -607,6 +624,8 @@ async fn handle_connection<Q, C>(
     // we only use that for some stats here, so if it gets stale during connection lifetime
     // it is not the end of the world.
     let rtt = connection.rtt();
+    let stake_revalidation_timer = sleep(stake_revalidation_interval());
+    tokio::pin!(stake_revalidation_timer);
     'conn: loop {
         // Wait for new streams. If the peer is disconnected we get a cancellation signal and stop
         // the connection task.
@@ -619,6 +638,16 @@ async fn handle_connection<Q, C>(
                 }
             },
             _ = cancel.cancelled() => break,
+            _ = &mut stake_revalidation_timer, if peer_type.is_staked() => {
+                if !qos.has_sufficient_stake(&context) {
+                    debug!("Closing connection from {remote_address}: peer stake dropped");
+                    break;
+                }
+                stake_revalidation_timer
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + stake_revalidation_interval());
+                continue;
+            },
         };
 
         qos.on_new_stream(&context).await;

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -27,6 +27,7 @@ use {
         array, fmt,
         iter::repeat_with,
         net::{IpAddr, SocketAddr},
+        ops::RangeInclusive,
         pin::Pin,
         sync::{
             Arc, RwLock,
@@ -78,10 +79,6 @@ const MAX_CONNECTION_BURST: u64 = 1000;
 /// Timeout for connection handshake. Timer starts once we get Initial from the
 /// peer, and is canceled when we get a Handshake packet from them.
 const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
-
-// Bounds for the randomized interval between checks for stale cached stake.
-const MIN_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(60 * 60);
-const MAX_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(2 * 60 * 60);
 
 /// Absolute max RTT to allow for a legitimate connection.
 /// Enough to cover any non-malicious link on Earth.
@@ -438,10 +435,10 @@ pub(crate) fn get_pubkey_stake(
     ))
 }
 
-fn stake_revalidation_interval() -> Duration {
-    Duration::from_secs(rng().random_range(
-        MIN_STAKE_REVALIDATION_INTERVAL.as_secs()..=MAX_STAKE_REVALIDATION_INTERVAL.as_secs(),
-    ))
+fn stake_revalidation_interval(range: &RangeInclusive<Duration>) -> Duration {
+    Duration::from_millis(
+        rng().random_range(range.start().as_millis() as u64..=range.end().as_millis() as u64),
+    )
 }
 
 #[derive(Debug)]
@@ -540,8 +537,7 @@ async fn setup_connection<Q, C>(
                         from,
                         new_connection,
                         stats,
-                        server_params.wait_for_chunk_timeout,
-                        server_params.max_stream_data_bytes,
+                        server_params.clone(),
                         conn_context.clone(),
                         qos,
                         cancel_connection,
@@ -602,8 +598,7 @@ async fn handle_connection<Q, C>(
     remote_address: SocketAddr,
     connection: Connection,
     stats: Arc<StreamerStats>,
-    wait_for_chunk_timeout: Duration,
-    max_stream_data_bytes: u32,
+    server_params: Arc<QuicStreamerConfig>,
     context: C,
     qos: Arc<Q>,
     cancel: CancellationToken,
@@ -624,7 +619,9 @@ async fn handle_connection<Q, C>(
     // we only use that for some stats here, so if it gets stale during connection lifetime
     // it is not the end of the world.
     let rtt = connection.rtt();
-    let stake_revalidation_timer = sleep(stake_revalidation_interval());
+    let stake_revalidation_timer = sleep(stake_revalidation_interval(
+        &server_params.stake_revalidation_interval,
+    ));
     tokio::pin!(stake_revalidation_timer);
     'conn: loop {
         // Wait for new streams. If the peer is disconnected we get a cancellation signal and stop
@@ -643,9 +640,10 @@ async fn handle_connection<Q, C>(
                     debug!("Closing connection from {remote_address}: peer stake dropped");
                     break;
                 }
-                stake_revalidation_timer
-                    .as_mut()
-                    .reset(tokio::time::Instant::now() + stake_revalidation_interval());
+                stake_revalidation_timer.as_mut().reset(
+                    tokio::time::Instant::now()
+                        + stake_revalidation_interval(&server_params.stake_revalidation_interval),
+                );
                 continue;
             },
         };
@@ -679,7 +677,7 @@ async fn handle_connection<Q, C>(
             // packet loss or the peer stops sending for whatever reason.
             let n_chunks = match tokio::select! {
                 chunk = tokio::time::timeout(
-                    wait_for_chunk_timeout,
+                    server_params.wait_for_chunk_timeout,
                     stream.read_chunks(&mut chunks)) => chunk,
 
                 // If the peer gets disconnected stop the task right away.
@@ -713,7 +711,7 @@ async fn handle_connection<Q, C>(
                 &packet_sender,
                 &stats,
                 peer_type,
-                max_stream_data_bytes,
+                server_params.max_stream_data_bytes,
             ) {
                 // The stream is finished, break out of the loop and close the stream.
                 Ok(StreamState::Finished) => {
@@ -1164,8 +1162,9 @@ pub mod test {
             qos::NullStreamerCounter,
             swqos::SwQosConfig,
             testing_utilities::{
-                SpawnTestServerResult, check_multiple_streams, get_client_config,
-                make_client_endpoint, setup_quic_server, spawn_stake_weighted_qos_server,
+                SpawnTestServerResult, check_multiple_streams, create_quic_server_sockets,
+                get_client_config, make_client_endpoint, setup_quic_server,
+                spawn_stake_weighted_qos_server,
             },
         },
         assert_matches::assert_matches,
@@ -1556,6 +1555,85 @@ pub mod test {
         );
         assert_eq!(stats.connection_removed.load(Ordering::Relaxed), 1);
         assert_eq!(stats.connection_remove_failed.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_quic_server_evicts_destaked_connection() {
+        agave_logger::setup();
+
+        let client_keypair = Keypair::new();
+        let initial_stake = 100_000;
+        let set_stake = |staked_nodes: &RwLock<StakedNodes>, stake: u64| {
+            *staked_nodes.write().unwrap() = StakedNodes::new(
+                Arc::new(HashMap::from([(client_keypair.pubkey(), stake)])),
+                HashMap::default(),
+            );
+        };
+        let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
+        set_stake(&staked_nodes, initial_stake);
+
+        let sockets = create_quic_server_sockets();
+        let server_address = sockets[0].local_addr().unwrap();
+        let (sender, receiver) = bounded(1024);
+        let cancel = CancellationToken::new();
+        let SpawnNonBlockingServerResult {
+            endpoints: _,
+            stats,
+            thread,
+            max_concurrent_connections: _,
+        } = spawn_stake_weighted_qos_server(
+            "quic_streamer_test",
+            sockets,
+            &Keypair::new(),
+            sender,
+            staked_nodes.clone(),
+            QuicStreamerConfig {
+                stake_revalidation_interval: Duration::from_millis(50)..=Duration::from_millis(100),
+                ..QuicStreamerConfig::default_for_tests()
+            },
+            SwQosConfig::default(),
+            cancel.clone(),
+        )
+        .unwrap();
+
+        let connection = make_client_endpoint(&server_address, Some(&client_keypair)).await;
+        // Send one packet to make sure the connection is fully established.
+        let mut stream = connection.open_uni().await.unwrap();
+        stream.write_all(&[0u8]).await.unwrap();
+        stream.finish().unwrap();
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("packet from the staked client should be received");
+        assert_eq!(
+            stats
+                .connection_added_from_staked_peer
+                .load(Ordering::Relaxed),
+            1
+        );
+
+        // A reduction down to half of the stake cached at handshake is tolerated.
+        set_stake(&staked_nodes, initial_stake / 2);
+        assert!(
+            timeout(Duration::from_millis(500), connection.closed())
+                .await
+                .is_err(),
+            "connection should survive a reduction to half of the cached stake"
+        );
+
+        // A reduction below half of the cached stake evicts the connection.
+        set_stake(&staked_nodes, initial_stake / 2 - 1);
+        let reason = timeout(Duration::from_secs(5), connection.closed())
+            .await
+            .expect("connection should be closed after the stake dropped");
+        assert_matches!(
+            reason,
+            ConnectionError::ApplicationClosed(ApplicationClose { error_code, .. })
+                if error_code == CONNECTION_CLOSE_CODE_DROPPED_ENTRY.into()
+        );
+        assert_eq!(stats.connection_removed.load(Ordering::Relaxed), 1);
+
+        cancel.cancel();
+        thread.await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/streamer/src/nonblocking/simple_qos.rs
+++ b/streamer/src/nonblocking/simple_qos.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         nonblocking::{
-            qos::{ConnectionContext, OpaqueStreamerCounter, QosController},
+            qos::{ConnectionContext, OpaqueStreamerCounter, QosController, has_sufficient_stake},
             quic::{
                 CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_REASON_DISALLOWED,
                 ClientConnectionTracker, ConnectionHandlerError, ConnectionPeerType,
@@ -270,6 +270,10 @@ impl QosController<SimpleQosConnectionContext> for SimpleQos {
             last_update: Arc::new(AtomicU64::new(timing::timestamp())),
             stream_counter: None,
         }
+    }
+
+    fn has_sufficient_stake(&self, context: &SimpleQosConnectionContext) -> bool {
+        has_sufficient_stake(context, &self.staked_nodes)
     }
 
     fn spawn_background_tasks(&mut self) {

--- a/streamer/src/nonblocking/swqos.rs
+++ b/streamer/src/nonblocking/swqos.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         nonblocking::{
-            qos::{ConnectionContext, QosController},
+            qos::{ConnectionContext, QosController, has_sufficient_stake},
             quic::{
                 CONNECTION_CLOSE_CODE_DISALLOWED, CONNECTION_CLOSE_REASON_DISALLOWED,
                 ClientConnectionTracker, ConnectionHandlerError, ConnectionPeerType,
@@ -339,6 +339,10 @@ impl QosController<SwQosConnectionContext> for SwQos {
                 }
             },
         )
+    }
+
+    fn has_sufficient_stake(&self, context: &SwQosConnectionContext) -> bool {
+        has_sufficient_stake(context, &self.staked_nodes)
     }
 
     #[allow(clippy::manual_async_fn)]

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -550,8 +550,8 @@ impl StreamerStats {
 
 /// Default bounds for the randomized interval between checks that a staked
 /// connection's peer still retains sufficient stake.
-pub const DEFAULT_MIN_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(60 * 60);
-pub const DEFAULT_MAX_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(2 * 60 * 60);
+pub const DEFAULT_STAKE_REVALIDATION_INTERVAL: RangeInclusive<Duration> =
+    Duration::from_secs(60 * 60)..=Duration::from_secs(2 * 60 * 60);
 
 #[derive(Clone)]
 pub struct QuicStreamerConfig {
@@ -588,8 +588,7 @@ impl Default for QuicStreamerConfig {
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
             stream_receive_window_size: PACKET_DATA_SIZE as u32,
             max_stream_data_bytes: PACKET_DATA_SIZE as u32,
-            stake_revalidation_interval: DEFAULT_MIN_STAKE_REVALIDATION_INTERVAL
-                ..=DEFAULT_MAX_STAKE_REVALIDATION_INTERVAL,
+            stake_revalidation_interval: DEFAULT_STAKE_REVALIDATION_INTERVAL,
         }
     }
 }

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -22,6 +22,7 @@ use {
     solana_tls_utils::{NotifyKeyUpdate, new_dummy_x509_certificate, tls_server_config_builder},
     std::{
         num::NonZeroUsize,
+        ops::RangeInclusive,
         sync::{
             Arc, RwLock,
             atomic::{AtomicUsize, Ordering},
@@ -547,6 +548,11 @@ impl StreamerStats {
     }
 }
 
+/// Default bounds for the randomized interval between checks that a staked
+/// connection's peer still retains sufficient stake.
+pub const DEFAULT_MIN_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(60 * 60);
+pub const DEFAULT_MAX_STAKE_REVALIDATION_INTERVAL: Duration = Duration::from_secs(2 * 60 * 60);
+
 #[derive(Clone)]
 pub struct QuicStreamerConfig {
     pub max_connections_per_ipaddr_per_min: u64,
@@ -556,6 +562,10 @@ pub struct QuicStreamerConfig {
     pub stream_receive_window_size: u32,
     /// Maximum total bytes allowed per stream (hard cap).
     pub max_stream_data_bytes: u32,
+    /// Bounds for the randomized interval between checks that a staked
+    /// connection's peer still retains sufficient stake; randomized to spread
+    /// reconnects of evicted peers over time.
+    pub stake_revalidation_interval: RangeInclusive<Duration>,
 }
 
 #[derive(Clone)]
@@ -578,6 +588,8 @@ impl Default for QuicStreamerConfig {
             num_threads: NonZeroUsize::new(num_cpus::get().min(1)).expect("1 is non-zero"),
             stream_receive_window_size: PACKET_DATA_SIZE as u32,
             max_stream_data_bytes: PACKET_DATA_SIZE as u32,
+            stake_revalidation_interval: DEFAULT_MIN_STAKE_REVALIDATION_INTERVAL
+                ..=DEFAULT_MAX_STAKE_REVALIDATION_INTERVAL,
         }
     }
 }


### PR DESCRIPTION
#### Problem

QUIC peer stake is read once during the handshake and cached in the connection context. A connection can therefore retain staked status after its peer loses some of its stake.

#### Summary of Changes

Periodically revalidate the live stake of staked QUIC peers at a randomized 1-2 hour interval. Close a connection when the peer is de-staked or its live stake falls below half of the handshake-cached value. The half-stake threshold tolerates normal stake drift while bounding stale over-allocation at 2x. Stake increases do not trigger eviction.

Make the revalidation interval configurable so the behavior can be covered by an end-to-end QUIC test.

#### Testing

- Added unit tests.
- Tested on a single-validator cluster (details in the followup message).