### PR TITLE
global program cache: key all builtins at deployment slot 0

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -1069,7 +1069,7 @@ pub fn mock_process_instruction_with_feature_set<
         } else {
             program_owner
         },
-        Arc::new(ProgramCacheEntry::new_builtin(0, builtin)),
+        Arc::new(ProgramCacheEntry::new_builtin(builtin)),
     );
     program_cache_for_tx_batch.set_slot_for_tests(
         invoke_context
@@ -1500,7 +1500,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             callee_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1555,7 +1555,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             callee_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1639,7 +1639,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             program_key,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -1927,7 +1927,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             TEST_CALLEE_PROGRAM_ID,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         invoke_context.program_cache_for_tx_batch = &mut program_cache_for_tx_batch;
 
@@ -2146,7 +2146,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_system_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         let account_keys = (0..transaction_context.get_number_of_accounts())
             .map(|index| {
@@ -2364,7 +2364,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
         let account_metas = vec![
             AccountMeta::new(
@@ -2591,7 +2591,7 @@ mod tests {
         let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::default();
         program_cache_for_tx_batch.replenish(
             mock_program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0, MockBuiltin::register)),
+            Arc::new(ProgramCacheEntry::new_builtin(MockBuiltin::register)),
         );
 
         struct MockCallback {}

--- a/program-runtime/src/program_cache_entry.rs
+++ b/program-runtime/src/program_cache_entry.rs
@@ -281,11 +281,11 @@ impl ProgramCacheEntry {
     }
 
     /// Creates a new built-in program
-    pub fn new_builtin(deployment_slot: Slot, register_fn: BuiltinFunctionRegisterer) -> Self {
+    pub fn new_builtin(register_fn: BuiltinFunctionRegisterer) -> Self {
         let mut program = BuiltinProgram::new_builtin();
         register_fn(&mut program, "entrypoint").unwrap();
         Self {
-            deployment_slot,
+            deployment_slot: 0, // Deployment slot is always zero
             account_owner: ProgramCacheEntryOwner::NativeLoader,
             program: ProgramCacheEntryType::Builtin(program),
             stats: Arc::default(),

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -993,7 +993,7 @@ impl ProgramTest {
         self.builtin_programs.push((
             program_id,
             program_name,
-            ProgramCacheEntry::new_builtin(0, builtin),
+            ProgramCacheEntry::new_builtin(builtin),
         ));
     }
 

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -2483,7 +2483,6 @@ mod tests {
                     invoke_context.program_cache_for_tx_batch.replenish(
                         system_program::id(),
                         Arc::new(ProgramCacheEntry::new_builtin(
-                            0,
                             solana_system_program::system_processor::Entrypoint::register,
                         )),
                     );

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -594,7 +594,6 @@ mod tests {
                 invoke_context.program_cache_for_tx_batch.replenish(
                     solana_sdk_ids::system_program::id(),
                     Arc::new(ProgramCacheEntry::new_builtin(
-                        0,
                         solana_system_program::system_processor::Entrypoint::register,
                     )),
                 );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4805,7 +4805,7 @@ pub mod tests {
             solana_pubkey::pubkey!("TestProgram11111111111111111111111111111111");
 
         fn cache_entry() -> ProgramCacheEntry {
-            ProgramCacheEntry::new_builtin(0, Self::register)
+            ProgramCacheEntry::new_builtin(Self::register)
         }
 
         fn instruction(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5956,7 +5956,7 @@ impl Bank {
         self.add_builtin(
             program_id,
             "mockup",
-            ProgramCacheEntry::new_builtin(0, builtin),
+            ProgramCacheEntry::new_builtin(builtin),
         );
     }
 
@@ -6287,7 +6287,7 @@ impl Bank {
                 self.add_builtin(
                     builtin.program_id,
                     builtin.name,
-                    ProgramCacheEntry::new_builtin(0, builtin.register_fn),
+                    ProgramCacheEntry::new_builtin(builtin.register_fn),
                 );
             }
 
@@ -6437,7 +6437,7 @@ impl Bank {
             if builtin_is_active {
                 self.transaction_processor.add_builtin(
                     builtin.program_id,
-                    ProgramCacheEntry::new_builtin(0, builtin.register_fn),
+                    ProgramCacheEntry::new_builtin(builtin.register_fn),
                 );
             }
         }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -800,7 +800,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(NoopBuiltin::register),
             );
             account
         };
@@ -936,7 +936,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(NoopBuiltin::register),
             );
             account
         };
@@ -986,7 +986,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(NoopBuiltin::register),
             );
             account
         };
@@ -1036,7 +1036,7 @@ pub(crate) mod tests {
             bank.add_builtin(
                 builtin_id,
                 builtin_name.as_str(),
-                ProgramCacheEntry::new_builtin(0, NoopBuiltin::register),
+                ProgramCacheEntry::new_builtin(NoopBuiltin::register),
             );
             account
         };
@@ -1452,7 +1452,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
+            ProgramCacheEntry::new_builtin(cpi_mockup::Entrypoint::register),
         );
 
         let (builtin_id, config) = prototype.deconstruct();
@@ -1988,7 +1988,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
+            ProgramCacheEntry::new_builtin(cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.
@@ -2243,7 +2243,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
+            ProgramCacheEntry::new_builtin(cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.
@@ -2304,7 +2304,7 @@ pub(crate) mod tests {
         root_bank.add_builtin(
             cpi_program_id,
             cpi_program_name,
-            ProgramCacheEntry::new_builtin(0, cpi_mockup::Entrypoint::register),
+            ProgramCacheEntry::new_builtin(cpi_mockup::Entrypoint::register),
         );
 
         // Add the feature to the bank's inactive feature set.

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3751,12 +3751,12 @@ fn test_add_instruction_processor_for_existing_unrelated_accounts() {
         bank.add_builtin(
             vote_id,
             "mock_program1",
-            ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
+            ProgramCacheEntry::new_builtin(MockBuiltin::register),
         );
         bank.add_builtin(
             stake_id,
             "mock_program2",
-            ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
+            ProgramCacheEntry::new_builtin(MockBuiltin::register),
         );
         {
             let stakes = bank.stakes_cache.stakes();
@@ -5144,7 +5144,7 @@ fn test_fuzz_instructions() {
             bank.add_builtin(
                 key,
                 name.as_str(),
-                ProgramCacheEntry::new_builtin(0, MockBuiltin::register),
+                ProgramCacheEntry::new_builtin(MockBuiltin::register),
             );
             (key, name.as_bytes().to_vec())
         })

--- a/svm/src/conformance/programs.rs
+++ b/svm/src/conformance/programs.rs
@@ -111,7 +111,7 @@ pub fn new_program_cache_with_builtins(slot: u64) -> ProgramCacheForTxBatch {
     for builtin in SVM_BUILTINS {
         cache.replenish(
             builtin.program_id,
-            Arc::new(ProgramCacheEntry::new_builtin(0u64, builtin.register_fn)),
+            Arc::new(ProgramCacheEntry::new_builtin(builtin.register_fn)),
         );
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -365,6 +365,14 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             false,
         );
 
+        // Every registered builtin must be present in the global program cache,
+        // since `add_builtin` writes both together.
+        debug_assert!(
+            search_for.is_empty(),
+            "builtin(s) registered on this fork but missing from the global program cache: \
+             {search_for:?}"
+        );
+
         Self {
             slot,
             epoch,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -208,12 +208,20 @@ pub struct TransactionBatchProcessor<FG: ForkGraph> {
     /// ProgramRuntimeEnvironment of the current epoch
     pub program_runtime_environment: ProgramRuntimeEnvironment,
 
-    /// Builtin program ids
+    /// Builtin program ids for this fork.
+    /// Used to see the `builtin_program_cache` between slots via
+    /// `new_from()`.
     pub builtin_program_ids: RwLock<HashSet<Pubkey>>,
 
     /// Cached ProgramCacheForTxBatch pre-populated with builtin entries.
-    /// Populated once per block in `new_from()` from the global program cache,
-    /// avoiding re-acquiring the lock and re-running extract() on every batch.
+    /// Populated once per slot in `new_from()` from the global program cache.
+    ///
+    /// Keeping a dedicated builtin program cache for each slot:
+    ///
+    /// - Protects different forks from extracting the another fork's version
+    ///   of a builtin that may have been recently enabled or migrated to Core
+    ///   BPF.
+    /// - Avoids re-acquiring the lock and re-running extract() on every batch.
     builtin_program_cache: RwLock<ProgramCacheForTxBatch>,
 
     execution_cost: SVMTransactionExecutionCost,
@@ -320,6 +328,25 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
         // Pre-populate the builtin program cache from the global cache.
         // This is done once per block rather than once per batch.
+        //
+        // Note: Only the builtins already-listed in this slot's builtin program
+        // IDs can be extracted from the global program cache. This is important
+        // for cross-fork extraction when a builtin may be activated for the
+        // first time or migrated to Core BPF.
+        //
+        // The `builtin_program_ids` on the batch processor are effectively a
+        // guard against cross-fork extraction:
+        //
+        // - If a builtin appears in one fork's `builtin_program_ids`, it will
+        //   never be extracted by a fork whose `builtin_program_ids` _doesn't_
+        //   have it.
+        // - If a builtin is removed from one fork's `builtin_program_ids`, it
+        //   may still be extracted on another fork whose `builtin_program_ids`
+        //   still has it.
+        //
+        // `builtin_program_ids` seeds the `builtin_program_cache` below, which
+        // ensures only non-cached program IDs are extracted from the global
+        // program cache during `replenish_program_cache`.
         let mut builtin_program_cache = ProgramCacheForTxBatch::new(slot);
         let mut search_for: Vec<ProgramToLoad> = builtin_program_ids
             .iter()
@@ -1353,7 +1380,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
         self.sysvar_cache.read().unwrap().clone()
     }
 
-    /// Add a built-in program
+    /// Add a built-in program to this fork.
+    ///
+    /// A builtin program should _never_ be inserted directly into the global
+    /// program cache without updating the fork guard: `builtin_program_ids`
+    /// and `builtin_program_cache`.
     pub fn add_builtin(&self, program_id: Pubkey, builtin: ProgramCacheEntry) {
         self.builtin_program_ids.write().unwrap().insert(program_id);
         let entry = Arc::new(builtin);
@@ -2155,7 +2186,7 @@ mod tests {
                 ),
             )
         };
-        let program = ProgramCacheEntry::new_builtin(0, register_fn);
+        let program = ProgramCacheEntry::new_builtin(register_fn);
         batch_processor.add_builtin(key, program);
 
         let mut loaded_programs_for_tx_batch = ProgramCacheForTxBatch::new(0);
@@ -2180,7 +2211,7 @@ mod tests {
         let entry = loaded_programs_for_tx_batch.find(&key).unwrap();
 
         // Repeating code because ProgramCacheEntry does not implement clone.
-        let program = ProgramCacheEntry::new_builtin(0, register_fn);
+        let program = ProgramCacheEntry::new_builtin(register_fn);
         assert_eq!(entry, Arc::new(program));
     }
 

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1449,7 +1449,7 @@ mod tests {
         },
         solana_rent::Rent,
         solana_sbpf::vm,
-        solana_sdk_ids::{bpf_loader, system_program, sysvar},
+        solana_sdk_ids::{bpf_loader, native_loader, system_program, sysvar},
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
@@ -2221,6 +2221,323 @@ mod tests {
         // Repeating code because ProgramCacheEntry does not implement clone.
         let program = ProgramCacheEntry::new_builtin(register_fn);
         assert_eq!(entry, Arc::new(program));
+    }
+
+    #[test]
+    fn test_builtin_in_global_cache_but_not_in_fork_is_not_extracted() {
+        let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
+
+        let key = Pubkey::new_unique();
+        let register_fn: BuiltinFunctionRegisterer = |p, n| {
+            p.register_function(
+                n,
+                (
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                    |_| {},
+                ),
+            )
+        };
+
+        // Insert the builtin into the global program cache only, but bypass the
+        // `builtin_program_ids` fork guard.
+        batch_processor
+            .global_program_cache
+            .write()
+            .unwrap()
+            .assign_program(
+                &batch_processor.program_runtime_environment,
+                key,
+                0,
+                Arc::new(ProgramCacheEntry::new_builtin(register_fn)),
+            );
+        assert!(
+            !batch_processor
+                .builtin_program_ids
+                .read()
+                .unwrap()
+                .contains(&key)
+        );
+
+        // Roll over into another slot.
+        // Assert this bank does not pick up the inserted builtin.
+        let next_slot = batch_processor.new_from(1, 0);
+        assert!(!next_slot.builtin_program_ids.read().unwrap().contains(&key));
+        assert!(
+            next_slot
+                .builtin_program_cache
+                .read()
+                .unwrap()
+                .find(&key)
+                .is_none()
+        );
+
+        // Now register the address on this fork.
+        // Assert the builtin is still not available without a slot rollover.
+        batch_processor
+            .builtin_program_ids
+            .write()
+            .unwrap()
+            .insert(key);
+        assert!(
+            next_slot
+                .builtin_program_cache
+                .read()
+                .unwrap()
+                .find(&key)
+                .is_none()
+        );
+
+        // Now roll over into another slot.
+        // Assert the builtin was extracted from the global cache.
+        let next_slot = batch_processor.new_from(2, 0);
+        let entry = next_slot
+            .builtin_program_cache
+            .read()
+            .unwrap()
+            .find(&key)
+            .unwrap();
+        assert_eq!(entry, Arc::new(ProgramCacheEntry::new_builtin(register_fn)));
+    }
+
+    #[test]
+    fn test_builtin_not_in_fork_is_never_searched_for() {
+        let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
+
+        let key = Pubkey::new_unique();
+        let register_fn: BuiltinFunctionRegisterer = |p, n| {
+            p.register_function(
+                n,
+                (
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                    |_| {},
+                ),
+            )
+        };
+
+        // Insert a builtin into the global program cache.
+        // This is a builtin added by another fork, but not by ours.
+        batch_processor
+            .global_program_cache
+            .write()
+            .unwrap()
+            .assign_program(
+                &batch_processor.program_runtime_environment,
+                key,
+                0,
+                Arc::new(ProgramCacheEntry::new_builtin(register_fn)),
+            );
+
+        // Assert that a transaction naming the builtin's address does not
+        // tamper with the global program cache.
+        let mock_bank = MockBankCallback::default();
+        for account_exists in [false, true] {
+            if account_exists {
+                // Even if the account exists owned by the native loader,
+                // the invariant should hold.
+                mock_bank
+                    .account_shared_data
+                    .write()
+                    .unwrap()
+                    .insert(key, AccountSharedData::new(1, 1, &native_loader::id()));
+            }
+
+            let program_cache_for_tx_batch = batch_processor
+                .builtin_program_cache
+                .read()
+                .unwrap()
+                .clone();
+            assert!(program_cache_for_tx_batch.find(&key).is_none());
+
+            let search_for = filter_executable_program_accounts(
+                &mock_bank,
+                &program_cache_for_tx_batch,
+                std::iter::once(&key),
+            );
+            assert!(search_for.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_core_bpf_migration_of_a_builtin() {
+        const BUILTIN_SLOT: Slot = 0;
+        const MIGRATION_SLOT: Slot = 10;
+        const NEXT_SLOT: Slot = 11;
+
+        struct SingleChainForkGraph;
+        impl ForkGraph for SingleChainForkGraph {
+            fn relationship(&self, a: Slot, b: Slot) -> BlockRelation {
+                if a == b {
+                    BlockRelation::Equal
+                } else if a < b {
+                    BlockRelation::Ancestor
+                } else {
+                    BlockRelation::Descendant
+                }
+            }
+        }
+
+        let fork_graph = Arc::new(RwLock::new(SingleChainForkGraph));
+        let batch_processor =
+            TransactionBatchProcessor::new(BUILTIN_SLOT, 0, Arc::downgrade(&fork_graph), None);
+
+        let key = Pubkey::new_unique();
+        let register_fn: BuiltinFunctionRegisterer = |p, n| {
+            p.register_function(
+                n,
+                (
+                    |_invoke_context, _param0, _param1, _param2, _param3, _param4| {},
+                    |_| {},
+                ),
+            )
+        };
+
+        // Start with a properly guarded builtin: registered on the fork and
+        // present in the global program cache.
+        batch_processor.add_builtin(key, ProgramCacheEntry::new_builtin(register_fn));
+        assert!(
+            batch_processor
+                .builtin_program_ids
+                .read()
+                .unwrap()
+                .contains(&key)
+        );
+
+        // Simulate migrating the builtin program to Core BPF: "deploy" the
+        // program by assigning it a new Unloaded entry owned by Loader V3 in
+        // the global program cache, then remove it from `builtin_program_ids`.
+        batch_processor
+            .global_program_cache
+            .write()
+            .unwrap()
+            .assign_program(
+                &batch_processor.program_runtime_environment,
+                key,
+                MIGRATION_SLOT,
+                Arc::new(ProgramCacheEntry::new_unloaded(
+                    MIGRATION_SLOT,
+                    ProgramCacheEntryOwner::LoaderV3,
+                    batch_processor.program_runtime_environment.clone(),
+                )),
+            );
+        batch_processor
+            .builtin_program_ids
+            .write()
+            .unwrap()
+            .remove(&key);
+
+        // For the rest of the slot the builtin is still served: the batch cache was
+        // seeded at the start of the block and is unaffected by the guard change.
+        // `filter_executable_program_accounts` finds it there and short circuits,
+        // so the newly deployed program is never even searched for.
+        let program_cache_for_tx_batch = batch_processor
+            .builtin_program_cache
+            .read()
+            .unwrap()
+            .clone();
+        let entry = program_cache_for_tx_batch.find(&key).unwrap();
+        assert!(matches!(entry.program, ProgramCacheEntryType::Builtin(_)));
+        assert_eq!(entry.deployment_slot, BUILTIN_SLOT);
+
+        // Had it been searched for, it would not have been usable anyway: the
+        // program is deployed in this slot, so it is not effective until the next
+        // one and extraction yields a delay visibility tombstone.
+        let mut search_for = vec![ProgramToLoad {
+            program_id: &key,
+            loader: ProgramCacheEntryOwner::LoaderV3,
+            deployed_on_or_after_slot: MIGRATION_SLOT,
+            last_modification_slot: MIGRATION_SLOT,
+        }];
+        let mut extracted = ProgramCacheForTxBatch::new(MIGRATION_SLOT);
+        batch_processor
+            .global_program_cache
+            .read()
+            .unwrap()
+            .extract(
+                &mut search_for,
+                &mut extracted,
+                &batch_processor.program_runtime_environment,
+                false,
+                false,
+            );
+        assert!(matches!(
+            extracted.find(&key).unwrap().program,
+            ProgramCacheEntryType::DelayVisibility
+        ));
+
+        // Rolling to the next slot rebuilds the batch cache from the fork guard,
+        // which no longer lists the address, so the builtin is gone.
+        let next_slot = batch_processor.new_from(NEXT_SLOT, 0);
+        assert!(
+            next_slot
+                .builtin_program_cache
+                .read()
+                .unwrap()
+                .find(&key)
+                .is_none()
+        );
+
+        // A caller reporting the deployed slot now reaches the migrated program's
+        // entry, which is unloaded, so the cache signals a reload from account
+        // state. Crucially the builtin is not served in its place.
+        let mut search_for = vec![ProgramToLoad {
+            program_id: &key,
+            loader: ProgramCacheEntryOwner::LoaderV3,
+            deployed_on_or_after_slot: MIGRATION_SLOT,
+            last_modification_slot: MIGRATION_SLOT,
+        }];
+        let mut extracted = ProgramCacheForTxBatch::new(NEXT_SLOT);
+        next_slot.global_program_cache.read().unwrap().extract(
+            &mut search_for,
+            &mut extracted,
+            &next_slot.program_runtime_environment,
+            false,
+            false,
+        );
+        assert!(extracted.find(&key).is_none());
+        assert_eq!(search_for.len(), 1);
+
+        // The builtin entry does survive in the global program cache, but keyed at
+        // slot 0 under `NativeLoader`, which the lookup above cannot reach.
+        let mut search_for = vec![ProgramToLoad {
+            program_id: &key,
+            loader: ProgramCacheEntryOwner::NativeLoader,
+            deployed_on_or_after_slot: BUILTIN_SLOT,
+            last_modification_slot: BUILTIN_SLOT,
+        }];
+        let mut extracted = ProgramCacheForTxBatch::new(NEXT_SLOT);
+        next_slot.global_program_cache.read().unwrap().extract(
+            &mut search_for,
+            &mut extracted,
+            &next_slot.program_runtime_environment,
+            false,
+            false,
+        );
+        assert!(matches!(
+            extracted.find(&key).unwrap().program,
+            ProgramCacheEntryType::Builtin(_)
+        ));
+    }
+
+    #[test]
+    #[should_panic(expected = "missing from the global program cache")]
+    fn test_builtin_in_fork_but_not_in_global_cache_panics() {
+        let fork_graph = Arc::new(RwLock::new(TestForkGraph {}));
+        let batch_processor =
+            TransactionBatchProcessor::new(0, 0, Arc::downgrade(&fork_graph), None);
+
+        // Register a builtin without going through `add_builtin()` and just
+        // add it to `builtin_program_ids` directly. This will trip the debug
+        // assertion for the fork guard's `search_for`.
+        batch_processor
+            .builtin_program_ids
+            .write()
+            .unwrap()
+            .insert(Pubkey::new_unique());
+        batch_processor.new_from(1, 0);
     }
 
     #[test]

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -275,17 +275,13 @@ pub fn register_builtins(
     mock_bank: &MockBankCallback,
     batch_processor: &TransactionBatchProcessor<MockForkGraph>,
 ) {
-    const DEPLOYMENT_SLOT: u64 = 0;
     // We must register LoaderV3 as a loadable account, otherwise programs won't execute.
     let loader_v3_name = "solana_bpf_loader_upgradeable_program";
     mock_bank.add_builtin(
         batch_processor,
         solana_sdk_ids::bpf_loader_upgradeable::id(),
         loader_v3_name,
-        ProgramCacheEntry::new_builtin(
-            DEPLOYMENT_SLOT,
-            solana_bpf_loader_program::Entrypoint::register,
-        ),
+        ProgramCacheEntry::new_builtin(solana_bpf_loader_program::Entrypoint::register),
     );
 
     // Other loaders are needed for testing program cache behavior.
@@ -294,10 +290,7 @@ pub fn register_builtins(
         batch_processor,
         bpf_loader_deprecated::id(),
         loader_v1_name,
-        ProgramCacheEntry::new_builtin(
-            DEPLOYMENT_SLOT,
-            solana_bpf_loader_program::Entrypoint::register,
-        ),
+        ProgramCacheEntry::new_builtin(solana_bpf_loader_program::Entrypoint::register),
     );
 
     let loader_v2_name = "solana_bpf_loader_program";
@@ -305,10 +298,7 @@ pub fn register_builtins(
         batch_processor,
         bpf_loader::id(),
         loader_v2_name,
-        ProgramCacheEntry::new_builtin(
-            DEPLOYMENT_SLOT,
-            solana_bpf_loader_program::Entrypoint::register,
-        ),
+        ProgramCacheEntry::new_builtin(solana_bpf_loader_program::Entrypoint::register),
     );
 
     // In order to perform a transference of native tokens using the system instruction,
@@ -319,7 +309,6 @@ pub fn register_builtins(
         solana_system_program::id(),
         system_program_name,
         ProgramCacheEntry::new_builtin(
-            DEPLOYMENT_SLOT,
             solana_system_program::system_processor::Entrypoint::register,
         ),
     );
@@ -330,10 +319,7 @@ pub fn register_builtins(
         batch_processor,
         compute_budget::id(),
         compute_budget_program_name,
-        ProgramCacheEntry::new_builtin(
-            DEPLOYMENT_SLOT,
-            solana_compute_budget_program::Entrypoint::register,
-        ),
+        ProgramCacheEntry::new_builtin(solana_compute_budget_program::Entrypoint::register),
     );
 }
 


### PR DESCRIPTION
#### Problem
In #14484 and #14509, we made the catchup-only requirement of a "deployed on or after slot" for global program cache extraction become always required.

Since builtin programs do not retain any information in their account state about what slot they were deployed in, we should not couple newly-activated builtins in the cache to their feature activation slot.

#### Summary of Changes
Internally, within `ProgramCacheEntry::new_builtin`, set `deployment_slot` to `0` and update all call sites, of which majority were already passing `0`.

The only sites that were passing non-zero values were in the various feature-activation codepaths in Bank. These would instead use `feature_activation_slot.unwrap_or(0)`.

I also added documentation to describe how builtin programs are guarded from cross-fork interactions thanks to the `builtin_program_ids` and `builtin_program_cache` on each Bank's `TransactionBatchProcessor`. This should help illuminate how the global program cache deals with builtins, and ensure these guards aren't accidentally disrupted during future development.

#### Testing
We have existing tests covering builtin invocations, feature activations, and Core BPF migrations that should pick up any program cache discrepancies as a result of this change.