### PR TITLE
refactor(accounts-db): consolidate the per-account hash input behind a sink trait 

### DIFF
--- a/accounts-db/benches/bench_hashing.rs
+++ b/accounts-db/benches/bench_hashing.rs
@@ -24,9 +24,13 @@ const DATA_SIZES: [usize; 6] = [
 /// The number of bytes of *non account data* that are also hashed as
 /// part of computing an account's hash.
 ///
-/// Ensure this constant stays in sync with the value of `META_SIZE` in
-/// AccountsDb::hash_account_helper().
-const META_SIZE: usize = 73;
+/// Ensure this constant stays in sync with the non-data parts written by
+/// AccountsDb::write_account_hash_input().
+const META_SIZE: usize = size_of::<u64>() // lamports
+    + size_of::<bool>() // executable
+    + size_of::<Pubkey>() // owner
+    + size_of::<Pubkey>(); // pubkey
+const _: () = assert!(META_SIZE == 73);
 
 fn bench_hash_account(c: &mut Criterion) {
     let lamports = 123_456_789;

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -71,11 +71,13 @@ use {
     rand::{Rng, rng},
     rayon::{ThreadPool, prelude::*},
     seqlock::SeqLock,
-    smallvec::SmallVec,
     solana_account::{Account, AccountSharedData, ReadableAccount},
     solana_clock::{BankId, Epoch, Slot},
     solana_epoch_schedule::EpochSchedule,
-    solana_lattice_hash::{batch, lt_hash::LtHash},
+    solana_lattice_hash::{
+        batch,
+        lt_hash::{LtHash, SingleLtHashUpdater},
+    },
     solana_measure::{measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
@@ -3751,45 +3753,39 @@ impl AccountsDb {
             return ZERO_LAMPORT_ACCOUNT_LT_HASH;
         }
 
-        let hasher = Self::hash_account_helper(account, pubkey);
-        let lt_hash = LtHash::with(&hasher);
-        AccountLtHash(lt_hash)
+        let hasher = Self::write_account_hash_input(account, pubkey, blake3::Hasher::new());
+        AccountLtHash(LtHash::with(&hasher))
     }
 
-    /// Hashes `account` and returns the underlying Hasher
-    fn hash_account_helper(account: &impl ReadableAccount, pubkey: &Pubkey) -> blake3::Hasher {
-        let mut hasher = blake3::Hasher::new();
-
-        // allocate a buffer on the stack that's big enough
-        // to hold a token account or a stake account
-        const META_SIZE: usize = 8 /* lamports */ + 1 /* executable */ + 32 /* owner */ + 32 /* pubkey */;
-        const DATA_SIZE: usize = 200; // stake accounts are 200 B and token accounts are 165-182ish B
-        const BUFFER_SIZE: usize = META_SIZE + DATA_SIZE;
-        let mut buffer = SmallVec::<[u8; BUFFER_SIZE]>::new();
-
-        // collect lamports into buffer to hash
-        buffer.extend_from_slice(&account.lamports().to_le_bytes());
-
-        let data = account.data();
-        if data.len() > DATA_SIZE {
-            // For larger accounts whose data can't fit into the buffer, update the hash now.
-            hasher.update(&buffer);
-            buffer.clear();
-
-            // hash account's data
-            hasher.update(data);
-        } else {
-            // For small accounts whose data can fit into the buffer, append it to the buffer.
-            buffer.extend_from_slice(data);
+    /// Group-adds `account`'s lattice hash into `accumulator`, folded in once the
+    /// batch flushes. Zero-lamport accounts hash to the identity and are skipped.
+    ///
+    /// The batch API only adds, so subtracting an account means feeding it into a
+    /// separate accumulator and mixing that accumulator's final hash out.
+    pub fn add_account_to_lt_hash(
+        accumulator: &mut batch::Accumulator,
+        account: &impl ReadableAccount,
+        pubkey: &Pubkey,
+    ) {
+        if account.lamports() == 0 {
+            return;
         }
+        Self::write_account_hash_input(account, pubkey, accumulator.start_message()).finish();
+    }
 
-        // collect executable, owner, and pubkey into buffer to hash
-        buffer.push(account.executable().into());
-        buffer.extend_from_slice(account.owner().as_ref());
-        buffer.extend_from_slice(pubkey.as_ref());
-        hasher.update(&buffer);
-
-        hasher
+    /// The single source of truth for the per-account hash input layout.
+    #[inline]
+    fn write_account_hash_input<S: SingleLtHashUpdater>(
+        account: &impl ReadableAccount,
+        pubkey: &Pubkey,
+        mut sink: S,
+    ) -> S {
+        sink.write_part(&account.lamports().to_le_bytes());
+        sink.write_part(account.data());
+        sink.write_part(&[u8::from(account.executable())]);
+        sink.write_part(account.owner().as_ref());
+        sink.write_part(pubkey.as_ref());
+        sink
     }
 
     pub fn mark_slot_frozen(&self, slot: Slot) {
@@ -5320,19 +5316,8 @@ impl AccountsDb {
                     );
                 }
 
-                // Stream the account's lt-hash message into the (per-thread) batch.
-                // Skip zero-lamport accounts: their `AccountLtHash` is the identity,
-                // so mixing it in is a no-op. These bytes must match the stream that
-                // `hash_account_helper` feeds the `blake3` hasher.
                 if !is_account_zero_lamport {
-                    let mut message = lt_hash_acc.start_message();
-                    message
-                        .add_part(&account.lamports().to_le_bytes())
-                        .add_part(account.data())
-                        .add_part(&[u8::from(account.executable())])
-                        .add_part(account.owner().as_ref())
-                        .add_part(account.pubkey().as_ref());
-                    message.finish();
+                    Self::add_account_to_lt_hash(lt_hash_acc, &account, account.pubkey);
                 }
 
                 // SAFETY: The bank capitalization field is a u64, so the lamport sum of

--- a/lattice-hash/benches/bench_batch.rs
+++ b/lattice-hash/benches/bench_batch.rs
@@ -5,11 +5,25 @@ use {
     criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main},
     rand::prelude::*,
     rand_chacha::ChaChaRng,
-    solana_lattice_hash::{batch, lt_hash::LtHash},
+    solana_lattice_hash::{
+        batch,
+        lt_hash::{LtHash, SingleLtHashUpdater},
+    },
 };
 
 const NUM_ACCOUNTS: usize = 1024;
 const MSG_LEN: usize = 273; // 8 lamports + ~200B data + 1 + 32 owner + 32 pubkey
+
+/// End offsets of a five-part split, sized after practical account layouts.
+const PART_ENDS: [usize; 5] = [8, 208, 209, 241, MSG_LEN];
+
+fn parts(msg: &[u8]) -> impl Iterator<Item = &[u8]> {
+    PART_ENDS.iter().scan(0, |start, &end| {
+        let range = *start..end;
+        *start = end;
+        Some(&msg[range])
+    })
+}
 
 fn make_messages(rng: &mut impl Rng) -> Vec<Vec<u8>> {
     (0..NUM_ACCOUNTS)
@@ -31,6 +45,16 @@ fn baseline(messages: &[&[u8]], acc: &mut LtHash) {
     }
 }
 
+fn serial_per_part(messages: &[&[u8]], acc: &mut LtHash) {
+    for msg in messages {
+        let mut h = blake3::Hasher::new();
+        for part in parts(msg) {
+            h.write_part(part);
+        }
+        acc.mix_in(&LtHash::with(&h));
+    }
+}
+
 fn bench(c: &mut Criterion) {
     let mut rng = ChaChaRng::seed_from_u64(7);
     let msgs = make_messages(&mut rng);
@@ -47,6 +71,15 @@ fn bench(c: &mut Criterion) {
         )
     });
 
+    // Same bytes as above, split up: the gap is the per-part call overhead.
+    group.bench_function("serial_per_part", |b| {
+        b.iter_batched_ref(
+            LtHash::identity,
+            |acc| serial_per_part(&refs, acc),
+            BatchSize::SmallInput,
+        )
+    });
+
     // Streaming `Accumulator`: the shape the accounts-hash hot loop uses —
     // create once, `add_message` (copies the message into the owned buffer the
     // kernel then reads in place) each account, `into_lt_hash`.
@@ -55,6 +88,21 @@ fn bench(c: &mut Criterion) {
             let mut acc = batch::Accumulator::new();
             for &msg in &refs {
                 acc.add_message(msg);
+            }
+            acc.into_lt_hash()
+        })
+    });
+
+    // The same, split up: the parts land straight in the lane buffer.
+    group.bench_function("batched_per_part", |b| {
+        b.iter(|| {
+            let mut acc = batch::Accumulator::new();
+            for &msg in &refs {
+                let mut message = acc.start_message();
+                for part in parts(msg) {
+                    message.write_part(part);
+                }
+                message.finish();
             }
             acc.into_lt_hash()
         })

--- a/lattice-hash/src/batch.rs
+++ b/lattice-hash/src/batch.rs
@@ -20,7 +20,7 @@
 mod arch;
 
 use {
-    crate::lt_hash::LtHash,
+    crate::lt_hash::{LtHash, SingleLtHashUpdater},
     blake3::{BLOCK_LEN, CHUNK_LEN},
 };
 
@@ -388,6 +388,12 @@ impl MessageBuilder<'_> {
         self.acc.commit_message();
         // Committed — skip the discarding `Drop`.
         core::mem::forget(self);
+    }
+}
+
+impl SingleLtHashUpdater for MessageBuilder<'_> {
+    fn write_part(&mut self, bytes: &[u8]) {
+        self.add_part(bytes);
     }
 }
 

--- a/lattice-hash/src/lt_hash.rs
+++ b/lattice-hash/src/lt_hash.rs
@@ -63,6 +63,19 @@ impl fmt::Display for LtHash {
     }
 }
 
+/// Receives the input of one [`LtHash`]. Only the concatenation of the parts
+/// matters, so an implementor may consume each part as it arrives or coalesce them
+/// first.
+pub trait SingleLtHashUpdater {
+    fn write_part(&mut self, bytes: &[u8]);
+}
+
+impl SingleLtHashUpdater for blake3::Hasher {
+    fn write_part(&mut self, bytes: &[u8]) {
+        self.update(bytes);
+    }
+}
+
 /// A smaller "checksum" of the LtHash, useful when 2 KiB is too large
 //
 // Developer notes:


### PR DESCRIPTION
#### Problem
`hash_account_helper` gathers an account's parts into a `SmallVec` before handing one slice to the `blake3` hasher, and index generation keeks its own hand-inlined copy of the same layout, under a comment warning that "these bytes must match the stream that `hash_account_helper` feeds the `blake3` hasher".

#### Summary of Changes
Add a `SingleLtHashUpdater` sink trait in lattice-hash, implemented for `blake3::Hasher` and for `batch::MessageBuilder`, and write the layout exactly once in `AccountsDb::write_account_hash_input` over that sink. `lt_hash_account` and the new `add_account_to_lt_hash` (which group-adds an account into a `batch::Accumulator`, skipping zero-lamport accounts, whose hash is the identity) both go through it, and index generation calls `add_account_to_lt_hash` instead of
repeating the layout.

Handing the parts over one at a time, rather than gathering them first, is also the faster shape on both paths. Per account, over 1024 token/stake-sized accounts (`bench_batch`):
```
  batched   223.3 ns part-by-part  vs  242.8 ns gathered first   (-8.0%)
  serial    536.2 ns part-by-part  vs  539.9 ns gathered first   (-0.7%)
```
Gathering through a `SmallVec` costs 22-26 ns per account, while the extra calls it saves cost 18.1 ns on the serial path (~4.5 ns per `blake3::update`) and 6.5 ns on the batched one (~1.6 ns per lane-buffer append), so the gather does not pay for itself.

#### Testing
* CI
* ledger-tool verify