### PR TITLE
clap-utils: return validation error for malformed structured seed

### DIFF
--- a/clap-utils/src/input_validators.rs
+++ b/clap-utils/src/input_validators.rs
@@ -372,8 +372,7 @@ where
     let (prefix, value) = value
         .as_ref()
         .split_once(':')
-        .ok_or("Seed must contain ':' as delimiter")
-        .unwrap();
+        .ok_or("Seed must contain ':' as delimiter")?;
     if prefix.is_empty() || value.is_empty() {
         Err(String::from("Seed prefix or value is empty"))
     } else {
@@ -491,6 +490,34 @@ mod tests {
         assert!(is_derivation("4294967296").is_err());
         assert!(is_derivation("a/b").is_err());
         assert!(is_derivation("0/4294967296").is_err());
+    }
+
+    #[test]
+    fn test_is_structured_seed() {
+        for seed in [
+            "string:value",
+            "pubkey:value",
+            "hex:value",
+            "u8:1",
+            "u16le:1",
+            "i128be:-1",
+            "string:value:with:delimiters",
+        ] {
+            assert_eq!(is_structured_seed(seed), Ok(()), "{seed}");
+        }
+
+        for seed in [":value", "string:"] {
+            assert_eq!(
+                is_structured_seed(seed),
+                Err(String::from("Seed prefix or value is empty")),
+                "{seed}"
+            );
+        }
+
+        assert_eq!(
+            is_structured_seed("missing-delimiter"),
+            Err(String::from("Seed must contain ':' as delimiter"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

`is_structured_seed` currently unwraps the result of `split_once(':')`. A malformed structured seed without the delimiter therefore panics instead of returning the existing `Seed must contain ':' as delimiter` validation error.

#### Summary of Changes

- Propagate the missing-delimiter error through the validator's `Result`.
- Add direct validator coverage for valid structured seeds, missing and empty fields, and multiple delimiters without changing the existing parsing rules.

#### Testing

RED before the production change:

- `cargo test -p solana-clap-utils --features agave-unstable-api --lib input_validators::tests::test_is_structured_seed -- --exact`
  - Failed with `called Result::unwrap() on an Err value: "Seed must contain ':' as delimiter"`.

GREEN after the production change:

- The focused command above: 1 passed.
- `cargo test -p solana-clap-utils --features agave-unstable-api -- --skip keypair::tests::signer_from_path_with_file`: 14 passed, 1 ignored, 1 filtered out; 8 doctests passed.
- `cargo +nightly fmt --all -- --check`: passed.
- `cargo clippy -p solana-clap-utils --all-targets --features agave-unstable-api -- -D warnings`: passed.
- `cargo check -p solana-clap-utils --all-targets --features agave-unstable-api`: passed.
- `cargo build -p solana-clap-utils --features agave-unstable-api`: passed.

The unfiltered package test command was also run. The new validator test passed, while the existing `keypair::tests::signer_from_path_with_file` test failed because `hidapi` compilation is disabled in `solana-remote-wallet` in this environment. The package result was 14 passed, 1 failed, and 1 ignored.

Full-workspace tests and the repository CI scripts were not run. Formatting used the installed `nightly-2026-08-09`; clippy, check, build, and tests used the repository's stable `1.97.1` toolchain rather than CI's pinned `nightly-2026-05-23`.
