### PR TITLE
blockstore: mark Exists conflict as dead for alpenglow

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -178,9 +178,18 @@ fn run_check_duplicate(
             &root_bank,
         );
 
-        let Some((shred1, shred2)) =
-            check_duplicate_shred(blockstore, shred, no_verify_chained_merkle_root)?
-        else {
+        let duplicate = check_duplicate_shred(blockstore, shred, no_verify_chained_merkle_root)?;
+
+        let should_mark_dead = migration_status
+            .genesis_block()
+            .is_some_and(|genesis| shred_slot > genesis.slot);
+        if should_mark_dead {
+            // Apart from Exists all existing cases mark dead inline in blockstore.
+            // Once Alpenglow is active we can fully remove this thread and move Exists to inline as well.
+            blockstore.set_dead_slot_if_duplicate_and_not_full(shred_slot)?;
+        }
+
+        let Some((shred1, shred2)) = duplicate else {
             return Ok(());
         };
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5365,6 +5365,17 @@ impl Blockstore {
         self.dead_slots_cf.put(slot, &true)
     }
 
+    /// Marks a duplicate slot dead unless it is full, for external use.
+    pub fn set_dead_slot_if_duplicate_and_not_full(&self, slot: Slot) -> Result<()> {
+        let _lock = self.insert_shreds_lock.lock().unwrap();
+        if self.has_duplicate_shreds_in_slot(slot)
+            && !self.meta(slot)?.is_some_and(|meta| meta.is_full())
+        {
+            self.set_dead_slot(slot)?;
+        }
+        Ok(())
+    }
+
     pub fn remove_dead_slot(&self, slot: Slot) -> Result<()> {
         self.dead_slots_cf.delete(slot)
     }


### PR DESCRIPTION
#### Problem
As found in the AG bug bounty report.

In Alpenglow we require that every block received through turbine/repair will eventually either:
- Be full
- Marked dead

This is critical for nodes to catchup in case of leader equivocation.
If a leader perfectly partitions Turbine, they can submit version A and B with the same # of shreds such that:
- Version A ends with the last shred correctly setting `LAST_SHRED_IN_SLOT`
- Version B does not have the `LAST_SHRED_IN_SLOT`

Victims who receive version B will send `HighestShred` repair requests to try to complete the block. Everyone responds with the shred index they already have. When the victim receives version A of this shred (with `LAST_SHRED_IN_SLOT` set), they reject it and send `PossibleDuplicateShred::Exists`.

`Exists` returns early and skips the rest of the checks:
https://github.com/anza-xyz/agave/blob/d71b6883792351a905cb0696b67ab41792246940/ledger/src/blockstore.rs#L2967

Unlike TowerBFT we don't take any action on `Exists`. All other `PossibleDuplicateShred` variants mark the slot as dead inline, but this one was forgotten.

Thus we violate the invariant, the block can never be full or dead and the victim stalls. 

#### Summary of Changes
Mark the slot as dead when Alpenglow is active. For simplicity we mark all successful variants of `PossibleDuplicateShred` as dead - the rest are already marked dead inline but it doesn't hurt. Once AG is active we can just remove this separate thread and mark all variants inline.

#### Testing
Unit Test