### PR TITLE
chore: Update EOL exclusion branch list to exclude v4.3

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -154,9 +154,9 @@ pull_request_rules:
   - name: close PRs against EoL version branches
     conditions:
       - base ~= ^v[0-9]+\.[0-9]+$
-      - base != v4.0
       - base != v4.1
       - base != v4.2
+      - base != v4.3
     actions:
       close:
         message: "`{{base}}` is end-of-life and no longer accepts changes."


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/agave/pull/13573 added a rule to auto-close old BP's; however, the allowed list is manually populated

#### Summary of Changes
Remove the allow for dated v4.0 and add the new v4.3 branch to list