### PR TITLE
votor: scale votor rate limit based on slot duration

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -37,7 +37,7 @@ use {
         slot_clock::SharedAlpenglowSlotClock,
         vote_history::VoteHistory,
         vote_history_storage::VoteHistoryStorage,
-        voting_service::{VOTOR_RATE_LIMIT_PPS, VotingService as BLSVotingService},
+        voting_service::{VotingService as BLSVotingService, votor_rate_limit_pps},
         votor::{Votor, VotorConfig},
     },
     agave_votor_messages::{
@@ -339,7 +339,7 @@ impl Tvu {
             votor_client_socket,
             votor_ingress_sender,
             votor_peer_list_receiver,
-            VOTOR_RATE_LIMIT_PPS,
+            votor_rate_limit_pps(),
             cancel,
         )
         .map_err(|e| format!("alpenglow endpoint: {e:?}"))?;

--- a/local-cluster/src/cluster_tests.rs
+++ b/local-cluster/src/cluster_tests.rs
@@ -5,7 +5,7 @@
 use log::*;
 use {
     crate::local_cluster::LocalCluster,
-    agave_votor::voting_service::VOTOR_RATE_LIMIT_PPS,
+    agave_votor::voting_service::votor_rate_limit_pps,
     agave_votor_messages::{
         consensus_message::VoteMessage, unverified_vote_message::DecodedWireConsensusMessage,
         wire::VersionedWireConsensusMessage,
@@ -657,7 +657,7 @@ pub fn start_datagram_listener_for_alpenglow_votor(
         client_socket,
         sender,
         peer_list_receiver,
-        VOTOR_RATE_LIMIT_PPS,
+        votor_rate_limit_pps(),
         CancellationToken::new(),
     )
     .expect("alpenglow datagram listener");

--- a/votor/src/voting_service.rs
+++ b/votor/src/voting_service.rs
@@ -7,7 +7,10 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
-    solana_runtime::validated_block_finalization::ValidatedBlockFinalizationCert,
+    solana_runtime::{
+        slot_params::slot_time_feature_gates,
+        validated_block_finalization::ValidatedBlockFinalizationCert,
+    },
     std::{
         collections::{BTreeMap, HashSet},
         ops::Bound::{Excluded, Included, Unbounded},
@@ -18,18 +21,46 @@ use {
     tokio::sync::{mpsc, mpsc::error::TrySendError},
 };
 
-/// The maximum amount of packets per second we expect from an honest node
-pub const VOTOR_RATE_LIMIT_PPS: usize = 50;
-
-/// Max new packets per second in steady state:
+/// Max new packets per slot in steady state:
 /// - Notarize + Finalize votes
 /// - NotarizeFallback + Notarize + FastFinalize + Finalize certificates
-///
-/// 200ms slots, 6 packets * 5 slots per second = 30 PPS
-const NEW_PACKETS_PER_SECOND: usize = 30;
+const NEW_PACKETS_PER_SLOT: usize = 6;
 
 /// The amount of packets we should send per second from the standstill queue
-const STANDSTILL_REFRESH_BATCH_SIZE: usize = VOTOR_RATE_LIMIT_PPS - NEW_PACKETS_PER_SECOND;
+const STANDSTILL_REFRESH_BATCH_SIZE: usize = 20;
+
+/// The packets per second an honest node produces at `slot_duration`.
+///
+/// `NEW_PACKETS_PER_SLOT` for every slot in a second, plus the standstill refresh
+/// budget:
+///
+/// `pps = NEW_PACKETS_PER_SLOT * 1_000 / slot_duration_ms + STANDSTILL_REFRESH_BATCH_SIZE`
+fn rate_limit_pps_for_slot_duration(slot_duration: Duration) -> usize {
+    const MS_IN_SEC: usize = 1_000;
+
+    let slot_ms = slot_duration.as_millis();
+    assert!(slot_ms > 0, "slot duration must be at least 1ms");
+
+    let new_packets_per_second = NEW_PACKETS_PER_SLOT
+        .saturating_mul(MS_IN_SEC)
+        .div_ceil(slot_ms.try_into().expect("slot_ms can't exceed usize::MAX"));
+
+    new_packets_per_second.saturating_add(STANDSTILL_REFRESH_BATCH_SIZE)
+}
+
+/// The maximum amount of packets per second we expect from an honest node.
+/// Calculated based on the min slot duration from `slot_time_feature_gates`.
+pub fn votor_rate_limit_pps() -> usize {
+    // The shortest slot duration the runtime can run at, across every slot-time
+    // reduction feature.
+    let min_slot_duration = slot_time_feature_gates()
+        .iter()
+        .min_by_key(|(_, params)| params.ns_per_slot())
+        .map(|(_, params)| Duration::from_nanos_u128(params.ns_per_slot()))
+        .expect("slot_time_feature_gates is never empty");
+
+    rate_limit_pps_for_slot_duration(min_slot_duration)
+}
 
 /// How often we should refresh messages from the standstill queue
 const STANDSTILL_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
@@ -404,6 +435,35 @@ mod tests {
     }
 
     #[test]
+    fn test_rate_limit_pps_for_slot_duration() {
+        assert_eq!(
+            rate_limit_pps_for_slot_duration(Duration::from_millis(100)),
+            80
+        );
+        assert_eq!(
+            rate_limit_pps_for_slot_duration(Duration::from_millis(200)),
+            50
+        );
+        assert_eq!(
+            rate_limit_pps_for_slot_duration(Duration::from_millis(400)),
+            35
+        );
+    }
+
+    #[test]
+    fn test_votor_rate_limit_pps_covers_every_slot_time_reduction() {
+        let limit = votor_rate_limit_pps();
+
+        for (_, params) in slot_time_feature_gates() {
+            let duration = Duration::from_nanos_u128(params.ns_per_slot());
+            assert!(
+                limit >= rate_limit_pps_for_slot_duration(duration),
+                "limit {limit} is below the honest rate at {duration:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_standstill_refresh_queue_cycles_by_slot() {
         let shred_verion = rand::rng().random();
         let mut queue = StandstillRefreshQueue::default();
@@ -500,7 +560,7 @@ mod tests {
             client_socket,
             ingress_sender,
             peer_list_receiver,
-            VOTOR_RATE_LIMIT_PPS,
+            votor_rate_limit_pps(),
             CancellationToken::new(),
         )
         .expect("QuicDatagramEndpoint::spawn");


### PR DESCRIPTION
#### Problem
`VOTOR_RATE_LIMIT_PPS` was tied down to 200ms slot time implicitly.

#### Summary of Changes
Replaced constant with fn `votor_rate_limit_pps` which calculate limit from the min slot-time in `slot_time_feature_gates`. This selects most lenient approach to limit as if we are in before epoch slot times decreases we will have higher limit for the current slot-time - but I think this is fine because if we are fine with LIMIT = N after change the code should handle it from load perspective in before slot time change(?). I feel like this is good enough.

Alternative is to observe slot-time value and on change (on some epoch boundaries) notify about change consumers of this value. They will need to rebuild some of the services so this is much more complex solution but 'more' correct.

#### Testing
Added tests for new path and adjusted existing ones.

I have run all: 
```
./ci/test-sanity.sh
./ci/test-checks.sh
./ci/feature-check/test-feature.sh  
```

Fixes #
#14299



cc @alexpyattaev I went with this solution as opposed to dynamically changing and rebuilding the services based on potential slot-time changes across epoch boundaries. I think this is simple and good enough but happy to impl alternative solution or something different that I didnt think about.