### PR TITLE
chore(ci): bump anza-xtask to 0.2.1

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -51,7 +51,7 @@ jobs:
           cargo install toml-cli --locked
 
           # install xtask
-          cargo install anza-xtask@0.2.0 --locked
+          cargo install anza-xtask@0.2.1 --locked
 
       - name: Process
         id: process

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: install anza-xtask
         run: |
-          cargo install anza-xtask@0.2.0 --locked
+          cargo install anza-xtask@0.2.1 --locked
 
       - name: update code
         env:


### PR DESCRIPTION
#### Problem

`Bump Version` with level `minor`/`major` mis-resets the pre-release counter in anza-xtask 0.2.0, blocking the master bump needed to cut the v4.3 branch.

#### Summary of Changes

Pin both workflows to anza-xtask 0.2.1, which carries anza-xyz/xtask#35 (minor/major reset to `-alpha.0`) and anza-xyz/xtask#37 (update-crate only bumps requirements pinning the current version).

Blocked on anza-xyz/xtask#40 publishing 0.2.1 to crates.io.