### PR TITLE
remove Result from get_write_batch

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2891,7 +2891,7 @@ fn cleanup_blockstore_incorrect_shred_versions(
             let mut num_slots_copied = 0;
             let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
             let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
-            let mut write_batch = backup_blockstore.get_write_batch()?;
+            let mut write_batch = backup_blockstore.get_write_batch();
             for (slot, _meta) in slot_meta_iterator {
                 let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -442,7 +442,7 @@ impl WindowService {
                     shred_version,
                 );
                 let mut pinnable_slice = blockstore.new_pinnable_slice();
-                let mut write_batch = blockstore.get_write_batch().unwrap();
+                let mut write_batch = blockstore.get_write_batch();
 
                 while !exit.load(Ordering::Relaxed) {
                     shred_recovery_context.maybe_update(sharable_banks.root());

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -631,7 +631,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 AccessType::PrimaryForMaintenance,
             );
             let mut pinnable_slice = target.new_pinnable_slice();
-            let mut write_batch = target.get_write_batch()?;
+            let mut write_batch = target.get_write_batch();
 
             for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
                 if slot > ending_slot {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2446,7 +2446,7 @@ fn main() {
                                 AccessType::PrimaryForMaintenance,
                             ));
                             let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
-                            let mut write_batch = backup_blockstore.get_write_batch().unwrap();
+                            let mut write_batch = backup_blockstore.get_write_batch();
                             let _ = backup_blockstore
                                 .insert_cow_shreds(
                                     shreds.into_iter().map(Cow::Owned),
@@ -2494,9 +2494,7 @@ fn main() {
                             .map(Cow::Owned)
                             .collect();
                         let mut pinnable_slice = rw_blockstore.new_pinnable_slice();
-                        let mut write_batch = rw_blockstore
-                            .get_write_batch()
-                            .expect("Blockstore operation must succeed");
+                        let mut write_batch = rw_blockstore.get_write_batch();
                         rw_blockstore
                             .insert_cow_shreds(shreds, true, &mut pinnable_slice, &mut write_batch)
                             .expect("Blockstore operation must succeed");

--- a/ledger/benches/blockstore.rs
+++ b/ledger/benches/blockstore.rs
@@ -155,7 +155,7 @@ fn bench_add_transaction_memos_to_batch(b: &mut Bencher) {
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
     let signatures: Vec<Signature> = (0..64).map(|_| Signature::new_unique()).collect();
     b.iter(|| {
-        let mut memos_batch = blockstore.get_write_batch().unwrap();
+        let mut memos_batch = blockstore.get_write_batch();
 
         for (slot, signature) in signatures.iter().enumerate() {
             blockstore
@@ -226,7 +226,7 @@ fn bench_add_transaction_status_to_batch(b: &mut Bencher) {
     let slot = 5;
 
     b.iter(|| {
-        let mut status_batch = blockstore.get_write_batch().unwrap();
+        let mut status_batch = blockstore.get_write_batch();
 
         for (tx_idx, signature) in signatures.iter().enumerate() {
             blockstore

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2353,7 +2353,7 @@ impl Blockstore {
         F: Fn(PossibleDuplicateShred),
     {
         let mut pinnable_slice = self.new_pinnable_slice();
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
         self.insert_shreds_at_location_handle_duplicate(
             shreds
                 .into_iter()
@@ -2484,7 +2484,7 @@ impl Blockstore {
         let shreds = shreds.into_iter().map(|shred| {
             (Cow::Owned(shred), /*is_repaired:*/ false, to_location)
         });
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
         self.do_insert_shreds_locked(
             lock,
             shreds,
@@ -2622,7 +2622,7 @@ impl Blockstore {
         is_trusted: bool,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let mut pinnable_slice = self.new_pinnable_slice();
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
         let shreds = shreds.into_iter().map(Cow::Owned);
         self.insert_cow_shreds(shreds, is_trusted, &mut pinnable_slice, &mut write_batch)
     }
@@ -2630,7 +2630,7 @@ impl Blockstore {
     #[cfg(test)]
     fn insert_shred_return_duplicate(&self, shred: Shred) -> Vec<PossibleDuplicateShred> {
         let mut pinnable_slice = self.new_pinnable_slice();
-        let mut write_batch = self.get_write_batch().unwrap();
+        let mut write_batch = self.get_write_batch();
         let insert_results = self
             .do_insert_shreds(
                 [(
@@ -5308,7 +5308,7 @@ impl Blockstore {
         &self,
         duplicate_confirmed_slot_hashes: impl Iterator<Item = (Slot, Hash)>,
     ) -> Result<()> {
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
         for (slot, frozen_hash) in duplicate_confirmed_slot_hashes {
             let data = FrozenHashVersioned::Current(FrozenHashStatus {
                 frozen_hash,
@@ -5323,7 +5323,7 @@ impl Blockstore {
     }
 
     pub fn set_roots<'a>(&self, rooted_slots: impl Iterator<Item = &'a Slot>) -> Result<()> {
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
         let mut max_new_rooted_slot = 0;
         for slot in rooted_slots {
             max_new_rooted_slot = std::cmp::max(max_new_rooted_slot, *slot);
@@ -5597,7 +5597,7 @@ impl Blockstore {
             return Ok(());
         }
         info!("Marking slot {root} and any full children slots as connected");
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
 
         // Mark both connected bits on the root slot so that the flags for this
         // slot match the flags of slots that become connected the typical way.
@@ -6138,7 +6138,7 @@ impl Blockstore {
         Ok(index_meta_entry)
     }
 
-    pub fn get_write_batch(&self) -> Result<WriteBatch> {
+    pub fn get_write_batch(&self) -> WriteBatch {
         self.db.batch()
     }
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -136,7 +136,7 @@ impl Blockstore {
         let Some(mut slot_meta) = self.meta(slot)? else {
             return Err(BlockstoreError::SlotUnavailable);
         };
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
 
         self.purge_range(
             &mut write_batch,
@@ -193,7 +193,7 @@ impl Blockstore {
         cleanup_chaining: bool,
         purge_stats: &mut PurgeStats,
     ) -> Result<()> {
-        let mut write_batch = self.get_write_batch()?;
+        let mut write_batch = self.get_write_batch();
 
         let mut delete_range_timer = Measure::start("delete_range");
         self.purge_range(
@@ -1184,7 +1184,7 @@ pub mod tests {
         );
         blockstore.insert_shreds(shreds, false).unwrap();
 
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
         blockstore
             .purge_special_columns_exact(&mut write_batch, slot, slot + 1)
             .unwrap();

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -1892,7 +1892,7 @@ fn test_merkle_root_metas_coding() {
     let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let coding_shred = coding_shreds[index as usize].clone();
 
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
         ShredInsertionTracker::new(coding_shreds.len(), &mut write_batch);
     blockstore
@@ -1949,7 +1949,7 @@ fn test_merkle_root_metas_coding() {
     let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let new_coding_shred = coding_shreds[(index + 1) as usize].clone();
 
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
         ShredInsertionTracker::new(coding_shreds.len(), &mut write_batch);
 
@@ -2084,7 +2084,7 @@ fn test_merkle_root_metas_data() {
     let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred = data_shreds[0].clone();
 
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
         ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
     blockstore
@@ -2141,7 +2141,7 @@ fn test_merkle_root_metas_data() {
     let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let new_data_shred = data_shreds[1].clone();
 
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
         ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
 
@@ -2237,7 +2237,7 @@ fn test_merkle_root_metas_data() {
         .next()
         .unwrap();
 
-    let mut write_batch = blockstore.db.batch().unwrap();
+    let mut write_batch = blockstore.db.batch();
     let mut shred_insertion_tracker =
         ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
     blockstore
@@ -2313,7 +2313,7 @@ fn test_check_insert_coding_shred() {
         );
     let coding_shred = code_shreds[0].clone();
 
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker = ShredInsertionTracker::new(1, &mut write_batch);
     blockstore
         .check_insert_coding_shred(
@@ -2443,7 +2443,7 @@ fn test_mark_slot_dead_if_not_full() {
         block_id: Hash::new_unique(),
     };
 
-    let mut write_batch = blockstore.db.batch().unwrap();
+    let mut write_batch = blockstore.db.batch();
     let mut shred_insertion_tracker = ShredInsertionTracker::new(1, &mut write_batch);
 
     blockstore.mark_slot_dead_if_not_full(empty_slot, location, &mut shred_insertion_tracker);
@@ -4685,7 +4685,7 @@ fn test_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4736,7 +4736,7 @@ fn test_skip_alt_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4814,7 +4814,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
 
     let genesis_config = create_genesis_config(2).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -6188,7 +6188,7 @@ fn test_chained_merkle_root_upgrade_inconsistency_backwards() {
     blockstore
         .put_erasure_meta(coding_shred_previous.erasure_set(), &erasure_meta)
         .unwrap();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     blockstore
         .merkle_root_meta_cf
         .delete_range_in_batch(&mut write_batch, slot, slot);
@@ -6259,7 +6259,7 @@ fn test_chained_merkle_root_upgrade_inconsistency_forwards() {
 
     // Remove the merkle root meta in order to simulate this blockstore originating from
     // an older version.
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     blockstore
         .merkle_root_meta_cf
         .delete_range_in_batch(&mut write_batch, slot, slot);
@@ -6303,7 +6303,7 @@ fn test_add_transaction_memos_to_batch() {
     let blockstore =
         Blockstore::open(ledger_path.path()).expect("Expected to be able to open database ledger");
     let signatures: Vec<Signature> = (0..2).map(|_| Signature::new_unique()).collect();
-    let mut memos_batch = blockstore.get_write_batch().unwrap();
+    let mut memos_batch = blockstore.get_write_batch();
 
     blockstore
         .add_transaction_memos_to_batch(
@@ -6378,7 +6378,7 @@ fn test_add_transaction_status_to_batch() {
         .map(|_| vec![(Pubkey::new_unique(), true), (Pubkey::new_unique(), false)])
         .collect();
     let slot = 5;
-    let mut status_batch = blockstore.get_write_batch().unwrap();
+    let mut status_batch = blockstore.get_write_batch();
 
     for (tx_idx, signature) in signatures.iter().enumerate() {
         blockstore
@@ -6427,7 +6427,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
 
     let parent_slot = 990;
     let parent_block_id = Hash::default();
@@ -6598,7 +6598,7 @@ fn insert_test_block_at_location(
     location: BlockLocation,
 ) -> (Vec<Shred>, Hash) {
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let (data_shreds, _) = setup_erasure_shreds(slot, parent_slot, 200);
     let is_repaired = location != BlockLocation::Original;
     let shreds = data_shreds
@@ -6714,7 +6714,7 @@ fn test_get_data_shreds_for_slot() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
-    let mut write_batch = blockstore.get_write_batch().unwrap();
+    let mut write_batch = blockstore.get_write_batch();
     let parent_slot = 990;
     let slot = 1000;
     let num_entries = 200;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -417,10 +417,10 @@ impl Rocks {
         Ok(self.db.raw_iterator_cf(cf))
     }
 
-    pub(crate) fn batch(&self) -> Result<WriteBatch> {
-        Ok(WriteBatch {
+    pub(crate) fn batch(&self) -> WriteBatch {
+        WriteBatch {
             write_batch: RWriteBatch::default(),
-        })
+        }
     }
 
     pub(crate) fn write<B: AsMut<WriteBatch>>(&self, mut batch: B) -> Result<()> {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -141,7 +141,7 @@ impl TransactionStatusService {
                 work_id,
             )) => {
                 let mut status_and_memos_batch = if enable_rpc_transaction_history {
-                    Some(blockstore.get_write_batch()?)
+                    Some(blockstore.get_write_batch())
                 } else {
                     None
                 };

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -275,7 +275,7 @@ impl BroadcastStage {
         mut broadcast_stage_run: impl BroadcastRun,
     ) -> BroadcastStageReturnType {
         let mut pinnable_slice = blockstore.new_pinnable_slice();
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
         loop {
             let res = broadcast_stage_run.run(
                 &cluster_info.keypair(),
@@ -427,7 +427,7 @@ impl BroadcastStage {
             let blockstore = blockstore.clone();
             let run_record = move || {
                 let mut pinnable_slice = blockstore.new_pinnable_slice();
-                let mut write_batch = blockstore.get_write_batch().unwrap();
+                let mut write_batch = blockstore.get_write_batch();
                 loop {
                     let res = broadcast_stage_run.record(
                         &blockstore_receiver,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -323,7 +323,7 @@ impl StandardBroadcastRun {
         let (bsend, brecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let (ssend, srecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
         self.process_receive_results(
             keypair,
             blockstore,
@@ -821,7 +821,7 @@ mod test {
         let (socket_sender, _socket_receiver) = bounded(1024);
         let (blockstore_sender, _blockstore_receiver) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
@@ -1060,7 +1060,7 @@ mod test {
         let (bsend, brecv) = bounded(1024);
         let (ssend, _srecv) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut last_tick_height = bank.tick_height();
         let mut standard_broadcast_run = StandardBroadcastRun::new(
@@ -1193,7 +1193,7 @@ mod test {
         let (bsend, brecv) = bounded(1024);
         let (ssend, srecv) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
-        let mut write_batch = blockstore.get_write_batch().unwrap();
+        let mut write_batch = blockstore.get_write_batch();
 
         let ticks = create_ticks(1, 0, genesis_config.hash());
         let err = standard_broadcast_run


### PR DESCRIPTION
#### Problem

`get_write_batch` always returns Ok nowadays. We may just remove Result. Follow up of https://github.com/anza-xyz/agave/pull/14585

#### Summary of Changes

Remove result, simplify the code.

