### PR TITLE
accounts-db: Moves test helpers out of impl.rs

### DIFF
--- a/accounts-db/src/accounts_db/tests.rs
+++ b/accounts-db/src/accounts_db/tests.rs
@@ -6,8 +6,36 @@ use super::*;
 mod append_vec;
 
 pub use append_vec::DEFAULT_ACCOUNTS_DB_CONFIG as ACCOUNTS_DB_CONFIG_APPEND_VEC;
-// re-export these fns that live in impl.rs because ancient append vec tests use them...
-pub(crate) use append_vec::r#impl::{
-    append_single_account_with_default_hash, compare_all_accounts,
-    get_account_from_account_from_storage, get_all_accounts, remove_account_for_tests,
-};
+
+pub fn append_single_account_with_default_hash(
+    storage: &AccountStorageEntry,
+    pubkey: &Pubkey,
+    account: &AccountSharedData,
+    mark_alive: bool,
+    add_to_index: Option<&AccountInfoAccountsIndex>,
+) {
+    let slot = storage.slot();
+    let accounts = [(pubkey, account)];
+    let slice = &accounts[..];
+    let storable_accounts = (slot, slice);
+    let stored_accounts_info = storage.accounts.write_accounts(&storable_accounts).unwrap();
+    if mark_alive {
+        // updates 'alive_bytes' on the storage
+        storage.add_accounts(1, stored_accounts_info.size);
+    }
+
+    if let Some(index) = add_to_index {
+        let account_info = AccountInfo::new(
+            StorageLocation::AccountsFile(storage.id(), stored_accounts_info.offsets[0]),
+            account.lamports() == 0,
+        );
+        index.upsert(
+            slot,
+            slot,
+            pubkey,
+            account_info,
+            &mut ReclaimsSlotList::new(),
+            UpsertReclaim::IgnoreReclaims,
+        );
+    }
+}

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -12,7 +12,7 @@ use {
     rand::{prelude::SliceRandom as _, rng},
     solana_account::{
         Account, AccountSharedData, DUMMY_INHERITABLE_ACCOUNT_FIELDS, InheritableAccountFields,
-        WritableAccount as _, accounts_equal,
+        WritableAccount as _,
     },
     solana_clock::Slot,
     solana_lattice_hash::lt_hash::Checksum as LtHashChecksum,
@@ -201,39 +201,6 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
     db.clean_accounts_for_tests();
     assert!(!db.accounts_index.contains(&pubkey));
     assert!(db.storage.get_slot_storage_entry(slot0).is_none());
-}
-
-pub(crate) fn append_single_account_with_default_hash(
-    storage: &AccountStorageEntry,
-    pubkey: &Pubkey,
-    account: &AccountSharedData,
-    mark_alive: bool,
-    add_to_index: Option<&AccountInfoAccountsIndex>,
-) {
-    let slot = storage.slot();
-    let accounts = [(pubkey, account)];
-    let slice = &accounts[..];
-    let storable_accounts = (slot, slice);
-    let stored_accounts_info = storage.accounts.write_accounts(&storable_accounts).unwrap();
-    if mark_alive {
-        // updates 'alive_bytes' on the storage
-        storage.add_accounts(1, stored_accounts_info.size);
-    }
-
-    if let Some(index) = add_to_index {
-        let account_info = AccountInfo::new(
-            StorageLocation::AccountsFile(storage.id(), stored_accounts_info.offsets[0]),
-            account.lamports() == 0,
-        );
-        index.upsert(
-            slot,
-            slot,
-            pubkey,
-            account_info,
-            &mut ReclaimsSlotList::new(),
-            UpsertReclaim::IgnoreReclaims,
-        );
-    }
 }
 
 #[test]
@@ -6245,107 +6212,6 @@ fn test_combine_ancient_slots_simple() {
         unique_accounts_post.stored_accounts.len(),
         unique_accounts_pre.stored_accounts.len(),
     );
-}
-
-fn get_all_accounts_from_storages<'a>(
-    storages: impl Iterator<Item = &'a Arc<AccountStorageEntry>>,
-) -> Vec<(Pubkey, AccountSharedData)> {
-    let mut reader = crate::append_vec::new_scan_accounts_reader();
-    storages
-        .flat_map(|storage| {
-            let mut vec = Vec::default();
-            storage
-                .accounts
-                .scan_accounts(&mut reader, |_offset, account| {
-                    vec.push((*account.pubkey(), create_account_shared_data(&account)));
-                })
-                .expect("must scan accounts storage");
-            // make sure scan_pubkeys results match
-            // Note that we assume traversals are both in the same order, but this doesn't have to be true.
-            let mut compare = Vec::default();
-            storage
-                .accounts
-                .scan_pubkeys(|k| {
-                    compare.push(*k);
-                })
-                .expect("must scan accounts storage");
-            assert_eq!(compare, vec.iter().map(|(k, _)| *k).collect::<Vec<_>>());
-            vec
-        })
-        .collect::<Vec<_>>()
-}
-
-pub(crate) fn get_all_accounts(
-    db: &AccountsDb,
-    slots: impl Iterator<Item = Slot>,
-) -> Vec<(Pubkey, AccountSharedData)> {
-    slots
-        .filter_map(|slot| {
-            let storage = db.storage.get_slot_storage_entry(slot);
-            storage.map(|storage| get_all_accounts_from_storages(std::iter::once(&storage)))
-        })
-        .flatten()
-        .collect::<Vec<_>>()
-}
-
-#[track_caller]
-pub(crate) fn compare_all_accounts(
-    one: &[(Pubkey, AccountSharedData)],
-    two: &[(Pubkey, AccountSharedData)],
-) {
-    let mut failures = 0;
-    let mut two_indexes = (0..two.len()).collect::<Vec<_>>();
-    one.iter().for_each(|(pubkey, account)| {
-        for i in 0..two_indexes.len() {
-            let pubkey2 = two[two_indexes[i]].0;
-            if pubkey2 == *pubkey {
-                if !accounts_equal(account, &two[two_indexes[i]].1) {
-                    failures += 1;
-                }
-                two_indexes.remove(i);
-                break;
-            }
-        }
-    });
-    // helper method to reduce the volume of logged data to help identify differences
-    // modify this when you hit a failure
-    let clean = |accounts: &[(Pubkey, AccountSharedData)]| {
-        accounts
-            .iter()
-            .map(|(_pubkey, account)| account.lamports())
-            .collect::<Vec<_>>()
-    };
-    assert_eq!(
-        failures,
-        0,
-        "one: {:?}, two: {:?}, two_indexes: {:?}",
-        clean(one),
-        clean(two),
-        two_indexes,
-    );
-    assert!(
-        two_indexes.is_empty(),
-        "one: {one:?}, two: {two:?}, two_indexes: {two_indexes:?}"
-    );
-}
-
-pub fn get_account_from_account_from_storage(
-    account: &AccountFromStorage,
-    db: &AccountsDb,
-    slot: Slot,
-) -> AccountSharedData {
-    let storage = db
-        .storage
-        .get_slot_storage_entry_shrinking_in_progress_ok(slot)
-        .unwrap();
-    storage
-        .accounts
-        .get_account_shared_data(account.index_info.offset())
-        .unwrap()
-}
-
-pub(crate) fn remove_account_for_tests(storage: &AccountStorageEntry, num_bytes: usize) {
-    storage.remove_accounts(num_bytes, 1);
 }
 
 /// Ensure the calculating capitalization produces the correct value

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1125,11 +1125,7 @@ mod tests {
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
                 AccountsDbConfig, ShrinkCollectRefs,
-                tests::{
-                    ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash,
-                    compare_all_accounts, get_account_from_account_from_storage, get_all_accounts,
-                    remove_account_for_tests,
-                },
+                tests::{ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash},
             },
             accounts_index::{ReclaimsSlotList, UpsertReclaim},
             append_vec::{self, AppendVec},
@@ -1138,7 +1134,7 @@ mod tests {
             utils::create_account_shared_data,
         },
         rand::seq::SliceRandom as _,
-        solana_account::{AccountSharedData, ReadableAccount, WritableAccount},
+        solana_account::{AccountSharedData, ReadableAccount, WritableAccount, accounts_equal},
         solana_pubkey::Pubkey,
         std::{collections::HashSet, ops::Range},
         strum::IntoEnumIterator,
@@ -1264,7 +1260,7 @@ mod tests {
         .collect()
     }
 
-    pub(crate) fn compare_all_vec_accounts<'a>(
+    fn compare_all_vec_accounts<'a>(
         one: impl Iterator<Item = &'a GetUniqueAccountsResult>,
         two: impl Iterator<Item = &'a GetUniqueAccountsResult>,
         db: &AccountsDb,
@@ -1274,6 +1270,103 @@ mod tests {
             &unique_to_accounts(one, db, slot),
             &unique_to_accounts(two, db, slot),
         );
+    }
+
+    #[track_caller]
+    fn compare_all_accounts(
+        one: &[(Pubkey, AccountSharedData)],
+        two: &[(Pubkey, AccountSharedData)],
+    ) {
+        let mut failures = 0;
+        let mut two_indexes = (0..two.len()).collect::<Vec<_>>();
+        one.iter().for_each(|(pubkey, account)| {
+            for i in 0..two_indexes.len() {
+                let pubkey2 = two[two_indexes[i]].0;
+                if pubkey2 == *pubkey {
+                    if !accounts_equal(account, &two[two_indexes[i]].1) {
+                        failures += 1;
+                    }
+                    two_indexes.remove(i);
+                    break;
+                }
+            }
+        });
+        // helper method to reduce the volume of logged data to help identify differences
+        // modify this when you hit a failure
+        let clean = |accounts: &[(Pubkey, AccountSharedData)]| {
+            accounts
+                .iter()
+                .map(|(_pubkey, account)| account.lamports())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            failures,
+            0,
+            "one: {:?}, two: {:?}, two_indexes: {:?}",
+            clean(one),
+            clean(two),
+            two_indexes,
+        );
+        assert!(
+            two_indexes.is_empty(),
+            "one: {one:?}, two: {two:?}, two_indexes: {two_indexes:?}"
+        );
+    }
+
+    fn get_account_from_account_from_storage(
+        account: &AccountFromStorage,
+        db: &AccountsDb,
+        slot: Slot,
+    ) -> AccountSharedData {
+        let storage = db
+            .storage
+            .get_slot_storage_entry_shrinking_in_progress_ok(slot)
+            .unwrap();
+        storage
+            .accounts
+            .get_account_shared_data(account.index_info.offset())
+            .unwrap()
+    }
+
+    fn get_all_accounts(
+        db: &AccountsDb,
+        slots: impl Iterator<Item = Slot>,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        slots
+            .filter_map(|slot| {
+                let storage = db.storage.get_slot_storage_entry(slot);
+                storage.map(|storage| get_all_accounts_from_storages(std::iter::once(&storage)))
+            })
+            .flatten()
+            .collect::<Vec<_>>()
+    }
+
+    fn get_all_accounts_from_storages<'a>(
+        storages: impl Iterator<Item = &'a Arc<AccountStorageEntry>>,
+    ) -> Vec<(Pubkey, AccountSharedData)> {
+        let mut reader = crate::append_vec::new_scan_accounts_reader();
+        storages
+            .flat_map(|storage| {
+                let mut vec = Vec::default();
+                storage
+                    .accounts
+                    .scan_accounts(&mut reader, |_offset, account| {
+                        vec.push((*account.pubkey(), create_account_shared_data(&account)));
+                    })
+                    .expect("must scan accounts storage");
+                // make sure scan_pubkeys results match
+                // Note that we assume traversals are both in the same order, but this doesn't have to be true.
+                let mut compare = Vec::default();
+                storage
+                    .accounts
+                    .scan_pubkeys(|k| {
+                        compare.push(*k);
+                    })
+                    .expect("must scan accounts storage");
+                assert_eq!(compare, vec.iter().map(|(k, _)| *k).collect::<Vec<_>>());
+                vec
+            })
+            .collect::<Vec<_>>()
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -2665,7 +2758,7 @@ mod tests {
                         let alive = alives[slot as usize];
                         if !alive {
                             // make this storage not alive
-                            remove_account_for_tests(storage, storage.written_bytes() as usize);
+                            storage.remove_accounts(storage.written_bytes() as usize, 1);
                         }
                     });
                     let alive_storages = storages


### PR DESCRIPTION
#### Problem

We export some test helpers from `impl.rs`. But when we add another storage file format, and then do the same tricks as `tests/append_vec.rs`, the compiler will not be happy that these test helpers are defined twice and error out.


#### Summary of Changes

Move the test helpers out of `impl.rs`.

The majority are only used in `ancient_append_vec.rs` anyway, so move them there. The lone remainder can live in `tests.rs`.

Reviewing commit-by-commit will show how each test helper fn is moved. I plan to squash the commits prior to merging.