### PR TITLE
nit: rewards container: various minor fixes

### DIFF
--- a/core/src/block_creation_loop/rewards/certs_builder.rs
+++ b/core/src/block_creation_loop/rewards/certs_builder.rs
@@ -87,10 +87,12 @@ impl CertsBuilder {
         match input {
             RewardInput::External(aggregates) => {
                 for aggregate in aggregates {
-                    let slot = aggregate.vote().slot();
-                    let Some(rank_map) = root_bank.get_rank_map(slot) else {
+                    let vote = *aggregate.vote();
+                    let vote_slot = vote.slot();
+                    let Some(rank_map) = root_bank.get_rank_map(vote_slot) else {
                         warn!(
-                            "failed to look up rank_map for slot {slot} using bank for slot {}",
+                            "failed to look up rank_map for slot {vote_slot} using bank for slot \
+                             {}",
                             root_bank.slot()
                         );
                         return;
@@ -104,10 +106,9 @@ impl CertsBuilder {
                         vote_account_pubkeys.push(stake_entry.vote_account_pubkey);
                     }
 
-                    let vote = *aggregate.vote();
                     match self
                         .aggregates
-                        .entry(aggregate.vote().slot())
+                        .entry(vote_slot)
                         .or_insert_with(|| Entry::new(max_validators))
                         .add_aggregate(aggregate, vote_account_pubkeys)
                     {
@@ -119,10 +120,11 @@ impl CertsBuilder {
                 }
             }
             RewardInput::Own(vote_msg) => {
-                let slot = vote_msg.vote.slot();
-                let Some(rank_map) = root_bank.get_rank_map(slot) else {
+                let vote = vote_msg.vote;
+                let vote_slot = vote.slot();
+                let Some(rank_map) = root_bank.get_rank_map(vote_slot) else {
                     warn!(
-                        "failed to look up rank_map for slot {slot} using bank for slot {}",
+                        "failed to look up rank_map for slot {vote_slot} using bank for slot {}",
                         root_bank.slot()
                     );
                     return;
@@ -133,7 +135,6 @@ impl CertsBuilder {
                     return;
                 };
 
-                let vote = vote_msg.vote;
                 match self
                     .aggregates
                     .entry(vote_msg.vote.slot())


### PR DESCRIPTION
#### Problem

While working on https://github.com/anza-xyz/agave/issues/14467, I hit some minor clean ups in the rewards container.  Namely, if we copy `Vote`, we will copy it fewer times.


#### Summary of Changes

Moves the copying of `Vote` earlier.


#### Testing

No new tests added