### PR TITLE
refactor(runtime): centralize bank removal cleanup

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -1497,11 +1497,7 @@ mod tests {
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
-            let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
-            if let Some(bank) = bank_to_clear {
-                let _ = bank.wait_for_completed_scheduler();
-            }
-            self.bank_forks.write().unwrap().clear_bank(slot, false);
+            BankForks::clear_bank(&self.bank_forks, slot, false);
             Ok(())
         }
     }

--- a/core/src/drop_bank_service.rs
+++ b/core/src/drop_bank_service.rs
@@ -17,10 +17,9 @@ impl DropBankService {
                 for banks in bank_receiver.iter() {
                     let len = banks.len();
                     let mut dropped_banks_time = Measure::start("drop_banks");
-                    // Drop BankWithScheduler with no alive lock to avoid deadlocks. That's because
-                    // BankWithScheduler::drop() could block on transaction execution if unified
-                    // scheduler is installed. As a historical context, it's dropped early inside
-                    // the replaying stage not here and that caused a deadlock for BankForks.
+                    // Keep bank destruction off the replay thread. BankForks completes installed
+                    // schedulers before pruning, but dropping can still cascade through Bank
+                    // parents and defensively waits if a scheduler remains installed.
                     drop(banks);
                     dropped_banks_time.stop();
                     if dropped_banks_time.as_ms() > 10 {

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -52,7 +52,7 @@ use {
     rayon::{ThreadPool, prelude::*},
     smallvec::SmallVec,
     solana_accounts_db::contains::Contains,
-    solana_clock::{BankId, Slot},
+    solana_clock::Slot,
     solana_geyser_plugin_manager::block_metadata_notifier_interface::BlockMetadataNotifierArc,
     solana_gossip::cluster_info::ClusterInfo,
     solana_hash::Hash,
@@ -2288,49 +2288,18 @@ impl ReplayStage {
         let slot_descendants = slot_descendants.unwrap();
         Self::purge_ancestors_descendants(slot_to_purge, &slot_descendants, ancestors, descendants);
 
-        let banks_to_remove: Vec<_> = {
-            let bank_forks = bank_forks.read().unwrap();
-            slot_descendants
-                .iter()
-                .chain(std::iter::once(&slot_to_purge))
-                .filter_map(|slot| bank_forks.get_with_scheduler(*slot))
-                .collect()
-        };
-        for bank in banks_to_remove {
-            let _ = bank.wait_for_completed_scheduler();
-        }
-
         // Grab the Slot and BankId's of the banks we need to purge, then clear the banks
         // from BankForks
-        let (slots_to_purge, removed_banks): (Vec<(Slot, BankId)>, Vec<BankWithScheduler>) = {
-            let mut w_bank_forks = bank_forks.write().unwrap();
-            w_bank_forks.dump_slots(
-                slot_descendants
-                    .iter()
-                    .chain(std::iter::once(&slot_to_purge)),
-                true,
-            )
-        };
-
-        // Clear the accounts for these slots so that any ongoing RPC scans fail.
-        // These have to be atomically cleared together in the same batch, in order
-        // to prevent RPC from seeing inconsistent results in scans.
-        root_bank.remove_unrooted_slots(&slots_to_purge);
-
-        // Once the slots above have been purged, now it's safe to remove the banks from
-        // BankForks, allowing the Bank::drop() purging to run and not race with the
-        // `remove_unrooted_slots()` call.
-        drop(removed_banks);
+        let slots_to_purge = BankForks::dump_slots(
+            bank_forks,
+            slot_descendants
+                .iter()
+                .copied()
+                .chain(std::iter::once(slot_to_purge)),
+            true,
+        );
 
         for (slot, slot_id) in slots_to_purge {
-            // Clear the slot signatures from status cache for this slot.
-            // TODO: What about RPC queries that had already cloned the Bank for this slot
-            // and are looking up the signature for this slot?
-            root_bank.clear_slot_signatures(slot);
-
-            // Remove cached entries of the programs that were deployed in this slot.
-            root_bank.prune_program_cache_by_deployment_slot(slot);
-
             if let Some(bank_hash) = blockstore.get_bank_hash(slot) {
                 // If a descendant was successfully replayed and chained from a duplicate it must
                 // also be a duplicate. In this case we *need* to repair it, so we clear from
@@ -2566,8 +2535,7 @@ impl ReplayStage {
         progress: &mut ProgressMap,
         async_verification_freelist: &mut Vec<AsyncVerificationProgress>,
     ) {
-        let (slots_to_purge, banks_to_clear) =
-            bank_forks.read().unwrap().slots_to_clear(slots_to_clear);
+        let slots_to_purge = bank_forks.read().unwrap().slots_to_clear(slots_to_clear);
         if slots_to_purge.is_empty() {
             return;
         }
@@ -2584,51 +2552,8 @@ impl ReplayStage {
             }
         }
 
-        // Wait for any in progress execution
-        for bank in banks_to_clear.iter() {
-            let _ = bank.wait_for_completed_scheduler();
-        }
-        let bank_slots_to_clear = banks_to_clear
-            .iter()
-            .map(|bank| bank.slot())
-            .collect::<BTreeSet<_>>();
-
-        // Only dump banks that are still present. `slots_to_purge` can also contain slots that
-        // were already removed, but whose shared cache entries still need to be cleared before the
-        // slots are revived.
-        let (root_bank, slot_bank_ids_to_purge, removed_banks) = {
-            let mut w_bank_forks = bank_forks.write().unwrap();
-
-            let root_bank = w_bank_forks.root_bank();
-            let bank_slots_to_clear = bank_slots_to_clear
-                .into_iter()
-                .filter(|slot| w_bank_forks.get(*slot).is_some())
-                .collect::<BTreeSet<_>>();
-            let (slot_bank_ids_to_purge, removed_banks) =
-                w_bank_forks.dump_slots(bank_slots_to_clear.iter(), false);
-            (root_bank, slot_bank_ids_to_purge, removed_banks)
-        };
-
-        // Clear the accounts for these slots so that any ongoing RPC scans fail.
-        // These have to be atomically cleared together in the same batch, in order
-        // to prevent RPC from seeing inconsistent results in scans.
-        if !slot_bank_ids_to_purge.is_empty() {
-            root_bank.remove_unrooted_slots(&slot_bank_ids_to_purge);
-        }
-
-        // Once the slots above have been purged, now it's safe to remove the banks from
-        // BankForks, allowing the Bank::drop() purging to run and not race with the
-        // `remove_unrooted_slots()` call.
-        drop(banks_to_clear);
-        drop(removed_banks);
-
-        // Clear the shared caches even for requested slots whose banks were already removed.
-        // Those slots can be revived by an Alpenglow switch, and stale entries from the old block
-        // version must not affect replay of the new version.
-        for slot in slots_to_purge {
-            root_bank.clear_slot_signatures(slot);
-            root_bank.prune_program_cache_by_deployment_slot(slot);
-        }
+        // `dump_slots` also clears shared cache entries for slots whose banks were already removed.
+        let _ = BankForks::dump_slots(bank_forks, slots_to_purge, false);
     }
 
     fn recycle_async_verification(

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -25,6 +25,7 @@ use {
     solana_accounts_db::accounts_db::{ACCOUNTS_DB_CONFIG_FOR_TESTING, AccountsDbConfig},
     solana_bls_signatures::{BLS_SIGNATURE_AFFINE_SIZE, Signature as BLSSignature},
     solana_client::connection_cache::ConnectionCache,
+    solana_clock::BankId,
     solana_entry::{
         block_component::{
             BlockComponent, BlockFooterV1, BlockHeaderV1, UpdateParentV1, VersionedBlockMarker,
@@ -2807,7 +2808,7 @@ fn test_check_propagation_skip_propagation_check() {
 }
 
 #[test]
-fn test_clear_slots_clears_status_cache_for_removed_bank() {
+fn test_clear_slots_clears_status_cache_for_absent_bank() {
     let VoteSimulator {
         bank_forks,
         node_pubkeys,
@@ -2816,7 +2817,7 @@ fn test_clear_slots_clears_status_cache_for_removed_bank() {
         ..
     } = VoteSimulator::new(1);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
-    let bank1 = Bank::new_from_parent(bank0, SlotLeader::default(), 1);
+    let bank1 = Arc::new(Bank::new_from_parent(bank0, SlotLeader::default(), 1));
     let sender = node_pubkeys[0];
     let transfer_signature = bank1
         .transfer(
@@ -2825,14 +2826,8 @@ fn test_clear_slots_clears_status_cache_for_removed_bank() {
             &Pubkey::new_unique(),
         )
         .unwrap();
-    bank_forks.write().unwrap().insert(bank1);
-    let bank1 = bank_forks.read().unwrap().get(1).unwrap();
     assert!(bank1.get_signature_status(&transfer_signature).is_some());
-
-    let removed_bank = bank_forks.write().unwrap().remove(1).unwrap();
-    drop(removed_bank);
     assert!(bank_forks.read().unwrap().get(1).is_none());
-    assert!(bank1.get_signature_status(&transfer_signature).is_some());
 
     ReplayStage::clear_slots([1], &bank_forks, &mut progress, &mut Vec::new());
 
@@ -4041,9 +4036,9 @@ fn test_purge_anc_desc() {
     // Result should be equivalent to removing slot from BankForks
     // and regenerating the `ancestor` `descendant` maps
     for d in slot_2_descendants {
-        bank_forks.write().unwrap().remove(d);
+        let _removed_bank = BankForks::remove(&bank_forks, d);
     }
-    bank_forks.write().unwrap().remove(2);
+    let _removed_bank = BankForks::remove(&bank_forks, 2);
     assert!(check_map_eq(
         &ancestors,
         &bank_forks.read().unwrap().ancestors()

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2721,14 +2721,22 @@ fn maybe_warp_slot(
         // `RwLock<BankForks>` (deadlock with an exclusive lock).
         let warp_bank = Bank::warp_from_parent(root_bank, SlotLeader::default(), warp_slot);
 
-        let mut bank_forks = bank_forks.write().unwrap();
-        bank_forks.insert(warp_bank);
-        // The bank must have a block id set to take a snapshot.
-        // Also must be set before calling set_root() just incase the warp slot triggers a
-        // snapshot request based on the snapshot config inside snapshot_controller.
-        let warp_bank = bank_forks.get(warp_slot).unwrap();
-        Bank::calculate_and_set_block_id_for_dcou(&warp_bank);
-        bank_forks.set_root(warp_slot, Some(snapshot_controller), Some(warp_slot));
+        {
+            let mut bank_forks = bank_forks.write().unwrap();
+            bank_forks.insert(warp_bank);
+            // The bank must have a block id set to take a snapshot.
+            // Also must be set before calling set_root() just incase the warp slot triggers a
+            // snapshot request based on the snapshot config inside snapshot_controller.
+            let warp_bank = bank_forks.get(warp_slot).unwrap();
+            Bank::calculate_and_set_block_id_for_dcou(&warp_bank);
+        }
+        BankForks::set_root_from_shared(
+            bank_forks,
+            warp_slot,
+            Some(snapshot_controller),
+            Some(warp_slot),
+        );
+        let warp_bank = bank_forks.read().unwrap().get(warp_slot).unwrap();
         leader_schedule_cache.set_root(&warp_bank);
 
         let snapshot_config = SnapshotConfig {
@@ -2747,7 +2755,6 @@ fn maybe_warp_slot(
             full_snapshot_archive_info.path().display()
         );
 
-        drop(bank_forks);
         // Process blockstore after warping bank forks to make sure tower and
         // bank forks are in sync.
         process_blockstore.process()?;

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -1794,8 +1794,8 @@ fn cleanup_outdated_tower_bft_startup_banks(
 
 /// Clean up failed startup slots and restart processing from the given genesis slot
 ///
-/// `first_alpenglow_bank` and any current `pending_slots` banks are removed from runtime caches,
-/// and their dead statuses are reset.
+/// `first_alpenglow_bank` has already been removed from runtime caches by `BankForks::remove`.
+/// Current `pending_slots` banks are removed from runtime caches, and all dead statuses are reset.
 /// `pending_slots` is the current child blocks left to be processed. We clear and update
 /// this with the children of `genesis_slot` instead.
 fn cleanup_and_populate_pending_from_alpenglow_genesis(
@@ -1810,16 +1810,17 @@ fn cleanup_and_populate_pending_from_alpenglow_genesis(
 ) -> result::Result<(), BlockstoreProcessorError> {
     // The frontier is now out of date, as all banks were created as TowerBFT banks.
     // Cleanup all the banks in the frontier and recreate them as Alpenglow banks.
-    let slots_to_cleanup =
-        std::iter::once((first_alpenglow_bank.slot(), first_alpenglow_bank.bank_id()))
-            .chain(
-                pending_slots
-                    .iter()
-                    .map(|(_, bank, _)| (bank.slot(), bank.bank_id())),
-            )
-            .collect::<Vec<_>>();
+    // The failed bank was removed and cleaned by `BankForks::remove()`. The pending banks were
+    // never inserted into BankForks, so clean their runtime state here before dropping them.
+    let slots_to_cleanup = pending_slots
+        .iter()
+        .map(|(_, bank, _)| (bank.slot(), bank.bank_id()))
+        .collect::<Vec<_>>();
     let root_bank = bank_forks.read().unwrap().root_bank();
-    cleanup_outdated_tower_bft_startup_banks(&root_bank, blockstore, &slots_to_cleanup);
+    if !slots_to_cleanup.is_empty() {
+        cleanup_outdated_tower_bft_startup_banks(&root_bank, blockstore, &slots_to_cleanup);
+    }
+    reset_dead_if_primary_access(blockstore, first_alpenglow_bank.slot());
 
     let genesis_slot_meta = blockstore
         .meta(genesis_slot)
@@ -2067,7 +2068,7 @@ fn load_frozen_forks(
                 timing,
                 &migration_status,
             ) {
-                assert!(bank_forks.write().unwrap().remove(bank.slot()).is_some());
+                BankForks::remove(bank_forks, bank.slot()).unwrap();
                 if error.is_alpenglow_migration_transition() {
                     assert!(migration_status.is_ready_to_enable());
                     // This was the first Alpenglow block. Enable Alpenglow and replay it with
@@ -2172,11 +2173,7 @@ fn load_frozen_forks(
                 root = new_root_bank.slot();
 
                 leader_schedule_cache.set_root(new_root_bank);
-                new_root_bank.prune_program_cache(&bank_forks.read().unwrap());
-                let _ = bank_forks
-                    .write()
-                    .unwrap()
-                    .set_root(root, snapshot_controller, None);
+                BankForks::set_root_from_shared(bank_forks, root, snapshot_controller, None);
                 m.stop();
                 set_root_us += m.as_us();
 
@@ -6060,11 +6057,7 @@ pub mod tests {
         let first_alpenglow_key = Pubkey::new_unique();
         let pending_key = Pubkey::new_unique();
 
-        let first_alpenglow_bank = Arc::new(Bank::new_from_parent(
-            bank0.clone(),
-            SlotLeader::default(),
-            1,
-        ));
+        let first_alpenglow_bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 1);
         first_alpenglow_bank
             .store_account(&first_alpenglow_key, &AccountSharedData::new(1, 0, &owner));
         assert!(
@@ -6072,8 +6065,13 @@ pub mod tests {
                 .get_account(&first_alpenglow_key)
                 .is_some()
         );
-        let first_alpenglow_bank =
-            BankWithScheduler::new_without_scheduler(first_alpenglow_bank.clone());
+        bank_forks.write().unwrap().insert(first_alpenglow_bank);
+        let first_alpenglow_bank = BankForks::remove(&bank_forks, 1).unwrap();
+        assert!(
+            first_alpenglow_bank
+                .get_account(&first_alpenglow_key)
+                .is_none()
+        );
 
         let pending_bank = Bank::new_from_parent(bank0.clone(), SlotLeader::default(), 2);
         pending_bank.store_account(&pending_key, &AccountSharedData::new(1, 0, &owner));

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -1438,7 +1438,8 @@ impl ProgramTestContext {
                 .clone_without_scheduler()
         };
 
-        self.bank_forks.write().unwrap().set_root(
+        BankForks::set_root_from_shared(
+            &self.bank_forks,
             pre_warp_slot,
             None, // snapshots are disabled
             Some(pre_warp_slot),
@@ -1480,7 +1481,8 @@ impl ProgramTestContext {
         bank.fill_bank_with_ticks_for_tests();
         let pre_warp_slot = bank.slot();
 
-        self.bank_forks.write().unwrap().set_root(
+        BankForks::set_root_from_shared(
+            &self.bank_forks,
             pre_warp_slot,
             None, // snapshot_controller
             Some(pre_warp_slot),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9333,7 +9333,7 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     bank2.squash();
     add_root_and_flush_write_cache(&bank2);
 
-    bank_forks.write().unwrap().remove(1);
+    let _removed_bank = BankForks::remove(&bank_forks, 1);
     drop(bank1);
     bank2.clean_accounts_for_tests();
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -1,5 +1,7 @@
 //! The `bank_forks` module implements BankForks a DAG of checkpointed Banks
 
+#[cfg(any(test, feature = "dev-context-only-utils"))]
+use qualifier_attr::qualifiers;
 use {
     crate::{
         bank::{Bank, SquashTiming, bank_hash_details},
@@ -94,6 +96,76 @@ impl Index<u64> for BankForks {
 }
 
 impl BankForks {
+    /// Completes the bank's scheduler without holding a `BankForks` lock, removes the bank under
+    /// the write lock, and cleans its runtime state.
+    pub fn remove(bank_forks: &RwLock<Self>, slot: Slot) -> Option<BankWithScheduler> {
+        Self::remove_and_clean_bank(bank_forks, slot, false)
+    }
+
+    /// Completes the bank's scheduler without holding a `BankForks` lock, clears the bank under the
+    /// write lock, and cleans its runtime state.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bank is not present in bank forks.
+    pub fn clear_bank(bank_forks: &RwLock<Self>, slot: Slot, write_bank_hash_details: bool) {
+        Self::remove_and_clean_bank(bank_forks, slot, write_bank_hash_details)
+            .unwrap_or_else(|| panic!("bank at slot {slot} does not exist"));
+    }
+
+    /// Completes the selected banks' schedulers without holding a `BankForks` lock, removes the
+    /// banks under the write lock, and cleans their runtime state before dropping them.
+    pub fn dump_slots(
+        bank_forks: &RwLock<Self>,
+        slots: impl IntoIterator<Item = Slot>,
+        write_bank_hash_details: bool,
+    ) -> Vec<(Slot, BankId)> {
+        let requested_slots = slots.into_iter().collect::<BTreeSet<_>>();
+        let (root_bank, banks) = {
+            let bank_forks = bank_forks.read().unwrap();
+            let banks = requested_slots
+                .iter()
+                .filter_map(|slot| bank_forks.get_with_scheduler(*slot))
+                .collect::<Vec<_>>();
+            (bank_forks.root_bank(), banks)
+        };
+        for bank in &banks {
+            let _ = bank.wait_for_completed_scheduler();
+        }
+        let removed_banks = bank_forks
+            .write()
+            .unwrap()
+            .dump_slots_inner(banks.iter().map(|bank| bank.slot()));
+        Self::write_bank_hash_details(&removed_banks, write_bank_hash_details);
+        Self::clean_removed_banks(&root_bank, &removed_banks, requested_slots)
+    }
+
+    /// Completes schedulers for every bank the root update will remove, then updates BankForks
+    /// under the write lock.
+    pub fn set_root_from_shared(
+        bank_forks: &RwLock<Self>,
+        root: Slot,
+        snapshot_controller: Option<&SnapshotController>,
+        highest_super_majority_root: Option<Slot>,
+    ) -> Vec<BankWithScheduler> {
+        let banks = {
+            let bank_forks = bank_forks.read().unwrap();
+            bank_forks
+                .get_non_rooted(root, highest_super_majority_root)
+                .map(BankWithScheduler::clone_with_scheduler)
+                .collect::<Vec<_>>()
+        };
+        for bank in banks {
+            let _ = bank.wait_for_completed_scheduler();
+        }
+        bank_forks.read().unwrap().prune_program_cache(root);
+        bank_forks.write().unwrap().set_root_inner(
+            root,
+            snapshot_controller,
+            highest_super_majority_root,
+        )
+    }
+
     pub fn new_rw_arc(root_bank: Bank) -> Arc<RwLock<Self>> {
         let root_bank = Arc::new(root_bank);
         let root_slot = root_bank.slot();
@@ -193,25 +265,18 @@ impl BankForks {
     /// a bank if it's descendant(s) are still in BankForks.
     ///
     /// Returns the supplied unrooted slots and all descendants that are still present in bank
-    /// forks as `slots_to_purge`, plus the subset that still has a bank as `banks_to_clear`.
-    pub fn slots_to_clear(
-        &self,
-        slots: impl IntoIterator<Item = Slot>,
-    ) -> (BTreeSet<Slot>, Vec<BankWithScheduler>) {
+    /// forks.
+    pub fn slots_to_clear(&self, slots: impl IntoIterator<Item = Slot>) -> BTreeSet<Slot> {
         let root = self.root();
-        let mut slots_to_purge = BTreeSet::new();
-        let mut bank_slots_to_clear = BTreeSet::new();
+        let mut slots_to_clear = BTreeSet::new();
 
         for slot in slots {
             if slot <= root {
                 continue;
             }
-            slots_to_purge.insert(slot);
-            if self.banks.contains_key(&slot) {
-                bank_slots_to_clear.insert(slot);
-            }
+            slots_to_clear.insert(slot);
             if let Some(slot_descendants) = self.descendants.get(&slot) {
-                bank_slots_to_clear.extend(
+                slots_to_clear.extend(
                     slot_descendants
                         .iter()
                         .copied()
@@ -220,15 +285,7 @@ impl BankForks {
             }
         }
 
-        slots_to_purge.extend(&bank_slots_to_clear);
-        let banks_to_clear = bank_slots_to_clear
-            .into_iter()
-            .map(|slot| {
-                self.get_with_scheduler(slot)
-                    .expect("bank slot was present while collecting slots to clear")
-            })
-            .collect();
-        (slots_to_purge, banks_to_clear)
+        slots_to_clear
     }
 
     pub fn frozen_banks(&self) -> impl Iterator<Item = (Slot, Arc<Bank>)> + '_ {
@@ -344,7 +401,7 @@ impl BankForks {
         bank_with_scheduler
     }
 
-    pub fn remove(&mut self, slot: Slot) -> Option<BankWithScheduler> {
+    fn remove_inner(&mut self, slot: Slot) -> Option<BankWithScheduler> {
         let bank = self.banks.remove(&slot)?;
         for parent in bank.proper_ancestors() {
             let Entry::Occupied(mut entry) = self.descendants.entry(parent) else {
@@ -400,51 +457,71 @@ impl BankForks {
         self.banks[&self.highest_slot()].clone_with_scheduler()
     }
 
-    /// Clears associated banks from BankForks.
-    pub fn dump_slots<'a, I>(
-        &mut self,
-        slots: I,
+    fn remove_and_clean_bank(
+        bank_forks: &RwLock<Self>,
+        slot: Slot,
         write_bank_hash_details: bool,
-    ) -> (Vec<(Slot, BankId)>, Vec<BankWithScheduler>)
-    where
-        I: Iterator<Item = &'a Slot>,
-    {
-        slots
-            .map(|slot| {
-                // Clear the banks from BankForks
-                let bank = self
-                    .remove(*slot)
-                    .expect("BankForks should not have been purged yet");
-                if write_bank_hash_details {
-                    bank_hash_details::write_bank_hash_details_file(&bank)
-                        .map_err(|err| {
-                            warn!("Unable to write bank hash details file: {err}");
-                        })
-                        .ok();
-                }
-                ((*slot, bank.bank_id()), bank)
-            })
-            .unzip()
+    ) -> Option<BankWithScheduler> {
+        let (root_bank, bank) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.get_with_scheduler(slot)?)
+        };
+        let _ = bank.wait_for_completed_scheduler();
+        let removed_bank = bank_forks.write().unwrap().remove_inner(slot)?;
+        Self::write_bank_hash_details(std::slice::from_ref(&removed_bank), write_bank_hash_details);
+        Self::clean_removed_banks(
+            &root_bank,
+            std::slice::from_ref(&removed_bank),
+            std::iter::once(slot),
+        );
+        Some(removed_bank)
     }
 
-    /// Clears a bank from bank forks. Panics if the bank is not present in bank forks.
-    ///
-    /// Callers must quiesce any scheduler for this bank before calling this
-    /// method. ReplayStage does that outside the `BankForks` write lock before
-    /// servicing clear-bank controller commands.
-    pub fn clear_bank(&mut self, slot: Slot, write_bank_hash_details: bool) {
-        let (slots_to_purge, removed_banks) =
-            self.dump_slots(std::iter::once(&slot), write_bank_hash_details);
+    fn dump_slots_inner(
+        &mut self,
+        slots: impl IntoIterator<Item = Slot>,
+    ) -> Vec<BankWithScheduler> {
+        slots
+            .into_iter()
+            .map(|slot| {
+                self.remove_inner(slot)
+                    .expect("BankForks should not have been purged yet")
+            })
+            .collect()
+    }
 
-        let root_bank = self.root_bank();
+    fn write_bank_hash_details(banks: &[BankWithScheduler], write_bank_hash_details: bool) {
+        if !write_bank_hash_details {
+            return;
+        }
+        for bank in banks {
+            bank_hash_details::write_bank_hash_details_file(bank)
+                .map_err(|err| warn!("Unable to write bank hash details file: {err}"))
+                .ok();
+        }
+    }
 
-        root_bank.remove_unrooted_slots(&slots_to_purge);
-        drop(removed_banks);
-
-        for (slot, _) in slots_to_purge {
+    fn clean_removed_banks(
+        root_bank: &Bank,
+        removed_banks: &[BankWithScheduler],
+        slots_to_clean: impl IntoIterator<Item = Slot>,
+    ) -> Vec<(Slot, BankId)> {
+        let slots_to_purge = removed_banks
+            .iter()
+            .map(|bank| (bank.slot(), bank.bank_id()))
+            .collect::<Vec<_>>();
+        if !slots_to_purge.is_empty() {
+            // Invalidate scans and purge all removed slots atomically. `removed_banks` keeps the
+            // banks alive until this cleanup finishes so `Bank::drop()` cannot race with it.
+            root_bank.remove_unrooted_slots(&slots_to_purge);
+        }
+        // Also clear shared cache entries for requested slots that were already absent. These
+        // slots can be revived, and stale entries from the old bank must not affect replay.
+        for slot in slots_to_clean {
             root_bank.clear_slot_signatures(slot);
             root_bank.prune_program_cache_by_deployment_slot(slot);
         }
+        slots_to_purge
     }
 
     fn do_set_root_return_metrics(
@@ -540,13 +617,14 @@ impl BankForks {
         )
     }
 
-    pub fn prune_program_cache(&self, root: Slot) {
+    #[cfg_attr(any(test, feature = "dev-context-only-utils"), qualifiers(pub))]
+    fn prune_program_cache(&self, root: Slot) {
         if let Some(root_bank) = self.banks.get(&root) {
             root_bank.prune_program_cache(self);
         }
     }
 
-    pub fn set_root(
+    fn set_root_inner(
         &mut self,
         root: Slot,
         snapshot_controller: Option<&SnapshotController>,
@@ -629,6 +707,24 @@ impl BankForks {
         removed_banks
     }
 
+    /// Test-only convenience for updating the root without concurrent scheduler activity.
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub fn set_root(
+        &mut self,
+        root: Slot,
+        snapshot_controller: Option<&SnapshotController>,
+        highest_super_majority_root: Option<Slot>,
+    ) -> Vec<BankWithScheduler> {
+        let banks_to_remove = self
+            .get_non_rooted(root, highest_super_majority_root)
+            .map(BankWithScheduler::clone_with_scheduler)
+            .collect::<Vec<_>>();
+        for bank in banks_to_remove {
+            let _ = bank.wait_for_completed_scheduler();
+        }
+        self.set_root_inner(root, snapshot_controller, highest_super_majority_root)
+    }
+
     pub fn root(&self) -> Slot {
         self.root
     }
@@ -693,13 +789,17 @@ impl BankForks {
         let mut prune_slots_time = Measure::start("prune_slots");
         let prune_slots: Vec<_> = self
             .get_non_rooted(root, highest_super_majority_root)
+            .map(|bank| bank.slot())
             .collect();
         prune_slots_time.stop();
 
         let mut prune_remove_time = Measure::start("prune_slots");
         let removed_banks = prune_slots
             .into_iter()
-            .filter_map(|slot| self.remove(slot))
+            .map(|slot| {
+                self.remove_inner(slot)
+                    .expect("bank should still be present")
+            })
             .collect();
         prune_remove_time.stop();
 
@@ -710,18 +810,20 @@ impl BankForks {
         )
     }
 
-    pub fn get_non_rooted(
+    /// Returns banks that will be pruned by a root update.
+    fn get_non_rooted(
         &self,
         root: Slot,
         highest_super_majority_root: Option<Slot>,
-    ) -> impl Iterator<Item = Slot> + '_ {
+    ) -> impl Iterator<Item = &BankWithScheduler> + '_ {
         let highest_super_majority_root = highest_super_majority_root.unwrap_or(root);
-        self.banks.keys().copied().filter(move |slot| {
-            let keep = *slot == root
-                || self.descendants[&root].contains(slot)
-                || (*slot < root
-                    && *slot >= highest_super_majority_root
-                    && self.descendants[slot].contains(&root));
+        self.banks.values().filter(move |bank| {
+            let slot = bank.slot();
+            let keep = slot == root
+                || self.descendants[&root].contains(&slot)
+                || (slot < root
+                    && slot >= highest_super_majority_root
+                    && self.descendants[&slot].contains(&root));
             !keep
         })
     }
@@ -947,13 +1049,7 @@ mod tests {
         let clear_bank_forks = bank_forks.clone();
         let (finish_done_sender, finish_done_receiver) = bounded(1);
         let finish_thread = thread::spawn(move || {
-            let bank_to_clear = clear_bank_forks
-                .read()
-                .unwrap()
-                .get_with_scheduler(1)
-                .unwrap();
-            let _ = bank_to_clear.wait_for_completed_scheduler();
-            clear_bank_forks.write().unwrap().clear_bank(1, false);
+            BankForks::clear_bank(&clear_bank_forks, 1, false);
             finish_done_sender.send(()).unwrap();
         });
 
@@ -1175,43 +1271,16 @@ mod tests {
         );
 
         let slots = |slots: &[Slot]| {
-            let (slots_to_purge, banks_to_clear) = bank_forks
+            bank_forks
                 .read()
                 .unwrap()
-                .slots_to_clear(slots.iter().copied());
-            let bank_slots_to_clear = banks_to_clear
-                .iter()
-                .map(|bank| bank.slot())
-                .collect::<BTreeSet<_>>();
-            assert_eq!(banks_to_clear.len(), bank_slots_to_clear.len());
-            (slots_to_purge, bank_slots_to_clear)
+                .slots_to_clear(slots.iter().copied())
         };
-        assert_eq!(
-            slots(&[2]),
-            ([2, 4].into_iter().collect(), [2, 4].into_iter().collect())
-        );
-        assert_eq!(
-            slots(&[1]),
-            (
-                [1, 2, 3, 4].into_iter().collect(),
-                [1, 2, 3, 4].into_iter().collect(),
-            )
-        );
-        assert_eq!(
-            slots(&[0]),
-            (BTreeSet::<Slot>::new(), BTreeSet::<Slot>::new())
-        );
-        assert_eq!(
-            slots(&[6]),
-            ([6].into_iter().collect(), BTreeSet::<Slot>::new())
-        );
-        assert_eq!(
-            slots(&[1, 2, 2, 3]),
-            (
-                [1, 2, 3, 4].into_iter().collect(),
-                [1, 2, 3, 4].into_iter().collect(),
-            )
-        );
+        assert_eq!(slots(&[2]), [2, 4].into_iter().collect());
+        assert_eq!(slots(&[1]), [1, 2, 3, 4].into_iter().collect());
+        assert_eq!(slots(&[0]), BTreeSet::<Slot>::new());
+        assert_eq!(slots(&[6]), [6].into_iter().collect());
+        assert_eq!(slots(&[1, 2, 2, 3]), [1, 2, 3, 4].into_iter().collect());
     }
 
     #[test]

--- a/runtime/src/bank_forks_controller.rs
+++ b/runtime/src/bank_forks_controller.rs
@@ -366,16 +366,7 @@ mod tests {
                         slot,
                         response_sender,
                     } => {
-                        let bank_to_clear =
-                            replay_bank_forks.read().unwrap().get_with_scheduler(slot);
-                        if let Some(bank) = bank_to_clear {
-                            let _ = bank.wait_for_completed_scheduler();
-                        }
-
-                        {
-                            let mut bank_forks = replay_bank_forks.write().unwrap();
-                            bank_forks.clear_bank(slot, false);
-                        }
+                        BankForks::clear_bank(&replay_bank_forks, slot, false);
                         response_sender.send(()).unwrap();
                     }
                 }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -346,9 +346,8 @@ impl SchedulerStatus {
 /// Very thin wrapper around Arc<Bank>
 ///
 /// It brings type-safety against accidental mixing of bank and scheduler with different slots,
-/// which is a pretty dangerous condition. Also, it guarantees to call wait_for_termination() via
-/// ::drop() by DropBankService, which receives Vec<BankWithScheduler> from BankForks::set_root()'s
-/// pruning, mostly matching to Arc<Bank>'s lifetime by piggybacking on the pruning.
+/// which is a pretty dangerous condition. BankForks normally completes the scheduler before
+/// removing the bank; dropping this wrapper also waits for termination as a fallback.
 ///
 /// Semantically, a scheduler is tightly coupled with a particular bank. But scheduler wasn't put
 /// into Bank fields to avoid circular-references (a scheduler needs to refer to its accompanied

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -2659,12 +2659,9 @@ mod tests {
 
         // child_bank inserted after pool so it gets a scheduler
         Bank::new_from_parent_with_bank_forks(bank_forks.as_ref(), bank, SlotLeader::default(), 1);
-        let mut bank_forks = bank_forks.write().unwrap();
-        let mut child_bank = bank_forks.get_with_scheduler(1).unwrap();
+        let child_bank = bank_forks.read().unwrap().get_with_scheduler(1).unwrap();
         assert!(child_bank.has_installed_scheduler());
-        bank_forks.remove(child_bank.slot());
-        child_bank.drop_scheduler();
-        assert!(!child_bank.has_installed_scheduler());
+        let _removed_bank = BankForks::remove(&bank_forks, child_bank.slot()).unwrap();
     }
 
     fn setup_dummy_fork_graph(bank: Bank) -> (Arc<Bank>, Arc<RwLock<BankForks>>) {

--- a/votor/src/event_handler.rs
+++ b/votor/src/event_handler.rs
@@ -1143,12 +1143,7 @@ mod tests {
         }
 
         fn clear_bank(&self, slot: Slot) -> Result<(), BankForksControllerError> {
-            let bank_to_clear = self.bank_forks.read().unwrap().get_with_scheduler(slot);
-            if let Some(bank) = bank_to_clear {
-                let _ = bank.wait_for_completed_scheduler();
-            }
-
-            self.bank_forks.write().unwrap().clear_bank(slot, false);
+            BankForks::clear_bank(&self.bank_forks, slot, false);
             Ok(())
         }
     }

--- a/votor/src/root_utils.rs
+++ b/votor/src/root_utils.rs
@@ -215,19 +215,8 @@ pub fn set_bank_forks_root<CB>(
 ) where
     CB: FnOnce(&BankForks),
 {
-    let banks_to_remove: Vec<_> = {
-        let bank_forks = bank_forks.read().unwrap();
-        bank_forks
-            .get_non_rooted(new_root, highest_super_majority_root)
-            .filter_map(|slot| bank_forks.get_with_scheduler(slot))
-            .collect()
-    };
-    for bank in banks_to_remove {
-        let _ = bank.wait_for_completed_scheduler();
-    }
-
-    bank_forks.read().unwrap().prune_program_cache(new_root);
-    let removed_banks = bank_forks.write().unwrap().set_root(
+    let removed_banks = BankForks::set_root_from_shared(
+        bank_forks,
         new_root,
         snapshot_controller,
         highest_super_majority_root,


### PR DESCRIPTION
#### Problem
- BankForks interfaces exposes removal methods that are easy to misuse:
	- can cause live-locks, not clean up resources, etc.
	- relies on callers to do things in correct order and remember to do it  

#### Summary of Changes
- Reworked public BankForks removal APIs to own:
	- scheduler completion
	- fork removal
	- runtime cleanup


#### Testing
- CI

Fixes #
