### PR TITLE
replay: clear stale account state before bank replacement

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2846,6 +2846,13 @@ impl AccountsDb {
     where
         F: FnMut(Option<(&Pubkey, AccountSharedData, Slot)>),
     {
+        if self.scan_tracker.was_scan_bank_removed(bank_id, ancestors) {
+            return Err(ScanError::SlotRemoved {
+                slot: ancestors.max_slot(),
+                bank_id,
+            });
+        }
+
         // Register this scan so that slots needed by the scan are not cleaned out from under us.
         let scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
             .ok_or(ScanError::SlotRemoved {
@@ -2857,7 +2864,7 @@ impl AccountsDb {
         // Scan Guard max root must be used as the scan guard guarantees that
         // the account state as of max root is persisted in the database
         let max_root_ancestors = Ancestors::from(vec![scan_guard.max_root()]);
-        let ancestors = if scan_guard.should_use_ancestors(ancestors) {
+        let effective_ancestors = if scan_guard.should_use_ancestors(ancestors) {
             ancestors
         } else {
             &max_root_ancestors
@@ -2874,8 +2881,9 @@ impl AccountsDb {
                 break;
             }
 
-            if let Some((cached_account, slot)) =
-                self.accounts_cache.load_latest(&pubkey, ancestors)
+            if let Some((cached_account, slot)) = self
+                .accounts_cache
+                .load_latest(&pubkey, effective_ancestors)
             {
                 cached_versions.insert(pubkey, (cached_account, slot));
             }
@@ -2887,11 +2895,11 @@ impl AccountsDb {
         // Bound max_root by ancestors.min_slot() so that roots from slots
         // beyond the querying bank's ancestor chain are not visible.
         let mut max_root = scan_guard.max_root();
-        if let Some(min) = ancestors.min_slot() {
+        if let Some(min) = effective_ancestors.min_slot() {
             max_root = max_root.min(min);
         }
         self.accounts_index.scan_accounts(
-            ancestors,
+            effective_ancestors,
             max_root,
             |pubkey, (account_info, slot)| {
                 if let Some((cached_account, cache_slot)) = cached_versions.remove(pubkey)
@@ -2922,7 +2930,9 @@ impl AccountsDb {
         }
 
         // Check whether the bank was removed while the scan was in progress.
-        if scan_guard.was_scan_corrupted() {
+        if scan_guard.was_scan_corrupted()
+            || self.scan_tracker.was_scan_bank_removed(bank_id, ancestors)
+        {
             return Err(ScanError::SlotRemoved {
                 slot: ancestors.max_slot(),
                 bank_id,
@@ -2954,6 +2964,13 @@ impl AccountsDb {
             return Ok(used_index);
         }
 
+        if self.scan_tracker.was_scan_bank_removed(bank_id, ancestors) {
+            return Err(ScanError::SlotRemoved {
+                slot: ancestors.max_slot(),
+                bank_id,
+            });
+        }
+
         // Register this scan so that slots needed by the scan are not cleaned out from under us.
         let scan_guard = ScanGuard::try_new(&self.scan_tracker, bank_id, || self.max_root())
             .ok_or(ScanError::SlotRemoved {
@@ -2965,7 +2982,7 @@ impl AccountsDb {
         // Scan Guard max root must be used as the scan guard guarantees that
         // the account state as of max root is persisted in the database
         let max_root_ancestors = Ancestors::from(vec![scan_guard.max_root()]);
-        let ancestors = if scan_guard.should_use_ancestors(ancestors) {
+        let effective_ancestors = if scan_guard.should_use_ancestors(ancestors) {
             ancestors
         } else {
             &max_root_ancestors
@@ -2976,7 +2993,7 @@ impl AccountsDb {
                 break;
             }
             if let Some((account, slot)) = self.do_load(
-                ancestors,
+                effective_ancestors,
                 &pubkey,
                 LoadHint::Unspecified,
                 PopulateReadCache::False,
@@ -2986,7 +3003,9 @@ impl AccountsDb {
         }
 
         // Check whether the bank was removed while the scan was in progress.
-        if scan_guard.was_scan_corrupted() {
+        if scan_guard.was_scan_corrupted()
+            || self.scan_tracker.was_scan_bank_removed(bank_id, ancestors)
+        {
             return Err(ScanError::SlotRemoved {
                 slot: ancestors.max_slot(),
                 bank_id,
@@ -3488,6 +3507,10 @@ impl AccountsDb {
             )
         }
 
+        // Serialize against manual same-slot removal so an old bank cannot begin purging before
+        // the cutoff is installed and finish after its replacement starts writing.
+        let removed_bank_id_cutoffs = self.scan_tracker.removed_bank_id_cutoffs.read().unwrap();
+
         // BANK_DROP_SAFETY: Because this function only runs once the bank is dropped,
         // we know that there are no longer any ongoing scans on this bank, because scans require
         // and hold a reference to the bank at the tip of the fork they're scanning. Hence it's
@@ -3500,6 +3523,13 @@ impl AccountsDb {
             .remove(&bank_id)
         {
             // If this slot was already cleaned up, no need to do any further cleans
+            return;
+        }
+
+        if removed_bank_id_cutoffs
+            .get(&slot)
+            .is_some_and(|cutoff| bank_id <= *cutoff)
+        {
             return;
         }
 
@@ -3743,6 +3773,40 @@ impl AccountsDb {
             &remove_unrooted_purge_stats,
         );
         remove_unrooted_purge_stats.report("remove_unrooted_slots_purge_slots_stats", None);
+    }
+
+    /// Removes slots without requiring their old `Bank` instances to still be available. Delayed
+    /// drops and scans from banks allocated through `max_bank_id` are ignored. Callers must stop
+    /// those banks from writing or creating descendants and serialize replacement creation after
+    /// this call.
+    pub fn remove_unrooted_slots_by_slot(
+        &self,
+        remove_slots: impl IntoIterator<Item = Slot>,
+        max_bank_id: BankId,
+    ) {
+        let remove_slots = remove_slots.into_iter().collect::<Vec<_>>();
+        assert!(
+            remove_slots
+                .iter()
+                .all(|slot| !self.accounts_cache.contains_unflushed_root(*slot)),
+            "Trying to remove accounts for rooted slots {remove_slots:?}"
+        );
+
+        let max_root = self.max_root();
+        let mut removed_bank_id_cutoffs =
+            self.scan_tracker.removed_bank_id_cutoffs.write().unwrap();
+        // Slots below the root cannot be reused, and `purge_slot()` never removes rooted state.
+        removed_bank_id_cutoffs.retain(|slot, _| *slot >= max_root);
+        for slot in &remove_slots {
+            removed_bank_id_cutoffs
+                .entry(*slot)
+                .and_modify(|cutoff| *cutoff = (*cutoff).max(max_bank_id))
+                .or_insert(max_bank_id);
+        }
+
+        let purge_stats = PurgeStats::default();
+        self.purge_slots_from_cache(remove_slots.iter(), &purge_stats);
+        purge_stats.report("remove_unrooted_slots_by_slot_purge_slots_stats", None);
     }
 
     /// Calculates the `AccountLtHash` of `account`

--- a/accounts-db/src/accounts_scan.rs
+++ b/accounts-db/src/accounts_scan.rs
@@ -2,7 +2,7 @@ use {
     crate::ancestors::Ancestors,
     solana_clock::{BankId, Slot},
     std::{
-        collections::{HashSet, btree_map::BTreeMap},
+        collections::{HashMap, HashSet, btree_map::BTreeMap},
         sync::{
             Arc, Mutex, RwLock,
             atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
@@ -70,6 +70,9 @@ pub struct ScanTracker {
     // on any of these slots fails. This is safe to purge once the associated Bank is dropped and
     // scanning the fork with that Bank at the tip is no longer possible.
     pub removed_bank_ids: Mutex<HashSet<BankId>>,
+    /// Highest bank ID manually removed for each slot. Unlike `removed_bank_ids`, these cutoffs
+    /// remain after old banks are dropped so a delayed drop cannot purge a newer bank.
+    pub(crate) removed_bank_id_cutoffs: RwLock<HashMap<Slot, BankId>>,
     /// # scans active currently
     pub active_scans: AtomicUsize,
     /// # of slots between latest max and latest scan
@@ -77,6 +80,13 @@ pub struct ScanTracker {
 }
 
 impl ScanTracker {
+    pub(crate) fn was_scan_bank_removed(&self, bank_id: BankId, ancestors: &Ancestors) -> bool {
+        let cutoffs = self.removed_bank_id_cutoffs.read().unwrap();
+        ancestors
+            .iter()
+            .any(|slot| cutoffs.get(&slot).is_some_and(|cutoff| bank_id <= *cutoff))
+    }
+
     fn min_ongoing_scan_root_from_btree(ongoing_scan_roots: &BTreeMap<Slot, u64>) -> Option<Slot> {
         ongoing_scan_roots.keys().next().cloned()
     }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2609,16 +2609,27 @@ impl ReplayStage {
             (root_bank, slot_bank_ids_to_purge, removed_banks)
         };
 
-        // Clear the accounts for these slots so that any ongoing RPC scans fail.
-        // These have to be atomically cleared together in the same batch, in order
-        // to prevent RPC from seeing inconsistent results in scans.
+        // Use exact bank IDs where they are still available, and a bank-ID cutoff for banks that
+        // were already pruned. Both paths make overlapping RPC scans discard their results.
         if !slot_bank_ids_to_purge.is_empty() {
             root_bank.remove_unrooted_slots(&slot_bank_ids_to_purge);
+        }
+        let purged_bank_slots = slot_bank_ids_to_purge
+            .iter()
+            .map(|(slot, _)| *slot)
+            .collect::<BTreeSet<_>>();
+        let missing_bank_slots = slots_to_purge
+            .iter()
+            .filter(|slot| !purged_bank_slots.contains(slot))
+            .copied()
+            .collect::<Vec<_>>();
+        if !missing_bank_slots.is_empty() {
+            root_bank.remove_unrooted_slots_by_slot(missing_bank_slots);
         }
 
         // Once the slots above have been purged, now it's safe to remove the banks from
         // BankForks, allowing the Bank::drop() purging to run and not race with the
-        // `remove_unrooted_slots()` call.
+        // the accounts purge.
         drop(banks_to_clear);
         drop(removed_banks);
 
@@ -5389,7 +5400,12 @@ impl ReplayStage {
                     migration_status,
                 ) {
                     ChildBankReplayStart::FromStart => None,
-                    ChildBankReplayStart::FromUpdateParent(num_shreds) => Some(num_shreds),
+                    ChildBankReplayStart::FromUpdateParent(num_shreds) => {
+                        parent_bank.remove_unrooted_slots_by_slot([child_slot]);
+                        parent_bank.clear_slot_signatures(child_slot);
+                        parent_bank.prune_program_cache_by_deployment_slot(child_slot);
+                        Some(num_shreds)
+                    }
                     ChildBankReplayStart::Defer => continue,
                 };
 

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -21,8 +21,11 @@ use {
     },
     crossbeam_channel::bounded,
     itertools::Itertools,
-    solana_account::{ReadableAccount, state_traits::StateMutWincode as _},
-    solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+    solana_account::{AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _},
+    solana_accounts_db::{
+        accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
+        accounts_scan::ScanError,
+    },
     solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
     solana_client::connection_cache::ConnectionCache,
     solana_entry::{
@@ -2818,13 +2821,15 @@ fn test_clear_slots_clears_status_cache_for_removed_bank() {
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
     let sender = node_pubkeys[0];
+    let old_account = Pubkey::new_unique();
     let transfer_signature = bank1
         .transfer(
             1,
             &validator_keypairs.get(&sender).unwrap().node_keypair,
-            &Pubkey::new_unique(),
+            &old_account,
         )
         .unwrap();
+    bank1.freeze();
     bank_forks.write().unwrap().insert(bank1);
     let bank1 = bank_forks.read().unwrap().get(1).unwrap();
     assert!(bank1.get_signature_status(&transfer_signature).is_some());
@@ -2837,6 +2842,28 @@ fn test_clear_slots_clears_status_cache_for_removed_bank() {
     ReplayStage::clear_slots([1], &bank_forks, &mut progress, &mut Vec::new());
 
     assert!(bank1.get_signature_status(&transfer_signature).is_none());
+    assert_eq!(bank1.get_balance(&old_account), 0);
+    assert_eq!(
+        bank1.scan_all_accounts(|_| {}),
+        Err(ScanError::SlotRemoved {
+            slot: 1,
+            bank_id: bank1.bank_id(),
+        })
+    );
+
+    let replacement_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        1,
+    );
+    let replacement_account = Pubkey::new_unique();
+    replacement_bank.store_account(
+        &replacement_account,
+        &AccountSharedData::new(2, 0, &Pubkey::default()),
+    );
+    drop(bank1);
+    assert_eq!(replacement_bank.get_balance(&replacement_account), 2);
+    assert_eq!(replacement_bank.scan_all_accounts(|_| {}), Ok(()));
 }
 
 #[test]
@@ -3297,6 +3324,21 @@ fn test_headerless_update_parent() {
     let my_pubkey = Pubkey::new_unique();
     let slot = 4;
     let migration_status = post_migration_status_for_tests();
+    let old_account = Pubkey::new_unique();
+    let old_bank = Bank::new_from_parent(
+        bank_forks.read().unwrap().root_bank(),
+        SlotLeader::default(),
+        slot,
+    );
+    old_bank.store_account(
+        &old_account,
+        &AccountSharedData::new(1, 0, &Pubkey::default()),
+    );
+    old_bank.freeze();
+    bank_forks.write().unwrap().insert(old_bank);
+    let old_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    drop(bank_forks.write().unwrap().remove(slot).unwrap());
+    assert_eq!(old_bank.get_balance(&old_account), 1);
 
     let footer_marker = || {
         VersionedBlockMarker::from_block_footer(BlockFooterV1 {
@@ -3357,6 +3399,17 @@ fn test_headerless_update_parent() {
             .num_shreds,
         32
     );
+
+    let replacement_bank = bank_forks.read().unwrap().get(slot).unwrap();
+    assert_eq!(old_bank.get_balance(&old_account), 0);
+    assert_eq!(replacement_bank.get_balance(&old_account), 0);
+    let replacement_account = Pubkey::new_unique();
+    replacement_bank.store_account(
+        &replacement_account,
+        &AccountSharedData::new(2, 0, &Pubkey::default()),
+    );
+    drop(old_bank);
+    assert_eq!(replacement_bank.get_balance(&replacement_account), 2);
 }
 
 #[test]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3989,6 +3989,14 @@ impl Bank {
         self.rc.accounts.accounts_db.remove_unrooted_slots(slots)
     }
 
+    pub fn remove_unrooted_slots_by_slot(&self, slots: impl IntoIterator<Item = Slot>) {
+        let max_bank_id = self.rc.bank_id_generator.load(Relaxed);
+        self.rc
+            .accounts
+            .accounts_db
+            .remove_unrooted_slots_by_slot(slots, max_bank_id)
+    }
+
     pub fn get_hash_age(&self, hash: &Hash) -> Option<u64> {
         self.blockhash_queue.read().unwrap().get_hash_age(hash)
     }


### PR DESCRIPTION
#### Problem
Alternate to https://github.com/anza-xyz/agave/pull/14546

As stated by the AG bug bounty program

When performing an UpdateParent or SwitchBank, there is no guard against the prior bank in the slot being flushed from accounts db. Although the bank is dropped, it could have been held up due to ABS or RPC scans. This could lead to the new bank being created with inherited state from the old bank.

#### Summary of Changes
Manually clears accounts db state before UpdateParent or BankSwitch recreates a bank

#### Testing


Fixes #
