### PR TITLE
xdp: fix ring-size panic on bad ethtool report; geyser: add sendTransaction ingress notification

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -902,6 +902,7 @@ impl Validator {
         let (
             accounts_update_notifier,
             transaction_notifier,
+            received_transaction_notifier,
             deshred_transaction_notifier,
             entry_notifier,
             block_metadata_notifier,
@@ -910,13 +911,14 @@ impl Validator {
             (
                 service.get_accounts_update_notifier(),
                 service.get_transaction_notifier(),
+                service.get_received_transaction_notifier(),
                 service.get_deshred_transaction_notifier(),
                 service.get_entry_notifier(),
                 service.get_block_metadata_notifier(),
                 service.get_slot_status_notifier(),
             )
         } else {
-            (None, None, None, None, None, None)
+            (None, None, None, None, None, None, None)
         };
 
         info!(
@@ -1313,6 +1315,7 @@ impl Validator {
                 max_complete_transaction_status_slot: max_complete_transaction_status_slot.clone(),
                 prioritization_fee_cache: prioritization_fee_cache.clone(),
                 rpc_tpu_client_args,
+                received_transaction_notifier,
             };
             let json_rpc_service =
                 JsonRpcService::new_with_config(rpc_svc_config).map_err(ValidatorError::Other)?;

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -519,6 +519,34 @@ pub enum ReplicaContactInfoVersions<'a> {
     V0_0_1(&'a ReplicaContactInfoV0_0_1<'a>),
 }
 
+/// Information about a transaction accepted on the RPC sendTransaction
+/// ingress path, captured after decode and sanitization succeed and
+/// independent of TPU forwarding.
+#[derive(Debug)]
+#[repr(C)]
+pub struct ReceivedTransactionInfo<'a> {
+    /// First signature of the transaction.
+    pub signature: &'a Signature,
+
+    /// Serialized wire transaction, exactly as received.
+    pub transaction: &'a [u8],
+
+    /// Nanoseconds since the UNIX epoch at which the node accepted the transaction.
+    pub received_ns: u64,
+
+    /// The node's view of the current slot at admission (best-effort).
+    pub slot_hint: Slot,
+
+    /// Whether the client requested `skipPreflight`. When true, the transaction's
+    /// signatures were NOT verified before this notification fired.
+    pub preflight_skipped: bool,
+}
+
+#[repr(u32)]
+pub enum ReceivedTransactionInfoVersions<'a> {
+    V0_0_1(&'a ReceivedTransactionInfo<'a>),
+}
+
 /// Errors returned by plugin calls
 #[derive(Error, Debug)]
 #[repr(u32)]
@@ -877,6 +905,24 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// Default is false -- if the plugin is interested in
     /// transaction data, please return true.
     fn transaction_notifications_enabled(&self) -> bool {
+        false
+    }
+
+    /// Called when a transaction is accepted on the RPC sendTransaction ingress
+    /// path, before it is known whether the transaction lands. Only called when
+    /// `transaction_received_notifications_enabled()` returns true.
+    #[allow(unused_variables)]
+    fn notify_transaction_received(
+        &self,
+        transaction: ReceivedTransactionInfoVersions,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check if the plugin is interested in sendTransaction ingress data.
+    /// Default is false -- if the plugin is interested in this data,
+    /// please return true.
+    fn transaction_received_notifications_enabled(&self) -> bool {
         false
     }
 

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -103,6 +103,16 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if there is any plugin interested in sendTransaction ingress data
+    pub fn transaction_received_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.transaction_received_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Check if there is any plugin interested in entry data
     pub fn entry_notifications_enabled(&self) -> bool {
         for plugin in &self.plugins {

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -8,7 +8,7 @@ use {
         geyser_plugin_manager::{GeyserPluginManager, GeyserPluginManagerRequest},
         slot_status_notifier::SlotStatusNotifierImpl,
         slot_status_observer::SlotStatusObserver,
-        transaction_notifier::TransactionNotifierImpl,
+        transaction_notifier::{ReceivedTransactionNotifierImpl, TransactionNotifierImpl},
     },
     arc_swap::ArcSwap,
     crossbeam_channel::Receiver,
@@ -21,7 +21,7 @@ use {
     solana_rpc::{
         optimistically_confirmed_bank_tracker::SlotNotification,
         slot_status_notifier::SlotStatusNotifier,
-        transaction_notifier_interface::TransactionNotifierArc,
+        transaction_notifier_interface::{ReceivedTransactionNotifierArc, TransactionNotifierArc},
     },
     std::{
         path::{Path, PathBuf},
@@ -44,6 +44,7 @@ pub struct GeyserPluginService {
     plugin_manager: Arc<ArcSwap<GeyserPluginManager>>,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
     transaction_notifier: Option<TransactionNotifierArc>,
+    received_transaction_notifier: Option<ReceivedTransactionNotifierArc>,
     deshred_transaction_notifier: Option<DeshredTransactionNotifierArc>,
     entry_notifier: Option<EntryNotifierArc>,
     block_metadata_notifier: Option<BlockMetadataNotifierArc>,
@@ -105,6 +106,10 @@ impl GeyserPluginService {
         let transaction_notifications_enabled =
             plugin_manager.load().transaction_notifications_enabled()
                 || geyser_plugin_always_enabled;
+        let transaction_received_notifications_enabled = plugin_manager
+            .load()
+            .transaction_received_notifications_enabled()
+            || geyser_plugin_always_enabled;
         let deshred_transaction_notifications_enabled = plugin_manager
             .load()
             .deshred_transaction_notifications_enabled()
@@ -129,6 +134,15 @@ impl GeyserPluginService {
             if transaction_notifications_enabled {
                 let transaction_notifier = TransactionNotifierImpl::new(plugin_manager.clone());
                 Some(Arc::new(transaction_notifier))
+            } else {
+                None
+            };
+
+        let received_transaction_notifier: Option<ReceivedTransactionNotifierArc> =
+            if transaction_received_notifications_enabled {
+                let received_transaction_notifier =
+                    ReceivedTransactionNotifierImpl::new(plugin_manager.clone());
+                Some(Arc::new(received_transaction_notifier))
             } else {
                 None
             };
@@ -187,6 +201,7 @@ impl GeyserPluginService {
             plugin_manager,
             accounts_update_notifier,
             transaction_notifier,
+            received_transaction_notifier,
             deshred_transaction_notifier,
             entry_notifier,
             block_metadata_notifier,
@@ -218,6 +233,10 @@ impl GeyserPluginService {
 
     pub fn get_transaction_notifier(&self) -> Option<TransactionNotifierArc> {
         self.transaction_notifier.clone()
+    }
+
+    pub fn get_received_transaction_notifier(&self) -> Option<ReceivedTransactionNotifierArc> {
+        self.received_transaction_notifier.clone()
     }
 
     pub fn get_deshred_transaction_notifier(&self) -> Option<DeshredTransactionNotifierArc> {

--- a/geyser-plugin-manager/src/transaction_notifier.rs
+++ b/geyser-plugin-manager/src/transaction_notifier.rs
@@ -2,13 +2,14 @@
 use {
     crate::geyser_plugin_manager::GeyserPluginManager,
     agave_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaTransactionInfoV3, ReplicaTransactionInfoVersions,
+        ReceivedTransactionInfo, ReceivedTransactionInfoVersions, ReplicaTransactionInfoV3,
+        ReplicaTransactionInfoVersions,
     },
     arc_swap::ArcSwap,
     log::*,
     solana_clock::{BankId, Slot},
     solana_hash::Hash,
-    solana_rpc::transaction_notifier_interface::TransactionNotifier,
+    solana_rpc::transaction_notifier_interface::{ReceivedTransactionNotifier, TransactionNotifier},
     solana_signature::Signature,
     solana_transaction::versioned::VersionedTransaction,
     solana_transaction_status::TransactionStatusMeta,
@@ -98,5 +99,69 @@ impl TransactionNotifierImpl {
             transaction,
             transaction_status_meta,
         }
+    }
+}
+
+/// This implementation of ReceivedTransactionNotifier is passed to the RPC service's
+/// sendTransaction handler at validator startup. The handler invokes
+/// notify_transaction_received for each transaction it admits, independent of TPU
+/// forwarding; the implementation in turn invokes notify_transaction_received of each
+/// plugin enabled with sendTransaction-ingress notification managed by the
+/// GeyserPluginManager.
+pub(crate) struct ReceivedTransactionNotifierImpl {
+    plugin_manager: Arc<ArcSwap<GeyserPluginManager>>,
+}
+
+impl ReceivedTransactionNotifier for ReceivedTransactionNotifierImpl {
+    fn notify_transaction_received(
+        &self,
+        signature: &Signature,
+        transaction: &[u8],
+        received_ns: u64,
+        slot_hint: Slot,
+        preflight_skipped: bool,
+    ) {
+        let plugin_manager = self.plugin_manager.load();
+
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+
+        let info = ReceivedTransactionInfo {
+            signature,
+            transaction,
+            received_ns,
+            slot_hint,
+            preflight_skipped,
+        };
+
+        for plugin in plugin_manager.plugins.iter() {
+            if !plugin.transaction_received_notifications_enabled() {
+                continue;
+            }
+            match plugin
+                .notify_transaction_received(ReceivedTransactionInfoVersions::V0_0_1(&info))
+            {
+                Err(err) => {
+                    error!(
+                        "Failed to notify received transaction, error: ({}) to plugin {}",
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Successfully notified received transaction to plugin {}",
+                        plugin.name()
+                    );
+                }
+            }
+        }
+    }
+}
+
+impl ReceivedTransactionNotifierImpl {
+    pub fn new(plugin_manager: Arc<ArcSwap<GeyserPluginManager>>) -> Self {
+        Self { plugin_manager }
     }
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -8,6 +8,7 @@ use {
         filter::filter_allows, max_slots::MaxSlots,
         optimistically_confirmed_bank_tracker::OptimisticallyConfirmedBank,
         parsed_token_accounts::*, rpc_cache::LargestAccountsCache, rpc_health::*,
+        transaction_notifier_interface::ReceivedTransactionNotifierArc,
     },
     agave_snapshots::{paths as snapshot_paths, snapshot_config::SnapshotConfig},
     agave_votor_messages::wire::{WireBlockCertMessage, WireCertSignature},
@@ -114,7 +115,7 @@ use {
             Arc, RwLock,
             atomic::{AtomicBool, AtomicU64, Ordering},
         },
-        time::Duration,
+        time::{Duration, SystemTime, UNIX_EPOCH},
     },
     tokio::runtime::Runtime,
 };
@@ -250,6 +251,7 @@ pub struct JsonRpcRequestProcessor {
     cluster_info: Arc<ClusterInfo>,
     genesis_hash: Hash,
     transaction_sender: Sender<TransactionInfo>,
+    received_transaction_notifier: Option<ReceivedTransactionNotifierArc>,
     bigtable_ledger_storage: Option<solana_storage_bigtable::LedgerStorage>,
     optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
     largest_accounts_cache: Arc<RwLock<LargestAccountsCache>>,
@@ -422,6 +424,7 @@ impl JsonRpcRequestProcessor {
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         runtime: Arc<Runtime>,
+        received_transaction_notifier: Option<ReceivedTransactionNotifierArc>,
     ) -> (Self, Receiver<TransactionInfo>) {
         let (transaction_sender, transaction_receiver) = unbounded();
         (
@@ -436,6 +439,7 @@ impl JsonRpcRequestProcessor {
                 cluster_info,
                 genesis_hash,
                 transaction_sender,
+                received_transaction_notifier,
                 bigtable_ledger_storage,
                 optimistically_confirmed_bank,
                 largest_accounts_cache,
@@ -523,6 +527,7 @@ impl JsonRpcRequestProcessor {
             cluster_info,
             genesis_hash,
             transaction_sender,
+            received_transaction_notifier: None,
             bigtable_ledger_storage: None,
             optimistically_confirmed_bank,
             largest_accounts_cache: Arc::new(RwLock::new(LargestAccountsCache::new(30))),
@@ -2746,7 +2751,17 @@ fn _send_transaction(
     last_valid_block_height: u64,
     durable_nonce_info: Option<(Pubkey, Hash)>,
     max_retries: Option<usize>,
+    slot_hint: Slot,
+    preflight_skipped: bool,
 ) -> Result<String> {
+    // Preserved for the received-transaction notification below: `wire_transaction` is
+    // moved into `transaction_info` and forwarded through the channel, so the raw bytes
+    // are no longer available to us once `.send()` is called.
+    let received_transaction_bytes = meta
+        .received_transaction_notifier
+        .as_ref()
+        .map(|_| wire_transaction.clone());
+
     let transaction_info = TransactionInfo::new(
         message_hash,
         signature,
@@ -2760,6 +2775,24 @@ fn _send_transaction(
     meta.transaction_sender
         .send(transaction_info)
         .unwrap_or_else(|err| warn!("Failed to enqueue transaction: {err}"));
+
+    // Fired after the transaction is already handed off above, so plugin cost can never
+    // delay forwarding to the leader.
+    if let (Some(notifier), Some(wire_transaction)) =
+        (&meta.received_transaction_notifier, received_transaction_bytes)
+    {
+        let received_ns = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0);
+        notifier.notify_transaction_received(
+            &signature,
+            &wire_transaction,
+            received_ns,
+            slot_hint,
+            preflight_skipped,
+        );
+    }
 
     Ok(signature.to_string())
 }
@@ -3866,6 +3899,8 @@ pub mod rpc_full {
                 last_valid_block_height,
                 None,
                 None,
+                bank.slot(),
+                true, // request_airdrop never runs preflight simulation
             )
         }
 
@@ -4011,6 +4046,8 @@ pub mod rpc_full {
                 last_valid_block_height,
                 durable_nonce_info,
                 max_retries,
+                preflight_bank.slot(),
+                skip_preflight,
             )
         }
 
@@ -4916,6 +4953,7 @@ pub mod tests {
                 max_complete_transaction_status_slot.clone(),
                 prioritization_fee_cache,
                 service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj),
+                None,
             )
             .0;
 
@@ -6992,6 +7030,7 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Some(Arc::new(PrioritizationFeeCache::default())),
             runtime.clone(),
+            None,
         );
 
         let (tpu_sender, _client) =
@@ -7307,6 +7346,7 @@ pub mod tests {
             Arc::new(AtomicU64::default()),
             Some(Arc::new(PrioritizationFeeCache::default())),
             runtime,
+            None,
         );
 
         SendTransactionService::new(
@@ -9077,6 +9117,7 @@ pub mod tests {
             max_complete_transaction_status_slot,
             prioritization_fee_cache_inner.clone(),
             service_runtime(rpc_threads, rpc_blocking_threads, rpc_niceness_adj),
+            None,
         );
 
         let mut io = MetaIoHandler::default();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -8,6 +8,7 @@ use {
         rpc::{rpc_accounts::*, rpc_accounts_scan::*, rpc_bank::*, rpc_full::*, rpc_minimal::*, *},
         rpc_cache::LargestAccountsCache,
         rpc_health::*,
+        transaction_notifier_interface::ReceivedTransactionNotifierArc,
     },
     agave_snapshots::{
         SnapshotInterval, paths as snapshot_paths,
@@ -495,6 +496,7 @@ pub struct JsonRpcServiceConfig<'a> {
     pub max_complete_transaction_status_slot: Arc<AtomicU64>,
     pub prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
     pub rpc_tpu_client_args: RpcTpuClientArgs<'a>,
+    pub received_transaction_notifier: Option<ReceivedTransactionNotifierArc>,
 }
 
 /// Arguments required to create a TPU client for the RPC service.
@@ -571,6 +573,7 @@ impl JsonRpcService {
             config.max_complete_transaction_status_slot,
             config.prioritization_fee_cache,
             runtime,
+            config.received_transaction_notifier,
         )?;
         Ok(json_rpc_service)
     }
@@ -600,6 +603,7 @@ impl JsonRpcService {
         max_complete_transaction_status_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Option<Arc<PrioritizationFeeCache>>,
         runtime: Arc<TokioRuntime>,
+        received_transaction_notifier: Option<ReceivedTransactionNotifierArc>,
     ) -> Result<Self, String> {
         info!("rpc bound to {rpc_addr:?}");
         info!("rpc configuration: {config:?}");
@@ -692,6 +696,7 @@ impl JsonRpcService {
             max_complete_transaction_status_slot,
             prioritization_fee_cache,
             Arc::clone(&runtime),
+            received_transaction_notifier,
         );
 
         let _send_transaction_service = Arc::new(SendTransactionService::new(
@@ -924,6 +929,7 @@ mod tests {
             Arc::new(AtomicU64::default()),
             Some(Arc::new(PrioritizationFeeCache::default())),
             runtime,
+            None,
         )
         .expect("assume successful JsonRpcService start");
         let thread = rpc_service.thread_hdl.thread();

--- a/rpc/src/transaction_notifier_interface.rs
+++ b/rpc/src/transaction_notifier_interface.rs
@@ -22,3 +22,16 @@ pub trait TransactionNotifier {
 }
 
 pub type TransactionNotifierArc = Arc<dyn TransactionNotifier + Sync + Send>;
+
+pub trait ReceivedTransactionNotifier {
+    fn notify_transaction_received(
+        &self,
+        signature: &Signature,
+        transaction: &[u8],
+        received_ns: u64,
+        slot_hint: Slot,
+        preflight_skipped: bool,
+    );
+}
+
+pub type ReceivedTransactionNotifierArc = Arc<dyn ReceivedTransactionNotifier + Sync + Send>;

--- a/xdp/src/device.rs
+++ b/xdp/src/device.rs
@@ -200,10 +200,7 @@ impl NetworkDevice {
             return Err(io::Error::last_os_error());
         }
 
-        Ok(RingSizes {
-            rx: rp.rx_pending as usize,
-            tx: rp.tx_pending as usize,
-        })
+        RingSizes::from_ethtool_pending(if_name, rp.rx_pending, rp.tx_pending)
     }
 }
 
@@ -218,6 +215,45 @@ impl Default for RingSizes {
         // These are reasonable defaults for devices which don't have a set ring size. Values must
         // be a power of two.
         Self { rx: 1024, tx: 1024 }
+    }
+}
+
+impl RingSizes {
+    /// A driver-reported ring size this large would mean multi-gigabyte UMEM allocations;
+    /// anything at or above this is treated as an unusable ioctl response rather than a
+    /// legitimate configuration. Real NICs top out in the tens of thousands.
+    const MAX_RING_SIZE: u32 = 1 << 20;
+
+    /// Validates raw ethtool ring-parameter values before they can reach [`RingSizes`].
+    ///
+    /// A "successful" `SIOCETHTOOL` ioctl (e.g. on some bonded interfaces) can still report
+    /// `rx_pending == 0` or `tx_pending == 0`, or report values that are individually nonzero
+    /// but not powers of two, or not power-of-two once combined by callers (see
+    /// `xdp::tx_loop::umem_frame_count`). Rejecting anything that isn't a usable nonzero
+    /// power of two here means every caller of `ring_sizes()` gets a `None`/`Err` instead of a
+    /// value that later panics deep inside `PageAlignedMemory::alloc_with_page_size`'s
+    /// `debug_assert!(frame_count.is_power_of_two())` -- the kernel itself rejects non-power-of-two
+    /// ring sizes with `EINVAL` at `xsk_init_queue()` bind time, and this crate's own ring index
+    /// masking (`index & (size - 1)`) is only correct for powers of two, so a non-power-of-two
+    /// value was never actually usable.
+    fn from_ethtool_pending(if_name: &str, rx_pending: u32, tx_pending: u32) -> io::Result<Self> {
+        let usable = |pending: u32| -> bool {
+            pending != 0 && pending.is_power_of_two() && pending < Self::MAX_RING_SIZE
+        };
+        if !usable(rx_pending) || !usable(tx_pending) {
+            return Err(io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "{if_name} reported an unusable ring size despite a successful ethtool \
+                     query (rx={rx_pending}, tx={tx_pending}); expected both to be a nonzero \
+                     power of two"
+                ),
+            ));
+        }
+        Ok(Self {
+            rx: rx_pending as usize,
+            tx: tx_pending as usize,
+        })
     }
 }
 
@@ -496,6 +532,51 @@ pub(crate) unsafe fn mmap_ring<T>(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_ring_sizes_default_is_usable() {
+        let default = RingSizes::default();
+        assert!(RingSizes::from_ethtool_pending(
+            "test0",
+            default.rx as u32,
+            default.tx as u32
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_ring_sizes_from_ethtool_pending_accepts_valid_sizes() {
+        // symmetric and legitimately ASYMMETRIC nonzero power-of-two sizes must both
+        // be accepted -- individually valid ring sizes are not required to be equal.
+        for (rx, tx) in [(1024, 1024), (4096, 512), (512, 4096), (1, 1), (65536, 32768)] {
+            assert!(
+                RingSizes::from_ethtool_pending("test0", rx, tx).is_ok(),
+                "expected rx={rx}, tx={tx} to be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_ring_sizes_from_ethtool_pending_rejects_unusable_sizes() {
+        // This is the real discriminator for the original issue: a "successful" ioctl
+        // (res >= 0) that reports a zero, non-power-of-two, or absurdly large ring size
+        // must be rejected here so a bad value never reaches TxLoopBuilder::new.
+        for (rx, tx) in [
+            (0, 0),
+            (0, 1024),
+            (1024, 0),
+            (1023, 1024),
+            (1024, 1023),
+            (RingSizes::MAX_RING_SIZE, 1024),
+        ] {
+            let result = RingSizes::from_ethtool_pending("test0", rx, tx);
+            assert!(
+                result.is_err(),
+                "expected rx={rx}, tx={tx} to be rejected, got {result:?}"
+            );
+            assert_eq!(result.unwrap_err().kind(), ErrorKind::InvalidData);
+        }
+    }
 
     #[test]
     fn test_ring_producer() {

--- a/xdp/src/socket.rs
+++ b/xdp/src/socket.rs
@@ -245,7 +245,7 @@ impl<U: Umem> Socket<U> {
             // See Socket::new() as to why this is needed
             let rx = queue
                 .ring_sizes()
-                .ok_or_else(|| io::Error::other("zero copy requires a set ring size"))?
+                .ok_or_else(|| io::Error::other("zero copy requires a usable device ring size"))?
                 .rx;
             (rx, rx)
         } else {

--- a/xdp/src/tx_loop.rs
+++ b/xdp/src/tx_loop.rs
@@ -33,6 +33,22 @@ use {
     },
 };
 
+/// Derives the UMEM frame count from a device's RX/TX ring sizes.
+///
+/// `PageAlignedMemory::alloc_with_page_size` requires `frame_count` to be a nonzero power of
+/// two. `RingSizes::from_ethtool_pending` already guarantees `rx_size`/`tx_size` are each a
+/// nonzero power of two individually, but their sum is not necessarily one -- e.g. a driver
+/// legitimately reporting rx=4096/tx=512 yields `(4096 + 512) * 2 = 9216`, which is not a power
+/// of two. Rounding up (rather than erroring) is safe here: a larger UMEM than the exact ring
+/// size is just a bigger pool of spare TX frames, never fewer than what the ring needs.
+fn umem_frame_count(rx_size: usize, tx_size: usize) -> usize {
+    rx_size
+        .saturating_add(tx_size)
+        .saturating_mul(2)
+        .checked_next_power_of_two()
+        .unwrap_or(1usize << 63)
+}
+
 pub struct TxLoopConfigBuilder {
     zero_copy: bool,
     maybe_src_mac: Option<MacAddress>,
@@ -128,7 +144,7 @@ impl TxLoopBuilder<OwnedUmem> {
             RingSizes::default()
         });
 
-        let frame_count = (rx_size + tx_size) * 2;
+        let frame_count = umem_frame_count(rx_size, tx_size);
 
         // try to allocate huge pages first, then fall back to regular pages
         const HUGE_2MB: usize = 2 * 1024 * 1024;
@@ -692,7 +708,47 @@ fn kick_error(e: std::io::Error) {
 
 #[cfg(test)]
 mod tests {
-    use crate::tx_loop::{Receiver, TryRecvError, TrySendError, channel};
+    use crate::{
+        tx_loop::{Receiver, TryRecvError, TrySendError, channel, umem_frame_count},
+        umem::PageAlignedMemory,
+    };
+
+    #[test]
+    fn test_umem_frame_count_is_always_a_nonzero_power_of_two() {
+        // (rx, tx) pairs include the exact zero case from the original issue, symmetric
+        // sizes whose sum is already a power of two, and legitimate ASYMMETRIC nonzero
+        // sizes (e.g. rx=4096/tx=512, a realistic ethtool -G configuration) whose sum is
+        // NOT a power of two -- this is the case the original zero-only guard missed.
+        for (rx, tx) in [
+            (0, 0),
+            (1024, 1024),
+            (1, 1),
+            (2048, 128),
+            (4096, 512),
+            (511, 512),
+            (65536, 32768),
+        ] {
+            let frame_count = umem_frame_count(rx, tx);
+            assert!(
+                frame_count.is_power_of_two(),
+                "umem_frame_count({rx}, {tx}) = {frame_count} is not a power of two"
+            );
+            assert!(frame_count >= (rx + tx) * 2);
+
+            // The real discriminator: this must not panic. On the pre-fix computation
+            // `(rx_size + tx_size) * 2`, (4096, 512) produces 9216, which is not a power
+            // of two and trips `debug_assert!(frame_count.is_power_of_two())` below.
+            let frame_size = 4096;
+            let memory = PageAlignedMemory::alloc(frame_size, frame_count)
+                .expect("frame_count must be usable for a real allocation");
+            assert_eq!(memory.len(), frame_size * frame_count);
+        }
+    }
+
+    #[test]
+    fn test_umem_frame_count_does_not_overflow() {
+        assert_eq!(umem_frame_count(usize::MAX, usize::MAX), 1usize << 63);
+    }
 
     #[test]
     fn test_send_full() {


### PR DESCRIPTION
Fixes #14564
Fixes #14508

Heads up: these two are unrelated. I bundled them because I worked
through them back to back and it was convenient. Happy to split into
two PRs if that's easier to review.

#### Problem

**#14564**: a successful ethtool ioctl can still report a ring size
of zero. Bonded interfaces do this. That zero flows straight into
`frame_count = (rx + tx) * 2` with no guard and panics on the
power-of-two debug_assert inside `PageAlignedMemory::alloc_with_page_size`.

The zero case turned out to be only half of it. Any driver reporting
legitimate but asymmetric sizes hits the same panic. rx=4096/tx=512
is a normal `ethtool -G` config, and 4096+512 doubled isn't a power
of two either, so it blows up the same way.

**#14508**: every Geyser notification fires after execution today
(replay, commitment, etc). There's no way to observe a transaction the
moment RPC accepts it. If you want to measure submit-to-land latency
from the node's own point of view, the earliest data point available
right now is a full submit -> Turbine -> replay round trip, even
though the node has the bytes in hand a few ms after sendTransaction
returns.

#### Summary of Changes

xdp:
- `RingSizes::from_ethtool_pending` now validates that rx and tx are
  both a nonzero power of two before anything downstream touches them.
  A bad report becomes an error instead of garbage. Callers either
  fall back to `RingSizes::default()` (the non-zero-copy path) or fail
  loudly where a fabricated default would be wrong (zero-copy needs a
  real ring size).
- `frame_count` now rounds up to the next power of two instead of
  trusting the raw sum. That's what actually fixes the asymmetric case.
- Tests for the zero case, asymmetric sizes, and the frame count math
  itself. The frame count test fails against the old `(rx + tx) * 2`,
  so it's not just testing itself.

geyser / rpc:
- New `ReceivedTransactionInfo` type plus two default-implemented
  `GeyserPlugin` methods (`notify_transaction_received`,
  `transaction_received_notifications_enabled`). Both default to no-op,
  so existing plugins keep compiling untouched.
- Wired through the same path as the existing `TransactionNotifier`
  (rpc -> geyser-plugin-manager -> validator startup), just for the
  ingress event instead of the replay-time one.
- Fires in `_send_transaction` right after the tx is handed to the
  forwarding channel, so plugin overhead can't delay forwarding to the
  leader.

One thing I'm not sure about and would want a second opinion on: the
ingress notification also fires for `request_airdrop` transactions
(faucet-generated, not client-submitted), because they go through the
same `_send_transaction` path. That's arguably out of scope for
#14508, which is about client-submitted tx latency.

cc @alessandrod for the xdp side, @alex-lind1
for the geyser/rpc side figured you two would know fastest whether
I'm missing something. 

Also tagging @martyn-coburn-smith and @karmaol
since you filed the original issues.