### PR TITLE
fix(core): silence dead_code for alpenglow_slot_clock on non-unix

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -341,6 +341,7 @@ pub struct BankingStage {
     transaction_recorder: TransactionRecorder,
     poh_recorder: Arc<RwLock<PohRecorder>>,
     bank_forks: Arc<RwLock<BankForks>>,
+    #[cfg_attr(not(unix), allow(dead_code))]
     alpenglow_slot_clock: SharedAlpenglowSlotClock,
     committer: Committer,
     log_messages_bytes_limit: Option<usize>,


### PR DESCRIPTION
#### Problem

`BankingStage::alpenglow_slot_clock` (added in #14323) is only read by the external scheduler in the `#[cfg(unix)]` `external` module, so non-unix builds fail under `-D warnings`:

```
error: field `alpenglow_slot_clock` is never read
   --> core\src\banking_stage.rs:344:5
```

The `clippy-nightly (windows-2025)` job only runs on `push`, so this went red on master post-merge rather than on the PR.

#### Summary of Changes

`#[cfg_attr(not(unix), allow(dead_code))]` on the field.