### PR TITLE
rpc: update health check for alpenglow

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1165,6 +1165,8 @@ impl Validator {
 
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        // Updated by Votor and shared with RPC health and block creation.
+        let highest_finalized = Arc::new(RwLock::new(None));
 
         let max_slots = Arc::new(MaxSlots::default());
 
@@ -1266,6 +1268,7 @@ impl Validator {
                 exit: exit.clone(),
                 override_health_check: rpc_override_health_check.clone(),
                 optimistically_confirmed_bank: optimistically_confirmed_bank.clone(),
+                highest_finalized: highest_finalized.clone(),
                 send_transaction_service_config: config.send_transaction_service_config.clone(),
                 max_slots: max_slots.clone(),
                 leader_schedule_cache: leader_schedule_cache.clone(),
@@ -1516,8 +1519,6 @@ impl Validator {
 
         let replay_highest_frozen = Arc::new(ReplayHighestFrozen::default());
         let highest_parent_ready = Arc::new(RwLock::default());
-        // Shared state for highest finalized certificates (updated by Votor, read by block creation loop)
-        let highest_finalized = Arc::new(RwLock::new(None));
         // This channel growing > ~1 indicates problems, so bound channel at a
         // small (but highly overprovisioned) number for performance and easier
         // debug if things go off the rails.

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -500,6 +500,7 @@ impl JsonRpcRequestProcessor {
         let slot = bank.slot();
         let optimistically_confirmed_bank =
             Arc::new(RwLock::new(OptimisticallyConfirmedBank { bank }));
+        let migration_status = bank_forks.read().unwrap().migration_status();
         Self {
             config,
             snapshot_config: None,
@@ -514,6 +515,8 @@ impl JsonRpcRequestProcessor {
             health: Arc::new(RpcHealth::new(
                 Arc::clone(&optimistically_confirmed_bank),
                 blockstore,
+                Arc::default(),
+                migration_status,
                 0,
                 exit,
             )),

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -1,7 +1,9 @@
 use {
     crate::optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
+    agave_votor_messages::migration::MigrationStatus,
     solana_clock::Slot,
     solana_ledger::blockstore::Blockstore,
+    solana_runtime::validated_block_finalization::ValidatedBlockFinalizationCert,
     std::sync::{
         Arc, RwLock,
         atomic::{AtomicBool, Ordering},
@@ -18,6 +20,8 @@ pub enum RpcHealthStatus {
 pub struct RpcHealth {
     optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
     blockstore: Arc<Blockstore>,
+    highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
+    migration_status: Arc<MigrationStatus>,
     health_check_slot_distance: u64,
     override_health_check: Arc<AtomicBool>,
     #[cfg(test)]
@@ -28,17 +32,29 @@ impl RpcHealth {
     pub fn new(
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
         blockstore: Arc<Blockstore>,
+        highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
+        migration_status: Arc<MigrationStatus>,
         health_check_slot_distance: u64,
         override_health_check: Arc<AtomicBool>,
     ) -> Self {
         Self {
             optimistically_confirmed_bank,
             blockstore,
+            highest_finalized,
+            migration_status,
             health_check_slot_distance,
             override_health_check,
             #[cfg(test)]
             stub_health_status: std::sync::RwLock::new(None),
         }
+    }
+
+    fn highest_finalized_slot(&self) -> Option<Slot> {
+        self.highest_finalized
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|cert| cert.block().slot)
     }
 
     pub fn check(&self) -> RpcHealthStatus {
@@ -53,7 +69,7 @@ impl RpcHealth {
             return RpcHealthStatus::Ok;
         }
 
-        // A node can observe votes by both replaying blocks and observing gossip.
+        // Before Alpenglow, a node can observe votes by both replaying blocks and observing gossip.
         //
         // ClusterInfoVoteListener receives votes from both of these sources and then records
         // optimistically confirmed slots in the Blockstore via OptimisticConfirmationVerifier.
@@ -75,32 +91,43 @@ impl RpcHealth {
             .bank
             .slot();
 
-        let mut optimistic_slot_infos = match self.blockstore.get_latest_optimistic_slots(1) {
-            Ok(infos) => infos,
-            Err(err) => {
-                warn!("health check: blockstore error: {err}");
+        // Under Alpenglow, Votor may observe a finalization certificate before this node has
+        // replayed and rooted the corresponding block. Before Alpenglow, use the latest optimistic
+        // slot observed through gossip.
+        let cluster_latest_slot = if self.migration_status.is_alpenglow_enabled() {
+            let Some(slot) = self.highest_finalized_slot() else {
+                warn!("health check: Votor has not observed a finalized slot");
                 return RpcHealthStatus::Unknown;
-            }
-        };
-        let Some((cluster_latest_optimistically_confirmed_slot, _, _)) =
-            optimistic_slot_infos.pop()
-        else {
-            warn!("health check: blockstore does not contain any optimistically confirmed slots");
-            return RpcHealthStatus::Unknown;
+            };
+            slot
+        } else {
+            let mut optimistic_slot_infos = match self.blockstore.get_latest_optimistic_slots(1) {
+                Ok(infos) => infos,
+                Err(err) => {
+                    warn!("health check: blockstore error: {err}");
+                    return RpcHealthStatus::Unknown;
+                }
+            };
+            let Some((slot, _, _)) = optimistic_slot_infos.pop() else {
+                warn!(
+                    "health check: blockstore does not contain any optimistically confirmed slots"
+                );
+                return RpcHealthStatus::Unknown;
+            };
+            slot
         };
 
         if my_latest_optimistically_confirmed_slot
-            >= cluster_latest_optimistically_confirmed_slot
-                .saturating_sub(self.health_check_slot_distance)
+            >= cluster_latest_slot.saturating_sub(self.health_check_slot_distance)
         {
             RpcHealthStatus::Ok
         } else {
-            let num_slots = cluster_latest_optimistically_confirmed_slot
-                .saturating_sub(my_latest_optimistically_confirmed_slot);
+            let num_slots =
+                cluster_latest_slot.saturating_sub(my_latest_optimistically_confirmed_slot);
             warn!(
                 "health check: behind by {num_slots} slots: \
                  me={my_latest_optimistically_confirmed_slot}, latest \
-                 cluster={cluster_latest_optimistically_confirmed_slot}",
+                 cluster={cluster_latest_slot}",
             );
             RpcHealthStatus::Behind { num_slots }
         }
@@ -114,6 +141,8 @@ impl RpcHealth {
         Arc::new(Self::new(
             optimistically_confirmed_bank,
             blockstore,
+            Arc::default(),
+            Arc::default(),
             42,
             Arc::new(AtomicBool::new(false)),
         ))
@@ -129,6 +158,7 @@ impl RpcHealth {
 pub mod tests {
     use {
         super::*,
+        agave_votor_messages::{certificate::FastFinalizeCert, consensus_message::Block},
         solana_clock::UnixTimestamp,
         solana_hash::Hash,
         solana_ledger::{
@@ -150,6 +180,8 @@ pub mod tests {
         let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>> = Arc::default();
+        let migration_status = Arc::new(MigrationStatus::default());
         let bank0 = bank_forks.read().unwrap().root_bank();
         assert!(bank0.slot() == 0);
 
@@ -158,6 +190,8 @@ pub mod tests {
         let health = RpcHealth::new(
             optimistically_confirmed_bank.clone(),
             blockstore.clone(),
+            highest_finalized.clone(),
+            migration_status.clone(),
             health_check_slot_distance,
             override_health_check.clone(),
         );
@@ -180,7 +214,11 @@ pub mod tests {
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 15 });
 
         // Simulate this node observing slot 4 as optimistically confirmed - status still behind
-        let bank4 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 4));
+        let bank4 = Arc::new(Bank::new_from_parent(
+            bank0.clone(),
+            SlotLeader::default(),
+            4,
+        ));
         optimistically_confirmed_bank.write().unwrap().bank = bank4.clone();
         assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 11 });
 
@@ -200,6 +238,34 @@ pub mod tests {
         // OptimisticallyConfirmedBank. Either way, not a problem and status is ok.
         let bank16 = Arc::new(Bank::new_from_parent(bank15, SlotLeader::default(), 16));
         optimistically_confirmed_bank.write().unwrap().bank = bank16.clone();
+        assert_eq!(health.check(), RpcHealthStatus::Ok);
+
+        // Once Alpenglow is enabled, stale optimistic slots must not be used as a fallback.
+        migration_status.enable_alpenglow_for_tests();
+        assert_eq!(health.check(), RpcHealthStatus::Unknown);
+
+        // Votor's highest finalized slot takes precedence over the optimistic Blockstore slot.
+        let mut signature = migration_status
+            .genesis_certificate()
+            .unwrap()
+            .signature
+            .clone();
+        signature.bitmap = vec![0, 0, 0];
+        *highest_finalized.write().unwrap() =
+            Some(ValidatedBlockFinalizationCert::from_validated_fast(
+                FastFinalizeCert {
+                    block: Block {
+                        slot: 30,
+                        block_id: Hash::default(),
+                    },
+                    signature,
+                },
+                &bank0,
+            ));
+        assert_eq!(health.check(), RpcHealthStatus::Behind { num_slots: 14 });
+
+        let bank20 = Arc::new(Bank::new_from_parent(bank16, SlotLeader::default(), 20));
+        optimistically_confirmed_bank.write().unwrap().bank = bank20;
         assert_eq!(health.check(), RpcHealthStatus::Ok);
     }
 }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -13,6 +13,7 @@ use {
         SnapshotInterval, paths as snapshot_paths,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
     },
+    agave_votor_messages::migration::MigrationStatus,
     crossbeam_channel::unbounded,
     jsonrpc_core::{MetaIoHandler, futures::prelude::*},
     jsonrpc_http_server::{
@@ -38,6 +39,7 @@ use {
         bank::Bank, bank_forks::BankForks, commitment::BlockCommitmentCache,
         non_circulating_supply::calculate_non_circulating_supply,
         prioritization_fee_cache::PrioritizationFeeCache,
+        validated_block_finalization::ValidatedBlockFinalizationCert,
     },
     solana_send_transaction_service::{
         send_transaction_service::{self, SendTransactionService},
@@ -486,6 +488,7 @@ pub struct JsonRpcServiceConfig<'a> {
     pub exit: Arc<AtomicBool>,
     pub override_health_check: Arc<AtomicBool>,
     pub optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
+    pub highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
     pub send_transaction_service_config: send_transaction_service::Config,
     pub max_slots: Arc<MaxSlots>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
@@ -558,6 +561,8 @@ impl JsonRpcService {
             config.exit,
             config.override_health_check,
             config.optimistically_confirmed_bank,
+            config.highest_finalized,
+            migration_status,
             config.send_transaction_service_config,
             config.max_slots,
             config.leader_schedule_cache,
@@ -585,6 +590,8 @@ impl JsonRpcService {
         exit: Arc<AtomicBool>,
         override_health_check: Arc<AtomicBool>,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
+        highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
+        migration_status: Arc<MigrationStatus>,
         send_transaction_service_config: send_transaction_service::Config,
         max_slots: Arc<MaxSlots>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
@@ -601,6 +608,8 @@ impl JsonRpcService {
         let health = Arc::new(RpcHealth::new(
             Arc::clone(&optimistically_confirmed_bank),
             Arc::clone(&blockstore),
+            highest_finalized,
+            migration_status,
             config.health_check_slot_distance,
             override_health_check,
         ));
@@ -871,6 +880,7 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+        let migration_status = bank_forks.read().unwrap().migration_status();
         let json_rpc_config = JsonRpcConfig::default();
         let runtime = service_runtime(
             json_rpc_config.rpc_threads,
@@ -904,6 +914,8 @@ mod tests {
             exit,
             Arc::new(AtomicBool::new(false)),
             optimistically_confirmed_bank,
+            Arc::default(),
+            migration_status,
             send_transaction_service_config,
             Arc::new(MaxSlots::default()),
             Arc::new(LeaderScheduleCache::default()),


### PR DESCRIPTION
#### Problem
In Tower, we have our latest frozen bank that is OC vs the highest OC observed through gossip
We use this as our measure for the RPC health check.

In alpenglow we don't have this concept so it doesn't work instead:
- Latest confirmed block is = latest rooted block (frozen + finalized)
- No OC via gossip

#### Summary of Changes
So instead compare our latest confirmed block, to the highest Finalized observed through A2A / block footer
This gives the same semantics as the Tower check and still works regardless of staked/unstaked

#### Testing
Unit Test
