### PR TITLE
chore(ci): make fmt step independently runnable

### DIFF
--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -29,7 +29,7 @@ fi
 _ scripts/check-dev-context-only-utils.sh tree
 
 # fmt
-_ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" fmt --all -- --check
+_ scripts/do-fmt.sh --check
 
 # run cargo check for all rust files in this monorepo for faster turnaround in
 # case of any compilation/build error for nightly

--- a/scripts/do-fmt.sh
+++ b/scripts/do-fmt.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+source ci/rust-version.sh stable
+source ci/rust-version.sh nightly
+
+scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" fmt --all -- "${@}"


### PR DESCRIPTION
#### Problem
can't easily run cargo fmt as it is in ci

#### Summary of Changes
break the command out to its own script
call it from ci

#### Testing
dog, it is the test