### PR TITLE
votor-transport: test that an identity rotation only interrupts delivery briefly

### DIFF
--- a/votor-transport/src/endpoint.rs
+++ b/votor-transport/src/endpoint.rs
@@ -407,7 +407,7 @@ mod tests {
             net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
             sync::{
                 Arc,
-                atomic::{AtomicU64, Ordering},
+                atomic::{AtomicBool, AtomicU64, Ordering},
             },
             time::{Duration, Instant},
         },
@@ -1045,6 +1045,86 @@ mod tests {
             (d.peer_pubkey == pubkey2 && d.message == payload2).then_some(())
         })
         .expect("server never received message attributed to K2 after rotation");
+    }
+
+    /// An identity change stops delivery only for as long as the re-handshake
+    /// takes. Only an upper bound is asserted: on loopback the outage is
+    /// sub-millisecond and often drops nothing, so requiring a loss would be flaky.
+    #[test]
+    fn test_client_identity_change_delivery_gap_is_bounded() {
+        // Under HIGH_PPS, so the peer rate limiter cannot manufacture a gap.
+        const SEND_INTERVAL: Duration = Duration::from_millis(5);
+        const MAX_RESUME_DELAY: Duration = Duration::from_secs(2);
+        // Longer than the bound, so the assert fails rather than the loop timing out.
+        const WAIT_LIMIT: Duration = Duration::from_secs(5);
+
+        let rt = make_runtime_for_tests();
+        let keypair1 = Keypair::new();
+        let pubkey1 = keypair1.pubkey();
+        let keypair2 = Keypair::new();
+        let pubkey2 = keypair2.pubkey();
+        let server = Node::spawn_node(
+            &rt,
+            Keypair::new(),
+            HashMap::from([(pubkey1, None), (pubkey2, None)]),
+            HIGH_PPS,
+        );
+        let client = Node::spawn_node(
+            &rt,
+            keypair1,
+            peer_list_of(server.pubkey(), server.addr),
+            HIGH_PPS,
+        );
+
+        let probe = Bytes::from_static(b"probe");
+        send_until_received(&client, &probe, &server.ingress_receiver, |d| {
+            (d.message == probe).then_some(())
+        })
+        .expect("server never received the pre-change probe");
+        drain_backlog(&server.ingress_receiver);
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let sender_stop = stop.clone();
+        let egress = client.egress.clone();
+        let sender = std::thread::spawn(move || {
+            let mut seq = 0u32;
+            while !sender_stop.load(Ordering::Relaxed) {
+                let _ = egress.try_send(Bytes::from(seq.to_be_bytes().to_vec()));
+                seq = seq.wrapping_add(1);
+                std::thread::sleep(SEND_INTERVAL);
+            }
+        });
+
+        client
+            .endpoint
+            .key_updater()
+            .update_key(&keypair2)
+            .expect("identity change accepted");
+        let changed_at = Instant::now();
+
+        // Attribution to the new identity is what proves the re-handshake completed.
+        let mut resumed = None;
+        while changed_at.elapsed() < WAIT_LIMIT {
+            match server.ingress_receiver.recv_timeout(SEND_INTERVAL * 4) {
+                Ok(d) if d.peer_pubkey == pubkey2 && d.message.len() == 4 => {
+                    resumed = Some(Instant::now());
+                    break;
+                }
+                Ok(_) => continue,
+                Err(_) => continue,
+            }
+        }
+        stop.store(true, Ordering::Relaxed);
+        sender.join().expect("sender thread panicked");
+
+        let resumed = resumed.unwrap_or_else(|| {
+            panic!("delivery never resumed under the new identity within {WAIT_LIMIT:?}")
+        });
+        let gap = resumed.saturating_duration_since(changed_at);
+        assert!(
+            gap < MAX_RESUME_DELAY,
+            "delivery resumed {gap:?} after the change, over the {MAX_RESUME_DELAY:?} bound"
+        );
     }
 
     /// Changing the server identity closes every inbound connection that was


### PR DESCRIPTION
A rotation tears down every outbound connection and reconnects, so votes broadcast in the window between the two reach nobody. Nothing covered that window, only that delivery eventually resumed.

Add a unit test for the mechanism: after apply_identity_change the peer table is drained, so perform_broadcast sends to zero peers. This is deterministic, with no timing involved.

Add an integration test for the duration: stream numbered datagrams across a rotation and bound how long delivery stays interrupted. Only an upper bound is asserted. On loopback the outage is under a millisecond and often swallows no datagram at all, so requiring that something was dropped would be flaky; the unit test covers that the drop happens.

### Measured: identity rotation cost vs network latency

A rotation makes the node's own outbound unavailable for one QUIC handshake
round trip. Votes broadcast in that window reach nobody, so each rotation costs
the rotating node roughly `RTT / slot_time` slots of credit.

**Setup:** 4-validator local cluster, equal genesis stake, loopback, 200 ms
slots (measured 50 roots per 10 s report). Latency injected with `tc netem` on
the rotating node's votor sockets only, in both directions, so a handshake pays
a full round trip. Rotation is `set-identity` to the node's *own* keypair:
`apply_identity_change` does not check whether the pubkey changed, so the full
teardown/reconnect happens while the node stays staked and voting. Pooled over
two independent runs (150 and 570 rotations, 5 s and 3 s spacing; spacing
exceeds `RECONCILE_INTERVAL` so rotations are isolated).

| netem delay (each way) | RTT | rotations | slots lost | per rotation | max in one 10 s report | implied window | window ÷ RTT |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 0 ms   | 0 ms   | 90  | 0   | 0.00        | 0 | –          | –           |
| 25 ms  | 50 ms  | 210 | 34  | 0.16 ± 0.03 | 4 | 43 ± 7 ms  | 0.86 ± 0.15 |
| 50 ms  | 100 ms | 190 | 109 | 0.57 ± 0.05 | 6 | 153 ± 15 ms| 1.53 ± 0.15 |
| 100 ms | 200 ms | 140 | 90  | 0.64 ± 0.07 | 4 | 171 ± 18 ms| 0.86 ± 0.09 |
| 200 ms | 400 ms | 90  | 136 | 1.51 ± 0.13 | 9 | 403 ± 35 ms| 1.01 ± 0.09 |

`implied window = (slots lost per rotation) × 200 ms ÷ 0.75`, where 0.75 is the
probability the node is not itself the S+8 leader (its own votes reach the
reward-cert builder via `add_own_msg` and cannot be lost in transit).
Uncertainties are Poisson on the event count. A 10 s report spans 2–3
rotations, so the max column is an upper extreme over groups, not per rotation.

**Result: the outage is one RTT.** Least-squares fit through the origin over
all four latency points gives **window = 1.00 × RTT**. Zero slots were lost
across 90 rotations with no added latency, bounding the software cost of a
rotation below one slot.

Per-point scatter (0.86, 1.53, 0.86, 1.01) exceeds the Poisson bars. Losses
within a single rotation are correlated — one window takes consecutive slots —
so Poisson understates the true error, and the 100 ms point should be read as
scatter rather than structure.

### Measured: packet loss (metric validation)

Single configuration, confirming the metric responds to real loss and
attributes it to the right node.

| configured loss | measured actual | duration | slots | slots lost | observed | predicted |
|---:|---:|---:|---:|---:|---:|---:|
| 30% | 28.1% (2367 of 8414 pkts) | 100 s | ~500 | 103 | 20.6% | 21.1% |

Predicted = `0.75 × 0.281`. The three non-impaired nodes reported **0**
throughout baseline, loss and recovery.

### Extrapolation to mainnet

Slot time cancels — loss = `(window / slot) × reward_per_slot`, and
`reward_per_slot` scales with slot time — so:

> **loss per rotation = your revenue rate × one handshake RTT**

The self-leader factor also rises from 0.75 to ~1.0 (mainnet leader share ~1%,
not 25%), making mainnet 1.33× worse than measured. At 50–150 ms RTT that is
0.25–0.75 slots per rotation. For a validator with 5% of stake
(~0.033 SOL/s of revenue) one rotation costs **~0.003 SOL**.

For contrast, the 5 s peer-list poll that preceded the notify gives a 5 s window
instead of one RTT: ~25 slots per rotation, ~0.17 SOL for the same validator.