### PR TITLE
fix(svm): move solana-account bincode feature to dev-dependencies

### DIFF
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -81,7 +81,7 @@ protosol = { workspace = true, optional = true }
 qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 shuttle = { workspace = true, optional = true }
-solana-account = { workspace = true, features = ["bincode", "wincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
     "bincode",
     "bytemuck",
@@ -142,7 +142,7 @@ assert_matches = { workspace = true }
 env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand = { workspace = true }
-solana-account = { workspace = true }
+solana-account = { workspace = true, features = ["bincode"] }
 solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }


### PR DESCRIPTION
#### Problem

`solana-svm` compilation failed:

```
$ cargo build -p solana-svm

error[E0277]: the trait bound `Versions: serde::Serialize` is not satisfied
   --> /home/sol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-nonce-account-4.3.0/src/lib.rs:29:13
    |
 27 |         AccountSharedData::new_data_with_space(
    |         -------------------------------------- required by a bound introduced by this call
 28 |             lamports,
 29 |             &Versions::new(State::Uninitialized),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `serde_core::ser::Serialize` is not implemented for `Versions`
    |
    = note: for local types consider adding `#[derive(serde::Serialize)]` to your `Versions` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = note: `Versions` implements similarly named trait `wincode::serde::Serialize`, but not `serde_core::ser::Serialize`
    = help: the following other types implement trait `serde_core::ser::Serialize`:
              &'a T
              &'a mut T
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
              (T0, T1, T2, T3, T4)
            and 162 others
note: required by a bound in `solana_account::account::bincode::<impl AccountSharedData>::new_data_with_space`
   --> /home/sol/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/solana-account-4.5.0/src/account/bincode.rs:100:35
    |
100 |     pub fn new_data_with_space<T: serde::Serialize>(
    |                                   ^^^^^^^^^^^^^^^^ required by this bound in `solana_account::account::bincode::<impl AccountSharedData>::new_data_with_space`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `solana-nonce-account` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

it looks like the solana-account bincode feature is causing the issue

#### Summary of Changes

move the `solana-account/bincode` to dev-dependencies