### PR TITLE
ci: bind remaining dispatch inputs and tag outputs via env

### DIFF
--- a/.github/workflows/publish-windows-tarball.yml
+++ b/.github/workflows/publish-windows-tarball.yml
@@ -42,7 +42,7 @@ jobs:
           echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
 
           # print the info
-          echo "::notice::commit: ${{ env.COMMIT }}"
+          echo "::notice::commit: $COMMIT"
           echo "::notice::tag: $CI_TAG"
           echo "::notice::channel: $CHANNEL"
 
@@ -51,8 +51,9 @@ jobs:
       - name: Prepare Upload Files
         if: ${{ steps.build.outputs.channel != '' || steps.build.outputs.tag != '' }}
         shell: bash
+        env:
+          FOLDER_NAME: ${{ steps.build.outputs.tag || steps.build.outputs.channel }}
         run: |
-          FOLDER_NAME=${{ steps.build.outputs.tag || steps.build.outputs.channel }}
           mkdir -p "windows-release/$FOLDER_NAME"
           cp -v "solana-release-x86_64-pc-windows-msvc.tar.bz2" "windows-release/$FOLDER_NAME/"
           cp -v "solana-release-x86_64-pc-windows-msvc.yml" "windows-release/$FOLDER_NAME/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,21 @@ jobs:
     if: github.repository_owner == 'anza-xyz'
     runs-on: ubuntu-24.04
     steps:
+      - name: Build env vars JSON
+        id: build-env-vars
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          echo "json=$(jq -cn --arg tag "$REF_NAME" '{"TRIGGERED_BUILDKITE_TAG": $tag}')" >> "$GITHUB_OUTPUT"
+
       - name: Trigger a Buildkite Build
         uses: "buildkite/trigger-pipeline-action@41fd38b69189bf186cf69cf10ec807a850cae593"  # v2.5.0
         with:
           buildkite_api_access_token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
           pipeline: "anza/agave-secondary"
           branch: "${{ github.ref_name }}"
-          build_env_vars: '{"TRIGGERED_BUILDKITE_TAG": "${{ github.ref_name }}"}'
+          build_env_vars: ${{ steps.build-env-vars.outputs.json }}
           commit: "HEAD"
           message: ":github: Triggered from a GitHub Action"
 


### PR DESCRIPTION
Completes the env-binding sweep started in #14336 and extended in #14357.

- publish-windows-tarball.yml: the dispatch commit input was referenced as `${{ env.COMMIT }}` inside the run shell (bypassing the binding created one line earlier), and `steps.build.outputs.tag` was interpolated directly into bash. Tag names legally contain `$()`, backticks and other shell metacharacters, and tags/dispatches skip PR review, so this keeps the write-access-only path consistent with the rest of the workflows.
- release.yml: `build_env_vars` was hand-built JSON with raw `${{ github.ref_name }}` inside; a `"` in a tag name breaks out of the string. Now built with `jq -cn --arg`, matching trigger-buildkite-pipeline.yml.

Both are insider-gated (write access required), so this is hardening, not a security report. Happy to split or drop either hunk if you'd rather handle them differently.

Made with [Cursor](https://cursor.com)