### PR TITLE
program-runtime: clean up ProgramCacheMatchCriteria

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -203,8 +203,8 @@ pub struct ProgramToLoad<'a> {
     pub program_id: &'a Pubkey,
     /// The program loader
     pub loader: ProgramCacheEntryOwner,
-    /// Potentially filter out / ignore some entries during the start up / catch up phase
-    pub match_criteria: ProgramCacheMatchCriteria,
+    /// Ignore entries deployed before this slot.
+    pub deployed_on_or_after_slot: Slot,
     /// When the program account was last written to (might be after the deployment slot)
     pub last_modification_slot: Slot,
 }
@@ -364,12 +364,6 @@ impl ProgramCacheForTxBatch {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
-}
-
-#[derive(Clone, PartialEq, Debug)]
-pub enum ProgramCacheMatchCriteria {
-    DeployedOnOrAfterSlot(Slot),
-    NoCriteria,
 }
 
 impl<FG: ForkGraph> ProgramCache<FG> {
@@ -583,18 +577,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         environment == program_runtime_environment
     }
 
-    fn matches_criteria(
-        program: &Arc<ProgramCacheEntry>,
-        criteria: &ProgramCacheMatchCriteria,
-    ) -> bool {
-        match criteria {
-            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(slot) => {
-                program.deployment_slot >= *slot
-            }
-            ProgramCacheMatchCriteria::NoCriteria => true,
-        }
-    }
-
     /// Extracts a subset of the programs relevant to a transaction batch
     /// and returns which program accounts the accounts DB needs to load.
     pub fn extract(
@@ -654,10 +636,9 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                             .or(Some(entry.deployment_slot));
                                         continue;
                                     }
-                                    if !Self::matches_criteria(
-                                        entry,
-                                        &program_to_load.match_criteria,
-                                    ) {
+                                    if entry.deployment_slot
+                                        < program_to_load.deployed_on_or_after_slot
+                                    {
                                         break;
                                     }
                                     if let ProgramCacheEntryType::Unloaded(_environment) =
@@ -972,8 +953,7 @@ pub(crate) mod tests {
         crate::{
             loaded_programs::{
                 BlockRelation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
-                ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramToLoad,
-                get_mock_program_runtime_environment,
+                ProgramRuntimeEnvironment, ProgramToLoad, get_mock_program_runtime_environment,
             },
             program_cache_entry::{
                 ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
@@ -1837,7 +1817,7 @@ pub(crate) mod tests {
                     .map(|(_program_id, entry)| ProgramToLoad {
                         program_id: key,
                         loader: entry.account_owner,
-                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                        deployed_on_or_after_slot: 0,
                         last_modification_slot: entry.deployment_slot,
                     })
             })
@@ -2099,10 +2079,8 @@ pub(crate) mod tests {
 
         // Test the same fork, but request the program modified at a later slot than what's in the cache.
         let mut missing = get_entries_to_load(&cache, 12, keys);
-        missing.get_mut(0).unwrap().match_criteria =
-            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
-        missing.get_mut(1).unwrap().match_criteria =
-            ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(5);
+        missing.get_mut(0).unwrap().deployed_on_or_after_slot = 5;
+        missing.get_mut(1).unwrap().deployed_on_or_after_slot = 5;
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
@@ -2249,7 +2227,7 @@ pub(crate) mod tests {
         let mut missing = vec![ProgramToLoad {
             program_id: &program1,
             loader: ProgramCacheEntryOwner::LoaderV3,
-            match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+            deployed_on_or_after_slot: 0,
             last_modification_slot: 0,
         }];
         let mut extracted = ProgramCacheForTxBatch::new(0);
@@ -2408,63 +2386,5 @@ pub(crate) mod tests {
         let mut extracted = ProgramCacheForTxBatch::new(20);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_slot(&extracted, &program1, 0, 20));
-    }
-
-    #[test]
-    fn test_usable_entries_for_slot() {
-        ProgramCache::<TestForkGraph>::new(0);
-        let tombstone = Arc::new(ProgramCacheEntry::new_closed_tombstone(
-            0,
-            ProgramCacheEntryOwner::LoaderV2,
-        ));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &tombstone,
-            &ProgramCacheMatchCriteria::NoCriteria
-        ));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &tombstone,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
-        ));
-
-        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
-            &tombstone,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
-        ));
-
-        let program = new_test_entry(0);
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::NoCriteria
-        ));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
-        ));
-
-        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
-        ));
-
-        let program = Arc::new(new_test_entry_with_usage(0, ProgramStatistics::default()));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::NoCriteria
-        ));
-
-        assert!(ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)
-        ));
-
-        assert!(!ProgramCache::<TestForkGraph>::matches_criteria(
-            &program,
-            &ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(1)
-        ));
     }
 }

--- a/svm/src/program_loader.rs
+++ b/svm/src/program_loader.rs
@@ -7,10 +7,7 @@ use {
     solana_loader_v3_interface::state::UpgradeableLoaderState,
     solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
     solana_program_runtime::{
-        loaded_programs::{
-            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironment,
-            ProgramToLoad,
-        },
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironment, ProgramToLoad},
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
     },
     solana_pubkey::Pubkey,
@@ -278,7 +275,7 @@ pub fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>
             result.push(ProgramToLoad {
                 program_id: account_key,
                 loader,
-                match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(deployment_slot),
+                deployed_on_or_after_slot: deployment_slot,
                 last_modification_slot,
             });
         }
@@ -897,13 +894,13 @@ mod tests {
                 ProgramToLoad {
                     program_id: &program_ids[1],
                     loader: ProgramCacheEntryOwner::LoaderV2,
-                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
+                    deployed_on_or_after_slot: 0,
                     last_modification_slot: 0,
                 },
                 ProgramToLoad {
                     program_id: &program_ids[2],
                     loader: ProgramCacheEntryOwner::LoaderV3,
-                    match_criteria: ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0),
+                    deployed_on_or_after_slot: 0,
                     last_modification_slot: 0,
                 },
             ]

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -42,8 +42,7 @@ use {
         invoke_context::{EnvironmentConfig, InvokeContext},
         loaded_programs::{
             EpochBoundaryPreparation, ForkGraph, Percent, ProgramCache, ProgramCacheForTxBatch,
-            ProgramCacheMatchCriteria, ProgramRuntimeEnvironment, ProgramRuntimeEnvironments,
-            ProgramToLoad,
+            ProgramRuntimeEnvironment, ProgramRuntimeEnvironments, ProgramToLoad,
         },
         program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryOwner},
         program_metrics::ProgramStatistics,
@@ -327,7 +326,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .map(|program_id| ProgramToLoad {
                 program_id,
                 loader: ProgramCacheEntryOwner::NativeLoader,
-                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                deployed_on_or_after_slot: 0,
                 last_modification_slot: 0,
             })
             .collect();
@@ -1865,7 +1864,7 @@ mod tests {
             vec![ProgramToLoad {
                 program_id: &key,
                 loader: ProgramCacheEntryOwner::LoaderV3,
-                match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                deployed_on_or_after_slot: 0,
                 last_modification_slot: 0,
             }],
             &program_runtime_environment_for_execution,
@@ -1904,7 +1903,7 @@ mod tests {
                 vec![ProgramToLoad {
                     program_id: &key,
                     loader: ProgramCacheEntryOwner::LoaderV2,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    deployed_on_or_after_slot: 0,
                     last_modification_slot: 0,
                 }],
                 &program_runtime_environment_for_execution,
@@ -2151,7 +2150,7 @@ mod tests {
                 &mut vec![ProgramToLoad {
                     program_id: &key,
                     loader: ProgramCacheEntryOwner::NativeLoader,
-                    match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                    deployed_on_or_after_slot: 0,
                     last_modification_slot: 0,
                 }],
                 &mut loaded_programs_for_tx_batch,

--- a/svm/tests/concurrent_tests.rs
+++ b/svm/tests/concurrent_tests.rs
@@ -13,10 +13,7 @@ use {
     solana_instruction::{AccountMeta, Instruction},
     solana_program_runtime::{
         execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
-        loaded_programs::{
-            ProgramCacheForTxBatch, ProgramCacheMatchCriteria, ProgramRuntimeEnvironments,
-            ProgramToLoad,
-        },
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments, ProgramToLoad},
         program_cache_entry::{ProgramCacheEntryOwner, ProgramCacheEntryType},
         program_metrics::ProgramStatistics,
     },
@@ -65,7 +62,7 @@ fn program_cache_execution(threads: usize) {
                     .map(|program_id| ProgramToLoad {
                         program_id,
                         loader: ProgramCacheEntryOwner::LoaderV3,
-                        match_criteria: ProgramCacheMatchCriteria::NoCriteria,
+                        deployed_on_or_after_slot: 0,
                         last_modification_slot: 0,
                     })
                     .collect();


### PR DESCRIPTION
#### Problem
In #14484 we made `ProgramCacheMatchCritera::DeployedOnOrAfterSlot` the de facto match criteria for `filter_executable_program_accounts`.

`ProgramCacheMatchCritera::NoCriteria` is effectively the same as `ProgramCacheMatchCriteria::DeployedOnOrAfterSlot(0)`.

#### Summary of Changes
Remove `ProgramCacheMatchCritera` in favor of just a slot value, using `0` for anywhere that was previously using `NoCriteria`.

#### Testing
Behavior is unchanged by the commit, therefore existing test coverage should suffice.

