### PR TITLE
clippy: drop unused HRTB lifetime binder in accounts index

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -269,7 +269,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         &self,
         pubkey: &Pubkey,
         // return true if item should be added to in_mem cache
-        callback: impl for<'a> FnOnce(Option<&AccountMapEntry<T>>) -> (bool, RT),
+        callback: impl FnOnce(Option<&AccountMapEntry<T>>) -> (bool, RT),
     ) -> RT {
         self.get_only_in_mem(pubkey, true, |entry| {
             if let Some(entry) = entry {


### PR DESCRIPTION
#### Problem
Newer clippy's extra_unused_lifetimes fires on the `for<'a>` binder in `get_internal_cloned`'s callback bound, since `'a` is never referenced by the closure signature. 

#### Summary of Changes
The binder was a no-op, so remove it.

#### Testing
CI