### PR TITLE
chore: remove unused solana-account bincode feature enables

### DIFF
--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -62,7 +62,6 @@ zstd = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -61,7 +61,7 @@ solana-vote-interface = { workspace = true, features = ["bincode", "wincode"] }
 agave-logger = { path = "../../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
-solana-account = { workspace = true, features = ["bincode", "wincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-clock = { workspace = true, features = ["wincode"] }
 solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -65,7 +65,6 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
-solana-account = { workspace = true, features = ["bincode"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }


### PR DESCRIPTION
#### Problem
After https://github.com/anza-xyz/agave/pull/14417 some `solana-account` dev-dependencies no longer need `bincode` feature

#### Summary of Changes
Remove bincode feature / kill dev-dependency as regular dependency is enough.

#### Testing
CI
