### PR TITLE
tests: init sysvar-account test lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7254,9 +7254,9 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
- "wincode",
 ]
 
 [[package]]
@@ -10139,6 +10139,7 @@ dependencies = [
  "solana-system-interface 3.3.0",
  "solana-system-transaction",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-time-utils",
  "solana-transaction",
@@ -10737,6 +10738,7 @@ dependencies = [
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
@@ -10747,7 +10749,6 @@ dependencies = [
  "spl-token-interface",
  "test-case",
  "thiserror 2.0.20",
- "wincode",
  "xxhash-rust",
 ]
 
@@ -10917,9 +10918,9 @@ dependencies = [
  "solana-system-interface 3.3.0",
  "solana-system-program",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
- "wincode",
 ]
 
 [[package]]
@@ -10970,6 +10971,18 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-history",
+ "solana-sysvar-id",
+ "wincode",
+]
+
+[[package]]
+name = "solana-sysvar-account"
+version = "4.4.0-alpha.3"
+dependencies = [
+ "solana-account 4.7.0",
+ "solana-pubkey 4.3.0",
+ "solana-sdk-ids",
+ "solana-sysvar",
  "solana-sysvar-id",
  "wincode",
 ]
@@ -11552,12 +11565,12 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-vote-interface",
  "solana-vote-program",
  "test-case",
- "wincode",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7208,9 +7208,9 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
- "wincode",
 ]
 
 [[package]]
@@ -10089,6 +10089,7 @@ dependencies = [
  "solana-system-interface 3.3.0",
  "solana-system-transaction",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-time-utils",
  "solana-transaction",
@@ -10688,6 +10689,7 @@ dependencies = [
  "solana-system-program",
  "solana-system-transaction",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction",
  "solana-transaction-context",
@@ -10698,7 +10700,6 @@ dependencies = [
  "spl-token-interface",
  "test-case",
  "thiserror 2.0.20",
- "wincode",
  "xxhash-rust",
 ]
 
@@ -10868,9 +10869,9 @@ dependencies = [
  "solana-system-interface 3.3.0",
  "solana-system-program",
  "solana-sysvar",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
- "wincode",
 ]
 
 [[package]]
@@ -10921,6 +10922,18 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-history",
+ "solana-sysvar-id",
+ "wincode",
+]
+
+[[package]]
+name = "solana-sysvar-account"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "solana-account 4.6.0",
+ "solana-pubkey 4.3.0",
+ "solana-sdk-ids",
+ "solana-sysvar",
  "solana-sysvar-id",
  "wincode",
 ]
@@ -11503,12 +11516,12 @@ dependencies = [
  "solana-svm-feature-set",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
  "solana-sysvar-id",
  "solana-transaction-context",
  "solana-vote-interface",
  "solana-vote-program",
  "test-case",
- "wincode",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "svm-type-overrides",
     "syscalls",
     "syscalls/gen-syscall-list",
+    "sysvar-account",
     "test-validator",
     "tls-utils",
     "tokens",
@@ -507,6 +508,7 @@ solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "
 solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.1.0"
 solana-sysvar = "4.3.0"
+solana-sysvar-account = { path = "sysvar-account" }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-time-utils = "3.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ members = [
     "svm-type-overrides",
     "syscalls",
     "syscalls/gen-syscall-list",
+    "sysvar-account",
     "test-validator",
     "tls-utils",
     "tokens",
@@ -506,6 +507,7 @@ solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "
 solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.1.0"
 solana-sysvar = "4.3.0"
+solana-sysvar-account = { path = "sysvar-account" }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-time-utils = "3.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8407,11 +8407,9 @@ version = "4.4.0-alpha.3"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
- "bincode",
  "clap 4.6.1",
  "prost",
  "protosol",
- "serde",
  "solana-account 4.7.0",
  "solana-clock",
  "solana-compute-budget",
@@ -8424,7 +8422,10 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
+ "solana-sysvar-id",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -8612,6 +8613,18 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-history",
+ "solana-sysvar-id",
+ "wincode",
+]
+
+[[package]]
+name = "solana-sysvar-account"
+version = "4.4.0-alpha.3"
+dependencies = [
+ "solana-account 4.7.0",
+ "solana-pubkey 4.3.0",
+ "solana-sdk-ids",
+ "solana-sysvar",
  "solana-sysvar-id",
  "wincode",
 ]

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8335,11 +8335,9 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
- "bincode",
  "clap 4.6.1",
  "prost",
  "protosol",
- "serde",
  "solana-account 4.6.0",
  "solana-clock",
  "solana-compute-budget",
@@ -8352,7 +8350,10 @@ dependencies = [
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-system-program",
+ "solana-sysvar-account",
+ "solana-sysvar-id",
  "solana-transaction-error",
+ "wincode",
 ]
 
 [[package]]
@@ -8540,6 +8541,18 @@ dependencies = [
  "solana-slot-hashes",
  "solana-slot-history",
  "solana-stake-history",
+ "solana-sysvar-id",
+ "wincode",
+]
+
+[[package]]
+name = "solana-sysvar-account"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "solana-account 4.6.0",
+ "solana-pubkey 4.3.0",
+ "solana-sdk-ids",
+ "solana-sysvar",
  "solana-sysvar-id",
  "wincode",
 ]

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -151,6 +151,7 @@ solana-svm-transaction = "5.0.0"
 solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-system-interface = "3.2"
 solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
+solana-sysvar-account = { path = "../sysvar-account" }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.4.0-alpha.3" }
 solana-time-utils = "3.0.0"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -141,6 +141,7 @@ solana-svm-transaction = "5.0.0"
 solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-interface = "3.2"
 solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-sysvar-account = { path = "../sysvar-account" }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.4.0-alpha.0" }
 solana-time-utils = "3.0.0"

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -71,9 +71,9 @@ solana-rent = { workspace = true, features = ["wincode"] }
 solana-slot-hashes = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
 solana-system-program = { workspace = true }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
-wincode = { workspace = true }
 
 [[bench]]
 name = "serialization"

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1114,26 +1114,9 @@ mod tests {
         solana_sbpf::program::{BuiltinFunctionDefinition, BuiltinProgram},
         solana_sdk_ids::{system_program, sysvar},
         solana_svm_type_overrides::sync::atomic::{AtomicU64, Ordering},
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
         std::{fs::File, io::Read, ops::Range},
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::clock::ID => solana_clock::SIZE,
-            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     // 10 iterations is intentionally low: `mock_process_instruction` runs on a
     // single thread, so additional `shuttle::check_random` iterations validate

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -53,9 +53,9 @@ solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable
 solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sysvar-id = { workspace = true }
 solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
-wincode = { workspace = true }
 
 [[bench]]
 name = "system"

--- a/programs/system/benches/system.rs
+++ b/programs/system/benches/system.rs
@@ -14,31 +14,15 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{
         system_program,
-        sysvar::{self, recent_blockhashes, rent},
+        sysvar::{recent_blockhashes, rent},
     },
     solana_system_interface::instruction::SystemInstruction,
     solana_sysvar::recent_blockhashes::{IterItem, MAX_ENTRIES, RecentBlockhashes},
-    solana_sysvar_id::SysvarId,
+    solana_sysvar_account::create_sysvar_account,
 };
 
 const SEED: &str = "bench test";
 const ACCOUNT_BALANCE: u64 = u64::MAX / 4;
-
-fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-where
-    T: wincode::Serialize<Src = T> + SysvarId,
-{
-    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-    let canonical_data_len = match T::id() {
-        sysvar::recent_blockhashes::ID => solana_sysvar::recent_blockhashes::SIZE,
-        sysvar::rent::ID => solana_rent::SIZE,
-        id => panic!("unsupported sysvar: {id}"),
-    };
-    let required_data_len = canonical_data_len.max(serialized_len);
-    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-    account
-}
 
 #[derive(Default)]
 struct TestSetup {

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -579,8 +579,7 @@ mod tests {
     #[allow(deprecated)]
     use {
         solana_account::{
-            Account, AccountSharedData, ReadableAccount, WritableAccount,
-            state_traits::StateMutWincode as _,
+            Account, AccountSharedData, ReadableAccount, state_traits::StateMutWincode as _,
         },
         solana_fee_calculator::FeeCalculator,
         solana_hash::Hash,
@@ -598,25 +597,8 @@ mod tests {
             recent_blockhashes::{IntoIterSorted, IterItem, MAX_ENTRIES, RecentBlockhashes},
             rent::Rent,
         },
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::recent_blockhashes::ID => sysvar::recent_blockhashes::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account =
-            AccountSharedData::new(1, required_data_len, &solana_sdk_ids::sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     impl From<Pubkey> for Address {
         fn from(address: Pubkey) -> Self {

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -75,10 +75,10 @@ solana-sha256-hasher = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
 solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
 solana-system-program = { path = "../system", features = ["agave-unstable-api"] }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sysvar-id = { workspace = true }
 solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
-wincode = { workspace = true }
 
 [[bench]]
 name = "vote_instructions"

--- a/programs/vote/benches/process_vote.rs
+++ b/programs/vote/benches/process_vote.rs
@@ -1,7 +1,7 @@
 use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
     criterion::{BatchSize, Criterion, criterion_group, criterion_main},
-    solana_account::{Account, AccountSharedData, WritableAccount},
+    solana_account::{Account, AccountSharedData},
     solana_clock::{Clock, Slot},
     solana_hash::Hash,
     solana_instruction::AccountMeta,
@@ -12,7 +12,7 @@ use {
     solana_pubkey::Pubkey,
     solana_sdk_ids::sysvar,
     solana_slot_hashes::{MAX_ENTRIES, SlotHashes},
-    solana_sysvar_id::SysvarId,
+    solana_sysvar_account::create_sysvar_account,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_program::{
         vote_instruction::VoteInstruction,
@@ -23,22 +23,6 @@ use {
     },
     std::time::Duration,
 };
-
-fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-where
-    T: wincode::Serialize<Src = T> + SysvarId,
-{
-    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-    let canonical_data_len = match T::id() {
-        sysvar::clock::ID => solana_clock::SIZE,
-        sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
-        id => panic!("unsupported sysvar: {id}"),
-    };
-    let required_data_len = canonical_data_len.max(serialized_len);
-    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-    account
-}
 
 fn create_accounts() -> (
     Slot,

--- a/programs/vote/benches/vote_instructions.rs
+++ b/programs/vote/benches/vote_instructions.rs
@@ -2,7 +2,7 @@ use {
     agave_feature_set::{FeatureSet, deprecate_legacy_vote_ixs},
     bincode::serialize,
     criterion::{Criterion, criterion_group, criterion_main},
-    solana_account::{Account, AccountSharedData, WritableAccount},
+    solana_account::{Account, AccountSharedData},
     solana_clock::{Clock, Slot},
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
@@ -15,7 +15,7 @@ use {
     solana_rent::Rent,
     solana_sdk_ids::{sysvar, vote::id},
     solana_slot_hashes::{MAX_ENTRIES, SlotHashes},
-    solana_sysvar_id::SysvarId,
+    solana_sysvar_account::create_sysvar_account,
     solana_transaction_context::transaction_accounts::KeyedAccountSharedData,
     solana_vote_interface::state::BLS_PUBLIC_KEY_COMPRESSED_SIZE,
     solana_vote_program::{
@@ -30,24 +30,6 @@ use {
         },
     },
 };
-
-fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-where
-    T: wincode::Serialize<Src = T> + SysvarId,
-{
-    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-    let canonical_data_len = match T::id() {
-        sysvar::clock::ID => solana_clock::SIZE,
-        sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-        sysvar::rent::ID => solana_rent::SIZE,
-        sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
-        id => panic!("unsupported sysvar: {id}"),
-    };
-    let required_data_len = canonical_data_len.max(serialized_len);
-    let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-    account
-}
 
 fn create_default_rent_account() -> AccountSharedData {
     create_sysvar_account(&Rent::free())

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -449,7 +449,7 @@ mod tests {
         solana_slot_hashes::SlotHashes,
         solana_svm_feature_set::SVMFeatureSet,
         solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as SYSTEM_PROGRAM_COMPUTE_UNITS,
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
         solana_vote_interface::{
             instruction::{CommissionKind, tower_sync, tower_sync_switch},
             state::{
@@ -460,24 +460,6 @@ mod tests {
         std::{cell::RefCell, collections::HashSet, str::FromStr, sync::Arc},
         test_case::test_matrix,
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::clock::ID => solana_clock::SIZE,
-            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     fn vote_state_size_of() -> usize {
         VoteStateV4::size_of()

--- a/programs/vote/src/vote_processor.rs
+++ b/programs/vote/src/vote_processor.rs
@@ -467,7 +467,7 @@ mod tests {
         solana_slot_hashes::SlotHashes,
         solana_svm_feature_set::SVMFeatureSet,
         solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as SYSTEM_PROGRAM_COMPUTE_UNITS,
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
         solana_vote_interface::{
             instruction::{CommissionKind, tower_sync, tower_sync_switch},
             state::{
@@ -478,24 +478,6 @@ mod tests {
         std::{cell::RefCell, collections::HashSet, str::FromStr, sync::Arc},
         test_case::test_matrix,
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::clock::ID => solana_clock::SIZE,
-            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            sysvar::slot_hashes::ID => solana_slot_hashes::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     fn vote_state_size_of() -> usize {
         VoteStateV4::size_of()

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -217,6 +217,7 @@ solana-signature = { workspace = true, features = ["std"] }
 solana-signer-store = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode"] }
 solana-svm = { path = "../svm", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 solana-vote-program = { path = "../programs/vote", default-features = false, features = ["agave-unstable-api", "dev-context-only-utils"] }
 static_assertions = { workspace = true }

--- a/runtime/src/conformance/block.rs
+++ b/runtime/src/conformance/block.rs
@@ -761,7 +761,6 @@ mod tests {
 
     use {
         super::{LEADER_SCHEDULE_HASH_SEED, execute_block, hash_epoch_leaders},
-        crate::sysvar_account::create_account,
         protosol::protos::{
             AcctState, BlockBank as ProtoBlockBank, BlockContext as ProtoBlockContext,
             BlockhashQueueEntry as ProtoBlockhashQueueEntry,
@@ -773,7 +772,7 @@ mod tests {
             SanitizedTransaction as ProtoSanitizedTransaction,
             TransactionMessage as ProtoTransactionMessage, VoteAccountVersion,
         },
-        solana_account::{Account, DUMMY_INHERITABLE_ACCOUNT_FIELDS},
+        solana_account::Account,
         solana_clock::Clock,
         solana_epoch_schedule::EpochSchedule,
         solana_hash::Hash,
@@ -788,6 +787,7 @@ mod tests {
             epoch_rewards::EpochRewards, last_restart_slot::LastRestartSlot,
             recent_blockhashes::RecentBlockhashes,
         },
+        solana_sysvar_account::keyed_sysvar_account,
         solana_sysvar_id::SysvarId,
     };
 
@@ -815,14 +815,12 @@ mod tests {
         ))
     }
 
-    fn sysvar_account<T>(pubkey: Pubkey, value: &T) -> AcctState
+    fn sysvar_account<T>(value: &T) -> AcctState
     where
         T: wincode::Serialize<Src = T> + SysvarId,
     {
-        account_to_proto((
-            pubkey,
-            create_account(value, DUMMY_INHERITABLE_ACCOUNT_FIELDS).into(),
-        ))
+        let (pubkey, account) = keyed_sysvar_account(value);
+        account_to_proto((pubkey, account.into()))
     }
 
     fn block_sysvar_accounts(parent_slot: u64, epoch_schedule: &EpochSchedule) -> Vec<AcctState> {
@@ -842,15 +840,12 @@ mod tests {
         slot_history.add(parent_slot);
 
         vec![
-            sysvar_account(sysvar::clock::id(), &clock),
-            sysvar_account(sysvar::epoch_schedule::id(), epoch_schedule),
-            sysvar_account(sysvar::epoch_rewards::id(), &EpochRewards::default()),
-            sysvar_account(sysvar::rent::id(), &Rent::default()),
-            sysvar_account(sysvar::slot_hashes::id(), &slot_hashes),
-            sysvar_account(
-                sysvar::recent_blockhashes::id(),
-                &RecentBlockhashes::default(),
-            ),
+            sysvar_account(&clock),
+            sysvar_account(epoch_schedule),
+            sysvar_account(&EpochRewards::default()),
+            sysvar_account(&Rent::default()),
+            sysvar_account(&slot_hashes),
+            sysvar_account(&RecentBlockhashes::default()),
             account_to_proto((
                 sysvar::stake_history::id(),
                 Account {
@@ -861,8 +856,8 @@ mod tests {
                     rent_epoch: u64::MAX,
                 },
             )),
-            sysvar_account(sysvar::last_restart_slot::id(), &LastRestartSlot::default()),
-            sysvar_account(sysvar::slot_history::id(), &slot_history),
+            sysvar_account(&LastRestartSlot::default()),
+            sysvar_account(&slot_history),
         ]
     }
 

--- a/runtime/src/conformance/txn.rs
+++ b/runtime/src/conformance/txn.rs
@@ -568,12 +568,13 @@ mod tests {
         },
         solana_pubkey::Pubkey,
         solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
-        solana_sdk_ids::{bpf_loader_upgradeable, native_loader, sysvar},
+        solana_sdk_ids::{bpf_loader_upgradeable, native_loader},
         solana_signature::Signature,
         solana_slot_hashes::SlotHashes,
         solana_svm::transaction_processing_result::{
             ProcessedTransaction, TransactionProcessingResultExtensions,
         },
+        solana_sysvar_account::keyed_sysvar_account,
         solana_transaction::versioned::VersionedTransaction,
         std::{borrow::Cow, env, fs, sync::Arc},
     };
@@ -627,18 +628,6 @@ mod tests {
         account(lamports, vec![], Pubkey::default(), false)
     }
 
-    fn sysvar_account<T: serde::Serialize>(id: Pubkey, state: &T) -> (Pubkey, AccountSharedData) {
-        (
-            id,
-            account(
-                1,
-                bincode::serialize(state).unwrap(),
-                native_loader::id(),
-                false,
-            ),
-        )
-    }
-
     fn clock_sysvar_account() -> (Pubkey, AccountSharedData) {
         let clock = Clock {
             slot: 20,
@@ -647,7 +636,7 @@ mod tests {
             leader_schedule_epoch: 1,
             unix_timestamp: 1720556855,
         };
-        sysvar_account(sysvar::clock::id(), &clock)
+        keyed_sysvar_account(&clock)
     }
 
     fn epoch_schedule_sysvar_account() -> (Pubkey, AccountSharedData) {
@@ -658,23 +647,15 @@ mod tests {
             first_normal_epoch: 14,
             first_normal_slot: 524256,
         };
-        sysvar_account(sysvar::epoch_schedule::id(), &epoch_schedule)
+        keyed_sysvar_account(&epoch_schedule)
     }
 
     fn rent_sysvar_account() -> (Pubkey, AccountSharedData) {
-        sysvar_account(sysvar::rent::id(), &solana_rent::Rent::default())
+        keyed_sysvar_account(&solana_rent::Rent::default())
     }
 
     fn slot_hashes_sysvar_account() -> (Pubkey, AccountSharedData) {
-        (
-            sysvar::slot_hashes::id(),
-            account(
-                1,
-                wincode::serialize(&SlotHashes::default()).unwrap(),
-                native_loader::id(),
-                false,
-            ),
-        )
+        keyed_sysvar_account(&SlotHashes::default())
     }
 
     fn system_program_account() -> (Pubkey, AccountSharedData) {

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -75,14 +75,15 @@ solana-syscalls = { workspace = true, optional = true }
 solana-transaction-error = { workspace = true, optional = true }
 
 [dev-dependencies]
-bincode = { workspace = true }
-serde = { workspace = true }
 solana-account = { workspace = true }
 solana-clock = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-program = { workspace = true }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
+solana-sysvar-id = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/svm-conformance/src/instr.rs
+++ b/svm-conformance/src/instr.rs
@@ -105,8 +105,8 @@ pub unsafe extern "C" fn sol_compat_instr_execute_v1(
 #[cfg(test)]
 mod tests {
     use {
-        super::*, solana_account::Account, solana_pubkey::Pubkey,
-        solana_svm::conformance::programs::keyed_account_for_system_program,
+        super::*, crate::test_utils::proto_sysvar_account, solana_account::Account,
+        solana_pubkey::Pubkey, solana_svm::conformance::programs::keyed_account_for_system_program,
         solana_system_program::system_processor::DEFAULT_COMPUTE_UNITS as SYSTEM_TRANSFER_CUS,
     };
 
@@ -133,19 +133,6 @@ mod tests {
         }
     }
 
-    fn proto_sysvar_account<T: serde::Serialize>(
-        pubkey: Pubkey,
-        sysvar: &T,
-    ) -> protosol::protos::AcctState {
-        protosol::protos::AcctState {
-            address: pubkey.to_bytes().to_vec(),
-            owner: solana_sdk_ids::sysvar::id().to_bytes().to_vec(),
-            lamports: 1,
-            data: bincode::serialize(sysvar).unwrap(),
-            executable: false,
-        }
-    }
-
     #[test]
     #[should_panic(expected = "invariant violation: duplicate account load")]
     fn test_duplicate_accounts_panic_with_invariant_violation() {
@@ -165,10 +152,7 @@ mod tests {
                     keyed_account_for_system_program().0,
                     keyed_account_for_system_program().1,
                 ),
-                proto_sysvar_account(
-                    solana_sdk_ids::sysvar::clock::id(),
-                    &solana_clock::Clock::default(),
-                ),
+                proto_sysvar_account(&solana_clock::Clock::default()),
             ],
             instr_accounts: vec![
                 protosol::protos::InstrAcct {

--- a/svm-conformance/src/lib.rs
+++ b/svm-conformance/src/lib.rs
@@ -11,5 +11,7 @@ pub mod instr;
 pub mod serialization;
 #[cfg(feature = "ffi")]
 pub mod syscall;
+#[cfg(test)]
+mod test_utils;
 #[cfg(feature = "ffi")]
 pub mod txn;

--- a/svm-conformance/src/serialization.rs
+++ b/svm-conformance/src/serialization.rs
@@ -148,10 +148,11 @@ pub unsafe extern "C" fn sol_compat_vm_serialize_execute_v1(
 mod tests {
     use {
         super::*,
+        crate::test_utils::proto_sysvar_account,
         protosol::protos::{AcctState as ProtoAcctState, InstrAcct as ProtoInstrAcct},
         solana_pubkey::Pubkey,
         solana_rent::Rent,
-        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable, sysvar},
+        solana_sdk_ids::{bpf_loader_deprecated, bpf_loader_upgradeable},
     };
 
     const PROGRAM_ID: [u8; 32] = [7; 32];
@@ -174,21 +175,11 @@ mod tests {
         }
     }
 
-    fn rent_sysvar() -> ProtoAcctState {
-        ProtoAcctState {
-            address: sysvar::rent::id().to_bytes().to_vec(),
-            lamports: 1,
-            data: bincode::serialize(&Rent::default()).unwrap(),
-            executable: false,
-            owner: sysvar::id().to_bytes().to_vec(),
-        }
-    }
-
     fn serialize(
         mut accounts: Vec<ProtoAcctState>,
         instr_accounts: Vec<ProtoInstrAcct>,
     ) -> ProtoVmSerializationEffects {
-        accounts.push(rent_sysvar()); // <-- Loads Rent into SysvarCache
+        accounts.push(proto_sysvar_account(&Rent::default())); // <-- Loads Rent into SysvarCache
         execute_vm_serialize(ProtoInstrContext {
             program_id: PROGRAM_ID.to_vec(),
             accounts,

--- a/svm-conformance/src/syscall.rs
+++ b/svm-conformance/src/syscall.rs
@@ -364,12 +364,12 @@ pub unsafe extern "C" fn sol_compat_vm_syscall_execute_v1(
 mod tests {
     use {
         super::*,
+        crate::test_utils::proto_sysvar_account,
         protosol::protos::{
             AcctState as ProtoAcctState, InstrContext as ProtoInstrContext,
             SyscallInvocation as ProtoSyscallInvocation, VmContext as ProtoVmContext,
         },
         solana_rent::Rent,
-        solana_sdk_ids::sysvar,
     };
 
     const PROGRAM_ID: [u8; 32] = [7; 32];
@@ -389,13 +389,7 @@ mod tests {
             executable: true,
             owner: Pubkey::default().to_bytes().to_vec(),
         };
-        let rent_sysvar = ProtoAcctState {
-            address: sysvar::rent::id().to_bytes().to_vec(),
-            lamports: 1,
-            data: bincode::serialize(&Rent::default()).unwrap(),
-            executable: false,
-            owner: sysvar::id().to_bytes().to_vec(),
-        };
+        let rent_sysvar = proto_sysvar_account(&Rent::default());
         ProtoSyscallContext {
             instr_ctx: Some(ProtoInstrContext {
                 program_id: PROGRAM_ID.to_vec(),

--- a/svm-conformance/src/test_utils.rs
+++ b/svm-conformance/src/test_utils.rs
@@ -1,0 +1,16 @@
+//! Shared test fixtures.
+
+use {
+    protosol::protos::AcctState as ProtoAcctState,
+    solana_svm::conformance::account_state::account_to_proto,
+    solana_sysvar_account::keyed_sysvar_account, solana_sysvar_id::SysvarId,
+};
+
+/// The proto account for the sysvar holding `value`.
+pub(crate) fn proto_sysvar_account<T>(value: &T) -> ProtoAcctState
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    let (pubkey, account) = keyed_sysvar_account(value);
+    account_to_proto((pubkey, account.into()))
+}

--- a/svm-conformance/src/txn.rs
+++ b/svm-conformance/src/txn.rs
@@ -130,6 +130,7 @@ pub unsafe extern "C" fn sol_compat_svm_txn_execute_v1(
 mod tests {
     use {
         super::*,
+        crate::test_utils::proto_sysvar_account,
         protosol::protos::{
             AcctState as ProtoAcctState, CompiledInstruction as ProtoCompiledInstruction,
             MessageHeader as ProtoMessageHeader, SanitizedTransaction as ProtoSanitizedTransaction,
@@ -200,17 +201,10 @@ mod tests {
                     executable: false,
                     owner: system_program::id().to_bytes().to_vec(),
                 },
-                ProtoAcctState {
-                    address: clock_pubkey.to_bytes().to_vec(),
-                    lamports: 1,
-                    data: bincode::serialize(&Clock {
-                        slot: 1,
-                        ..Clock::default()
-                    })
-                    .unwrap(),
-                    executable: false,
-                    owner: sysvar::id().to_bytes().to_vec(),
-                },
+                proto_sysvar_account(&Clock {
+                    slot: 1,
+                    ..Clock::default()
+                }),
                 ProtoAcctState {
                     address: system_program_id.to_bytes().to_vec(),
                     lamports: system_program_account.lamports,

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -165,11 +165,11 @@ solana-syscalls = { path = "../syscalls", features = ["agave-unstable-api"] }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true, features = ["wincode"] }
+solana-sysvar-account = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
-wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1468,31 +1468,13 @@ mod tests {
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
         solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::clock::ID => solana_clock::SIZE,
-            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-            sysvar::fees::ID => solana_sysvar::fees::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1454,31 +1454,13 @@ mod tests {
         solana_signature::Signature,
         solana_svm_callback::{AccountState, InvokeContextCallback},
         solana_system_interface::instruction as system_instruction,
-        solana_sysvar_id::SysvarId,
+        solana_sysvar_account::create_sysvar_account,
         solana_transaction::sanitized::SanitizedTransaction,
         solana_transaction_context::transaction::TransactionContext,
         solana_transaction_error::TransactionError,
         std::{borrow::Cow, collections::HashMap},
         test_case::test_case,
     };
-
-    fn create_sysvar_account<T>(value: &T) -> AccountSharedData
-    where
-        T: wincode::Serialize<Src = T> + SysvarId,
-    {
-        let serialized_len = wincode::serialized_size(value).unwrap() as usize;
-        let canonical_data_len = match T::id() {
-            sysvar::clock::ID => solana_clock::SIZE,
-            sysvar::epoch_schedule::ID => solana_epoch_schedule::SIZE,
-            sysvar::fees::ID => solana_sysvar::fees::SIZE,
-            sysvar::rent::ID => solana_rent::SIZE,
-            id => panic!("unsupported sysvar: {id}"),
-        };
-        let required_data_len = canonical_data_len.max(serialized_len);
-        let mut account = AccountSharedData::new(1, required_data_len, &sysvar::id());
-        wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
-        account
-    }
 
     fn new_unchecked_sanitized_message(message: Message) -> SanitizedMessage {
         SanitizedMessage::Legacy(LegacyMessage::new(message, &HashSet::new()))

--- a/sysvar-account/Cargo.toml
+++ b/sysvar-account/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "solana-sysvar-account"
+description = "Sysvar account construction for tests and benches"
+publish = false
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[features]
+dev-context-only-utils = []
+
+[dependencies]
+solana-account = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-sysvar = { workspace = true, features = ["wincode"] }
+solana-sysvar-id = { workspace = true }
+wincode = { workspace = true }
+
+[lints]
+workspace = true

--- a/sysvar-account/src/lib.rs
+++ b/sysvar-account/src/lib.rs
@@ -1,0 +1,49 @@
+//! Sysvar account construction for tests and benches.
+
+#![cfg(feature = "dev-context-only-utils")]
+
+use {
+    solana_account::{AccountSharedData, WritableAccount},
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::sysvar,
+    solana_sysvar_id::SysvarId,
+};
+
+/// The canonical on-chain data length of the sysvar account at `sysvar_id`.
+fn canonical_data_len(sysvar_id: &Pubkey) -> usize {
+    match *sysvar_id {
+        sysvar::clock::ID => solana_sysvar::clock::SIZE,
+        sysvar::epoch_rewards::ID => solana_sysvar::epoch_rewards::SIZE,
+        sysvar::epoch_schedule::ID => solana_sysvar::epoch_schedule::SIZE,
+        sysvar::fees::ID => solana_sysvar::fees::SIZE,
+        sysvar::last_restart_slot::ID => solana_sysvar::last_restart_slot::SIZE,
+        sysvar::recent_blockhashes::ID => solana_sysvar::recent_blockhashes::SIZE,
+        sysvar::rent::ID => solana_sysvar::rent::SIZE,
+        sysvar::rewards::ID => solana_sysvar::rewards::SIZE,
+        sysvar::slot_hashes::ID => solana_sysvar::slot_hashes::SIZE,
+        sysvar::slot_history::ID => solana_sysvar::slot_history::SIZE,
+        sysvar::stake_history::ID => solana_sysvar::stake_history::SIZE,
+        id => panic!("unsupported sysvar: {id}"),
+    }
+}
+
+/// Build the sysvar account holding `value`, sized to the sysvar's canonical
+/// data length, or to the serialized value when that is larger.
+pub fn create_sysvar_account<T>(value: &T) -> AccountSharedData
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    let serialized_len = wincode::serialized_size(value).unwrap() as usize;
+    let data_len = canonical_data_len(&T::id()).max(serialized_len);
+    let mut account = AccountSharedData::new(1, data_len, &sysvar::id());
+    wincode::serialize_into(account.data_as_mut_slice(), value).unwrap();
+    account
+}
+
+/// [`create_sysvar_account`], keyed by the sysvar's address.
+pub fn keyed_sysvar_account<T>(value: &T) -> (Pubkey, AccountSharedData)
+where
+    T: wincode::Serialize<Src = T> + SysvarId,
+{
+    (T::id(), create_sysvar_account(value))
+}


### PR DESCRIPTION
#### Problem
As a result of all of the `SysvarSerialize` churn - most recently #14417 - we have a bunch of duplicated sysvar account constructors. We can use a test crate to deduplicate this, as I mentioned in [this comment here](https://github.com/anza-xyz/agave/pull/14417#discussion_r3746081201).

#### Summary of Changes
Introduce `solana-sysvar-account` as a `publish=false` test-only crate gated entirely under `dev-context-only-utils`, then use it everywhere to dedupe all of the `create_sysvar_account` functions.

In follow-up, I'm going to use this in more conformance work as well.

#### Testing
No additional tests added. The lib is a test util.