### PR TITLE
runtime: core bpf migration: update batch processor builtin cache on migration

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -361,6 +361,12 @@ impl ProgramCacheForTxBatch {
         })
     }
 
+    /// Remove an entry from the `entries` list.
+    /// Note: DOES NOT remove modified entries!
+    pub fn remove_entry(&mut self, key: &Pubkey) {
+        self.entries.remove(key);
+    }
+
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -298,12 +298,9 @@ impl Bank {
         );
         self.store_account(&source.buffer_address, &AccountSharedData::default());
 
-        // Remove the built-in program from the bank's list of built-ins.
+        // Remove the built-in program from the bank's fork-guarded builtin cache.
         self.transaction_processor
-            .builtin_program_ids
-            .write()
-            .unwrap()
-            .remove(&target.program_address);
+            .remove_builtin(&target.program_address);
 
         // Update the account data size delta.
         self.calculate_and_update_accounts_data_size_delta_off_chain(old_data_size, new_data_size);
@@ -532,13 +529,16 @@ pub(crate) mod tests {
         solana_message::Message,
         solana_native_token::LAMPORTS_PER_SOL,
         solana_program_runtime::{
-            program_cache_entry::{ProgramCacheEntry, ProgramCacheEntryType},
+            program_cache_entry::{
+                ProgramCacheEntry, ProgramCacheEntryOwner, ProgramCacheEntryType,
+            },
             solana_sbpf::{self, program::BuiltinFunctionDefinition, vm::ContextObject},
         },
         solana_pubkey::Pubkey,
         solana_sdk_ids::{bpf_loader, bpf_loader_upgradeable, native_loader, system_program},
         solana_signer::Signer,
         solana_transaction::Transaction,
+        solana_transaction_error::TransactionError,
         std::{fs::File, io::Read, sync::Arc},
         test_case::test_case,
     };
@@ -774,7 +774,8 @@ pub(crate) mod tests {
             assert_eq!(target_entry.deployment_slot, migration_or_upgrade_slot);
             assert_eq!(target_entry.effective_slot(), migration_or_upgrade_slot + 1);
 
-            // The target program entry should be a BPF program.
+            // The target program entry should be a loader v3 BPF program.
+            assert_eq!(target_entry.account_owner, ProgramCacheEntryOwner::LoaderV3);
             assert_matches!(
                 target_entry.program,
                 ProgramCacheEntryType::Unloaded(..) | ProgramCacheEntryType::Loaded(..)
@@ -1348,6 +1349,32 @@ pub(crate) mod tests {
         // Run the post-migration program checks.
         assert!(bank.feature_set.is_active(feature_id));
         test_context.run_program_checks(&bank, migration_slot);
+
+        // The migrated program is not effective until the next slot, so invoking
+        // it in the migration slot must fail (delayed visibility).
+        let meta = bank
+            .process_transaction_with_metadata(Transaction::new(
+                &vec![&mint_keypair],
+                Message::new(
+                    &[Instruction::new_with_bytes(*program_id, &[], Vec::new())],
+                    Some(&mint_keypair.pubkey()),
+                ),
+                bank.last_blockhash(),
+            ))
+            .unwrap();
+        assert_eq!(
+            meta.status,
+            Err(TransactionError::InstructionError(
+                0,
+                InstructionError::UnsupportedProgramId
+            )),
+        );
+        // The loader only logs this for a `DelayVisibility` cache entry.
+        assert!(
+            meta.log_messages
+                .unwrap()
+                .contains(&"Program is not deployed".to_string())
+        );
 
         // Advance one slot so that the new BPF loader v3 program becomes
         // effective in the program cache.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1409,6 +1409,19 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
             .replenish(program_id, entry);
     }
 
+    /// Remove a builtin-program from this fork.
+    ///
+    /// This removes the builtin from the fork guard (`builtin_program_ids` and
+    /// `builtin_program_cache`), but it does not remove it from the global
+    /// program cache. Another fork could be relying on the global entry.
+    pub fn remove_builtin(&self, program_id: &Pubkey) {
+        self.builtin_program_cache
+            .write()
+            .unwrap()
+            .remove_entry(program_id);
+        self.builtin_program_ids.write().unwrap().remove(program_id);
+    }
+
     #[cfg(feature = "dev-context-only-utils")]
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     fn writable_sysvar_cache(&self) -> &RwLock<SysvarCache> {
@@ -2424,28 +2437,19 @@ mod tests {
                     batch_processor.program_runtime_environment.clone(),
                 )),
             );
-        batch_processor
-            .builtin_program_ids
-            .write()
-            .unwrap()
-            .remove(&key);
+        batch_processor.remove_builtin(&key);
 
-        // For the rest of the slot the builtin is still served: the batch cache was
-        // seeded at the start of the block and is unaffected by the guard change.
-        // `filter_executable_program_accounts` finds it there and short circuits,
-        // so the newly deployed program is never even searched for.
+        // The builtin leaves the batch cache in the same slot.
         let program_cache_for_tx_batch = batch_processor
             .builtin_program_cache
             .read()
             .unwrap()
             .clone();
-        let entry = program_cache_for_tx_batch.find(&key).unwrap();
-        assert!(matches!(entry.program, ProgramCacheEntryType::Builtin(_)));
-        assert_eq!(entry.deployment_slot, BUILTIN_SLOT);
+        assert!(program_cache_for_tx_batch.find(&key).is_none());
 
-        // Had it been searched for, it would not have been usable anyway: the
-        // program is deployed in this slot, so it is not effective until the next
-        // one and extraction yields a delay visibility tombstone.
+        // The new account state seeds the extraction search, and since the
+        // program was just "deployed" in this slot, we get a delayed visibility
+        // tombstone.
         let mut search_for = vec![ProgramToLoad {
             program_id: &key,
             loader: ProgramCacheEntryOwner::LoaderV3,


### PR DESCRIPTION
#### Problem
While working on #14518, I noticed that a Core BPF migration only removes the builtin's address from the Bank's `TransactionBatchProcessor`, but it does not remove the program from the _builtin cache_.

Right now, this is actually not an issue, since we just happened to fall into the same error we are _supposed_ to throw.

When a builtin is migrated to Core BPF, it runs through the same deployment pipeline (`solana_program_runtime::deploy`) as any other program deployment, only it does the account checks internally in the runtime rather than in the Loader V3 program. Therefore, just like any other deployment, the newly-migrated program is supposed to become a delayed-visibility `Unloaded` entry with `ProgramCacheEntryOwner::LoaderV3`.

This specific error is supposed to be thrown here:

https://github.com/anza-xyz/agave/blob/49da4eedbfa69ee4c78ba713449cf38334cbdb0d/programs/bpf_loader/src/lib.rs#L135-L144

Instead, since we only remove its ID from `transaction_processor.builtin_program_ids`, the call to `find` above continues to serve a `ProgramCacheEntryType::Builtin`. The reason it reaches the same site is because we do successfully convert the account to be owned by Loader V3, and therefore the builtin dispatch in the `InvokeContext` successfully dispatches Loader V3:

https://github.com/anza-xyz/agave/blob/49da4eedbfa69ee4c78ba713449cf38334cbdb0d/program-runtime/src/invoke_context.rs#L642-L655

#### Summary of Changes

Add a function `TransactionBatchProcessor::remove_builtin`, which removes the builtin both from the `builtin_program_ids` list and the `builtin_program_cache` cache, then call it from Core BPF migration.

#### Testing
I added additional coverage to the already-extensive Core BPF migration tests to distinguish between a different `UnsupportedProgramId` and the actual intended `DelayedVisibility` case.