### PR TITLE
svm: slot-based criteria for program cache extract

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -273,7 +273,6 @@ impl Consumer {
                 &mut error_counters,
                 TransactionProcessingConfig {
                     account_overrides: None,
-                    check_program_deployment_slot: bank.check_program_deployment_slot(),
                     log_messages_bytes_limit: self.log_messages_bytes_limit,
                     limit_to_load_programs: true,
                     recording_config: ExecutionRecordingConfig::new_single_setting(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -2053,7 +2053,7 @@ fn load_frozen_forks(
                 progress.num_shreds = u64::from(meta.replay_fec_set_index);
             }
             let mut m = Measure::start("process_single_slot");
-            let bank = bank_forks.write().unwrap().insert_from_ledger(bank);
+            let bank = bank_forks.write().unwrap().insert(bank);
             if let Err(error) = process_single_slot(
                 blockstore,
                 &bank,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -696,7 +696,6 @@ impl PartialEq for Bank {
             accounts_data_size_delta_off_chain: _,
             epoch_reward_status: _,
             transaction_processor: _,
-            check_program_deployment_slot: _,
             collector_fee_details: _,
             compute_budget: _,
             transaction_account_lock_limit: _,
@@ -1018,8 +1017,6 @@ pub struct Bank {
 
     transaction_processor: TransactionBatchProcessor<BankForks>,
 
-    check_program_deployment_slot: bool,
-
     /// Collected fee details
     collector_fee_details: RwLock<CollectorFeeDetails>,
 
@@ -1260,7 +1257,6 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
-            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: None,
             transaction_account_lock_limit: None,
@@ -1527,7 +1523,6 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: parent.epoch_reward_status.clone(),
             transaction_processor,
-            check_program_deployment_slot: false,
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: parent.compute_budget,
             transaction_account_lock_limit: parent.transaction_account_lock_limit,
@@ -1641,7 +1636,6 @@ impl Bank {
                 self.transaction_processor
                     .prepare_one_program_for_upcoming_feature_set(
                         self,
-                        self.check_program_deployment_slot(),
                         &upcoming_environment,
                         &key,
                         &program_to_recompile.stats,
@@ -2182,7 +2176,6 @@ impl Bank {
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             epoch_reward_status: EpochRewardStatus::default(),
             transaction_processor: TransactionBatchProcessor::default(),
-            check_program_deployment_slot: false,
             // collector_fee_details is not serialized to snapshot
             collector_fee_details: RwLock::new(CollectorFeeDetails::default()),
             compute_budget: runtime_config.compute_budget,
@@ -3852,7 +3845,6 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: Some(&account_overrides),
-                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit: None,
                 limit_to_load_programs: true,
                 recording_config: ExecutionRecordingConfig {
@@ -4615,7 +4607,6 @@ impl Bank {
             &mut TransactionErrorMetrics::default(),
             TransactionProcessingConfig {
                 account_overrides: None,
-                check_program_deployment_slot: self.check_program_deployment_slot,
                 log_messages_bytes_limit,
                 limit_to_load_programs: false,
                 recording_config,
@@ -6539,14 +6530,6 @@ impl Bank {
             return slot_hashes.get(slot).is_some();
         }
         false
-    }
-
-    pub fn check_program_deployment_slot(&self) -> bool {
-        self.check_program_deployment_slot
-    }
-
-    pub fn set_check_program_deployment_slot(&mut self, check: bool) {
-        self.check_program_deployment_slot = check;
     }
 
     pub fn fee_structure(&self) -> &FeeStructure {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -79,7 +79,6 @@ pub struct BankForks {
     root: Slot,
     working_slot: Slot,
     sharable_banks: SharableBanks,
-    highest_slot_at_startup: Slot,
     scheduler_pool: Option<InstalledSchedulerPoolArc>,
 
     /// The status tracker for the Alpenglow migration. Initialized via either
@@ -136,7 +135,6 @@ impl BankForks {
             },
             banks,
             descendants,
-            highest_slot_at_startup: 0,
             scheduler_pool: None,
             migration_status,
         }));
@@ -303,12 +301,8 @@ impl BankForks {
     pub fn insert_with_scheduling_mode(
         &mut self,
         mode: SchedulingMode,
-        mut bank: Bank,
+        bank: Bank,
     ) -> BankWithScheduler {
-        if self.root < self.highest_slot_at_startup {
-            bank.set_check_program_deployment_slot(true);
-        }
-
         let bank = Arc::new(bank);
         let bank = if let Some(scheduler_pool) = &self.scheduler_pool {
             Self::install_scheduler_into_bank(scheduler_pool, mode, bank)
@@ -348,11 +342,6 @@ impl BankForks {
             scheduler_pool.register_timeout_listener(bank_with_scheduler.create_timeout_listener());
         }
         bank_with_scheduler
-    }
-
-    pub fn insert_from_ledger(&mut self, bank: Bank) -> BankWithScheduler {
-        self.highest_slot_at_startup = std::cmp::max(self.highest_slot_at_startup, bank.slot());
-        self.insert(bank)
     }
 
     pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -240,7 +240,6 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
     callbacks: &CB,
     program_cache_for_tx_batch: &ProgramCacheForTxBatch,
     keys: impl Iterator<Item = &'a Pubkey>,
-    check_program_deployment_slot: bool,
 ) -> Vec<ProgramToLoad<'a>> {
     let mut result = Vec::new();
     for account_key in keys {
@@ -276,15 +275,10 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             else {
                 continue;
             };
-            let match_criteria = if check_program_deployment_slot {
-                ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot)
-            } else {
-                ProgramCacheMatchCriteria::NoCriteria
-            };
             result.push(ProgramToLoad {
                 program_id: account_key,
                 loader,
-                match_criteria,
+                match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot),
                 last_modification_slot,
             });
         }
@@ -896,31 +890,6 @@ mod tests {
             &mock_bank,
             &loaded_programs_for_tx_batch,
             sanitized_tx.account_keys().iter(),
-            false,
-        );
-        assert_eq!(
-            missing_programs,
-            &[
-                ProgramToLoad {
-                    program_id: &program_ids[1],
-                    loader: ProgramCacheEntryOwner::LoaderV2,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
-                    last_modification_slot: 0,
-                },
-                ProgramToLoad {
-                    program_id: &program_ids[2],
-                    loader: ProgramCacheEntryOwner::LoaderV3,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
-                    last_modification_slot: 0,
-                },
-            ]
-        );
-
-        let missing_programs = filter_executable_program_accounts(
-            &mock_bank,
-            &loaded_programs_for_tx_batch,
-            sanitized_tx.account_keys().iter(),
-            true,
         );
         assert_eq!(
             missing_programs,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -118,9 +118,6 @@ pub struct TransactionProcessingConfig<'a> {
     /// Encapsulates overridden accounts, typically used for transaction
     /// simulation.
     pub account_overrides: Option<&'a AccountOverrides>,
-    /// Whether or not to check a program's deployment slot when replenishing
-    /// a program cache instance.
-    pub check_program_deployment_slot: bool,
     /// The maximum number of bytes that log messages can consume.
     pub log_messages_bytes_limit: Option<usize>,
     /// Whether to limit the number of programs loaded for the transaction
@@ -535,7 +532,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             &account_loader,
                             &program_cache_for_tx_batch,
                             tx.account_keys().iter(),
-                            config.check_program_deployment_slot,
                         ));
                     execute_timings.saturating_add_in_place(
                         ExecuteTimingType::FilterExecutableUs,
@@ -975,7 +971,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     pub fn prepare_one_program_for_upcoming_feature_set<CB: TransactionProcessingCallback>(
         &self,
         account_loader: &CB,
-        check_program_deployment_slot: bool,
         upcoming_environment: &ProgramRuntimeEnvironment,
         key: &Pubkey,
         stats_of_enqueued_program: &ProgramStatistics,
@@ -985,7 +980,6 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             account_loader,
             &program_cache_for_tx_batch,
             std::iter::once(key),
-            check_program_deployment_slot,
         );
         if missing_programs.is_empty() {
             // Program account was closed

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -117,7 +117,6 @@ fn program_cache_execution(threads: usize) {
                     .program_runtime_environment_for_epoch(processor.epoch.saturating_add(1));
                 processor.prepare_one_program_for_upcoming_feature_set(
                     &account_loader,
-                    false,
                     &upcoming_environment,
                     &program,
                     &ProgramStatistics::default(),


### PR DESCRIPTION
#### Problem
We leverage a `check_program_deployment_slot` flag when a node is catching up, but we should just use it all the time.

#### Summary of Changes
Unwind the plumbing for the configurable `check_program_deployment_slot` and just enable it all the time.

#### Testing
More tests will arrive on the back of this in follow-up, but existing cache & SVM tests cover this a bit.