### PR TITLE
Remove zero lamport single ref

### DIFF
--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -175,11 +175,12 @@ impl AccountStorageEntry {
         num_tombstones > 0 && self.count() == num_tombstones
     }
 
-    /// Return the "alive_bytes" minus "zero_lamport_single_ref_accounts bytes".
-    pub(crate) fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
+    /// Return the "alive_bytes" minus the bytes of this storage's tombstones
+    /// (zero-lamport accounts already purged from the index).
+    pub(crate) fn alive_bytes_exclude_zero_lamport_accounts(&self) -> usize {
         let zero_lamport_dead_bytes = self
             .accounts
-            .dead_bytes_due_to_zero_lamport_single_ref(self.num_tombstones());
+            .dead_bytes_due_to_zero_lamport_accounts(self.num_tombstones());
         self.alive_bytes().saturating_sub(zero_lamport_dead_bytes)
     }
 

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -168,24 +168,6 @@ impl AccountStorageEntry {
         zero_lamport_single_ref_offsets.insert(offset)
     }
 
-    /// Insert offsets into the zero lamport single ref account offset set.
-    /// Return the number of new offsets that were inserted.
-    #[cfg(test)]
-    pub(crate) fn batch_insert_zero_lamport_single_ref_account_offsets(
-        &self,
-        offsets: &[Offset],
-    ) -> u64 {
-        let mut zero_lamport_single_ref_offsets =
-            self.zero_lamport_single_ref_offsets.write().unwrap();
-        let mut count = 0;
-        for offset in offsets {
-            if zero_lamport_single_ref_offsets.insert(*offset) {
-                count += 1;
-            }
-        }
-        count
-    }
-
     /// Number of dead zero-lamport accounts in the storage, counting both in-index single-ref
     /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
     /// (`tombstone_offsets`). Used for shrink-productivity accounting.

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -33,18 +33,6 @@ pub struct AccountStorageEntry {
 
     pub(crate) num_alive_bytes: AtomicUsize,
 
-    /// offsets to accounts that are zero lamport single ref (ZLSR) stored in this
-    /// storage. These are still alive. But, shrink will be able to remove them.
-    ///
-    /// NOTE: It's possible that one of these zero lamport single ref accounts
-    /// could be written in a new transaction (and later rooted & flushed) and a
-    /// later clean runs and marks this account dead before this storage gets a
-    /// chance to be shrunk, thus making the account dead in both "num_alive_bytes"
-    /// and as a zero lamport single ref. If this happens, we will count this
-    /// account as "dead" twice. However, this should be fine. It just makes
-    /// shrink more likely to visit this storage.
-    zero_lamport_single_ref_offsets: RwLock<IntSet<Offset>>,
-
     /// offsets to zero-lamport accounts that have been removed from the accounts index entirely
     /// (a tombstone — carried forward to this storage by shrink). The index has no slot_list entry
     /// pointing at them; their bytes are retained only so an incremental snapshot taken after the
@@ -81,7 +69,6 @@ impl AccountStorageEntry {
             accounts,
             num_alive_accounts: AtomicUsize::new(0),
             num_alive_bytes: AtomicUsize::new(0),
-            zero_lamport_single_ref_offsets: RwLock::default(),
             tombstone_offsets: RwLock::default(),
             obsolete_accounts: RwLock::default(),
         }
@@ -95,9 +82,6 @@ impl AccountStorageEntry {
             num_alive_accounts: AtomicUsize::new(self.count()),
             num_alive_bytes: AtomicUsize::new(self.alive_bytes()),
             accounts,
-            zero_lamport_single_ref_offsets: RwLock::new(
-                self.zero_lamport_single_ref_offsets.read().unwrap().clone(),
-            ),
             tombstone_offsets: RwLock::new(self.tombstone_offsets.read().unwrap().clone()),
             obsolete_accounts: RwLock::new(self.obsolete_accounts.read().unwrap().clone()),
         })
@@ -115,7 +99,6 @@ impl AccountStorageEntry {
             accounts,
             num_alive_accounts: AtomicUsize::new(0),
             num_alive_bytes: AtomicUsize::new(0),
-            zero_lamport_single_ref_offsets: RwLock::default(),
             tombstone_offsets: RwLock::default(),
             obsolete_accounts: RwLock::new(obsolete_accounts),
         }
@@ -163,7 +146,7 @@ impl AccountStorageEntry {
     /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
     /// (`tombstone_offsets`). Used for shrink-productivity accounting.
     pub(crate) fn num_zero_lamport_single_ref_accounts(&self) -> usize {
-        self.zero_lamport_single_ref_offsets.read().unwrap().len() + self.num_tombstones()
+        self.num_tombstones()
     }
 
     /// Batch-insert tombstone offsets, taking the offsets lock once.

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -324,10 +324,6 @@ impl AccountStorageEntry {
     pub(crate) fn obsolete_accounts(&self) -> &RwLock<ObsoleteAccounts> {
         &self.obsolete_accounts
     }
-
-    pub(crate) fn zero_lamport_single_ref_offsets(&self) -> &RwLock<IntSet<Offset>> {
-        &self.zero_lamport_single_ref_offsets
-    }
 }
 
 #[cfg(test)]

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -142,13 +142,6 @@ impl AccountStorageEntry {
         obsolete_bytes
     }
 
-    /// Number of dead zero-lamport accounts in the storage, counting both in-index single-ref
-    /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
-    /// (`tombstone_offsets`). Used for shrink-productivity accounting.
-    pub(crate) fn num_zero_lamport_single_ref_accounts(&self) -> usize {
-        self.num_tombstones()
-    }
-
     /// Batch-insert tombstone offsets, taking the offsets lock once.
     /// Returns the number of offsets inserted.
     pub(crate) fn batch_insert_tombstone_offsets(
@@ -186,7 +179,7 @@ impl AccountStorageEntry {
     pub(crate) fn alive_bytes_exclude_zero_lamport_single_ref_accounts(&self) -> usize {
         let zero_lamport_dead_bytes = self
             .accounts
-            .dead_bytes_due_to_zero_lamport_single_ref(self.num_zero_lamport_single_ref_accounts());
+            .dead_bytes_due_to_zero_lamport_single_ref(self.num_tombstones());
         self.alive_bytes().saturating_sub(zero_lamport_dead_bytes)
     }
 

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -159,15 +159,6 @@ impl AccountStorageEntry {
         obsolete_bytes
     }
 
-    /// Return true if offset is "new" and inserted successfully. Otherwise,
-    /// return false if the offset exists already.
-    #[cfg(test)]
-    pub(crate) fn insert_zero_lamport_single_ref_account_offset(&self, offset: usize) -> bool {
-        let mut zero_lamport_single_ref_offsets =
-            self.zero_lamport_single_ref_offsets.write().unwrap();
-        zero_lamport_single_ref_offsets.insert(offset)
-    }
-
     /// Number of dead zero-lamport accounts in the storage, counting both in-index single-ref
     /// entries (`zero_lamport_single_ref_offsets`) and tombstones removed from the index
     /// (`tombstone_offsets`). Used for shrink-productivity accounting.

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1609,7 +1609,7 @@ impl AccountsDb {
         // then its tombstones must be retained for an incremental snapshot to propagate the deletion
         // (see `filter_zero_lamport_clean_for_incremental_snapshots`).
         dirty_stores.retain(|(slot, _dirty_store)| {
-            if self.can_purge_zero_lamport_single_ref_after_shrink(*slot)
+            if self.can_purge_zero_lamport_accounts(*slot)
                 && self
                     .storage
                     .get_slot_storage_entry(*slot)
@@ -2433,8 +2433,7 @@ impl AccountsDb {
         stats: &ShrinkStats,
         slot_to_shrink: Slot,
     ) -> LoadAccountsIndexForShrink<'a, T> {
-        let can_purge_zero_lamport_single_ref =
-            self.can_purge_zero_lamport_single_ref_after_shrink(slot_to_shrink);
+        let can_purge_zero_lamport_accounts = self.can_purge_zero_lamport_accounts(slot_to_shrink);
         let count = accounts.len();
         let mut alive_accounts = T::with_capacity(count, slot_to_shrink);
         let mut zero_lamport_single_ref_pubkeys = Vec::with_capacity(count);
@@ -2454,7 +2453,7 @@ impl AccountsDb {
                         // The lone instance of a zero-lamport account. A load of a zero-lamport
                         // account already reports "not found", so dropping its index entry is safe.
                         zero_lamport_single_ref_pubkeys.push(pubkey);
-                        if !can_purge_zero_lamport_single_ref {
+                        if !can_purge_zero_lamport_accounts {
                             // Newer than the latest full snapshot: keep the bytes in storage as a
                             // tombstone so an incremental snapshot can still propagate the deletion,
                             // rather than dropping it.
@@ -2590,15 +2589,14 @@ impl AccountsDb {
         let num_obsolete_filtered = total_starting_accounts - stored_accounts.len();
 
         // Filter and collect tombstones
-        let can_purge_zero_lamport_single_ref =
-            self.can_purge_zero_lamport_single_ref_after_shrink(slot);
+        let can_purge_zero_lamport_accounts = self.can_purge_zero_lamport_accounts(slot);
         let mut tombstones_to_carry_forward = Vec::new();
         let tombstone_offsets = store.tombstone_offsets_read_lock();
         if !tombstone_offsets.is_empty() {
             stored_accounts.retain(|account| {
                 if tombstone_offsets.contains(&account.index_info.offset()) {
                     // If we can't purge zero lamport accounts, they need to be rewritten after shrink
-                    if !can_purge_zero_lamport_single_ref {
+                    if !can_purge_zero_lamport_accounts {
                         tombstones_to_carry_forward.push(*account);
                     }
                     false
@@ -4993,8 +4991,8 @@ impl AccountsDb {
         alive_bytes >= total_bytes
     }
 
-    /// Can zero lamport single ref accounts in `slot` be purged?
-    fn can_purge_zero_lamport_single_ref_after_shrink(&self, slot: Slot) -> bool {
+    /// Can zero lamport accounts in `slot` be purged?
+    fn can_purge_zero_lamport_accounts(&self, slot: Slot) -> bool {
         self.latest_full_snapshot_slot()
             .is_none_or(|latest_full_snapshot_slot| slot <= latest_full_snapshot_slot)
     }
@@ -5002,10 +5000,10 @@ impl AccountsDb {
     /// Returns the expected alive bytes after shrinking `store`.
     pub(crate) fn alive_bytes_after_shrink(&self, store: &AccountStorageEntry) -> usize {
         // Obsolete accounts are already excluded from `store.alive_bytes()`.
-        // Zero-lamport single-ref accounts are counted as alive until shrink can purge them,
+        // Tombstones are counted as alive until shrink can purge them,
         // which is gated by the latest full snapshot slot.
-        if self.can_purge_zero_lamport_single_ref_after_shrink(store.slot()) {
-            store.alive_bytes_exclude_zero_lamport_single_ref_accounts()
+        if self.can_purge_zero_lamport_accounts(store.slot()) {
+            store.alive_bytes_exclude_zero_lamport_accounts()
         } else {
             store.alive_bytes()
         }
@@ -5133,7 +5131,7 @@ impl AccountsDb {
                     self.dirty_stores.insert(slot, store);
                     dead_slots.insert(slot);
                 } else if remaining_accounts == store.num_tombstones()
-                    && self.can_purge_zero_lamport_single_ref_after_shrink(slot)
+                    && self.can_purge_zero_lamport_accounts(slot)
                 {
                     // Every remaining account is a tombstone and the slot is older than
                     // the latest full snapshot slot, safe to remove

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -361,10 +361,8 @@ pub struct ShrinkStats {
     pub index_read_elapsed: AtomicU64,
     pub create_and_insert_store_elapsed: AtomicU64,
     pub write_accounts_us: AtomicU64,
-    pub mark_zero_lamport_single_ref_accounts_us: AtomicU64,
     pub update_index_us: AtomicU64,
     pub num_accounts_stored: AtomicU64,
-    pub num_zero_lamport_single_ref_accounts_marked: AtomicU64,
     pub remove_old_stores_shrink_us: AtomicU64,
     pub rewrite_elapsed: AtomicU64,
     pub tombstone_carry_forward_us: AtomicU64,
@@ -479,12 +477,6 @@ impl ShrinkStats {
                     i64
                 ),
                 (
-                    "mark_zero_lamport_single_ref_accounts_us",
-                    self.mark_zero_lamport_single_ref_accounts_us
-                        .swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
                     "update_index_us",
                     self.update_index_us.swap(0, Ordering::Relaxed),
                     i64
@@ -492,12 +484,6 @@ impl ShrinkStats {
                 (
                     "num_accounts_stored",
                     self.num_accounts_stored.swap(0, Ordering::Relaxed),
-                    i64
-                ),
-                (
-                    "num_zero_lamport_single_ref_accounts_marked",
-                    self.num_zero_lamport_single_ref_accounts_marked
-                        .swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (
@@ -660,13 +646,6 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "mark_zero_lamport_single_ref_accounts_us",
-                self.shrink_stats
-                    .mark_zero_lamport_single_ref_accounts_us
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
                 "update_index_us",
                 self.shrink_stats.update_index_us.swap(0, Ordering::Relaxed),
                 i64
@@ -675,13 +654,6 @@ impl ShrinkAncientStats {
                 "num_accounts_stored",
                 self.shrink_stats
                     .num_accounts_stored
-                    .swap(0, Ordering::Relaxed),
-                i64
-            ),
-            (
-                "num_zero_lamport_single_ref_accounts_marked",
-                self.shrink_stats
-                    .num_zero_lamport_single_ref_accounts_marked
                     .swap(0, Ordering::Relaxed),
                 i64
             ),

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -155,7 +155,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     assert_eq!(append_vec.accounts_count(), 1);
     assert_eq!(append_vec.count(), 1);
     assert_eq!(result.accounts_data_len, 0);
-    assert_eq!(0, append_vec.num_zero_lamport_single_ref_accounts());
+    assert_eq!(0, append_vec.num_tombstones());
     assert_eq!(
         db.uncleaned_pubkeys.get(&slot0).unwrap().value(),
         &vec![pubkey]
@@ -1412,7 +1412,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
         DEFAULT_FILE_SIZE,
         accounts_db.accounts_file_provider,
     ));
-    // store an obsolete account; it should not be marked ZLSR
+    // store an obsolete account; shrink drops it entirely
     append_single_account_with_default_hash(
         &storage1,
         &obsolete_pubkey,
@@ -1420,7 +1420,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
         true,
         Some(&accounts_db.accounts_index),
     );
-    // store an obsolete zero lamport account; it should not be marked ZLSR
+    // store an obsolete zero lamport account; shrink drops it rather than tombstoning it
     append_single_account_with_default_hash(
         &storage1,
         &obsolete_zero_lamport_pubkey,
@@ -1436,7 +1436,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
         true,
         Some(&accounts_db.accounts_index),
     );
-    // store a zero lamport multi ref account; it should not be marked ZLSR
+    // store a zero lamport multi ref account; multi ref means it stays alive, not tombstoned
     append_single_account_with_default_hash(
         &storage1,
         &zero_lamport_multi_ref_pubkey,
@@ -1444,7 +1444,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
         true,
         Some(&accounts_db.accounts_index),
     );
-    // store an alive account; it should not be marked ZLSR
+    // store an alive account; it stays alive
     append_single_account_with_default_hash(
         &storage1,
         &alive_pubkey,
@@ -1456,7 +1456,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
     accounts_db.add_root(slot1);
 
     // we manually created the storage, so nothing got marked
-    assert_eq!(storage1.num_zero_lamport_single_ref_accounts(), 0);
+    assert_eq!(storage1.num_tombstones(), 0);
 
     // store the multi ref account again, in slot 2, so it becomes multi ref
     let slot2 = slot1 + 1;
@@ -1465,7 +1465,7 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
         [(&zero_lamport_multi_ref_pubkey, &closed_account)].as_slice(),
     ));
     accounts_db.add_root(slot2);
-    // flush without clean so the ZLMR account isn't marked obsolete in slot 1
+    // flush without clean so the multi reference account isn't marked obsolete in slot 1
     accounts_db.flush_rooted_accounts_cache_without_clean();
 
     // mark the obsolete accounts as obsolete
@@ -1504,8 +1504,6 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
 
     // it is recorded on the new storage's tombstone list
     assert_eq!(new_storage1.num_tombstones(), 1);
-    // the combined single-ref + tombstone count still reflects the one removable account
-    assert_eq!(new_storage1.num_zero_lamport_single_ref_accounts(), 1);
 }
 
 /// `shrink_collect` must recognize tombstone offsets already recorded on a storage (carried
@@ -1563,7 +1561,7 @@ fn test_shrink_collect_carries_forward_existing_tombstones() {
         })
         .unwrap();
     storage.batch_insert_tombstone_offsets([tombstone_offset.unwrap()]);
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 1);
+    assert_eq!(storage.num_tombstones(), 1);
 
     // Newer than the latest full snapshot: the tombstone must be carried forward, not dropped and
     // not mis-routed into the alive set.
@@ -1784,15 +1782,12 @@ fn test_alive_bytes_after_shrink_with_zero_lamport_single_ref_accounts() {
     accounts_db.add_root_and_flush_write_cache(slot);
 
     // We must set the latest full snapshot slot to `slot` or greater
-    // to ensure that ZLSR accounts are treated as dead for `shrink`.
+    // to ensure that tombstones are treated as dead for `shrink`.
     accounts_db.set_latest_full_snapshot_slot(slot);
 
     let storage = accounts_db.get_storage_for_slot(slot).unwrap();
 
-    assert_eq!(
-        storage.num_zero_lamport_single_ref_accounts(),
-        dead_pubkeys.len(),
-    );
+    assert_eq!(storage.num_tombstones(), dead_pubkeys.len());
 
     let alive_bytes_before_shrink = storage.alive_bytes();
     let expected_alive_bytes_after_shrink = accounts_db.alive_bytes_after_shrink(&storage);
@@ -4296,8 +4291,8 @@ fn test_alive_bytes_exclude_zero_lamport_single_ref_accounts() {
     let alive_bytes = storage.alive_bytes();
     assert!(alive_bytes > 0);
 
-    // assert the number of zlsr accounts
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), num_keys);
+    // assert the number of tombstones
+    assert_eq!(storage.num_tombstones(), num_keys);
 
     // assert the "alive_bytes_exclude_zero_lamport_single_ref_accounts"
     assert_eq!(
@@ -4878,11 +4873,7 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     // alive account, it is not completely dead, so clean won't drop it. Instead it is a candidate
     // for next round shrinking.
     assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 0);
-    assert_eq!(
-        db.get_and_assert_single_storage(1)
-            .num_zero_lamport_single_ref_accounts(),
-        1
-    );
+    assert_eq!(db.get_and_assert_single_storage(1).num_tombstones(), 1);
     assert!(db.shrink_candidate_slots.lock().unwrap().contains(&1));
 }
 

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -1502,15 +1502,8 @@ fn test_shrink_converts_zero_lamport_single_ref_account_to_tombstone() {
             .is_none()
     );
 
-    // it is recorded on the new storage's tombstone list, not the zero-lamport-single-ref list
+    // it is recorded on the new storage's tombstone list
     assert_eq!(new_storage1.num_tombstones(), 1);
-    assert!(
-        new_storage1
-            .zero_lamport_single_ref_offsets()
-            .read()
-            .unwrap()
-            .is_empty()
-    );
     // the combined single-ref + tombstone count still reflects the one removable account
     assert_eq!(new_storage1.num_zero_lamport_single_ref_accounts(), 1);
 }

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -4261,9 +4261,9 @@ fn test_alive_bytes() {
         .expect("must scan accounts storage");
 }
 
-// Test alive_bytes_exclude_zero_lamport_single_ref_accounts calculation
+// Test alive_bytes_exclude_zero_lamport_accounts calculation
 #[test]
-fn test_alive_bytes_exclude_zero_lamport_single_ref_accounts() {
+fn test_alive_bytes_exclude_zero_lamport_accounts() {
     let accounts_db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let slot: Slot = 0;
     let num_keys = 10;
@@ -4294,11 +4294,8 @@ fn test_alive_bytes_exclude_zero_lamport_single_ref_accounts() {
     // assert the number of tombstones
     assert_eq!(storage.num_tombstones(), num_keys);
 
-    // assert the "alive_bytes_exclude_zero_lamport_single_ref_accounts"
-    assert_eq!(
-        storage.alive_bytes_exclude_zero_lamport_single_ref_accounts(),
-        0,
-    );
+    // assert the "alive_bytes_exclude_zero_lamport_accounts"
+    assert_eq!(storage.alive_bytes_exclude_zero_lamport_accounts(), 0,);
 }
 
 /// When the full snapshot advances past slots that still hold zero-lamport single-ref

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -81,7 +81,7 @@ fn create_store_for_shrink_tests(
     slot: Slot,
     file_size: u64,
     alive_bytes: usize,
-    num_zero_lamport_single_ref_accounts: usize,
+    num_tombstones: usize,
     accounts_file_provider: AccountsFileProvider,
 ) -> (TempDir, Arc<AccountStorageEntry>) {
     let temp_dir = TempDir::new().unwrap();
@@ -93,10 +93,8 @@ fn create_store_for_shrink_tests(
         accounts_file_provider,
     ));
     accounts_db.storage.insert(Arc::clone(&store));
-    store.add_accounts(num_zero_lamport_single_ref_accounts.max(1), alive_bytes);
-    for offset in 0..num_zero_lamport_single_ref_accounts {
-        store.insert_zero_lamport_single_ref_account_offset(offset);
-    }
+    store.add_accounts(num_tombstones.max(1), alive_bytes);
+    store.batch_insert_tombstone_offsets(0..num_tombstones);
     (temp_dir, store)
 }
 
@@ -1682,76 +1680,76 @@ fn test_fully_tombstoned_storage_reclaim() {
 /// unit test for `alive_bytes_after_shrink()`
 ///
 /// Check all the permutations of latest full snapshot slot w.r.t. if/how
-/// zero lamport single ref accounts are counted as alive bytes or not.
+/// tombstones are counted as alive bytes or not.
 #[test]
 fn test_alive_bytes_after_shrink() {
     let accounts_db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let slot = 5;
     // note the initial alive bytes should be big enough so that subtracting
-    // all the zero lamport single ref accounts does not saturate at zero.
+    // all the tombstones does not saturate at zero.
     let initial_alive_bytes = 123_456;
     let (_temp_dir, store) = create_store_for_shrink_tests(
         &accounts_db,
         slot,
         4096, // <-- file size
         initial_alive_bytes,
-        2, // <-- num zero lamport single ref accounts
+        2, // <-- tombstones
         accounts_db.accounts_file_provider,
     );
 
-    // test case: latest full snapshot slot is None -- ZLSR accounts are dead
+    // test case: latest full snapshot slot is None -- tombstones are dead
     {
         // latest full snapshot slot starts off as None
         assert!(accounts_db.latest_full_snapshot_slot().is_none());
 
-        // ensure ZLSR accounts are dead bytes
+        // ensure tombstones are dead bytes
         let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
 
-        // add a ZLSR account, and ensure alive bytes reduces
-        store.insert_zero_lamport_single_ref_account_offset(2);
+        // add a tombstone, and ensure alive bytes reduces
+        store.batch_insert_tombstone_offsets([2]);
         let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
     }
 
-    // test case: slot > latest full snapshot -- ZLSR accounts are alive
+    // test case: slot > latest full snapshot -- tombstones are alive
     {
         accounts_db.set_latest_full_snapshot_slot(slot - 1);
 
-        // ensure ZLSR accounts are *not* dead bytes
+        // ensure tombstones are *not* dead bytes
         let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
         assert_eq!(alive_bytes_after_shrink1, initial_alive_bytes);
 
-        // add a ZLSR account, and ensure alive bytes is unchanged
-        store.insert_zero_lamport_single_ref_account_offset(3);
+        // add a tombstone, and ensure alive bytes is unchanged
+        store.batch_insert_tombstone_offsets([3]);
         let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
         assert_eq!(alive_bytes_after_shrink2, initial_alive_bytes);
     }
 
-    // test case: slot == latest full snapshot -- ZLSR accounts are dead
+    // test case: slot == latest full snapshot -- tombstones are dead
     {
         accounts_db.set_latest_full_snapshot_slot(slot);
 
-        // ensure ZLSR accounts are dead bytes
+        // ensure tombstones are dead bytes
         let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
 
-        // add a ZLSR account, and ensure alive bytes reduces
-        store.insert_zero_lamport_single_ref_account_offset(4);
+        // add a tombstone, and ensure alive bytes reduces
+        store.batch_insert_tombstone_offsets([4]);
         let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
     }
 
-    // test case: slot < latest full snapshot -- ZLSR accounts are dead
+    // test case: slot < latest full snapshot -- tombstones are dead
     {
         accounts_db.set_latest_full_snapshot_slot(slot + 1);
 
-        // ensure ZLSR accounts are dead bytes
+        // ensure tombstones are dead bytes
         let alive_bytes_after_shrink1 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink1 < initial_alive_bytes);
 
-        // add a ZLSR account, and ensure alive bytes reduces
-        store.insert_zero_lamport_single_ref_account_offset(5);
+        // add a tombstone, and ensure alive bytes reduces
+        store.batch_insert_tombstone_offsets([5]);
         let alive_bytes_after_shrink2 = accounts_db.alive_bytes_after_shrink(&store);
         assert!(alive_bytes_after_shrink2 < alive_bytes_after_shrink1);
     }

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -3087,78 +3087,80 @@ fn test_select_candidates_by_total_usage_all_clean() {
     assert_eq!(0, next_candidates.len());
 }
 
-/// Ensure selecting shrink candidates respects zero-lamport single-ref accounts.
+/// Ensure selecting shrink candidates respects tombstones.
 #[test]
-fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts() {
+fn test_select_candidates_by_total_usage_with_tombstones() {
     let temp_dir = TempDir::new().unwrap();
     let accounts_db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let mut shrink_candidates = ShrinkCandidates::default();
 
     let file_size = 10_000;
-    let num_zero_lamport_single_ref_accounts = 4;
+    let num_tombstones = 4;
     let closed_account = AccountSharedData::new(0, 0, &Pubkey::default());
     let accounts_to_store: Vec<_> =
         iter::repeat_with(|| (Pubkey::new_unique(), closed_account.clone()))
-            .take(num_zero_lamport_single_ref_accounts)
+            .take(num_tombstones)
             .collect();
 
-    let slot_with_zlsr = 11;
-    let store_with_zlsr = Arc::new(AccountStorageEntry::new(
+    let slot_with_tombstones = 11;
+    let store_with_tombstones = Arc::new(AccountStorageEntry::new(
         temp_dir.path(),
-        slot_with_zlsr,
-        slot_with_zlsr as AccountsFileId,
+        slot_with_tombstones,
+        slot_with_tombstones as AccountsFileId,
         file_size,
         accounts_db.accounts_file_provider,
     ));
-    let stored_accounts_info = store_with_zlsr
+    let stored_accounts_info = store_with_tombstones
         .accounts
-        .write_accounts(&(slot_with_zlsr, accounts_to_store.as_slice()))
+        .write_accounts(&(slot_with_tombstones, accounts_to_store.as_slice()))
         .unwrap();
-    store_with_zlsr.batch_insert_zero_lamport_single_ref_account_offsets(
-        &stored_accounts_info.offsets[..num_zero_lamport_single_ref_accounts],
+    store_with_tombstones.batch_insert_tombstone_offsets(stored_accounts_info.offsets);
+    store_with_tombstones.num_alive_bytes.store(
+        store_with_tombstones.written_bytes() as usize,
+        Ordering::Release,
     );
-    store_with_zlsr
-        .num_alive_bytes
-        .store(store_with_zlsr.written_bytes() as usize, Ordering::Release);
-    accounts_db.storage.insert(Arc::clone(&store_with_zlsr));
-    shrink_candidates.insert(slot_with_zlsr);
+    accounts_db
+        .storage
+        .insert(Arc::clone(&store_with_tombstones));
+    shrink_candidates.insert(slot_with_tombstones);
 
-    let slot_no_zlsr = 22;
-    let store_no_zlsr = Arc::new(AccountStorageEntry::new(
+    let slot_no_tombstones = 22;
+    let store_no_tombstones = Arc::new(AccountStorageEntry::new(
         temp_dir.path(),
-        slot_no_zlsr,
-        slot_no_zlsr as AccountsFileId,
+        slot_no_tombstones,
+        slot_no_tombstones as AccountsFileId,
         file_size,
         accounts_db.accounts_file_provider,
     ));
-    store_no_zlsr
+    store_no_tombstones
         .accounts
-        .write_accounts(&(slot_with_zlsr, accounts_to_store.as_slice()))
+        .write_accounts(&(slot_with_tombstones, accounts_to_store.as_slice()))
         .unwrap();
-    store_no_zlsr
-        .num_alive_bytes
-        .store(store_no_zlsr.written_bytes() as usize, Ordering::Release);
-    accounts_db.storage.insert(Arc::clone(&store_no_zlsr));
-    shrink_candidates.insert(slot_no_zlsr);
+    store_no_tombstones.num_alive_bytes.store(
+        store_no_tombstones.written_bytes() as usize,
+        Ordering::Release,
+    );
+    accounts_db.storage.insert(Arc::clone(&store_no_tombstones));
+    shrink_candidates.insert(slot_no_tombstones);
 
     // test case: The latest full snapshot slot is *older* than
-    // the store with zero lamport single ref accounts.
-    // Ensure shrink will see ZLSR accounts as *alive*.
+    // the store with tombstones.
+    // Ensure shrink will see tombstones as *alive*.
     {
-        accounts_db.set_latest_full_snapshot_slot(slot_with_zlsr - 1);
+        accounts_db.set_latest_full_snapshot_slot(slot_with_tombstones - 1);
 
-        // Bytes from ZLSR accounts are alive, and will stay alive after shrink.
+        // Bytes from tombstones are alive, and will stay alive after shrink.
         assert_eq!(
-            accounts_db.alive_bytes_after_shrink(&store_with_zlsr),
-            store_with_zlsr.alive_bytes(),
+            accounts_db.alive_bytes_after_shrink(&store_with_tombstones),
+            store_with_tombstones.alive_bytes(),
         );
-        assert!(!accounts_db.is_candidate_for_shrink(&store_with_zlsr));
-        assert!(!accounts_db.is_shrinking_productive(&store_with_zlsr));
+        assert!(!accounts_db.is_candidate_for_shrink(&store_with_tombstones));
+        assert!(!accounts_db.is_shrinking_productive(&store_with_tombstones));
 
-        // Stores without ZLSR accounts use the raw alive bytes.
+        // Stores without tombstones use the raw alive bytes.
         assert_eq!(
-            accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
-            store_no_zlsr.alive_bytes(),
+            accounts_db.alive_bytes_after_shrink(&store_no_tombstones),
+            store_no_tombstones.alive_bytes(),
         );
 
         let (selected_candidates, next_candidates) = accounts_db
@@ -3170,27 +3172,34 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
     }
 
     // test case: The latest full snapshot slot is either:
-    // * newer than the store with ZLSR accounts
-    // * the same as the store with ZLSR accounts
+    // * newer than the store with tombstones
+    // * the same as the store with tombstones
     // * unset
-    // Ensure shrink will see ZLSR accounts as *dead*.
+    // Ensure shrink will see tombstones as *dead*.
     {
-        for latest_full_snapshot_slot in [Some(slot_with_zlsr + 1), Some(slot_with_zlsr), None] {
+        for latest_full_snapshot_slot in [
+            Some(slot_with_tombstones + 1),
+            Some(slot_with_tombstones),
+            None,
+        ] {
             *accounts_db.latest_full_snapshot_slot.lock_write() = latest_full_snapshot_slot;
 
-            // Bytes from ZLSR accounts are alive, but would be dead after shrink.
+            // Bytes from tombstones are alive, but would be dead after shrink.
             assert_eq!(
-                store_with_zlsr.alive_bytes() as u64,
-                store_with_zlsr.written_bytes(),
+                store_with_tombstones.alive_bytes() as u64,
+                store_with_tombstones.written_bytes(),
             );
-            assert_eq!(accounts_db.alive_bytes_after_shrink(&store_with_zlsr), 0);
-            assert!(accounts_db.is_candidate_for_shrink(&store_with_zlsr));
-            assert!(accounts_db.is_shrinking_productive(&store_with_zlsr));
-
-            // Stores without ZLSR accounts use the raw alive bytes.
             assert_eq!(
-                accounts_db.alive_bytes_after_shrink(&store_no_zlsr),
-                store_no_zlsr.alive_bytes(),
+                accounts_db.alive_bytes_after_shrink(&store_with_tombstones),
+                0
+            );
+            assert!(accounts_db.is_candidate_for_shrink(&store_with_tombstones));
+            assert!(accounts_db.is_shrinking_productive(&store_with_tombstones));
+
+            // Stores without tombstones use the raw alive bytes.
+            assert_eq!(
+                accounts_db.alive_bytes_after_shrink(&store_no_tombstones),
+                store_no_tombstones.alive_bytes(),
             );
 
             let (selected_candidates, next_candidates) = accounts_db
@@ -3199,9 +3208,9 @@ fn test_select_candidates_by_total_usage_with_zero_lamport_single_ref_accounts()
                     DEFAULT_ACCOUNTS_SHRINK_RATIO,
                 );
 
-            // slot 11 with the ZLSR accounts *is* selected for shrink
+            // slot 11 with the tombstones *is* selected for shrink
             assert_eq!(1, selected_candidates.len());
-            assert!(selected_candidates.contains_key(&slot_with_zlsr));
+            assert!(selected_candidates.contains_key(&slot_with_tombstones));
 
             // slot 22 is above the shrink ratio, so ensure it is not a candidate
             assert!(next_candidates.is_empty());
@@ -6734,42 +6743,6 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
     // Ensure that stats were accumulated correctly
     assert_eq!(obsolete_stats.accounts_marked_obsolete, 2);
     assert_eq!(obsolete_stats.slots_removed, 1);
-}
-
-#[test]
-fn test_batch_insert_zero_lamport_single_ref_account_offsets() {
-    let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
-    let storage = accounts.create_store(1, 100);
-
-    // Test inserting new offsets
-    let offsets1 = vec![10, 20, 30];
-    let count1 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets1);
-    assert_eq!(count1, 3, "Should insert all 3 new offsets");
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 3);
-
-    // Test inserting some duplicate and some new offsets
-    let offsets2 = vec![20, 30, 40, 50]; // 20,30 are duplicates, 40,50 are new
-    let count2 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets2);
-    assert_eq!(count2, 2, "Should insert only 2 new offsets (40, 50)");
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
-
-    // Test inserting all duplicates
-    let offsets3 = vec![10, 20];
-    let count3 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets3);
-    assert_eq!(count3, 0, "Should not insert any duplicates");
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
-
-    // Test inserting empty slice
-    let empty_offsets: Vec<usize> = vec![];
-    let count4 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&empty_offsets);
-    assert_eq!(count4, 0, "Should handle empty slice");
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 5);
-
-    // Test inserting large batch with mixed duplicates
-    let offsets5 = vec![10, 60, 20, 70, 30, 80, 40]; // 10,20,30,40 duplicates, 60,70,80 new
-    let count5 = storage.batch_insert_zero_lamport_single_ref_account_offsets(&offsets5);
-    assert_eq!(count5, 3, "Should insert only 3 new offsets (60, 70, 80)");
-    assert_eq!(storage.num_zero_lamport_single_ref_accounts(), 8);
 }
 
 #[test]

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -84,11 +84,11 @@ impl AccountsFile {
         }
     }
 
-    /// Return the total number of bytes of the zero lamport single ref accounts in the storage.
+    /// Return the total number of bytes of the zero lamport accounts in the storage.
     /// Those bytes are "dead" and can be shrunk away.
-    pub(crate) fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
+    pub(crate) fn dead_bytes_due_to_zero_lamport_accounts(&self, count: usize) -> usize {
         match self {
-            Self::AppendVec(av) => av.dead_bytes_due_to_zero_lamport_single_ref(count),
+            Self::AppendVec(av) => av.dead_bytes_due_to_zero_lamport_accounts(count),
         }
     }
 

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -263,7 +263,7 @@ impl AppendVec {
         }
     }
 
-    pub fn dead_bytes_due_to_zero_lamport_single_ref(&self, count: usize) -> usize {
+    pub fn dead_bytes_due_to_zero_lamport_accounts(&self, count: usize) -> usize {
         Self::calculate_stored_size(0) * count
     }
 


### PR DESCRIPTION
#### Problem
Zero lamprot single ref data structure is only used in tests now. 

#### Summary of Changes
Separated into 7 commits, best viewed that way!
1. Remove batch insert zero lamport accounts test function and modify tests to use the tombstone terminology
2. Remover insert zero lamport accounts test function and modify tests to use the tombstone terminology
3. Remove test helper that gets the storage zero_lamport_single_ref_account list 
4. Remove ZLSR structure
5. num_zero_lamport_single_ref_account is now just num_tombstones. No need for the wrapper, remove it.
6. Rename functions that use zero_lamport_single_ref to just zero_lamport. Ref is not particularly meaningful in this case anymore. They could be renamed tombstone functions instead, but that didn't seem appropriate: accounts-db and the account_storage file don't really know what tombstones are, they could store them in some other way
7. Remove zero lamport stats that are now dead. 

#### Testing


Fixes #
