### PR TITLE
Update solana-sysvar/account deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-clap-utils",
@@ -6985,9 +6985,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
+checksum = "2c83d346056532a7ef16177dbb799abf73da080e93eae3de6a901c726ce47fb0"
 dependencies = [
  "bincode",
  "serde",
@@ -7016,7 +7016,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -7057,7 +7057,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-pubkey 4.3.0",
  "zstd",
 ]
@@ -7146,7 +7146,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
@@ -7265,7 +7265,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "borsh",
  "futures 0.3.33",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-banks-interface",
  "solana-banks-server",
  "solana-clock",
@@ -7295,7 +7295,7 @@ name = "solana-banks-interface"
 version = "4.4.0-alpha.0"
 dependencies = [
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-hash 4.6.0",
@@ -7314,7 +7314,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
@@ -7461,7 +7461,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "shuttle",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -7498,7 +7498,7 @@ dependencies = [
  "agave-feature-set",
  "assert_matches",
  "bincode",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bpf-loader-program",
  "solana-clock",
  "solana-instruction",
@@ -7653,7 +7653,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-bls-signatures",
@@ -7751,7 +7751,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-bls-signatures",
@@ -7862,7 +7862,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0255645cb08e00df08f889d593581d569a8f347072d77946abea320c48f1a80f"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-commitment-config",
  "solana-epoch-info",
  "solana-hash 4.6.0",
@@ -8073,7 +8073,7 @@ dependencies = [
  "signal-hook",
  "slab",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -8500,7 +8500,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
@@ -8607,7 +8607,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bls-signatures",
  "solana-borsh",
  "solana-clap-utils",
@@ -8655,7 +8655,7 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
@@ -8711,7 +8711,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
@@ -9088,7 +9088,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bls-signatures",
@@ -9213,7 +9213,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "serial_test",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-client-traits",
  "solana-clock",
@@ -9398,7 +9398,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
@@ -9661,7 +9661,7 @@ name = "solana-program-binaries"
 version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -9731,7 +9731,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-clock",
  "solana-ed25519-program",
@@ -9790,7 +9790,7 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address 2.7.0",
@@ -10008,7 +10008,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "soketto",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
@@ -10108,7 +10108,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-bls-signatures",
@@ -10164,7 +10164,7 @@ dependencies = [
  "clap 2.33.3",
  "futures 0.3.33",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-commitment-config",
@@ -10294,7 +10294,7 @@ dependencies = [
  "serde_with",
  "shuttle",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-info",
  "solana-accounts-db",
@@ -10538,7 +10538,7 @@ dependencies = [
  "crossbeam-channel",
  "itertools 0.14.0",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-fee-calculator",
  "solana-genesis-config",
  "solana-hash 4.6.0",
@@ -10720,7 +10720,7 @@ name = "solana-stake-accounts"
 version = "4.4.0-alpha.0"
 dependencies = [
  "clap 2.33.3",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clap-utils",
  "solana-cli-config",
  "solana-cli-output",
@@ -10917,7 +10917,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "shuttle",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -10985,7 +10985,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.4.0-alpha.0"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.3.0",
@@ -11046,7 +11046,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -11128,7 +11128,7 @@ dependencies = [
  "bincode",
  "criterion",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-fee-calculator",
  "solana-hash 4.6.0",
@@ -11169,9 +11169,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0214d668b0aab7a64b49e43b7947307985fca4e03d3ef880cd8ee43f52f13a34"
+checksum = "552f9d54ec9597f5a17469df500a1ac345c262e5a9859938ef5e5541844fdac5"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -11227,7 +11227,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-bls-signatures",
  "solana-cli-output",
@@ -11437,7 +11437,7 @@ dependencies = [
  "bincode",
  "qualifier_attr",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-instruction",
  "solana-instructions-sysvar 4.0.0",
@@ -11689,7 +11689,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -11757,7 +11757,7 @@ dependencies = [
  "criterion",
  "log",
  "qualifier_attr",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -11839,7 +11839,7 @@ name = "solana-zk-elgamal-proof-program-tests"
 version = "4.4.0-alpha.0"
 dependencies = [
  "bytemuck",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-compute-budget",
  "solana-compute-budget-interface",
  "solana-instruction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,7 +344,7 @@ smallvec = { version = "1.15.2", default-features = false, features = ["union"] 
 smpl_jwt = "0.9.0"
 socket2 = "0.6.5"
 soketto = "0.8"
-solana-account = "4.5.0"
+solana-account = "4.6.0"
 solana-account-decoder = { path = "account-decoder", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-account-info = "3.1.1"
@@ -504,7 +504,7 @@ solana-syscalls = { path = "syscalls", version = "=4.4.0-alpha.0", default-featu
 solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }
 solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-system-transaction = "4.1.0"
-solana-sysvar = "4.2.0"
+solana-sysvar = "4.3.0"
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-time-utils = "3.0.0"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "signal-hook",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-bls-signatures",
@@ -366,7 +366,7 @@ dependencies = [
  "ahash 0.8.12",
  "clap 2.34.0",
  "rayon",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-pubkey 4.3.0",
  "solana-system-interface 3.3.0",
@@ -5792,9 +5792,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
+checksum = "2c83d346056532a7ef16177dbb799abf73da080e93eae3de6a901c726ce47fb0"
 dependencies = [
  "bincode",
  "serde",
@@ -5820,7 +5820,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -5860,7 +5860,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-pubkey 4.3.0",
  "zstd",
 ]
@@ -5895,7 +5895,7 @@ dependencies = [
  "seqlock",
  "serde",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
  "solana-clock",
@@ -6107,7 +6107,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "qualifier_attr",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-clock",
  "solana-instruction",
@@ -6230,7 +6230,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-bls-signatures",
@@ -6299,7 +6299,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0255645cb08e00df08f889d593581d569a8f347072d77946abea320c48f1a80f"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-commitment-config",
  "solana-epoch-info",
  "solana-hash 4.6.0",
@@ -6480,7 +6480,7 @@ dependencies = [
  "signal-hook",
  "slab",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -6798,7 +6798,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
@@ -6861,7 +6861,7 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
@@ -6917,7 +6917,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
@@ -7215,7 +7215,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -7420,7 +7420,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
@@ -7587,7 +7587,7 @@ name = "solana-program-binaries"
 version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -7652,7 +7652,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
@@ -7830,7 +7830,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-cli-output",
@@ -7906,7 +7906,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-bls-signatures",
@@ -7952,7 +7952,7 @@ dependencies = [
 name = "solana-rpc-client-nonce-utils"
 version = "4.4.0-alpha.0"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-commitment-config",
  "solana-hash 4.6.0",
  "solana-message",
@@ -8026,7 +8026,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-info",
  "solana-accounts-db",
@@ -8557,7 +8557,7 @@ dependencies = [
  "protosol",
  "qualifier_attr",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -8609,7 +8609,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.4.0-alpha.0"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.3.0",
@@ -8626,7 +8626,7 @@ dependencies = [
  "prost",
  "protosol",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-compute-budget",
  "solana-instruction",
@@ -8693,7 +8693,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -8764,7 +8764,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-fee-calculator",
  "solana-instruction",
@@ -8797,9 +8797,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0214d668b0aab7a64b49e43b7947307985fca4e03d3ef880cd8ee43f52f13a34"
+checksum = "552f9d54ec9597f5a17469df500a1ac345c262e5a9859938ef5e5541844fdac5"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8944,7 +8944,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-instruction",
  "solana-instructions-sysvar 4.0.0",
  "solana-pubkey 4.3.0",
@@ -9159,7 +9159,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -9214,7 +9214,7 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1.0.151"
 serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
-solana-account = "4.5.0"
+solana-account = "4.6.0"
 solana-account-decoder = { path = "../account-decoder", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-accounts-db = { path = "../accounts-db", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-bls-signatures = { version = "3.3.0", features = ["serde"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-clap-utils",
  "solana-cli-config",
@@ -5804,9 +5804,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4dec15c69d94074ef92131303fed68dbccae2472cf09409d9205c180fe5258"
+checksum = "2c83d346056532a7ef16177dbb799abf73da080e93eae3de6a901c726ce47fb0"
 dependencies = [
  "bincode",
  "serde",
@@ -5832,7 +5832,7 @@ dependencies = [
  "bv",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -5872,7 +5872,7 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-pubkey 4.3.0",
  "zstd",
 ]
@@ -5919,7 +5919,7 @@ dependencies = [
  "seqlock",
  "serde",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bucket-map",
  "solana-clock",
@@ -6022,7 +6022,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "borsh",
  "futures 0.3.33",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
@@ -6048,7 +6048,7 @@ name = "solana-banks-interface"
 version = "4.4.0-alpha.0"
 dependencies = [
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-hash 4.6.0",
@@ -6067,7 +6067,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "crossbeam-channel",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-banks-interface",
  "solana-clock",
  "solana-commitment-config",
@@ -6199,7 +6199,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "qualifier_attr",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-clock",
  "solana-instruction",
@@ -6322,7 +6322,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-bincode",
  "solana-bls-signatures",
@@ -6391,7 +6391,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0255645cb08e00df08f889d593581d569a8f347072d77946abea320c48f1a80f"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-commitment-config",
  "solana-epoch-info",
  "solana-hash 4.6.0",
@@ -6572,7 +6572,7 @@ dependencies = [
  "signal-hook",
  "slab",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-bincode",
@@ -6923,7 +6923,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-instruction",
  "solana-program-error",
@@ -6986,7 +6986,7 @@ dependencies = [
  "memmap2 0.5.10",
  "serde",
  "serde_derive",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-cluster-type",
  "solana-epoch-schedule",
@@ -7042,7 +7042,7 @@ dependencies = [
  "libloading",
  "log",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-clock",
  "solana-entry",
@@ -7342,7 +7342,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-address-lookup-table-interface",
  "solana-clock",
@@ -7547,7 +7547,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337cf70e23d7e33d61e5020106ae9894fe10434b3de943e8bc57eb5d7207c1bf"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-hash 4.6.0",
  "solana-nonce",
  "solana-sdk-ids",
@@ -7760,7 +7760,7 @@ name = "solana-program-binaries"
 version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-loader-v3-interface",
  "solana-pubkey 4.3.0",
  "solana-rent",
@@ -7827,7 +7827,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-clock",
  "solana-epoch-rewards",
@@ -7874,7 +7874,7 @@ dependencies = [
  "chrono-humanize",
  "log",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-accounts-db",
  "solana-address 2.7.0",
@@ -8067,7 +8067,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soketto",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-accounts-db",
  "solana-cli-output",
@@ -8142,7 +8142,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-decoder-client-types",
  "solana-bls-signatures",
@@ -8188,7 +8188,7 @@ dependencies = [
 name = "solana-rpc-client-nonce-utils"
 version = "4.4.0-alpha.0"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-commitment-config",
  "solana-hash 4.6.0",
  "solana-message",
@@ -8262,7 +8262,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smallvec",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-decoder",
  "solana-account-info",
  "solana-accounts-db",
@@ -8391,7 +8391,7 @@ dependencies = [
  "agave-validator",
  "bincode",
  "borsh",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-client-traits",
  "solana-clock",
@@ -9518,7 +9518,7 @@ dependencies = [
  "log",
  "qualifier_attr",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-address-lookup-table-interface",
  "solana-bpf-loader-program",
  "solana-clock",
@@ -9564,7 +9564,7 @@ dependencies = [
 name = "solana-svm-callback"
 version = "4.4.0-alpha.0"
 dependencies = [
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-clock",
  "solana-precompile-error",
  "solana-pubkey 4.3.0",
@@ -9622,7 +9622,7 @@ dependencies = [
  "bincode",
  "libsecp256k1",
  "num-traits",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-account-info",
  "solana-big-mod-exp",
  "solana-blake3-hasher",
@@ -9693,7 +9693,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-fee-calculator",
  "solana-instruction",
@@ -9726,9 +9726,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sysvar"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0214d668b0aab7a64b49e43b7947307985fca4e03d3ef880cd8ee43f52f13a34"
+checksum = "552f9d54ec9597f5a17469df500a1ac345c262e5a9859938ef5e5541844fdac5"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9784,7 +9784,7 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "serde_json",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-accounts-db",
  "solana-bls-signatures",
  "solana-cli-output",
@@ -9931,7 +9931,7 @@ version = "4.4.0-alpha.0"
 dependencies = [
  "bincode",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-instruction",
  "solana-instructions-sysvar 4.0.0",
  "solana-pubkey 4.3.0",
@@ -10146,7 +10146,7 @@ dependencies = [
  "qualifier_attr",
  "rand 0.9.4",
  "serde",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",
@@ -10201,7 +10201,7 @@ dependencies = [
  "agave-feature-set",
  "bincode",
  "log",
- "solana-account 4.5.0",
+ "solana-account 4.6.0",
  "solana-bincode",
  "solana-bls-signatures",
  "solana-clock",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -162,7 +162,7 @@ solana-svm-timings = { path = "../../svm-timings", version = "=4.4.0-alpha.0" }
 solana-svm-transaction = "=5.0.0"
 solana-svm-type-overrides = { path = "../../svm-type-overrides", version = "=4.4.0-alpha.0" }
 solana-system-interface = { version = "=3.3.0", features = ["bincode"] }
-solana-sysvar = "=4.2.0"
+solana-sysvar = "=4.3.0"
 solana-sysvar-id = "=3.1.0"
 solana-test-validator = { path = "../../test-validator", version = "=4.4.0-alpha.0" }
 solana-vote = { path = "../../vote", version = "=4.4.0-alpha.0" }
@@ -188,7 +188,7 @@ agave-reserved-account-keys = { workspace = true }
 agave-validator = { workspace = true }
 bincode = { workspace = true }
 borsh = { workspace = true }
-solana-account = "4.0.0"
+solana-account = "4.6.0"
 solana-account-info = "3.1.0"
 solana-client-traits = "4.0.0"
 solana-clock = "3.0.0"
@@ -226,7 +226,7 @@ solana-svm-timings = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
-solana-sysvar = "4.1.0"
+solana-sysvar = "4.3.0"
 solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-transaction = "4.1.0"
 solana-transaction-error = "3.3.0"


### PR DESCRIPTION
Closes https://github.com/anza-xyz/agave/issues/10672

Updates to `solana-sysvar` and `solana-account` crate versions that have deprecated trait+methods https://github.com/anza-xyz/solana-sdk/pull/873 we are trying to prevent use of.

This concludes the work related to resolving the `SysvarSerialize`  agave+sdk dependency lockstep upgrade issue.