### PR TITLE
feat(entry): add EntryView types and block_component_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8349,8 +8349,10 @@ version = "4.3.0-alpha.3"
 dependencies = [
  "agave-logger",
  "agave-reserved-account-keys",
+ "agave-transaction-view",
  "agave-votor-messages",
  "assert_matches",
+ "bytes",
  "criterion",
  "crossbeam-channel",
  "log",
@@ -8379,6 +8381,7 @@ dependencies = [
  "solana-system-transaction",
  "solana-transaction",
  "solana-transaction-error",
+ "test-case",
  "thiserror 2.0.19",
  "wincode",
 ]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -6686,7 +6686,9 @@ dependencies = [
 name = "solana-entry"
 version = "4.3.0-alpha.3"
 dependencies = [
+ "agave-transaction-view",
  "agave-votor-messages",
+ "bytes",
  "crossbeam-channel",
  "log",
  "num_cpus",

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -24,7 +24,9 @@ agave-unstable-api = []
 dev-context-only-utils = []
 
 [dependencies]
+agave-transaction-view = { workspace = true }
 agave-votor-messages = { workspace = true }
+bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 log = { workspace = true }
 num_cpus = { workspace = true }
@@ -64,6 +66,7 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["verify"] }
+test-case = { workspace = true }
 
 [[bench]]
 name = "verify_signatures"

--- a/entry/src/block_component.rs
+++ b/entry/src/block_component.rs
@@ -130,13 +130,14 @@
 /// └─────────────────────────────────────────┘
 /// ```
 use {
-    crate::entry::{Entry, MaxDataShredsLen},
+    crate::entry::{Entry, EntryView, MaxDataShredsLen},
     agave_votor_messages::{
         certificate::{CertSignature, CertificateType, GenesisCert},
         consensus_message::Block,
         reward_certificate::{NotarRewardCertificate, SkipRewardCertificate},
         unverified_vote_message::UnverifiedCertificate,
     },
+    bytes::Bytes,
     solana_bls_signatures::{
         BlsError, Signature as BLSSignature, SignatureCompressed as BLSSignatureCompressed,
         signature::AsSignatureAffine,
@@ -488,10 +489,17 @@ pub enum BlockComponent {
     BlockMarker(VersionedBlockMarker),
 }
 
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum ParsedBlockComponent {
+    EntryBatch(Vec<EntryView<Bytes>>),
+    BlockMarker(VersionedBlockMarker),
+}
+
 impl BlockComponent {
-    const MAX_ENTRIES: usize = u32::MAX as usize;
-    const ENTRY_COUNT_SIZE: usize = 8;
-    const EMPTY_ENTRY_BATCH: [u8; Self::ENTRY_COUNT_SIZE] = 0u64.to_le_bytes();
+    pub(crate) const MAX_ENTRIES: usize = u32::MAX as usize;
+    pub(crate) const ENTRY_COUNT_SIZE: usize = 8;
+    pub(crate) const EMPTY_ENTRY_BATCH: [u8; Self::ENTRY_COUNT_SIZE] = 0u64.to_le_bytes();
 
     pub fn new_entry_batch(entries: Vec<Entry>) -> Result<Self, BlockComponentError> {
         if entries.is_empty() {

--- a/entry/src/block_component_parser.rs
+++ b/entry/src/block_component_parser.rs
@@ -1,0 +1,521 @@
+use {
+    crate::{
+        block_component::{BlockComponent, ParsedBlockComponent, VersionedBlockMarker},
+        entry::{Entry, EntryView, MAX_DATA_SHREDS_SIZE},
+    },
+    agave_transaction_view::{
+        result::TransactionViewError, transaction_view::UnsanitizedTransactionView,
+    },
+    bytes::Bytes,
+    solana_hash::Hash,
+    solana_transaction::versioned::VersionedTransaction,
+    std::mem::size_of,
+    wincode::{SchemaRead, config::DefaultConfig, io::Reader},
+};
+
+const _: () = assert!(
+    size_of::<EntryView<Bytes>>() <= size_of::<Entry>(),
+    "EntryView must stay no larger than Entry, or pre-allocating by entry_count could \
+     over-allocate past the checked limit"
+);
+const _: () = assert!(
+    size_of::<UnsanitizedTransactionView<Bytes>>() <= size_of::<VersionedTransaction>(),
+    "UnsanitizedTransactionView must stay no larger than VersionedTransaction, or pre-allocating \
+     by tx_count could over-allocate past the checked limit"
+);
+
+/// Parses a [`ParsedBlockComponent`] from `bytes`, using the same wire format
+/// as [`BlockComponent`].
+pub fn parse<B: Into<Bytes>>(bytes: B) -> Result<ParsedBlockComponent, ParseError> {
+    let bytes: Bytes = bytes.into();
+
+    let mut header: &[u8] = bytes.as_ref();
+    let entry_count =
+        <u64 as SchemaRead<DefaultConfig>>::get(header.by_ref()).map_err(ParseError::EntryCount)?;
+
+    // entry count of zero encodes a block marker
+    let entry_count_encodes_block_marker = entry_count == 0;
+    if entry_count_encodes_block_marker {
+        let remaining = &bytes[BlockComponent::ENTRY_COUNT_SIZE..];
+        let marker = wincode::deserialize::<VersionedBlockMarker>(remaining)
+            .map_err(ParseError::BlockMarker)?;
+        return Ok(ParsedBlockComponent::BlockMarker(marker));
+    }
+
+    let entry_count = usize::try_from(entry_count)
+        .map_err(|_| ParseError::EntryCountOverflow { count: entry_count })?;
+    if entry_count >= BlockComponent::MAX_ENTRIES {
+        return Err(ParseError::TooManyEntries {
+            count: entry_count,
+            max: BlockComponent::MAX_ENTRIES,
+        });
+    }
+    let needed = prealloc_bytes_needed::<Entry>(entry_count);
+    if needed > MAX_DATA_SHREDS_SIZE {
+        return Err(ParseError::EntryCountPreallocLimit {
+            count: entry_count,
+            needed,
+            limit: MAX_DATA_SHREDS_SIZE,
+        });
+    }
+
+    // Safe to pre-allocate: entry_count already passed the preallocation-size check above.
+    let mut entry_views = Vec::with_capacity(entry_count);
+    let mut offset = BlockComponent::ENTRY_COUNT_SIZE;
+
+    for entry_index in 0..entry_count {
+        let mut cursor: &[u8] = &bytes[offset..];
+
+        let num_hashes =
+            <u64 as SchemaRead<DefaultConfig>>::get(cursor.by_ref()).map_err(|source| {
+                ParseError::EntryHeader {
+                    entry_index,
+                    field: "num_hashes",
+                    source,
+                }
+            })?;
+        let hash = <Hash as SchemaRead<DefaultConfig>>::get(cursor.by_ref()).map_err(|source| {
+            ParseError::EntryHeader {
+                entry_index,
+                field: "hash",
+                source,
+            }
+        })?;
+        let tx_count =
+            <u64 as SchemaRead<DefaultConfig>>::get(cursor.by_ref()).map_err(|source| {
+                ParseError::EntryHeader {
+                    entry_index,
+                    field: "tx_count",
+                    source,
+                }
+            })?;
+
+        offset = bytes.len() - cursor.len();
+
+        let tx_count =
+            usize::try_from(tx_count).map_err(|_| ParseError::TransactionCountOverflow {
+                entry_index,
+                count: tx_count,
+            })?;
+        let needed = prealloc_bytes_needed::<VersionedTransaction>(tx_count);
+        if needed > MAX_DATA_SHREDS_SIZE {
+            return Err(ParseError::TransactionCountPreallocLimit {
+                entry_index,
+                count: tx_count,
+                needed,
+                limit: MAX_DATA_SHREDS_SIZE,
+            });
+        }
+
+        // Safe to pre-allocate: tx_count already passed the preallocation-size check above.
+        let mut transactions = Vec::with_capacity(tx_count);
+
+        for tx_index in 0..tx_count {
+            let remaining_bytes = bytes.slice(offset..);
+            let (view, consumed_len) =
+                UnsanitizedTransactionView::try_new_unsanitized_from_prefix(remaining_bytes)
+                    .map_err(|error| ParseError::Transaction {
+                        entry_index,
+                        tx_index,
+                        error,
+                    })?;
+            offset += consumed_len;
+            transactions.push(view);
+        }
+
+        entry_views.push(EntryView {
+            num_hashes,
+            hash,
+            transactions,
+        });
+    }
+
+    // Trailing bytes after the last entry are intentionally ignored, matching
+    // legacy `wincode::deserialize` behavior.
+    Ok(ParsedBlockComponent::EntryBatch(entry_views))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("failed to read entry count: {0}")]
+    EntryCount(wincode::ReadError),
+
+    #[error("entry count {count} does not fit in usize")]
+    EntryCountOverflow { count: u64 },
+
+    #[error("entry count {count} exceeds max {max}")]
+    TooManyEntries { count: usize, max: usize },
+
+    #[error("entry count {count} would need {needed} bytes, exceeding preallocation limit {limit}")]
+    EntryCountPreallocLimit {
+        count: usize,
+        needed: usize,
+        limit: usize,
+    },
+
+    #[error("failed to read {field} for entry {entry_index}: {source}")]
+    EntryHeader {
+        entry_index: usize,
+        field: &'static str,
+        source: wincode::ReadError,
+    },
+
+    #[error("transaction count {count} for entry {entry_index} does not fit in usize")]
+    TransactionCountOverflow { entry_index: usize, count: u64 },
+
+    #[error(
+        "transaction count {count} for entry {entry_index} would need {needed} bytes, exceeding \
+         preallocation limit {limit}"
+    )]
+    TransactionCountPreallocLimit {
+        entry_index: usize,
+        count: usize,
+        needed: usize,
+        limit: usize,
+    },
+
+    #[error("failed to parse transaction {tx_index} of entry {entry_index}: {error:?}")]
+    Transaction {
+        entry_index: usize,
+        tx_index: usize,
+        error: TransactionViewError,
+    },
+
+    #[error("failed to deserialize block marker: {0}")]
+    BlockMarker(wincode::ReadError),
+}
+
+/// Computes `count * size_of::<T>()`
+fn prealloc_bytes_needed<T>(count: usize) -> usize {
+    // max(1) to count zero sized types
+    let size_of_t = size_of::<T>().max(1);
+
+    count.saturating_mul(size_of_t)
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            block_component::{
+                BlockFooterV1, BlockHeaderV1, GenesisCertBlockMarker, UpdateParentV1,
+            },
+            entry::Entry,
+        },
+        solana_bls_signatures::Keypair as BlsKeypair,
+        solana_keypair::Keypair,
+        solana_pubkey::Pubkey,
+        solana_transaction::versioned::VersionedTransaction,
+        std::{assert_matches, iter::repeat_n},
+        test_case::test_case,
+    };
+
+    fn tick_entries(n: usize) -> Vec<Entry> {
+        repeat_n(Entry::default(), n).collect()
+    }
+
+    fn entry_with_transactions(num_hashes: u64, transactions: Vec<VersionedTransaction>) -> Entry {
+        Entry {
+            num_hashes,
+            hash: Hash::new_unique(),
+            transactions,
+        }
+    }
+
+    fn transfer_transaction(amount: u64) -> VersionedTransaction {
+        solana_system_transaction::transfer(
+            &Keypair::new(),
+            &Pubkey::new_unique(),
+            amount,
+            Hash::default(),
+        )
+        .into()
+    }
+
+    fn sample_footer() -> BlockFooterV1 {
+        BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 1234567890,
+            block_user_agent: b"test-agent".to_vec(),
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        }
+    }
+
+    /// Serializes `entries` as a `BlockComponent` entry batch and parses it back.
+    fn parse_entry_batch(entries: Vec<Entry>) -> Vec<EntryView<Bytes>> {
+        let component = BlockComponent::new_entry_batch(entries).unwrap();
+        let bytes = wincode::serialize(&component).unwrap();
+        let ParsedBlockComponent::EntryBatch(views) = parse(bytes).unwrap() else {
+            panic!("expected EntryBatch");
+        };
+        views
+    }
+
+    #[test]
+    fn parsed_tick_entry_view_has_same_num_hashes_and_hash_as_source_entry() {
+        let source_tick_entry = Entry {
+            num_hashes: 7,
+            hash: Hash::new_unique(),
+            transactions: vec![],
+        };
+
+        let parsed_entry_views = parse_entry_batch(vec![source_tick_entry.clone()]);
+
+        assert_eq!(parsed_entry_views.len(), 1);
+        assert_eq!(
+            parsed_entry_views[0].num_hashes,
+            source_tick_entry.num_hashes
+        );
+        assert_eq!(parsed_entry_views[0].hash, source_tick_entry.hash);
+        assert!(parsed_entry_views[0].transactions.is_empty());
+    }
+
+    #[test]
+    fn parsed_entry_views_preserve_source_entry_order_across_multiple_entries() {
+        let source_entries_with_distinct_num_hashes: Vec<Entry> = (0..5)
+            .map(|num_hashes| Entry {
+                num_hashes,
+                hash: Hash::new_unique(),
+                transactions: vec![],
+            })
+            .collect();
+
+        let parsed_entry_views = parse_entry_batch(source_entries_with_distinct_num_hashes.clone());
+
+        assert_eq!(
+            parsed_entry_views.len(),
+            source_entries_with_distinct_num_hashes.len()
+        );
+        for (parsed_entry_view, source_entry) in parsed_entry_views
+            .iter()
+            .zip(source_entries_with_distinct_num_hashes.iter())
+        {
+            assert_eq!(parsed_entry_view.num_hashes, source_entry.num_hashes);
+            assert_eq!(parsed_entry_view.hash, source_entry.hash);
+        }
+    }
+
+    #[test]
+    fn parsed_transaction_view_exposes_same_signature_as_source_transaction() {
+        let source_transaction = transfer_transaction(1);
+        let source_entry = entry_with_transactions(1, vec![source_transaction.clone()]);
+
+        let parsed_entry_views = parse_entry_batch(vec![source_entry]);
+
+        assert_eq!(parsed_entry_views.len(), 1);
+        assert_eq!(parsed_entry_views[0].transactions.len(), 1);
+        assert_eq!(
+            parsed_entry_views[0].transactions[0].signatures(),
+            source_transaction.signatures.as_slice()
+        );
+    }
+
+    #[test]
+    fn parsed_transaction_views_preserve_source_transaction_order_within_entry() {
+        let first_source_transaction = transfer_transaction(1);
+        let second_source_transaction = transfer_transaction(2);
+        let source_entry = entry_with_transactions(
+            1,
+            vec![
+                first_source_transaction.clone(),
+                second_source_transaction.clone(),
+            ],
+        );
+
+        let parsed_entry_views = parse_entry_batch(vec![source_entry]);
+
+        let parsed_transaction_views = &parsed_entry_views[0].transactions;
+        assert_eq!(parsed_transaction_views.len(), 2);
+        assert_eq!(
+            parsed_transaction_views[0].signatures(),
+            first_source_transaction.signatures.as_slice()
+        );
+        assert_eq!(
+            parsed_transaction_views[1].signatures(),
+            second_source_transaction.signatures.as_slice()
+        );
+    }
+
+    #[test_case(VersionedBlockMarker::from_block_footer(sample_footer()); "block_footer")]
+    #[test_case(
+        VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+            parent_slot: 42,
+            parent_block_id: Hash::new_unique(),
+        });
+        "block_header"
+    )]
+    #[test_case(
+        VersionedBlockMarker::from_update_parent(UpdateParentV1 {
+            new_parent_slot: 43,
+            new_parent_block_id: Hash::new_unique(),
+        });
+        "update_parent"
+    )]
+    #[test_case(
+        VersionedBlockMarker::from_genesis_cert_block_marker(GenesisCertBlockMarker {
+            slot: 44,
+            block_id: Hash::new_unique(),
+            bls_signature: BlsKeypair::new().sign(b"genesis").into(),
+            bitmap: vec![1, 2, 3],
+        });
+        "genesis_certificate"
+    )]
+    fn parsed_block_marker_view_matches_source_marker_for_each_variant(
+        source_marker: VersionedBlockMarker,
+    ) {
+        let component = BlockComponent::new_block_marker(source_marker.clone());
+        let bytes = wincode::serialize(&component).unwrap();
+
+        let view = parse(bytes).unwrap();
+
+        let ParsedBlockComponent::BlockMarker(parsed_marker) = view else {
+            panic!("expected BlockMarker");
+        };
+        assert_eq!(parsed_marker, source_marker);
+    }
+
+    #[test]
+    fn parse_rejects_all_zero_empty_entry_batch_payload() {
+        let empty_entry_batch_payload = Bytes::from(BlockComponent::EMPTY_ENTRY_BATCH.to_vec());
+
+        let parse_result = parse(empty_entry_batch_payload);
+
+        assert!(parse_result.is_err());
+    }
+
+    #[test]
+    fn parse_rejects_entry_count_header_claiming_max_entries_with_no_further_bytes() {
+        let mut header_claiming_max_entries =
+            (BlockComponent::MAX_ENTRIES as u64).to_le_bytes().to_vec();
+        header_claiming_max_entries.resize(BlockComponent::ENTRY_COUNT_SIZE, 0);
+
+        let parse_result = parse(header_claiming_max_entries);
+
+        assert_matches!(parse_result, Err(ParseError::TooManyEntries { .. }));
+    }
+
+    #[test]
+    fn parse_ignores_extra_trailing_byte_appended_after_valid_entry_batch() {
+        let source_entries = tick_entries(1);
+        let component = BlockComponent::new_entry_batch(source_entries.clone()).unwrap();
+        let mut entry_batch_bytes_with_trailing_byte = wincode::serialize(&component).unwrap();
+        entry_batch_bytes_with_trailing_byte.push(0);
+
+        let parse_result = parse(entry_batch_bytes_with_trailing_byte);
+
+        // trailing bytes are ignored matching legacy `wincode::deserialize`
+        let Ok(ParsedBlockComponent::EntryBatch(views)) = parse_result else {
+            panic!("expected EntryBatch");
+        };
+        assert_eq!(views.len(), source_entries.len());
+    }
+
+    #[test]
+    fn parse_ignores_extra_trailing_byte_appended_after_valid_block_marker() {
+        let marker = VersionedBlockMarker::from_block_footer(sample_footer());
+        let component = BlockComponent::new_block_marker(marker.clone());
+        let mut block_marker_bytes_with_trailing_byte = wincode::serialize(&component).unwrap();
+        block_marker_bytes_with_trailing_byte.push(0);
+
+        let parse_result = parse(block_marker_bytes_with_trailing_byte);
+
+        let Ok(ParsedBlockComponent::BlockMarker(parsed_marker)) = parse_result else {
+            panic!("expected BlockMarker");
+        };
+        assert_eq!(parsed_marker, marker);
+    }
+
+    #[test]
+    fn parse_rejects_entry_count_over_prealloc_limit() {
+        // One past the largest entry_count that fits the preallocation-size guard, but
+        // still well under MAX_ENTRIES, so only the prealloc check can reject it.
+        let entry_count = MAX_DATA_SHREDS_SIZE / size_of::<Entry>() + 1;
+        assert!(entry_count < BlockComponent::MAX_ENTRIES);
+
+        // Just the entry_count header; no entry data needs to follow it.
+        let header = (entry_count as u64).to_le_bytes().to_vec();
+
+        let owned_result = wincode::deserialize::<BlockComponent>(&header);
+        let view_result = parse(header);
+
+        assert_matches!(
+            owned_result,
+            Err(wincode::ReadError::PreallocationSizeLimit { .. })
+        );
+        assert_matches!(view_result, Err(ParseError::EntryCountPreallocLimit { .. }));
+    }
+
+    #[test]
+    fn parse_accepts_entry_count_at_prealloc_limit() {
+        // The largest entry_count that still fits the preallocation-size guard. No
+        // entry data follows it, so both decoders still error out - just not because
+        // of this guard, which is the only thing this test checks.
+        let entry_count = MAX_DATA_SHREDS_SIZE / size_of::<Entry>();
+        let header = (entry_count as u64).to_le_bytes().to_vec();
+
+        let owned_result = wincode::deserialize::<BlockComponent>(&header);
+        let view_result = parse(header);
+
+        assert!(!matches!(
+            owned_result,
+            Err(wincode::ReadError::PreallocationSizeLimit { .. })
+        ));
+        assert!(!matches!(
+            view_result,
+            Err(ParseError::EntryCountPreallocLimit { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_transaction_count_over_prealloc_limit() {
+        // A real single-entry, zero-transaction batch, with its tx_count field (the
+        // last 8 bytes, since no transactions follow it) patched to one past the
+        // largest tx_count that fits the preallocation-size guard.
+        let component = BlockComponent::new_entry_batch(vec![Entry::default()]).unwrap();
+        let mut bytes = wincode::serialize(&component).unwrap();
+
+        let tx_count = MAX_DATA_SHREDS_SIZE / size_of::<VersionedTransaction>() + 1;
+        let tx_count_offset = bytes.len() - size_of::<u64>();
+        bytes[tx_count_offset..].copy_from_slice(&(tx_count as u64).to_le_bytes());
+
+        let owned_result = wincode::deserialize::<BlockComponent>(&bytes);
+        let view_result = parse(bytes);
+
+        assert_matches!(
+            owned_result,
+            Err(wincode::ReadError::PreallocationSizeLimit { .. })
+        );
+        assert_matches!(
+            view_result,
+            Err(ParseError::TransactionCountPreallocLimit { .. })
+        );
+    }
+
+    #[test]
+    fn parse_accepts_transaction_count_at_prealloc_limit() {
+        // The largest tx_count that still fits the preallocation-size guard, patched
+        // into a real zero-transaction entry. No transaction data follows it, so both
+        // decoders still error out - just not because of this guard.
+        let component = BlockComponent::new_entry_batch(vec![Entry::default()]).unwrap();
+        let mut bytes = wincode::serialize(&component).unwrap();
+
+        let tx_count = MAX_DATA_SHREDS_SIZE / size_of::<VersionedTransaction>();
+        let tx_count_offset = bytes.len() - size_of::<u64>();
+        bytes[tx_count_offset..].copy_from_slice(&(tx_count as u64).to_le_bytes());
+
+        let owned_result = wincode::deserialize::<BlockComponent>(&bytes);
+        let view_result = parse(bytes);
+
+        assert!(!matches!(
+            owned_result,
+            Err(wincode::ReadError::PreallocationSizeLimit { .. })
+        ));
+        assert!(!matches!(
+            view_result,
+            Err(ParseError::TransactionCountPreallocLimit { .. })
+        ));
+    }
+}

--- a/entry/src/block_component_parser.rs
+++ b/entry/src/block_component_parser.rs
@@ -13,17 +13,6 @@ use {
     wincode::{SchemaRead, config::DefaultConfig, io::Reader},
 };
 
-const _: () = assert!(
-    size_of::<EntryView<Bytes>>() <= size_of::<Entry>(),
-    "EntryView must stay no larger than Entry, or pre-allocating by entry_count could \
-     over-allocate past the checked limit"
-);
-const _: () = assert!(
-    size_of::<UnsanitizedTransactionView<Bytes>>() <= size_of::<VersionedTransaction>(),
-    "UnsanitizedTransactionView must stay no larger than VersionedTransaction, or pre-allocating \
-     by tx_count could over-allocate past the checked limit"
-);
-
 /// Parses a [`ParsedBlockComponent`] from `bytes`, using the same wire format
 /// as [`BlockComponent`].
 pub fn parse<B: Into<Bytes>>(bytes: B) -> Result<ParsedBlockComponent, ParseError> {
@@ -50,14 +39,17 @@ pub fn parse<B: Into<Bytes>>(bytes: B) -> Result<ParsedBlockComponent, ParseErro
             max: BlockComponent::MAX_ENTRIES,
         });
     }
-    let needed = prealloc_bytes_needed::<Entry>(entry_count);
-    if needed > MAX_DATA_SHREDS_SIZE {
-        return Err(ParseError::EntryCountPreallocLimit {
+
+    // Since the bytes are wincode serialization of [`BlockComponent::EntryBatch`] which
+    // contains regular [`Entry`]s, bound by Entry's size to match wincode's prealloc check
+    // behavior for deserialization.
+    check_prealloc_limit::<Entry>(entry_count).map_err(|needed| {
+        ParseError::EntryCountPreallocLimit {
             count: entry_count,
             needed,
             limit: MAX_DATA_SHREDS_SIZE,
-        });
-    }
+        }
+    })?;
 
     // Safe to pre-allocate: entry_count already passed the preallocation-size check above.
     let mut entry_views = Vec::with_capacity(entry_count);
@@ -97,15 +89,17 @@ pub fn parse<B: Into<Bytes>>(bytes: B) -> Result<ParsedBlockComponent, ParseErro
                 entry_index,
                 count: tx_count,
             })?;
-        let needed = prealloc_bytes_needed::<VersionedTransaction>(tx_count);
-        if needed > MAX_DATA_SHREDS_SIZE {
-            return Err(ParseError::TransactionCountPreallocLimit {
+        // Since the bytes are wincode serialization of [`BlockComponent::EntryBatch`] whose
+        // entries contain regular [`VersionedTransaction`]s, bound by VersionedTransaction's
+        // size to match wincode's prealloc check behavior for deserialization.
+        check_prealloc_limit::<VersionedTransaction>(tx_count).map_err(|needed| {
+            ParseError::TransactionCountPreallocLimit {
                 entry_index,
                 count: tx_count,
                 needed,
                 limit: MAX_DATA_SHREDS_SIZE,
-            });
-        }
+            }
+        })?;
 
         // Safe to pre-allocate: tx_count already passed the preallocation-size check above.
         let mut transactions = Vec::with_capacity(tx_count);
@@ -185,12 +179,19 @@ pub enum ParseError {
     BlockMarker(wincode::ReadError),
 }
 
-/// Computes `count * size_of::<T>()`
-fn prealloc_bytes_needed<T>(count: usize) -> usize {
+/// Checks that pre-allocating `count` elements of `T` would stay within
+/// [`MAX_DATA_SHREDS_SIZE`] bytes (`count * size_of::<T>()`), returning the bytes needed as
+/// the error otherwise.
+fn check_prealloc_limit<T>(count: usize) -> Result<(), usize> {
     // max(1) to count zero sized types
     let size_of_t = size_of::<T>().max(1);
+    let needed = count.saturating_mul(size_of_t);
 
-    count.saturating_mul(size_of_t)
+    if needed > MAX_DATA_SHREDS_SIZE {
+        Err(needed)
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -517,5 +518,33 @@ mod tests {
             view_result,
             Err(ParseError::TransactionCountPreallocLimit { .. })
         ));
+    }
+
+    const ENTRY_PREALLOC_LIMIT: usize = MAX_DATA_SHREDS_SIZE / size_of::<Entry>();
+
+    #[test_case(0; "zero_count")]
+    #[test_case(1; "one_count")]
+    #[test_case(ENTRY_PREALLOC_LIMIT; "at_limit")]
+    fn check_prealloc_limit_for_entry_accepts_within_limit(count: usize) {
+        assert_matches!(check_prealloc_limit::<Entry>(count), Ok(()));
+    }
+
+    #[test_case(ENTRY_PREALLOC_LIMIT + 1; "over_limit")]
+    #[test_case(usize::MAX; "count_overflows_and_saturates")]
+    fn check_prealloc_limit_for_entry_rejects_count_over_limit(count: usize) {
+        assert_eq!(
+            check_prealloc_limit::<Entry>(count),
+            Err(count.saturating_mul(size_of::<Entry>()))
+        );
+    }
+
+    #[test]
+    fn check_prealloc_limit_treats_zero_sized_types_as_one_byte_each() {
+        struct ZeroSized;
+        assert_eq!(size_of::<ZeroSized>(), 0);
+
+        let count = MAX_DATA_SHREDS_SIZE + 1;
+
+        assert_eq!(check_prealloc_limit::<ZeroSized>(count), Err(count));
     }
 }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -4,6 +4,9 @@
 //! represents an approximate amount of time since the last Entry was created.
 use {
     crate::poh::Poh,
+    agave_transaction_view::{
+        transaction_data::TransactionData, transaction_view::UnsanitizedTransactionView,
+    },
     crossbeam_channel::{Receiver, Sender},
     log::*,
     rayon::{ThreadPool, prelude::*},
@@ -16,7 +19,7 @@ use {
     solana_signature::Signature,
     solana_transaction::{Transaction, versioned::VersionedTransaction},
     solana_transaction_error::{TransactionError, TransactionResult as Result},
-    std::{iter::repeat_with, time::Instant},
+    std::{fmt::Formatter, iter::repeat_with, time::Instant},
     wincode::{SchemaRead, SchemaWrite, containers::Vec as WincodeVec, len::BincodeLen},
 };
 
@@ -56,6 +59,53 @@ pub struct Entry {
     pub transactions: Vec<VersionedTransaction>,
 }
 
+pub struct EntryView<D: TransactionData> {
+    /// The number of hashes since the previous Entry ID.
+    pub num_hashes: u64,
+
+    /// The SHA-256 hash `num_hashes` after the previous Entry ID.
+    pub hash: Hash,
+
+    /// An ordered list of transactions that were observed before the Entry ID was
+    /// generated. They may have been observed before a previous Entry ID but were
+    /// pushed back into this list to ensure deterministic interpretation of the ledger.
+    pub transactions: Vec<UnsanitizedTransactionView<D>>,
+}
+
+impl<D> std::fmt::Debug for EntryView<D>
+where
+    D: TransactionData,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EntryView")
+            .field("num_hashes", &self.num_hashes)
+            .field("hash", &self.hash)
+            .field("transactions", &self.transactions)
+            .finish()
+    }
+}
+
+impl<D: TransactionData> EntryView<D> {
+    pub fn is_tick(&self) -> bool {
+        self.transactions.is_empty()
+    }
+}
+
+/// Serializes `entries` and re-parses them through [`crate::block_component_parser::parse`] to
+/// get byte-backed [`EntryView`]s, reusing the same parsing path production uses rather than
+/// hand-constructing transaction views.
+#[cfg(feature = "dev-context-only-utils")]
+pub fn entry_views_for_tests(entries: Vec<Entry>) -> Vec<EntryView<bytes::Bytes>> {
+    let component = crate::block_component::BlockComponent::new_entry_batch(entries).unwrap();
+    let bytes = wincode::serialize(&component).unwrap();
+    let crate::block_component::ParsedBlockComponent::EntryBatch(views) =
+        crate::block_component_parser::parse(bytes).unwrap()
+    else {
+        panic!("expected EntryBatch");
+    };
+    views
+}
+
 // The data needed to verify an Entry.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EntryVerificationData {
@@ -75,6 +125,21 @@ impl From<&Entry> for EntryVerificationData {
                 .transactions
                 .iter()
                 .flat_map(|tx| tx.signatures.iter().copied())
+                .collect(),
+        }
+    }
+}
+
+impl<D: TransactionData> From<&EntryView<D>> for EntryVerificationData {
+    fn from(entry: &EntryView<D>) -> Self {
+        Self {
+            num_hashes: entry.num_hashes,
+            hash: entry.hash,
+            num_transactions: entry.transactions.len(),
+            signatures: entry
+                .transactions
+                .iter()
+                .flat_map(|tx| tx.signatures().iter().copied())
                 .collect(),
         }
     }
@@ -103,6 +168,12 @@ pub fn entries_to_verification_data(entries: &[Entry]) -> Vec<EntryVerificationD
     entries.iter().map(Into::into).collect()
 }
 
+pub fn entry_views_to_verification_data<D: TransactionData>(
+    entries: &[EntryView<D>],
+) -> Vec<EntryVerificationData> {
+    entries.iter().map(Into::into).collect()
+}
+
 pub struct EntrySummary {
     pub num_hashes: u64,
     pub hash: Hash,
@@ -111,6 +182,16 @@ pub struct EntrySummary {
 
 impl From<&Entry> for EntrySummary {
     fn from(entry: &Entry) -> Self {
+        Self {
+            num_hashes: entry.num_hashes,
+            hash: entry.hash,
+            num_transactions: entry.transactions.len() as u64,
+        }
+    }
+}
+
+impl<D: TransactionData> From<&EntryView<D>> for EntrySummary {
+    fn from(entry: &EntryView<D>) -> Self {
         Self {
             num_hashes: entry.num_hashes,
             hash: entry.hash,
@@ -522,6 +603,48 @@ impl EntrySlice for [Entry] {
         verify_entries_cpu(&verification_entries, start_hash)
     }
 
+    fn verify_tick_hash_count(&self, tick_hash_count: &mut u64, hashes_per_tick: u64) -> bool {
+        // When hashes_per_tick is 0, hashing is disabled.
+        if hashes_per_tick == 0 {
+            return true;
+        }
+
+        for entry in self {
+            *tick_hash_count = tick_hash_count.saturating_add(entry.num_hashes);
+            if entry.is_tick() {
+                if entry.num_hashes == 0 {
+                    return false;
+                }
+                if *tick_hash_count != hashes_per_tick {
+                    warn!(
+                        "invalid tick hash count!: entry: {entry:#?}, tick_hash_count: \
+                         {tick_hash_count}, hashes_per_tick: {hashes_per_tick}"
+                    );
+                    return false;
+                }
+                *tick_hash_count = 0;
+            }
+        }
+        *tick_hash_count < hashes_per_tick
+    }
+
+    fn tick_count(&self) -> u64 {
+        self.iter().filter(|e| e.is_tick()).count() as u64
+    }
+}
+
+/// Additive counterpart to [`EntrySlice`]'s tick-checking methods, for [`EntryView`] slices.
+pub trait EntrySliceTickCheck {
+    /// Checks that each entry tick has the correct number of hashes. Entry slices do not
+    /// necessarily end in a tick, so `tick_hash_count` is used to carry over the hash count
+    /// for the next entry slice.
+    fn verify_tick_hash_count(&self, tick_hash_count: &mut u64, hashes_per_tick: u64) -> bool;
+
+    /// Counts tick entries
+    fn tick_count(&self) -> u64;
+}
+
+impl<D: TransactionData> EntrySliceTickCheck for [EntryView<D>] {
     fn verify_tick_hash_count(&self, tick_hash_count: &mut u64, hashes_per_tick: u64) -> bool {
         // When hashes_per_tick is 0, hashing is disabled.
         if hashes_per_tick == 0 {
@@ -1002,7 +1125,7 @@ mod tests {
 
         // empty batch should succeed if hashes_per_tick hasn't been reached
         let mut tick_hash_count = 0;
-        let mut entries = vec![];
+        let mut entries: Vec<Entry> = vec![];
         assert!(entries.verify_tick_hash_count(&mut tick_hash_count, hashes_per_tick));
         assert_eq!(tick_hash_count, 0);
 

--- a/entry/src/lib.rs
+++ b/entry/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "agave-unstable-api")]
 #![allow(clippy::arithmetic_side_effects)]
 pub mod block_component;
+pub mod block_component_parser;
 pub mod entry;
 pub mod entry_or_marker;
 pub mod poh;

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6800,7 +6800,9 @@ dependencies = [
 name = "solana-entry"
 version = "4.3.0-alpha.3"
 dependencies = [
+ "agave-transaction-view",
  "agave-votor-messages",
+ "bytes",
  "crossbeam-channel",
  "log",
  "num_cpus",


### PR DESCRIPTION
#### Problem
See https://github.com/anza-xyz/agave/pull/14356 for full view. We need new types for `Entry` and `BlockComponent` that can hold transactions as `UnsanitizedTransactionView`s instead of `ParsedTransaction` to make replay behavior more similar to block making.

#### Summary of Changes
- Mostly break out of #14356 for the non breaking entry changes.
- Introcued `EntryView` and `ParsedBlockComponent`.
- New module to parse bytes into `ParsedBlockComponent` in `entry/src/block_component_parser.rs`.

#### Testing
- Added extensive unit testing in the parsing of block components.


Fixes https://github.com/anza-xyz/agave/issues/14212?issue=anza-xyz%7Cagave%7C14499
