### PR TITLE
v4.2: Pin spl-token-cli and cargo-build-sbf versions

### DIFF
--- a/scripts/cargo-build-sbf-version.sh
+++ b/scripts/cargo-build-sbf-version.sh
@@ -1,6 +1,6 @@
 # populate this on the stable branch
-cargoBuildSbfVersion=
-cargoTestSbfVersion=
+cargoBuildSbfVersion=4.1.0
+cargoTestSbfVersion=4.0.0
 
 maybeCargoBuildSbfVersionArg=
 if [[ -n "$cargoBuildSbfVersion" ]]; then

--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=5.6.1
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

v4.2 is now stable; `ci/check-install-all.sh` requires `splTokenCliVersion`, `cargoBuildSbfVersion` and `cargoTestSbfVersion`.

#### Summary of Changes

Pin to latest releases: spl-token-cli 5.6.1, cargo-build-sbf 4.1.0, cargo-test-sbf 4.0.0.