### PR TITLE
fix(poh): bound entry channels with lossless backpressure

### DIFF
--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -27,13 +27,13 @@ use {
     agave_votor::event::VotorEventSender,
     agave_votor_messages::VerifiedVoterSlotsSender,
     agave_xdp::transmitter::XdpSender,
-    crossbeam_channel::{Receiver, bounded, unbounded},
+    crossbeam_channel::{Receiver, bounded},
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
     solana_ledger::{blockstore::Blockstore, entry_notifier_service::EntryNotifierSender},
     solana_poh::{
-        poh_recorder::{PohRecorder, WorkingBankEntryOrMarker},
+        poh_recorder::{PohRecorder, WORKING_BANK_CHANNEL_CAPACITY, WorkingBankEntryOrMarker},
         transaction_recorder::TransactionRecorder,
     },
     solana_pubkey::Pubkey,
@@ -346,7 +346,10 @@ impl Tpu {
 
         let (entry_receiver, tpu_entry_notifier) =
             if let Some(entry_notification_sender) = entry_notification_sender {
-                let (broadcast_entry_sender, broadcast_entry_receiver) = unbounded();
+                // Preserve every entry while bounding memory. If BroadcastStage falls behind,
+                // the notifier blocks here and propagates backpressure to PohRecorder.
+                let (broadcast_entry_sender, broadcast_entry_receiver) =
+                    bounded(WORKING_BANK_CHANNEL_CAPACITY);
                 let tpu_entry_notifier = TpuEntryNotifier::new(
                     entry_receiver,
                     entry_notification_sender,

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -1,10 +1,12 @@
 use {
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
+    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
     solana_clock::BankId,
     solana_entry::{
         block_component::VersionedBlockMarker, entry::EntrySummary, entry_or_marker::EntryOrMarker,
     },
-    solana_ledger::entry_notifier_service::{EntryNotification, EntryNotifierSender},
+    solana_ledger::entry_notifier_service::{
+        EntryNotification, EntryNotifierSender, send_entry_notification,
+    },
     solana_poh::poh_recorder::WorkingBankEntryOrMarker,
     std::{
         sync::{
@@ -18,6 +20,25 @@ use {
 
 pub(crate) struct TpuEntryNotifier {
     thread_hdl: JoinHandle<()>,
+}
+
+/// Try the nonblocking fast path first so saturation is observable, then block
+/// rather than dropping an entry on its way to BroadcastStage.
+fn send_broadcast_entry(
+    sender: &Sender<WorkingBankEntryOrMarker>,
+    entry: WorkingBankEntryOrMarker,
+) -> Result<(), Box<SendError<WorkingBankEntryOrMarker>>> {
+    match sender.try_send(entry) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(entry)) => {
+            log::error!(
+                "TPU entry notifier to BroadcastStage channel is full; blocking to preserve the \
+                 entry"
+            );
+            sender.send(entry).map_err(Box::new)
+        }
+        Err(TrySendError::Disconnected(entry)) => Err(Box::new(SendError(entry))),
+    }
 }
 
 impl TpuEntryNotifier {
@@ -86,13 +107,16 @@ impl TpuEntryNotifier {
                     hash: entry.hash,
                     num_transactions: entry.transactions.len() as u64,
                 };
-                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
-                    slot,
-                    bank_id,
-                    index,
-                    entry: entry_summary,
-                    starting_transaction_index: *current_transaction_index,
-                }) {
+                if let Err(err) = send_entry_notification(
+                    entry_notification_sender,
+                    EntryNotification::Entry {
+                        slot,
+                        bank_id,
+                        index,
+                        entry: entry_summary,
+                        starting_transaction_index: *current_transaction_index,
+                    },
+                ) {
                     warn!(
                         "Failed to send slot {slot:?} entry {index:?} from Tpu to \
                          EntryNotifierService, error {err:?}",
@@ -103,12 +127,14 @@ impl TpuEntryNotifier {
             }
             EntryOrMarker::Marker(VersionedBlockMarker::V1(marker)) => {
                 if let Some(block_footer) = marker.as_block_footer()
-                    && let Err(err) =
-                        entry_notification_sender.send(EntryNotification::BlockFooter {
+                    && let Err(err) = send_entry_notification(
+                        entry_notification_sender,
+                        EntryNotification::BlockFooter {
                             slot,
                             bank_id,
                             block_footer: Box::new(block_footer.clone()),
-                        })
+                        },
+                    )
                 {
                     warn!(
                         "Failed to send slot {slot:?} block footer from Tpu to \
@@ -118,7 +144,10 @@ impl TpuEntryNotifier {
             }
         }
 
-        if let Err(err) = broadcast_entry_sender.send((bank, (entry_or_marker, tick_height))) {
+        if let Err(err) = send_broadcast_entry(
+            broadcast_entry_sender,
+            (bank, (entry_or_marker, tick_height)),
+        ) {
             warn!(
                 "Failed to send slot {slot:?} entry/marker {index:?} from Tpu to BroadcastStage, \
                  error {err:?}",

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3,7 +3,7 @@ use {
         block_error::BlockError,
         blockstore::{Blockstore, BlockstoreError},
         blockstore_meta::SlotMeta,
-        entry_notifier_service::{EntryNotification, EntryNotifierSender},
+        entry_notifier_service::{EntryNotification, EntryNotifierSender, send_entry_notification},
         leader_schedule_cache::LeaderScheduleCache,
         shred::MAX_FEC_SETS_PER_SLOT,
         thread_pool::{WorkerJob, WorkerPool},
@@ -1495,12 +1495,14 @@ pub fn confirm_slot(
                         })?;
                     if let Some(block_footer) = block_footer
                         && let Some(entry_notification_sender) = entry_notification_sender
-                        && let Err(err) =
-                            entry_notification_sender.send(EntryNotification::BlockFooter {
+                        && let Err(err) = send_entry_notification(
+                            entry_notification_sender,
+                            EntryNotification::BlockFooter {
                                 slot,
                                 bank_id: bank.bank_id(),
                                 block_footer: Box::new(block_footer),
-                            })
+                            },
+                        )
                     {
                         warn!(
                             "Slot {slot} block footer entry_notification_sender send failed: \
@@ -1563,13 +1565,16 @@ fn confirm_slot_entries(
         .map(|(i, entry)| {
             if let Some(entry_notification_sender) = entry_notification_sender {
                 let entry_index = progress.num_entries.saturating_add(i);
-                if let Err(err) = entry_notification_sender.send(EntryNotification::Entry {
-                    slot,
-                    bank_id,
-                    index: entry_index,
-                    entry: entry.into(),
-                    starting_transaction_index: entry_tx_starting_index,
-                }) {
+                if let Err(err) = send_entry_notification(
+                    entry_notification_sender,
+                    EntryNotification::Entry {
+                        slot,
+                        bank_id,
+                        index: entry_index,
+                        entry: entry.into(),
+                        starting_transaction_index: entry_tx_starting_index,
+                    },
+                ) {
                     warn!(
                         "Slot {slot}, entry {entry_index} entry_notification_sender send failed: \
                          {err:?}"

--- a/ledger/src/entry_notifier_service.rs
+++ b/ledger/src/entry_notifier_service.rs
@@ -1,6 +1,6 @@
 use {
     crate::entry_notifier_interface::{EntryNotifierArc, EntryUpdateParentInfo},
-    crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded},
+    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, TrySendError, bounded},
     solana_clock::{BankId, Slot},
     solana_entry::{block_component::VersionedBlockFooter, entry::EntrySummary},
     std::{
@@ -32,6 +32,30 @@ pub enum EntryNotification {
 pub type EntryNotifierSender = Sender<EntryNotification>;
 pub type EntryNotifierReceiver = Receiver<EntryNotification>;
 
+/// Maximum number of entry notifications buffered while a notifier is busy.
+/// Blocking producers on saturation preserves notifications without allowing an
+/// arbitrarily slow notifier to grow validator memory without bound.
+const ENTRY_NOTIFICATION_CHANNEL_CAPACITY: usize = 2048;
+
+/// Try the nonblocking fast path first so saturation is observable, then block
+/// rather than dropping an entry notification.
+pub fn send_entry_notification(
+    sender: &EntryNotifierSender,
+    notification: EntryNotification,
+) -> Result<(), SendError<EntryNotification>> {
+    match sender.try_send(notification) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(notification)) => {
+            log::error!(
+                "EntryNotifier channel is full (capacity {ENTRY_NOTIFICATION_CHANNEL_CAPACITY}); \
+                 blocking to preserve the notification"
+            );
+            sender.send(notification)
+        }
+        Err(TrySendError::Disconnected(notification)) => Err(SendError(notification)),
+    }
+}
+
 pub struct EntryNotifierService {
     sender: EntryNotifierSender,
     thread_hdl: JoinHandle<()>,
@@ -39,7 +63,8 @@ pub struct EntryNotifierService {
 
 impl EntryNotifierService {
     pub fn new(entry_notifier: EntryNotifierArc, exit: Arc<AtomicBool>) -> Self {
-        let (entry_notification_sender, entry_notification_receiver) = unbounded();
+        let (entry_notification_sender, entry_notification_receiver) =
+            bounded(ENTRY_NOTIFICATION_CHANNEL_CAPACITY);
         let thread_hdl = Builder::new()
             .name("solEntryNotif".to_string())
             .spawn(move || {
@@ -177,7 +202,7 @@ mod tests {
 
     #[test]
     fn test_forwards_entry_notifications_in_order() {
-        let (sender, receiver) = unbounded();
+        let (sender, receiver) = bounded(3);
         let notifier = Arc::new(TestEntryNotifier::default());
         let block_footer = VersionedBlockFooter::V1(BlockFooterV1 {
             bank_hash: Hash::new_unique(),

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -21,7 +21,7 @@ use {
         migration::MigrationStatus, reward_certificate::BuildRewardCertsRespError,
     },
     arc_swap::ArcSwap,
-    crossbeam_channel::{Receiver, SendError, Sender, TrySendError, bounded, unbounded},
+    crossbeam_channel::{Receiver, SendError, Sender, TrySendError, bounded},
     log::*,
     solana_clock::{BankId, Slot},
     solana_entry::{
@@ -55,6 +55,32 @@ use {
 
 pub const GRACE_TICKS_FACTOR: u64 = 2;
 pub const MAX_GRACE_SLOTS: u64 = 2;
+
+/// Maximum number of entries waiting to be consumed by the broadcast pipeline.
+///
+/// Sending is intentionally blocking: once a record has been mixed into PoH, its
+/// entry must not be dropped. This capacity absorbs transient downstream stalls;
+/// a sustained stall applies backpressure instead of growing memory without bound.
+pub const WORKING_BANK_CHANNEL_CAPACITY: usize = 2048;
+
+/// Try the nonblocking fast path first so saturation is observable, then block
+/// rather than dropping an entry that has already been mixed into PoH.
+fn send_working_bank_entry(
+    sender: &Sender<WorkingBankEntryOrMarker>,
+    entry: WorkingBankEntryOrMarker,
+) -> std::result::Result<(), Box<SendError<WorkingBankEntryOrMarker>>> {
+    match sender.try_send(entry) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(entry)) => {
+            error!(
+                "PohRecorder output channel is full (capacity {WORKING_BANK_CHANNEL_CAPACITY}); \
+                 blocking to preserve the entry"
+            );
+            sender.send(entry).map_err(Box::new)
+        }
+        Err(TrySendError::Disconnected(entry)) => Err(Box::new(SendError(entry))),
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum PohRecorderError {
@@ -265,7 +291,7 @@ impl PohRecorder {
             tick_number,
         )));
 
-        let (working_bank_sender, working_bank_receiver) = unbounded();
+        let (working_bank_sender, working_bank_receiver) = bounded(WORKING_BANK_CHANNEL_CAPACITY);
         let (leader_first_tick_height, leader_last_tick_height, grace_ticks) =
             Self::compute_leader_slot_tick_heights(next_leader_slot, ticks_per_slot);
         (
@@ -327,12 +353,13 @@ impl PohRecorder {
             .as_mut()
             .ok_or(PohRecorderError::MaxHeightReached)?;
 
-        self.working_bank_sender
-            .send((
+        send_working_bank_entry(
+            &self.working_bank_sender,
+            (
                 working_bank.bank.clone(),
                 (EntryOrMarker::Marker(marker), tick_height),
-            ))
-            .map_err(Box::new)?;
+            ),
+        )?;
 
         Ok(())
     }
@@ -379,8 +406,9 @@ impl PohRecorder {
             drop(poh_lock);
 
             if let Some(entry) = entry {
-                let (send_entry_res, send_entry_us) = measure_us!(
-                    self.working_bank_sender.send((
+                let (send_entry_res, send_entry_us) = measure_us!(send_working_bank_entry(
+                    &self.working_bank_sender,
+                    (
                         working_bank.bank.clone(),
                         (
                             Entry {
@@ -391,10 +419,10 @@ impl PohRecorder {
                             .into(),
                             tick_height,
                         ),
-                    ))
-                );
+                    ),
+                ));
                 self.metrics.send_entry_us += send_entry_us;
-                send_entry_res.map_err(Box::new)?;
+                send_entry_res?;
 
                 return Ok(RecordSummary {
                     remaining_hashes_in_slot,
@@ -614,15 +642,17 @@ impl PohRecorder {
             working_bank.max_tick_height - 1,
         );
 
-        self.working_bank_sender
-            .send((working_bank.bank.clone(), footer_entry_marker))
-            .map_err(|err| {
-                error!(
-                    "slot = {} block production failure. failed to broadcast footer",
-                    working_bank.bank.slot()
-                );
-                PohRecorderError::SendError(Box::new(err))
-            })
+        send_working_bank_entry(
+            &self.working_bank_sender,
+            (working_bank.bank.clone(), footer_entry_marker),
+        )
+        .map_err(|err| {
+            error!(
+                "slot = {} block production failure. failed to broadcast footer",
+                working_bank.bank.slot()
+            );
+            PohRecorderError::SendError(err)
+        })
     }
 
     // Flush cache will delay flushing the cache for a bank until it past the WorkingBank::min_tick_height
@@ -672,10 +702,11 @@ impl PohRecorder {
 
                 let tick = (EntryOrMarker::from(entry.clone()), *tick_height);
 
-                send_result = self
-                    .working_bank_sender
-                    .send((working_bank.bank.clone(), tick))
-                    .map_err(|err| PohRecorderError::SendError(Box::new(err)));
+                send_result = send_working_bank_entry(
+                    &self.working_bank_sender,
+                    (working_bank.bank.clone(), tick),
+                )
+                .map_err(PohRecorderError::SendError);
                 if send_result.is_err() {
                     break;
                 }


### PR DESCRIPTION
#### Problem
- unbounded channels in poh recorder
- crossbeam allocates/frees in 32 item chunks even when this doesn't back up

#### Summary of Changes
- Use bounded channels in poh recorder
- use blocking send:
	- same pattern as used in broadcast so we have visibility if these back up and block us
	- try_send
	- if full: error log
	- send

#### Testing

Fixes #
