### PR TITLE
Sets `Clock::epoch_start_timestamp` correctly on epoch boundaries

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2494,11 +2494,16 @@ impl Bank {
     /// bank's footer.
     fn update_clock_slot_for_alpenglow(&self) {
         let clock = self.clock();
+        let epoch_start_timestamp = match (self.slot, self.parent()) {
+            (0, _) => self.unix_timestamp_from_genesis(),
+            (_, Some(parent)) if parent.epoch() != self.epoch() => clock.unix_timestamp,
+            _ => clock.epoch_start_timestamp,
+        };
         let clock = sysvar::clock::Clock {
             slot: self.slot,
             epoch: self.epoch_schedule().get_epoch(self.slot),
             leader_schedule_epoch: self.epoch_schedule().get_leader_schedule_epoch(self.slot),
-            epoch_start_timestamp: clock.epoch_start_timestamp,
+            epoch_start_timestamp,
             unix_timestamp: clock.unix_timestamp,
         };
         self.update_sysvar_account(&sysvar::clock::id(), |account| {

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -8,6 +8,7 @@ mod tests {
         crate::{
             genesis_utils::activate_all_features_alpenglow, inflation_rewards::points::PointValue,
         },
+        solana_epoch_schedule::{EpochSchedule, MINIMUM_SLOTS_PER_EPOCH},
         solana_genesis_config::create_genesis_config,
         solana_leader_schedule::SlotLeader,
         solana_sysvar::epoch_rewards::EpochRewards,
@@ -221,5 +222,41 @@ mod tests {
         };
         assert_eq!(cached_post_footer_clock.slot, bank1_slot);
         assert_eq!(cached_post_footer_clock.unix_timestamp, footer_timestamp);
+    }
+
+    #[test]
+    fn test_alpenglow_clock_epoch_start_timestamp_before_footer() {
+        let (mut genesis_config, _mint_keypair) = create_genesis_config(100_000);
+        genesis_config.epoch_schedule =
+            EpochSchedule::custom(MINIMUM_SLOTS_PER_EPOCH, MINIMUM_SLOTS_PER_EPOCH, false);
+        activate_all_features_alpenglow(&mut genesis_config);
+        let (parent, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+
+        let parent_footer_timestamp = parent.clock().unix_timestamp.saturating_add(42);
+        parent.update_clock_from_footer(parent_footer_timestamp.saturating_mul(1_000_000_000));
+        assert_ne!(
+            parent.clock().epoch_start_timestamp,
+            parent_footer_timestamp
+        );
+
+        let bank = Bank::new_from_parent_with_bank_forks(
+            bank_forks.as_ref(),
+            parent,
+            SlotLeader::default(),
+            MINIMUM_SLOTS_PER_EPOCH,
+        );
+        assert_eq!(bank.epoch(), 1);
+
+        let clock = bank.clock();
+        assert_eq!(clock.unix_timestamp, parent_footer_timestamp);
+        assert_eq!(clock.epoch_start_timestamp, parent_footer_timestamp);
+
+        let cached_clock = bank
+            .transaction_processor
+            .sysvar_cache()
+            .get_clock()
+            .unwrap();
+        assert_eq!(cached_clock.epoch_start_timestamp, parent_footer_timestamp);
     }
 }


### PR DESCRIPTION
#### Problem

As reported by the bug bounty:

In Alpenglow, we are currently not updating the `Clock::epoch_start_timestamp` correctly on epoch boundaries before we start executing the bank.  We do update it properly after bank execution so it is fixed up later on.


#### Summary of Changes

Adds some logic to check if we are at the epoch boundary and then sets `epoch_start_timestamp` to `Clock::unix_timestamp`.


#### Testing

Added a unit test to ensure that we do update clocks correctly at epoch boundaries.

