### PR TITLE
runtime: use slot 0 for builtin program cache entries

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5956,7 +5956,7 @@ impl Bank {
         self.add_builtin(
             program_id,
             "mockup",
-            ProgramCacheEntry::new_builtin(self.slot, builtin),
+            ProgramCacheEntry::new_builtin(0, builtin),
         );
     }
 
@@ -6287,10 +6287,7 @@ impl Bank {
                 self.add_builtin(
                     builtin.program_id,
                     builtin.name,
-                    ProgramCacheEntry::new_builtin(
-                        self.feature_set.activated_slot(&feature_id).unwrap_or(0),
-                        builtin.register_fn,
-                    ),
+                    ProgramCacheEntry::new_builtin(0, builtin.register_fn),
                 );
             }
 
@@ -6438,13 +6435,9 @@ impl Bank {
                 .unwrap_or(true);
 
             if builtin_is_active {
-                let activation_slot = builtin
-                    .enable_feature_id
-                    .and_then(|feature_id| self.feature_set.activated_slot(&feature_id))
-                    .unwrap_or(0);
                 self.transaction_processor.add_builtin(
                     builtin.program_id,
-                    ProgramCacheEntry::new_builtin(activation_slot, builtin.register_fn),
+                    ProgramCacheEntry::new_builtin(0, builtin.register_fn),
                 );
             }
         }


### PR DESCRIPTION
#### Problem
Since builtin programs do not retain any information in their account state about what slot they were deployed in, we should not couple newly-activated builtins in the cache to their feature activation slot.

#### Summary of Changes
This is extracted from #14518 specially crafted for backport. Simply pass `0` everywhere we call `ProgramCacheEntry::new_builtin` and are not already passing `0`.

#### Testing
All tests are landing on `master` with the follow-up #14518.

This change is consensus safe, as proven by the tests, debug assertions, and documentation provided in #14518. TL;DR: builtin access across forks is guarded by `TransactionBatchProcessor.builtin_program_cache`, so the slot never even mattered in the first place.