### PR TITLE
votor: use a BTreeSet for ParentReadyStatus::parents_ready

### DIFF
--- a/votor/src/consensus_pool/parent_ready_tracker.rs
+++ b/votor/src/consensus_pool/parent_ready_tracker.rs
@@ -19,7 +19,10 @@ use {
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
-    std::{collections::HashMap, sync::Arc},
+    std::{
+        collections::{BTreeSet, HashMap},
+        sync::Arc,
+    },
 };
 
 pub(crate) type ParentReady = (Slot, Block);
@@ -61,7 +64,19 @@ struct ParentReadyStatus {
     notar_fallbacks: Vec<Block>,
     /// The parent blocks that achieve parent ready in this slot,
     /// Theses blocks are all potential parents choosable in this slot
-    parents_ready: Vec<Block>,
+    /// Membership is tested on every insertion, and this grows with the length
+    /// of a finalization stall (it is only cleared when the root advances), so
+    /// this is a set rather than a `Vec`: a linear `contains` scan makes the
+    /// per-certificate cost grow with the size of the structure. `BTreeSet`
+    /// gives O(log n) membership and O(log n) access to the lowest-slot parent
+    /// for block production, instead of O(n) for both.
+    ///
+    /// Note this iterates in sorted `Block` order rather than insertion order,
+    /// so `ParentReady` events for a slot are emitted lowest-slot-first. Every
+    /// entry is an equally valid parent, and the previous insertion order was
+    /// certificate-arrival order, i.e. network-timing dependent; sorted order
+    /// is deterministic across nodes.
+    parents_ready: BTreeSet<Block>,
 }
 
 impl ParentReadyTracker {
@@ -79,7 +94,7 @@ impl ParentReadyTracker {
             ParentReadyStatus {
                 skip: false,
                 notar_fallbacks: vec![parent_block],
-                parents_ready: vec![],
+                parents_ready: BTreeSet::new(),
             },
         );
         // Intermediate blocks have skips
@@ -89,7 +104,7 @@ impl ParentReadyTracker {
                 ParentReadyStatus {
                     skip: true,
                     notar_fallbacks: vec![],
-                    parents_ready: vec![parent_block],
+                    parents_ready: BTreeSet::from([parent_block]),
                 },
             );
         }
@@ -99,7 +114,7 @@ impl ParentReadyTracker {
             ParentReadyStatus {
                 skip: false,
                 notar_fallbacks: vec![],
-                parents_ready: vec![parent_block],
+                parents_ready: BTreeSet::from([parent_block]),
             },
         );
 
@@ -152,9 +167,7 @@ impl ParentReadyTracker {
                 self.cluster_info.0.id()
             );
             let status = self.slot_statuses.entry(s).or_default();
-            if !status.parents_ready.contains(&block) {
-                status.parents_ready.push(block);
-
+            if status.parents_ready.insert(block) {
                 // Only notify for parent ready on first leader slots
                 if s.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot) {
                     events.push(VotorEvent::ParentReady {
@@ -221,11 +234,10 @@ impl ParentReadyTracker {
             );
             let status = self.slot_statuses.entry(s).or_default();
             for &block in &potential_parents {
-                if status.parents_ready.contains(&block) {
+                if !status.parents_ready.insert(block) {
                     // We already have this parent ready
                     continue;
                 }
-                status.parents_ready.push(block);
                 // Only notify for parent ready on first leader slots
                 if s.is_multiple_of(NUM_CONSECUTIVE_LEADER_SLOTS.get() as Slot) {
                     events.push(VotorEvent::ParentReady {
@@ -257,7 +269,7 @@ impl ParentReadyTracker {
         match self
             .slot_statuses
             .get(&slot)
-            .and_then(|ss| ss.parents_ready.iter().min().copied())
+            .and_then(|ss| ss.parents_ready.first().copied())
         {
             Some(parent) => BlockProductionParent::Parent(parent),
             None => BlockProductionParent::ParentNotReady,


### PR DESCRIPTION
### Problem

`ParentReadyStatus::parents_ready` accumulates for the duration of a finalization stall. It is only cleared by `set_root`, and its caller `ConsensusPool::maybe_prune` returns early unless the finalized root advances — which by definition it does not while finalization is stalled.

Two costs scale with that accumulation:

- `add_new_skip` copies slot `s-1`'s entire `parents_ready` onto every connected future slot, and each insertion did a linear `contains` scan over a list that is itself growing.
- `block_production_parent` scanned the whole list with `iter().min()`.

So the per-certificate CPU cost grows with the size of the structure. During an extended stall that becomes the dominant cost of processing the very certificates needed to end the stall.

The sibling field `notar_fallbacks` in the same struct is already bounded by `MAX_NOTAR_FALLBACK_BLOCKS`; `parents_ready` has no equivalent bound.

### Change

Switch `parents_ready` from `Vec<Block>` to `BTreeSet<Block>`:

- membership becomes `O(log n)` instead of `O(n)`
- `block_production_parent` uses `first()` instead of `iter().min()`

`Block` derives `Ord` over `(slot, block_id)`, so `first()` selects exactly the same block the previous `min()` did — lowest slot, then lowest block id. Both `contains`-then-`push` sites now use the `bool` returned by `insert()`, so `ParentReady` events are still emitted only for newly added parents, and `highest_with_parent_ready` is updated under the same conditions as before.

### Behaviour note

The copy-forward loop now iterates in sorted `Block` order rather than insertion order, so `ParentReady` events for a slot are emitted lowest-slot-first.

Every entry is an equally valid parent, and the previous ordering was certificate-arrival order — i.e. network-timing dependent and potentially different on every node — so sorted order is deterministic across nodes rather than less so. Flagging it explicitly since it is an observable change and current tests do not cover event-order-dependent competing forks.

### Scope

This addresses the CPU cost only. `parents_ready` still grows quadratically in the length of a stall.

I did not attempt a memory bound because it is not obviously behaviour-preserving: each distinct parent emits its own `VotorEvent::ParentReady`, and slot `s`'s set is propagated forward to build slot `s+1`'s, so discarding entries would drop events and alter what downstream slots observe. Which parents are safely discardable — and how deep a stall the tracker should usefully support — seemed like a question for maintainers rather than something to decide in this PR. Happy to follow up if there is a preferred direction.

Related context: `vote_history_storage.rs` models a 30,000-slot no-finalization stall (`MAX_SLOTS_WITHOUT_FINALIZATION`) for `VoteHistory`, which records parent-ready state only at leader-window starts. `ParentReadyTracker` records every slot — as noted in the existing TODO at the top of `ParentReadyStatus`.

### Testing

All 66 existing `consensus_pool` tests pass unchanged, including `pick_more_skips` and `test_too_many_notar_fallback_blocks`:

```
cargo test -p agave-votor --lib --features agave-unstable-api,dev-context-only-utils consensus_pool
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 70 filtered out
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
