### PR TITLE
bugfix: fixes AG rewards going over budget when inflation rate decreases

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1290,7 +1290,7 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    solana_pubkey::declare_id!("A1pENGLtPKvimJcQ8eNJ3cN6hMPLg1PWEyCvc7i5LFL8");
+    solana_pubkey::declare_id!("A1PeNgLEYU9sdwWJH5SEcRGVVKXLQYnyq26kpL6G3iJH");
 }
 
 pub mod disable_zk_elgamal_proof_program {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5537,9 +5537,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "GGJNQQv8iVqr2qfeLpUtgFVMjTWPiSXUBwE6SzRNRiqX"
+                    "5UrLWHi74qXWsyEHruqoz8g5XA31u4G7aADAt3Y81q5v"
                 } else {
-                    "2SeoDNxK19FqNQFQgsfYZkRsCpvyAQYANkifuCtvXDtf"
+                    "BSbYeY7uRBu3yoE5pJAJtunekoc6N9XjgDgek8uV3oZH"
                 },
             );
         }
@@ -5548,9 +5548,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "pPMYHdcq9eTJcJEwNnAupggSwgrfbHqL8eaD6LsXT6Q"
+                    "2umT1LU1YvfhfKsGDUah9ChnqSGfnJo4r9EHRKxiPbF2"
                 } else {
-                    "HXKPk3qZVsQ1TdefvfhTi4hcMMAXVyVdCLW8hUwDc7iU"
+                    "FiredfFXh5u9GWcFfqDn9tG5mCEfnX8vAecJbgnwXKgC"
                 },
             );
             break;
@@ -5853,8 +5853,8 @@ fn test_bank_hash_deterministic_with_stakes_cache() {
     assert_eq!(
         bank2.hash().as_bytes(),
         &[
-            93, 121, 219, 248, 56, 199, 240, 90, 102, 118, 226, 197, 72, 77, 171, 85, 169, 230, 25,
-            25, 138, 146, 93, 197, 57, 27, 26, 228, 224, 145, 124, 159
+            167, 152, 211, 107, 117, 229, 2, 86, 15, 156, 174, 32, 113, 116, 240, 38, 14, 205, 174,
+            168, 10, 67, 5, 124, 73, 110, 6, 45, 149, 236, 149, 180
         ]
     );
 }

--- a/runtime/src/block_component_processor/vote_reward.rs
+++ b/runtime/src/block_component_processor/vote_reward.rs
@@ -52,13 +52,8 @@ pub enum RewardStateError {
     MissingEpochStakes { reward_slot: Slot, bank_slot: Slot },
     #[error("missing EpochInflationAccountState for bank_slot {bank_slot}")]
     MissingEpochInflationAccountState { bank_slot: Slot },
-    #[error(
-        "missing validator stake info for reward epoch {reward_epoch} in bank_slot {bank_slot}"
-    )]
-    NoEpochValidatorStake {
-        reward_epoch: Epoch,
-        bank_slot: Slot,
-    },
+    #[error("missing epoch inflation state for in bank_slot {bank_slot}")]
+    MissingEpochInflationState { bank_slot: Slot },
     #[error("validator {pubkey} missing in bank_slot {bank_slot} for reward slot {reward_slot}")]
     MissingRewardSlotValidator {
         pubkey: Pubkey,
@@ -175,7 +170,7 @@ struct RewardState<'a> {
     accounts: &'a HashMap<Pubkey, (u64, VoteAccount)>,
     /// Total stake at `reward_slot`.
     total_stake: u64,
-    /// inflation state at `reward_slot`.
+    /// inflation state at the current bank's epoch.
     epoch_inflation_state: EpochInflationState,
     migration_epoch: Epoch,
 }
@@ -196,21 +191,18 @@ impl<'a> RewardState<'a> {
         )?;
         let accounts = epoch_stakes.stakes().vote_accounts().as_ref();
         let total_stake = epoch_stakes.total_stake();
-        // This assumes that if the epoch_schedule ever changes, the new schedule will maintain correct
-        // info about older slots as well.
-        let reward_epoch = bank.epoch_schedule.get_epoch(reward_slot);
+        let current_epoch = bank.epoch();
         let epoch_inflation_state = {
+            // rewards are always credited to the bank's epoch so use the inflation budget from that
+            // epoch.
             let epoch_inflation_account_state = EpochInflationAccountState::new_from_bank(bank);
             // This function should only be called after alpenglow is active and the slot in the the epoch
             // that activated Alpenglow should have created the account.
             debug_assert!(epoch_inflation_account_state.is_some());
             epoch_inflation_account_state
                 .ok_or(RewardStateError::MissingEpochInflationAccountState { bank_slot })?
-                .get_epoch_state(reward_epoch)
-                .ok_or(RewardStateError::NoEpochValidatorStake {
-                    reward_epoch,
-                    bank_slot,
-                })?
+                .get_epoch_state(current_epoch)
+                .ok_or(RewardStateError::MissingEpochInflationState { bank_slot })?
         };
         let migration_epoch =
             get_migration_epoch(bank).ok_or(RewardStateError::GenesisCertNotFound {
@@ -221,7 +213,7 @@ impl<'a> RewardState<'a> {
             calc_slot_timestamp(bank, reward_slot, block_producer_time_nanos);
         Ok(Self {
             reward_slot_timestamp_ns,
-            current_epoch: bank.epoch(),
+            current_epoch,
             reward_slot,
             reward_validators,
             bank_slot,
@@ -1542,13 +1534,12 @@ mod tests {
             .collect::<HashMap<_, HashMap<Epoch, u64>>>();
         let leader_vote_pubkey = rewarded_bank.leader().vote_address;
         for &reward_slot in &reward_slots {
-            let reward_epoch = rewarded_bank.epoch_schedule.get_epoch(reward_slot);
             let processing_epoch = rewarded_bank
                 .epoch_schedule
                 .get_epoch(reward_slot.saturating_add(NUM_SLOTS_FOR_REWARD));
             let epoch_state = EpochInflationAccountState::new_from_bank(&rewarded_bank)
                 .unwrap()
-                .get_epoch_state(reward_epoch)
+                .get_epoch_state(processing_epoch)
                 .unwrap();
             let epoch_stakes = rewarded_bank.epoch_stakes_from_slot(reward_slot).unwrap();
             let total_stake = epoch_stakes.total_stake();


### PR DESCRIPTION
#### Problem

In AG, rewards for slot S are processed in slot S+8.  If both S and S+8 are in the same epoch, then the vote state's epoch credits for that epoch are incremented.  However, if S+8 is in the next epoch, then the next epoch's credits are incremented.  

The problem is that we are using the inflation state from the slot S's epoch to calculate the rewards.  And in the scenario where the inflation rate decreases between slot S's and slot S+8's epoch, we can exceed the inflation budget for slot S+8's epoch.


#### Summary of Changes

Always use the inflation state of the epoch in which a reward slot is processed i.e. always use the inflation state of the the processing bank's epoch.  This means that when the inflation rate decreases, validators would get paid a bit less for the work they did in the final 8 slots of the epoch.  However, given how slowly the inflation rate decreases and 8 is relatively few compared to the number of slots in an epoch, I don't think this is going to be big incentive for validators to modify their behaviour for these slots.

#### Testing

No tests added to support backporting.  Tests will be added in a separate PR after this lands.


Fixes #14581 