### PR TITLE
relax simple constraints in ingress -> svm path

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -17,7 +17,9 @@ use {
         },
         transaction_batch::TransactionBatch,
     },
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::transaction_with_meta::{
+        StaticMessageWithMeta, TransactionWithMeta,
+    },
     solana_svm::{
         account_loader::validate_fee_payer,
         transaction_error_metrics::TransactionErrorMetrics,
@@ -474,7 +476,7 @@ impl Consumer {
 
     pub fn check_fee_payer_unlocked(
         bank: &Bank,
-        transaction: &impl TransactionWithMeta,
+        transaction: &impl StaticMessageWithMeta,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Result<(), TransactionError> {
         let fee_payer = transaction.fee_payer();

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -6,7 +6,7 @@ use {
     solana_perf::packet::bytes::Bytes,
     solana_pubkey::{Pubkey, PubkeyHasherBuilder},
     solana_runtime_transaction::{
-        runtime_transaction::RuntimeTransaction, transaction_with_meta::TransactionWithMeta,
+        runtime_transaction::RuntimeTransaction, transaction_with_meta::StaticTransactionWithMeta,
     },
     std::{
         collections::{BTreeSet, HashMap, hash_map::Entry},
@@ -40,7 +40,7 @@ use {
 ///
 /// The container maintains a fixed capacity. If the queue is full when pushing
 /// a new transaction, the lowest priority transaction will be dropped.
-pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
+pub(crate) struct TransactionStateContainer<Tx: StaticTransactionWithMeta> {
     capacity: usize,
     priority_queue: BTreeSet<TransactionPriorityId>,
     id_to_transaction_state: Slab<TransactionState<Tx>>,
@@ -48,7 +48,7 @@ pub(crate) struct TransactionStateContainer<Tx: TransactionWithMeta> {
     nonces_in_use: HashMap<Pubkey, TransactionPriorityId, PubkeyHasherBuilder>,
 }
 
-pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
+pub(crate) trait StateContainer<Tx: StaticTransactionWithMeta> {
     /// Create a new `TransactionStateContainer` with the given capacity.
     fn with_capacity(capacity: usize) -> Self;
 
@@ -135,7 +135,7 @@ pub(crate) trait StateContainer<Tx: TransactionWithMeta> {
 // is added to the slab before anything can be evicted from a full queue.
 pub(crate) const EXTRA_CAPACITY: usize = 1;
 
-impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<Tx> {
+impl<Tx: StaticTransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<Tx> {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             capacity,
@@ -262,7 +262,7 @@ impl<Tx: TransactionWithMeta> StateContainer<Tx> for TransactionStateContainer<T
     }
 }
 
-impl<Tx: TransactionWithMeta> TransactionStateContainer<Tx> {
+impl<Tx: StaticTransactionWithMeta> TransactionStateContainer<Tx> {
     /// Insert into the map, but NOT into the priority queue.
     /// Returns the id of the inserted transaction.
     pub(crate) fn insert_map_only(&mut self, state: TransactionState<Tx>) -> TransactionId {

--- a/runtime-transaction/src/transaction_with_meta.rs
+++ b/runtime-transaction/src/transaction_with_meta.rs
@@ -1,9 +1,15 @@
 use {
     crate::transaction_meta::TransactionMeta,
-    solana_svm_transaction::svm_transaction::{SVMStaticTransaction, SVMTransaction},
+    solana_svm_transaction::{
+        svm_message::SVMStaticMessage,
+        svm_transaction::{SVMStaticTransaction, SVMTransaction},
+    },
     solana_transaction::{sanitized::SanitizedTransaction, versioned::VersionedTransaction},
     std::borrow::Cow,
 };
+
+pub trait StaticMessageWithMeta: TransactionMeta + SVMStaticMessage {}
+impl<T: TransactionMeta + SVMStaticMessage> StaticMessageWithMeta for T {}
 
 pub trait StaticTransactionWithMeta: TransactionMeta + SVMStaticTransaction {
     /// Required to interact with several legacy interfaces that require

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -13,12 +13,14 @@ use {
     solana_nonce_account as nonce_account,
     solana_program_runtime::execution_budget::SVMTransactionExecutionAndFeeBudgetLimits,
     solana_pubkey::Pubkey,
-    solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
+    solana_runtime_transaction::transaction_with_meta::{
+        StaticMessageWithMeta, TransactionWithMeta,
+    },
     solana_svm::{
         account_loader::{CheckedTransactionDetails, TransactionCheckResult},
         transaction_error_metrics::TransactionErrorMetrics,
     },
-    solana_svm_transaction::svm_message::SVMMessage,
+    solana_svm_transaction::svm_message::{SVMMessage, SVMStaticMessage},
     solana_transaction::versioned::TransactionVersion,
     solana_transaction_error::{TransactionError, TransactionResult},
 };
@@ -126,14 +128,14 @@ impl Bank {
         )
     }
 
-    fn filter_v1_transactions<'a, Tx: TransactionWithMeta>(
+    fn filter_v1_transactions<'a, Msg: SVMStaticMessage>(
         &self,
-        sanitized_txs: &'a [impl core::borrow::Borrow<Tx>],
+        messages: &'a [impl core::borrow::Borrow<Msg>],
         lock_results: &'a [TransactionResult<()>],
     ) -> impl Iterator<Item = TransactionResult<()>> + 'a {
         let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
         // Discard v1 transactions until feature gate is activated.
-        sanitized_txs
+        messages
             .iter()
             .zip(lock_results)
             .map(move |(tx, lock_result)| match lock_result {
@@ -299,24 +301,24 @@ impl Bank {
         Some((*nonce_address, nonce_data))
     }
 
-    fn check_status_cache<Tx: TransactionWithMeta>(
+    fn check_status_cache<Msg: StaticMessageWithMeta>(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
+        messages: &[impl core::borrow::Borrow<Msg>],
         mut lock_results: Vec<TransactionCheckResult>,
         collect_processed_slots: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
         // Do allocation before acquiring the lock on the status cache.
         let mut processed_slots = if collect_processed_slots {
-            Some(Vec::with_capacity(sanitized_txs.len()))
+            Some(Vec::with_capacity(messages.len()))
         } else {
             None
         };
         let rcache = self.status_cache.read().unwrap();
 
-        for (sanitized_tx_ref, lock_result) in sanitized_txs.iter().zip(lock_results.iter_mut()) {
+        for (message_ref, lock_result) in messages.iter().zip(lock_results.iter_mut()) {
             let processed_slot = if lock_result.is_ok() {
-                self.get_processed_slot(sanitized_tx_ref.borrow(), &rcache)
+                self.get_processed_slot(message_ref.borrow(), &rcache)
             } else {
                 None
             };
@@ -336,13 +338,13 @@ impl Bank {
 
     fn get_processed_slot(
         &self,
-        sanitized_tx: &impl TransactionWithMeta,
+        message: &impl StaticMessageWithMeta,
         status_cache: &BankStatusCache,
     ) -> Option<Slot> {
-        let key = sanitized_tx.message_hash();
-        let transaction_blockhash = sanitized_tx.recent_blockhash();
+        let key = message.message_hash();
+        let message_blockhash = message.recent_blockhash();
         status_cache
-            .get_status(key, transaction_blockhash, &self.ancestors)
+            .get_status(key, message_blockhash, &self.ancestors)
             .map(|status| status.0)
     }
 }

--- a/vote/src/vote_parser.rs
+++ b/vote/src/vote_parser.rs
@@ -1,7 +1,11 @@
 use {
-    crate::vote_transaction::VoteTransaction, solana_bincode::limited_deserialize,
-    solana_hash::Hash, solana_pubkey::Pubkey, solana_signature::Signature,
-    solana_svm_transaction::svm_transaction::SVMTransaction, solana_transaction::Transaction,
+    crate::vote_transaction::VoteTransaction,
+    solana_bincode::limited_deserialize,
+    solana_hash::Hash,
+    solana_pubkey::Pubkey,
+    solana_signature::Signature,
+    solana_svm_transaction::{svm_message::SVMStaticMessage, svm_transaction::SVMTransaction},
+    solana_transaction::Transaction,
     solana_vote_interface::instruction::VoteInstruction,
 };
 
@@ -12,7 +16,7 @@ pub type ParsedVote = (Pubkey, VoteTransaction, Option<Hash>, Signature);
 /// 1. Have exactly one instruction
 /// 2. That instruction must be to the vote program
 /// 3. That instruction must be a single vote state update (UpdateVoteState, TowerSync, etc.)
-pub fn is_valid_vote_only_transaction(tx: &impl SVMTransaction) -> bool {
+pub fn is_valid_vote_only_transaction(tx: &impl SVMStaticMessage) -> bool {
     let mut instructions = tx.program_instructions_iter();
 
     let Some((program_id, instruction)) = instructions.next() else {


### PR DESCRIPTION
#### Problem
we want to relax ALTs... but we are too constrained... we have to break free...

#### Summary of Changes
step one, this is the easiest, relax constraints that require no code changes. now that we have a full repertoire of static traits, these are all ready to go static:
* consumer fee-payer check
* scheduler transaction container. this is ready to be changed to hold static transactions, given types we added in the last pr, once all the other code is fine with this
* v1 transaction filter
* single-ix vote transaction check. which does not imply simple vote transaction. but not relevant to us
* status cache check

im inconsistent with whether i change "transaction" to "message" when i relax `SVMTransaction` or `TransactionWithMeta` to `SVMStaticMessage` or `StaticMessageWithMeta`. i went with "message" in `check_transactions.rs` because this is done for existing `SVMMessage` functions, but others we will always have a transaction and it seems weird to do that