### PR TITLE
feat(ledger): add parsed block component accessor

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -45,10 +45,11 @@ use {
     solana_clock::{Slot, UnixTimestamp},
     solana_entry::{
         block_component::{
-            BlockComponent, VersionedBlockFooter, VersionedBlockHeader, VersionedBlockMarker,
-            VersionedUpdateParent, finalization_certificates_from_footer,
+            BlockComponent, ParsedBlockComponent, VersionedBlockFooter, VersionedBlockHeader,
+            VersionedBlockMarker, VersionedUpdateParent, finalization_certificates_from_footer,
             genesis_certificate_from_shred,
         },
+        block_component_parser,
         entry::{Entry, create_ticks},
     },
     solana_genesis_config::{DEFAULT_GENESIS_ARCHIVE, DEFAULT_GENESIS_FILE, GenesisConfig},
@@ -4973,6 +4974,26 @@ impl Blockstore {
         Ok((components, completed_ranges, slot_meta.is_full()))
     }
 
+    /// Returns parsed block components for the slot starting with `start_index`, the completed
+    /// shred range for each component, and whether the slot is full.
+    pub fn get_slot_component_views_with_shred_info(
+        &self,
+        slot: Slot,
+        start_index: u64,
+        allow_dead_slots: bool,
+    ) -> Result<(Vec<ParsedBlockComponent>, Vec<Range<u32>>, bool)> {
+        let Some((completed_ranges, slot_meta, _)) =
+            self.get_slot_data_with_shred_info_common(slot, start_index, allow_dead_slots)?
+        else {
+            return Ok((vec![], vec![], false));
+        };
+
+        let components =
+            self.get_slot_component_views_in_block(slot, &completed_ranges, Some(&slot_meta))?;
+        debug_assert_eq!(completed_ranges.len(), components.len());
+        Ok((components, completed_ranges, slot_meta.is_full()))
+    }
+
     /// Gets accounts used in transactions in the slot range [starting_slot, ending_slot].
     /// Additionally returns a bool indicating if the set may be incomplete.
     /// Used by ledger-tool to create a minimized snapshot
@@ -5168,6 +5189,31 @@ impl Blockstore {
                     } else {
                         BlockstoreError::InvalidShredData(format!(
                             "could not reconstruct block component: {e}"
+                        ))
+                    }
+                })
+        })
+    }
+
+    /// Fetch the parsed components corresponding to all shred indices in `completed_ranges`.
+    /// Note that one range in `CompletedRanges` corresponds to one parsed block component.
+    fn get_slot_component_views_in_block(
+        &self,
+        slot: Slot,
+        completed_ranges: &CompletedRanges,
+        slot_meta: Option<&SlotMeta>,
+    ) -> Result<Vec<ParsedBlockComponent>> {
+        self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
+            let is_empty_entry_batch = BlockComponent::infer_is_empty_entry_batch(&payload);
+
+            block_component_parser::parse(payload)
+                .map(|component| vec![component])
+                .map_err(|error| {
+                    if is_empty_entry_batch {
+                        BlockstoreError::BlockAborted(slot)
+                    } else {
+                        BlockstoreError::InvalidShredData(format!(
+                            "could not reconstruct block component view: {error}"
                         ))
                     }
                 })

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -7210,6 +7210,61 @@ fn test_complete_block_skips_pre_update_parent_entries() {
 }
 
 #[test]
+fn test_get_slot_component_views_with_shred_info() {
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+
+    let slot = 100;
+    let original_parent = 99;
+    let update_parent = 96;
+    let fixture =
+        insert_complete_update_parent_slot(&blockstore, slot, original_parent, update_parent);
+
+    let (raw_components, raw_completed_ranges, raw_is_full) = blockstore
+        .get_slot_components_with_shred_info(slot, 0, false)
+        .unwrap();
+    let (parsed_components, parsed_completed_ranges, parsed_is_full) = blockstore
+        .get_slot_component_views_with_shred_info(slot, 0, false)
+        .unwrap();
+
+    assert_eq!(parsed_components.len(), raw_components.len());
+    assert_eq!(parsed_completed_ranges, raw_completed_ranges);
+    assert_eq!(parsed_is_full, raw_is_full);
+    assert!(parsed_is_full);
+
+    assert!(matches!(
+        &parsed_components[0],
+        ParsedBlockComponent::BlockMarker(_)
+    ));
+    assert!(matches!(
+        &parsed_components[1],
+        ParsedBlockComponent::EntryBatch(entries)
+            if entries
+                .iter()
+                .flat_map(|entry| &entry.transactions)
+                .map(|transaction| transaction.signatures()[0])
+                .collect::<Vec<_>>() == fixture.pre_update_signatures
+    ));
+    assert!(matches!(
+        &parsed_components[2],
+        ParsedBlockComponent::BlockMarker(marker) if marker.is_update_parent()
+    ));
+    assert!(matches!(
+        &parsed_components[3],
+        ParsedBlockComponent::EntryBatch(entries)
+            if entries
+                .iter()
+                .flat_map(|entry| &entry.transactions)
+                .map(|transaction| transaction.signatures()[0])
+                .collect::<Vec<_>>() == fixture.post_update_signatures
+    ));
+    assert!(matches!(
+        &parsed_components[4],
+        ParsedBlockComponent::BlockMarker(marker) if marker.is_footer()
+    ));
+}
+
+#[test]
 fn test_get_transaction_uses_post_update_parent_indexes() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();


### PR DESCRIPTION
#### Problem
As part of #14356 replay needs to load block components containing transaction views without fully deserializing transactions into `VersionedTransactions`.

#### Summary of Changes
- Added `Blockstore::get_slot_component_views_with_shred_info()` to public API

This change is split out of #14356.

#### Testing
Added integration test `test_get_slot_component_views_with_shred_info`
