### PR TITLE
Revert "replace reserve/refund with track-with-actual-cost in banking-stage (#12986)"

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -65,6 +65,7 @@ mod decision_maker;
 mod latest_validator_vote_packet;
 mod leader_slot_metrics;
 mod leader_slot_timing_metrics;
+mod qos_service;
 mod scheduler_messages;
 mod vote_packet_receiver;
 mod vote_storage;

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -78,8 +78,9 @@ impl Committer {
         let commit_transaction_statuses = commit_results
             .iter()
             .map(|commit_result| match commit_result {
-                // Reports actual execution CUs and loaded accounts size for
-                // actual-cost tracking of transactions committed to the block.
+                // reports actual execution CUs, and actual loaded accounts size for
+                // transaction committed to block. qos_service uses these information to adjust
+                // reserved block space.
                 Ok(committed_tx) => CommitTransactionDetails::Committed {
                     compute_units: committed_tx.executed_units,
                     loaded_accounts_data_size: committed_tx

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2,11 +2,10 @@ use {
     super::{
         committer::{CommitTransactionDetails, Committer},
         leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
+        qos_service::QosService,
         scheduler_messages::MaxAge,
     },
     smallvec::SmallVec,
-    solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
-    solana_hash::Hash,
     solana_measure::measure_us,
     solana_poh::{
         poh_recorder::PohRecorderError,
@@ -14,8 +13,7 @@ use {
     },
     solana_runtime::{
         bank::{
-            Bank, LoadAndExecuteTransactionsOutput, ProcessedTransactionCounts,
-            entry_bytes_budget::EntryBytesReserveError,
+            Bank, LoadAndExecuteTransactionsOutput, entry_bytes_budget::EntryBytesReserveError,
         },
         transaction_batch::TransactionBatch,
     },
@@ -23,9 +21,7 @@ use {
     solana_svm::{
         account_loader::validate_fee_payer,
         transaction_error_metrics::TransactionErrorMetrics,
-        transaction_processing_result::{
-            TransactionProcessingResult, TransactionProcessingResultExtensions,
-        },
+        transaction_processing_result::TransactionProcessingResultExtensions,
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
     solana_transaction_error::TransactionError,
@@ -81,10 +77,6 @@ pub struct ProcessTransactionBatchOutput {
 }
 
 pub struct ExecuteAndCommitTransactionsOutput {
-    // The number of transactions filtered out by the cost model
-    pub(crate) cost_model_throttled_transactions_count: u64,
-    // Amount of time spent running the cost model
-    pub(crate) cost_model_us: u64,
     // Transactions counts reported to `ConsumeWorkerMetrics` and then
     // accumulated later for `LeaderSlotMetrics`
     pub(crate) transaction_counts: LeaderProcessedTransactionCounts,
@@ -203,17 +195,49 @@ impl Consumer {
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
         flags: &ExecutionFlags,
     ) -> ProcessTransactionBatchOutput {
-        // Only lock accounts for transactions that passed pre-lock checks;
+        let (
+            (transaction_qos_cost_results, cost_model_throttled_transactions_count),
+            cost_model_us,
+        ) = measure_us!(QosService::select_and_accumulate_transaction_costs(
+            bank,
+            txs,
+            pre_results
+        ));
+
+        // Only lock accounts for those transactions are selected for the block;
         // Once accounts are locked, other threads cannot encode transactions that will modify the
         // same account state
-        let (batch, lock_us) =
-            measure_us!(bank.prepare_sanitized_batch_with_results(txs, pre_results));
+        let (batch, lock_us) = measure_us!(bank.prepare_sanitized_batch_with_results(
+            txs,
+            transaction_qos_cost_results.iter().map(|r| match r {
+                Ok(_cost) => Ok(()),
+                Err(err) => Err(err.clone()),
+            })
+        ));
 
+        // retryable_txs includes AccountInUse, WouldExceedMaxBlockCostLimit
+        // WouldExceedMaxAccountCostLimit, WouldExceedMaxVoteCostLimit
+        // and WouldExceedMaxAccountDataCostLimit
         let execute_and_commit_transactions_output =
             self.execute_and_commit_transactions_locked(bank, &batch, flags);
 
         // Once the accounts are new transactions can enter the pipeline to process them
         let (_, unlock_us) = measure_us!(drop(batch));
+
+        let ExecuteAndCommitTransactionsOutput {
+            ref commit_transactions_result,
+            ..
+        } = execute_and_commit_transactions_output;
+
+        // Costs of all transactions are added to the cost_tracker before processing.
+        // To ensure accurate tracking of compute units, transactions that ultimately
+        // were not included in the block should have their cost removed, the rest
+        // should update with their actually consumed units.
+        QosService::remove_or_update_costs(
+            transaction_qos_cost_results.iter(),
+            commit_transactions_result.as_ref().ok(),
+            bank,
+        );
 
         debug!(
             "bank: {} lock: {}us unlock: {}us txs_len: {}",
@@ -224,9 +248,8 @@ impl Consumer {
         );
 
         ProcessTransactionBatchOutput {
-            cost_model_throttled_transactions_count: execute_and_commit_transactions_output
-                .cost_model_throttled_transactions_count,
-            cost_model_us: execute_and_commit_transactions_output.cost_model_us,
+            cost_model_throttled_transactions_count,
+            cost_model_us,
             execute_and_commit_transactions_output,
         }
     }
@@ -246,13 +269,41 @@ impl Consumer {
             .iter()
             .enumerate()
             .filter_map(|(index, res)| match res {
-                // Account lock conflicts are immediately retryable.
+                // following are retryable errors
                 Err(TransactionError::AccountInUse) => {
                     error_counters.account_in_use += 1;
                     // locking failure due to vote conflict or jito - immediately retry.
                     Some(RetryableIndex {
                         index,
                         immediately_retryable: true,
+                    })
+                }
+                Err(TransactionError::WouldExceedMaxBlockCostLimit) => {
+                    error_counters.would_exceed_max_block_cost_limit += 1;
+                    Some(RetryableIndex {
+                        index,
+                        immediately_retryable: false,
+                    })
+                }
+                Err(TransactionError::WouldExceedMaxVoteCostLimit) => {
+                    error_counters.would_exceed_max_vote_cost_limit += 1;
+                    Some(RetryableIndex {
+                        index,
+                        immediately_retryable: false,
+                    })
+                }
+                Err(TransactionError::WouldExceedMaxAccountCostLimit) => {
+                    error_counters.would_exceed_max_account_cost_limit += 1;
+                    Some(RetryableIndex {
+                        index,
+                        immediately_retryable: false,
+                    })
+                }
+                Err(TransactionError::WouldExceedAccountDataBlockLimit) => {
+                    error_counters.would_exceed_account_data_block_limit += 1;
+                    Some(RetryableIndex {
+                        index,
+                        immediately_retryable: false,
                     })
                 }
                 // following are non-retryable errors
@@ -288,62 +339,10 @@ impl Consumer {
         execute_and_commit_timings.load_execute_us = load_execute_us;
 
         let LoadAndExecuteTransactionsOutput {
-            mut processing_results,
-            mut processed_counts,
+            processing_results,
+            processed_counts,
             balance_collector,
         } = load_and_execute_transactions_output;
-
-        // Calculate actual transaction costs before blocking freeze. Processed
-        // transactions' costs are added to Cost Tracker while holding bank
-        // freeze_lock, ensuring cost_update_service to report finalized stats.
-        let (transaction_costs, mut cost_model_us) =
-            measure_us!(Self::calculate_processed_transaction_costs(
-                bank,
-                batch.sanitized_transactions(),
-                &processing_results,
-            ));
-
-        let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
-        execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
-        let bank_already_frozen = *freeze_lock != Hash::default();
-        if bank_already_frozen {
-            let transaction_counts = LeaderProcessedTransactionCounts {
-                processed_count: processed_counts.processed_transactions_count,
-                processed_with_successful_result_count: processed_counts
-                    .processed_with_successful_result_count,
-                attempted_processing_count: processing_results.len() as u64,
-            };
-            Self::extend_processed_retryable_transaction_indexes(
-                &mut retryable_transaction_indexes,
-                &processing_results,
-            );
-
-            return ExecuteAndCommitTransactionsOutput {
-                cost_model_throttled_transactions_count: 0,
-                cost_model_us,
-                transaction_counts,
-                retryable_transaction_indexes,
-                commit_transactions_result: Err(PohRecorderError::MaxHeightReached),
-                execute_and_commit_timings,
-                error_counters,
-            };
-        }
-
-        let ((transaction_costs, mut actual_cost_retryable_transaction_indexes), cost_add_us) =
-            measure_us!(Self::try_add_processed_transaction_costs(
-                bank,
-                batch.sanitized_transactions(),
-                transaction_costs,
-                &mut processing_results,
-                &mut processed_counts,
-                &mut error_counters,
-                flags.all_or_nothing,
-            ));
-        cost_model_us = cost_model_us.saturating_add(cost_add_us);
-        let cost_model_throttled_transactions_count =
-            actual_cost_retryable_transaction_indexes.len() as u64;
-        retryable_transaction_indexes.append(&mut actual_cost_retryable_transaction_indexes);
-        retryable_transaction_indexes.sort_unstable();
 
         let transaction_counts = LeaderProcessedTransactionCounts {
             processed_count: processed_counts.processed_transactions_count,
@@ -367,6 +366,9 @@ impl Consumer {
             }
             processed_transactions
         });
+
+        let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
+        execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
 
         let reserved_bytes =
             bank.entry_bytes_budget()
@@ -395,16 +397,20 @@ impl Consumer {
         };
 
         if let Err(recorder_err) = recording_result {
-            Self::remove_added_transaction_costs(bank, &transaction_costs);
+            retryable_transaction_indexes.extend(processing_results.iter().enumerate().filter_map(
+                |(index, processing_result)| {
+                    processing_result.was_processed().then_some(RetryableIndex {
+                        index,
+                        immediately_retryable: true, // recording errors are always immediately retryable
+                    })
+                },
+            ));
 
-            Self::extend_processed_retryable_transaction_indexes(
-                &mut retryable_transaction_indexes,
-                &processing_results,
-            );
+            // retryable indexes are expected to be sorted - in this case the
+            // `extend` can cause that assumption to be violated.
+            retryable_transaction_indexes.sort_unstable();
 
             return ExecuteAndCommitTransactionsOutput {
-                cost_model_throttled_transactions_count,
-                cost_model_us,
                 transaction_counts,
                 retryable_transaction_indexes,
                 commit_transactions_result: Err(recorder_err),
@@ -459,251 +465,11 @@ impl Consumer {
         );
 
         ExecuteAndCommitTransactionsOutput {
-            cost_model_throttled_transactions_count,
-            cost_model_us,
             transaction_counts,
             retryable_transaction_indexes,
             commit_transactions_result: Ok(commit_transaction_statuses),
             execute_and_commit_timings,
             error_counters,
-        }
-    }
-
-    fn extend_processed_retryable_transaction_indexes(
-        retryable_transaction_indexes: &mut Vec<RetryableIndex>,
-        processing_results: &[TransactionProcessingResult],
-    ) {
-        retryable_transaction_indexes.extend(processing_results.iter().enumerate().filter_map(
-            |(index, processing_result)| {
-                processing_result.was_processed().then_some(RetryableIndex {
-                    index,
-                    immediately_retryable: true, // block-ending errors are immediately retryable
-                })
-            },
-        ));
-
-        // retryable indexes are expected to be sorted - in this case the
-        // `extend` can cause that assumption to be violated.
-        retryable_transaction_indexes.sort_unstable();
-    }
-
-    fn calculate_processed_transaction_costs<'a, Tx: TransactionWithMeta>(
-        bank: &Bank,
-        transactions: &'a [Tx],
-        processing_results: &[TransactionProcessingResult],
-    ) -> Vec<Option<TransactionCost<'a, Tx>>> {
-        let mut transaction_costs = Vec::with_capacity(processing_results.len());
-
-        for (tx, processing_result) in transactions.iter().zip(processing_results) {
-            let Some((executed_units, loaded_accounts_data_size)) = processing_result
-                .processed_transaction()
-                .map(|processed_tx| {
-                    (
-                        processed_tx.executed_units(),
-                        processed_tx.loaded_accounts_data_size(),
-                    )
-                })
-            else {
-                transaction_costs.push(None);
-                continue;
-            };
-
-            transaction_costs.push(Some(CostModel::calculate_cost_for_executed_transaction(
-                tx,
-                executed_units,
-                loaded_accounts_data_size,
-                &bank.feature_set,
-            )));
-        }
-
-        transaction_costs
-    }
-
-    /// Returns `(added_transaction_costs, retryable_indexes)`.
-    ///
-    /// `added_transaction_costs` has one entry per input transaction. `Some(cost)` means
-    /// the processed transaction's actual cost was added to the cost tracker.
-    /// `None` means no cost added for that transaction due to: the transaction was
-    /// not processed, its cost was rejected by the cost tracker, a prior
-    /// cost-tracker rejection canceled the rest of the batch, or an
-    /// all-or-nothing cost failure rolled back the batch.
-    fn try_add_processed_transaction_costs<'a, Tx: TransactionWithMeta>(
-        bank: &Bank,
-        transactions: &'a [Tx],
-        mut transaction_costs: Vec<Option<TransactionCost<'a, Tx>>>,
-        processing_results: &mut [TransactionProcessingResult],
-        processed_counts: &mut ProcessedTransactionCounts,
-        error_counters: &mut TransactionErrorMetrics,
-        all_or_nothing: bool,
-    ) -> (Vec<Option<TransactionCost<'a, Tx>>>, Vec<RetryableIndex>) {
-        let mut retryable_transaction_indexes = Vec::with_capacity(processing_results.len());
-        let mut all_or_nothing_error = None;
-        let mut remaining_batch_error = None;
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-
-        for (index, transaction_cost) in transaction_costs.iter_mut().enumerate() {
-            let Some(cost) = transaction_cost.as_ref() else {
-                continue;
-            };
-
-            match cost_tracker.try_add(cost) {
-                Ok(_) => {}
-                Err(err) => {
-                    let transaction_error = TransactionError::from(err);
-                    *transaction_cost = None;
-                    if all_or_nothing {
-                        all_or_nothing_error = Some((index, transaction_error));
-                        break;
-                    } else {
-                        remaining_batch_error = Some((index, transaction_error));
-                        break;
-                    }
-                }
-            }
-        }
-
-        if let Some((failed_index, transaction_error)) = all_or_nothing_error {
-            for transaction_cost in transaction_costs[..failed_index].iter().flatten() {
-                cost_tracker.remove(transaction_cost);
-            }
-            transaction_costs.iter_mut().for_each(|cost| *cost = None);
-            retryable_transaction_indexes.clear();
-
-            Self::cancel_processed_transactions_for_retry(
-                transactions,
-                processing_results,
-                processed_counts,
-                error_counters,
-                &mut retryable_transaction_indexes,
-                failed_index,
-                &transaction_error,
-                0,
-            );
-        } else if let Some((failed_index, transaction_error)) = remaining_batch_error {
-            transaction_costs[failed_index..]
-                .iter_mut()
-                .for_each(|cost| *cost = None);
-
-            Self::cancel_processed_transactions_for_retry(
-                transactions,
-                processing_results,
-                processed_counts,
-                error_counters,
-                &mut retryable_transaction_indexes,
-                failed_index,
-                &transaction_error,
-                failed_index,
-            );
-        }
-
-        (transaction_costs, retryable_transaction_indexes)
-    }
-
-    fn cancel_processed_transactions_for_retry<Tx: TransactionWithMeta>(
-        transactions: &[Tx],
-        processing_results: &mut [TransactionProcessingResult],
-        processed_counts: &mut ProcessedTransactionCounts,
-        error_counters: &mut TransactionErrorMetrics,
-        retryable_transaction_indexes: &mut Vec<RetryableIndex>,
-        failed_index: usize,
-        transaction_error: &TransactionError,
-        start_index: usize,
-    ) {
-        for (index, (tx, processing_result)) in transactions
-            .iter()
-            .zip(processing_results.iter_mut())
-            .enumerate()
-            .skip(start_index)
-        {
-            if processing_result.was_processed() {
-                Self::decrement_processed_counts(tx, processing_result, processed_counts);
-                let retry_error = if index == failed_index {
-                    transaction_error.clone()
-                } else {
-                    TransactionError::CommitCancelled
-                };
-                Self::accumulate_post_execution_transaction_error(
-                    processing_result,
-                    &retry_error,
-                    error_counters,
-                );
-                *processing_result = Err(retry_error);
-                retryable_transaction_indexes.push(RetryableIndex {
-                    index,
-                    // The cost-limit failure should be held until a later retry opportunity.
-                    // Transactions canceled behind it did not fail cost are immediately retryable..
-                    immediately_retryable: index != failed_index,
-                });
-            }
-        }
-    }
-
-    fn accumulate_post_execution_transaction_error(
-        previous_processing_result: &TransactionProcessingResult,
-        transaction_error: &TransactionError,
-        error_counters: &mut TransactionErrorMetrics,
-    ) {
-        // To avoid double counting, only increment `total` by 1 if a successful transaction
-        // is turned into error (eg cost limit error, or CommitCancelled).
-        if previous_processing_result.flattened_result().is_ok() {
-            error_counters.total += 1;
-        }
-        Self::accumulate_cost_limit_error(transaction_error, error_counters);
-    }
-
-    fn remove_added_transaction_costs<Tx: TransactionWithMeta>(
-        bank: &Bank,
-        transaction_costs: &[Option<TransactionCost<'_, Tx>>],
-    ) {
-        let mut cost_tracker = bank.write_cost_tracker().unwrap();
-        for transaction_cost in transaction_costs.iter().flatten() {
-            cost_tracker.remove(transaction_cost);
-        }
-    }
-
-    fn decrement_processed_counts(
-        transaction: &impl TransactionWithMeta,
-        processing_result: &TransactionProcessingResult,
-        processed_counts: &mut ProcessedTransactionCounts,
-    ) {
-        processed_counts.processed_transactions_count = processed_counts
-            .processed_transactions_count
-            .saturating_sub(1);
-        processed_counts.signature_count = processed_counts
-            .signature_count
-            .saturating_sub(transaction.signature_details().num_transaction_signatures());
-
-        if !transaction.is_simple_vote_transaction() {
-            processed_counts.processed_non_vote_transactions_count = processed_counts
-                .processed_non_vote_transactions_count
-                .saturating_sub(1);
-        }
-
-        if processing_result.was_processed_with_successful_result() {
-            processed_counts.processed_with_successful_result_count = processed_counts
-                .processed_with_successful_result_count
-                .saturating_sub(1);
-        }
-    }
-
-    fn accumulate_cost_limit_error(
-        transaction_error: &TransactionError,
-        error_counters: &mut TransactionErrorMetrics,
-    ) {
-        match transaction_error {
-            TransactionError::WouldExceedMaxBlockCostLimit => {
-                error_counters.would_exceed_max_block_cost_limit += 1;
-            }
-            TransactionError::WouldExceedMaxVoteCostLimit => {
-                error_counters.would_exceed_max_vote_cost_limit += 1;
-            }
-            TransactionError::WouldExceedMaxAccountCostLimit => {
-                error_counters.would_exceed_max_account_cost_limit += 1;
-            }
-            TransactionError::WouldExceedAccountDataBlockLimit => {
-                error_counters.would_exceed_account_data_block_limit += 1;
-            }
-            _ => {}
         }
     }
 
@@ -751,7 +517,7 @@ mod tests {
             self as address_lookup_table,
             state::{AddressLookupTable, LookupTableMeta},
         },
-        solana_cost_model::{cost_model::CostModel, cost_tracker::CostTrackerLimits},
+        solana_cost_model::cost_model::CostModel,
         solana_fee_calculator::FeeCalculator,
         solana_hash::Hash,
         solana_instruction::error::InstructionError,
@@ -797,20 +563,13 @@ mod tests {
     }
 
     fn setup_test(transaction_status_sender: Option<TransactionStatusSender>) -> TestFrame {
-        setup_test_with_lamports(10_000, transaction_status_sender)
-    }
-
-    fn setup_test_with_lamports(
-        lamports: u64,
-        transaction_status_sender: Option<TransactionStatusSender>,
-    ) -> TestFrame {
         agave_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
             mint_keypair,
             ..
         } = create_genesis_config_with_leader(
-            lamports,
+            10_000,
             &Pubkey::new_unique(),
             bootstrap_validator_stake_lamports(),
         );
@@ -976,64 +735,6 @@ mod tests {
         );
 
         assert_eq!(bank.get_balance(&pubkey), 1);
-    }
-
-    #[test]
-    fn test_bank_process_and_record_transactions_already_frozen() {
-        let TestFrame {
-            mint_keypair,
-            bank,
-            bank_forks: _bank_forks,
-            record_receiver,
-            consumer,
-        } = setup_test(None);
-
-        let pubkey = solana_pubkey::new_rand();
-        let transactions = sanitize_transactions(vec![system_transaction::transfer(
-            &mint_keypair,
-            &pubkey,
-            1,
-            bank.confirmed_last_blockhash(),
-        )]);
-
-        bank.freeze();
-        assert_ne!(bank.hash(), Hash::default());
-
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
-
-        let ExecuteAndCommitTransactionsOutput {
-            transaction_counts,
-            retryable_transaction_indexes,
-            commit_transactions_result,
-            ..
-        } = process_transactions_batch_output.execute_and_commit_transactions_output;
-        assert_eq!(
-            transaction_counts,
-            LeaderProcessedTransactionCounts {
-                attempted_processing_count: 1,
-                processed_count: 1,
-                processed_with_successful_result_count: 1,
-            }
-        );
-        assert_eq!(
-            retryable_transaction_indexes,
-            vec![RetryableIndex {
-                index: 0,
-                immediately_retryable: true,
-            }]
-        );
-        assert_matches!(
-            commit_transactions_result,
-            Err(PohRecorderError::MaxHeightReached)
-        );
-
-        let cost_tracker = bank.read_cost_tracker().unwrap();
-        assert_eq!(cost_tracker.transaction_count(), 0);
-        assert_eq!(cost_tracker.block_cost(), 0);
-        drop(cost_tracker);
-        assert!(record_receiver.try_recv().is_err());
-        assert_eq!(bank.get_balance(&pubkey), 0);
     }
 
     #[test]
@@ -1326,240 +1027,6 @@ mod tests {
         // and the cost tracker is unchanged after processing it
         assert_eq!(get_block_cost(), 0);
         assert_eq!(get_tx_count(), 0);
-    }
-
-    #[test]
-    fn test_actual_cost_limit_rejects_after_execution_before_record() {
-        const TRANSACTION_COUNT: usize = 32;
-
-        let TestFrame {
-            mint_keypair,
-            bank,
-            bank_forks: _bank_forks,
-            record_receiver,
-            consumer,
-        } = setup_test_with_lamports(1_000_000_000, None);
-
-        let payer_keypairs = (0..TRANSACTION_COUNT)
-            .map(|_| Keypair::new())
-            .collect::<Vec<_>>();
-        for payer in &payer_keypairs {
-            bank.transfer(1_000_000, &mint_keypair, &payer.pubkey())
-                .unwrap();
-        }
-
-        let transactions = sanitize_transactions(
-            payer_keypairs
-                .iter()
-                .map(|payer| {
-                    system_transaction::transfer(
-                        payer,
-                        &Pubkey::new_unique(),
-                        1,
-                        bank.last_blockhash(),
-                    )
-                })
-                .collect(),
-        );
-        let estimated_cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set).sum();
-        let block_limit = estimated_cost.saturating_mul(2);
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(CostTrackerLimits {
-                account_cost: block_limit,
-                block_cost: block_limit,
-                allocated_data_size: u64::MAX,
-            });
-
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
-        let ProcessTransactionBatchOutput {
-            cost_model_throttled_transactions_count,
-            execute_and_commit_transactions_output,
-            ..
-        } = process_transactions_batch_output;
-        let ExecuteAndCommitTransactionsOutput {
-            transaction_counts,
-            retryable_transaction_indexes,
-            commit_transactions_result,
-            error_counters,
-            ..
-        } = execute_and_commit_transactions_output;
-        let commit_transaction_details = commit_transactions_result.unwrap();
-        let committed_count = commit_transaction_details
-            .iter()
-            .filter(|details| matches!(details, CommitTransactionDetails::Committed { .. }))
-            .count();
-        let late_cost_rejected_indexes = commit_transaction_details
-            .iter()
-            .enumerate()
-            .filter_map(|(index, details)| {
-                matches!(
-                    details,
-                    CommitTransactionDetails::NotCommitted(
-                        TransactionError::WouldExceedMaxBlockCostLimit
-                    )
-                )
-                .then_some(index)
-            })
-            .collect::<Vec<_>>();
-        let commit_cancelled_count = commit_transaction_details
-            .iter()
-            .filter(|details| {
-                matches!(
-                    details,
-                    CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled)
-                )
-            })
-            .count();
-        let retryable_indexes = (committed_count..TRANSACTION_COUNT)
-            .map(|index| RetryableIndex::new(index, index != committed_count))
-            .collect::<Vec<_>>();
-
-        assert!(committed_count > 0);
-        assert_eq!(late_cost_rejected_indexes, vec![committed_count]);
-        assert_eq!(
-            commit_cancelled_count,
-            TRANSACTION_COUNT - committed_count - late_cost_rejected_indexes.len()
-        );
-        assert_eq!(error_counters.total.0, TRANSACTION_COUNT - committed_count);
-        assert_eq!(
-            error_counters.would_exceed_max_block_cost_limit.0,
-            late_cost_rejected_indexes.len()
-        );
-        assert_eq!(
-            cost_model_throttled_transactions_count,
-            retryable_indexes.len() as u64
-        );
-        assert_eq!(
-            transaction_counts.attempted_processing_count,
-            TRANSACTION_COUNT as u64
-        );
-        assert_eq!(transaction_counts.processed_count, committed_count as u64);
-        assert_eq!(
-            transaction_counts.processed_with_successful_result_count,
-            committed_count as u64
-        );
-        assert_eq!(retryable_transaction_indexes, retryable_indexes);
-
-        let cost_tracker = bank.read_cost_tracker().unwrap();
-        assert_eq!(cost_tracker.transaction_count(), committed_count as u64);
-        assert!(cost_tracker.block_cost() <= block_limit);
-        drop(cost_tracker);
-
-        let record = record_receiver.drain().next().unwrap();
-        assert_eq!(record.transactions.len(), committed_count);
-    }
-
-    #[test]
-    fn test_actual_cost_limit_honors_all_or_nothing() {
-        const TRANSACTION_COUNT: usize = 32;
-
-        let TestFrame {
-            mint_keypair,
-            bank,
-            bank_forks: _bank_forks,
-            record_receiver: _record_receiver,
-            consumer,
-        } = setup_test_with_lamports(1_000_000_000, None);
-
-        let payer_keypairs = (0..TRANSACTION_COUNT)
-            .map(|_| Keypair::new())
-            .collect::<Vec<_>>();
-        for payer in &payer_keypairs {
-            bank.transfer(1_000_000, &mint_keypair, &payer.pubkey())
-                .unwrap();
-        }
-
-        let transactions = sanitize_transactions(
-            payer_keypairs
-                .iter()
-                .map(|payer| {
-                    system_transaction::transfer(
-                        payer,
-                        &Pubkey::new_unique(),
-                        1,
-                        bank.last_blockhash(),
-                    )
-                })
-                .collect(),
-        );
-        let estimated_cost = CostModel::calculate_cost(&transactions[0], &bank.feature_set).sum();
-        let block_limit = estimated_cost.saturating_mul(2);
-        bank.write_cost_tracker()
-            .unwrap()
-            .set_limits(CostTrackerLimits {
-                account_cost: block_limit,
-                block_cost: block_limit,
-                allocated_data_size: u64::MAX,
-            });
-
-        let process_transactions_batch_output = consumer
-            .process_and_record_transactions_with_pre_results(
-                &bank,
-                &transactions,
-                std::iter::repeat(Ok(())),
-                &ExecutionFlags {
-                    drop_on_failure: false,
-                    all_or_nothing: true,
-                },
-            );
-        let ExecuteAndCommitTransactionsOutput {
-            transaction_counts,
-            retryable_transaction_indexes,
-            commit_transactions_result,
-            error_counters,
-            ..
-        } = process_transactions_batch_output.execute_and_commit_transactions_output;
-        let commit_transaction_details = commit_transactions_result.unwrap();
-
-        assert_eq!(
-            process_transactions_batch_output.cost_model_throttled_transactions_count,
-            TRANSACTION_COUNT as u64
-        );
-        assert_eq!(
-            transaction_counts.attempted_processing_count,
-            TRANSACTION_COUNT as u64
-        );
-        assert_eq!(transaction_counts.processed_count, 0);
-        assert_eq!(transaction_counts.processed_with_successful_result_count, 0);
-        let cost_limit_failure_indexes = commit_transaction_details
-            .iter()
-            .enumerate()
-            .filter_map(|(index, details)| {
-                matches!(
-                    details,
-                    CommitTransactionDetails::NotCommitted(
-                        TransactionError::WouldExceedMaxBlockCostLimit
-                    )
-                )
-                .then_some(index)
-            })
-            .collect::<Vec<_>>();
-        let commit_cancelled_count = commit_transaction_details
-            .iter()
-            .filter(|details| {
-                matches!(
-                    details,
-                    CommitTransactionDetails::NotCommitted(TransactionError::CommitCancelled)
-                )
-            })
-            .count();
-        assert_eq!(cost_limit_failure_indexes.len(), 1);
-        assert_eq!(commit_cancelled_count, TRANSACTION_COUNT - 1);
-        assert_eq!(error_counters.total.0, TRANSACTION_COUNT);
-        assert_eq!(error_counters.would_exceed_max_block_cost_limit.0, 1);
-        let failed_index = cost_limit_failure_indexes[0];
-        assert_eq!(
-            retryable_transaction_indexes,
-            (0..TRANSACTION_COUNT)
-                .map(|index| RetryableIndex::new(index, index != failed_index))
-                .collect::<Vec<_>>()
-        );
-
-        let cost_tracker = bank.read_cost_tracker().unwrap();
-        assert_eq!(cost_tracker.transaction_count(), 0);
-        assert_eq!(cost_tracker.block_cost(), 0);
     }
 
     #[test_case(false; "locked")]

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -1,0 +1,677 @@
+//! Quality of service for block producer.
+//! Provides logic and functions to allow a Leader to prioritize
+//! how transactions are included in blocks, and optimize those blocks.
+//!
+
+use {
+    super::committer::CommitTransactionDetails,
+    agave_feature_set::FeatureSet,
+    smallvec::SmallVec,
+    solana_cost_model::{
+        cost_model::CostModel, cost_tracker::UpdatedCosts, transaction_cost::TransactionCost,
+    },
+    solana_runtime::bank::Bank,
+    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_transaction_error::TransactionError,
+};
+
+mod transaction {
+    pub use solana_transaction_error::TransactionResult as Result;
+}
+
+type TransactionCostResults<'a, Tx> = SmallVec<
+    [transaction::Result<TransactionCost<'a, Tx>>;
+        super::consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH],
+>;
+
+// QosService is local to each banking thread, each instance of QosService provides services to
+// one banking thread.
+// Banking thread calls `report_metrics(slot)` at end of `process_and_record_transaction()`, or any time
+// it wants.
+//
+pub struct QosService;
+
+impl QosService {
+    /// Calculate cost of transactions, if not already filtered out, determine which ones to
+    /// include in the slot, and accumulate costs in the cost tracker.
+    /// Returns a vector of results containing selected transaction costs, and the number of
+    /// transactions that were *NOT* selected.
+    pub fn select_and_accumulate_transaction_costs<'a, Tx: TransactionWithMeta>(
+        bank: &Bank,
+        transactions: &'a [Tx],
+        pre_results: impl Iterator<Item = transaction::Result<()>>,
+    ) -> (TransactionCostResults<'a, Tx>, u64) {
+        let transaction_costs =
+            Self::compute_transaction_costs(&bank.feature_set, transactions.iter(), pre_results);
+        let (transactions_qos_cost_results, num_included) =
+            Self::select_transactions_per_cost(transactions.iter(), transaction_costs, bank);
+        let cost_model_throttled_transactions_count =
+            transactions.len().saturating_sub(num_included) as u64;
+
+        (
+            transactions_qos_cost_results,
+            cost_model_throttled_transactions_count,
+        )
+    }
+
+    // invoke cost_model to calculate cost for the given list of transactions that have not
+    // been filtered out already.
+    fn compute_transaction_costs<'a, Tx: TransactionWithMeta>(
+        feature_set: &FeatureSet,
+        transactions: impl Iterator<Item = &'a Tx>,
+        pre_results: impl Iterator<Item = transaction::Result<()>>,
+    ) -> TransactionCostResults<'a, Tx> {
+        transactions
+            .zip(pre_results)
+            .map(|(tx, pre_result)| {
+                pre_result.map(|()| {
+                    let mut reserving_cost = CostModel::calculate_cost(tx, feature_set);
+
+                    let usage_cost_details = reserving_cost.usage_cost_details_mut();
+                    // To maintain cost tracking consistency, reserve at least one page for
+                    // loading the fee payer account in fee-only fallback scenarios.
+                    usage_cost_details.loaded_accounts_data_size_cost = usage_cost_details
+                        .loaded_accounts_data_size_cost
+                        .max(CostModel::calculate_pages_cost(1));
+
+                    reserving_cost
+                })
+            })
+            .collect()
+    }
+
+    /// Given a list of transactions and their costs, this function returns a corresponding
+    /// list of Results that indicate if a transaction is selected to be included in the current block,
+    /// and a count of the number of transactions that would fit in the block
+    fn select_transactions_per_cost<'a, Tx: TransactionWithMeta>(
+        transactions: impl Iterator<Item = &'a Tx>,
+        mut transactions_costs: TransactionCostResults<'a, Tx>,
+        bank: &Bank,
+    ) -> (TransactionCostResults<'a, Tx>, usize) {
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        let mut num_included = 0;
+        transactions
+            .zip(transactions_costs.iter_mut())
+            .for_each(|(tx, cost_result)| {
+                let Ok(cost) = cost_result else {
+                    return;
+                };
+
+                match cost_tracker.try_add(cost) {
+                    Ok(UpdatedCosts {
+                        updated_block_cost,
+                        updated_costliest_account_cost,
+                    }) => {
+                        debug!(
+                            "slot {:?}, transaction {:?}, cost {:?}, fit into current block, \
+                             current block cost {}, updated costliest account cost {}",
+                            bank.slot(),
+                            tx,
+                            cost,
+                            updated_block_cost,
+                            updated_costliest_account_cost
+                        );
+                        num_included += 1;
+                    }
+                    Err(e) => {
+                        debug!(
+                            "slot {:?}, transaction {:?}, cost {:?}, not fit into current block, \
+                             '{:?}'",
+                            bank.slot(),
+                            tx,
+                            cost,
+                            e
+                        );
+                        *cost_result = Err(TransactionError::from(e));
+                    }
+                }
+            });
+        cost_tracker.add_transactions_in_flight(num_included);
+
+        (transactions_costs, num_included)
+    }
+
+    /// Removes transaction costs from the cost tracker if not committed or recorded, or
+    /// updates the transaction costs for committed transactions.
+    pub fn remove_or_update_costs<'a, Tx: TransactionWithMeta + 'a>(
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
+        bank: &Bank,
+    ) {
+        match transaction_committed_status {
+            Some(transaction_committed_status) => {
+                Self::remove_or_update_recorded_transaction_costs(
+                    transaction_cost_results,
+                    transaction_committed_status,
+                    bank,
+                )
+            }
+            None => Self::remove_unrecorded_transaction_costs(transaction_cost_results, bank),
+        }
+    }
+
+    /// For recorded transactions, remove units reserved by uncommitted transaction, or update
+    /// units for committed transactions.
+    fn remove_or_update_recorded_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        transaction_committed_status: &Vec<CommitTransactionDetails>,
+        bank: &Bank,
+    ) {
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        let mut num_included = 0;
+        transaction_cost_results
+            .zip(transaction_committed_status)
+            .for_each(|(tx_cost, transaction_committed_details)| {
+                // Only transactions that the qos service included have to be
+                // checked for update
+                if let Ok(tx_cost) = tx_cost {
+                    num_included += 1;
+                    match transaction_committed_details {
+                        CommitTransactionDetails::Committed {
+                            compute_units,
+                            loaded_accounts_data_size,
+                            result: _,
+                            fee_payer_post_balance: _,
+                        } => {
+                            cost_tracker.update_execution_cost(
+                                tx_cost,
+                                *compute_units,
+                                CostModel::calculate_loaded_accounts_data_size_cost(
+                                    *loaded_accounts_data_size,
+                                    &bank.feature_set,
+                                ),
+                            );
+                        }
+                        CommitTransactionDetails::NotCommitted(_err) => {
+                            cost_tracker.remove(tx_cost);
+                        }
+                    }
+                }
+            });
+        cost_tracker.sub_transactions_in_flight(num_included);
+    }
+
+    /// Remove reserved units for transaction batch that unsuccessfully recorded.
+    fn remove_unrecorded_transaction_costs<'a, Tx: TransactionWithMeta + 'a>(
+        transaction_cost_results: impl Iterator<Item = &'a transaction::Result<TransactionCost<'a, Tx>>>,
+        bank: &Bank,
+    ) {
+        let mut cost_tracker = bank.write_cost_tracker().unwrap();
+        let mut num_included = 0;
+        transaction_cost_results.for_each(|tx_cost| {
+            // Only transactions that the qos service included have to be
+            // removed
+            if let Ok(tx_cost) = tx_cost {
+                num_included += 1;
+                cost_tracker.remove(tx_cost);
+            }
+        });
+        cost_tracker.sub_transactions_in_flight(num_included);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        itertools::Itertools,
+        solana_cost_model::cost_tracker::CostTrackerLimits,
+        solana_hash::Hash,
+        solana_keypair::Keypair,
+        solana_runtime::genesis_utils::{GenesisConfigInfo, create_genesis_config},
+        solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
+        solana_signer::Signer,
+        solana_system_transaction as system_transaction,
+        solana_vote::vote_transaction,
+        solana_vote_program::vote_state::TowerSync,
+        std::sync::Arc,
+    };
+
+    #[test]
+    fn test_compute_transaction_costs() {
+        agave_logger::setup();
+
+        // make a vec of txs
+        let keypair = Keypair::new();
+        let transfer_tx = RuntimeTransaction::from_transaction_for_tests(
+            system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
+        );
+        let vote_tx = RuntimeTransaction::from_transaction_for_tests(
+            vote_transaction::new_tower_sync_transaction(
+                TowerSync::from(vec![(42, 1)]),
+                Hash::default(),
+                &keypair,
+                &keypair,
+                &keypair,
+                None,
+            ),
+        );
+        let txs = [transfer_tx.clone(), vote_tx.clone(), vote_tx, transfer_tx];
+
+        let txs_costs = QosService::compute_transaction_costs(
+            &FeatureSet::all_enabled(),
+            txs.iter(),
+            std::iter::repeat(Ok(())),
+        );
+
+        // verify the size of txs_costs and its contents
+        assert_eq!(txs_costs.len(), txs.len());
+        txs_costs
+            .iter()
+            .enumerate()
+            .map(|(index, cost)| {
+                assert_eq!(
+                    cost.as_ref().unwrap().sum(),
+                    CostModel::calculate_cost(&txs[index], &FeatureSet::all_enabled()).sum()
+                );
+            })
+            .collect_vec();
+    }
+
+    #[test]
+    fn test_select_transactions_per_cost() {
+        agave_logger::setup();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let keypair = Keypair::new();
+        let transfer_tx = RuntimeTransaction::from_transaction_for_tests(
+            system_transaction::transfer(&keypair, &keypair.pubkey(), 1, Hash::default()),
+        );
+        let vote_tx = RuntimeTransaction::from_transaction_for_tests(
+            vote_transaction::new_tower_sync_transaction(
+                TowerSync::from(vec![(42, 1)]),
+                Hash::default(),
+                &keypair,
+                &keypair,
+                &keypair,
+                None,
+            ),
+        );
+        let transfer_tx_cost =
+            CostModel::calculate_cost(&transfer_tx, &FeatureSet::all_enabled()).sum();
+        let vote_tx_cost = CostModel::calculate_cost(&vote_tx, &FeatureSet::all_enabled()).sum();
+        // make a vec of txs
+        let txs = [transfer_tx.clone(), vote_tx.clone(), transfer_tx, vote_tx];
+
+        let txs_costs = QosService::compute_transaction_costs(
+            &FeatureSet::all_enabled(),
+            txs.iter(),
+            std::iter::repeat(Ok(())),
+        );
+
+        // set cost tracker limit to bare minimum that will fit 1 transfer tx
+        // and 1 vote tx
+        let cost_limit = transfer_tx_cost + vote_tx_cost;
+        bank.write_cost_tracker()
+            .unwrap()
+            .set_limits(CostTrackerLimits::new(cost_limit, cost_limit, 0));
+        let (results, num_selected) =
+            QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+        assert_eq!(num_selected, 2);
+
+        // verify that first transfer tx and first vote are allowed
+        assert_eq!(results.len(), txs.len());
+        assert!(results[0].is_ok());
+        assert!(results[1].is_ok());
+        assert!(results[2].is_err());
+        assert!(results[3].is_err());
+    }
+
+    #[test]
+    fn test_update_and_remove_transaction_costs_committed() {
+        agave_logger::setup();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        // make some transfer transactions
+        // calculate their costs, apply to cost_tracker
+        let transaction_count = 5;
+        let keypair = Keypair::new();
+        let loaded_accounts_data_size: u32 = 1_000_000;
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+            &[
+                solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
+                solana_system_interface::instruction::transfer(&keypair.pubkey(), &solana_pubkey::Pubkey::new_unique(), 1),
+            ],
+            Some(&keypair.pubkey()),
+        ));
+        let transfer_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| transfer_tx.clone())
+            .collect();
+        let execute_units_adjustment: u64 = 10;
+        let loaded_accounts_data_size_adjustment: u32 = 32000;
+        let loaded_accounts_data_size_cost_adjustment =
+            CostModel::calculate_loaded_accounts_data_size_cost(
+                loaded_accounts_data_size_adjustment,
+                &bank.feature_set,
+            );
+
+        // assert all tx_costs should be applied to cost_tracker if all execution_results are all committed
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+            assert_eq!(
+                total_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+            // all transactions are committed with actual units more than estimated
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .map(|tx_cost| CommitTransactionDetails::Committed {
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost()
+                        + execute_units_adjustment,
+                    loaded_accounts_data_size: loaded_accounts_data_size
+                        + loaded_accounts_data_size_adjustment,
+                    result: Ok(()),
+                    fee_payer_post_balance: 0,
+                })
+                .collect();
+            let final_txs_cost = total_txs_cost
+                + (execute_units_adjustment + loaded_accounts_data_size_cost_adjustment)
+                    * transaction_count;
+
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+            assert_eq!(
+                final_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+            assert_eq!(
+                transaction_count,
+                bank.read_cost_tracker().unwrap().transaction_count()
+            );
+        }
+    }
+
+    #[test]
+    fn test_update_and_remove_transaction_costs_not_committed() {
+        agave_logger::setup();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        // make some transfer transactions
+        // calculate their costs, apply to cost_tracker
+        let transaction_count = 5;
+        let keypair = Keypair::new();
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| {
+                RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
+                    &keypair,
+                    &keypair.pubkey(),
+                    1,
+                    Hash::default(),
+                ))
+            })
+            .collect();
+
+        // assert all tx_costs should be removed from cost_tracker if all execution_results are all Not Committed
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+            assert_eq!(
+                total_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+
+            QosService::remove_or_update_costs(qos_cost_results.iter(), None, &bank);
+            assert_eq!(0, bank.read_cost_tracker().unwrap().block_cost());
+            assert_eq!(0, bank.read_cost_tracker().unwrap().transaction_count());
+        }
+    }
+
+    #[test]
+    fn test_update_and_remove_transaction_costs_mixed_execution() {
+        agave_logger::setup();
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        // make some transfer transactions
+        // calculate their costs, apply to cost_tracker
+        let transaction_count = 5;
+        let keypair = Keypair::new();
+        let loaded_accounts_data_size: u32 = 1_000_000;
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+            &[
+                solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(loaded_accounts_data_size),
+                solana_system_interface::instruction::transfer(&keypair.pubkey(), &solana_pubkey::Pubkey::new_unique(), 1),
+            ],
+            Some(&keypair.pubkey()),
+        ));
+        let txs: Vec<_> = (0..transaction_count)
+            .map(|_| RuntimeTransaction::from_transaction_for_tests(transaction.clone()))
+            .collect();
+        let execute_units_adjustment: u64 = 10;
+        let loaded_accounts_data_size_adjustment: u32 = 32000;
+        let loaded_accounts_data_size_cost_adjustment =
+            CostModel::calculate_loaded_accounts_data_size_cost(
+                loaded_accounts_data_size_adjustment,
+                &bank.feature_set,
+            );
+
+        // assert only committed tx_costs are applied cost_tracker
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+            assert_eq!(
+                total_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+            // Half of transactions are not committed, the rest with cost adjustment
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .enumerate()
+                .map(|(n, tx_cost)| {
+                    if n % 2 == 0 {
+                        CommitTransactionDetails::NotCommitted(
+                            TransactionError::InsufficientFundsForFee,
+                        )
+                    } else {
+                        CommitTransactionDetails::Committed {
+                            compute_units: tx_cost.as_ref().unwrap().programs_execution_cost()
+                                + execute_units_adjustment,
+                            loaded_accounts_data_size: loaded_accounts_data_size
+                                + loaded_accounts_data_size_adjustment,
+                            result: Ok(()),
+                            fee_payer_post_balance: 1,
+                        }
+                    }
+                })
+                .collect();
+
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+
+            // assert the final block cost
+            let mut expected_final_txs_count = 0u64;
+            let mut expected_final_block_cost = 0u64;
+            qos_cost_results.iter().enumerate().for_each(|(n, cost)| {
+                if n % 2 != 0 {
+                    expected_final_txs_count += 1;
+                    expected_final_block_cost += cost.as_ref().unwrap().sum()
+                        + execute_units_adjustment
+                        + loaded_accounts_data_size_cost_adjustment;
+                }
+            });
+            assert_eq!(
+                expected_final_block_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+            assert_eq!(
+                expected_final_txs_count,
+                bank.read_cost_tracker().unwrap().transaction_count()
+            );
+        }
+    }
+
+    #[test]
+    fn test_min_one_page_cost_reserved() {
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+    ));
+
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+        let tx_costs = QosService::compute_transaction_costs(
+            &FeatureSet::all_enabled(),
+            txs.iter(),
+            std::iter::repeat(Ok(())),
+        );
+
+        let tx_cost = tx_costs
+            .into_iter()
+            .next()
+            .expect("one tx cost")
+            .expect("tx cost should be computed");
+
+        let usage_cost_details = tx_cost.usage_cost_details();
+
+        assert_eq!(
+            usage_cost_details.loaded_accounts_data_size_cost,
+            CostModel::calculate_pages_cost(1),
+        );
+    }
+
+    #[test]
+    fn test_requested_zero_loaded_accounts_data_size_refund() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+        ));
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+            // transaction is committed with actual loaded account size == 0.
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .map(|tx_cost| CommitTransactionDetails::Committed {
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost(),
+                    loaded_accounts_data_size: 0,
+                    result: Ok(()),
+                    fee_payer_post_balance: 0,
+                })
+                .collect();
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+            // should refund cost of 1 page it over reserved
+            let final_txs_cost = total_txs_cost - CostModel::calculate_pages_cost(1);
+            assert_eq!(
+                final_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+        }
+    }
+
+    #[test]
+    fn test_requested_zero_loaded_accounts_data_size_no_refund() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+
+        let payer = Keypair::new();
+        let recipient = solana_pubkey::Pubkey::new_unique();
+        let transaction = solana_transaction::Transaction::new_unsigned(solana_message::Message::new(
+        &[
+            solana_compute_budget_interface::ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(0),
+            solana_system_interface::instruction::transfer(&payer.pubkey(), &recipient, 1),
+        ],
+        Some(&payer.pubkey()),
+        ));
+        let txs = [RuntimeTransaction::from_transaction_for_tests(transaction)];
+
+        {
+            let txs_costs = QosService::compute_transaction_costs(
+                &FeatureSet::all_enabled(),
+                txs.iter(),
+                std::iter::repeat(Ok(())),
+            );
+            let total_txs_cost: u64 = txs_costs
+                .iter()
+                .map(|cost| cost.as_ref().unwrap().sum())
+                .sum();
+            let (qos_cost_results, _num_included) =
+                QosService::select_transactions_per_cost(txs.iter(), txs_costs, &bank);
+            // transaction is committed with actual loaded account size == 1.
+            let committed_status: Vec<CommitTransactionDetails> = qos_cost_results
+                .iter()
+                .map(|tx_cost| CommitTransactionDetails::Committed {
+                    compute_units: tx_cost.as_ref().unwrap().programs_execution_cost(),
+                    loaded_accounts_data_size: 1,
+                    result: Ok(()),
+                    fee_payer_post_balance: 0,
+                })
+                .collect();
+            QosService::remove_or_update_costs(
+                qos_cost_results.iter(),
+                Some(&committed_status),
+                &bank,
+            );
+            // should be no refund, since the loaded size is same
+            assert_eq!(
+                total_txs_cost,
+                bank.read_cost_tracker().unwrap().block_cost()
+            );
+        }
+    }
+}

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -67,10 +67,9 @@ impl QosService {
                 pre_result.map(|()| {
                     let mut reserving_cost = CostModel::calculate_cost(tx, feature_set);
 
-                    let usage_cost_details = reserving_cost.usage_cost_details_mut();
                     // To maintain cost tracking consistency, reserve at least one page for
                     // loading the fee payer account in fee-only fallback scenarios.
-                    usage_cost_details.loaded_accounts_data_size_cost = usage_cost_details
+                    reserving_cost.loaded_accounts_data_size_cost = reserving_cost
                         .loaded_accounts_data_size_cost
                         .max(CostModel::calculate_pages_cost(1));
 
@@ -564,10 +563,8 @@ mod tests {
             .expect("one tx cost")
             .expect("tx cost should be computed");
 
-        let usage_cost_details = tx_cost.usage_cost_details();
-
         assert_eq!(
-            usage_cost_details.loaded_accounts_data_size_cost,
+            tx_cost.loaded_accounts_data_size_cost,
             CostModel::calculate_pages_cost(1),
         );
     }

--- a/core/src/cost_update_service.rs
+++ b/core/src/cost_update_service.rs
@@ -6,6 +6,7 @@ use {
     std::{
         sync::Arc,
         thread::{self, Builder, JoinHandle},
+        time::Duration,
     },
 };
 pub enum CostUpdate {
@@ -20,6 +21,12 @@ pub type CostUpdateReceiver = Receiver<CostUpdate>;
 pub struct CostUpdateService {
     thread_hdl: JoinHandle<()>,
 }
+
+// The maximum number of retries to check if CostTracker::in_flight_transaction_count() has settled
+// to zero. Bail out after this many retries; the in-flight count is reported so this is ok
+const MAX_LOOP_COUNT: usize = 25;
+// Throttle checking the count to avoid excessive polling
+const LOOP_LIMITER: Duration = Duration::from_millis(10);
 
 impl CostUpdateService {
     pub fn new(cost_update_receiver: CostUpdateReceiver) -> Self {
@@ -51,13 +58,33 @@ impl CostUpdateService {
                             collector_fee_details.total_priority_fee(),
                         )
                     };
-                    let cost_tracker = bank.read_cost_tracker().unwrap();
-                    cost_tracker.report_stats(
-                        bank.slot(),
-                        is_leader_block,
-                        total_transaction_fee,
-                        total_priority_fee,
-                    );
+                    for loop_count in 1..=MAX_LOOP_COUNT {
+                        {
+                            // Release the lock so that the thread that will
+                            // update the count is able to obtain a write lock
+                            //
+                            // Use inner scope to avoid sleeping with the lock
+                            let cost_tracker = bank.read_cost_tracker().unwrap();
+                            let in_flight_transaction_count =
+                                cost_tracker.in_flight_transaction_count();
+
+                            if in_flight_transaction_count == 0 || loop_count == MAX_LOOP_COUNT {
+                                let slot = bank.slot();
+                                trace!(
+                                    "inflight transaction count is {in_flight_transaction_count} \
+                                     for slot {slot} after {loop_count} iteration(s)"
+                                );
+                                cost_tracker.report_stats(
+                                    slot,
+                                    is_leader_block,
+                                    total_transaction_fee,
+                                    total_priority_fee,
+                                );
+                                break;
+                            }
+                        }
+                        std::thread::sleep(LOOP_LIMITER);
+                    }
                 }
             }
         }

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -255,6 +255,34 @@ impl CostTracker {
         })
     }
 
+    pub fn update_execution_cost(
+        &mut self,
+        estimated_tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        actual_execution_units: u64,
+        actual_loaded_accounts_data_size_cost: u64,
+    ) {
+        let actual_load_and_execution_units =
+            actual_execution_units.saturating_add(actual_loaded_accounts_data_size_cost);
+        let estimated_load_and_execution_units = estimated_tx_cost
+            .programs_execution_cost()
+            .saturating_add(estimated_tx_cost.loaded_accounts_data_size_cost());
+        match actual_load_and_execution_units.cmp(&estimated_load_and_execution_units) {
+            std::cmp::Ordering::Equal => (),
+            std::cmp::Ordering::Greater => {
+                self.add_transaction_execution_cost(
+                    estimated_tx_cost,
+                    actual_load_and_execution_units - estimated_load_and_execution_units,
+                );
+            }
+            std::cmp::Ordering::Less => {
+                self.sub_transaction_execution_cost(
+                    estimated_tx_cost,
+                    estimated_load_and_execution_units - actual_load_and_execution_units,
+                );
+            }
+        }
+    }
+
     /// Undoes the first `num_applied` per account cost applications of a
     /// partially applied transaction by subtracting the cost each one added.
     /// Entries left with zero cost are removed.
@@ -385,6 +413,22 @@ impl CostTracker {
         self.ed25519_instruction_signature_count -= tx_cost.num_ed25519_instruction_signatures();
         self.secp256r1_instruction_signature_count -=
             tx_cost.num_secp256r1_instruction_signatures();
+    }
+
+    /// Apply additional actual execution units to cost_tracker.
+    fn add_transaction_execution_cost(
+        &mut self,
+        tx_cost: &TransactionCost<impl TransactionWithMeta>,
+        adjustment: u64,
+    ) {
+        for account_key in tx_cost.writable_accounts() {
+            let account_cost = self
+                .cost_by_writable_accounts
+                .entry(*account_key)
+                .or_insert(0);
+            *account_cost = account_cost.saturating_add(adjustment);
+        }
+        self.block_cost.fetch_add(adjustment);
     }
 
     /// Subtract extra execution units from cost_tracker

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -104,6 +104,10 @@ pub struct CostTracker {
     transaction_signature_count: Saturating<u64>,
     secp256k1_instruction_signature_count: Saturating<u64>,
     ed25519_instruction_signature_count: Saturating<u64>,
+    /// The number of transactions that have had their estimated cost added to
+    /// the tracker, but are still waiting for an update with actual usage or
+    /// removal if the transaction does not end up getting committed.
+    in_flight_transaction_count: Saturating<usize>,
     secp256r1_instruction_signature_count: Saturating<u64>,
 }
 
@@ -121,6 +125,7 @@ impl Default for CostTracker {
             transaction_signature_count: Saturating(0),
             secp256k1_instruction_signature_count: Saturating(0),
             ed25519_instruction_signature_count: Saturating(0),
+            in_flight_transaction_count: Saturating(0),
             secp256r1_instruction_signature_count: Saturating(0),
         }
     }
@@ -160,6 +165,18 @@ impl CostTracker {
 
     pub fn set_limits_max(&mut self) {
         self.set_limits(CostTrackerLimits::MAX);
+    }
+
+    pub fn in_flight_transaction_count(&self) -> usize {
+        self.in_flight_transaction_count.0
+    }
+
+    pub fn add_transactions_in_flight(&mut self, in_flight_transaction_count: usize) {
+        self.in_flight_transaction_count += in_flight_transaction_count;
+    }
+
+    pub fn sub_transactions_in_flight(&mut self, in_flight_transaction_count: usize) {
+        self.in_flight_transaction_count -= in_flight_transaction_count
     }
 
     /// Checks the block and account limits and, if the transaction fits,
@@ -317,6 +334,11 @@ impl CostTracker {
             (
                 "ed25519_instruction_signature_count",
                 self.ed25519_instruction_signature_count.0,
+                i64
+            ),
+            (
+                "inflight_transaction_count",
+                self.in_flight_transaction_count.0,
                 i64
             ),
             (


### PR DESCRIPTION
This reverts commit 0ba741b.

Issues around non-global CU limits that lead to non-optimal scheduling / compute usage.

Plan is revert this (for 4.3), fix scheduling with this change in mind, re-apply.



