### PR TITLE
accounts-db: add conditional load path

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -111,7 +111,11 @@ impl Accounts {
         loaded_addresses: &mut LoadedAddresses,
     ) -> std::result::Result<Slot, AddressLookupError> {
         let table_account = self
-            .load_with_fixed_root(ancestors, address_table_lookup.account_key)
+            .load_with_fixed_root(
+                ancestors,
+                address_table_lookup.account_key,
+                None::<fn(_, &_, _) -> _>,
+            )
             .map(|(account, _rent)| account)
             .ok_or(AddressLookupError::LookupTableAccountNotFound)?;
 
@@ -165,12 +169,14 @@ impl Accounts {
         &self,
         ancestors: &Ancestors,
         pubkey: &Pubkey,
+        load_filter: Option<impl Fn(u64, &Pubkey, usize) -> bool>,
     ) -> Option<(AccountSharedData, Slot)> {
         self.accounts_db.load(
             ancestors,
             pubkey,
             LoadHint::FixedMaxRoot,
             PopulateReadCache::True,
+            load_filter,
         )
     }
 
@@ -186,6 +192,7 @@ impl Accounts {
             pubkey,
             LoadHint::FixedMaxRoot,
             PopulateReadCache::False,
+            None::<fn(_, &_, _) -> _>,
         )
     }
 
@@ -199,6 +206,7 @@ impl Accounts {
             pubkey,
             LoadHint::Unspecified,
             PopulateReadCache::True,
+            None::<fn(_, &_, _) -> _>,
         )
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -655,7 +655,10 @@ pub enum LoadedAccountAccessor {
 }
 
 impl LoadedAccountAccessor {
-    fn check_and_get_loaded_account_shared_data(&mut self) -> AccountSharedData {
+    fn check_and_get_loaded_account_shared_data(
+        &mut self,
+        load_filter: Option<impl Fn(u64, &Pubkey, usize) -> bool>,
+    ) -> Option<AccountSharedData> {
         // all of these following .expect() and .unwrap() are like serious logic errors,
         // ideal for representing this as rust type system....
 
@@ -666,15 +669,40 @@ impl LoadedAccountAccessor {
                 // was still in the storage map. This means even if the storage entry is removed
                 // from the storage map after we grabbed the storage entry, the recycler should not
                 // reset the storage entry until we drop the reference to the storage entry.
-                maybe_storage_entry
-                    .accounts
-                    .get_account_shared_data(*offset)
-                    .expect(
-                        "If a storage entry was found in the storage map, it must not have been \
-                         reset yet",
-                    )
+
+                // If there's a load filter, read only the account metadata first.
+                // This way we don't read the whole account (including its data)
+                // from disk, only to discard it later.
+                let should_load_account = load_filter.is_none_or(|load_filter| {
+                    maybe_storage_entry
+                        .accounts
+                        .get_stored_account_without_data_callback(*offset, |account| {
+                            load_filter(account.lamports, account.owner, account.data_len)
+                        })
+                        .expect(
+                            "If a storage entry was found in the storage map, it must not have \
+                             been reset yet",
+                        )
+                });
+
+                should_load_account.then(|| {
+                    maybe_storage_entry
+                        .accounts
+                        .get_account_shared_data(*offset)
+                        .expect(
+                            "If a storage entry was found in the storage map, it must not have \
+                             been reset yet",
+                        )
+                })
             }
-            _ => self.check_and_get_loaded_account(|loaded_account| loaded_account.take_account()),
+
+            // It is safe ("""safe""") to skip consulting `load_filter` here because this
+            // branch immediately and invariably panics.
+            LoadedAccountAccessor::Stored(None) => {
+                let account = self
+                    .check_and_get_loaded_account(|loaded_account| loaded_account.take_account());
+                unreachable!("{account:?}");
+            }
         }
     }
 
@@ -2749,6 +2777,7 @@ impl AccountsDb {
                 &pubkey,
                 LoadHint::Unspecified,
                 PopulateReadCache::False,
+                None::<fn(_, &_, _) -> _>,
             ) {
                 scan_func(Some((&pubkey, account, slot)));
             }
@@ -2869,9 +2898,16 @@ impl AccountsDb {
         pubkey: &Pubkey,
         load_hint: LoadHint,
         populate_read_cache: PopulateReadCache,
+        load_filter: Option<impl Fn(u64, &Pubkey, usize) -> bool>,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.do_load(ancestors, pubkey, load_hint, populate_read_cache)
-            .filter(|(account, _)| !account.is_zero_lamport())
+        self.do_load(
+            ancestors,
+            pubkey,
+            load_hint,
+            populate_read_cache,
+            load_filter,
+        )
+        .filter(|(account, _)| !account.is_zero_lamport())
     }
 
     fn read_index_for_accessor_or_load_slow<'a>(
@@ -3137,18 +3173,24 @@ impl AccountsDb {
         pubkey: &Pubkey,
         load_hint: LoadHint,
         populate_read_cache: PopulateReadCache,
+        load_filter: Option<impl Fn(u64, &Pubkey, usize) -> bool>,
     ) -> Option<(AccountSharedData, Slot)> {
         let starting_max_root = self.max_root();
 
-        // Check the write cache first; a hit is the freshest version visible on this fork,
-        // so return it
+        // Check the write cache first; a hit is the freshest version visible on this fork
         if let Some((cached_account, cached_slot)) =
             self.accounts_cache.load_latest(pubkey, ancestors)
         {
             self.load_account_stats
                 .num_loaded_from_write_cache
                 .fetch_add(1, Ordering::Relaxed);
-            return Some((cached_account.account.clone(), cached_slot));
+
+            let account = &cached_account.account;
+            let should_load_account = load_filter.as_ref().is_none_or(|load_filter| {
+                load_filter(account.lamports(), account.owner(), account.data().len())
+            });
+
+            return should_load_account.then(|| (cached_account.account.clone(), cached_slot));
         }
 
         let (slot, storage_location, _maybe_account_accessor) =
@@ -3160,7 +3202,12 @@ impl AccountsDb {
             self.load_account_stats
                 .num_loaded_from_read_cache
                 .fetch_add(1, Ordering::Relaxed);
-            return Some((account, slot));
+
+            let should_load_account = load_filter.as_ref().is_none_or(|load_filter| {
+                load_filter(account.lamports(), account.owner(), account.data().len())
+            });
+
+            return should_load_account.then_some((account, slot));
         }
 
         let (mut account_accessor, slot) = self.retry_to_get_account_accessor(
@@ -3174,9 +3221,12 @@ impl AccountsDb {
             .num_loaded_from_index_storage
             .fetch_add(1, Ordering::Relaxed);
 
-        let account = account_accessor.check_and_get_loaded_account_shared_data();
+        let maybe_account =
+            account_accessor.check_and_get_loaded_account_shared_data(load_filter.as_ref());
 
-        if populate_read_cache == PopulateReadCache::True {
+        if let Some(ref account) = maybe_account
+            && populate_read_cache == PopulateReadCache::True
+        {
             /*
             We show this store into the read-only cache for account 'A' and future loads of 'A' from the read-only cache are
             safe/reflect 'A''s latest state on this fork.
@@ -3203,7 +3253,7 @@ impl AccountsDb {
                 );
             }
         }
-        Some((account, slot))
+        maybe_account.map(|account| (account, slot))
     }
 
     #[cfg_attr(test, qualifiers(pub(crate)))]
@@ -4056,6 +4106,7 @@ impl AccountsDb {
                     pubkey,
                     LoadHint::FixedMaxRoot,
                     PopulateReadCache::False,
+                    None::<fn(_, &_, _) -> _>,
                 ) {
                     cache_lt_hash.mix_in(&Self::lt_hash_account(&account, pubkey).0);
                 }
@@ -4125,6 +4176,7 @@ impl AccountsDb {
                         pubkey,
                         LoadHint::FixedMaxRoot,
                         PopulateReadCache::False,
+                        None::<fn(_, &_, _) -> _>,
                     )
                     .map(|(account, _slot)| account.lamports())
                     .unwrap_or(0);
@@ -5781,6 +5833,7 @@ impl AccountsDb {
             pubkey,
             LoadHint::Unspecified,
             PopulateReadCache::True,
+            None::<fn(_, &_, _) -> _>,
         )
     }
 

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -32,6 +32,8 @@ use {
 
 const DEFAULT_FILE_SIZE: u64 = 4 * 1024 * 1024;
 
+const NO_LOAD_FILTER: Option<fn(u64, &Pubkey, usize) -> bool> = None;
+
 impl AccountsDb {
     fn get_storage_for_slot(&self, slot: Slot) -> Option<Arc<AccountStorageEntry>> {
         self.storage.get_slot_storage_entry(slot)
@@ -61,7 +63,9 @@ impl AccountsDb {
                 let storage_location = account_info.storage_location();
                 let mut accessor = self.get_account_accessor(slot, &storage_location);
 
-                accessor.check_and_get_loaded_account_shared_data()
+                accessor
+                    .check_and_get_loaded_account_shared_data(NO_LOAD_FILTER)
+                    .unwrap()
             },
         )
     }
@@ -3421,6 +3425,7 @@ fn test_read_only_accounts_cache() {
             &account_key,
             LoadHint::FixedMaxRoot,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .map(|(account, _)| account)
         .unwrap();
@@ -3432,6 +3437,7 @@ fn test_read_only_accounts_cache() {
             &account_key,
             LoadHint::FixedMaxRoot,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .map(|(account, _)| account)
         .unwrap();
@@ -3445,6 +3451,7 @@ fn test_read_only_accounts_cache() {
             &account_key,
             LoadHint::FixedMaxRoot,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .map(|(account, _)| account);
     assert!(account.is_none());
@@ -3478,6 +3485,7 @@ fn test_load_with_read_only_accounts_cache() {
             &account_key,
             LoadHint::Unspecified,
             PopulateReadCache::False,
+            NO_LOAD_FILTER,
         )
         .unwrap();
     assert_eq!(account.lamports(), 1);
@@ -3490,6 +3498,7 @@ fn test_load_with_read_only_accounts_cache() {
             &account_key,
             LoadHint::Unspecified,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .unwrap();
     assert_eq!(account.lamports(), 1);
@@ -3502,6 +3511,7 @@ fn test_load_with_read_only_accounts_cache() {
         &account_key,
         LoadHint::Unspecified,
         PopulateReadCache::False,
+        NO_LOAD_FILTER,
     );
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
@@ -3513,6 +3523,7 @@ fn test_load_with_read_only_accounts_cache() {
         &account_key,
         LoadHint::Unspecified,
         PopulateReadCache::True,
+        NO_LOAD_FILTER,
     );
     assert!(account.is_none());
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
@@ -3525,6 +3536,7 @@ fn test_load_with_read_only_accounts_cache() {
             &account_key,
             LoadHint::Unspecified,
             PopulateReadCache::False,
+            NO_LOAD_FILTER,
         )
         .unwrap();
     assert_eq!(account.lamports(), 2);
@@ -3539,12 +3551,143 @@ fn test_load_with_read_only_accounts_cache() {
             &account_key,
             LoadHint::Unspecified,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .unwrap();
     assert_eq!(account.lamports(), 2);
     // The account shouldn't be added to read_only_cache because it is in write_cache.
     assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
     assert_eq!(slot, 2);
+}
+
+#[test]
+fn test_load_filter_with_open_accounts() {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let ancestors = Ancestors::from(vec![0]);
+
+    let account_key = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let data_size = 40;
+    let account = AccountSharedData::new(123, data_size, &owner);
+
+    let satisfied = |_, o: &_, d| o == &owner && d == data_size;
+    let wrong_owner = |_, o: &_, _| o != &owner;
+    let wrong_size = |_, _: &_, d| d != data_size;
+
+    fn load_if(
+        db: &AccountsDb,
+        ancestors: &Ancestors,
+        pubkey: &Pubkey,
+        load_filter: impl Fn(u64, &Pubkey, usize) -> bool,
+    ) -> Option<AccountSharedData> {
+        db.load(
+            ancestors,
+            pubkey,
+            LoadHint::Unspecified,
+            PopulateReadCache::True,
+            Some(load_filter),
+        )
+        .map(|(account, _slot)| account)
+    }
+
+    // storing the account puts it in write cache
+    db.store_for_tests((0, &[(&account_key, &account)][..]));
+
+    // load from write cache
+    let loaded = load_if(&db, &ancestors, &account_key, satisfied).unwrap();
+    assert_eq!(loaded, account);
+
+    assert!(load_if(&db, &ancestors, &account_key, wrong_owner).is_none());
+    assert!(load_if(&db, &ancestors, &account_key, wrong_size).is_none());
+
+    // never populate from write to read
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+
+    // storage. rejected loads do not enter the read cache
+    db.add_root_and_flush_write_cache(0);
+    assert!(load_if(&db, &ancestors, &account_key, wrong_owner).is_none());
+    assert!(load_if(&db, &ancestors, &account_key, wrong_size).is_none());
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+
+    // load from storage succeeds and populates read cache
+    let loaded = load_if(&db, &ancestors, &account_key, satisfied).unwrap();
+    assert_eq!(loaded, account);
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+
+    // load from read cache
+    let loaded = load_if(&db, &ancestors, &account_key, satisfied).unwrap();
+    assert_eq!(loaded, account);
+
+    // account remains despite rejection
+    assert!(load_if(&db, &ancestors, &account_key, wrong_owner).is_none());
+    assert!(load_if(&db, &ancestors, &account_key, wrong_size).is_none());
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
+}
+
+#[test]
+fn test_load_filter_with_closed_accounts() {
+    let db = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
+    let ancestors = Ancestors::from(vec![0, 1]);
+
+    let missing_key = Pubkey::new_unique();
+    let cached_key = Pubkey::new_unique();
+    let stored_key = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    let data_size = 40;
+    let always_load = |_, _: &_, _| true;
+
+    // this always becomes AccountSharedData::default() on readback
+    let zero_lamport_account = AccountSharedData::new(0, data_size, &owner);
+
+    let assert_absent = |pubkey: &Pubkey| {
+        assert!(
+            db.load(
+                &ancestors,
+                pubkey,
+                LoadHint::Unspecified,
+                PopulateReadCache::True,
+                Some(&always_load),
+            )
+            .is_none()
+        );
+
+        assert!(
+            db.load(
+                &ancestors,
+                pubkey,
+                LoadHint::Unspecified,
+                PopulateReadCache::True,
+                NO_LOAD_FILTER,
+            )
+            .is_none()
+        );
+    };
+
+    // no entry
+    assert_absent(&missing_key);
+
+    // zero lamports, from write cache
+    db.store_for_tests((0, &[(&cached_key, &zero_lamport_account)][..]));
+    assert_absent(&cached_key);
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 0);
+
+    // zero lamports in storage *and* index, so we actually check the account
+    let slot = 1;
+    db.set_latest_full_snapshot_slot(slot - 1);
+    let storage = db.create_store(slot, DEFAULT_FILE_SIZE);
+    append_single_account_with_default_hash(
+        &storage,
+        &stored_key,
+        &zero_lamport_account,
+        true,
+        Some(&db.accounts_index),
+    );
+    db.storage.insert(Arc::new(storage));
+    db.add_root(slot);
+
+    // the filtered load reads storage and caches, so the unfiltered one hits the read cache
+    assert_absent(&stored_key);
+    assert_eq!(db.read_only_accounts_cache.cache_len(), 1);
 }
 
 /// `select_pubkeys_to_store` stores only the newest version of each account across the
@@ -3684,6 +3827,7 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
             &zero_lamport_account_key,
             load_hint,
             PopulateReadCache::True,
+            NO_LOAD_FILTER,
         )
         .is_none()
     );
@@ -4684,7 +4828,13 @@ fn start_load_thread(
 
                 // Load should never be unable to find this key
                 let loaded_account = db
-                    .do_load(&ancestors, &pubkey, load_hint, PopulateReadCache::True)
+                    .do_load(
+                        &ancestors,
+                        &pubkey,
+                        load_hint,
+                        PopulateReadCache::True,
+                        NO_LOAD_FILTER,
+                    )
                     .unwrap();
                 // slot + 1 == account.lamports because of the account-cache-flush thread
                 assert_eq!(

--- a/accounts-db/tests/accounts_db.rs
+++ b/accounts-db/tests/accounts_db.rs
@@ -85,6 +85,7 @@ fn test_load_after_remove_unrooted_and_restore_to_same_slot() {
                         &pubkey,
                         LoadHint::FixedMaxRoot,
                         PopulateReadCache::False,
+                        None::<fn(_, &_, _) -> _>,
                     );
                 }
             })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5114,6 +5114,23 @@ impl Bank {
         self.load_slow_with_fixed_root(&self.ancestors, pubkey)
     }
 
+    // See note above get_account_with_fixed_root() about when to prefer this function.
+    //
+    // `load_filter` is a predicate over an account's lamports, owner, and data length,
+    // which AccountsDb uses to avoid loading the full data. Callers should regard
+    // the predicate as a performance hint, not a validation function, and perform
+    // all necessary validation on the returned account themselves.
+    pub fn get_account_with_fixed_root_if(
+        &self,
+        pubkey: &Pubkey,
+        load_filter: impl Fn(u64, &Pubkey, usize) -> bool,
+    ) -> Option<AccountSharedData> {
+        self.rc
+            .accounts
+            .load_with_fixed_root(&self.ancestors, pubkey, Some(load_filter))
+            .map(|(acc, _slot)| acc)
+    }
+
     pub fn get_account_modified_slot(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.load_slow(&self.ancestors, pubkey)
     }
@@ -5134,7 +5151,9 @@ impl Bank {
         ancestors: &Ancestors,
         pubkey: &Pubkey,
     ) -> Option<(AccountSharedData, Slot)> {
-        self.rc.accounts.load_with_fixed_root(ancestors, pubkey)
+        self.rc
+            .accounts
+            .load_with_fixed_root(ancestors, pubkey, None::<fn(_, &_, _) -> _>)
     }
 
     pub fn get_program_accounts(
@@ -6769,7 +6788,7 @@ impl TransactionProcessingCallback for Bank {
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
         self.rc
             .accounts
-            .load_with_fixed_root(&self.ancestors, pubkey)
+            .load_with_fixed_root(&self.ancestors, pubkey, None::<fn(_, &_, _) -> _>)
     }
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {


### PR DESCRIPTION
#### Problem
we want to be able to avoid loading large accounts in certain contexts where we expect small accounts, but it is presently impossible to know how large an account is before loading it. while we are at it it would also be nice to be able to check the owner

there was a previous attempt to do something like this, `account_matches_owners()`, but it had intractable performance issues that were never solved but were believed to result from not correctly using the accounts-db caches in some way

in my mind the best way to do this is to just follow the path that existing loads take, enriched with some bailouts, to use the same cache order and if we miss both to avoid reading more from disk than we actually need to confirm the size and owner are to our liking

#### Summary of Changes
introduce `load_with_fixed_root_conditional()`, which is `load_with_fixed_root()`, but conditional

that is, we pass in a predicate `impl Fn(u64, &Pubkey, usize) -> bool` at the top-level `Bank` wrapper `get_account_with_fixed_root_conditional()`, through new wrappers `load_with_fixed_root_conditional()` and `load_conditional()` which resemble `load_with_fixed_root()` and `load()` respectively. the predicate accepts the lamports, owner, and data length of the account, allowing callers to define the conditions under which they actually require the account. this is primarily intended to avoid loading large accounts in contexts where they would be considered invalid and immediately rejected

`do_load()` optionally accepts this callback. we take it to a trait object at this boundary to avoid making `do_load()` polymorphic. existing callers pass in `None` and behave as before

in the past we had trouble with special functions for checking account state without loading; the goal of routing everything through `do_load()` is to ensure we take the same path through the caches and down to disk in all cases

with `Some` callback, we first check the write and read caches as normal, running the predicate over the account before deciding whether to return it. this is not strictly necessary, but we do it for consistency. we leave a note on `get_account_with_fixed_root_conditional()` warning callers not to depend on this behavior 

if we miss on both caches we go to disk via `check_and_get_loaded_account_shared_data()`. if `should_load` is `Some` here, we read metadata with `get_stored_account_without_data_callback()` before deciding whether to proceed with the load; the existing behavior, corresponding to `None`, is not affected

the only difference between load and load-conditional other than the conditionality is that if we go to disk and reject the load, we do not put the account in the read cache regardless of `PopulateReadCache`. this is by design, and anyway obviously unavoidable

we continue returning `Option<AccountSharedData>` instead of trying to signal why a load failed eg by letting the new closure return an `Err` we bubble up or something. i think philosophically this whole mechanism is to make accounts-db more efficient, not to save a few lines of code in runtime or core. if accounts-db decides its cheaper to behave inconsistently then thats its prerogative

we do bump the LRU on cache hits even if we fail the constraint. i felt to do otherwise would be surprising, particularly if people start using this function in other parts of the codebase for accounts we may actually be happy to see

we increment `LoadAccountsStats` even if we fail the constraint. this seems to be consistent with master, where we bump the stat if we hit a 0 lamport account indicator. therefore i inferred the stats are to track cache hits and disk access rather than to track successful loads. i experimented with introducing new stats for constraint failures but getting the right interplay with the existing stats was highly troublesome

#### Testing
`test_load_conditional_from_every_tier()` tests conditional load, accept and reject, from all three layers (write read storage). `test_load_conditional_nonexistent_and_zero_lamport()` tests that zero lamport loads continue to behave as expected