### PR TITLE
(WIP) vat: fix filtering for commissions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -54,7 +54,7 @@ use {
         },
         epoch_stakes::{
             BLSPubkeyToRankMap, DeserializableVersionedEpochStakes, NodeVoteAccounts,
-            VersionedEpochStakes,
+            VersionedEpochStakes, VoteAccountCommission, VoteAccountCommissions,
         },
         inflation_rewards::points::InflationPointCalculationEvent,
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
@@ -1338,10 +1338,21 @@ impl Bank {
         //  slot = 0 and genesis configuration
         {
             let stakes = bank.get_top_epoch_stakes();
+            let leader_schedule_epoch = bank.get_leader_schedule_epoch(bank.slot);
+            let vote_account_commissions = Self::collect_filtered_vote_account_commissions(
+                bank.stakes_cache.stakes().vote_accounts(),
+                stakes.vote_accounts(),
+            );
             let stakes = SerdeStakesToStakeFormat::from(stakes);
-            for epoch in 0..=bank.get_leader_schedule_epoch(bank.slot) {
-                bank.epoch_stakes
-                    .insert(epoch, VersionedEpochStakes::new(stakes.clone(), epoch));
+            for epoch in 0..=leader_schedule_epoch {
+                bank.epoch_stakes.insert(
+                    epoch,
+                    VersionedEpochStakes::new(
+                        stakes.clone(),
+                        epoch,
+                        Some(vote_account_commissions.clone()),
+                    ),
+                );
             }
             bank.update_stake_history(None);
         }
@@ -1733,18 +1744,14 @@ impl Bank {
         // Snapshot of vote account state from the beginning of the epoch prior to
         // the rewarded epoch. This snapshot state is saved a full epoch before
         // being used to prevent last minute commission rugs.
-        let snapshot_epoch_vote_accounts = self
-            .epoch_stakes(rewarded_epoch)
-            .map(|epoch_stakes| epoch_stakes.stakes().vote_accounts());
+        let snapshot_epoch_stakes = self.epoch_stakes(rewarded_epoch);
 
         // Vote account state from the beginning of the rewarded epoch.
-        let rewarded_epoch_vote_accounts = self
-            .epoch_stakes(self.epoch())
-            .map(|epoch_stakes| epoch_stakes.stakes().vote_accounts());
+        let rewarded_epoch_stakes = self.epoch_stakes(self.epoch());
 
         CachedVoteAccounts {
-            snapshot_epoch_vote_accounts,
-            rewarded_epoch_vote_accounts,
+            snapshot_epoch_stakes,
+            rewarded_epoch_stakes,
             distribution_epoch_vote_accounts,
         }
     }
@@ -2621,8 +2628,16 @@ impl Bank {
                 Some(prefiltered) => Stakes::new(prefiltered, self.epoch()),
                 None => self.get_top_epoch_stakes(),
             };
+            let vote_account_commissions = Self::collect_filtered_vote_account_commissions(
+                self.stakes_cache.stakes().vote_accounts(),
+                stakes.vote_accounts(),
+            );
             let stakes = SerdeStakesToStakeFormat::from(stakes);
-            let new_epoch_stakes = VersionedEpochStakes::new(stakes, leader_schedule_epoch);
+            let new_epoch_stakes = VersionedEpochStakes::new(
+                stakes,
+                leader_schedule_epoch,
+                Some(vote_account_commissions),
+            );
             info!(
                 "new epoch stakes, epoch: {}, total_stake: {}",
                 leader_schedule_epoch,
@@ -6720,6 +6735,28 @@ impl Bank {
     pub fn clear_accounts_lt_hash_async_progress_is_at_end(&self) {
         self.accounts_lt_hash_async_progress
             .clear_is_at_end_of_slot();
+    }
+
+    fn collect_filtered_vote_account_commissions(
+        unfiltered_vote_accounts: &VoteAccounts,
+        filtered_vote_accounts: &VoteAccounts,
+    ) -> Arc<VoteAccountCommissions> {
+        Arc::new(
+            unfiltered_vote_accounts
+                .iter()
+                .filter(|(vote_pubkey, _)| filtered_vote_accounts.get(vote_pubkey).is_none())
+                .map(|(vote_pubkey, vote_account)| {
+                    let vote_state = vote_account.vote_state_view();
+                    (
+                        *vote_pubkey,
+                        VoteAccountCommission::new(
+                            vote_state.commission(),
+                            vote_state.inflation_rewards_commission(),
+                        ),
+                    )
+                })
+                .collect(),
+        )
     }
 }
 

--- a/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/calculation.rs
@@ -633,11 +633,8 @@ impl Bank {
             }
         });
 
-        let CachedVoteAccounts {
-            snapshot_epoch_vote_accounts,
-            rewarded_epoch_vote_accounts,
-            distribution_epoch_vote_accounts,
-        } = cached_vote_accounts;
+        let distribution_epoch_vote_accounts =
+            cached_vote_accounts.distribution_epoch_vote_accounts;
 
         let vote_pubkey = stake_account.delegation().voter_pubkey;
 
@@ -706,21 +703,28 @@ impl Bank {
         // When `commission_rate_in_basis_points` is true, use the new field
         // `inflation_rewards_commission_bps`; otherwise use the legacy
         // percentage field and convert to basis points by multiplying by 100.
-        let commission_bps = if delay_commission_updates {
-            let vote_state_for_commission = snapshot_epoch_vote_accounts
-                .and_then(|eva| eva.get(&vote_pubkey))
-                .or_else(|| rewarded_epoch_vote_accounts.and_then(|eva| eva.get(&vote_pubkey)))
-                .map(|vote_account| vote_account.vote_state_view())
-                .unwrap_or(vote_state);
-            if commission_rate_in_basis_points {
-                vote_state_for_commission.inflation_rewards_commission()
-            } else {
-                vote_state_for_commission.commission() as u16 * 100
-            }
-        } else if commission_rate_in_basis_points {
+        let current_commission_bps = if commission_rate_in_basis_points {
             vote_state.inflation_rewards_commission()
         } else {
-            vote_state.commission() as u16 * 100
+            u16::from(vote_state.commission()) * 100
+        };
+        let commission_bps = if delay_commission_updates {
+            cached_vote_accounts
+                .snapshot_epoch_stakes
+                .and_then(|epoch_stakes| {
+                    epoch_stakes.get_commission_bps(&vote_pubkey, commission_rate_in_basis_points)
+                })
+                .or_else(|| {
+                    cached_vote_accounts
+                        .rewarded_epoch_stakes
+                        .and_then(|epoch_stakes| {
+                            epoch_stakes
+                                .get_commission_bps(&vote_pubkey, commission_rate_in_basis_points)
+                        })
+                })
+                .unwrap_or(current_commission_bps)
+        } else {
+            current_commission_bps
         };
 
         match redeem_rewards(
@@ -1381,8 +1385,8 @@ mod tests {
             }
             let distribution_epoch_vote_accounts = VoteAccounts::from(Arc::new(vote_accounts_map));
             let cached_vote_accounts = CachedVoteAccounts {
-                snapshot_epoch_vote_accounts: None,
-                rewarded_epoch_vote_accounts: None,
+                snapshot_epoch_stakes: None,
+                rewarded_epoch_stakes: None,
                 distribution_epoch_vote_accounts: &distribution_epoch_vote_accounts,
             };
 
@@ -2139,6 +2143,217 @@ mod tests {
                 )],
             },
         );
+    }
+
+    #[test_case(false; "tower")]
+    #[test_case(true; "migration_epoch")]
+    fn test_vat_filtered_history_delays_commission(migration: bool) {
+        const HISTORICAL_COMMISSION_BPS: u16 = 500;
+        const CURRENT_COMMISSION_BPS: u16 = 10_000;
+        const MIGRATION_SLOT: u64 = SLOTS_PER_EPOCH + SLOTS_PER_EPOCH / 2 - 1;
+
+        let GenesisConfigInfo {
+            mut genesis_config,
+            mint_keypair,
+            ..
+        } = genesis_utils::create_genesis_config_with_leader(
+            1_000_000 * LAMPORTS_PER_SOL,
+            &Pubkey::new_unique(),
+            42 * LAMPORTS_PER_SOL,
+        );
+        genesis_config.epoch_schedule = EpochSchedule::new(SLOTS_PER_EPOCH);
+        for feature_id in [
+            agave_feature_set::alpenglow::id(),
+            agave_feature_set::bls_pubkey_management_in_vote_account::id(),
+            agave_feature_set::validator_admission_ticket::id(),
+        ] {
+            genesis_utils::activate_feature(&mut genesis_config, feature_id);
+        }
+        deactivate_features(
+            &mut genesis_config,
+            &vec![agave_feature_set::custom_commission_collector::id()],
+        );
+
+        let vote_pubkey = Pubkey::new_unique();
+        let stake_pubkey = Pubkey::new_unique();
+        let authority = Keypair::new();
+        let vote_lamports = genesis_utils::minimum_vote_account_balance_for_vat(100);
+        let stake_lamports = 100_000 * LAMPORTS_PER_SOL;
+        let (bls_pubkey, proof_of_possession) =
+            vote_state::create_bls_pubkey_and_proof_of_possession(&vote_pubkey);
+
+        let edit_vote_state = |account: &mut AccountSharedData, edit: &dyn Fn(&mut VoteStateV4)| {
+            let VoteStateVersions::V4(mut vote_state) =
+                account.deserialize_data::<VoteStateVersions>().unwrap()
+            else {
+                unreachable!();
+            };
+            edit(&mut vote_state);
+            account
+                .serialize_data(&VoteStateVersions::V4(vote_state))
+                .unwrap();
+        };
+        let mut vote_account = vote_state::create_v4_account_with_authorized(
+            &vote_pubkey,
+            &authority.pubkey(),
+            bls_pubkey,
+            &authority.pubkey(),
+            HISTORICAL_COMMISSION_BPS,
+            &vote_pubkey,
+            0,
+            &authority.pubkey(),
+            vote_lamports,
+        );
+        edit_vote_state(&mut vote_account, &|vote_state| {
+            vote_state.bls_pubkey_compressed = None;
+        });
+        genesis_config.accounts.insert(
+            stake_pubkey,
+            stake_utils::create_stake_account(
+                &stake_pubkey,
+                &vote_pubkey,
+                &vote_account,
+                &genesis_config.rent,
+                stake_lamports,
+            )
+            .into(),
+        );
+        genesis_config
+            .accounts
+            .insert(vote_pubkey, vote_account.into());
+
+        let (bank, bank_forks) =
+            Bank::new_for_tests(&genesis_config).wrap_with_bank_forks_for_tests();
+        let next_bank = |bank, slot| {
+            Bank::new_from_parent_with_bank_forks(
+                bank_forks.as_ref(),
+                bank,
+                SlotLeader::new_unique(),
+                slot,
+            )
+        };
+        let send = |bank: &Bank, instruction, authority: &Keypair| {
+            let transaction = solana_transaction::Transaction::new_signed_with_payer(
+                &[instruction],
+                Some(&mint_keypair.pubkey()),
+                &[&mint_keypair, authority],
+                bank.last_blockhash(),
+            );
+            bank.process_transaction(&transaction).unwrap();
+        };
+        let assert_filtered_but_historical = |bank: &Bank, epoch| {
+            let epoch_stakes = bank.epoch_stakes(epoch).unwrap();
+            assert!(
+                epoch_stakes
+                    .stakes()
+                    .vote_accounts()
+                    .get(&vote_pubkey)
+                    .is_none()
+            );
+            assert_eq!(
+                epoch_stakes.get_commission_bps(&vote_pubkey, true),
+                Some(HISTORICAL_COMMISSION_BPS),
+            );
+        };
+
+        assert_filtered_but_historical(&bank, 1);
+        let bank = next_bank(bank, SLOTS_PER_EPOCH);
+        assert_filtered_but_historical(&bank, 2);
+
+        send(
+            &bank,
+            solana_vote_program::vote_instruction::authorize(
+                &vote_pubkey,
+                &authority.pubkey(),
+                &Pubkey::new_unique(),
+                solana_vote_interface::state::VoteAuthorize::VoterWithBLS(
+                    solana_vote_interface::state::VoterWithBLSArgs {
+                        bls_pubkey,
+                        bls_proof_of_possession: proof_of_possession,
+                    },
+                ),
+            ),
+            &authority,
+        );
+        send(
+            &bank,
+            solana_vote_program::vote_instruction::update_commission(
+                &vote_pubkey,
+                &authority.pubkey(),
+                100,
+            ),
+            &authority,
+        );
+        let mut account = bank.get_account(&vote_pubkey).unwrap();
+        edit_vote_state(&mut account, &|vote_state| {
+            assert_eq!(
+                vote_state.inflation_rewards_commission_bps,
+                CURRENT_COMMISSION_BPS,
+            );
+            let old_credits = vote_state.credits();
+            vote_state
+                .epoch_credits
+                .push((1, old_credits + 1_000, old_credits));
+        });
+        bank.store_account(&vote_pubkey, &account);
+
+        let bank = if migration {
+            let bank = next_bank(bank, MIGRATION_SLOT);
+            bank.set_alpenglow_genesis_certificate(
+                &agave_votor_messages::certificate::GenesisCert {
+                    block: agave_votor_messages::consensus_message::Block {
+                        slot: MIGRATION_SLOT,
+                        block_id: solana_hash::Hash::default(),
+                    },
+                    signature: agave_votor_messages::certificate::CertSignature {
+                        signature: solana_bls_signatures::Signature(
+                            [0; solana_bls_signatures::BLS_SIGNATURE_AFFINE_SIZE],
+                        ),
+                        bitmap: vec![],
+                    },
+                },
+            );
+            bank
+        } else {
+            bank
+        };
+        let bank = next_bank(bank, 2 * SLOTS_PER_EPOCH);
+
+        let ag_epoch_type =
+            AlpenglowEpochType::get(&bank, 1, || RewardEpochDelegatedStakes::get(&bank));
+        match (&ag_epoch_type, migration) {
+            (AlpenglowEpochType::Tower, false) => {}
+            (
+                AlpenglowEpochType::MigrationEpoch {
+                    num_tower_slots,
+                    num_ag_slots,
+                    migration_epoch: 1,
+                    ..
+                },
+                true,
+            ) => assert_eq!(
+                (*num_tower_slots, *num_ag_slots),
+                (SLOTS_PER_EPOCH / 2, SLOTS_PER_EPOCH / 2),
+            ),
+            _ => panic!("wrong epoch type for migration={migration}: {ag_epoch_type:?}"),
+        }
+
+        let EpochRewardStatus::Active(EpochRewardPhase::Calculation(calculation)) =
+            &bank.epoch_reward_status
+        else {
+            unreachable!();
+        };
+        let reward = calculation
+            .all_stake_rewards
+            .enumerated_rewards_iter()
+            .find(|(_, reward)| reward.stake_pubkey == stake_pubkey)
+            .map(|(_, reward)| reward)
+            .unwrap();
+        assert_eq!(
+            reward.inflation.commission_bps,
+            Some(HISTORICAL_COMMISSION_BPS),
+        );
+        assert!(reward.inflation.stake_reward > 0);
     }
 
     #[test]

--- a/runtime/src/bank/partitioned_epoch_rewards/mod.rs
+++ b/runtime/src/bank/partitioned_epoch_rewards/mod.rs
@@ -6,8 +6,8 @@ mod sysvar;
 use {
     super::Bank,
     crate::{
-        inflation_rewards::points::PointValue, reward_info::RewardInfo,
-        stake_account::StakeAccount, stake_history::StakeHistory,
+        epoch_stakes::VersionedEpochStakes, inflation_rewards::points::PointValue,
+        reward_info::RewardInfo, stake_account::StakeAccount, stake_history::StakeHistory,
     },
     solana_account::{AccountSharedData, ReadableAccount},
     solana_accounts_db::{
@@ -308,11 +308,11 @@ pub(super) struct CachedVoteAccounts<'a> {
     /// being used to prevent last minute commission rugs.
     ///
     /// Developer note: This field is `Option` to handle large bank warps
-    pub(super) snapshot_epoch_vote_accounts: Option<&'a VoteAccounts>,
+    pub(super) snapshot_epoch_stakes: Option<&'a VersionedEpochStakes>,
     /// Vote account state from the beginning of the rewarded epoch.
     ///
     /// Developer note: This field is `Option` to handle large bank warps
-    pub(super) rewarded_epoch_vote_accounts: Option<&'a VoteAccounts>,
+    pub(super) rewarded_epoch_stakes: Option<&'a VersionedEpochStakes>,
     /// Vote account state from the end of the rewarded epoch / beginning of the
     /// distribution epoch.
     pub(super) distribution_epoch_vote_accounts: &'a VoteAccounts,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -6889,7 +6889,7 @@ fn test_vat_burn_slot_params() {
         let vote_lamports_before = bank.get_balance(&vote_pubkey);
         let incinerator_lamports_before = bank.get_balance(&incinerator::id());
         let stakes = SerdeStakesToStakeFormat::from(bank.get_top_epoch_stakes());
-        let epoch_stakes = VersionedEpochStakes::new(stakes, bank.epoch());
+        let epoch_stakes = VersionedEpochStakes::new(stakes, bank.epoch(), None);
         bank.maybe_burn_vat_from_staked_accounts(&epoch_stakes);
         assert_eq!(
             bank.get_balance(&vote_pubkey),
@@ -13083,6 +13083,7 @@ fn test_new_for_txn_tests_system_transfer() {
             VersionedEpochStakes::new(
                 SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
                 key,
+                None,
             ),
         );
     }

--- a/runtime/src/conformance/block.rs
+++ b/runtime/src/conformance/block.rs
@@ -504,6 +504,7 @@ pub fn execute_block(context: &ProtoBlockContext) -> ProtoBlockEffects {
         VersionedEpochStakes::new(
             SerdeStakesToStakeFormat::from(stakes_t_2),
             leader_schedule_epoch.saturating_sub(1),
+            None,
         ),
     );
     epoch_stakes.insert(
@@ -511,6 +512,7 @@ pub fn execute_block(context: &ProtoBlockContext) -> ProtoBlockEffects {
         VersionedEpochStakes::new(
             SerdeStakesToStakeFormat::from(stakes_t_1),
             leader_schedule_epoch,
+            None,
         ),
     );
 

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -124,6 +124,7 @@ pub fn execute_txn(
         let mut entry = VersionedEpochStakes::new(
             SerdeStakesToStakeFormat::Stake(Stakes::<Stake>::default()),
             key,
+            None,
         );
         entry.set_total_stake(total_epoch_stake);
         epoch_stakes.insert(key, entry);

--- a/runtime/src/epoch_stakes.rs
+++ b/runtime/src/epoch_stakes.rs
@@ -194,6 +194,32 @@ pub struct NodeVoteAccounts {
     pub total_stake: u64,
 }
 
+#[cfg_attr(feature = "frozen-abi", derive(AbiExample, StableAbi, StableAbiSample))]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, SchemaRead, SchemaWrite)]
+pub struct VoteAccountCommission {
+    commission: u8,
+    inflation_rewards_commission_bps: u16,
+}
+
+impl VoteAccountCommission {
+    pub(crate) fn new(commission: u8, inflation_rewards_commission_bps: u16) -> Self {
+        Self {
+            commission,
+            inflation_rewards_commission_bps,
+        }
+    }
+
+    fn commission_bps(self, commission_rate_in_basis_points: bool) -> u16 {
+        if commission_rate_in_basis_points {
+            self.inflation_rewards_commission_bps
+        } else {
+            u16::from(self.commission) * 100
+        }
+    }
+}
+
+pub(crate) type VoteAccountCommissions = HashMap<Pubkey, VoteAccountCommission>;
+
 /// Simplified, intermediate representation of [`VersionedEpochStakes`]
 ///
 /// Its bincode serializaiton format is identical as `VersionedEpochStakes`, but allows faster
@@ -214,6 +240,17 @@ pub(crate) enum DeserializableVersionedEpochStakes {
         total_stake: u64,
         node_id_to_vote_accounts: NodeIdToVoteAccounts,
         epoch_authorized_voters: EpochAuthorizedVoters,
+    },
+    CommissionHistory {
+        #[cfg_attr(
+            feature = "frozen-abi",
+            stable_abi_sample(with = "stable_abi_sample_deserializable_epoch_stakes(rng)")
+        )]
+        stakes: DeserializableEpochStakes,
+        total_stake: u64,
+        node_id_to_vote_accounts: NodeIdToVoteAccounts,
+        epoch_authorized_voters: EpochAuthorizedVoters,
+        vote_account_commissions: VoteAccountCommissions,
     },
 }
 
@@ -254,39 +291,81 @@ pub enum VersionedEpochStakes {
         #[wincode(skip)]
         bls_pubkey_to_rank_map: OnceLock<Arc<BLSPubkeyToRankMap>>,
     },
+    CommissionHistory {
+        stakes: EpochStakes,
+        /// Total stake in Lamports
+        total_stake: u64,
+        node_id_to_vote_accounts: Arc<NodeIdToVoteAccounts>,
+        epoch_authorized_voters: Arc<EpochAuthorizedVoters>,
+        vote_account_commissions: Arc<VoteAccountCommissions>,
+        #[cfg_attr(feature = "frozen-abi", stable_abi_sample(with = "Default::default()"))]
+        #[serde(skip)]
+        #[wincode(skip)]
+        bls_pubkey_to_rank_map: OnceLock<Arc<BLSPubkeyToRankMap>>,
+    },
 }
 
 impl From<DeserializableVersionedEpochStakes> for VersionedEpochStakes {
     fn from(epoch_stakes: DeserializableVersionedEpochStakes) -> Self {
-        let DeserializableVersionedEpochStakes::Current {
-            stakes,
-            total_stake,
-            node_id_to_vote_accounts,
-            epoch_authorized_voters,
-        } = epoch_stakes;
-        Self::Current {
-            stakes: stakes.into(),
-            total_stake,
-            node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
-            epoch_authorized_voters: Arc::new(epoch_authorized_voters),
-            bls_pubkey_to_rank_map: OnceLock::new(),
+        match epoch_stakes {
+            DeserializableVersionedEpochStakes::Current {
+                stakes,
+                total_stake,
+                node_id_to_vote_accounts,
+                epoch_authorized_voters,
+            } => Self::Current {
+                stakes: stakes.into(),
+                total_stake,
+                node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
+                epoch_authorized_voters: Arc::new(epoch_authorized_voters),
+                bls_pubkey_to_rank_map: OnceLock::new(),
+            },
+            DeserializableVersionedEpochStakes::CommissionHistory {
+                stakes,
+                total_stake,
+                node_id_to_vote_accounts,
+                epoch_authorized_voters,
+                vote_account_commissions,
+            } => Self::CommissionHistory {
+                stakes: stakes.into(),
+                total_stake,
+                node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
+                epoch_authorized_voters: Arc::new(epoch_authorized_voters),
+                vote_account_commissions: Arc::new(vote_account_commissions),
+                bls_pubkey_to_rank_map: OnceLock::new(),
+            },
         }
     }
 }
 
 impl VersionedEpochStakes {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
-    pub(crate) fn new(stakes: SerdeStakesToStakeFormat, leader_schedule_epoch: Epoch) -> Self {
+    pub(crate) fn new(
+        stakes: SerdeStakesToStakeFormat,
+        leader_schedule_epoch: Epoch,
+        vote_account_commissions: Option<Arc<VoteAccountCommissions>>,
+    ) -> Self {
         let stakes = EpochStakes::from(stakes);
         let epoch_vote_accounts = stakes.vote_accounts();
         let (total_stake, node_id_to_vote_accounts, epoch_authorized_voters) =
             Self::parse_epoch_vote_accounts(epoch_vote_accounts.as_ref(), leader_schedule_epoch);
-        Self::Current {
-            stakes,
-            total_stake,
-            node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
-            epoch_authorized_voters: Arc::new(epoch_authorized_voters),
-            bls_pubkey_to_rank_map: OnceLock::new(),
+        if let Some(vote_account_commissions) = vote_account_commissions {
+            Self::CommissionHistory {
+                stakes,
+                total_stake,
+                node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
+                epoch_authorized_voters: Arc::new(epoch_authorized_voters),
+                vote_account_commissions,
+                bls_pubkey_to_rank_map: OnceLock::new(),
+            }
+        } else {
+            Self::Current {
+                stakes,
+                total_stake,
+                node_id_to_vote_accounts: Arc::new(node_id_to_vote_accounts),
+                epoch_authorized_voters: Arc::new(epoch_authorized_voters),
+                bls_pubkey_to_rank_map: OnceLock::new(),
+            }
         }
     }
 
@@ -302,19 +381,22 @@ impl VersionedEpochStakes {
                 imbl::HashMap::default(),
             )),
             leader_schedule_epoch,
+            None,
         )
     }
 
     pub fn stakes(&self) -> &EpochStakes {
         match self {
-            Self::Current { stakes, .. } => stakes,
+            Self::Current { stakes, .. } | Self::CommissionHistory { stakes, .. } => stakes,
         }
     }
 
     /// Returns the total stake in Lamports.
     pub fn total_stake(&self) -> u64 {
         match self {
-            Self::Current { total_stake, .. } => *total_stake,
+            Self::Current { total_stake, .. } | Self::CommissionHistory { total_stake, .. } => {
+                *total_stake
+            }
         }
     }
 
@@ -322,6 +404,10 @@ impl VersionedEpochStakes {
     pub fn set_total_stake(&mut self, total_stake: u64) {
         match self {
             Self::Current {
+                total_stake: total_stake_field,
+                ..
+            }
+            | Self::CommissionHistory {
                 total_stake: total_stake_field,
                 ..
             } => {
@@ -333,6 +419,10 @@ impl VersionedEpochStakes {
     pub fn node_id_to_vote_accounts(&self) -> &Arc<NodeIdToVoteAccounts> {
         match self {
             Self::Current {
+                node_id_to_vote_accounts,
+                ..
+            }
+            | Self::CommissionHistory {
                 node_id_to_vote_accounts,
                 ..
             } => node_id_to_vote_accounts,
@@ -350,6 +440,10 @@ impl VersionedEpochStakes {
             Self::Current {
                 epoch_authorized_voters,
                 ..
+            }
+            | Self::CommissionHistory {
+                epoch_authorized_voters,
+                ..
             } => epoch_authorized_voters,
         }
     }
@@ -357,6 +451,10 @@ impl VersionedEpochStakes {
     pub fn bls_pubkey_to_rank_map(&self) -> &Arc<BLSPubkeyToRankMap> {
         match self {
             Self::Current {
+                bls_pubkey_to_rank_map,
+                ..
+            }
+            | Self::CommissionHistory {
                 bls_pubkey_to_rank_map,
                 ..
             } => bls_pubkey_to_rank_map.get_or_init(|| {
@@ -372,6 +470,32 @@ impl VersionedEpochStakes {
         self.stakes()
             .vote_accounts()
             .get_delegated_stake(vote_account)
+    }
+
+    pub(crate) fn get_commission_bps(
+        &self,
+        vote_pubkey: &Pubkey,
+        commission_rate_in_basis_points: bool,
+    ) -> Option<u16> {
+        if let Some(vote_account) = self.stakes().vote_accounts().get(vote_pubkey) {
+            let vote_state = vote_account.vote_state_view();
+            return Some(if commission_rate_in_basis_points {
+                vote_state.inflation_rewards_commission()
+            } else {
+                u16::from(vote_state.commission()) * 100
+            });
+        }
+        let Self::CommissionHistory {
+            vote_account_commissions,
+            ..
+        } = self
+        else {
+            return None;
+        };
+        vote_account_commissions
+            .get(vote_pubkey)
+            .copied()
+            .map(|commission| commission.commission_bps(commission_rate_in_basis_points))
     }
 
     fn parse_epoch_vote_accounts(
@@ -581,6 +705,13 @@ pub(crate) mod tests {
         vote_account: Pubkey,
         account: AccountSharedData,
         authorized_voter: Pubkey,
+    }
+
+    #[test]
+    fn test_vote_account_commission_bps() {
+        let commission = VoteAccountCommission::new(5, 550);
+        assert_eq!(commission.commission_bps(false), 500);
+        assert_eq!(commission.commission_bps(true), 550);
     }
 
     fn new_vote_accounts(
@@ -1013,7 +1144,8 @@ pub(crate) mod tests {
         // ensure stake delegations start off *not* empty
         assert!(!stakes.stake_delegations().is_empty());
 
-        let epoch_stakes = VersionedEpochStakes::new(SerdeStakesToStakeFormat::Account(stakes), 0);
+        let epoch_stakes =
+            VersionedEpochStakes::new(SerdeStakesToStakeFormat::Account(stakes), 0, None);
 
         assert_eq!(
             epoch_stakes

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -466,7 +466,7 @@ struct ExtraFieldsToDeserialize {
     // Write-only type (its deserialize counterpart is `ExtraFieldsToDeserialize`), so the abi digest
     // only verifies the serialized wire format; there is no roundtrip.
     frozen_abi(
-        abi_digest = "A1hmQvmrkwy33dXMpHXTweArYefPfWtsmwXK6EbNV4K6",
+        abi_digest = "ELErqds2desqt1K4tVFJN1UbfXtiLdjBrg5nBcGp7VZc",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "no"
     )
@@ -491,7 +491,7 @@ pub struct ExtraFieldsToSerialize {
     feature = "frozen-abi",
     derive(Deserialize, Serialize, SchemaWrite, StableAbi, StableAbiSample),
     frozen_abi(
-        abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
+        abi_digest = "J6QGPbqRhhgeuLkvvgD1vjisWyd5BsKC9w4nt8D6jCjc",
         abi_serializer = ["bincode", "wincode"],
         test_roundtrip = "wire_only"
     )
@@ -689,7 +689,7 @@ struct SerializableBankSnapshot<E> {
 // roundtrip.
 #[cfg(all(test, feature = "frozen-abi"))]
 #[frozen_abi(
-    abi_digest = "2TVKjhahaEGqUZAJtMmaaagcxWzhMPUsNrVHsSoNboK7",
+    abi_digest = "J6QGPbqRhhgeuLkvvgD1vjisWyd5BsKC9w4nt8D6jCjc",
     abi_serializer = ["bincode", "wincode"],
     test_roundtrip = "no"
 )]


### PR DESCRIPTION
#### Problem
VAT filtering could remove existing vote accounts from the epoch data used by delayed commission updates, causing reward calculation to incorrectly use the live commission.

#### Summary of Changes


#### Testing


Fixes #
