### PR TITLE
chore: remove eq + partialeq for `TxVerificationData`

### DIFF
--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -125,7 +125,7 @@ pub enum EntryType<Tx: TransactionWithMeta> {
     Tick(Hash),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 struct TxVerificationData {
     is_simple_vote: bool,
     signatures: SmallVec<[Signature; 2]>,


### PR DESCRIPTION
#### Problem
`TxVerificationData` will be using transaction view types in https://github.com/anza-xyz/agave/pull/14356. These view types don't implement `eq` + `partialeq` and there currently is no use for these traits on `TxVerificationData`, so it makes sense to remove these.

#### Summary of Changes
Removed derive `eq + partialeq` on `TxVerificationData`

#### Testing
n/a
