### PR TITLE
clippy: allow result_large_err on async fns in rpc and quic-client

### DIFF
--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -446,6 +446,7 @@ impl QuicClient {
         Err(last_error.expect("QuicClient::_send_buffer last_error.expect"))
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn send_buffer<T>(
         &self,
         data: T,
@@ -461,6 +462,7 @@ impl QuicClient {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     pub async fn send_batch<T>(
         &self,
         buffers: &[T],

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1067,6 +1067,7 @@ impl JsonRpcRequestProcessor {
         largest_accounts_cache.set_largest_accounts(filter, slot, accounts)
     }
 
+    #[allow(clippy::result_large_err)]
     async fn get_largest_accounts(
         &self,
         config: Option<RpcLargestAccountsConfig>,
@@ -1121,6 +1122,7 @@ impl JsonRpcRequestProcessor {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     async fn get_supply(
         &self,
         config: Option<RpcSupplyConfig>,
@@ -2311,6 +2313,7 @@ impl JsonRpcRequestProcessor {
     }
 
     /// Get an iterator of spl-token accounts by owner address
+    #[allow(clippy::result_large_err)]
     async fn get_filtered_spl_token_accounts_by_owner(
         &self,
         bank: Arc<Bank>,
@@ -2360,6 +2363,7 @@ impl JsonRpcRequestProcessor {
     }
 
     /// Get an iterator of spl-token accounts by mint address
+    #[allow(clippy::result_large_err)]
     async fn get_filtered_spl_token_accounts_by_mint(
         &self,
         bank: Arc<Bank>,


### PR DESCRIPTION
#### Problem
Newer clippy looks through `async fn` return types for result_large_err, so six previously-quiet async functions now trip it on `ErrorKind` (384 bytes) and `RpcCustomError`.

#### Summary of Changes
Boxing those error types would be a cross-crate API break, so follow the existing precedent in this repo (rpc.rs, banks-client) and allow the lint at the call sites.

#### Testing
CI
