### PR TITLE
votor-transport: reduce quinn buffered INITIALs to 200ms of steady state

### DIFF
--- a/votor-transport/src/lib.rs
+++ b/votor-transport/src/lib.rs
@@ -115,7 +115,8 @@ pub(crate) const HANDSHAKE_DRAIN_RATE: usize = {
 /// a deeper queue does not admit more handshakes (the drain rate is fixed), it only
 /// adds latency to the attempts we do serve, so we keep it short and let the excess
 /// be shed by quinn.
-pub(crate) const MAX_INCOMING_DELAY: Duration = Duration::from_millis(1000);
+pub(crate) const MAX_INCOMING_DELAY: Duration =
+    Duration::from_millis(HANDSHAKE_BURST * 1000 / HANDSHAKE_GLOBAL_RATE as u64);
 
 /// How often endpoint metrics are reported.
 pub(crate) const METRICS_INTERVAL: Duration = Duration::from_secs(1);


### PR DESCRIPTION
#### Problem

Followup to #14439. Currently valid connection request can spend up to 1 second waiting in the buffers before we start serving it. This adds nothing but silly latency (bufferbloat).
Part of https://github.com/anza-xyz/agave/issues/14301

#### Summary of Changes

Reduce amount of time INITIAL can spend in the quinn queue before we look at it to 200ms. This can not be set any lower as it would result in losses under normal loads:

#### Testing

Artificial load-testing: ~2000 requests/s coming in all the time, we measure how many are admitted into processing per second (should be 100% as it is just below ratelimiters):

| depth | admitted     | vs budget |
  | ----- | ------------ | --------- |
  | 500   | 2024, 2029/s | 100%      |
  | 250   | 2038, 2042/s | 100%      |
  | 125   | 1994, 2019/s | −1%       |
  | 100   | 1969, 1898/s | −4%       |
  | 75    | 1793, 1809/s | −10%      |
  | 50    | 1585, 1635/s | −20%      |
  | 10    | 771/s        | −61%      |
  | 1     | 286/s        | −86%      |
