### PR TITLE
clippy: use unwrap_or instead of identity map_or in blockstore

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3859,7 +3859,7 @@ impl Blockstore {
         entries: Vec<Entry>,
         version: u16,
     ) -> Result<usize /*num of data shreds*/> {
-        let mut parent_slot = parent.map_or(start_slot.saturating_sub(1), |v| v);
+        let mut parent_slot = parent.unwrap_or(start_slot.saturating_sub(1));
         let num_slots = (start_slot - parent_slot).max(1); // Note: slot 0 has parent slot 0
         assert!(num_ticks_in_start_slot < num_slots * ticks_per_slot);
         let mut remaining_ticks_in_slot = num_slots * ticks_per_slot - num_ticks_in_start_slot;


### PR DESCRIPTION
#### Problem
Newer clippy adds the map_or_identity lint, which flags `parent.map_or(default, |v| v)` in `write_entries`. 

#### Summary of Changes
Replace it with the equivalent `unwrap_or`.

#### Testing
CI
