### PR TITLE
Defer purge pubkey handling to clean

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1596,8 +1596,8 @@ impl AccountsDb {
 
         self.report_store_stats();
 
-        // purge_slots_from_cache delays handling of pubkeys removed from the cache
-        // to avoid collisions with background threads. Handle any removals here
+        // purge_slots_from_cache delays handling of the pubkeys it removes from the cache
+        // so that the purge path never modifies the accounts index. Handle them here
         let (_, handle_pubkeys_removed_from_cache_us) =
             measure_us!(self.handle_pubkeys_removed_from_cache());
 
@@ -2990,22 +2990,17 @@ impl AccountsDb {
         // P1 purge_slot()                        | N/A
         //          |                             |
         //          V                             |
-        // P2 purge_slots_from_cache()            | map of caches/stores (removes old entry)
+        // P2 purge_slots_from_cache()            | map of caches (removes old entry)
         //          |                             |
         //          V                             |
-        // P3 purge_slots_from_cache()/           | index
-        //       remove_dead_slots_metadata()     | (removes index roots metadata for cached slot)
-        //       purge_slot_storage()/            |
-        //          purge_keys_exact()            | (removes accounts index entries)
-        //          handle_reclaims()             | (removes storage entries)
-        //      OR                                |
-        //    clean_accounts()/                   |
-        //        clean_accounts_older_than_root()| (removes existing store_id, offset for stores)
-        //                                        V
+        // P3 clean_accounts()/                   | index
+        //     handle_pubkeys_removed_from_cache()| (secondary index removal + write-through
+        //                                        |  for pubkeys that P2 removed from the cache)
         //
         // Remarks for purger: So, for any reading operations, it's a race condition
-        // where P2 happens between R1 and R2. In that case, retrying from R1 is safu.
-        // In that case, we may bail at index read retry when P3 hasn't been run
+        // where P2 happens between R1 and R2. In that case, retrying from R1 is safu,
+        // and None would be returned: a purged (unrooted) slot is never present in the
+        // primary index, so P3 (deferred to clean) is not a step readers race with.
 
         #[cfg(test)]
         {
@@ -3297,7 +3292,7 @@ impl AccountsDb {
         self.purge_slots(std::iter::once(&slot));
     }
 
-    /// Purges each slot in `removed_slots` from the write cache, and queues any pubkeys that
+    /// Purges each slot in `removed_slots` from the write cache, and defers any pubkeys that
     /// were fully removed from the write cache to clean to handle removal from the secondary
     /// index. Slots no longer present in the cache are skipped. This never touches backing
     /// storage, so it cannot delete a flushed slot's data. Returns whether any slot was actually
@@ -3326,7 +3321,7 @@ impl AccountsDb {
                     .accounts_cache
                     .remove_slot(*remove_slot)
                     .expect("slot cache entry must still be present");
-                self.queue_pubkeys_removed_from_cache(pubkeys_removed);
+                self.add_pubkeys_removed_from_cache(pubkeys_removed);
             }
         }
 
@@ -3343,10 +3338,10 @@ impl AccountsDb {
         num_cached_slots_removed > 0
     }
 
-    /// Queue any keys that were removed from the cache and need follow-up work by clean
-    /// Only required if secondary indexes are enabled, or disk index is enabled
-    fn queue_pubkeys_removed_from_cache(&self, pubkeys: Vec<Pubkey>) {
-        if self.account_indexes.is_empty() && !self.accounts_index.is_disk_index_enabled() {
+    /// Add any keys that were removed from the cache and need follow-up work by clean
+    /// Only required if secondary indexes are enabled, or write-through is enabled
+    fn add_pubkeys_removed_from_cache(&self, pubkeys: Vec<Pubkey>) {
+        if self.account_indexes.is_empty() && !self.accounts_index.should_write_through() {
             return;
         }
         self.pubkeys_removed_from_cache
@@ -3356,26 +3351,21 @@ impl AccountsDb {
     }
 
     /// For each pubkey in the list:
-    /// 1. write-through to disk if the pubkey is dirty and not present in the cache
-    /// 2. remove the pubkey from the secondary index if it is not present in either teh cache
+    /// 1. remove the pubkey from the secondary index if it is not present in either the cache
     ///    or the index
+    /// 2. write-through to disk if the pubkey is dirty and not present in the cache
     fn handle_pubkeys_removed_from_cache(&self) {
-        let queued = mem::take(&mut *self.pubkeys_removed_from_cache.lock().unwrap());
-        for pubkeys in queued {
+        let pubkeys_removed_from_cache =
+            mem::take(&mut *self.pubkeys_removed_from_cache.lock().unwrap());
+        for mut pubkeys in pubkeys_removed_from_cache {
             if !self.account_indexes.is_empty() {
                 let removed_keys = self.accounts_index.handle_dead_keys(&pubkeys);
                 self.purge_secondary_indexes_for_dead_keys(&removed_keys);
             }
 
-            // If the pubkey hasn't been re-added to the cache in the meantime, write
-            // it to disk
-            for pubkey in pubkeys
-            {
-                if !self.accounts_cache.contains_pubkey(&pubkey)
-                {
-                    self.accounts_index.write_through_pubkeys(vec![pubkey]);
-                }
-            }
+            // Write through any pubkey that hasn't been re-added to the cache in the meantime
+            pubkeys.retain(|pubkey| !self.accounts_cache.contains_pubkey(pubkey));
+            self.accounts_index.write_through_pubkeys(pubkeys);
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3366,7 +3366,16 @@ impl AccountsDb {
                 let removed_keys = self.accounts_index.handle_dead_keys(&pubkeys);
                 self.purge_secondary_indexes_for_dead_keys(&removed_keys);
             }
-            self.accounts_index.write_through_pubkeys(pubkeys);
+
+            // If the pubkey hasn't been re-added to the cache in the meantime, write
+            // it to disk
+            for pubkey in pubkeys
+            {
+                if !self.accounts_cache.contains_pubkey(&pubkey)
+                {
+                    self.accounts_index.write_through_pubkeys(vec![pubkey]);
+                }
+            }
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1208,26 +1208,37 @@ impl AccountsDb {
     ///
     /// Cache writes populate the secondary indexes but not the primary index, so a key that is gone
     /// from the primary index can still be alive in the write cache and must keep its secondary
-    /// entries. This is tricky due to the races that need to be considered:
+    /// entries.
+    ///
+    /// Clean calls this for the keys whose last primary index entry it removed, and for the keys
+    /// that `purge_slots_from_cache` removed from the cache and deferred to
+    /// `handle_pubkeys_removed_from_cache`. Flush calls it for a zero-lamport account that leaves
+    /// the cache without a primary index entry, either skipped or stored as a tombstone and deleted
+    /// from the index. Callers never run concurrently with each other: clean and flush both run on
+    /// the ABS thread and the snapshot minimizer runs standalone, so the only concurrent writer is
+    /// replay. This is tricky due to the races that need to be considered:
     /// 1) Removed from the cache then re-added to the cache by replay
     /// - This is protected by re-checking the cache in the closure passed to purge. Since purge
     ///   holds the secondary index's reverse-index lock when it re-checks cache presence, and a
     ///   cache store writes the cache before inserting into the secondary index under that same
     ///   lock, either the re-check sees the cache write and the entry is not removed, or the
     ///   removal wins and the store's later insert re-adds it.
-    /// 2) Removed from the cache, and also removed from storage by clean
-    /// - Since both the cache removal and the index removal are done before the removal from the
+    /// 2) The same key is handled twice, e.g. flush purges a tombstoned key that clean then purges
+    ///    again from the deferred list
+    /// - Since the cache removal and the index removal are both done before the removal from the
     ///   secondary index, the worst case is a double removal (both paths remove the same secondary
     ///   index entry). This is safe since the secondary index removal is idempotent.
-    /// 3) Removed from the storage, but still present in the cache
+    /// 3) Removed from the primary index, but still present in the cache
     /// - This is protected by checking the cache presence in the closure. If the pubkey is still
-    ///   present in the cache, the secondary index entry is not removed.
-    ///
-    /// We do not need to consider removed from cache -> added to storage. Adding to storage
-    /// requires a cache entry to be present first, so a fresh store of the key would have to be
-    /// rooted and flushed inside this window — impossible because rooting is driven by the same
-    /// ReplayStage thread that purges unrooted slots, and clean runs serially with flush on the
-    /// ABS thread.
+    ///   present in the cache, the secondary index entry is not removed. It is purged when the key
+    ///   later leaves the cache: by flush if the key is skipped or tombstoned, otherwise by the
+    ///   deferred handling in clean.
+    /// 4) A deferred key is re-added to the cache, rooted, and flushed to storage before clean
+    ///    handles it
+    /// - The deferred keys are passed through `handle_dead_keys` first, which yields a key only
+    ///   when its slot list is absent or empty, checked under the key's index entry lock. A key
+    ///   that regained a primary index entry in the deferral window is not yielded, and flush
+    ///   cannot add one while clean is running since both run on the ABS thread.
     fn purge_secondary_indexes_for_dead_keys<'a>(
         &self,
         removed_keys: impl IntoIterator<Item = &'a Pubkey>,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -912,6 +912,10 @@ pub struct AccountsDb {
     /// Populated when flushing the accounts write cache
     uncleaned_pubkeys: DashMap<Slot, Vec<Pubkey>, BuildNoHashHasher<Slot>>,
 
+    /// Pubkeys of the slots purged from the write cache, one entry per purged slot, waiting to be
+    /// cleaned
+    pubkeys_removed_from_cache: Mutex<Vec<Vec<Pubkey>>>,
+
     #[cfg(test)]
     load_delay: u64,
 
@@ -1085,6 +1089,7 @@ impl AccountsDb {
             storage: AccountStorage::default(),
             accounts_cache: AccountsCache::default(),
             uncleaned_pubkeys: DashMap::default(),
+            pubkeys_removed_from_cache: Mutex::default(),
             next_id: AtomicAccountsFileId::new(0),
             shrink_candidate_slots: Mutex::new(ShrinkCandidates::default()),
             write_version: AtomicU64::new(0),
@@ -1210,7 +1215,7 @@ impl AccountsDb {
     ///   cache store writes the cache before inserting into the secondary index under that same
     ///   lock, either the re-check sees the cache write and the entry is not removed, or the
     ///   removal wins and the store's later insert re-adds it.
-    /// 2) Removed from the cache, and also simultaneously removed from storage by clean
+    /// 2) Removed from the cache, and also removed from storage by clean
     /// - Since both the cache removal and the index removal are done before the removal from the
     ///   secondary index, the worst case is a double removal (both paths remove the same secondary
     ///   index entry). This is safe since the secondary index removal is idempotent.
@@ -1591,6 +1596,11 @@ impl AccountsDb {
 
         self.report_store_stats();
 
+        // purge_slots_from_cache delays handling of pubkeys removed from the cache
+        // to avoid collisions with background threads. Handle any removals here
+        let (_, handle_pubkeys_removed_from_cache_us) =
+            measure_us!(self.handle_pubkeys_removed_from_cache());
+
         let active_guard = self
             .active_stats
             .activate(ActiveStatItem::CleanConstructCandidates);
@@ -1728,6 +1738,11 @@ impl AccountsDb {
                 i64
             ),
             ("construct_candidates_us", measure_construct_candidates.as_us(), i64),
+            (
+                "handle_pubkeys_removed_from_cache_us",
+                handle_pubkeys_removed_from_cache_us,
+                i64
+            ),
             ("accounts_scan", accounts_scan.as_us(), i64),
             ("clean_old_rooted", clean_old_rooted.as_us(), i64),
             (
@@ -3282,7 +3297,8 @@ impl AccountsDb {
         self.purge_slots(std::iter::once(&slot));
     }
 
-    /// Purges each slot in `removed_slots` from the write cache and potentially the secondary
+    /// Purges each slot in `removed_slots` from the write cache, and queues any pubkeys that
+    /// were fully removed from the write cache to clean to handle removal from the secondary
     /// index. Slots no longer present in the cache are skipped. This never touches backing
     /// storage, so it cannot delete a flushed slot's data. Returns whether any slot was actually
     /// removed from the cache. This allows the snapshot minimizer to determine whether
@@ -3298,8 +3314,7 @@ impl AccountsDb {
         for remove_slot in removed_slots {
             // This function runs in parallel with the ABS operations (flush, shrink, clean) and
             // must be safe with respect to them. ABS operations will not operate on this slot as
-            // it is unrooted (unless the snapshot minimizer is being used), but pubkey operations
-            // must be safe with respect to collisions (eg. write_through and handle_dead_keys)
+            // it is unrooted (unless the snapshot minimizer is being used).
             let mut remove_cache_elapsed = Measure::start("remove_cache_elapsed");
             if let Some(slot_cache) = self.accounts_cache.slot_cache(*remove_slot) {
                 num_cached_slots_removed += 1;
@@ -3311,12 +3326,7 @@ impl AccountsDb {
                     .accounts_cache
                     .remove_slot(*remove_slot)
                     .expect("slot cache entry must still be present");
-                // Potentially purge the secondary entries for any key that has now left the cache
-                if !self.account_indexes.is_empty() {
-                    let removed_keys = self.accounts_index.handle_dead_keys(&pubkeys_removed);
-                    self.purge_secondary_indexes_for_dead_keys(&removed_keys);
-                }
-                self.accounts_index.write_through_pubkeys(pubkeys_removed);
+                self.queue_pubkeys_removed_from_cache(pubkeys_removed);
             }
         }
 
@@ -3331,6 +3341,33 @@ impl AccountsDb {
             .fetch_add(total_removed_cached_bytes, Ordering::Relaxed);
 
         num_cached_slots_removed > 0
+    }
+
+    /// Queue any keys that were removed from the cache and need follow-up work by clean
+    /// Only required if secondary indexes are enabled, or disk index is enabled
+    fn queue_pubkeys_removed_from_cache(&self, pubkeys: Vec<Pubkey>) {
+        if self.account_indexes.is_empty() && !self.accounts_index.is_disk_index_enabled() {
+            return;
+        }
+        self.pubkeys_removed_from_cache
+            .lock()
+            .unwrap()
+            .push(pubkeys);
+    }
+
+    /// For each pubkey in the list:
+    /// 1. write-through to disk if the pubkey is dirty and not present in the cache
+    /// 2. remove the pubkey from the secondary index if it is not present in either teh cache
+    ///    or the index
+    fn handle_pubkeys_removed_from_cache(&self) {
+        let queued = mem::take(&mut *self.pubkeys_removed_from_cache.lock().unwrap());
+        for pubkeys in queued {
+            if !self.account_indexes.is_empty() {
+                let removed_keys = self.accounts_index.handle_dead_keys(&pubkeys);
+                self.purge_secondary_indexes_for_dead_keys(&removed_keys);
+            }
+            self.accounts_index.write_through_pubkeys(pubkeys);
+        }
     }
 
     /// Purges every slot in `removed_slots` from both the cache and storage. This includes

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -564,8 +564,9 @@ fn test_flush_does_not_write_through_when_write_through_disabled() {
 }
 
 /// The dead-slot purge path removes only the purged slot's index entries, so a pubkey with
-/// a surviving dirty single-ref entry at another slot must be written through when the purge
-/// drops its last cached slot.
+/// a surviving dirty single-ref entry at another slot must be written through once the purge
+/// drops its last cached slot. To avoid contention the write-through is queued for the clean
+/// thread to handle.
 #[test]
 fn test_purge_unrooted_slot_writes_through_surviving_entry() {
     let db = AccountsDb::new_for_tests_with_config(
@@ -614,16 +615,18 @@ fn test_purge_unrooted_slot_writes_through_surviving_entry() {
 
     // Purge the unrooted slot 1 from the cache. `purge_slot_cache` removes only the slot-1
     // entry, leaving the slot-0 entry as a single-ref dirty entry; the pubkey leaves the cache
-    // entirely, so the purge path's write-through fires on that surviving entry exactly once.
+    // entirely, so it is queued for write-through, but nothing is written yet.
     db.remove_unrooted_slots(&[(1, 1)]);
     assert!(
-        !is_dirty_in_mem(&pubkey),
-        "should be clean after purge writes through the surviving entry"
+        is_dirty_in_mem(&pubkey),
+        "still dirty until clean drains the queue"
     );
-    assert_eq!(
-        immediate_disk_writes(),
-        baseline_writes + 1,
-        "purge path must write through the surviving single-ref entry exactly once"
+
+    // Clean drains the queue and writes through the surviving entry exactly once.
+    db.clean_accounts_for_tests();
+    assert!(
+        !is_dirty_in_mem(&pubkey),
+        "should be clean after clean writes through the surviving entry"
     );
 }
 
@@ -682,14 +685,53 @@ fn test_remove_unrooted_slot_purges_secondary_index_for_cache_only_account() {
         Some(1)
     );
 
-    // Dropping the unrooted slot must reclaim the secondary entry, not leak it.
+    // Dropping the unrooted slot queues the key, and the following clean must reclaim the
+    // secondary entry, not leak it.
     db.remove_unrooted_slots(&[(slot, bank_id)]);
     assert!(!db.accounts_cache.contains_pubkey(&pubkey));
+    db.clean_accounts_for_tests();
     assert_eq!(
         db.accounts_index
             .get_index_key_size(&AccountIndex::ProgramId, &owner),
         None
     );
+}
+
+/// A pubkey queued by `remove_unrooted_slots` can be stored again, rooted and flushed before the
+/// next clean drains the queue. The key is alive in the primary index at that point and no longer
+/// in the write cache, clean must not purge its secondary index entry.
+#[test]
+fn test_purged_pubkey_restored_before_clean_keeps_secondary_index() {
+    let db = AccountsDb {
+        account_indexes: program_id_index_enabled(),
+        ..AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG)
+    };
+
+    let owner = Pubkey::new_unique();
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &owner);
+
+    // Store the pubkey in an unrooted slot, then purge that slot. The pubkey is queued for clean,
+    // and has no primary index entry at all.
+    db.store_for_tests((1, &[(&pubkey, &account)][..]));
+    db.remove_unrooted_slots(&[(1, 1)]);
+    assert!(!db.accounts_index.contains(&pubkey));
+
+    // Store the pubkey again and flush it to storage, which creates an entry in the accounts index
+    db.store_for_tests((2, &[(&pubkey, &account)][..]));
+    db.add_root_and_flush_write_cache(2);
+    assert!(!db.accounts_cache.contains_pubkey(&pubkey));
+
+    db.clean_accounts_for_tests();
+
+    // Assert that the pubkey is still in the secondary index
+    assert_eq!(
+        db.accounts_index
+            .get_index_key_pubkeys(&IndexKey::ProgramId(owner)),
+        vec![pubkey],
+        "clean purged the secondary index entry of a key that was stored again"
+    );
+    db.assert_load_account(2, pubkey, 1);
 }
 
 // Test that removing a rooted storage works correctly. This is behaviour specific to
@@ -1869,9 +1911,10 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
 
     accounts.purge_slots_from_cache(iter::once(&cache_slot), &PurgeStats::default());
 
-    // The pubkey has been removed from both the index and the write cache. Ensure it is
-    // removed from the secondary index as well.
+    // The pubkey has been removed from both the index and the write cache. The purge only queued
+    // it, so the following clean must remove it from the secondary index as well.
     assert!(!accounts.accounts_cache.contains_pubkey(&pubkey));
+    accounts.clean_accounts_for_tests();
     assert_eq!(
         accounts
             .accounts_index

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -565,8 +565,7 @@ fn test_flush_does_not_write_through_when_write_through_disabled() {
 
 /// The dead-slot purge path removes only the purged slot's index entries, so a pubkey with
 /// a surviving dirty single-ref entry at another slot must be written through once the purge
-/// drops its last cached slot. To avoid contention the write-through is queued for the clean
-/// thread to handle.
+/// drops its last cached slot. The write-through is deferred to the clean thread.
 #[test]
 fn test_purge_unrooted_slot_writes_through_surviving_entry() {
     let db = AccountsDb::new_for_tests_with_config(
@@ -615,14 +614,14 @@ fn test_purge_unrooted_slot_writes_through_surviving_entry() {
 
     // Purge the unrooted slot 1 from the cache. `purge_slot_cache` removes only the slot-1
     // entry, leaving the slot-0 entry as a single-ref dirty entry; the pubkey leaves the cache
-    // entirely, so it is queued for write-through, but nothing is written yet.
+    // entirely, so its write-through is deferred to clean; nothing is written yet.
     db.remove_unrooted_slots(&[(1, 1)]);
     assert!(
         is_dirty_in_mem(&pubkey),
-        "still dirty until clean drains the queue"
+        "still dirty until clean writes it through"
     );
 
-    // Clean drains the queue and writes through the surviving entry exactly once.
+    // Clean writes through the surviving entry exactly once.
     db.clean_accounts_for_tests();
     assert!(
         !is_dirty_in_mem(&pubkey),
@@ -685,8 +684,8 @@ fn test_remove_unrooted_slot_purges_secondary_index_for_cache_only_account() {
         Some(1)
     );
 
-    // Dropping the unrooted slot queues the key, and the following clean must reclaim the
-    // secondary entry, not leak it.
+    // Dropping the unrooted slot defers the key to clean, and the following clean must reclaim
+    // the secondary entry, not leak it.
     db.remove_unrooted_slots(&[(slot, bank_id)]);
     assert!(!db.accounts_cache.contains_pubkey(&pubkey));
     db.clean_accounts_for_tests();
@@ -697,9 +696,9 @@ fn test_remove_unrooted_slot_purges_secondary_index_for_cache_only_account() {
     );
 }
 
-/// A pubkey queued by `remove_unrooted_slots` can be stored again, rooted and flushed before the
-/// next clean drains the queue. The key is alive in the primary index at that point and no longer
-/// in the write cache, clean must not purge its secondary index entry.
+/// A pubkey deferred to clean by `remove_unrooted_slots` can be stored again, rooted and flushed
+/// before the next clean handles it. The key is alive in the primary index at that point and no
+/// longer in the write cache, clean must not purge its secondary index entry.
 #[test]
 fn test_purged_pubkey_restored_before_clean_keeps_secondary_index() {
     let db = AccountsDb {
@@ -711,8 +710,8 @@ fn test_purged_pubkey_restored_before_clean_keeps_secondary_index() {
     let pubkey = Pubkey::new_unique();
     let account = AccountSharedData::new(1, 0, &owner);
 
-    // Store the pubkey in an unrooted slot, then purge that slot. The pubkey is queued for clean,
-    // and has no primary index entry at all.
+    // Store the pubkey in an unrooted slot, then purge that slot. The pubkey is deferred to
+    // clean, and has no primary index entry at all.
     db.store_for_tests((1, &[(&pubkey, &account)][..]));
     db.remove_unrooted_slots(&[(1, 1)]);
     assert!(!db.accounts_index.contains(&pubkey));
@@ -1911,8 +1910,8 @@ fn test_clean_retains_secondary_index_for_still_cached_key() {
 
     accounts.purge_slots_from_cache(iter::once(&cache_slot), &PurgeStats::default());
 
-    // The pubkey has been removed from both the index and the write cache. The purge only queued
-    // it, so the following clean must remove it from the secondary index as well.
+    // The pubkey has been removed from both the index and the write cache. The purge only
+    // deferred it, so the following clean must remove it from the secondary index as well.
     assert!(!accounts.accounts_cache.contains_pubkey(&pubkey));
     accounts.clean_accounts_for_tests();
     assert_eq!(

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -254,6 +254,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.storage.storage.is_disk_index_enabled()
     }
 
+    /// If true, dirty entries are flushed to disk once `slot_list.len() == 1`, making them
+    /// evictable
+    pub(crate) fn should_write_through(&self) -> bool {
+        self.storage.storage.should_write_through()
+    }
+
     /// Gets the index's entry for `pubkey` and applies `callback` to it
     ///
     /// If `callback`'s boolean return value is true, add this entry to the in-mem cache.

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -254,8 +254,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         self.storage.storage.is_disk_index_enabled()
     }
 
-    /// If true, dirty entries are flushed to disk once `slot_list.len() == 1`, making them
-    /// evictable
+    /// If true, dirty entries are flushed to disk once they exit the write cache
     pub(crate) fn should_write_through(&self) -> bool {
         self.storage.storage.should_write_through()
     }


### PR DESCRIPTION
#### Problem
Index handling and secondary index handling in threads other than the ABS is complex. It is easier to ensure it is handled entirely in the background threads. 

#### Summary of Changes
- In purge_slots_from_cache, add an pubkeys that were removed from the cache entirely to a queue for clean to handle
- In clean, perform the same handling as before: handle write-through and remove from the secondary index if the key is not present in the accounts index or the write cache index. 

#### Testing


Fixes #
