### PR TITLE
ci: retry create-stake-account cmd in localnet test

### DIFF
--- a/multinode-demo/common.sh
+++ b/multinode-demo/common.sh
@@ -107,3 +107,27 @@ replace_arg() {
     fi
   done
 }
+
+retry_command() {
+  declare max_attempts=$1
+  declare delay_seconds=$2
+  shift 2
+
+  declare attempt=1
+  declare status
+  while true; do
+    if "$@"; then
+      return 0
+    else
+      status=$?
+    fi
+
+    if ((attempt >= max_attempts)); then
+      return "$status"
+    fi
+
+    echo "Command failed; retrying in $delay_seconds seconds ($attempt/$max_attempts)" >&2
+    sleep "$delay_seconds"
+    attempt=$((attempt + 1))
+  done
+}

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -341,6 +341,7 @@ setup_validator_accounts() {
         ) || return $?
       fi
       echo "Creating stake account"
+      # in case partitioned epoch rewards distribution is active. retry the command to add more tlorercnce
       retry_command 10 2 \
         wallet create-stake-account "$stake_account" "$stake_sol" || return $?
       echo "Delegating stake"

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -341,7 +341,8 @@ setup_validator_accounts() {
         ) || return $?
       fi
       echo "Creating stake account"
-      wallet create-stake-account "$stake_account" "$stake_sol" || return $?
+      retry_command 10 2 \
+        wallet create-stake-account "$stake_account" "$stake_sol" || return $?
       echo "Delegating stake"
       declare vote_pubkey
       vote_pubkey=$($solana_keygen pubkey "$vote_account") || return $?


### PR DESCRIPTION
#### Problem

I saw this error in localnet step

```
Creating stake account
validator.sh: cargo run --bin solana -- --keypair /solana/net/../config/validator/identity.json --url http://127.0.0.1:8899 create-stake-account /solana/net/../config/validator/stake-account.json 2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s
     Running `target/debug/solana --keypair /solana/net/../config/validator/identity.json --url 'http://127.0.0.1:8899' create-stake-account /solana/net/../config/validator/stake-account.json 2`
Error: Error processing Instruction 1: custom program error: 0x10
```

the 0x10 should be this error `EpochRewardsActive`
https://github.com/solana-program/stake/blob/5847128c713296a2ed4fcae1659ed20af7ab26ec/interface/src/error.rs#L153-L161

#### Summary of Changes

that should only be a short period. let's retry 10 times with a 2s delay between attempts and see if that helps
