### PR TITLE
blockstore: only mark slot dead for Original column

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1603,13 +1603,16 @@ impl Blockstore {
         self.perf_samples_cf.submit_rocksdb_cf_metrics();
     }
 
-    /// If the block is not full, mark the slot as dead
+    /// If the original block is not full, mark the slot as dead
     fn mark_slot_dead_if_not_full(
         &self,
         slot: Slot,
         location: BlockLocation,
         shred_insertion_tracker: &mut ShredInsertionTracker,
     ) {
+        if !matches!(location, BlockLocation::Original) {
+            return;
+        }
         let mark_slot_dead = shred_insertion_tracker
             .slot_meta_working_set
             .get(&(location, slot))

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -2398,11 +2398,21 @@ fn test_mark_slot_dead_if_not_full() {
     blockstore.insert_shreds(shreds, false).unwrap();
     assert!(blockstore.meta(full_slot).unwrap().unwrap().is_full());
 
+    let alternate_slot = 15;
+    let alternate_location = BlockLocation::Alternate {
+        block_id: Hash::new_unique(),
+    };
+
     let mut shred_insertion_tracker = ShredInsertionTracker::new(1, blockstore.db.batch().unwrap());
 
     blockstore.mark_slot_dead_if_not_full(empty_slot, location, &mut shred_insertion_tracker);
     blockstore.mark_slot_dead_if_not_full(partial_slot, location, &mut shred_insertion_tracker);
     blockstore.mark_slot_dead_if_not_full(full_slot, location, &mut shred_insertion_tracker);
+    blockstore.mark_slot_dead_if_not_full(
+        alternate_slot,
+        alternate_location,
+        &mut shred_insertion_tracker,
+    );
     // Commit the write batch so state changes can be read back
     blockstore
         .write_batch(shred_insertion_tracker.write_batch)
@@ -2410,6 +2420,7 @@ fn test_mark_slot_dead_if_not_full() {
     assert!(blockstore.is_dead(empty_slot));
     assert!(blockstore.is_dead(partial_slot));
     assert!(!blockstore.is_dead(full_slot));
+    assert!(!blockstore.is_dead(alternate_slot));
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
As found by the bug bounty report.

Dead slots are only used for replay (the Original column).

Alternate columns cannot normally be marked as dead, because the shreds are verified on ingest with merkle proofs.
However there is one case where it could be marked as dead here for simply being late:
https://github.com/anza-xyz/agave/blob/aedfd0562a9cd46de1b43f3e8f332f2e5a8455b3/ledger/src/blockstore.rs#L6452-L6454

This doesn't matter because if the root has advanced this slot is not needed anyway. However we use `mark_slot_dead_if_not_full` which uses the *Alternate* column's slot meta to check full, causing the rooted slot to be marked dead post fact.

#### Summary of Changes
Instead only allow `mark_slot_dead_if_not_full` for original blocks. This covers us against the late clause and prevents future foot guns which could lead to a rooted slot being marked dead