### PR TITLE
replay: quiesce dropped banks before SwitchBank or UpdateParent

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -35,7 +35,6 @@ use {
         transaction_execution::TransactionStatusSender, vote_sender_types::ReplayVoteSender,
     },
     solana_time_utils::AtomicInterval,
-    solana_unified_scheduler_logic::SchedulingMode,
     std::{
         collections::HashSet,
         num::{NonZeroU64, NonZeroUsize},
@@ -805,7 +804,7 @@ pub(crate) fn update_bank_forks_and_poh_recorder_for_new_tpu_bank(
     let tpu_bank = bank_forks
         .write()
         .unwrap()
-        .insert_with_scheduling_mode(SchedulingMode::BlockProduction, tpu_bank);
+        .insert_for_block_production(tpu_bank);
     let tpu_bank_for_poh = tpu_bank.clone_with_scheduler();
     let set_bank_res = poh_controller.set_bank(tpu_bank_for_poh);
     if set_bank_res.is_err() {

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1484,7 +1484,11 @@ mod tests {
 
     impl BankForksController for TestBankForksController {
         fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
-            Ok(self.bank_forks.write().unwrap().insert(bank))
+            Ok(self
+                .bank_forks
+                .write()
+                .unwrap()
+                .insert_for_block_production(bank))
         }
 
         fn enqueue_set_root(&self, new_root: Block) {

--- a/core/src/drop_bank_service.rs
+++ b/core/src/drop_bank_service.rs
@@ -1,8 +1,12 @@
 use {
     crossbeam_channel::Receiver,
+    solana_clock::Slot,
     solana_measure::measure::Measure,
-    solana_runtime::installed_scheduler_pool::BankWithScheduler,
-    std::thread::{self, Builder, JoinHandle},
+    solana_runtime::installed_scheduler_pool::{BankWithScheduler, DropBankRequest},
+    std::{
+        collections::HashSet,
+        thread::{self, Builder, JoinHandle},
+    },
 };
 
 pub struct DropBankService {
@@ -10,30 +14,130 @@ pub struct DropBankService {
 }
 
 impl DropBankService {
-    pub fn new(bank_receiver: Receiver<Vec<BankWithScheduler>>) -> Self {
+    pub fn new(bank_receiver: Receiver<DropBankRequest>) -> Self {
         let thread_hdl = Builder::new()
             .name("solDropBankSrvc".to_string())
             .spawn(move || {
-                for banks in bank_receiver.iter() {
-                    let len = banks.len();
-                    let mut dropped_banks_time = Measure::start("drop_banks");
-                    // Drop BankWithScheduler with no alive lock to avoid deadlocks. That's because
-                    // BankWithScheduler::drop() could block on transaction execution if unified
-                    // scheduler is installed. As a historical context, it's dropped early inside
-                    // the replaying stage not here and that caused a deadlock for BankForks.
-                    drop(banks);
-                    dropped_banks_time.stop();
-                    if dropped_banks_time.as_ms() > 10 {
-                        datapoint_info!(
-                            "handle_new_root-dropped_banks",
-                            ("elapsed_ms", dropped_banks_time.as_ms(), i64),
-                            ("len", len, i64)
-                        );
+                let mut pending_banks: Vec<BankWithScheduler> = Vec::new();
+                for request in bank_receiver.iter() {
+                    match request {
+                        DropBankRequest::DropBanks { banks, new_root } => {
+                            // Once the root reaches a pending bank's slot, that numeric slot can no
+                            // longer be replayed. Release it without retiring its account state.
+                            pending_banks.extend(banks);
+                            Self::drop_banks(
+                                pending_banks
+                                    .extract_if(.., |bank| bank.slot() <= new_root)
+                                    .collect(),
+                            );
+
+                            // An unfrozen bank published for transaction production can still
+                            // receive legacy BankingStage commits after removal from BankForks.
+                            // Keep it and all of its removed ancestors alive; the producer can
+                            // still load account state inherited from those ancestors.
+                            Self::retire_banks(Self::extract_unprotected_banks(&mut pending_banks));
+                        }
+                        DropBankRequest::Flush { slots, ack_sender } => {
+                            let mut banks_to_retire = pending_banks
+                                .extract_if(.., |bank| Self::matches_slots(bank, &slots))
+                                .collect::<Vec<_>>();
+                            banks_to_retire
+                                .extend(Self::extract_unprotected_banks(&mut pending_banks));
+
+                            // Retire the whole dependency group in one AccountsDb batch after all
+                            // execution and legacy commits have quiesced.
+                            Self::retire_banks(banks_to_retire);
+
+                            // FIFO channel ordering guarantees all matching retirement requests
+                            // have completed before this acknowledgement is sent.
+                            let _ = ack_sender.send(());
+                        }
+                        DropBankRequest::Barrier { slots, ack_sender } => {
+                            // Re-evaluate the dependency closure because producer banks can freeze
+                            // while pending. Retire everything that is no longer protected before
+                            // reporting whether a matching live producer group remains.
+                            Self::retire_banks(Self::extract_unprotected_banks(&mut pending_banks));
+
+                            let has_matching_pending = pending_banks
+                                .iter()
+                                .any(|bank| Self::matches_slots(bank, &slots));
+                            let _ = ack_sender.send(has_matching_pending);
+                        }
                     }
                 }
+
+                // Channel closure is shutdown, not proof that producer ingress has quiesced. Drop
+                // the service-owned references without explicitly retiring protected account
+                // state; any remaining Bank owners keep the generation alive until they stop.
+                Self::drop_banks(pending_banks);
             })
             .unwrap();
         Self { thread_hdl }
+    }
+
+    fn retire_banks(banks: Vec<BankWithScheduler>) {
+        if banks.is_empty() {
+            return;
+        }
+
+        // Waiting for both execution paths is required for unfrozen leader banks: unified
+        // scheduler completion alone does not fence legacy BankingStage commits.
+        for bank in &banks {
+            let _ = bank.wait_for_completed_scheduler();
+            bank.wait_for_inflight_commits();
+        }
+
+        let unrooted_slot_bank_ids = banks
+            .iter()
+            .map(|bank| (bank.slot(), bank.bank_id()))
+            .collect::<Vec<_>>();
+        banks[0].remove_unrooted_slots(&unrooted_slot_bank_ids);
+
+        for bank in &banks {
+            bank.clear_slot_signatures(bank.slot());
+            bank.prune_program_cache_by_deployment_slot(bank.slot());
+        }
+        Self::drop_banks(banks);
+    }
+
+    fn extract_unprotected_banks(banks: &mut Vec<BankWithScheduler>) -> Vec<BankWithScheduler> {
+        let mut protected_slots = HashSet::new();
+        for bank in banks
+            .iter()
+            .filter(|bank| bank.is_transaction_producer() && !bank.is_frozen())
+        {
+            protected_slots.insert(bank.slot());
+            protected_slots.extend(bank.ancestors.iter());
+        }
+
+        banks
+            .extract_if(.., |bank| !protected_slots.contains(&bank.slot()))
+            .collect()
+    }
+
+    fn matches_slots(bank: &BankWithScheduler, slots: &[Slot]) -> bool {
+        slots
+            .iter()
+            .any(|slot| *slot == bank.slot() || bank.ancestors.contains_key(slot))
+    }
+
+    fn drop_banks(banks: Vec<BankWithScheduler>) {
+        let len = banks.len();
+        let mut dropped_banks_time = Measure::start("drop_banks");
+
+        // Drop BankWithScheduler with no alive lock to avoid deadlocks. That's because
+        // BankWithScheduler::drop() could block on transaction execution if unified scheduler is
+        // installed. As historical context, it was dropped early inside ReplayStage rather than
+        // here, which caused a deadlock for BankForks.
+        drop(banks);
+        dropped_banks_time.stop();
+        if dropped_banks_time.as_ms() > 10 {
+            datapoint_info!(
+                "handle_new_root-dropped_banks",
+                ("elapsed_ms", dropped_banks_time.as_ms(), i64),
+                ("len", len, i64)
+            );
+        }
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -47,7 +47,7 @@ use {
         migration::{GENESIS_VOTE_REFRESH, MigrationStatus},
         vote::Vote,
     },
-    crossbeam_channel::{Receiver, Sender, TryRecvError, TrySendError, select},
+    crossbeam_channel::{Receiver, SendError, Sender, TryRecvError, TrySendError, bounded, select},
     itertools::Itertools,
     rayon::{ThreadPool, prelude::*},
     smallvec::SmallVec,
@@ -88,7 +88,7 @@ use {
         bank_forks_controller::{BankForksCommand, BankForksCommandReceiver, SetRootCommand},
         block_component_processor::BlockComponentProcessorError,
         commitment::BlockCommitmentCache,
-        installed_scheduler_pool::BankWithScheduler,
+        installed_scheduler_pool::{BankWithScheduler, DropBankRequest},
         leader_schedule_utils::first_of_consecutive_leader_slots,
         snapshot_controller::SnapshotController,
         transaction_execution::TransactionStatusSender,
@@ -273,7 +273,7 @@ struct ProcessBankForksContext {
     snapshot_controller: Option<Arc<SnapshotController>>,
     bank_notification_sender: Option<BankNotificationSenderConfig>,
     rpc_subscriptions: Option<Arc<RpcSubscriptions>>,
-    drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+    drop_bank_sender: Sender<DropBankRequest>,
     leader_schedule_cache: Arc<LeaderScheduleCache>,
 }
 
@@ -329,6 +329,8 @@ struct NewBankForksContext<'a> {
     migration_status: &'a MigrationStatus,
     /// This validator's identity, used to leave live own-leader banks to BCL.
     my_pubkey: &'a Pubkey,
+    /// Ordered bank-retirement service used to fence same-slot recreation.
+    drop_bank_sender: &'a Sender<DropBankRequest>,
 }
 
 struct LastVoteRefreshTime {
@@ -457,7 +459,7 @@ pub struct ReplaySenders {
     pub cost_update_sender: Sender<CostUpdate>,
     pub voting_sender: Sender<VoteOp>,
     pub bls_sender: Sender<BLSOp>,
-    pub drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+    pub drop_bank_sender: Sender<DropBankRequest>,
     pub block_metadata_notifier: Option<BlockMetadataNotifierArc>,
     pub dumped_slots_sender: Sender<Vec<(u64, Hash)>>,
     pub votor_event_sender: VotorEventSender,
@@ -975,6 +977,7 @@ impl ReplayStage {
                     &replay_vote_sender,
                     migration_status.as_ref(),
                     entry_notification_sender.as_ref(),
+                    &drop_bank_sender,
                 );
 
                 let mut generate_new_bank_forks_time =
@@ -988,6 +991,7 @@ impl ReplayStage {
                         slot_status_notifier: &slot_status_notifier,
                         migration_status: migration_status.as_ref(),
                         my_pubkey: &my_pubkey,
+                        drop_bank_sender: &drop_bank_sender,
                     },
                     &mut progress,
                     &mut replay_timing,
@@ -1078,6 +1082,7 @@ impl ReplayStage {
                         &replay_vote_sender,
                         migration_status.as_ref(),
                         entry_notification_sender.as_ref(),
+                        &drop_bank_sender,
                     );
                     Self::alpenglow_handle_newly_frozen_banks(
                         &new_frozen_slots,
@@ -1095,7 +1100,9 @@ impl ReplayStage {
                     // BCL inserts its bank before publishing it to PoH, so check both states.
                     let has_active_leader_bank =
                         bank_forks.read().unwrap().banks().values().any(|bank| {
-                            !bank.is_frozen() && Self::leader_is_me(bank.leader_id(), &my_pubkey)
+                            !bank.is_frozen()
+                                && (bank.is_transaction_producer()
+                                    || Self::leader_is_me(bank.leader_id(), &my_pubkey))
                         }) || poh_shared_leader_state.load().working_bank().is_some();
                     if !has_active_leader_bank {
                         Self::process_switch_bank_events(
@@ -1106,6 +1113,7 @@ impl ReplayStage {
                             &bank_forks,
                             &mut progress,
                             &mut async_verification_freelist,
+                            &drop_bank_sender,
                         )
                         .expect("Blockstore operations must succeed");
                     }
@@ -2433,6 +2441,7 @@ impl ReplayStage {
         bank_forks: &RwLock<BankForks>,
         progress: &mut ProgressMap,
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+        drop_bank_sender: &Sender<DropBankRequest>,
     ) -> Result<(), BlockstoreError> {
         let root = bank_forks.read().unwrap().root();
 
@@ -2529,7 +2538,20 @@ impl ReplayStage {
         let slots_to_clear = blocks_to_switch
             .iter()
             .map(|(slot, _)| *slot)
-            .chain(original_dead_slots_to_clear.iter().copied());
+            .chain(original_dead_slots_to_clear.iter().copied())
+            .collect::<Vec<_>>();
+
+        // A set-root request can remove a just-inserted BCL bank before BCL publishes it to PoH.
+        // In that window neither BankForks nor shared leader state exposes the producer, but the
+        // retirement service still owns its marked generation. Defer the switch until BCL has
+        // stopped ingress and cleared it.
+        if Self::has_pending_bank_retirement(drop_bank_sender, slots_to_clear.clone()) {
+            trace!(
+                "{my_pubkey}: deferring switch to {block:?} while a targeted producer bank is \
+                 still active"
+            );
+            return Ok(());
+        }
 
         info!("{my_pubkey}: Clearing banks for switching: {slots_to_clear:?}");
         Self::clear_slots(
@@ -2558,6 +2580,31 @@ impl ReplayStage {
         Ok(())
     }
 
+    fn flush_drop_bank_service(drop_bank_sender: &Sender<DropBankRequest>, slots: Vec<Slot>) {
+        let (ack_sender, ack_receiver) = bounded(1);
+        drop_bank_sender
+            .send(DropBankRequest::Flush { slots, ack_sender })
+            .expect("DropBankService must be running while replay can resurrect banks");
+        ack_receiver
+            .recv()
+            .expect("DropBankService must acknowledge retirement before bank resurrection");
+    }
+
+    /// Wait until all preceding root-pruning requests have been handled and report whether a
+    /// live local producer still protects account state at one of `slots` or its descendants.
+    fn has_pending_bank_retirement(
+        drop_bank_sender: &Sender<DropBankRequest>,
+        slots: Vec<Slot>,
+    ) -> bool {
+        let (ack_sender, ack_receiver) = bounded(1);
+        drop_bank_sender
+            .send(DropBankRequest::Barrier { slots, ack_sender })
+            .expect("DropBankService must be running while replay can resurrect banks");
+        ack_receiver
+            .recv()
+            .expect("DropBankService must acknowledge before bank resurrection")
+    }
+
     /// Clear the requested slots and their descendants from progress, bank forks, and shared
     /// caches. Requested slots are purged from shared caches even if their banks no longer exist.
     fn clear_slots(
@@ -2574,14 +2621,7 @@ impl ReplayStage {
 
         // Wait for async verify to complete
         for slot in &slots_to_purge {
-            if let Some(replay_progress) = progress.remove(slot) {
-                let mut w_replay_progress = replay_progress.replay_progress.write().unwrap();
-                let _ = w_replay_progress.wait_for_all_verification_results(&mut 0, &mut 0);
-                Self::recycle_async_verification(
-                    async_verification_freelist,
-                    w_replay_progress.take_async_verification(),
-                );
-            }
+            Self::clear_slot_progress(*slot, progress, async_verification_freelist);
         }
 
         // Wait for any in progress execution
@@ -2608,7 +2648,6 @@ impl ReplayStage {
                 w_bank_forks.dump_slots(bank_slots_to_clear.iter(), false);
             (root_bank, slot_bank_ids_to_purge, removed_banks)
         };
-
         // Clear the accounts for these slots so that any ongoing RPC scans fail.
         // These have to be atomically cleared together in the same batch, in order
         // to prevent RPC from seeing inconsistent results in scans.
@@ -2628,6 +2667,21 @@ impl ReplayStage {
         for slot in slots_to_purge {
             root_bank.clear_slot_signatures(slot);
             root_bank.prune_program_cache_by_deployment_slot(slot);
+        }
+    }
+
+    fn clear_slot_progress(
+        slot: Slot,
+        progress: &mut ProgressMap,
+        async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
+    ) {
+        if let Some(replay_progress) = progress.remove(&slot) {
+            let mut w_replay_progress = replay_progress.replay_progress.write().unwrap();
+            let _ = w_replay_progress.wait_for_all_verification_results(&mut 0, &mut 0);
+            Self::recycle_async_verification(
+                async_verification_freelist,
+                w_replay_progress.take_async_verification(),
+            );
         }
     }
 
@@ -3082,7 +3136,7 @@ impl ReplayStage {
         has_new_vote_been_rooted: &mut bool,
         replay_timing: &mut ReplayLoopTiming,
         voting_sender: &Sender<VoteOp>,
-        drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+        drop_bank_sender: &Sender<DropBankRequest>,
         wait_to_vote_slot: Option<Slot>,
         migration_status: &MigrationStatus,
         tbft_structs: &mut TowerBFTStructures,
@@ -5080,7 +5134,7 @@ impl ReplayStage {
         bank_notification_sender: &Option<BankNotificationSenderConfig>,
         has_new_vote_been_rooted: &mut bool,
         tracked_vote_transactions: &mut Vec<TrackedVoteTransaction>,
-        drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+        drop_bank_sender: &Sender<DropBankRequest>,
         tbft_structs: &mut TowerBFTStructures,
     ) {
         root_utils::check_and_handle_new_root(
@@ -5171,7 +5225,7 @@ impl ReplayStage {
         highest_super_majority_root: Option<Slot>,
         has_new_vote_been_rooted: &mut bool,
         tracked_vote_transactions: &mut Vec<TrackedVoteTransaction>,
-        drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+        drop_bank_sender: &Sender<DropBankRequest>,
         tbft_structs: &mut TowerBFTStructures,
     ) {
         root_utils::set_bank_forks_root(
@@ -5270,25 +5324,46 @@ impl ReplayStage {
                 response_sender,
             } => {
                 // Check that the bank is still valid to be inserted
-                let bank = {
+                let inserted_bank = {
                     let mut bank_forks = context.bank_forks.write().unwrap();
-                    if bank_forks.get(bank.slot()).is_none()
-                        && bank_forks.get(bank.parent_slot()).is_some()
+                    let parent_matches = bank
+                        .parent()
+                        .zip(bank_forks.get(bank.parent_slot()))
+                        .is_some_and(|(expected, current)| expected.bank_id() == current.bank_id());
+                    if bank.slot() > bank_forks.root()
+                        && bank_forks.get(bank.slot()).is_none()
+                        && parent_matches
                     {
-                        Some(bank_forks.insert(*bank))
+                        Some(bank_forks.insert_for_block_production(*bank))
                     } else {
                         None
                     }
                 };
 
-                response_sender.send(bank).unwrap_or_else(|_| {
-                    warn!("bank forks controller insert-bank response receiver dropped")
-                });
+                if let Err(SendError(inserted_bank)) = response_sender.send(inserted_bank) {
+                    warn!("bank forks controller insert-bank response receiver dropped");
+                    // The caller never received or published this bank, so it cannot have live
+                    // transaction ingress. Do not leave an unfrozen producer blocking future
+                    // UpdateParent or SwitchBank work.
+                    if let Some(inserted_bank) = inserted_bank {
+                        Self::clear_slots(
+                            [inserted_bank.slot()],
+                            &context.bank_forks,
+                            progress,
+                            async_verification_freelist,
+                        );
+                    }
+                }
             }
             BankForksCommand::ClearBank {
                 slot,
                 response_sender,
             } => {
+                if context.bank_forks.read().unwrap().get(slot).is_none() {
+                    // Root pruning removed this producer before BCL stopped ingress. Its ordered
+                    // DropBanks request must retire before BCL can reuse the numeric slot.
+                    Self::flush_drop_bank_service(&context.drop_bank_sender, vec![slot]);
+                }
                 Self::clear_slots(
                     [slot],
                     &context.bank_forks,
@@ -5315,6 +5390,7 @@ impl ReplayStage {
             slot_status_notifier,
             migration_status,
             my_pubkey,
+            drop_bank_sender,
         } = ctx;
 
         // Find the next slot that chains to the old slot
@@ -5389,7 +5465,26 @@ impl ReplayStage {
                     migration_status,
                 ) {
                     ChildBankReplayStart::FromStart => None,
-                    ChildBankReplayStart::FromUpdateParent(num_shreds) => Some(num_shreds),
+                    ChildBankReplayStart::FromUpdateParent(num_shreds) => {
+                        // `set_root()` may already have removed an older Bank at this numeric
+                        // slot. Fence its ordered retirement before constructing the replacement.
+                        // A still-active local producer protects its whole ancestor chain; defer
+                        // until BCL stops ingress and clears that generation.
+                        if Self::has_pending_bank_retirement(drop_bank_sender, vec![child_slot]) {
+                            trace!(
+                                "deferring UpdateParent replay for slot {child_slot} while its \
+                                 old bank generation is still active"
+                            );
+                            continue;
+                        }
+
+                        // AccountsDb retirement is fenced above. The status and program caches
+                        // are slot keyed as well, so clear their old generation immediately before
+                        // publishing the replacement Bank.
+                        parent_bank.clear_slot_signatures(child_slot);
+                        parent_bank.prune_program_cache_by_deployment_slot(child_slot);
+                        Some(num_shreds)
+                    }
                     ChildBankReplayStart::Defer => continue,
                 };
 

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -8,6 +8,7 @@ use {
             tower_storage::{FileTowerStorage, NullTowerStorage},
             tree_diff::TreeDiff,
         },
+        drop_bank_service::DropBankService,
         replay_stage::ReplayStage,
         vote_simulator::{self, VoteSimulator},
     },
@@ -21,7 +22,7 @@ use {
     },
     crossbeam_channel::bounded,
     itertools::Itertools,
-    solana_account::{ReadableAccount, state_traits::StateMutWincode as _},
+    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _},
     solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
     solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
     solana_client::connection_cache::ConnectionCache,
@@ -173,8 +174,18 @@ impl ProcessActiveBanksContext {
     }
 }
 
+fn test_drop_bank_service() -> (Sender<DropBankRequest>, DropBankService) {
+    let (drop_bank_sender, drop_bank_receiver) = bounded(1024);
+    (drop_bank_sender, DropBankService::new(drop_bank_receiver))
+}
+
 fn post_migration_status_for_tests() -> MigrationStatus {
     let migration_status = MigrationStatus::default();
+    enable_post_migration_status_for_tests(&migration_status);
+    migration_status
+}
+
+fn enable_post_migration_status_for_tests(migration_status: &MigrationStatus) {
     migration_status.record_feature_activation(0);
     let genesis_block = Block {
         slot: 0,
@@ -190,7 +201,6 @@ fn post_migration_status_for_tests() -> MigrationStatus {
     migration_status.set_genesis_block(genesis_block);
     migration_status.set_genesis_certificate(genesis_certificate);
     migration_status.enable_alpenglow_during_startup();
-    migration_status
 }
 
 fn cluster_info_for_tests() -> ClusterInfo {
@@ -263,6 +273,34 @@ fn insert_update_parent_slot(
         block_header_parent_slot,
         update_parent,
         replay_fec_set_index,
+    ));
+    blockstore.insert_shreds(shreds, true).unwrap();
+}
+
+fn insert_headerless_update_parent_slot(blockstore: &Blockstore, slot: Slot, parent_slot: Slot) {
+    let footer_marker = || {
+        VersionedBlockMarker::from_block_footer(BlockFooterV1 {
+            bank_hash: Hash::new_unique(),
+            block_producer_time_nanos: 0,
+            block_user_agent: vec![],
+            block_final_cert: None,
+            skip_reward_cert: None,
+            notar_reward_cert: None,
+        })
+    };
+    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
+        new_parent_slot: parent_slot,
+        new_parent_block_id: Hash::default(),
+    });
+
+    let mut shreds = block_marker_shreds(slot, parent_slot, footer_marker(), 0);
+    shreds.extend(block_marker_shreds(slot, parent_slot, update_parent, 32));
+    shreds.extend(block_marker_shreds_with_last(
+        slot,
+        parent_slot,
+        footer_marker(),
+        64,
+        true,
     ));
     blockstore.insert_shreds(shreds, true).unwrap();
 }
@@ -413,6 +451,7 @@ pub fn replay_blockstore_components(
 
 #[test]
 fn test_child_slots_of_same_parent() {
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let ReplayBlockstoreComponents {
         blockstore,
         validator_node_to_vote_keys,
@@ -478,6 +517,7 @@ fn test_child_slots_of_same_parent() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -510,6 +550,7 @@ fn test_child_slots_of_same_parent() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -730,6 +771,104 @@ fn test_process_set_root_command_requires_matching_frozen_bank() {
     );
     assert_eq!(bank_forks.read().unwrap().root(), 1);
     assert!(blockstore.is_root(1));
+}
+
+#[test]
+fn test_set_bank_forks_root_fails_if_retirement_service_disconnected() {
+    let genesis_config = create_genesis_config(10_000).genesis_config;
+    let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+    let root_bank = bank_forks.read().unwrap().root_bank();
+    let new_root = 1;
+    let new_root_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), new_root);
+    new_root_bank.freeze();
+    bank_forks.write().unwrap().insert(new_root_bank);
+
+    let (drop_bank_sender, drop_bank_receiver) = bounded(1);
+    drop(drop_bank_receiver);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        root_utils::set_bank_forks_root(
+            &Pubkey::new_unique(),
+            new_root,
+            &bank_forks,
+            None,
+            None,
+            &drop_bank_sender,
+            |_| {},
+        );
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(bank_forks.read().unwrap().root(), new_root);
+    assert!(bank_forks.try_write().is_ok());
+}
+
+#[test]
+fn test_process_insert_bank_command_rejects_stale_parent_generation() {
+    let (mut vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None);
+    let bank_forks = vote_simulator.bank_forks.clone();
+    enable_post_migration_status_for_tests(bank_forks.read().unwrap().migration_status().as_ref());
+    let root_bank = bank_forks.read().unwrap().root_bank();
+
+    let parent_slot = 1;
+    let old_parent = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), parent_slot);
+    let old_parent = bank_forks.write().unwrap().insert(old_parent);
+    let old_parent = old_parent.clone_without_scheduler();
+    let child_slot = 2;
+    let child = Bank::new_from_parent(old_parent.clone(), SlotLeader::default(), child_slot);
+
+    let removed_parent = bank_forks.write().unwrap().remove(parent_slot).unwrap();
+    drop(removed_parent);
+    let replacement_parent = Bank::new_from_parent(root_bank, SlotLeader::default(), parent_slot);
+    let replacement_parent = bank_forks
+        .write()
+        .unwrap()
+        .insert(replacement_parent)
+        .clone_without_scheduler();
+    assert_ne!(old_parent.bank_id(), replacement_parent.bank_id());
+
+    let blockstore = Arc::new(blockstore);
+    let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
+        &bank_forks.read().unwrap().root_bank(),
+    ));
+    let (drop_bank_sender, _drop_bank_receiver) = bounded(1);
+    let context = ProcessBankForksContext {
+        bank_forks: bank_forks.clone(),
+        blockstore,
+        snapshot_controller: None,
+        bank_notification_sender: None,
+        rpc_subscriptions: None,
+        drop_bank_sender,
+        leader_schedule_cache,
+    };
+    let (response_sender, response_receiver) = bounded(1);
+    ReplayStage::process_bank_forks_command(
+        BankForksCommand::InsertBank {
+            bank: Box::new(child),
+            response_sender,
+        },
+        &context,
+        &mut vote_simulator.progress,
+        &mut Vec::new(),
+    );
+
+    assert!(response_receiver.recv().unwrap().is_none());
+    assert!(bank_forks.read().unwrap().get(child_slot).is_none());
+
+    // If BCL exits after enqueueing a valid bank but before receiving the response, Replay must
+    // remove the unpublished producer instead of leaving it to block all future switches.
+    let child = Bank::new_from_parent(replacement_parent, SlotLeader::default(), child_slot);
+    let (response_sender, response_receiver) = bounded(1);
+    drop(response_receiver);
+    ReplayStage::process_bank_forks_command(
+        BankForksCommand::InsertBank {
+            bank: Box::new(child),
+            response_sender,
+        },
+        &context,
+        &mut vote_simulator.progress,
+        &mut Vec::new(),
+    );
+    assert!(bank_forks.read().unwrap().get(child_slot).is_none());
 }
 
 #[test]
@@ -2992,6 +3131,7 @@ fn test_purge_unconfirmed_duplicate_slot() {
 
 #[test]
 fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let ReplayBlockstoreComponents {
         blockstore,
         validator_node_to_vote_keys,
@@ -3084,6 +3224,7 @@ fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -3117,6 +3258,7 @@ fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -3151,6 +3293,7 @@ fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -3184,6 +3327,7 @@ fn test_purge_unconfirmed_duplicate_slots_and_reattach() {
             slot_status_notifier: &None,
             migration_status: &MigrationStatus::default(),
             my_pubkey: &Pubkey::default(),
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
@@ -3244,6 +3388,7 @@ fn test_update_parent_restart() {
     let cleared_bank_id = bank_forks.read().unwrap().get(4).unwrap().bank_id();
     let (replay_vote_sender, replay_vote_receiver) = bounded(1024);
     let (entry_notification_sender, entry_notification_receiver) = bounded(1);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3255,6 +3400,7 @@ fn test_update_parent_restart() {
         &replay_vote_sender,
         &post_migration_status_for_tests(),
         Some(&entry_notification_sender),
+        &drop_bank_sender,
     );
 
     assert!(progress.get(&4).is_none()); // cleared: 5 < 32
@@ -3282,7 +3428,324 @@ fn test_update_parent_restart() {
 }
 
 #[test]
+fn test_update_parent_restart_clears_removed_bank_state() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+    let slot = 4;
+    let old_account = Pubkey::new_unique();
+
+    let bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    bank.store_account(
+        &old_account,
+        &AccountSharedData::new(1, 0, &Pubkey::default()),
+    );
+    bank_forks.write().unwrap().insert(bank);
+    let old_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    let replay_progress = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+    replay_progress.replay_progress.write().unwrap().num_shreds = 5;
+    progress.insert(slot, replay_progress);
+    assert_eq!(old_bank.get_balance(&old_account), 1);
+
+    let (drop_bank_sender, drop_bank_service) = test_drop_bank_service();
+    let removed_bank = bank_forks.write().unwrap().remove(slot).unwrap();
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: vec![removed_bank],
+            new_root: bank_forks.read().unwrap().root(),
+        })
+        .unwrap();
+
+    insert_update_parent_slot(
+        &blockstore,
+        slot,
+        3, // optimistic block-header parent
+        0, // UpdateParent parent
+        Hash::new_unique(),
+        32,
+    );
+    let (tx, rx) = bounded(1);
+    tx.send(UpdateParentSignal { slot }).unwrap();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
+    handle_update_parent_interrupts(
+        &Pubkey::new_unique(),
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut Vec::new(),
+        &rx,
+        &replay_vote_sender,
+        &post_migration_status_for_tests(),
+        None,
+        &drop_bank_sender,
+    );
+
+    assert!(progress.get(&slot).is_none());
+    assert_eq!(old_bank.get_balance(&old_account), 0);
+    let replacement_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    assert_eq!(replacement_bank.get_balance(&old_account), 0);
+    let replacement_account = Pubkey::new_unique();
+    replacement_bank.store_account(
+        &replacement_account,
+        &AccountSharedData::new(2, 0, &Pubkey::default()),
+    );
+
+    drop(old_bank);
+    assert_eq!(replacement_bank.get_balance(&replacement_account), 2);
+    drop(drop_bank_sender);
+    drop_bank_service.join().unwrap();
+}
+
+#[test]
+fn test_update_parent_restart_defers_removed_producer_bank() {
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        leader_schedule_cache,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+    let slot = 4;
+    let old_account = Pubkey::new_unique();
+
+    let producer_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    producer_bank.store_account(
+        &old_account,
+        &AccountSharedData::new(1, 0, &Pubkey::default()),
+    );
+    let producer_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert_for_block_production(producer_bank);
+    let old_bank_id = producer_bank.bank_id();
+    let producer_bank = producer_bank.clone_without_scheduler();
+    let replay_progress = ForkProgress::new(Hash::default(), Some(0), None, 0, 0, None);
+    replay_progress.replay_progress.write().unwrap().num_shreds = 5;
+    progress.insert(slot, replay_progress);
+
+    let (drop_bank_sender, drop_bank_service) = test_drop_bank_service();
+    let removed_bank = bank_forks.write().unwrap().remove(slot).unwrap();
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: vec![removed_bank],
+            new_root: bank_forks.read().unwrap().root(),
+        })
+        .unwrap();
+    insert_update_parent_slot(&blockstore, slot, 3, 0, Hash::new_unique(), 32);
+
+    let (signal_sender, signal_receiver) = bounded(1);
+    signal_sender.send(UpdateParentSignal { slot }).unwrap();
+    let (replay_vote_sender, _replay_vote_receiver) = bounded(1);
+    let migration_status = post_migration_status_for_tests();
+    handle_update_parent_interrupts(
+        &Pubkey::new_unique(),
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut Vec::new(),
+        &signal_receiver,
+        &replay_vote_sender,
+        &migration_status,
+        None,
+        &drop_bank_sender,
+    );
+
+    // The removed producer is still live, so only stale replay bookkeeping is cleared. This lets
+    // generation retry without force-retiring account state while BankingStage can still commit.
+    assert!(!progress.contains_key(&slot));
+    assert_eq!(producer_bank.get_balance(&old_account), 1);
+    let my_pubkey = Pubkey::new_unique();
+    let mut replay_timing = ReplayLoopTiming::default();
+    ReplayStage::generate_new_bank_forks(
+        NewBankForksContext {
+            blockstore: &blockstore,
+            bank_forks: &bank_forks,
+            leader_schedule_cache: &leader_schedule_cache,
+            rpc_subscriptions: None,
+            slot_status_notifier: &None,
+            migration_status: &migration_status,
+            my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
+        },
+        &mut progress,
+        &mut replay_timing,
+    );
+    assert!(bank_forks.read().unwrap().get(slot).is_none());
+    assert_eq!(producer_bank.get_balance(&old_account), 1);
+
+    producer_bank.freeze();
+    ReplayStage::generate_new_bank_forks(
+        NewBankForksContext {
+            blockstore: &blockstore,
+            bank_forks: &bank_forks,
+            leader_schedule_cache: &leader_schedule_cache,
+            rpc_subscriptions: None,
+            slot_status_notifier: &None,
+            migration_status: &migration_status,
+            my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
+        },
+        &mut progress,
+        &mut replay_timing,
+    );
+
+    let replacement_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    assert_ne!(replacement_bank.bank_id(), old_bank_id);
+    assert_eq!(producer_bank.get_balance(&old_account), 0);
+    assert_eq!(replacement_bank.get_balance(&old_account), 0);
+    assert_eq!(
+        progress[&slot].replay_progress.read().unwrap().num_shreds,
+        32
+    );
+
+    drop(replacement_bank);
+    drop(producer_bank);
+    drop(drop_bank_sender);
+    drop_bank_service.join().unwrap();
+}
+
+#[test]
 fn test_headerless_update_parent() {
+    let (drop_bank_sender, drop_bank_service) = test_drop_bank_service();
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        leader_schedule_cache,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        node_pubkeys,
+        validator_keypairs,
+        ..
+    } = vote_simulator;
+    let my_pubkey = Pubkey::new_unique();
+    let slot = 4;
+    let migration_status = post_migration_status_for_tests();
+    let stale_account = Pubkey::new_unique();
+
+    insert_headerless_update_parent_slot(&blockstore, slot, 0);
+    let slot_meta = blockstore.meta(slot).unwrap().unwrap();
+    assert!(blockstore.is_full(slot), "{slot_meta:?}");
+    assert!(slot_meta.has_update_parent());
+
+    // Model an old slot generation that set_root() already removed before UpdateParent replay
+    // discovers the replacement. Keep an external Arc alive so the old Bank::drop callback runs
+    // only after the replacement has written its own state.
+    let old_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    old_bank.store_account(
+        &stale_account,
+        &AccountSharedData::new(1, 0, &Pubkey::default()),
+    );
+    let funded_validator = node_pubkeys[0];
+    let stale_signature = old_bank
+        .transfer(
+            1,
+            &validator_keypairs
+                .get(&funded_validator)
+                .unwrap()
+                .node_keypair,
+            &Pubkey::new_unique(),
+        )
+        .unwrap();
+    bank_forks.write().unwrap().insert(old_bank);
+    let old_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    assert_eq!(old_bank.get_balance(&stale_account), 1);
+    assert!(old_bank.get_signature_status(&stale_signature).is_some());
+    assert!(!progress.contains_key(&slot));
+
+    let removed_bank = bank_forks.write().unwrap().remove(slot).unwrap();
+    assert!(!removed_bank.is_transaction_producer());
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: vec![removed_bank],
+            new_root: bank_forks.read().unwrap().root(),
+        })
+        .unwrap();
+    assert!(bank_forks.read().unwrap().get(slot).is_none());
+
+    let mut replay_timing = ReplayLoopTiming::default();
+    ReplayStage::generate_new_bank_forks(
+        NewBankForksContext {
+            blockstore: &blockstore,
+            bank_forks: &bank_forks,
+            leader_schedule_cache: &leader_schedule_cache,
+            rpc_subscriptions: None,
+            slot_status_notifier: &None,
+            migration_status: &migration_status,
+            my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
+        },
+        &mut progress,
+        &mut replay_timing,
+    );
+
+    let replacement_bank = bank_forks.read().unwrap().get(slot).expect(
+        "headerless UpdateParent should fence retirement and create a replay bank from the marker",
+    );
+    assert_ne!(replacement_bank.bank_id(), old_bank.bank_id());
+    assert_eq!(old_bank.get_balance(&stale_account), 0);
+    assert!(old_bank.get_signature_status(&stale_signature).is_none());
+    assert_eq!(replacement_bank.get_balance(&stale_account), 0);
+    assert!(
+        replacement_bank
+            .get_signature_status(&stale_signature)
+            .is_none()
+    );
+    assert_eq!(
+        progress
+            .get(&slot)
+            .unwrap()
+            .replay_progress
+            .read()
+            .unwrap()
+            .num_shreds,
+        32
+    );
+
+    let replacement_account = Pubkey::new_unique();
+    replacement_bank.store_account(
+        &replacement_account,
+        &AccountSharedData::new(2, 0, &Pubkey::default()),
+    );
+    drop(old_bank);
+    assert_eq!(replacement_bank.get_balance(&replacement_account), 2);
+
+    drop(drop_bank_sender);
+    drop_bank_service.join().unwrap();
+}
+
+#[test]
+fn test_headerless_update_parent_defers_pending_producer_bank() {
+    let (drop_bank_sender, drop_bank_service) = test_drop_bank_service();
     let ReplayBlockstoreComponents {
         blockstore,
         vote_simulator,
@@ -3298,35 +3761,27 @@ fn test_headerless_update_parent() {
     let slot = 4;
     let migration_status = post_migration_status_for_tests();
 
-    let footer_marker = || {
-        VersionedBlockMarker::from_block_footer(BlockFooterV1 {
-            bank_hash: Hash::new_unique(),
-            block_producer_time_nanos: 0,
-            block_user_agent: vec![],
-            block_final_cert: None,
-            skip_reward_cert: None,
-            notar_reward_cert: None,
-        })
-    };
-    let update_parent = VersionedBlockMarker::from_update_parent(UpdateParentV1 {
-        new_parent_slot: 0,
-        new_parent_block_id: Hash::default(),
-    });
+    insert_headerless_update_parent_slot(&blockstore, slot, 0);
 
-    let mut shreds = block_marker_shreds(slot, 0, footer_marker(), 0);
-    shreds.extend(block_marker_shreds(slot, 0, update_parent, 32));
-    shreds.extend(block_marker_shreds_with_last(
+    let producer_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
         slot,
-        0,
-        footer_marker(),
-        64,
-        true,
-    ));
-    blockstore.insert_shreds(shreds, true).unwrap();
-    let slot_meta = blockstore.meta(slot).unwrap().unwrap();
-    assert!(blockstore.is_full(slot), "{slot_meta:?}");
-    assert!(slot_meta.has_update_parent());
-    assert!(bank_forks.read().unwrap().get(slot).is_none());
+    );
+    let producer_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert_for_block_production(producer_bank);
+    let old_bank_id = producer_bank.bank_id();
+    let producer_bank = producer_bank.clone_without_scheduler();
+    let removed_bank = bank_forks.write().unwrap().remove(slot).unwrap();
+    assert!(removed_bank.is_transaction_producer());
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: vec![removed_bank],
+            new_root: bank_forks.read().unwrap().root(),
+        })
+        .unwrap();
 
     let mut replay_timing = ReplayLoopTiming::default();
     ReplayStage::generate_new_bank_forks(
@@ -3338,25 +3793,150 @@ fn test_headerless_update_parent() {
             slot_status_notifier: &None,
             migration_status: &migration_status,
             my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,
     );
 
-    assert!(
-        bank_forks.read().unwrap().get(slot).is_some(),
-        "headerless UpdateParent should create a replay bank from the marker"
+    assert!(bank_forks.read().unwrap().get(slot).is_none());
+    assert!(!progress.contains_key(&slot));
+
+    // Once producer ingress stops, the next production retry uses Barrier to retire the old
+    // generation and create its replacement.
+    producer_bank.freeze();
+    ReplayStage::generate_new_bank_forks(
+        NewBankForksContext {
+            blockstore: &blockstore,
+            bank_forks: &bank_forks,
+            leader_schedule_cache: &leader_schedule_cache,
+            rpc_subscriptions: None,
+            slot_status_notifier: &None,
+            migration_status: &migration_status,
+            my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
+        },
+        &mut progress,
+        &mut replay_timing,
     );
+    let replacement_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    assert_ne!(replacement_bank.bank_id(), old_bank_id);
     assert_eq!(
-        progress
-            .get(&slot)
-            .unwrap()
-            .replay_progress
-            .read()
-            .unwrap()
-            .num_shreds,
+        progress[&slot].replay_progress.read().unwrap().num_shreds,
         32
     );
+    drop(replacement_bank);
+    drop(producer_bank);
+    drop(drop_bank_sender);
+    drop_bank_service.join().unwrap();
+}
+
+#[test]
+fn test_switch_bank_defers_missing_pending_producer_bank() {
+    let (drop_bank_sender, drop_bank_service) = test_drop_bank_service();
+    let ReplayBlockstoreComponents {
+        blockstore,
+        vote_simulator,
+        ..
+    } = replay_blockstore_components(Some(tr(0)), 1, None::<GenerateVotes>);
+    let VoteSimulator {
+        bank_forks,
+        mut progress,
+        ..
+    } = vote_simulator;
+    let slot = 4;
+    let protected_account = Pubkey::new_unique();
+
+    // A dead original block is already present, but its replay Bank was removed by set_root()
+    // while a marked producer generation can still receive transactions.
+    insert_headerless_update_parent_slot(&blockstore, slot, 0);
+    let block_id = blockstore
+        .get_double_merkle_root(slot, BlockLocation::Original)
+        .unwrap()
+        .unwrap();
+    blockstore.set_dead_slot(slot).unwrap();
+
+    let producer_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    producer_bank.store_account(
+        &protected_account,
+        &AccountSharedData::new(1, 0, &Pubkey::default()),
+    );
+    let producer_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert_for_block_production(producer_bank);
+    let producer_bank = producer_bank.clone_without_scheduler();
+    let removed_bank = bank_forks.write().unwrap().remove(slot).unwrap();
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: vec![removed_bank],
+            new_root: bank_forks.read().unwrap().root(),
+        })
+        .unwrap();
+
+    let event = SwitchBankEvent::Switch {
+        block: Block { slot, block_id },
+    };
+    let latest_switch_request = LatestSwitchRequest::default();
+    assert_eq!(latest_switch_request.try_advance(event), None);
+    let mut pending_switch = None;
+    let mut async_verification_freelist = Vec::new();
+    ReplayStage::process_switch_bank_events(
+        &Pubkey::new_unique(),
+        &latest_switch_request,
+        &mut pending_switch,
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut async_verification_freelist,
+        &drop_bank_sender,
+    )
+    .unwrap();
+
+    // Barrier observes the removed producer and defers without force-retiring it or mutating the
+    // original block. In particular, the dead marker must remain until producer ingress stops.
+    assert_eq!(pending_switch, Some(event));
+    assert!(blockstore.is_dead(slot));
+    assert_eq!(
+        blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .unwrap(),
+        Some(block_id)
+    );
+    assert_eq!(producer_bank.get_balance(&protected_account), 1);
+
+    // Once the producer is quiescent, targeted retirement is safe and the same pending switch can
+    // complete. Because the requested block is already in Original, completion clears its dead
+    // marker instead of moving an alternate column.
+    producer_bank.freeze();
+    ReplayStage::process_switch_bank_events(
+        &Pubkey::new_unique(),
+        &latest_switch_request,
+        &mut pending_switch,
+        &blockstore,
+        &bank_forks,
+        &mut progress,
+        &mut async_verification_freelist,
+        &drop_bank_sender,
+    )
+    .unwrap();
+    assert_eq!(producer_bank.get_balance(&protected_account), 0);
+    assert_eq!(pending_switch, None);
+    assert!(!blockstore.is_dead(slot));
+    assert_eq!(
+        blockstore
+            .get_double_merkle_root(slot, BlockLocation::Original)
+            .unwrap(),
+        Some(block_id)
+    );
+
+    drop(producer_bank);
+    drop(drop_bank_sender);
+    drop_bank_service.join().unwrap();
 }
 
 #[test]
@@ -3388,6 +3968,7 @@ fn test_update_parent_tower_gated() {
     tx.send(UpdateParentSignal { slot }).unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3399,6 +3980,7 @@ fn test_update_parent_tower_gated() {
         &replay_vote_sender,
         &MigrationStatus::default(),
         None,
+        &drop_bank_sender,
     );
 
     assert!(progress.get(&slot).is_some());
@@ -3433,6 +4015,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
     tx.send(UpdateParentSignal { slot }).unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3444,6 +4027,7 @@ fn test_update_parent_interrupt_ignores_non_first_leader_window_slot() {
         &replay_vote_sender,
         &post_migration_status_for_tests(),
         None,
+        &drop_bank_sender,
     );
 
     assert!(progress.get(&slot).is_some());
@@ -3481,6 +4065,7 @@ fn test_update_parent_keeps_hard() {
     tx.send(UpdateParentSignal { slot }).unwrap();
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     handle_update_parent_interrupts(
         &Pubkey::new_unique(),
@@ -3492,6 +4077,7 @@ fn test_update_parent_keeps_hard() {
         &replay_vote_sender,
         &post_migration_status_for_tests(),
         None,
+        &drop_bank_sender,
     );
 
     assert!(blockstore.is_dead(slot));
@@ -3694,6 +4280,7 @@ fn test_spurious_update_parent_boundary(replayed_shreds: u64, should_be_hard: bo
         Some(&expected_reason)
     );
 
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3706,6 +4293,7 @@ fn test_spurious_update_parent_boundary(replayed_shreds: u64, should_be_hard: bo
         &replay_vote_sender,
         &migration_status,
         None,
+        &drop_bank_sender,
     );
 
     assert!(!blockstore.is_dead(slot));
@@ -3804,6 +4392,7 @@ fn test_soft_dead_restarts() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3816,6 +4405,7 @@ fn test_soft_dead_restarts() {
         &replay_vote_sender,
         &post_migration_status_for_tests(),
         None,
+        &drop_bank_sender,
     );
 
     assert!(!blockstore.is_dead(slot));
@@ -3848,6 +4438,7 @@ fn test_full_soft_dead_hardens() {
     progress.insert(slot, p);
 
     let (replay_vote_sender, _replay_vote_receiver) = bounded(1024);
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let mut async_verification_freelist = Vec::new();
     process_soft_dead_slots(
         &Pubkey::new_unique(),
@@ -3860,6 +4451,7 @@ fn test_full_soft_dead_hardens() {
         &replay_vote_sender,
         &post_migration_status_for_tests(),
         None,
+        &drop_bank_sender,
     );
 
     assert!(blockstore.is_dead(slot));
@@ -3967,6 +4559,7 @@ fn test_latest_parent_coalesces() {
 
 #[test]
 fn test_skip_own_update_full() {
+    let (drop_bank_sender, _drop_bank_service) = test_drop_bank_service();
     let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
     let VoteSimulator {
         bank_forks,
@@ -4011,6 +4604,7 @@ fn test_skip_own_update_full() {
             slot_status_notifier: &None,
             migration_status: &migration_status,
             my_pubkey: &my_pubkey,
+            drop_bank_sender: &drop_bank_sender,
         },
         &mut progress,
         &mut replay_timing,

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -13,6 +13,7 @@ use {
         repair::cluster_slot_state_verifier::{DuplicateSlotsToRepair, PurgeRepairSlotCounter},
     },
     agave_votor_messages::migration::MigrationStatus,
+    crossbeam_channel::Sender,
     solana_clock::Slot,
     solana_entry::block_component::VersionedUpdateParent,
     solana_ledger::{
@@ -24,8 +25,8 @@ use {
     },
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank, bank_forks::BankForks, leader_schedule_utils::leader_slot_index,
-        vote_sender_types::ReplayVoteSender,
+        bank::Bank, bank_forks::BankForks, installed_scheduler_pool::DropBankRequest,
+        leader_schedule_utils::leader_slot_index, vote_sender_types::ReplayVoteSender,
     },
     std::sync::{Arc, RwLock},
 };
@@ -124,34 +125,44 @@ fn try_restart_slot_from_update_parent(
     migration_status: &MigrationStatus,
     source: &str,
     entry_notification_sender: Option<&EntryNotifierSender>,
-) -> bool {
+    drop_bank_sender: &Sender<DropBankRequest>,
+) {
     if !migration_status.should_allow_block_markers(slot) {
-        return false;
+        return;
     }
     if blockstore.is_dead(slot) {
-        return false;
+        return;
     }
     let Some(slot_meta) = blockstore.meta(slot).expect("Blockstore should not fail") else {
-        return false;
+        return;
     };
     let Some(replay_fec_set_index) =
         update_parent_replay_offset(slot, &slot_meta, bank_forks.read().unwrap().root())
     else {
-        return false;
+        return;
     };
 
     // Skip if neither replay bank nor progress exists. If progress exists
     // without a bank, clear it as stale state so the next replay iteration
     // can recreate the bank from the updated SlotMeta.
-    let bank = bank_forks.read().unwrap().get(slot);
+    let bank = {
+        let bank = bank_forks.read().unwrap().get_with_scheduler(slot);
+        if bank
+            .as_ref()
+            .is_some_and(|bank| bank.is_transaction_producer() && !bank.is_frozen())
+        {
+            return;
+        }
+        bank.map(|bank| bank.clone_without_scheduler())
+    };
     if bank.is_none() && !progress.contains_key(&slot) {
-        return false;
+        return;
     }
     if bank.as_ref().is_some_and(|bank| {
         ReplayStage::leader_is_me(bank.leader_id(), my_pubkey)
             || !bank.feature_set.snapshot().alpenglow_fast_leader_handover
     }) {
-        return false;
+        return;
     }
     let dead_reason = progress
         .get(&slot)
@@ -163,7 +174,7 @@ fn try_restart_slot_from_update_parent(
                 | DeadSlotReason::ReplayFailureAtUpdateParent(_)
         )
     }) {
-        return false;
+        return;
     }
 
     // Check if we've already replayed past the UpdateParent marker.
@@ -180,7 +191,19 @@ fn try_restart_slot_from_update_parent(
     if current_num_shreds > replay_fec_set_index
         || (current_num_shreds == replay_fec_set_index && !failed_at_replay_fec_set_index)
     {
-        return false;
+        return;
+    }
+
+    // `set_root()` may already have removed this bank from BankForks while a local producer still
+    // owns the old generation. Fence retirement before recreating the numeric slot.
+    if ReplayStage::has_pending_bank_retirement(drop_bank_sender, vec![slot]) {
+        if bank.is_none() {
+            // This progress entry describes the removed generation. Clear only replay bookkeeping
+            // so generate_new_bank_forks can retry; the producer and its account state must remain
+            // intact until a later Barrier observes that ingress has quiesced.
+            ReplayStage::clear_slot_progress(slot, progress, async_verification_freelist);
+        }
+        return;
     }
 
     // Clear and let generate_new_bank_forks restart from replay_fec_set_index.
@@ -206,7 +229,6 @@ fn try_restart_slot_from_update_parent(
             },
         );
     }
-    true
 }
 
 /// Revisit soft-dead slots as more shreds arrive.
@@ -226,6 +248,7 @@ pub(super) fn process_soft_dead_slots(
     replay_vote_sender: &ReplayVoteSender,
     migration_status: &MigrationStatus,
     entry_notification_sender: Option<&EntryNotifierSender>,
+    drop_bank_sender: &Sender<DropBankRequest>,
 ) {
     let soft_dead_slots = progress
         .iter()
@@ -267,6 +290,7 @@ pub(super) fn process_soft_dead_slots(
                 migration_status,
                 "soft-dead scan",
                 entry_notification_sender,
+                drop_bank_sender,
             );
             continue;
         }
@@ -304,6 +328,7 @@ pub(super) fn process_soft_dead_slots(
 /// Handles UpdateParent signals by clearing slot state so replay restarts from
 /// the new parent. Skips live own-leader banks, slots replay has not started,
 /// and slots that already replayed past the UpdateParent marker.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn handle_update_parent_interrupts(
     my_pubkey: &Pubkey,
     blockstore: &Blockstore,
@@ -314,6 +339,7 @@ pub(super) fn handle_update_parent_interrupts(
     replay_vote_sender: &ReplayVoteSender,
     migration_status: &MigrationStatus,
     entry_notification_sender: Option<&EntryNotifierSender>,
+    drop_bank_sender: &Sender<DropBankRequest>,
 ) {
     while let Ok(signal) = update_parent_receiver.try_recv() {
         try_restart_slot_from_update_parent(
@@ -327,6 +353,7 @@ pub(super) fn handle_update_parent_interrupts(
             migration_status,
             "UpdateParent signal",
             entry_notification_sender,
+            drop_bank_sender,
         );
     }
 }

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -11,6 +11,7 @@ use {
             progress_map::{ForkProgress, LockoutInterval, ProgressMap},
             tower_vote_state::TowerVoteState,
         },
+        drop_bank_service::DropBankService,
         repair::cluster_slot_state_verifier::{
             DuplicateConfirmedSlots, DuplicateSlotsTracker, EpochSlotsFrozenSlots,
         },
@@ -247,7 +248,8 @@ impl VoteSimulator {
     }
 
     pub fn set_root(&mut self, my_pubkey: &Pubkey, new_root: Slot) {
-        let (drop_bank_sender, _drop_bank_receiver) = bounded(1024);
+        let (drop_bank_sender, drop_bank_receiver) = bounded(1024);
+        let drop_bank_service = DropBankService::new(drop_bank_receiver);
         ReplayStage::handle_new_root(
             my_pubkey,
             new_root,
@@ -259,7 +261,9 @@ impl VoteSimulator {
             &mut Vec::new(),
             &drop_bank_sender,
             &mut self.tbft_structs,
-        )
+        );
+        drop(drop_bank_sender);
+        drop_bank_service.join().unwrap();
     }
 
     pub fn create_and_vote_new_branch(

--- a/core/tests/unified_scheduler.rs
+++ b/core/tests/unified_scheduler.rs
@@ -2,25 +2,17 @@ use {
     crossbeam_channel::bounded,
     itertools::Itertools,
     log::*,
-    solana_core::{
-        consensus::{
-            heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
-            progress_map::{ForkProgress, ProgressMap},
-        },
-        drop_bank_service::DropBankService,
-        repair::cluster_slot_state_verifier::{
-            DuplicateConfirmedSlots, DuplicateSlotsTracker, EpochSlotsFrozenSlots,
-        },
-        replay_stage::{ReplayStage, TowerBFTStructures},
-        unfrozen_gossip_verified_vote_hashes::UnfrozenGossipVerifiedVoteHashes,
-    },
-    solana_hash::Hash,
+    solana_account::AccountSharedData,
+    solana_accounts_db::accounts_scan::ScanError,
+    solana_core::drop_bank_service::DropBankService,
     solana_leader_schedule::SlotLeader,
     solana_ledger::genesis_utils::create_genesis_config,
     solana_pubkey::Pubkey,
     solana_runtime::{
-        bank::Bank, bank_forks::BankForks, genesis_utils::GenesisConfigInfo,
-        installed_scheduler_pool::SchedulingContext,
+        bank::Bank,
+        bank_forks::BankForks,
+        genesis_utils::GenesisConfigInfo,
+        installed_scheduler_pool::{DropBankRequest, SchedulingContext},
     },
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_svm_timings::ExecuteTimings,
@@ -31,13 +23,13 @@ use {
         DefaultTaskHandler, HandlerContext, PooledScheduler, SchedulerPool, TaskHandler,
     },
     std::{
-        collections::HashMap,
         sync::{Arc, Mutex},
+        time::Duration,
     },
 };
 
 #[test]
-fn test_scheduler_waited_by_drop_bank_service() {
+fn test_drop_bank_service_flush_waits_for_unrooted_retirement() {
     agave_logger::setup();
 
     static LOCK_TO_STALL: Mutex<()> = Mutex::new(());
@@ -54,8 +46,6 @@ fn test_scheduler_waited_by_drop_bank_service() {
         ) {
             info!("Stalling at StallingHandler::handle()...");
             *LOCK_TO_STALL.lock().unwrap();
-            // Wait a bit for the replay stage to prune banks
-            std::thread::sleep(std::time::Duration::from_secs(3));
             info!("Now entering into DefaultTaskHandler::handle()...");
 
             DefaultTaskHandler::handle(result, timings, scheduling_context, task, handler_context);
@@ -77,19 +67,73 @@ fn test_scheduler_waited_by_drop_bank_service() {
     let pool = pool_raw.clone();
     bank_forks.write().unwrap().install_scheduler_pool(pool);
     let genesis = 0;
-    let genesis_bank = &bank_forks.read().unwrap().get(genesis).unwrap();
+    let genesis_bank = bank_forks.read().unwrap().get(genesis).unwrap();
     genesis_bank.set_fork_graph_in_program_cache(Arc::downgrade(&bank_forks));
 
-    // Create bank, which is pruned later
-    let pruned = 2;
-    let pruned_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), pruned);
-    let pruned_bank = bank_forks.write().unwrap().insert(pruned_bank);
+    // Create a divergent parent and an unfrozen child above the eventual root. These slots can be
+    // replayed after they are pruned, so DropBankService must retire their exact account
+    // generations. Creating the child freezes its parent while leaving the child unfrozen.
+    let pruned_parent = 2;
+    let pruned_parent_bank =
+        Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), pruned_parent);
+    let inherited_account = Pubkey::new_unique();
+    pruned_parent_bank.store_account(
+        &inherited_account,
+        &AccountSharedData::new(24, 0, &Pubkey::default()),
+    );
+    let pruned_parent_bank = bank_forks.write().unwrap().insert(pruned_parent_bank);
+    let pruned_parent_bank_arc = pruned_parent_bank.clone_without_scheduler();
+    drop(pruned_parent_bank);
+
+    let pruned = 4;
+    let pruned_bank = Bank::new_from_parent(
+        pruned_parent_bank_arc.clone(),
+        SlotLeader::default(),
+        pruned,
+    );
+    let stale_account = Pubkey::new_unique();
+    pruned_bank.store_account(
+        &stale_account,
+        &AccountSharedData::new(42, 0, &Pubkey::default()),
+    );
+    let pruned_bank = bank_forks
+        .write()
+        .unwrap()
+        .insert_for_block_production(pruned_bank);
+    let pruned_bank_arc = pruned_bank.clone_without_scheduler();
+    assert_eq!(pruned_bank_arc.get_balance(&stale_account), 42);
+    assert_eq!(pruned_bank_arc.get_balance(&inherited_account), 24);
+    assert_eq!(pruned_bank_arc.scan_all_accounts(|_| {}), Ok(()));
+
+    // An unfrozen bank not published for transaction production cannot receive BankingStage
+    // commits, so it is safe to retire immediately.
+    let remote = 5;
+    let remote_bank = Bank::new_from_parent(
+        pruned_parent_bank_arc.clone(),
+        SlotLeader::new_unique(),
+        remote,
+    );
+    let remote_account = Pubkey::new_unique();
+    remote_bank.store_account(
+        &remote_account,
+        &AccountSharedData::new(12, 0, &Pubkey::default()),
+    );
+    let remote_signature = remote_bank
+        .transfer(1, &mint_keypair, &Pubkey::new_unique())
+        .unwrap();
+    let remote_bank = bank_forks.write().unwrap().insert(remote_bank);
+    let remote_bank_arc = remote_bank.clone_without_scheduler();
+    assert!(
+        remote_bank_arc
+            .get_signature_status(&remote_signature)
+            .is_some()
+    );
+    drop(remote_bank);
 
     // Create new root bank
-    let root = 3;
+    let root = 1;
     let root_bank = Bank::new_from_parent(genesis_bank.clone(), SlotLeader::default(), root);
     root_bank.freeze();
-    let root_hash = root_bank.hash();
     bank_forks.write().unwrap().insert(root_bank);
 
     let tx = RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -99,93 +143,137 @@ fn test_scheduler_waited_by_drop_bank_service() {
         genesis_config.hash(),
     ));
 
-    // Delay transaction execution to ensure transaction execution happens after termination has
-    // been started
+    // Block transaction execution so retirement cannot complete until the test releases it.
     let lock_to_stall = LOCK_TO_STALL.lock().unwrap();
     pruned_bank
         .schedule_transaction_executions([(tx, 0)].into_iter())
         .unwrap();
     drop(pruned_bank);
     assert_eq!(pool_raw.pooled_scheduler_count(), 0);
-    drop(lock_to_stall);
 
-    // Create 2 channels to check actual pruned banks
-    let (drop_bank_sender1, drop_bank_receiver1) = bounded(1024);
-    let (drop_bank_sender2, drop_bank_receiver2) = bounded(1024);
-    let drop_bank_service = DropBankService::new(drop_bank_receiver2);
-
-    info!("calling handle_new_root()...");
-    // Mostly copied from: test_handle_new_root()
-    {
-        let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new((root, root_hash));
-
-        let mut progress = ProgressMap::default();
-        for i in genesis..=root {
-            progress.insert(
-                i,
-                ForkProgress::new(Hash::default(), None, None, 0, 0, None),
-            );
-        }
-
-        let duplicate_slots_tracker: DuplicateSlotsTracker =
-            vec![root - 1, root, root + 1].into_iter().collect();
-        let duplicate_confirmed_slots: DuplicateConfirmedSlots = vec![root - 1, root, root + 1]
-            .into_iter()
-            .map(|s| (s, Hash::default()))
-            .collect();
-        let unfrozen_gossip_verified_vote_hashes: UnfrozenGossipVerifiedVoteHashes =
-            UnfrozenGossipVerifiedVoteHashes {
-                votes_per_slot: vec![root - 1, root, root + 1]
-                    .into_iter()
-                    .map(|s| (s, HashMap::new()))
-                    .collect(),
-            };
-        let epoch_slots_frozen_slots: EpochSlotsFrozenSlots = vec![root - 1, root, root + 1]
-            .into_iter()
-            .map(|slot| (slot, Hash::default()))
-            .collect();
-        let mut tbft_structs = TowerBFTStructures {
-            heaviest_subtree_fork_choice,
-            duplicate_slots_tracker,
-            duplicate_confirmed_slots,
-            unfrozen_gossip_verified_vote_hashes,
-            epoch_slots_frozen_slots,
-        };
-        ReplayStage::handle_new_root(
-            &Pubkey::new_unique(),
-            root,
-            &bank_forks,
-            &mut progress,
-            None, // snapshot_controller
-            None,
-            &mut true,
-            &mut Vec::new(),
-            &drop_bank_sender1,
-            &mut tbft_structs,
-        );
-    }
-
-    // Receive pruned banks from the above handle_new_root
-    let pruned_banks = drop_bank_receiver1.recv().unwrap();
+    // Call BankForks::set_root directly: root_utils intentionally waits for schedulers before
+    // pruning, while this test needs the bank to reach DropBankService with work still in flight.
+    let pruned_banks = bank_forks.write().unwrap().set_root(root, None, None);
     assert_eq!(
         pruned_banks
             .iter()
             .map(|b| b.slot())
             .sorted()
             .collect::<Vec<_>>(),
-        vec![genesis, pruned]
+        vec![genesis, pruned_parent, pruned, remote]
     );
-    info!("sending pruned banks to DropBankService...");
-    drop_bank_sender2.send(pruned_banks).unwrap();
 
-    info!("joining the drop bank service...");
-    drop((
-        (drop_bank_sender1, drop_bank_receiver1),
-        (drop_bank_sender2,),
-    ));
+    let (drop_bank_sender, drop_bank_receiver) = bounded(1024);
+    let drop_bank_service = DropBankService::new(drop_bank_receiver);
+    drop_bank_sender
+        .send(DropBankRequest::DropBanks {
+            banks: pruned_banks,
+            new_root: root,
+        })
+        .unwrap();
+
+    // The frozen parent remains protected while its producer child is live, while the unrelated
+    // non-producer bank retires immediately. Barrier reports the matching pending dependency group.
+    let (barrier_ack_sender, barrier_ack_receiver) = bounded(1);
+    drop_bank_sender
+        .send(DropBankRequest::Barrier {
+            slots: vec![pruned_parent],
+            ack_sender: barrier_ack_sender,
+        })
+        .unwrap();
+    assert!(
+        barrier_ack_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+    );
+    assert_eq!(remote_bank_arc.get_balance(&remote_account), 0);
+    assert!(
+        remote_bank_arc
+            .get_signature_status(&remote_signature)
+            .is_none()
+    );
+    assert_eq!(
+        remote_bank_arc.scan_all_accounts(|_| {}),
+        Err(ScanError::SlotRemoved {
+            slot: remote,
+            bank_id: remote_bank_arc.bank_id(),
+        })
+    );
+    assert_eq!(pruned_bank_arc.get_balance(&stale_account), 42);
+    assert_eq!(pruned_bank_arc.get_balance(&inherited_account), 24);
+    assert_eq!(pruned_bank_arc.scan_all_accounts(|_| {}), Ok(()));
+    assert_eq!(pruned_parent_bank_arc.scan_all_accounts(|_| {}), Ok(()));
+
+    let (unrelated_ack_sender, unrelated_ack_receiver) = bounded(1);
+    drop_bank_sender
+        .send(DropBankRequest::Barrier {
+            slots: vec![root],
+            ack_sender: unrelated_ack_sender,
+        })
+        .unwrap();
+    assert!(
+        !unrelated_ack_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+    );
+
+    let (ack_sender, ack_receiver) = bounded(1);
+    drop_bank_sender
+        .send(DropBankRequest::Flush {
+            // Targeting an ancestor must also retire its pending descendants.
+            slots: vec![pruned_parent],
+            ack_sender,
+        })
+        .unwrap();
+
+    // Flush is ordered behind retirement and cannot acknowledge while slot 4's scheduler is
+    // blocked. Account state and scan eligibility must remain intact until execution quiesces.
+    assert!(
+        ack_receiver
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+    assert_eq!(pruned_bank_arc.get_balance(&stale_account), 42);
+    assert_eq!(pruned_bank_arc.scan_all_accounts(|_| {}), Ok(()));
+
+    // Model a BankingStage record that has reserved this bank but has not completed its account
+    // commit. Retirement must fence this legacy path independently of unified-scheduler work.
+    let inflight_commit = pruned_bank_arc.freeze_lock();
+    drop(lock_to_stall);
+    assert!(
+        ack_receiver
+            .recv_timeout(Duration::from_millis(50))
+            .is_err()
+    );
+    assert_eq!(pruned_bank_arc.get_balance(&stale_account), 42);
+
+    drop(inflight_commit);
+    ack_receiver.recv_timeout(Duration::from_secs(5)).unwrap();
+
+    // The acknowledgement fences both account retirement and scan invalidation for the exact
+    // unrooted bank generation. The removed genesis Bank is at or below the new root and must not
+    // be tombstoned.
+    assert_eq!(pruned_bank_arc.get_balance(&stale_account), 0);
+    assert_eq!(pruned_bank_arc.get_balance(&inherited_account), 0);
+    assert_eq!(
+        pruned_bank_arc.scan_all_accounts(|_| {}),
+        Err(ScanError::SlotRemoved {
+            slot: pruned,
+            bank_id: pruned_bank_arc.bank_id(),
+        })
+    );
+    assert_eq!(
+        pruned_parent_bank_arc.scan_all_accounts(|_| {}),
+        Err(ScanError::SlotRemoved {
+            slot: pruned_parent,
+            bank_id: pruned_parent_bank_arc.bank_id(),
+        })
+    );
+    assert_eq!(genesis_bank.scan_all_accounts(|_| {}), Ok(()));
+
+    drop(drop_bank_sender);
     drop_bank_service.join().unwrap();
-    info!("finally joined the drop bank service!");
 
-    // the scheduler used by the pruned_bank have been returned now.
-    assert_eq!(pool_raw.pooled_scheduler_count(), 1);
+    // The flush acknowledgement is also ordered after the pruned bank releases its scheduler.
+    assert_eq!(pool_raw.pooled_scheduler_count(), 3);
 }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -298,17 +298,38 @@ impl BankForks {
         self.insert_with_scheduling_mode(SchedulingMode::BlockVerification, bank)
     }
 
-    pub fn insert_with_scheduling_mode(
+    /// Inserts a bank that will be published to transaction-ingress paths.
+    ///
+    /// Its producer role is fixed before the bank becomes visible through BankForks or
+    /// SharableBanks, allowing root pruning to preserve its account-state dependencies.
+    pub fn insert_for_block_production(&mut self, bank: Bank) -> BankWithScheduler {
+        self.insert_with_scheduling_mode(SchedulingMode::BlockProduction, bank)
+    }
+
+    fn insert_with_scheduling_mode(
         &mut self,
         mode: SchedulingMode,
         bank: Bank,
     ) -> BankWithScheduler {
         let bank = Arc::new(bank);
-        let bank = if let Some(scheduler_pool) = &self.scheduler_pool {
-            Self::install_scheduler_into_bank(scheduler_pool, mode, bank)
-        } else {
-            BankWithScheduler::new_without_scheduler(bank)
-        };
+        let is_transaction_producer = matches!(mode, SchedulingMode::BlockProduction);
+        let scheduler_pool = self.scheduler_pool.as_ref();
+        let scheduler = scheduler_pool.and_then(|scheduler_pool| {
+            scheduler_pool.take_scheduler(SchedulingContext::new(bank.clone()))
+        });
+        let has_scheduler = scheduler.is_some();
+        let bank = BankWithScheduler::new_with_transaction_producer(
+            bank,
+            scheduler,
+            is_transaction_producer,
+        );
+        // Block production is serialized, so only replay banks need timeout listeners.
+        if !is_transaction_producer
+            && has_scheduler
+            && let Some(scheduler_pool) = scheduler_pool
+        {
+            scheduler_pool.register_timeout_listener(bank.create_timeout_listener());
+        }
         let prev = self.banks.insert(bank.slot(), bank.clone_with_scheduler());
         assert!(prev.is_none());
         let slot = bank.slot();
@@ -323,27 +344,6 @@ impl BankForks {
 
         bank
     }
-
-    fn install_scheduler_into_bank(
-        scheduler_pool: &InstalledSchedulerPoolArc,
-        mode: SchedulingMode,
-        bank: Arc<Bank>,
-    ) -> BankWithScheduler {
-        let context = SchedulingContext::new(bank.clone());
-        let Some(scheduler) = scheduler_pool.take_scheduler(context) else {
-            return BankWithScheduler::new_without_scheduler(bank);
-        };
-        let bank_with_scheduler = BankWithScheduler::new(bank, Some(scheduler));
-        // Skip registering for block production. Both the tvu main loop in the replay stage
-        // and PohRecorder don't support _concurrent block production_ at all. It's strongly
-        // assumed that block is produced in singleton way and it's actually desired, while
-        // ignoring the opportunity cost of (hopefully rare!) fork switching...
-        if matches!(mode, SchedulingMode::BlockVerification) {
-            scheduler_pool.register_timeout_listener(bank_with_scheduler.create_timeout_listener());
-        }
-        bank_with_scheduler
-    }
-
     pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {
         let bank = self.banks.remove(&slot)?;
         for parent in bank.proper_ancestors() {
@@ -904,6 +904,32 @@ mod tests {
         let bank_forks = bank_forks.read().unwrap();
         assert_eq!(bank_forks[1u64].tick_height(), 1);
         assert_eq!(bank_forks.working_bank().tick_height(), 1);
+    }
+
+    #[test]
+    fn test_block_production_bank_is_marked_before_publication() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let root_bank = bank_forks.read().unwrap().root_bank();
+
+        let verification_bank = Bank::new_from_parent(root_bank.clone(), SlotLeader::default(), 1);
+        let verification_bank = bank_forks.write().unwrap().insert(verification_bank);
+        assert!(!verification_bank.is_transaction_producer());
+
+        let producer_bank = Bank::new_from_parent(root_bank, SlotLeader::default(), 2);
+        let producer_bank = bank_forks
+            .write()
+            .unwrap()
+            .insert_for_block_production(producer_bank);
+        assert!(producer_bank.is_transaction_producer());
+        assert!(
+            bank_forks
+                .read()
+                .unwrap()
+                .get_with_scheduler(2)
+                .unwrap()
+                .is_transaction_producer()
+        );
     }
 
     #[test]

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -358,7 +358,7 @@ mod tests {
                     } => {
                         let bank = {
                             let mut bank_forks = replay_bank_forks.write().unwrap();
-                            bank_forks.insert(*bank)
+                            bank_forks.insert_for_block_production(*bank)
                         };
                         response_sender.send(Some(bank)).unwrap();
                     }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -22,6 +22,7 @@
 
 use {
     crate::bank::Bank,
+    crossbeam_channel::Sender,
     log::*,
     solana_clock::Slot,
     solana_hash::Hash,
@@ -369,8 +370,38 @@ pub struct BankWithScheduler {
 pub struct BankWithSchedulerInner {
     bank: Arc<Bank>,
     scheduler: InstalledSchedulerRwLock,
+    is_transaction_producer: bool,
 }
 pub type InstalledSchedulerRwLock = RwLock<SchedulerStatus>;
+
+/// Ordered requests serviced by `DropBankService`.
+///
+/// `Flush` is a targeted FIFO barrier: its acknowledgement is sent only after matching pending
+/// banks have retired their account state and released their service-owned references. `Barrier`
+/// reports whether a targeted bank remains in a producer-protected retirement group after all
+/// preceding requests have been handled.
+#[derive(Debug)]
+pub enum DropBankRequest {
+    /// Transfers banks removed by `BankForks::set_root()` to the retirement service.
+    DropBanks {
+        banks: Vec<BankWithScheduler>,
+        new_root: Slot,
+    },
+    /// Retires pending banks at these slots or on forks descending from them.
+    ///
+    /// Callers must stop new transaction ingress for the targeted banks before sending this
+    /// request. The service waits for work already in flight, but cannot prevent new commits.
+    Flush {
+        slots: Vec<Slot>,
+        ack_sender: Sender<()>,
+    },
+    /// A FIFO barrier that reports whether a bank remains pending at one of these slots or on a
+    /// fork descending from one of them.
+    Barrier {
+        slots: Vec<Slot>,
+        ack_sender: Sender<bool>,
+    },
+}
 
 impl BankWithScheduler {
     /// Creates a new `BankWithScheduler` from bank and its associated scheduler.
@@ -381,6 +412,14 @@ impl BankWithScheduler {
     /// preallocation.
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(bank: Arc<Bank>, scheduler: Option<InstalledSchedulerBox>) -> Self {
+        Self::new_with_transaction_producer(bank, scheduler, false)
+    }
+
+    pub(crate) fn new_with_transaction_producer(
+        bank: Arc<Bank>,
+        scheduler: Option<InstalledSchedulerBox>,
+        is_transaction_producer: bool,
+    ) -> Self {
         // Avoid the fatal situation in which bank is being associated with a scheduler associated
         // to a different bank!
         if let Some(bank_in_context) = scheduler
@@ -394,6 +433,7 @@ impl BankWithScheduler {
             inner: Arc::new(BankWithSchedulerInner {
                 bank,
                 scheduler: RwLock::new(SchedulerStatus::new(scheduler)),
+                is_transaction_producer,
             }),
         }
     }
@@ -410,6 +450,10 @@ impl BankWithScheduler {
 
     pub fn clone_without_scheduler(&self) -> Arc<Bank> {
         self.inner.bank.clone()
+    }
+
+    pub fn is_transaction_producer(&self) -> bool {
+        self.inner.is_transaction_producer
     }
 
     pub fn register_tick(&self, hash: &Hash) {

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1072,7 +1072,7 @@ mod tests {
             genesis_utils::{
                 ValidatorVoteKeypairs, create_genesis_config_with_alpenglow_vote_accounts,
             },
-            installed_scheduler_pool::BankWithScheduler,
+            installed_scheduler_pool::{BankWithScheduler, DropBankRequest},
         },
         solana_streamer::evicting_sender::EvictingSender,
         std::{
@@ -1096,7 +1096,7 @@ mod tests {
         timer_manager: Arc<PlRwLock<TimerManager>>,
         leader_window_info_receiver: Receiver<LeaderWindowInfo>,
         highest_parent_ready: Arc<RwLock<(Slot, Block)>>,
-        drop_bank_receiver: Receiver<Vec<BankWithScheduler>>,
+        drop_bank_receiver: Receiver<DropBankRequest>,
         cluster_info: Arc<ClusterInfo>,
         consensus_metrics_receiver: ConsensusMetricsEventReceiver,
         #[allow(dead_code)] // Keep receiver alive to prevent SenderDisconnected errors
@@ -1116,12 +1116,16 @@ mod tests {
         bank_forks: Arc<RwLock<BankForks>>,
         blockstore: Arc<Blockstore>,
         leader_schedule_cache: Arc<LeaderScheduleCache>,
-        drop_bank_sender: Sender<Vec<BankWithScheduler>>,
+        drop_bank_sender: Sender<DropBankRequest>,
     }
 
     impl BankForksController for DirectBankForksController {
         fn insert_bank(&self, bank: Bank) -> Result<BankWithScheduler, BankForksControllerError> {
-            Ok(self.bank_forks.write().unwrap().insert(bank))
+            Ok(self
+                .bank_forks
+                .write()
+                .unwrap()
+                .insert_for_block_production(bank))
         }
 
         fn enqueue_set_root(&self, new_root: Block) {
@@ -2131,7 +2135,15 @@ mod tests {
             true,
         );
         // Listen on drop bank receiver, it should get bank 0
-        let dropped_banks = test_context.drop_bank_receiver.try_recv().unwrap();
+        let DropBankRequest::DropBanks {
+            banks: dropped_banks,
+            new_root,
+            ..
+        } = test_context.drop_bank_receiver.try_recv().unwrap()
+        else {
+            panic!("expected dropped banks request");
+        };
+        assert_eq!(new_root, 1);
         assert_eq!(dropped_banks.len(), 1);
         assert_eq!(dropped_banks[0].slot(), 0);
         // The bank forks root should be updated to 1

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -18,7 +18,7 @@ use {
     },
     solana_runtime::{
         bank_forks::BankForks, bank_forks_controller::BankForksController,
-        installed_scheduler_pool::BankWithScheduler, snapshot_controller::SnapshotController,
+        installed_scheduler_pool::DropBankRequest, snapshot_controller::SnapshotController,
     },
     solana_time_utils::timestamp,
     std::{
@@ -114,7 +114,7 @@ pub fn check_and_handle_new_root<CB>(
     snapshot_controller: Option<&SnapshotController>,
     highest_super_majority_root: Option<Slot>,
     bank_notification_sender: &Option<BankNotificationSenderConfig>,
-    drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+    drop_bank_sender: &Sender<DropBankRequest>,
     blockstore: &Blockstore,
     leader_schedule_cache: &Arc<LeaderScheduleCache>,
     bank_forks: &RwLock<BankForks>,
@@ -210,7 +210,7 @@ pub fn set_bank_forks_root<CB>(
     bank_forks: &RwLock<BankForks>,
     snapshot_controller: Option<&SnapshotController>,
     highest_super_majority_root: Option<Slot>,
-    drop_bank_sender: &Sender<Vec<BankWithScheduler>>,
+    drop_bank_sender: &Sender<DropBankRequest>,
     callback: CB,
 ) where
     CB: FnOnce(&BankForks),
@@ -227,20 +227,20 @@ pub fn set_bank_forks_root<CB>(
     }
 
     bank_forks.read().unwrap().prune_program_cache(new_root);
-    let removed_banks = bank_forks.write().unwrap().set_root(
-        new_root,
-        snapshot_controller,
-        highest_super_majority_root,
-    );
+    let mut w_bank_forks = bank_forks.write().unwrap();
+    let removed_banks =
+        w_bank_forks.set_root(new_root, snapshot_controller, highest_super_majority_root);
 
-    if let Err(channel_name) = nonblocking_send(
-        my_pubkey,
-        drop_bank_sender,
-        removed_banks,
-        "drop_bank_sender",
-    ) {
-        info!("{my_pubkey} channel {channel_name} disconnected");
-    }
+    // Enqueue under the write lock so observers cannot race ahead of FIFO retirement ordering.
+    let send_result = drop_bank_sender.try_send(DropBankRequest::DropBanks {
+        banks: removed_banks,
+        new_root,
+    });
+    drop(w_bank_forks);
+    assert!(
+        send_result.is_ok(),
+        "{my_pubkey}: DropBankService must be running and non-full while BankForks can prune banks"
+    );
     let r_bank_forks = bank_forks.read().unwrap();
     callback(&r_bank_forks);
 }


### PR DESCRIPTION
#### Problem
As stated by the AG bug bounty program

When performing an UpdateParent or SwitchBank, there is no guard against the prior bank in the slot being flushed from accounts db. Although the bank is dropped, it could have been held up due to ABS or RPC scans. This could lead to the new bank being created with inherited state from the old bank.

#### Summary of Changes
Track bank ids for banks that have been queued to drop, when processing UpdateParent or SwitchBank, wait until these bank ids have actually been dropped

#### Testing
Unit tests