### PR TITLE
runtime: prevent bank removal during outstanding execution

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -189,6 +189,12 @@ fn simulate_transaction(
         }
         Ok(tx) => tx,
     };
+    let Ok(bank) = bank.try_for_execution() else {
+        return BanksTransactionResultWithSimulation {
+            result: None,
+            simulation_details: None,
+        };
+    };
     let TransactionSimulationResult {
         result,
         logs,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -112,13 +112,16 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         let bank = leader_state
             .working_bank()
             .expect("active_leader_state should only return an active bank");
+        let Ok(bank_for_execution) = bank.try_for_execution() else {
+            return Ok(ProcessingStatus::CouldNotProcess(work));
+        };
         self.metrics
             .count_metrics
             .num_messages_processed
             .fetch_add(1, Ordering::Relaxed);
 
         let output = self.consumer.process_and_record_aged_transactions(
-            bank,
+            &bank_for_execution,
             &work.transactions,
             &work.max_ages,
             &ExecutionFlags {
@@ -425,8 +428,18 @@ pub(crate) mod external {
 
                 return Ok(false);
             }
+            let Ok(bank_for_execution) = bank.try_for_execution() else {
+                return self
+                    .return_not_included_with_reason(
+                        message,
+                        not_included_reasons::BANK_NOT_AVAILABLE,
+                        bank.slot(),
+                    )
+                    .map(|()| true);
+            };
+
             let output = self.consumer.process_and_record_aged_transactions(
-                bank,
+                &bank_for_execution,
                 &transactions,
                 &max_ages,
                 &execution_flags,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -14,7 +14,7 @@ use {
     },
     solana_runtime::{
         bank::{
-            Bank, LoadAndExecuteTransactionsOutput, ProcessedTransactionCounts,
+            Bank, BankForExecution, LoadAndExecuteTransactionsOutput, ProcessedTransactionCounts,
             entry_bytes_budget::EntryBytesReserveError,
         },
         transaction_batch::TransactionBatch,
@@ -131,7 +131,7 @@ impl Consumer {
 
     pub fn process_and_record_transactions(
         &self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         txs: &[impl TransactionWithMeta],
     ) -> ProcessTransactionBatchOutput {
         let mut error_counters = TransactionErrorMetrics::default();
@@ -178,7 +178,7 @@ impl Consumer {
 
     pub fn process_and_record_aged_transactions(
         &self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         txs: &[impl TransactionWithMeta],
         max_ages: &[MaxAge],
         flags: &ExecutionFlags,
@@ -198,7 +198,7 @@ impl Consumer {
 
     fn process_and_record_transactions_with_pre_results(
         &self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         txs: &[impl TransactionWithMeta],
         pre_results: impl Iterator<Item = Result<(), TransactionError>>,
         flags: &ExecutionFlags,
@@ -233,7 +233,7 @@ impl Consumer {
 
     fn execute_and_commit_transactions_locked(
         &self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         batch: &TransactionBatch<impl TransactionWithMeta>,
         flags: &ExecutionFlags,
     ) -> ExecuteAndCommitTransactionsOutput {
@@ -847,7 +847,7 @@ mod tests {
         let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
         let committer = Committer::new(None, replay_vote_sender, None);
         let consumer = Consumer::new(committer, recorder, None);
-        consumer.process_and_record_transactions(&bank, &transactions)
+        consumer.process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions)
     }
 
     fn generate_new_address_lookup_table(
@@ -912,8 +912,8 @@ mod tests {
             bank.confirmed_last_blockhash(),
         )]);
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -945,8 +945,8 @@ mod tests {
             bank.confirmed_last_blockhash(),
         )]);
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -999,8 +999,8 @@ mod tests {
         bank.freeze();
         assert_ne!(bank.hash(), Hash::default());
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1076,8 +1076,8 @@ mod tests {
             bank.register_default_tick_for_test();
         }
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
             commit_transactions_result,
@@ -1123,8 +1123,8 @@ mod tests {
             sanitize_transactions(vec![tx])
         };
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1181,8 +1181,8 @@ mod tests {
             bank.last_blockhash(),
         )]);
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1219,8 +1219,8 @@ mod tests {
         )]);
         bank.try_lock_accounts(&conflicting_transaction);
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1305,8 +1305,8 @@ mod tests {
             bank.last_blockhash(),
         )]);
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1371,8 +1371,8 @@ mod tests {
                 allocated_data_size: u64::MAX,
             });
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
         let ProcessTransactionBatchOutput {
             cost_model_throttled_transactions_count,
             execute_and_commit_transactions_output,
@@ -1496,7 +1496,7 @@ mod tests {
 
         let process_transactions_batch_output = consumer
             .process_and_record_transactions_with_pre_results(
-                &bank,
+                &bank.try_for_execution().unwrap(),
                 &transactions,
                 std::iter::repeat(Ok(())),
                 &ExecutionFlags {
@@ -1607,8 +1607,8 @@ mod tests {
             bank.try_lock_accounts(&conflicting_transaction);
         }
 
-        let process_transactions_batch_output =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_batch_output = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ExecuteAndCommitTransactionsOutput {
             transaction_counts,
@@ -1790,8 +1790,8 @@ mod tests {
         // Channel shutdown should result in error returned on record.
         record_receiver.shutdown();
 
-        let process_transactions_summary =
-            consumer.process_and_record_transactions(&bank, &transactions);
+        let process_transactions_summary = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
 
         let ProcessTransactionBatchOutput {
             mut execute_and_commit_transactions_output,
@@ -1878,7 +1878,8 @@ mod tests {
         bank.transfer(rent_exempt_amount, &mint_keypair, &keypair1.pubkey())
             .unwrap();
 
-        let _ = consumer.process_and_record_transactions(&bank, &transactions);
+        let _ = consumer
+            .process_and_record_transactions(&bank.try_for_execution().unwrap(), &transactions);
         drop(consumer); // drop/disconnect transaction_status_sender
 
         let status_messages = transaction_status_receiver.into_iter().collect::<Vec<_>>();
@@ -1968,7 +1969,10 @@ mod tests {
 
         bank.transfer(1, &mint_keypair, &keypair.pubkey()).unwrap();
 
-        let _ = consumer.process_and_record_transactions(&bank, slice::from_ref(&sanitized_tx));
+        let _ = consumer.process_and_record_transactions(
+            &bank.try_for_execution().unwrap(),
+            slice::from_ref(&sanitized_tx),
+        );
         drop(consumer); // drop/disconnect transaction_status_sender
 
         let status_messages = transaction_status_receiver.into_iter().collect::<Vec<_>>();

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -23,7 +23,10 @@ use {
     solana_measure::{measure::Measure, measure_us},
     solana_perf::packet::bytes::Bytes,
     solana_poh::poh_recorder::PohRecorderError,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::{
+        bank::{Bank, BankForExecution},
+        bank_forks::BankForks,
+    },
     solana_runtime_transaction::{
         runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
         transaction_with_meta::TransactionWithMeta,
@@ -153,6 +156,12 @@ impl VoteWorker {
 
         match decision {
             BufferedPacketsDecision::Consume(bank) => {
+                if self.storage.is_empty() {
+                    return;
+                }
+                let Ok(bank) = bank.try_for_execution() else {
+                    return;
+                };
                 let (_, consume_buffered_packets_us) = measure_us!(self.consume_buffered_packets(
                     &bank,
                     banking_stage_stats,
@@ -180,14 +189,10 @@ impl VoteWorker {
 
     fn consume_buffered_packets(
         &mut self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         banking_stage_stats: &BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
     ) {
-        if self.storage.is_empty() {
-            return;
-        }
-
         let mut consumed_buffered_packets_count = 0;
         let mut rebuffered_packet_count = 0;
         let mut proc_start = Measure::start("consume_buffered_process");
@@ -229,7 +234,7 @@ impl VoteWorker {
     // returns `true` if the end of slot is reached
     fn process_packets(
         &mut self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         consumed_buffered_packets_count: &mut usize,
         rebuffered_packet_count: &mut usize,
         banking_stage_stats: &BankingStageStats,
@@ -291,7 +296,7 @@ impl VoteWorker {
 
     fn process_packets_transactions(
         &self,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         sanitized_transactions: &[impl TransactionWithMeta],
         banking_stage_stats: &BankingStageStats,
         slot_metrics_tracker: &mut LeaderSlotMetricsTracker,
@@ -347,7 +352,7 @@ impl VoteWorker {
     #[cfg_attr(test, qualifier_attr::qualifiers(pub(crate)))]
     fn process_transactions(
         consumer: &Consumer,
-        bank: &Bank,
+        bank: &BankForExecution<'_>,
         transactions: &[impl TransactionWithMeta],
     ) -> ProcessTransactionsSummary {
         let process_transaction_batch_output =
@@ -604,7 +609,11 @@ mod tests {
         )]);
 
         // Process some transactions on a bank that hasn't finished.
-        let summary = VoteWorker::process_transactions(&consumer, &bank, &transactions);
+        let summary = VoteWorker::process_transactions(
+            &consumer,
+            &bank.try_for_execution().unwrap(),
+            &transactions,
+        );
 
         // Assert - Transaction were prcoessed.
         assert!(summary.transaction_counts.committed_transactions_count.0 > 0);

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1483,7 +1483,7 @@ mod tests {
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
             let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
             if let Some(bank) = bank_to_clear {
-                let _ = bank.wait_for_completed_scheduler();
+                let _ = bank.retire_and_wait_for_outstanding_executions();
             }
             self.bank_forks.write().unwrap().clear_bank(slot, false);
             Ok(())

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2297,7 +2297,7 @@ impl ReplayStage {
                 .collect()
         };
         for bank in banks_to_remove {
-            let _ = bank.wait_for_completed_scheduler();
+            let _ = bank.retire_and_wait_for_outstanding_executions();
         }
 
         // Grab the Slot and BankId's of the banks we need to purge, then clear the banks
@@ -2586,7 +2586,7 @@ impl ReplayStage {
 
         // Wait for any in progress execution
         for bank in banks_to_clear.iter() {
-            let _ = bank.wait_for_completed_scheduler();
+            let _ = bank.retire_and_wait_for_outstanding_executions();
         }
         let bank_slots_to_clear = banks_to_clear
             .iter()

--- a/programs/sbf/tests/simulation.rs
+++ b/programs/sbf/tests/simulation.rs
@@ -52,7 +52,10 @@ fn test_no_panic_banks_client() {
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank
+        .try_for_execution()
+        .unwrap()
+        .simulate_transaction(&sanitized_tx, false);
     assert!(result.result.is_ok());
 }
 

--- a/programs/sbf/tests/syscall_get_epoch_stake.rs
+++ b/programs/sbf/tests/syscall_get_epoch_stake.rs
@@ -96,7 +96,10 @@ fn test_syscall_get_epoch_stake() {
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
 
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank
+        .try_for_execution()
+        .unwrap()
+        .simulate_transaction(&sanitized_tx, false);
 
     assert!(result.result.is_ok());
 

--- a/programs/sbf/tests/sysvar.rs
+++ b/programs/sbf/tests/sysvar.rs
@@ -123,7 +123,10 @@ fn test_sysvar_syscalls() {
         let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
         let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-        let result = bank.simulate_transaction(&sanitized_tx, false);
+        let result = bank
+            .try_for_execution()
+            .unwrap()
+            .simulate_transaction(&sanitized_tx, false);
         assert!(result.result.is_ok());
     }
 
@@ -141,6 +144,9 @@ fn test_sysvar_syscalls() {
     let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
     let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
     let sanitized_tx = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let result = bank.simulate_transaction(&sanitized_tx, false);
+    let result = bank
+        .try_for_execution()
+        .unwrap()
+        .simulate_transaction(&sanitized_tx, false);
     assert!(result.result.is_err());
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -66,7 +66,7 @@ use {
         response::{Response as RpcResponse, *},
     },
     solana_runtime::{
-        bank::{Bank, TransactionSimulationResult},
+        bank::{Bank, BankForExecution, TransactionSimulationResult},
         bank_forks::BankForks,
         commitment::{BlockCommitmentArray, BlockCommitmentCache},
         non_circulating_supply::{NonCirculatingSupply, calculate_non_circulating_supply},
@@ -286,6 +286,19 @@ impl JsonRpcRequestProcessor {
             .into());
         }
         Ok(bank)
+    }
+
+    fn get_bank_for_execution_with_config(
+        &self,
+        config: RpcContextConfig,
+    ) -> Result<BankForExecution<'static>> {
+        loop {
+            let bank = self.get_bank_with_config(config)?;
+            if let Ok(bank) = BankForExecution::try_from(bank) {
+                return Ok(bank);
+            }
+            std::thread::yield_now();
+        }
     }
 
     fn check_if_transaction_history_enabled(&self) -> Result<()> {
@@ -3676,6 +3689,7 @@ pub mod rpc_full {
     }
 
     pub struct FullImpl;
+
     impl Full for FullImpl {
         type Metadata = JsonRpcRequestProcessor;
 
@@ -3890,14 +3904,14 @@ pub mod rpc_full {
             } else {
                 preflight_commitment.map(|commitment| CommitmentConfig { commitment })
             };
-            let preflight_bank = &*meta.get_bank_with_config(RpcContextConfig {
+            let preflight_bank = meta.get_bank_for_execution_with_config(RpcContextConfig {
                 commitment: preflight_commitment,
                 min_context_slot,
             })?;
 
             let transaction = sanitize_transaction(
                 unsanitized_tx,
-                preflight_bank,
+                &*preflight_bank,
                 preflight_bank.get_reserved_account_keys(),
             )?;
             let blockhash = *transaction.message().recent_blockhash();
@@ -4032,7 +4046,7 @@ pub mod rpc_full {
             let (_, mut unsanitized_tx) =
                 decode_and_deserialize::<VersionedTransaction>(data, binary_encoding)?;
 
-            let bank = &*meta.get_bank_with_config(RpcContextConfig {
+            let bank = meta.get_bank_for_execution_with_config(RpcContextConfig {
                 commitment,
                 min_context_slot,
             })?;
@@ -4057,7 +4071,7 @@ pub mod rpc_full {
             }
 
             let transaction =
-                sanitize_transaction(unsanitized_tx, bank, bank.get_reserved_account_keys())?;
+                sanitize_transaction(unsanitized_tx, &*bank, bank.get_reserved_account_keys())?;
 
             let verification_error = if sig_verify {
                 transaction.verify().err()
@@ -4121,7 +4135,7 @@ pub mod rpc_full {
                             .map(|address_str| {
                                 let pubkey = verify_pubkey(address_str)?;
                                 get_encoded_account(
-                                    bank,
+                                    &bank,
                                     &pubkey,
                                     accounts_encoding,
                                     None,
@@ -4142,7 +4156,7 @@ pub mod rpc_full {
             });
 
             Ok(new_response(
-                bank,
+                &bank,
                 RpcSimulateTransactionResult {
                     err: result.err().map(Into::into),
                     logs: Some(logs),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -197,7 +197,7 @@ use {
     std::{
         collections::{HashMap, HashSet},
         fmt,
-        ops::AddAssign,
+        ops::{AddAssign, Deref},
         path::PathBuf,
         slice,
         sync::{
@@ -354,6 +354,152 @@ pub struct LoadAndExecuteTransactionsOutput {
     // Balances accumulated for TransactionStatusSender when transaction
     // balance recording is enabled.
     pub balance_collector: Option<BalanceCollector>,
+}
+
+// The high bit is a permanent retirement latch; the remaining bits count active
+// execution leases. The count must never grow into the retirement bit.
+const BANK_EXECUTION_RETIRED: u64 = 1 << 63;
+const BANK_EXECUTION_COUNT_MASK: u64 = !BANK_EXECUTION_RETIRED;
+
+/// Error returned when work tries to begin after a bank has started retirement.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("bank at slot {slot} is retired and unavailable for execution")]
+pub struct BankExecutionError {
+    pub slot: Slot,
+}
+
+/// Tracks all transaction execution using a bank, including simulation.
+///
+/// The hot path is lock-free. Retirement is rare and yields while admitted execution drains.
+///
+/// Acquisition and retirement are ordered by atomic read-modify-write operations on `state`:
+///
+/// - If the acquisition's increment happens first, it observes an unset retirement bit and its
+///   count forces retirement to wait for the resulting lease to be released.
+/// - If retirement's `fetch_or` happens first, the increment observes the retirement bit, rolls
+///   back its provisional count, and rejects the acquisition.
+///
+/// Once set, the retirement bit is never cleared. Thus no execution can be admitted after
+/// retirement begins, while every execution admitted before retirement is included in the count
+/// that retirement waits to drain.
+#[derive(Debug, Default)]
+struct BankExecutionTracker {
+    state: AtomicU64,
+}
+
+impl BankExecutionTracker {
+    fn try_acquire(&self, slot: Slot) -> std::result::Result<(), BankExecutionError> {
+        // Avoid an increment and rollback when retirement is already visible. This relaxed load
+        // is only a fast rejection path; the value returned by `fetch_add` below is authoritative.
+        if self.state.load(Relaxed) & BANK_EXECUTION_RETIRED != 0 {
+            return Err(BankExecutionError { slot });
+        }
+
+        // Increment first so retirement cannot miss an acquisition that it races with. If
+        // retirement won the race, its permanent bit is present in `previous` and this
+        // provisional increment must be rolled back before returning an error.
+        let previous = self.state.fetch_add(1, AcqRel);
+        if previous & BANK_EXECUTION_RETIRED != 0 {
+            self.state.fetch_sub(1, AcqRel);
+            return Err(BankExecutionError { slot });
+        }
+        assert_ne!(
+            previous & BANK_EXECUTION_COUNT_MASK,
+            BANK_EXECUTION_COUNT_MASK,
+            "bank execution count overflow"
+        );
+        Ok(())
+    }
+
+    fn release(&self) {
+        let previous = self.state.fetch_sub(1, AcqRel);
+        assert_ne!(previous & BANK_EXECUTION_COUNT_MASK, 0);
+    }
+
+    fn retire_and_wait(&self) {
+        // Publishing retirement and sampling the active count use the same atomic state as
+        // acquisition, making the two operations unambiguously ordered.
+        self.state.fetch_or(BANK_EXECUTION_RETIRED, AcqRel);
+        while self.state.load(Acquire) & BANK_EXECUTION_COUNT_MASK != 0 {
+            std::thread::yield_now();
+        }
+    }
+
+    fn try_retire_if_idle(&self) -> bool {
+        // Transition directly from idle to retired. A concurrent acquisition changes zero to a
+        // positive count first and makes this fail; a successful transition makes every later
+        // acquisition observe the retirement bit and reject itself.
+        match self
+            .state
+            .compare_exchange(0, BANK_EXECUTION_RETIRED, AcqRel, Acquire)
+        {
+            Ok(_) => true,
+            Err(state) => state == BANK_EXECUTION_RETIRED,
+        }
+    }
+}
+
+enum BankForExecutionInner<'a> {
+    Borrowed(&'a Bank),
+    Owned(Arc<Bank>),
+}
+
+/// A bank with an active execution lease.
+pub struct BankForExecution<'a> {
+    bank: BankForExecutionInner<'a>,
+}
+
+impl BankForExecution<'_> {
+    fn bank(&self) -> &Bank {
+        match &self.bank {
+            BankForExecutionInner::Borrowed(bank) => bank,
+            BankForExecutionInner::Owned(bank) => bank,
+        }
+    }
+}
+
+impl Deref for BankForExecution<'_> {
+    type Target = Bank;
+
+    fn deref(&self) -> &Self::Target {
+        self.bank()
+    }
+}
+
+impl Drop for BankForExecution<'_> {
+    fn drop(&mut self) {
+        self.bank().execution_tracker.release();
+    }
+}
+
+impl<'a> TryFrom<&'a Bank> for BankForExecution<'a> {
+    type Error = BankExecutionError;
+
+    fn try_from(bank: &'a Bank) -> std::result::Result<Self, Self::Error> {
+        bank.execution_tracker.try_acquire(bank.slot())?;
+        Ok(Self {
+            bank: BankForExecutionInner::Borrowed(bank),
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a Arc<Bank>> for BankForExecution<'a> {
+    type Error = BankExecutionError;
+
+    fn try_from(bank: &'a Arc<Bank>) -> std::result::Result<Self, Self::Error> {
+        Self::try_from(bank.as_ref())
+    }
+}
+
+impl TryFrom<Arc<Bank>> for BankForExecution<'static> {
+    type Error = BankExecutionError;
+
+    fn try_from(bank: Arc<Bank>) -> std::result::Result<Self, Self::Error> {
+        bank.execution_tracker.try_acquire(bank.slot())?;
+        Ok(Self {
+            bank: BankForExecutionInner::Owned(bank),
+        })
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -707,6 +853,7 @@ impl PartialEq for Bank {
             bank_hash_stats: _,
             epoch_rewards_calculation_cache: _,
             block_component_processor: _,
+            execution_tracker: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -1069,6 +1216,9 @@ pub struct Bank {
 
     /// Cached Alpenglow migration state, derived from the genesis certificate account.
     is_alpenglow: AtomicBool,
+
+    /// Prevents the bank from being removed while any transaction execution is using it.
+    execution_tracker: BankExecutionTracker,
 }
 
 #[derive(Debug, Default)]
@@ -1275,6 +1425,7 @@ impl Bank {
             epoch_rewards_calculation_cache: Arc::new(Mutex::new(HashMap::default())),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(false),
+            execution_tracker: BankExecutionTracker::default(),
         };
 
         bank.transaction_processor =
@@ -1542,6 +1693,7 @@ impl Bank {
             epoch_rewards_calculation_cache: parent.epoch_rewards_calculation_cache.clone(),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(parent.is_alpenglow()),
+            execution_tracker: BankExecutionTracker::default(),
         };
 
         let (_, ancestors_time_us) = measure_us!({
@@ -2198,6 +2350,7 @@ impl Bank {
             expected_bank_hash: RwLock::new(None),
             block_component_processor: RwLock::new(BlockComponentProcessor::default()),
             is_alpenglow: AtomicBool::new(false),
+            execution_tracker: BankExecutionTracker::default(),
         };
 
         if bank.get_alpenglow_genesis_certificate().is_some() {
@@ -3812,20 +3965,21 @@ impl Bank {
 
         Ok(())
     }
+}
 
-    /// Run transactions against a frozen bank without committing the results
+impl BankForExecution<'_> {
+    /// Run transactions against a frozen bank without committing the results.
     pub fn simulate_transaction(
         &self,
         transaction: &impl TransactionWithMeta,
         enable_cpi_recording: bool,
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
-
         self.simulate_transaction_unchecked(transaction, enable_cpi_recording)
     }
 
     /// Run transactions against a bank without committing the results; does not check if the bank
-    /// is frozen, enabling use in single-Bank test frameworks
+    /// is frozen, enabling use in single-Bank test frameworks.
     pub fn simulate_transaction_unchecked(
         &self,
         transaction: &impl TransactionWithMeta,
@@ -3964,7 +4118,9 @@ impl Bank {
             post_token_balances,
         }
     }
+}
 
+impl Bank {
     fn get_account_overrides_for_simulation(&self, account_keys: &AccountKeys) -> AccountOverrides {
         let mut account_overrides = AccountOverrides::default();
         let slot_history_id = sysvar::slot_history::id();
@@ -4022,7 +4178,9 @@ impl Bank {
         }
         balances
     }
+}
 
+impl BankForExecution<'_> {
     pub fn load_and_execute_transactions(
         &self,
         batch: &TransactionBatch<impl TransactionWithMeta>,
@@ -4067,7 +4225,7 @@ impl Bank {
         let sanitized_output = self
             .transaction_processor
             .load_and_execute_sanitized_transactions(
-                self,
+                &**self,
                 sanitized_txs,
                 check_results,
                 &processing_environment,
@@ -4133,6 +4291,24 @@ impl Bank {
             processed_counts,
             balance_collector: sanitized_output.balance_collector,
         }
+    }
+}
+
+impl Bank {
+    pub fn try_for_execution(
+        &self,
+    ) -> std::result::Result<BankForExecution<'_>, BankExecutionError> {
+        BankForExecution::try_from(self)
+    }
+
+    /// Permanently prevents new execution and waits for every admitted execution to finish.
+    pub(crate) fn retire_from_execution(&self) {
+        self.execution_tracker.retire_and_wait();
+    }
+
+    /// Close the execution gate only when there is no admitted execution.
+    pub(crate) fn try_retire_from_execution_if_idle(&self) -> bool {
+        self.execution_tracker.try_retire_if_idle()
     }
 
     fn collect_logs(
@@ -4604,11 +4780,14 @@ impl Bank {
         log_messages_bytes_limit: Option<usize>,
         pre_commit_callback: Option<impl FnOnce(&[TransactionProcessingResult]) -> Result<()>>,
     ) -> Result<(Vec<TransactionCommitResult>, Option<BalanceCollector>)> {
+        let bank_for_execution = self
+            .try_for_execution()
+            .expect("retired bank reached load-and-commit execution");
         let LoadAndExecuteTransactionsOutput {
             processing_results,
             processed_counts,
             balance_collector,
-        } = self.load_and_execute_transactions(
+        } = bank_for_execution.load_and_execute_transactions(
             batch,
             self.max_processing_age(),
             timings,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11961,7 +11961,10 @@ fn test_failed_simulation_compute_units() {
 
     bank.freeze();
     let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(&sanitized, false);
+    let simulation = bank
+        .try_for_execution()
+        .unwrap()
+        .simulate_transaction(&sanitized, false);
     assert_eq!(expected_consumed_units, simulation.units_consumed);
     assert_eq!(
         expected_loaded_program_account_data_size,
@@ -11989,7 +11992,10 @@ fn test_failed_simulation_load_error() {
     bank.freeze();
     let mint_balance = bank.get_account(&mint_keypair.pubkey()).unwrap().lamports();
     let sanitized = RuntimeTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(&sanitized, false);
+    let simulation = bank
+        .try_for_execution()
+        .unwrap()
+        .simulate_transaction(&sanitized, false);
     assert_eq!(
         simulation,
         TransactionSimulationResult {
@@ -12006,6 +12012,54 @@ fn test_failed_simulation_load_error() {
             pre_token_balances: Some(vec![]),
             post_token_balances: Some(vec![]),
         }
+    );
+}
+
+#[test]
+fn test_bank_execution_retirement_waits_and_rejects_late_execution() {
+    let tracker = Arc::new(BankExecutionTracker::default());
+    tracker.try_acquire(42).unwrap();
+    let tracker_for_retirement = tracker.clone();
+    let (retired_sender, retired_receiver) = bounded(1);
+
+    let retirement_thread = Builder::new()
+        .name("bank-retirement".to_string())
+        .spawn(move || {
+            tracker_for_retirement.retire_and_wait();
+            retired_sender.send(()).unwrap();
+        })
+        .unwrap();
+
+    while tracker.state.load(Acquire) & BANK_EXECUTION_RETIRED == 0 {
+        std::hint::spin_loop();
+    }
+    assert_eq!(
+        tracker.try_acquire(42).unwrap_err(),
+        BankExecutionError { slot: 42 }
+    );
+    assert!(
+        retired_receiver
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+
+    tracker.release();
+    retired_receiver
+        .recv_timeout(Duration::from_secs(1))
+        .unwrap();
+    retirement_thread.join().unwrap();
+}
+
+#[test]
+fn test_execution_wrapper_rejected_after_bank_retirement() {
+    let (genesis_config, _) = create_genesis_config(LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    bank.retire_from_execution();
+
+    assert_eq!(
+        bank.try_for_execution().err().unwrap(),
+        BankExecutionError { slot: bank.slot() }
     );
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -356,7 +356,17 @@ impl BankForks {
     }
 
     pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {
-        let bank = self.banks.remove(&slot)?;
+        let bank = self.banks.get(&slot)?;
+        // Removal callers should retire and drain outside the BankForks write lock. Never wait
+        // here: execution may need a BankForks read lock for program-cache access.
+        if !bank.try_retire_from_execution_if_idle() {
+            warn!(
+                "refusing to remove bank at slot {slot} with outstanding execution; callers \
+                 should retire and drain before removal"
+            );
+            return None;
+        }
+        let bank = self.banks.remove(&slot).unwrap();
         for parent in bank.proper_ancestors() {
             let Entry::Occupied(mut entry) = self.descendants.entry(parent) else {
                 panic!("this should not happen!");
@@ -918,6 +928,23 @@ mod tests {
     }
 
     #[test]
+    fn test_remove_refuses_bank_with_outstanding_execution() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let parent = bank_forks.read().unwrap().root_bank();
+        let child = Bank::new_from_parent(parent, SlotLeader::default(), 1);
+        let child = bank_forks.write().unwrap().insert(child);
+        let bank_for_execution = child.try_for_execution().unwrap();
+
+        assert!(bank_forks.write().unwrap().remove(1).is_none());
+        assert!(bank_forks.read().unwrap().get(1).is_some());
+
+        drop(bank_for_execution);
+        assert!(bank_forks.write().unwrap().remove(1).is_some());
+        assert!(bank_forks.read().unwrap().get(1).is_none());
+    }
+
+    #[test]
     fn test_clear_bank_after_scheduler_wait() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
@@ -963,7 +990,7 @@ mod tests {
                 .unwrap()
                 .get_with_scheduler(1)
                 .unwrap();
-            let _ = bank_to_clear.wait_for_completed_scheduler();
+            let _ = bank_to_clear.retire_and_wait_for_outstanding_executions();
             clear_bank_forks.write().unwrap().clear_bank(1, false);
             finish_done_sender.send(()).unwrap();
         });

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -369,7 +369,7 @@ mod tests {
                         let bank_to_clear =
                             replay_bank_forks.read().unwrap().get_with_scheduler(slot);
                         if let Some(bank) = bank_to_clear {
-                            let _ = bank.wait_for_completed_scheduler();
+                            let _ = bank.retire_and_wait_for_outstanding_executions();
                         }
 
                         {

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -4,7 +4,7 @@
 //!
 //! * The **native** core ([`execute_txn`] + [`BankTxnProcessingResult`]) builds a
 //!   [`Bank`] via [`Bank::new_for_txn_tests`], runs
-//!   `bank.load_and_execute_transactions`, and returns the native execution
+//!   `BankForExecution::load_and_execute_transactions`, and returns the native execution
 //!   result. It depends only on `solana-runtime`/SVM types, so it is available
 //!   under `dev-context-only-utils` and is what the unit tests exercise.
 //! * The **conformance** layer (gated by the `conformance` feature) is the
@@ -180,19 +180,23 @@ pub fn execute_txn(
 
     let mut timings = ExecuteTimings::default();
     let mut metrics = TransactionErrorMetrics::default();
+    let bank_for_execution = bank
+        .try_for_execution()
+        .expect("new conformance bank must be available for execution");
     let result = {
-        let batch = bank.prepare_locked_batch_from_single_tx(&runtime_transaction);
-        bank.load_and_execute_transactions(
-            &batch,
-            MAX_PROCESSING_AGE,
-            &mut timings,
-            &mut metrics,
-            processing_config,
-        )
-        .processing_results
-        .into_iter()
-        .next()
-        .expect("single transaction execution must return one result")
+        let batch = bank_for_execution.prepare_locked_batch_from_single_tx(&runtime_transaction);
+        bank_for_execution
+            .load_and_execute_transactions(
+                &batch,
+                MAX_PROCESSING_AGE,
+                &mut timings,
+                &mut metrics,
+                processing_config,
+            )
+            .processing_results
+            .into_iter()
+            .next()
+            .expect("single transaction execution must return one result")
     };
 
     BankTxnProcessingResult::Processed {

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -36,6 +36,7 @@ use {
         ops::Deref,
         sync::{Arc, RwLock},
         thread,
+        time::Instant,
     },
 };
 #[cfg(feature = "dev-context-only-utils")]
@@ -498,6 +499,26 @@ impl BankWithScheduler {
             &self.inner.scheduler,
             WaitReason::TerminatedToFreeze,
         )
+    }
+
+    /// Drain scheduled work, close the bank's execution gate, and wait for all execution,
+    /// including direct execution and simulation, to finish.
+    ///
+    /// This must be called without holding the `BankForks` write lock. The bank must remain in
+    /// `BankForks` until this method returns so admitted execution can continue using its fork
+    /// graph safely.
+    #[must_use]
+    pub fn retire_and_wait_for_outstanding_executions(&self) -> Option<ResultWithTimings> {
+        let start = Instant::now();
+        let result = self.wait_for_completed_scheduler();
+        self.inner.bank.retire_from_execution();
+        self.inner.bank.wait_for_inflight_commits();
+        datapoint_info!(
+            "bank-execution-retirement",
+            ("slot", self.inner.bank.slot() as i64, i64),
+            ("elapsed_us", start.elapsed().as_micros() as i64, i64),
+        );
+        result
     }
 
     pub const fn no_scheduler_available() -> InstalledSchedulerRwLock {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2760,7 +2760,9 @@ mod tests {
             ));
         // make sure this tx is really a good one to execute.
         assert_matches!(
-            bank.simulate_transaction_unchecked(&good_tx_after_bad_tx, false)
+            bank.try_for_execution()
+                .unwrap()
+                .simulate_transaction_unchecked(&good_tx_after_bad_tx, false)
                 .result,
             Ok(_)
         );

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1133,7 +1133,7 @@ mod tests {
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
             let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
             if let Some(bank) = bank_to_clear {
-                let _ = bank.wait_for_completed_scheduler();
+                let _ = bank.retire_and_wait_for_outstanding_executions();
             }
 
             self.bank_forks.write().unwrap().clear_bank(slot, false);

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -223,7 +223,7 @@ pub fn set_bank_forks_root<CB>(
             .collect()
     };
     for bank in banks_to_remove {
-        let _ = bank.wait_for_completed_scheduler();
+        let _ = bank.retire_and_wait_for_outstanding_executions();
     }
 
     bank_forks.read().unwrap().prune_program_cache(new_root);


### PR DESCRIPTION
#### Problem
- We currently wait on scheduler completion for replay when removing from forks
- We want to remove the unified-scheduler but still need this waiting behavior

#### Summary of Changes
- Introduce `BankForExecution` which contains all the transaction execution fns
- Add explicit lifetime tracking to banks, with loan system for execution
- Banks are retried and wait for completed executions before removal from forks 

#### Testing
- CI

Fixes #
