### PR TITLE
genesis / ledger-tool: Default validator to max commission

### DIFF
--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -287,7 +287,7 @@ fn add_validator_accounts(
             identity_pubkey,
             u16::from(commission) * 100,
             vote_pubkey,
-            0,
+            10_000,
             identity_pubkey,
             vote_account_lamports,
         );

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2350,7 +2350,7 @@ fn main() {
                                 identity_pubkey,
                                 10000,
                                 vote_pubkey,
-                                0,
+                                10_000,
                                 identity_pubkey,
                                 rent.minimum_balance(VoteStateV4::size_of()).max(1),
                             );


### PR DESCRIPTION
#### Problem

As a follow-up to #14496, we should use a more correct default for block revenue commission.

#### Summary of changes

Update genesis and ledger-tool's defaults.

#### Testing

Let CI find the issues.