### PR TITLE
blockstore: avoid allocations/page faults by reusing pinnable slices

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2829,10 +2829,11 @@ fn cleanup_blockstore_incorrect_shred_versions(
             let mut print_timer = Instant::now();
             let mut num_slots_copied = 0;
             let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
+            let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
             for (slot, _meta) in slot_meta_iterator {
                 let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
-                let _ = backup_blockstore.insert_cow_shreds(shreds, true);
+                let _ = backup_blockstore.insert_cow_shreds(shreds, true, &mut pinnable_slice);
                 num_slots_copied += 1;
 
                 if print_timer.elapsed() > PRINT_INTERVAL {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -20,6 +20,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
+        blockstore_db::DBPinnableSlice,
         blockstore_meta::BlockLocation,
         shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
@@ -206,11 +207,12 @@ fn run_check_duplicate(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn run_insert<F>(
+fn run_insert<'db, F>(
     thread_pool: &ThreadPool,
     verified_receiver: &Receiver<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
-    blockstore: &Blockstore,
+    blockstore: &'db Blockstore,
     shred_recovery_context: &mut ShredRecoveryContext,
+    pinnable_slice: &mut DBPinnableSlice<'db>,
     handle_duplicate: F,
     metrics: &mut BlockstoreInsertionMetrics,
     ws_metrics: &mut WindowServiceMetrics,
@@ -247,6 +249,7 @@ where
         shreds,
         false, // is_trusted
         shred_recovery_context,
+        pinnable_slice,
         &handle_duplicate,
         metrics,
     )?;
@@ -436,6 +439,7 @@ impl WindowService {
                     sharable_banks.root(),
                     shred_version,
                 );
+                let mut pinnable_slice = blockstore.new_pinnable_slice();
 
                 while !exit.load(Ordering::Relaxed) {
                     shred_recovery_context.maybe_update(sharable_banks.root());
@@ -445,6 +449,7 @@ impl WindowService {
                         &verified_receiver,
                         &blockstore,
                         &mut shred_recovery_context,
+                        &mut pinnable_slice,
                         handle_duplicate,
                         &mut metrics,
                         &mut ws_metrics,

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -626,6 +626,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 arg_matches,
                 AccessType::PrimaryForMaintenance,
             );
+            let mut pinnable_slice = target.new_pinnable_slice();
 
             for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
                 if slot > ending_slot {
@@ -633,7 +634,10 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 }
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
-                if target.insert_cow_shreds(shreds, true).is_err() {
+                if target
+                    .insert_cow_shreds(shreds, true, &mut pinnable_slice)
+                    .is_err()
+                {
                     warn!("error inserting shreds for slot {slot}");
                 }
             }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2440,8 +2440,13 @@ fn main() {
                                 arg_matches,
                                 AccessType::PrimaryForMaintenance,
                             ));
+                            let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
                             let _ = backup_blockstore
-                                .insert_cow_shreds(shreds.into_iter().map(Cow::Owned), true)
+                                .insert_cow_shreds(
+                                    shreds.into_iter().map(Cow::Owned),
+                                    true,
+                                    &mut pinnable_slice,
+                                )
                                 .expect("Blockstore operation must succeed");
 
                             // Purge modifies state so use rw_blockstore
@@ -2481,8 +2486,9 @@ fn main() {
                             .filter(Shred::is_data)
                             .map(Cow::Owned)
                             .collect();
+                        let mut pinnable_slice = rw_blockstore.new_pinnable_slice();
                         rw_blockstore
-                            .insert_cow_shreds(shreds, true)
+                            .insert_cow_shreds(shreds, true, &mut pinnable_slice)
                             .expect("Blockstore operation must succeed");
                     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -989,6 +989,7 @@ impl Blockstore {
         false
     }
 
+    #[cfg(test)]
     fn erasure_meta(&self, erasure_set: ErasureSetId) -> Result<Option<ErasureMeta>> {
         let (slot, fec_set_index) = erasure_set.store_key();
         self.erasure_meta_cf.get((slot, u64::from(fec_set_index)))
@@ -1634,13 +1635,14 @@ impl Blockstore {
 
     /// Attempts to insert shreds into blockstore and updates relevant metrics
     /// based on the results, split out by shred source (turbine vs. repair).
-    fn attempt_shred_insertion<'a>(
-        &self,
+    fn attempt_shred_insertion<'a, 'db>(
+        &'db self,
         shreds: impl IntoIterator<
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
         is_trusted: bool,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) {
@@ -1662,6 +1664,7 @@ impl Blockstore {
                         shred_insertion_tracker,
                         is_trusted,
                         shred_source,
+                        pinnable_slice,
                     ) {
                         Err(InsertDataShredError::Exists) => {
                             if is_repaired {
@@ -1699,6 +1702,7 @@ impl Blockstore {
                         shred_insertion_tracker,
                         is_trusted,
                         shred_source,
+                        pinnable_slice,
                     ) {
                         Err(InsertCodingShredError::Exists) => {
                             metrics.num_coding_shreds_exists += 1;
@@ -1799,9 +1803,10 @@ impl Blockstore {
     /// 3. Send for retransmit.
     ///
     /// Note: We only perform recovery for the Original shred column
-    fn handle_shred_recovery(
-        &self,
+    fn handle_shred_recovery<'db>(
+        &'db self,
         shred_recovery_context: &mut ShredRecoveryContext,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         shred_insertion_tracker: &mut ShredInsertionTracker,
         is_trusted: bool,
         metrics: &mut BlockstoreInsertionMetrics,
@@ -1824,6 +1829,7 @@ impl Blockstore {
                 shred_insertion_tracker,
                 is_trusted,
                 ShredSource::Recovered,
+                pinnable_slice,
             ) {
                 Err(InsertDataShredError::Exists) => &mut metrics.num_recovered_exists,
                 Err(InsertDataShredError::InvalidShred) => {
@@ -2194,13 +2200,14 @@ impl Blockstore {
     ///    integrity checks.
     ///  - `shred_recovery_context`: recovery-time dependencies and policy for
     ///    erasure recovery. `None` disables recovery.
+    ///  - `pinnable_slice`: reusable RocksDB pinnable slice.
     ///  - `metrics`: the metric for reporting detailed stats
     ///
     /// On success, the function returns an Ok result with a vector of
     /// `CompletedDataSetInfo` and a vector of its corresponding index in the
     /// input `shreds` vector.
-    fn do_insert_shreds<'a>(
-        &self,
+    fn do_insert_shreds<'a, 'db>(
+        &'db self,
         shreds: impl IntoIterator<
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
@@ -2212,6 +2219,7 @@ impl Blockstore {
         // from another leader, we need to try erasure recovery and retransmit
         // recovered shreds.
         shred_recovery_context: Option<&mut ShredRecoveryContext>,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<InsertResults> {
         let mut total_start = Measure::start("Total elapsed");
@@ -2227,6 +2235,7 @@ impl Blockstore {
             shreds,
             is_trusted,
             shred_recovery_context,
+            pinnable_slice,
             metrics,
         );
 
@@ -2238,8 +2247,8 @@ impl Blockstore {
     }
 
     /// Core shred insertion logic.
-    fn do_insert_shreds_locked<'a>(
-        &self,
+    fn do_insert_shreds_locked<'a, 'db>(
+        &'db self,
         _insert_shreds_lock: &MutexGuard<'_, ()>,
         shreds: impl IntoIterator<
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
@@ -2247,16 +2256,24 @@ impl Blockstore {
         >,
         is_trusted: bool,
         shred_recovery_context: Option<&mut ShredRecoveryContext>,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<InsertResults> {
         let shreds = shreds.into_iter();
         let mut shred_insertion_tracker =
             ShredInsertionTracker::new(shreds.len(), self.get_write_batch()?);
 
-        self.attempt_shred_insertion(shreds, is_trusted, &mut shred_insertion_tracker, metrics);
+        self.attempt_shred_insertion(
+            shreds,
+            is_trusted,
+            pinnable_slice,
+            &mut shred_insertion_tracker,
+            metrics,
+        );
         if let Some(shred_recovery_context) = shred_recovery_context {
             self.handle_shred_recovery(
                 shred_recovery_context,
+                pinnable_slice,
                 &mut shred_insertion_tracker,
                 is_trusted,
                 metrics,
@@ -2327,12 +2344,14 @@ impl Blockstore {
     where
         F: Fn(PossibleDuplicateShred),
     {
+        let mut pinnable_slice = self.new_pinnable_slice();
         self.insert_shreds_at_location_handle_duplicate(
             shreds
                 .into_iter()
                 .map(|(shred, is_repaired)| (shred, is_repaired, BlockLocation::Original)),
             is_trusted,
             shred_recovery_context,
+            &mut pinnable_slice,
             handle_duplicate,
             metrics,
         )
@@ -2343,14 +2362,16 @@ impl Blockstore {
     /// Additionally attempts to recover and retransmit recovered shreds (also identifying
     /// and handling duplicate shreds). Broadcast stage should instead call
     /// Blockstore::insert_shreds when inserting own shreds during leader slots.
-    pub fn insert_shreds_at_location_handle_duplicate<'a, F>(
-        &self,
+    /// The pinnable slice can be reused across calls.
+    pub fn insert_shreds_at_location_handle_duplicate<'a, 'db, F>(
+        &'db self,
         shreds: impl IntoIterator<
             Item = (Cow<'a, Shred>, /*is_repaired:*/ bool, BlockLocation),
             IntoIter: ExactSizeIterator,
         >,
         is_trusted: bool,
         shred_recovery_context: &mut ShredRecoveryContext,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         handle_duplicate: &F,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<Vec<CompletedDataSetInfo>>
@@ -2360,7 +2381,13 @@ impl Blockstore {
         let InsertResults {
             completed_data_set_infos,
             duplicate_shreds,
-        } = self.do_insert_shreds(shreds, is_trusted, Some(shred_recovery_context), metrics)?;
+        } = self.do_insert_shreds(
+            shreds,
+            is_trusted,
+            Some(shred_recovery_context),
+            pinnable_slice,
+            metrics,
+        )?;
 
         for shred in duplicate_shreds {
             handle_duplicate(shred);
@@ -2428,12 +2455,13 @@ impl Blockstore {
 
     /// Helper to copy shreds from one location to another.
     /// Reads all data shreds from `from_location` and inserts them at `to_location`.
-    fn copy_shreds_locked(
-        &self,
+    fn copy_shreds_locked<'db>(
+        &'db self,
         lock: &std::sync::MutexGuard<'_, ()>,
         slot: Slot,
         from_location: BlockLocation,
         to_location: BlockLocation,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> Result<()> {
         let shreds = self.get_data_shreds_for_slot_from_location(
             slot,
@@ -2449,6 +2477,7 @@ impl Blockstore {
             shreds,
             true, // is_trusted
             None, // should_recover_shreds
+            pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )?;
 
@@ -2481,6 +2510,7 @@ impl Blockstore {
 
         let (_switch_block_lock, switch_lock_time_us) = measure_us!(self.switch_block_lock.lock());
         let (lock, insert_lock_time_us) = measure_us!(self.insert_shreds_lock.lock().unwrap());
+        let mut pinnable_slice = self.new_pinnable_slice();
         metrics.lock_elapsed_us = switch_lock_time_us.saturating_add(insert_lock_time_us);
 
         // 1. Backup the original block if needed
@@ -2491,7 +2521,13 @@ impl Blockstore {
                 .get_double_merkle_root(slot, backup_location)?
                 .is_none()
             {
-                self.copy_shreds_locked(&lock, slot, BlockLocation::Original, backup_location)?;
+                self.copy_shreds_locked(
+                    &lock,
+                    slot,
+                    BlockLocation::Original,
+                    backup_location,
+                    &mut pinnable_slice,
+                )?;
             }
         }
         backup_measure.stop();
@@ -2518,7 +2554,13 @@ impl Blockstore {
             .expect("Alternate slot must have SlotMeta");
         debug_assert!(alt_meta.is_full(), "Alternate slot must be full");
 
-        self.copy_shreds_locked(&lock, slot, from_location, BlockLocation::Original)?;
+        self.copy_shreds_locked(
+            &lock,
+            slot,
+            from_location,
+            BlockLocation::Original,
+            &mut pinnable_slice,
+        )?;
         copy_measure.stop();
         metrics.copy_elapsed_us = copy_measure.as_us();
 
@@ -2538,10 +2580,11 @@ impl Blockstore {
 
     // Bypasses erasure recovery becuase it is called from broadcast stage
     // when inserting own shreds during leader slots. Stores all shreds in the original column.
-    pub fn insert_cow_shreds<'a>(
-        &self,
+    pub fn insert_cow_shreds<'a, 'db>(
+        &'db self,
         shreds: impl IntoIterator<Item = Cow<'a, Shred>, IntoIter: ExactSizeIterator>,
         is_trusted: bool,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let shreds = shreds
             .into_iter()
@@ -2550,6 +2593,7 @@ impl Blockstore {
             shreds,
             is_trusted,
             None, // Skip recovery for locally produced shreds.
+            pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )?;
         Ok(insert_results.completed_data_set_infos)
@@ -2561,12 +2605,14 @@ impl Blockstore {
         shreds: impl IntoIterator<Item = Shred, IntoIter: ExactSizeIterator>,
         is_trusted: bool,
     ) -> Result<Vec<CompletedDataSetInfo>> {
+        let mut pinnable_slice = self.new_pinnable_slice();
         let shreds = shreds.into_iter().map(Cow::Owned);
-        self.insert_cow_shreds(shreds, is_trusted)
+        self.insert_cow_shreds(shreds, is_trusted, &mut pinnable_slice)
     }
 
     #[cfg(test)]
     fn insert_shred_return_duplicate(&self, shred: Shred) -> Vec<PossibleDuplicateShred> {
+        let mut pinnable_slice = self.new_pinnable_slice();
         let insert_results = self
             .do_insert_shreds(
                 [(
@@ -2576,6 +2622,7 @@ impl Blockstore {
                 )],
                 false,
                 None, // Skip recovery for this direct insertion path.
+                &mut pinnable_slice,
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();
@@ -2602,13 +2649,14 @@ impl Blockstore {
     /// - `shred_insertion_tracker`: collection of shred insertion tracking data.
     /// - `is_trusted`: if false, duplicate and integrity checks are applied.
     /// - `shred_source`: the source of the shred.
-    /// - `metrics`: insertion metrics to update.
-    fn check_insert_coding_shred<'a>(
-        &self,
+    /// - `pinnable_slice`: reusable RocksDB pinnable slice.
+    fn check_insert_coding_shred<'a, 'db>(
+        &'db self,
         shred: Cow<'a, Shred>,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         is_trusted: bool,
         shred_source: ShredSource,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> std::result::Result<(), InsertCodingShredError> {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
@@ -2629,6 +2677,7 @@ impl Blockstore {
             BlockLocation::Original,
             index_working_set,
             index_meta_time_us,
+            pinnable_slice,
         )?;
 
         let index_meta = &mut index_meta_working_set_entry.index;
@@ -2636,7 +2685,10 @@ impl Blockstore {
 
         if let HashMapEntry::Vacant(entry) =
             merkle_root_metas.entry((BlockLocation::Original, erasure_set))
-            && let Some(meta) = self.merkle_root_meta(erasure_set).unwrap()
+            && let Some(meta) = self
+                .merkle_root_meta_cf
+                .get_with_pinnable_slice(erasure_set.store_key(), pinnable_slice)
+                .unwrap()
         {
             entry.insert(WorkingEntry::Clean(meta));
         }
@@ -2673,7 +2725,9 @@ impl Blockstore {
         }
 
         let erasure_meta_entry = erasure_metas.entry(erasure_set).or_insert_with(|| {
-            self.erasure_meta(erasure_set)
+            let (slot, fec_set_index) = erasure_set.store_key();
+            self.erasure_meta_cf
+                .get_with_pinnable_slice((slot, u64::from(fec_set_index)), pinnable_slice)
                 .expect("Expect database get to succeed")
                 .map(WorkingEntry::Clean)
                 .unwrap_or_else(|| {
@@ -2820,13 +2874,15 @@ impl Blockstore {
     /// - `is_trusted`: if false, this function will check whether the
     ///   input shred is duplicate.
     /// - `shred_source`: the source of the shred.
-    fn check_insert_data_shred<'a>(
-        &self,
+    /// - `pinnable_slice`: reusable RocksDB pinnable slice.
+    fn check_insert_data_shred<'a, 'db>(
+        &'db self,
         shred: Cow<'a, Shred>,
         location: BlockLocation,
         shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
         is_trusted: bool,
         shred_source: ShredSource,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> std::result::Result<(), InsertDataShredError> {
         let slot = shred.slot();
         let shred_index = u64::from(shred.index());
@@ -2849,21 +2905,39 @@ impl Blockstore {
             newly_completed_data_sets,
         } = shred_insertion_tracker;
 
-        let index_meta_working_set_entry =
-            self.get_index_meta_entry(slot, location, index_working_set, index_meta_time_us)?;
+        let index_meta_working_set_entry = self.get_index_meta_entry(
+            slot,
+            location,
+            index_working_set,
+            index_meta_time_us,
+            pinnable_slice,
+        )?;
         let index_meta = &mut index_meta_working_set_entry.index;
         let shred_parent_slot = shred
             .parent()
             .map_err(|_| InsertDataShredError::InvalidShred)?;
-        let slot_meta_entry =
-            self.get_slot_meta_entry(slot_meta_working_set, slot, location, shred_parent_slot)?;
+        let slot_meta_entry = self.get_slot_meta_entry(
+            slot_meta_working_set,
+            slot,
+            location,
+            shred_parent_slot,
+            pinnable_slice,
+        )?;
 
         let slot_meta = &mut slot_meta_entry.new_slot_meta.borrow_mut();
         let erasure_set = shred.erasure_set();
         if let HashMapEntry::Vacant(entry) = merkle_root_metas.entry((location, erasure_set))
-            && let Some(meta) = self
-                .merkle_root_meta_from_location(erasure_set, location)
-                .unwrap()
+            && let Some(meta) = match location {
+                BlockLocation::Original => self
+                    .merkle_root_meta_cf
+                    .get_with_pinnable_slice(erasure_set.store_key(), pinnable_slice),
+                BlockLocation::Alternate { block_id } => {
+                    let (slot, fec_set_index) = erasure_set.store_key();
+                    self.alt_merkle_root_meta_cf
+                        .get_with_pinnable_slice((slot, block_id, fec_set_index), pinnable_slice)
+                }
+            }
+            .unwrap()
         {
             entry.insert(WorkingEntry::Clean(meta));
         }
@@ -2965,7 +3039,12 @@ impl Blockstore {
         index_meta_working_set_entry.did_insert_occur = true;
         slot_meta_entry.did_insert_occur = true;
         if let BTreeMapEntry::Vacant(entry) = erasure_metas.entry(erasure_set)
-            && let Some(meta) = self.erasure_meta(erasure_set).unwrap()
+            && let Some(meta) = {
+                let (slot, fec_set_index) = erasure_set.store_key();
+                self.erasure_meta_cf
+                    .get_with_pinnable_slice((slot, u64::from(fec_set_index)), pinnable_slice)
+                    .unwrap()
+            }
         {
             entry.insert(WorkingEntry::Clean(meta));
         }
@@ -5918,18 +5997,26 @@ impl Blockstore {
     ///
     /// This function returns the matched `SlotMetaWorkingSetEntry`.  If such entry
     /// does not exist in the database, a new entry will be created.
-    fn get_slot_meta_entry<'a>(
-        &self,
+    fn get_slot_meta_entry<'a, 'db>(
+        &'db self,
         slot_meta_working_set: &'a mut HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         slot: Slot,
         location: BlockLocation,
         parent_slot: Slot,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> Result<&'a mut SlotMetaWorkingSetEntry> {
         // Check if we've already inserted the slot metadata for this shred's slot
         let entry = match slot_meta_working_set.entry((location, slot)) {
             HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             HashMapEntry::Vacant(vacant_entry) => {
-                let meta = self.meta_from_location(slot, location)?;
+                let meta = match location {
+                    BlockLocation::Original => {
+                        self.meta_cf.get_with_pinnable_slice(slot, pinnable_slice)?
+                    }
+                    BlockLocation::Alternate { block_id } => self
+                        .alt_meta_cf
+                        .get_with_pinnable_slice((slot, block_id), pinnable_slice)?,
+                };
                 // Insert a new 2-tuple of the metadata (working copy, backup copy)
                 let slot_meta_entry = if let Some(mut meta) = meta {
                     let backup = Some(meta.clone());
@@ -5995,20 +6082,27 @@ impl Blockstore {
         Ok(insert_map.get(&slot).unwrap().clone())
     }
 
-    fn get_index_meta_entry<'a>(
-        &self,
+    fn get_index_meta_entry<'a, 'db>(
+        &'db self,
         slot: Slot,
         location: BlockLocation,
         index_working_set: &'a mut HashMap<(BlockLocation, u64), IndexMetaWorkingSetEntry>,
         index_meta_time_us: &mut u64,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
     ) -> Result<&'a mut IndexMetaWorkingSetEntry> {
         let mut total_start = Measure::start("Total elapsed");
         let index_meta_entry = match index_working_set.entry((location, slot)) {
             HashMapEntry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             HashMapEntry::Vacant(vacant_entry) => {
-                let index = self
-                    .get_index_from_location(slot, location)?
-                    .unwrap_or_else(|| Index::new(slot));
+                let index = match location {
+                    BlockLocation::Original => self
+                        .index_cf
+                        .get_with_pinnable_slice(slot, pinnable_slice)?,
+                    BlockLocation::Alternate { block_id } => self
+                        .alt_index_cf
+                        .get_with_pinnable_slice((slot, block_id), pinnable_slice)?,
+                }
+                .unwrap_or_else(|| Index::new(slot));
                 let index_entry = IndexMetaWorkingSetEntry {
                     index,
                     did_insert_occur: false,

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -1860,6 +1860,7 @@ fn test_is_data_shred_present() {
 fn test_merkle_root_metas_coding() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let parent_slot = 0;
     let slot = 1;
@@ -1875,6 +1876,7 @@ fn test_merkle_root_metas_coding() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         )
         .unwrap();
     let ShredInsertionTracker {
@@ -1931,6 +1933,7 @@ fn test_merkle_root_metas_coding() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         ),
         Err(InsertCodingShredError::InvalidShred)
     ));
@@ -1996,6 +1999,7 @@ fn test_merkle_root_metas_coding() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         )
         .unwrap();
 
@@ -2045,6 +2049,7 @@ fn test_merkle_root_metas_coding() {
 fn test_merkle_root_metas_data() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let parent_slot = 0;
     let slot = 1;
@@ -2062,6 +2067,7 @@ fn test_merkle_root_metas_data() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         )
         .unwrap();
     let ShredInsertionTracker {
@@ -2117,6 +2123,7 @@ fn test_merkle_root_metas_data() {
         &mut shred_insertion_tracker,
         false,
         ShredSource::Turbine,
+        &mut pinnable_slice,
     );
     assert_matches!(
         insert_result.unwrap_err(),
@@ -2211,6 +2218,7 @@ fn test_merkle_root_metas_data() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         )
         .unwrap();
     let ShredInsertionTracker {
@@ -2262,6 +2270,7 @@ fn test_merkle_root_metas_data() {
 fn test_check_insert_coding_shred() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let slot = 1;
     let (_data_shreds, code_shreds) =
@@ -2283,6 +2292,7 @@ fn test_check_insert_coding_shred() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         )
         .unwrap();
 
@@ -2293,6 +2303,7 @@ fn test_check_insert_coding_shred() {
             &mut shred_insertion_tracker,
             false,
             ShredSource::Turbine,
+            &mut pinnable_slice,
         ),
         Err(InsertCodingShredError::Exists)
     ));
@@ -4632,6 +4643,7 @@ fn test_highest_slot() {
 fn test_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4656,6 +4668,7 @@ fn test_recovery() {
                 root_bank,
                 0, // shred_version
             )),
+            &mut pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -4679,6 +4692,7 @@ fn test_recovery() {
 fn test_skip_alt_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4698,6 +4712,7 @@ fn test_skip_alt_recovery() {
             )),
             false, // is_trusted
             None,
+            &mut pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -4724,6 +4739,7 @@ fn test_skip_alt_recovery() {
                 root_bank,
                 0, // shred_version
             )),
+            &mut pinnable_slice,
             &mut metrics,
         )
         .unwrap();
@@ -4751,6 +4767,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
 
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let genesis_config = create_genesis_config(2).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -4820,6 +4837,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
                 root_bank,
                 0, // shred_version
             )),
+            &mut pinnable_slice,
             &mut metrics,
         )
         .unwrap();
@@ -6360,6 +6378,7 @@ fn test_add_transaction_status_to_batch() {
 fn test_get_double_merkle_root(use_alternate_location: bool) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
 
     let parent_slot = 990;
     let parent_block_id = Hash::default();
@@ -6410,6 +6429,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
             shreds,
             false,
             None,
+            &mut pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6506,6 +6526,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
             shreds,
             false,
             None,
+            &mut pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6525,6 +6546,7 @@ fn insert_test_block_at_location(
     parent_slot: Slot,
     location: BlockLocation,
 ) -> (Vec<Shred>, Hash) {
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
     let (data_shreds, _) = setup_erasure_shreds(slot, parent_slot, 200);
     let is_repaired = location != BlockLocation::Original;
     let shreds = data_shreds
@@ -6535,6 +6557,7 @@ fn insert_test_block_at_location(
             shreds,
             false,
             None,
+            &mut pinnable_slice,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6637,6 +6660,7 @@ fn test_block_id_reads_remain_consistent_after_switch() {
 fn test_get_data_shreds_for_slot() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut pinnable_slice = blockstore.new_pinnable_slice();
     let parent_slot = 990;
     let slot = 1000;
     let num_entries = 200;
@@ -6666,6 +6690,7 @@ fn test_get_data_shreds_for_slot() {
                 shreds,
                 false,
                 None,
+                &mut pinnable_slice,
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -929,6 +929,19 @@ where
         self.get_raw(key)
     }
 
+    pub(crate) fn get_with_pinnable_slice<'db>(
+        &'db self,
+        index: C::Index,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
+    ) -> Result<Option<C::Type>> {
+        if !self.get_slice_into(index, pinnable_slice)? {
+            return Ok(None);
+        }
+        let result = C::deserialize(pinnable_slice.as_ref()).map(Some);
+        pinnable_slice.reset();
+        result
+    }
+
     pub fn get_raw<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<C::Type>> {
         let mut result = Ok(None);
         let is_perf_enabled = maybe_enable_rocksdb_perf(

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -24,6 +24,7 @@ use {
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_ledger::{
         blockstore::Blockstore,
+        blockstore_db::DBPinnableSlice,
         leader_schedule_cache::LeaderScheduleCache,
         shred::{MAX_FEC_SETS_PER_SLOT, Shred},
     },
@@ -215,10 +216,11 @@ impl BroadcastStageType {
 }
 
 trait BroadcastRun {
-    fn run(
+    fn run<'db>(
         &mut self,
         keypair: &Keypair,
-        blockstore: &Blockstore,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -230,7 +232,12 @@ trait BroadcastRun {
         sock: BroadcastSocket,
         bank_forks: &RwLock<BankForks>,
     ) -> Result<()>;
-    fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()>;
+    fn record<'db>(
+        &mut self,
+        receiver: &RecordReceiver,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
+    ) -> Result<()>;
 }
 
 // Implement a destructor for the BroadcastStage thread to signal it exited
@@ -265,10 +272,12 @@ impl BroadcastStage {
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         mut broadcast_stage_run: impl BroadcastRun,
     ) -> BroadcastStageReturnType {
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
         loop {
             let res = broadcast_stage_run.run(
                 &cluster_info.keypair(),
                 blockstore,
+                &mut pinnable_slice,
                 receiver,
                 socket_sender,
                 blockstore_sender,
@@ -412,11 +421,18 @@ impl BroadcastStage {
         // Until this changes, only a single inserter thread is necessary.
         thread_hdls.push({
             let blockstore = blockstore.clone();
-            let run_record = move || loop {
-                let res = broadcast_stage_run.record(&blockstore_receiver, &blockstore);
-                let res = Self::handle_error(res, "solana-broadcaster-record");
-                if let Some(res) = res {
-                    return res;
+            let run_record = move || {
+                let mut pinnable_slice = blockstore.new_pinnable_slice();
+                loop {
+                    let res = broadcast_stage_run.record(
+                        &blockstore_receiver,
+                        &blockstore,
+                        &mut pinnable_slice,
+                    );
+                    let res = Self::handle_error(res, "solana-broadcaster-record");
+                    if let Some(res) = res {
+                        return res;
+                    }
                 }
             };
             Builder::new()

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -12,7 +12,7 @@ use {
     solana_signature::Signature,
     solana_signer::Signer,
     solana_system_transaction as system_transaction,
-    std::collections::HashSet,
+    std::{borrow::Cow, collections::HashSet},
 };
 
 pub const MINIMUM_DUPLICATE_SLOT: Slot = 20;
@@ -88,10 +88,11 @@ impl BroadcastDuplicatesRun {
 }
 
 impl BroadcastRun for BroadcastDuplicatesRun {
-    fn run(
+    fn run<'db>(
         &mut self,
         keypair: &Keypair,
-        blockstore: &Blockstore,
+        blockstore: &'db Blockstore,
+        _pinnable_slice: &mut DBPinnableSlice<'db>,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -442,10 +443,15 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         batch_send(sock, packets).map_err(|SendPktsError::IoError(err, _)| Error::Io(err))
     }
 
-    fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {
+    fn record<'db>(
+        &mut self,
+        receiver: &RecordReceiver,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
+    ) -> Result<()> {
         let (all_shreds, _) = receiver.recv()?;
         blockstore
-            .insert_shreds(all_shreds.to_vec(), true)
+            .insert_cow_shreds(all_shreds.iter().map(Cow::Borrowed), true, pinnable_slice)
             .expect("Failed to insert shreds in blockstore");
         Ok(())
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -322,9 +322,11 @@ impl StandardBroadcastRun {
     ) -> Result<()> {
         let (bsend, brecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let (ssend, srecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
         self.process_receive_results(
             keypair,
             blockstore,
+            &mut pinnable_slice,
             &ssend,
             &bsend,
             receive_results,
@@ -332,14 +334,15 @@ impl StandardBroadcastRun {
         )?;
         // Data and coding shreds are sent in a single batch.
         let _ = self.transmit(&srecv, cluster_info, BroadcastSocket::Udp(sock), bank_forks);
-        let _ = self.record(&brecv, blockstore);
+        let _ = self.record(&brecv, blockstore, &mut pinnable_slice);
         Ok(())
     }
 
-    fn process_receive_results(
+    fn process_receive_results<'db>(
         &mut self,
         keypair: &Keypair,
-        blockstore: &Blockstore,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         receive_results: ReceiveResults,
@@ -455,6 +458,7 @@ impl StandardBroadcastRun {
                 .insert_cow_shreds(
                     [Cow::Borrowed(shred)],
                     true, // is_trusted
+                    pinnable_slice,
                 )
                 .expect("Failed to insert shreds in blockstore");
         }
@@ -525,9 +529,10 @@ impl StandardBroadcastRun {
         Ok(())
     }
 
-    fn insert(
+    fn insert<'db>(
         &mut self,
-        blockstore: &Blockstore,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         shreds: Arc<Vec<Shred>>,
         broadcast_shred_batch_info: Option<BroadcastShredBatchInfo>,
     ) {
@@ -543,7 +548,7 @@ impl StandardBroadcastRun {
         let num_shreds = shreds.len();
         let shreds = shreds.iter().skip(offset).map(Cow::Borrowed);
         blockstore
-            .insert_cow_shreds(shreds, /*is_trusted:*/ true)
+            .insert_cow_shreds(shreds, /*is_trusted:*/ true, pinnable_slice)
             .expect("Failed to insert shreds in blockstore");
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
         let new_insert_shreds_stats = InsertShredsStats {
@@ -625,10 +630,11 @@ impl StandardBroadcastRun {
 }
 
 impl BroadcastRun for StandardBroadcastRun {
-    fn run(
+    fn run<'db>(
         &mut self,
         keypair: &Keypair,
-        blockstore: &Blockstore,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -644,6 +650,7 @@ impl BroadcastRun for StandardBroadcastRun {
         self.process_receive_results(
             keypair,
             blockstore,
+            pinnable_slice,
             socket_sender,
             blockstore_sender,
             receive_results,
@@ -660,9 +667,14 @@ impl BroadcastRun for StandardBroadcastRun {
         let (shreds, batch_info) = receiver.recv()?;
         self.broadcast(sock, cluster_info, shreds, batch_info, bank_forks)
     }
-    fn record(&mut self, receiver: &RecordReceiver, blockstore: &Blockstore) -> Result<()> {
+    fn record<'db>(
+        &mut self,
+        receiver: &RecordReceiver,
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
+    ) -> Result<()> {
         let (shreds, slot_start_ts) = receiver.recv()?;
-        self.insert(blockstore, shreds, slot_start_ts);
+        self.insert(blockstore, pinnable_slice, shreds, slot_start_ts);
         Ok(())
     }
 }
@@ -789,6 +801,7 @@ mod test {
         };
         let (socket_sender, _socket_receiver) = bounded(1024);
         let (blockstore_sender, _blockstore_receiver) = bounded(1024);
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
@@ -801,6 +814,7 @@ mod test {
             .process_receive_results(
                 &Keypair::new(),
                 &blockstore,
+                &mut pinnable_slice,
                 &socket_sender,
                 &blockstore_sender,
                 receive_results,
@@ -1024,6 +1038,7 @@ mod test {
         let bank = new_child_bank(&parent_bank, 1);
         let (bsend, brecv) = bounded(1024);
         let (ssend, _srecv) = bounded(1024);
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut last_tick_height = bank.tick_height();
         let mut standard_broadcast_run = StandardBroadcastRun::new(
@@ -1044,6 +1059,7 @@ mod test {
                 .process_receive_results(
                     &leader_keypair,
                     &blockstore,
+                    &mut pinnable_slice,
                     &ssend,
                     &bsend,
                     receive_results,
@@ -1153,12 +1169,14 @@ mod test {
         );
         let (bsend, brecv) = bounded(1024);
         let (ssend, srecv) = bounded(1024);
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
 
         let ticks = create_ticks(1, 0, genesis_config.hash());
         let err = standard_broadcast_run
             .process_receive_results(
                 &leader_keypair,
                 &blockstore,
+                &mut pinnable_slice,
                 &ssend,
                 &bsend,
                 ReceiveResults {
@@ -1176,6 +1194,7 @@ mod test {
             .process_receive_results(
                 &leader_keypair,
                 &blockstore,
+                &mut pinnable_slice,
                 &ssend,
                 &bsend,
                 ReceiveResults {
@@ -1198,6 +1217,7 @@ mod test {
             .process_receive_results(
                 &leader_keypair,
                 &blockstore,
+                &mut pinnable_slice,
                 &ssend,
                 &bsend,
                 ReceiveResults {


### PR DESCRIPTION
A few weeks ago we discovered that `get_pinned*()` don't work the way you'd expect them to work. Each call allocates a new pinnable slice and then the underlying memory incurs in page faults. This creates jemalloc churn and a constant stream of pagefaults which can be avoided. 

I've added APIs to rocks to make it possible to reuse pinnable slices, and this PR plumbs those APIs in the blockstore.

Profiles here https://github.com/facebook/rocksdb/pull/14984