### PR TITLE
replay: allow execution of leader banks after SwitchBank

### DIFF
--- a/core/src/banking_simulation.rs
+++ b/core/src/banking_simulation.rs
@@ -487,7 +487,8 @@ impl SimulatorLoop {
                     info!("new leader bank slot: {new_slot}");
                 }
                 let new_bank =
-                    Bank::new_from_parent(bank.clone_without_scheduler(), new_leader, new_slot);
+                    Bank::new_from_parent(bank.clone_without_scheduler(), new_leader, new_slot)
+                        .mark_leader_bank();
                 if *bank.leader_id() == self.simulated_leader {
                     logger.log_frozen_bank_cost(&bank, bank_created.elapsed());
                 }

--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1332,7 +1332,8 @@ fn create_and_insert_leader_bank(
         ctx.rpc_subscriptions.as_deref(),
         &ctx.slot_status_notifier,
         NewBankOptions::default(),
-    );
+    )
+    .mark_leader_bank();
     // make sure parent is frozen for finalized hashes via the above
     // new()-ing of its child bank
     ctx.banking_tracer.hash_event(
@@ -1659,6 +1660,7 @@ mod tests {
         assert!(ctx.bank_forks.read().unwrap().get(1).is_some());
 
         let bank = ctx.poh_recorder.read().unwrap().bank().unwrap();
+        assert!(!bank.should_replay_from_blockstore());
         let in_flight_commit = bank.freeze_lock();
         ctx.record_receiver.shutdown();
         for _ in ctx.record_receiver.drain_after_shutdown() {}

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1093,10 +1093,13 @@ impl ReplayStage {
                     let mut process_switch_bank_events_time =
                         Measure::start("process_switch_bank_events_time");
                     // BCL inserts its bank before publishing it to PoH, so check both states.
-                    let has_active_leader_bank =
-                        bank_forks.read().unwrap().banks().values().any(|bank| {
-                            !bank.is_frozen() && Self::leader_is_me(bank.leader_id(), &my_pubkey)
-                        }) || poh_shared_leader_state.load().working_bank().is_some();
+                    let has_active_leader_bank = bank_forks
+                        .read()
+                        .unwrap()
+                        .banks()
+                        .values()
+                        .any(|bank| !bank.is_frozen() && !bank.should_replay_from_blockstore())
+                        || poh_shared_leader_state.load().working_bank().is_some();
                     if !has_active_leader_bank {
                         Self::process_switch_bank_events(
                             &my_pubkey,
@@ -3008,7 +3011,8 @@ impl ReplayStage {
                 rpc_subscriptions,
                 slot_status_notifier,
                 NewBankOptions { vote_only_bank },
-            );
+            )
+            .mark_leader_bank();
             // make sure parent is frozen for finalized hashes via the above
             // new()-ing of its child bank
             banking_tracer.hash_event(parent.slot(), &parent.last_blockhash(), &parent.hash());
@@ -3701,7 +3705,6 @@ impl ReplayStage {
         my_shred_version: u16,
         process_active_banks_context: &ProcessActiveBanksContext,
         bank_replay_result_tracker: BankReplayResultTracker,
-        my_pubkey: &Pubkey,
         finalization_cert_sender: &Sender<SmallVec<[Certificate; 2]>>,
     ) -> (ReplaySlotFromBlockstore, Option<u64>) {
         let BankReplayResultTracker {
@@ -3718,7 +3721,7 @@ impl ReplayStage {
             replay_progress,
         } = bank_replay_tracker;
 
-        if Self::leader_is_me(bank.leader_id(), my_pubkey) {
+        if !bank.should_replay_from_blockstore() {
             return (replay_result, None);
         }
 
@@ -3764,10 +3767,7 @@ impl ReplayStage {
         (replay_result, Some(replay_blockstore_time.as_us()))
     }
 
-    /// Live replay must not execute this validator's own leader banks from
-    /// blockstore. Those banks are driven by BankingStage/PoH while the node is
-    /// live; already-recorded own slots are replayed by startup ledger replay
-    /// before ReplayStage starts.
+    /// Returns whether `slot_leader` is this validator.
     fn leader_is_me(slot_leader: &Pubkey, my_pubkey: &Pubkey) -> bool {
         slot_leader == my_pubkey
     }
@@ -3777,7 +3777,6 @@ impl ReplayStage {
         process_active_banks_context: &ProcessActiveBanksContext,
         bank_replay_result_trackers: Vec<BankReplayResultTracker>,
         replay_timing: &mut ReplayLoopTiming,
-        my_pubkey: &Pubkey,
         finalization_cert_sender: &Sender<SmallVec<[Certificate; 2]>>,
     ) -> Vec<ReplaySlotFromBlockstore> {
         match &process_active_banks_context.replay_mode {
@@ -3800,7 +3799,6 @@ impl ReplayStage {
                                         my_shred_version,
                                         process_active_banks_context,
                                         bank_replay_result_tracker,
-                                        my_pubkey,
                                         finalization_cert_sender,
                                     );
                                 if let Some(replay_blockstore_us) = replay_blockstore_us {
@@ -3829,7 +3827,6 @@ impl ReplayStage {
                         my_shred_version,
                         process_active_banks_context,
                         bank_replay_result_tracker,
-                        my_pubkey,
                         finalization_cert_sender,
                     );
                     if let Some(replay_blockstore_us) = replay_blockstore_us {
@@ -4049,7 +4046,7 @@ impl ReplayStage {
                     .blockstore
                     .get_block_id(bank.slot(), &process_active_banks_context.migration_status)
                     .expect("Blockstore operations must succeed");
-                debug_assert!(block_id.is_some() || is_leader_block);
+                debug_assert!(block_id.is_some() || !bank.should_replay_from_blockstore());
                 if block_id.is_some() {
                     bank.set_block_id(block_id);
                 }
@@ -4341,7 +4338,6 @@ impl ReplayStage {
             process_active_banks_context,
             bank_replay_result_trackers,
             replay_timing,
-            my_pubkey,
             finalization_cert_sender,
         );
 
@@ -5376,10 +5372,10 @@ impl ReplayStage {
                     .slot_leader_at(child_slot, Some(parent_bank))
                     .unwrap();
 
-                // Live ReplayStage should never create banks for our own
-                // leader slots. BCL/PoH own live block production, and startup
-                // replay handles any already-recorded own blocks after restart.
-                if Self::leader_is_me(&leader.id, my_pubkey) {
+                // We don't create the bank here for live leader banks, as that is handled by BCL
+                // and BankingStage. However, a full block may need to be replayed after a
+                // SwitchBank event or after repairing a block following a improper set-identity command.
+                if Self::leader_is_me(&leader.id, my_pubkey) && !blockstore.is_full(child_slot) {
                     trace!("skipping replay bank creation for own leader slot {child_slot}");
                     continue;
                 }

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -3966,7 +3966,7 @@ fn test_latest_parent_coalesces() {
 }
 
 #[test]
-fn test_skip_own_update_full() {
+fn test_replay_own_update_full() {
     let (vote_simulator, blockstore) = setup_forks_from_tree(tr(0), 1, None::<GenerateVotes>);
     let VoteSimulator {
         bank_forks,
@@ -4016,11 +4016,18 @@ fn test_skip_own_update_full() {
         &mut replay_timing,
     );
 
-    assert!(
-        bank_forks.read().unwrap().get(slot).is_none(),
-        "live replay must not create own leader banks from blockstore"
+    let bank = bank_forks.read().unwrap().get(slot).unwrap();
+    assert!(bank.should_replay_from_blockstore());
+    assert_eq!(
+        progress
+            .get(&slot)
+            .unwrap()
+            .replay_progress
+            .read()
+            .unwrap()
+            .num_shreds,
+        u64::from(replay_fec_set_index),
     );
-    assert!(progress.get(&slot).is_none());
 }
 
 #[test]

--- a/core/src/replay_stage/update_parent.rs
+++ b/core/src/replay_stage/update_parent.rs
@@ -148,7 +148,7 @@ fn try_restart_slot_from_update_parent(
         return false;
     }
     if bank.as_ref().is_some_and(|bank| {
-        ReplayStage::leader_is_me(bank.leader_id(), my_pubkey)
+        !bank.should_replay_from_blockstore()
             || !bank.feature_set.snapshot().alpenglow_fast_leader_handover
     }) {
         return false;

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -690,6 +690,7 @@ impl PartialEq for Bank {
             drop_callback: _,
             freeze_started: _,
             vote_only_bank: _,
+            should_replay_from_blockstore: _,
             cost_tracker: _,
             accounts_data_size_initial: _,
             accounts_data_size_delta_on_chain: _,
@@ -1004,6 +1005,11 @@ pub struct Bank {
 
     vote_only_bank: bool,
 
+    /// Whether ReplayStage should execute this bank from blockstore.
+    /// This defaults to true. Banks created for local block production opt out because BankingStage
+    /// executes them instead.
+    should_replay_from_blockstore: bool,
+
     cost_tracker: RwLock<CostTracker>,
 
     /// The initial accounts data size at the start of this Bank, before processing any transactions/etc
@@ -1251,6 +1257,7 @@ impl Bank {
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::default(),
             vote_only_bank: false,
+            should_replay_from_blockstore: true,
             cost_tracker: RwLock::<CostTracker>::default(),
             accounts_data_size_initial: 0,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
@@ -1479,6 +1486,7 @@ impl Bank {
             fee_rate_governor,
             capitalization: AtomicU64::new(parent.capitalization()),
             vote_only_bank,
+            should_replay_from_blockstore: true,
             inflation: parent.inflation.clone(),
             transaction_count: AtomicU64::new(parent.transaction_count()),
             non_vote_transaction_count_since_restart: AtomicU64::new(
@@ -1918,6 +1926,16 @@ impl Bank {
         self.vote_only_bank
     }
 
+    pub fn should_replay_from_blockstore(&self) -> bool {
+        self.should_replay_from_blockstore
+    }
+
+    // Indicate that this bank is a live leader bank
+    pub fn mark_leader_bank(mut self) -> Self {
+        self.should_replay_from_blockstore = false;
+        self
+    }
+
     /// Like `new_from_parent` but additionally:
     /// * Doesn't assume that the parent is anywhere near `slot`, parent could be millions of slots
     ///   in the past
@@ -2170,6 +2188,7 @@ impl Bank {
             drop_callback: RwLock::new(OptionalDropCallback(None)),
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
             vote_only_bank: false,
+            should_replay_from_blockstore: true,
             cost_tracker: RwLock::new(CostTracker::default()),
             accounts_data_size_initial,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),


### PR DESCRIPTION
#### Problem
As stated by the AG bug bounty report

Normally leader banks (collector_id = my_pubkey) are never replayed via ReplayStage, and instead handled by BankingStage.
However in Alpenglow, we could process a SwitchBank event that clears the leader bank, and then another SwitchBank that reinserts it.

After reinsertion the bank will not be replayed by either thread and we will be stuck. This situation is extremely rare as it requires a valid duplicate block with 2 or more votable versions and specific timing. The stall only affects the leader. 

Additionally in TowerBFT if you misuse `set-identity` before your node has caught up, it could be stuck trying to replay a repaired leader bank, this is also addressed by this fix. 

#### Summary of Changes
Add a field to Bank `should_replay_from_blockstore` indicating whether this is a live leader bank or not. In the future it would probably make sense to create a separate LeaderBank type. 

This is set to false only for banks inserted for BankingStage.