### PR TITLE
ci: format `.toml` files with `tombi`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -37,71 +37,71 @@ filter = "package(solana-gossip) & test(/^cluster_info::tests::new_with_external
 threads-required = "num-cpus"
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_progress$/)'
+filter = "package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_progress$/)"
 slow-timeout = { period = "60s", terminate-after = 10 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_no_progress$/)'
+filter = "package(solana-local-cluster) & test(/^test_kill_partition_switch_threshold_no_progress$/)"
 slow-timeout = { period = "60s", terminate-after = 10 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_run_test_load_program_accounts_partition_root$/)'
+filter = "package(solana-local-cluster) & test(/^test_run_test_load_program_accounts_partition_root$/)"
 slow-timeout = { period = "60s", terminate-after = 10 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_fork_choice_refresh_old_votes$/)'
+filter = "package(solana-local-cluster) & test(/^test_fork_choice_refresh_old_votes$/)"
 slow-timeout = { period = "60s", terminate-after = 5 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_cluster_partition/)'
+filter = "package(solana-local-cluster) & test(/^test_cluster_partition/)"
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_snapshots_restart_validity$/)'
+filter = "package(solana-local-cluster) & test(/^test_snapshots_restart_validity$/)"
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_slot_hash_expiry$/)'
+filter = "package(solana-local-cluster) & test(/^test_slot_hash_expiry$/)"
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_kill_heaviest_partition/)'
+filter = "package(solana-local-cluster) & test(/^test_kill_heaviest_partition/)"
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster) & test(/^test_boot_from_local_state$/)'
+filter = "package(solana-local-cluster) & test(/^test_boot_from_local_state$/)"
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-local-cluster)'
+filter = "package(solana-local-cluster)"
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-ledger) & test(/^shred::merkle::test::test_merkle_tree_round_trip/)'
+filter = "package(solana-ledger) & test(/^shred::merkle::test::test_merkle_tree_round_trip/)"
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_nonce_update_blockhash_queried_before_transaction_record/)'
+filter = "package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_nonce_update_blockhash_queried_before_transaction_record/)"
 slow-timeout = { period = "60s", terminate-after = 8 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_process_and_record_transactions/)'
+filter = "package(solana-core) & test(/^banking_stage::consumer::tests::test_bank_process_and_record_transactions/)"
 slow-timeout = { period = "60s", terminate-after = 8 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_slots_to_snapshot/)'
+filter = "package(solana-core) & test(/^test_slots_to_snapshot/)"
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-core) & test(/^test_snapshots_have_expected_epoch_accounts_hash/)'
+filter = "package(solana-core) & test(/^test_snapshots_have_expected_epoch_accounts_hash/)"
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)'
+filter = "package(solana-client-test) & test(/^test_send_and_confirm_transactions_in_parallel_with_tpu_client/)"
 slow-timeout = { period = "60s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
-filter = 'package(solana-svm) & test(/^execute_fixtures/)'
+filter = "package(solana-svm) & test(/^execute_fixtures/)"
 slow-timeout = { period = "60s", terminate-after = 2 }
 
 [[profile.ci.overrides]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,137 +1,137 @@
 [workspace]
 members = [
-    "account-decoder",
-    "account-decoder-client-types",
-    "accounts-cluster-bench",
-    "accounts-db",
-    "accounts-db/store-histogram",
-    "banking-stage-ingress-types",
-    "banks-client",
-    "banks-interface",
-    "banks-server",
-    "bloom",
-    "bls-cert-verify",
-    "bls-sigverify",
-    "bucket_map",
-    "builtins",
-    "builtins-default-costs",
-    "clap-utils",
-    "clap-v3-utils",
-    "cli",
-    "cli-config",
-    "cli-output",
-    "client",
-    "client-test",
-    "compute-budget",
-    "compute-budget-instruction",
-    "connection-cache",
-    "core",
-    "cost-model",
-    "cpu-utils",
-    "download-utils",
-    "entry",
-    "faucet",
-    "faucet-cli",
-    "feature-set",
-    "fee",
-    "fs",
-    "genesis",
-    "genesis-utils",
-    "geyser-plugin-interface",
-    "geyser-plugin-manager",
-    "gossip",
-    "gossip-cli",
-    "install",
-    "io-uring",
-    "keygen",
-    "lattice-hash",
-    "leader-schedule",
-    "ledger",
-    "local-cluster",
-    "logger",
-    "math-utils",
-    "measure",
-    "merkle-tree",
-    "metrics",
-    "net-utils",
-    "notifier",
-    "perf",
-    "poh",
-    "poh-bench",
-    "precompiles",
-    "program-binaries",
-    "program-runtime",
-    "program-test",
-    "programs/bpf-loader-tests",
-    "programs/bpf_loader",
-    "programs/compute-budget",
-    "programs/compute-budget-bench",
-    "programs/ed25519-tests",
-    "programs/system",
-    "programs/vote",
-    "programs/zk-elgamal-proof",
-    "programs/zk-elgamal-proof-tests",
-    "programs/zk-token-proof",
-    "pubsub-client",
-    "quic-client",
-    "random",
-    "rayon-threadlimit",
-    "rbpf-cli",
-    "remote-wallet",
-    "reserved-account-keys",
-    "rpc",
-    "rpc-client",
-    "rpc-client-api",
-    "rpc-client-nonce-utils",
-    "rpc-client-types",
-    "rpc-test",
-    "runtime",
-    "runtime-transaction",
-    "scheduling-utils",
-    "send-transaction-service",
-    "snapshots",
-    "stake-accounts",
-    "storage-bigtable",
-    "storage-bigtable/build-proto",
-    "storage-proto",
-    "streamer",
-    "svm",
-    "svm-callback",
-    "svm-feature-set",
-    "svm-log-collector",
-    "svm-measure",
-    "svm-timings",
-    "svm-type-overrides",
-    "syscalls",
-    "syscalls/gen-syscall-list",
-    "test-validator",
-    "tls-utils",
-    "tokens",
-    "tpu-client",
-    "tpu-client-next",
-    "transaction-context",
-    "transaction-status",
-    "transaction-status-client-types",
-    "turbine",
-    "udp-client",
-    "unified-scheduler-logic",
-    "unified-scheduler-pool",
-    "validator",
-    "version",
-    "vote",
-    "votor",
-    "votor-messages",
-    "votor-transport",
-    "watchtower",
-    "xdp",
-    "xdp-ebpf",
+  "account-decoder",
+  "account-decoder-client-types",
+  "accounts-cluster-bench",
+  "accounts-db",
+  "accounts-db/store-histogram",
+  "banking-stage-ingress-types",
+  "banks-client",
+  "banks-interface",
+  "banks-server",
+  "bloom",
+  "bls-cert-verify",
+  "bls-sigverify",
+  "bucket_map",
+  "builtins",
+  "builtins-default-costs",
+  "clap-utils",
+  "clap-v3-utils",
+  "cli",
+  "cli-config",
+  "cli-output",
+  "client",
+  "client-test",
+  "compute-budget",
+  "compute-budget-instruction",
+  "connection-cache",
+  "core",
+  "cost-model",
+  "cpu-utils",
+  "download-utils",
+  "entry",
+  "faucet",
+  "faucet-cli",
+  "feature-set",
+  "fee",
+  "fs",
+  "genesis",
+  "genesis-utils",
+  "geyser-plugin-interface",
+  "geyser-plugin-manager",
+  "gossip",
+  "gossip-cli",
+  "install",
+  "io-uring",
+  "keygen",
+  "lattice-hash",
+  "leader-schedule",
+  "ledger",
+  "local-cluster",
+  "logger",
+  "math-utils",
+  "measure",
+  "merkle-tree",
+  "metrics",
+  "net-utils",
+  "notifier",
+  "perf",
+  "poh",
+  "poh-bench",
+  "precompiles",
+  "program-binaries",
+  "program-runtime",
+  "program-test",
+  "programs/bpf_loader",
+  "programs/bpf-loader-tests",
+  "programs/compute-budget",
+  "programs/compute-budget-bench",
+  "programs/ed25519-tests",
+  "programs/system",
+  "programs/vote",
+  "programs/zk-elgamal-proof",
+  "programs/zk-elgamal-proof-tests",
+  "programs/zk-token-proof",
+  "pubsub-client",
+  "quic-client",
+  "random",
+  "rayon-threadlimit",
+  "rbpf-cli",
+  "remote-wallet",
+  "reserved-account-keys",
+  "rpc",
+  "rpc-client",
+  "rpc-client-api",
+  "rpc-client-nonce-utils",
+  "rpc-client-types",
+  "rpc-test",
+  "runtime",
+  "runtime-transaction",
+  "scheduling-utils",
+  "send-transaction-service",
+  "snapshots",
+  "stake-accounts",
+  "storage-bigtable",
+  "storage-bigtable/build-proto",
+  "storage-proto",
+  "streamer",
+  "svm",
+  "svm-callback",
+  "svm-feature-set",
+  "svm-log-collector",
+  "svm-measure",
+  "svm-timings",
+  "svm-type-overrides",
+  "syscalls",
+  "syscalls/gen-syscall-list",
+  "test-validator",
+  "tls-utils",
+  "tokens",
+  "tpu-client",
+  "tpu-client-next",
+  "transaction-context",
+  "transaction-status",
+  "transaction-status-client-types",
+  "turbine",
+  "udp-client",
+  "unified-scheduler-logic",
+  "unified-scheduler-pool",
+  "validator",
+  "version",
+  "vote",
+  "votor",
+  "votor-messages",
+  "votor-transport",
+  "watchtower",
+  "xdp",
+  "xdp-ebpf",
 ]
 
 exclude = [
-    "ci/xtask",
-    "dev-bins",
-    "programs/sbf",
-    "svm/tests/example-programs",
+  "ci/xtask",
+  "dev-bins",
+  "programs/sbf",
+  "svm/tests/example-programs",
 ]
 
 resolver = "2"
@@ -139,57 +139,93 @@ resolver = "2"
 [workspace.package]
 version = "4.4.0-alpha.2"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-description = "Blockchain, Rebuilt for Scale"
-repository = "https://github.com/anza-xyz/agave"
-homepage = "https://anza.xyz/"
-license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.98.0"
-
-[workspace.lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
-    'cfg(target_arch, values("sbf"))',
-]
-
-# Clippy lint configuration that can not be applied in clippy.toml
-[workspace.lints.clippy]
-# Denied lints
-arithmetic_side_effects = "deny"
-default_trait_access = "deny"
-manual_let_else = "deny"
-uninlined_format_args = "deny"
-used_underscore_binding = "deny"
-
-# Allowed lints
-new_without_default = "allow"
+description = "Blockchain, Rebuilt for Scale"
+homepage = "https://anza.xyz/"
+repository = "https://github.com/anza-xyz/agave"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-cpu-utils = { path = "cpu-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-feature-set = { path = "feature-set", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = {
+  path = "banking-stage-ingress-types",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-bls-cert-verify = {
+  path = "bls-cert-verify",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-bls-sigverify = {
+  path = "bls-sigverify",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-cpu-utils = {
+  path = "cpu-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-feature-set = {
+  path = "feature-set",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-fs = { path = "fs", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.4.0-alpha.2" }
-agave-io-uring = { path = "io-uring", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-io-uring = {
+  path = "io-uring",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-logger = { path = "logger", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-math-utils = {
+  path = "math-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-precompiles = {
+  path = "precompiles",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-random = { path = "random", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "reserved-account-keys",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-scheduler-bindings = "6.0.0"
-agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-scheduling-utils = {
+  path = "scheduling-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-snapshots = {
+  path = "snapshots",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-transaction-view = "6.1.0"
 agave-votor = { path = "votor", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-votor-messages = { path = "votor-messages", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-votor-transport = { path = "votor-transport", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-votor-messages = {
+  path = "votor-messages",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-votor-transport = {
+  path = "votor-transport",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-xdp = { path = "xdp", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-xdp-ebpf = { path = "xdp-ebpf", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-xdp-ebpf = {
+  path = "xdp-ebpf",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 ahash = "0.8.12"
 anyhow = "1.0.104"
 arbitrary = "1.4.2"
@@ -206,7 +242,7 @@ aya-ebpf = "0.2.1"
 base64 = "0.23.1"
 bencher = "0.1.5"
 bincode = "1.3.3"
-bip39 = { version = "2.2.2", features = ["rand", "all-languages"] }
+bip39 = { version = "2.2.2", features = ["all-languages", "rand"] }
 bitflags = { version = "2.13.1" }
 bitvec = { version = "1.1.1", features = ["serde"] }
 blake3 = "1.8.7"
@@ -234,8 +270,8 @@ crossbeam-utils = "0.8.22"
 csv = "1.4.0"
 ctrlc = "3.5.2"
 dashmap = "5.5.3"
-derive-where = "1.6.1"
 derive_more = { version = "2.1.1", features = ["full"] }
+derive-where = "1.6.1"
 dialoguer = "0.12.0"
 digest = "0.10.7"
 dirs-next = "2.0.0"
@@ -265,13 +301,21 @@ indexmap = "2.14.0"
 indicatif = "0.18.6"
 io-uring = { version = "0.7.14", features = ["io_safety"] }
 itertools = "0.15.0"
-jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0", features = [
+jemalloc-ctl = {
+  package = "tikv-jemalloc-ctl",
+  version = "0.6.0",
+  features = [
     "stats",
-] }
-jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
+  ]
+}
+jemallocator = {
+  package = "tikv-jemallocator",
+  version = "0.6.0",
+  features = [
+    "stats",
     "unprefixed_malloc_on_supported_platforms",
-    "stats",
-] }
+  ]
+}
 json5 = "1.3.1"
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = "18.0.0"
@@ -282,10 +326,14 @@ jsonrpc-pubsub = "18.0.0"
 lazy-lru = "0.1.3"
 libc = "0.2.189"
 libloading = "0.9.0"
-libsecp256k1 = { version = "0.7.2", default-features = false, features = [
-    "std",
+libsecp256k1 = {
+  version = "0.7.2",
+  default-features = false,
+  features = [
     "static-context",
-] }
+    "std",
+  ]
+}
 log = "0.4.34"
 lru = "0.18.2"
 lz4 = "1.28.1"
@@ -295,18 +343,18 @@ min-max-heap = "1.3.0"
 mockall = "0.15.0"
 modular-bitfield = "0.13.1"
 nix = "0.31.3"
-num-derive = "0.5"
-num-traits = "0.2"
 num_cpus = "1.17.0"
+num-derive = "0.5"
 num_enum = "0.7.6"
+num-traits = "0.2"
 openssl = "0.10"
 pairing = "0.23.0"
 parking_lot = "0.12"
 pem = "1.1.1"
 pickledb = { version = "0.5.1", default-features = false }
 predicates = "3.1"
-pretty-hex = "0.4.2"
 pretty_assertions = "1.4.1"
+pretty-hex = "0.4.2"
 proptest = "1.11"
 prost = "0.14.4"
 prost-types = "0.14.4"
@@ -325,7 +373,7 @@ rolling-file = "0.2.0"
 rpassword = "7.5"
 rts-alloc = { version = "5.1.0" }
 rusb = "0.9"
-rustls = { version = "0.23.43", features = ["std"], default-features = false }
+rustls = { version = "0.23.43", default-features = false, features = ["std"] }
 rustls-webpki = { version = "0.103.15", default-features = false, features = ["std"] }
 scopeguard = "1.2.0"
 semver = "1.0.28"
@@ -347,15 +395,39 @@ smpl_jwt = "0.9.0"
 socket2 = "0.6.5"
 soketto = "0.8"
 solana-account = "4.6.0"
-solana-account-decoder = { path = "account-decoder", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-account-decoder = {
+  path = "account-decoder",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-account-decoder-client-types = {
+  path = "account-decoder-client-types",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-account-info = "3.1.1"
-solana-accounts-db = { path = "accounts-db", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-accounts-db = {
+  path = "accounts-db",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-address = "2.7.0"
 solana-address-lookup-table-interface = "3.2.0"
-solana-banks-client = { path = "banks-client", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-banks-interface = { path = "banks-interface", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-banks-server = { path = "banks-server", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-banks-client = {
+  path = "banks-client",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-banks-interface = {
+  path = "banks-interface",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-banks-server = {
+  path = "banks-server",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-big-mod-exp = "4.0.0"
 solana-bincode = "3.1.0"
 solana-blake3-hasher = "3.1.0"
@@ -364,32 +436,86 @@ solana-bls-signatures = { version = "3.4.0", features = ["serde"] }
 solana-bls12-381-syscall = "0.1.1"
 solana-bn254 = "3.2.1"
 solana-borsh = "3.0.2"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
-solana-bucket-map = { path = "bucket_map", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-builtins = { path = "builtins", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "clap-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = {
+  path = "programs/bpf_loader",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
+solana-bucket-map = {
+  path = "bucket_map",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-builtins = {
+  path = "builtins",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-builtins-default-costs = {
+  path = "builtins-default-costs",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-clap-utils = {
+  path = "clap-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-clap-v3-utils = {
+  path = "clap-v3-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-cli-config = { path = "cli-config", version = "=4.4.0-alpha.2" }
-solana-cli-output = { path = "cli-output", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-cli-output = {
+  path = "cli-output",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-client = { path = "client", version = "=4.4.0-alpha.2" }
 solana-client-traits = "4.1.0"
 solana-clock = "3.2.0"
 solana-cluster-type = "3.2.0"
 solana-commitment-config = "3.1.1"
-solana-compute-budget = { path = "compute-budget", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-compute-budget = {
+  path = "compute-budget",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-compute-budget-instruction = {
+  path = "compute-budget-instruction",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-compute-budget-interface = "3.1.0"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-compute-budget-program = {
+  path = "programs/compute-budget",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-config-interface = "2.0.0"
-solana-connection-cache = { path = "connection-cache", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-connection-cache = {
+  path = "connection-cache",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-core = { path = "core", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "cost-model", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-cost-model = {
+  path = "cost-model",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-cpi = "3.1.0"
 solana-curve25519 = "4.0.1"
 solana-define-syscall = "5.2.0"
 solana-derivation-path = "3.0.0"
-solana-download-utils = { path = "download-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-download-utils = {
+  path = "download-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-ed25519-program = "3.0.0"
 solana-entry = { path = "entry", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-epoch-info = "3.1.0"
@@ -406,8 +532,16 @@ solana-frozen-abi = "3.8.0"
 solana-frozen-abi-macro = "3.6.0"
 solana-genesis = { path = "genesis", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-genesis-config = "4.1.0"
-solana-genesis-utils = { path = "genesis-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-genesis-utils = {
+  path = "genesis-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-geyser-plugin-manager = {
+  path = "geyser-plugin-manager",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-gossip = { path = "gossip", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-hard-forks = "3.2.0"
 solana-hash = "4.6.0"
@@ -419,24 +553,48 @@ solana-instructions-sysvar = "4.0.0"
 solana-keccak-hasher = "3.1.0"
 solana-keypair = "3.1.2"
 solana-last-restart-slot = "3.2.0"
-solana-lattice-hash = { path = "lattice-hash", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-leader-schedule = { path = "leader-schedule", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-lattice-hash = {
+  path = "lattice-hash",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-leader-schedule = {
+  path = "leader-schedule",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-ledger = { path = "ledger", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
-solana-local-cluster = { path = "local-cluster", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-local-cluster = {
+  path = "local-cluster",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-measure = { path = "measure", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-merkle-tree = { path = "merkle-tree", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-merkle-tree = {
+  path = "merkle-tree",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-message = "4.5.0"
 solana-metrics = { path = "metrics", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "net-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-net-utils = {
+  path = "net-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "3.3.0"
 solana-nonce-account = { version = "4.3.0", default-features = false }
-solana-notifier = { path = "notifier", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-notifier = {
+  path = "notifier",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-offchain-message = "3.0.0"
 solana-packet = "4.3.0"
 solana-perf = { path = "perf", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
@@ -446,18 +604,43 @@ solana-poseidon = "5.0.0"
 solana-precompile-error = "3.0.0"
 solana-presigner = "3.0.0"
 solana-program = { version = "4.1.0", default-features = false }
-solana-program-binaries = { path = "program-binaries", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-program-binaries = {
+  path = "program-binaries",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.1"
 solana-program-option = "3.1.0"
 solana-program-pack = "3.1.0"
-solana-program-runtime = { path = "program-runtime", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-program-test = { path = "program-test", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-program-runtime = {
+  path = "program-runtime",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-program-test = {
+  path = "program-test",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-pubkey = { version = "4.3.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=4.4.0-alpha.2" }
-solana-quic-client = { path = "quic-client", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-remote-wallet = { path = "remote-wallet", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-quic-client = {
+  path = "quic-client",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-rayon-threadlimit = {
+  path = "rayon-threadlimit",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-remote-wallet = {
+  path = "remote-wallet",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-rent = "4.4.0"
 solana-reward-info = "6.3.0"
 solana-rpc = { path = "rpc", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
@@ -466,7 +649,11 @@ solana-rpc-client-api = { path = "rpc-client-api", version = "=4.4.0-alpha.2" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=4.4.0-alpha.2" }
 solana-rpc-client-types = { path = "rpc-client-types", version = "=4.4.0-alpha.2" }
 solana-runtime = { path = "runtime", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-runtime-transaction = {
+  path = "runtime-transaction",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.24.0", default-features = false }
 solana-sdk-ids = "3.1.0"
@@ -475,7 +662,11 @@ solana-secp256k1-recover = "3.3.0"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"
 solana-seed-phrase = "3.0.0"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-send-transaction-service = {
+  path = "send-transaction-service",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.1"
 solana-serialize-utils = "3.1.2"
@@ -491,48 +682,147 @@ solana-slot-history = "3.2.0"
 solana-stable-layout = "3.0.1"
 solana-stake-history = "1.1.0"
 solana-stake-interface = "4.4.0"
-solana-storage-bigtable = { path = "storage-bigtable", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-storage-proto = { path = "storage-proto", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-streamer = { path = "streamer", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-storage-bigtable = {
+  path = "storage-bigtable",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-storage-proto = {
+  path = "storage-proto",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-streamer = {
+  path = "streamer",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-svm = { path = "svm", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "svm-callback", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "svm-feature-set", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "svm-log-collector", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-measure = { path = "svm-measure", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-timings = { path = "svm-timings", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-svm-callback = {
+  path = "svm-callback",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-feature-set = {
+  path = "svm-feature-set",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-log-collector = {
+  path = "svm-log-collector",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-measure = {
+  path = "svm-measure",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-timings = {
+  path = "svm-timings",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-svm-transaction = "5.0.0"
-solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-syscalls = { path = "syscalls", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-svm-type-overrides = {
+  path = "svm-type-overrides",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-syscalls = {
+  path = "syscalls",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }
-solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-system-program = {
+  path = "programs/system",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-system-transaction = "4.1.0"
 solana-sysvar = "4.3.0"
 solana-sysvar-id = "3.1.0"
-solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-test-validator = {
+  path = "test-validator",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-time-utils = "3.0.0"
-solana-tls-utils = { path = "tls-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "tpu-client", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-tls-utils = {
+  path = "tls-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-tpu-client = {
+  path = "tpu-client",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
+solana-tpu-client-next = {
+  path = "tpu-client-next",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-transaction = "4.3.0"
-solana-transaction-context = { path = "transaction-context", version = "=4.4.0-alpha.2", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = {
+  path = "transaction-context",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api", "bincode"]
+}
 solana-transaction-error = "3.4.0"
-solana-transaction-status = { path = "transaction-status", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-transaction-status = {
+  path = "transaction-status",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-transaction-status-client-types = {
+  path = "transaction-status-client-types",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-turbine = { path = "turbine", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-udp-client = { path = "udp-client", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-udp-client = {
+  path = "udp-client",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-unified-scheduler-logic = {
+  path = "unified-scheduler-logic",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-unified-scheduler-pool = {
+  path = "unified-scheduler-pool",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-validator-exit = "3.0.0"
 solana-version = { path = "version", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-vote = { path = "vote", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-vote-interface = "6.1.0"
-solana-vote-program = { path = "programs/vote", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-vote-program = {
+  path = "programs/vote",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-wincode-varint = "1.1.0"
 solana-zk-elgamal-proof-interface = "0.1.3"
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-zk-elgamal-proof-program = {
+  path = "programs/zk-elgamal-proof",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-zk-sdk = "7.0.1"
 solana-zk-sdk-pod = "0.1.2"
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-zk-token-proof-program = {
+  path = "programs/zk-token-proof",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"
 spl-memo-interface = "2.1.0"
@@ -575,6 +865,41 @@ winreg = "0.55"
 xxhash-rust = "0.8.5"
 zstd = "0.13.3"
 
+# Clippy lint configuration that can not be applied in clippy.toml
+[workspace.lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+  'cfg(target_arch, values("sbf"))',
+]
+
+[patch.crates-io]
+# for details, see https://github.com/anza-xyz/crossbeam/commit/5ee1c6ec671d94db14ed9238eb99e59a84555aad
+crossbeam-epoch = {
+  git = "https://github.com/anza-xyz/crossbeam",
+  rev = "5ee1c6ec671d94db14ed9238eb99e59a84555aad"
+}
+librocksdb-sys = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
+rocksdb = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
+
 [profile.dev]
 debug = "line-tables-only"
 
@@ -595,32 +920,26 @@ opt-level = 3
 [profile.dev.package.solana-ed25519]
 opt-level = 3
 
-[profile.full-dev]
-inherits = "dev"
-debug = "full"
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
 
 # Enable optimizations for ci unittests to trigger const propagation and inlining
 [profile.ci]
 inherits = "test"
 opt-level = 1
 
+[profile.full-dev]
+inherits = "dev"
+debug = "full"
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true
-strip = false
 split-debuginfo = "off"
-
-[profile.release]
-split-debuginfo = "unpacked"
-lto = "thin"
+strip = false
 
 [profile.release-with-lto]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-[patch.crates-io]
-# for details, see https://github.com/anza-xyz/crossbeam/commit/5ee1c6ec671d94db14ed9238eb99e59a84555aad
-crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "5ee1c6ec671d94db14ed9238eb99e59a84555aad" }
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,138 +1,133 @@
 [workspace]
 members = [
-    "account-decoder",
-    "account-decoder-client-types",
-    "accounts-cluster-bench",
-    "accounts-db",
-    "accounts-db/store-histogram",
-    "banking-stage-ingress-types",
-    "banks-client",
-    "banks-interface",
-    "banks-server",
-    "bloom",
-    "bls-cert-verify",
-    "bls-sigverify",
-    "bucket_map",
-    "builtins",
-    "builtins-default-costs",
-    "clap-utils",
-    "clap-v3-utils",
-    "cli",
-    "cli-config",
-    "cli-output",
-    "client",
-    "client-test",
-    "compute-budget",
-    "compute-budget-instruction",
-    "connection-cache",
-    "core",
-    "cost-model",
-    "cpu-utils",
-    "download-utils",
-    "entry",
-    "faucet",
-    "faucet-cli",
-    "feature-set",
-    "fee",
-    "fs",
-    "genesis",
-    "genesis-utils",
-    "geyser-plugin-interface",
-    "geyser-plugin-manager",
-    "gossip",
-    "gossip-cli",
-    "install",
-    "io-uring",
-    "keygen",
-    "lattice-hash",
-    "leader-schedule",
-    "ledger",
-    "local-cluster",
-    "logger",
-    "math-utils",
-    "measure",
-    "merkle-tree",
-    "metrics",
-    "net-utils",
-    "notifier",
-    "perf",
-    "poh",
-    "poh-bench",
-    "precompiles",
-    "program-binaries",
-    "program-runtime",
-    "program-test",
-    "programs/bpf-loader-tests",
-    "programs/bpf_loader",
-    "programs/compute-budget",
-    "programs/compute-budget-bench",
-    "programs/ed25519-tests",
-    "programs/system",
-    "programs/vote",
-    "programs/zk-elgamal-proof",
-    "programs/zk-elgamal-proof-tests",
-    "programs/zk-token-proof",
-    "pubsub-client",
-    "quic-client",
-    "random",
-    "rayon-threadlimit",
-    "rbpf-cli",
-    "remote-wallet",
-    "reserved-account-keys",
-    "rpc",
-    "rpc-client",
-    "rpc-client-api",
-    "rpc-client-nonce-utils",
-    "rpc-client-types",
-    "rpc-test",
-    "runtime",
-    "runtime-transaction",
-    "scheduling-utils",
-    "send-transaction-service",
-    "snapshots",
-    "stake-accounts",
-    "storage-bigtable",
-    "storage-bigtable/build-proto",
-    "storage-proto",
-    "streamer",
-    "svm",
-    "svm-callback",
-    "svm-feature-set",
-    "svm-log-collector",
-    "svm-measure",
-    "svm-timings",
-    "svm-type-overrides",
-    "syscalls",
-    "syscalls/gen-syscall-list",
-    "test-validator",
-    "tls-utils",
-    "tokens",
-    "tpu-client",
-    "tpu-client-next",
-    "transaction-context",
-    "transaction-status",
-    "transaction-status-client-types",
-    "turbine",
-    "udp-client",
-    "unified-scheduler-logic",
-    "unified-scheduler-pool",
-    "validator",
-    "version",
-    "vote",
-    "votor",
-    "votor-messages",
-    "votor-transport",
-    "watchtower",
-    "xdp",
-    "xdp-ebpf",
+  "account-decoder",
+  "account-decoder-client-types",
+  "accounts-cluster-bench",
+  "accounts-db",
+  "accounts-db/store-histogram",
+  "banking-stage-ingress-types",
+  "banks-client",
+  "banks-interface",
+  "banks-server",
+  "bloom",
+  "bls-cert-verify",
+  "bls-sigverify",
+  "bucket_map",
+  "builtins",
+  "builtins-default-costs",
+  "clap-utils",
+  "clap-v3-utils",
+  "cli",
+  "cli-config",
+  "cli-output",
+  "client",
+  "client-test",
+  "compute-budget",
+  "compute-budget-instruction",
+  "connection-cache",
+  "core",
+  "cost-model",
+  "cpu-utils",
+  "download-utils",
+  "entry",
+  "faucet",
+  "faucet-cli",
+  "feature-set",
+  "fee",
+  "fs",
+  "genesis",
+  "genesis-utils",
+  "geyser-plugin-interface",
+  "geyser-plugin-manager",
+  "gossip",
+  "gossip-cli",
+  "install",
+  "io-uring",
+  "keygen",
+  "lattice-hash",
+  "leader-schedule",
+  "ledger",
+  "local-cluster",
+  "logger",
+  "math-utils",
+  "measure",
+  "merkle-tree",
+  "metrics",
+  "net-utils",
+  "notifier",
+  "perf",
+  "poh",
+  "poh-bench",
+  "precompiles",
+  "program-binaries",
+  "program-runtime",
+  "program-test",
+  "programs/bpf-loader-tests",
+  "programs/bpf_loader",
+  "programs/compute-budget",
+  "programs/compute-budget-bench",
+  "programs/ed25519-tests",
+  "programs/system",
+  "programs/vote",
+  "programs/zk-elgamal-proof",
+  "programs/zk-elgamal-proof-tests",
+  "programs/zk-token-proof",
+  "pubsub-client",
+  "quic-client",
+  "random",
+  "rayon-threadlimit",
+  "rbpf-cli",
+  "remote-wallet",
+  "reserved-account-keys",
+  "rpc",
+  "rpc-client",
+  "rpc-client-api",
+  "rpc-client-nonce-utils",
+  "rpc-client-types",
+  "rpc-test",
+  "runtime",
+  "runtime-transaction",
+  "scheduling-utils",
+  "send-transaction-service",
+  "snapshots",
+  "stake-accounts",
+  "storage-bigtable",
+  "storage-bigtable/build-proto",
+  "storage-proto",
+  "streamer",
+  "svm",
+  "svm-callback",
+  "svm-feature-set",
+  "svm-log-collector",
+  "svm-measure",
+  "svm-timings",
+  "svm-type-overrides",
+  "syscalls",
+  "syscalls/gen-syscall-list",
+  "test-validator",
+  "tls-utils",
+  "tokens",
+  "tpu-client",
+  "tpu-client-next",
+  "transaction-context",
+  "transaction-status",
+  "transaction-status-client-types",
+  "turbine",
+  "udp-client",
+  "unified-scheduler-logic",
+  "unified-scheduler-pool",
+  "validator",
+  "version",
+  "vote",
+  "votor",
+  "votor-messages",
+  "votor-transport",
+  "watchtower",
+  "xdp",
+  "xdp-ebpf",
 ]
 
-exclude = [
-    "ci/xtask",
-    "dev-bins",
-    "programs/sbf",
-    "svm/tests/example-programs",
-]
+exclude = ["ci/xtask", "dev-bins", "programs/sbf", "svm/tests/example-programs"]
 
 resolver = "2"
 
@@ -149,9 +144,9 @@ rust-version = "1.97.1"
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
-    'cfg(target_arch, values("sbf"))',
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+  'cfg(target_arch, values("sbf"))',
 ]
 
 # Clippy lint configuration that can not be applied in clippy.toml
@@ -168,28 +163,66 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
-agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-cpu-utils = { path = "cpu-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-feature-set = { path = "feature-set", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-fs = { path = "fs", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-cpu-utils = { path = "cpu-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-feature-set = { path = "feature-set", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-fs = { path = "fs", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 agave-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=4.4.0-alpha.0" }
-agave-io-uring = { path = "io-uring", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "logger", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-random = { path = "random", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-io-uring = { path = "io-uring", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-logger = { path = "logger", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-math-utils = { path = "math-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-precompiles = { path = "precompiles", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-random = { path = "random", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-reserved-account-keys = { path = "reserved-account-keys", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 agave-scheduler-bindings = "5.0.0"
-agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-scheduling-utils = { path = "scheduling-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-snapshots = { path = "snapshots", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 agave-transaction-view = "6.1.0"
-agave-votor = { path = "votor", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-votor-messages = { path = "votor-messages", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-votor-transport = { path = "votor-transport", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-xdp = { path = "xdp", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-xdp-ebpf = { path = "xdp-ebpf", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-votor = { path = "votor", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-votor-messages = { path = "votor-messages", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-votor-transport = { path = "votor-transport", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-xdp = { path = "xdp", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-xdp-ebpf = { path = "xdp-ebpf", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 ahash = "0.8.12"
 anyhow = "1.0.104"
 arbitrary = "1.4.2"
@@ -223,7 +256,9 @@ caps = "0.5.6"
 cfg-if = "1.0.4"
 chrono = { version = "0.4.45", default-features = false }
 chrono-humanize = "0.2.3"
-clap = { version = "2.33.1", default-features = false, features = ["suggestions"] }
+clap = { version = "2.33.1", default-features = false, features = [
+  "suggestions",
+] }
 console = "0.16.4"
 const_format = "0.2.36"
 criterion = "0.8.2"
@@ -265,11 +300,11 @@ indicatif = "0.18.6"
 io-uring = { version = "0.7.13", features = ["io_safety"] }
 itertools = "0.14.0"
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0", features = [
-    "stats",
+  "stats",
 ] }
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
-    "unprefixed_malloc_on_supported_platforms",
-    "stats",
+  "unprefixed_malloc_on_supported_platforms",
+  "stats",
 ] }
 json5 = "1.3.1"
 jsonrpc-core = "18.0.0"
@@ -282,8 +317,8 @@ lazy-lru = "0.1.3"
 libc = "0.2.189"
 libloading = "0.9.0"
 libsecp256k1 = { version = "0.7.2", default-features = false, features = [
-    "std",
-    "static-context",
+  "std",
+  "static-context",
 ] }
 log = "0.4.33"
 lru = "0.18.2"
@@ -325,7 +360,9 @@ rpassword = "7.5"
 rts-alloc = { version = "4.0.0" }
 rusb = "0.9"
 rustls = { version = "0.23.43", features = ["std"], default-features = false }
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["std"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = [
+  "std",
+] }
 scopeguard = "1.2.0"
 semver = "1.0.28"
 seqlock = "0.2.0"
@@ -341,73 +378,131 @@ shuttle = "0.7.1"
 signal-hook = "0.4.4"
 slab = "0.4.12"
 slotmap = "1.0.7"
-smallvec = { version = "1.15.2", default-features = false, features = ["union"] }
+smallvec = { version = "1.15.2", default-features = false, features = [
+  "union",
+] }
 smpl_jwt = "0.9.0"
 socket2 = "0.6.5"
 soketto = "0.8"
 solana-account = "4.6.0"
-solana-account-decoder = { path = "account-decoder", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "account-decoder", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-account-decoder-client-types = { path = "account-decoder-client-types", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-account-info = "3.1.1"
-solana-accounts-db = { path = "accounts-db", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-accounts-db = { path = "accounts-db", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-address = "2.7.0"
 solana-address-lookup-table-interface = "3.2.0"
-solana-banks-client = { path = "banks-client", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-banks-interface = { path = "banks-interface", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-banks-server = { path = "banks-server", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-banks-client = { path = "banks-client", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-banks-interface = { path = "banks-interface", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-banks-server = { path = "banks-server", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-big-mod-exp = "4.0.0"
 solana-bincode = "3.1.0"
 solana-blake3-hasher = "3.1.0"
-solana-bloom = { path = "bloom", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-bloom = { path = "bloom", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-bls-signatures = { version = "3.4.0", features = ["serde"] }
 solana-bls12-381-syscall = "0.1.1"
 solana-bn254 = "3.2.1"
 solana-borsh = "3.0.2"
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-bucket-map = { path = "bucket_map", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-builtins = { path = "builtins", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "clap-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
+solana-bucket-map = { path = "bucket_map", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-builtins = { path = "builtins", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-builtins-default-costs = { path = "builtins-default-costs", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-clap-utils = { path = "clap-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-cli-config = { path = "cli-config", version = "=4.4.0-alpha.0" }
-solana-cli-output = { path = "cli-output", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-cli-output = { path = "cli-output", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-client = { path = "client", version = "=4.4.0-alpha.0" }
 solana-client-traits = "4.1.0"
 solana-clock = "3.2.0"
 solana-cluster-type = "3.2.0"
 solana-commitment-config = "3.1.1"
-solana-compute-budget = { path = "compute-budget", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "compute-budget", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-compute-budget-instruction = { path = "compute-budget-instruction", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-compute-budget-interface = "3.1.0"
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-config-interface = "2.0.0"
-solana-connection-cache = { path = "connection-cache", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "core", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "cost-model", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-connection-cache = { path = "connection-cache", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
+solana-core = { path = "core", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-cost-model = { path = "cost-model", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-cpi = "3.1.0"
 solana-curve25519 = "4.0.1"
 solana-define-syscall = "5.2.0"
 solana-derivation-path = "3.0.0"
-solana-download-utils = { path = "download-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-download-utils = { path = "download-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-ed25519-program = "3.0.0"
-solana-entry = { path = "entry", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-entry = { path = "entry", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-epoch-info = "3.1.0"
 solana-epoch-rewards = "3.2.0"
 solana-epoch-rewards-hasher = "3.1.0"
 solana-epoch-schedule = "3.3.0"
-solana-faucet = { path = "faucet", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-faucet = { path = "faucet", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-feature-gate-interface = "4.0.0"
-solana-fee = { path = "fee", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-fee = { path = "fee", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-fee-calculator = "3.3.0"
 solana-fee-structure = "4.1.0"
 solana-file-download = "3.1.4"
 solana-frozen-abi = "3.8.0"
 solana-frozen-abi-macro = "3.6.0"
-solana-genesis = { path = "genesis", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "genesis", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-genesis-config = "4.1.0"
-solana-genesis-utils = { path = "genesis-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-gossip = { path = "gossip", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "genesis-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-gossip = { path = "gossip", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-hard-forks = "3.2.0"
 solana-hash = "4.6.0"
 solana-hash-512 = "1.2.0"
@@ -418,54 +513,94 @@ solana-instructions-sysvar = "4.0.0"
 solana-keccak-hasher = "3.1.0"
 solana-keypair = "3.1.2"
 solana-last-restart-slot = "3.2.0"
-solana-lattice-hash = { path = "lattice-hash", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-leader-schedule = { path = "leader-schedule", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-ledger = { path = "ledger", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-lattice-hash = { path = "lattice-hash", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-leader-schedule = { path = "leader-schedule", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-ledger = { path = "ledger", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-loader-v2-interface = "3.0.0"
 solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
-solana-local-cluster = { path = "local-cluster", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "measure", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-merkle-tree = { path = "merkle-tree", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "local-cluster", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-measure = { path = "measure", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-merkle-tree = { path = "merkle-tree", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-message = "4.5.0"
-solana-metrics = { path = "metrics", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "metrics", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-msg = "3.1.0"
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "net-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "net-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-nohash-hasher = "0.2.1"
 solana-nonce = "3.3.0"
 solana-nonce-account = { version = "4.3.0", default-features = false }
-solana-notifier = { path = "notifier", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-notifier = { path = "notifier", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-offchain-message = "3.0.0"
 solana-packet = "4.3.0"
-solana-perf = { path = "perf", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-poh = { path = "poh", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-perf = { path = "perf", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-poh = { path = "poh", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-poh-config = "3.1.0"
 solana-poseidon = "5.0.0"
 solana-precompile-error = "3.0.0"
 solana-presigner = "3.0.0"
 solana-program = { version = "4.1.0", default-features = false }
-solana-program-binaries = { path = "program-binaries", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-program-binaries = { path = "program-binaries", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-program-entrypoint = "3.1.1"
 solana-program-error = "3.0.1"
 solana-program-option = "3.1.0"
 solana-program-pack = "3.1.0"
-solana-program-runtime = { path = "program-runtime", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-program-test = { path = "program-test", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "program-runtime", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-program-test = { path = "program-test", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-pubkey = { version = "4.3.0", default-features = false }
 solana-pubsub-client = { path = "pubsub-client", version = "=4.4.0-alpha.0" }
-solana-quic-client = { path = "quic-client", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-remote-wallet = { path = "remote-wallet", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-quic-client = { path = "quic-client", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-remote-wallet = { path = "remote-wallet", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
 solana-rent = "4.4.0"
 solana-reward-info = "6.3.0"
-solana-rpc = { path = "rpc", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "rpc", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-rpc-client = { path = "rpc-client", version = "=4.4.0-alpha.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=4.4.0-alpha.0" }
 solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=4.4.0-alpha.0" }
 solana-rpc-client-types = { path = "rpc-client-types", version = "=4.4.0-alpha.0" }
-solana-runtime = { path = "runtime", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "runtime-transaction", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-runtime = { path = "runtime", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-runtime-transaction = { path = "runtime-transaction", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.23.0", default-features = false }
 solana-sdk-ids = "3.1.0"
@@ -474,7 +609,9 @@ solana-secp256k1-recover = "3.3.0"
 solana-secp256r1-program = "3.0.0"
 solana-seed-derivable = "3.0.0"
 solana-seed-phrase = "3.0.0"
-solana-send-transaction-service = { path = "send-transaction-service", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-serde = "3.0.0"
 solana-serde-varint = "3.0.1"
 solana-serialize-utils = "3.1.2"
@@ -490,48 +627,110 @@ solana-slot-history = "3.2.0"
 solana-stable-layout = "3.0.1"
 solana-stake-history = "1.1.0"
 solana-stake-interface = "4.4.0"
-solana-storage-bigtable = { path = "storage-bigtable", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-storage-proto = { path = "storage-proto", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "streamer", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm = { path = "svm", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "svm-callback", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "svm-feature-set", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "svm-log-collector", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-measure = { path = "svm-measure", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-timings = { path = "svm-timings", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-storage-proto = { path = "storage-proto", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-streamer = { path = "streamer", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm = { path = "svm", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-callback = { path = "svm-callback", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-feature-set = { path = "svm-feature-set", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-log-collector = { path = "svm-log-collector", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-measure = { path = "svm-measure", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-timings = { path = "svm-timings", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-svm-transaction = "5.0.0"
-solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-syscalls = { path = "syscalls", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }
-solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-syscalls = { path = "syscalls", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
+solana-system-interface = { version = "3.3.0", features = [
+  "alloc",
+  "bincode",
+  "serde",
+  "wincode",
+] }
+solana-system-program = { path = "programs/system", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-system-transaction = "4.1.0"
 solana-sysvar = "4.3.0"
 solana-sysvar-id = "3.1.0"
-solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-test-validator = { path = "test-validator", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-time-utils = "3.0.0"
-solana-tls-utils = { path = "tls-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-tpu-client = { path = "tpu-client", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-tpu-client-next = { path = "tpu-client-next", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-tls-utils = { path = "tls-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-tpu-client = { path = "tpu-client", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
+solana-tpu-client-next = { path = "tpu-client-next", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-transaction = "4.2.0"
-solana-transaction-context = { path = "transaction-context", version = "=4.4.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "transaction-context", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+  "bincode",
+] }
 solana-transaction-error = "3.4.0"
-solana-transaction-status = { path = "transaction-status", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-turbine = { path = "turbine", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-udp-client = { path = "udp-client", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-transaction-status = { path = "transaction-status", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-transaction-status-client-types = { path = "transaction-status-client-types", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-turbine = { path = "turbine", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-udp-client = { path = "udp-client", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-validator-exit = "3.0.0"
-solana-version = { path = "version", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "vote", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-version = { path = "version", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-vote = { path = "vote", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-vote-interface = "6.1.0"
-solana-vote-program = { path = "programs/vote", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-vote-program = { path = "programs/vote", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
 solana-wincode-varint = "1.1.0"
 solana-zk-elgamal-proof-interface = "0.1.3"
-solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-zk-elgamal-proof-program = { path = "programs/zk-elgamal-proof", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-zk-sdk = "7.0.1"
 solana-zk-sdk-pod = "0.1.2"
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 spl-associated-token-account-interface = "2.0.0"
 spl-generic-token = "2.0.0"
 spl-memo-interface = "2.1.0"
@@ -562,10 +761,16 @@ tonic-prost = "0.14.6"
 tonic-prost-build = "0.14.6"
 tracing = "0.1"
 trees = "0.4.2"
-trezor-client = { version = "0.1.6", default-features = false, features = ["solana"] }
+trezor-client = { version = "0.1.6", default-features = false, features = [
+  "solana",
+] }
 tungstenite = "0.28.0"
-ur-parse-lib = { version = "1.0.8", default-features = false, features = ["std"] }
-ur-registry = { version = "1.0.8", default-features = false, features = ["std"] }
+ur-parse-lib = { version = "1.0.8", default-features = false, features = [
+  "std",
+] }
+ur-registry = { version = "1.0.8", default-features = false, features = [
+  "std",
+] }
 uriparse = "0.6.4"
 url = "2.5.8"
 winapi = "0.3.8"

--- a/account-decoder-client-types/Cargo.toml
+++ b/account-decoder-client-types/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "solana-account-decoder-client-types"
-description = "Core RPC client types for solana-account-decoder"
-documentation = "https://docs.rs/solana-account-decoder-client-types"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Core RPC client types for solana-account-decoder"
+documentation = "https://docs.rs/solana-account-decoder-client-types"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-zstd = ["dep:zstd"]
 
 [dependencies]
 base64 = { workspace = true }
@@ -27,6 +23,10 @@ serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-pubkey = { workspace = true }
 zstd = { workspace = true, optional = true }
+
+[features]
+agave-unstable-api = []
+zstd = ["dep:zstd"]
 
 [lints]
 workspace = true

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-account-decoder"
-description = "Solana account decoder"
-documentation = "https://docs.rs/solana-account-decoder"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana account decoder"
+documentation = "https://docs.rs/solana-account-decoder"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 Inflector = { workspace = true }
@@ -28,10 +25,13 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder-client-types = { workspace = true, features = ["zstd"] }
-solana-address-lookup-table-interface = { workspace = true, features = [
+solana-address-lookup-table-interface = {
+  workspace = true,
+  features = [
     "bincode",
     "bytemuck",
-] }
+  ]
+}
 solana-clock = { workspace = true }
 solana-config-interface = { workspace = true, features = ["bincode"] }
 solana-epoch-schedule = { workspace = true, features = ["serde"] }
@@ -64,6 +64,9 @@ zstd = { workspace = true }
 assert_matches = { workspace = true }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/account-decoder/Cargo.toml
+++ b/account-decoder/Cargo.toml
@@ -29,8 +29,8 @@ serde_json = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder-client-types = { workspace = true, features = ["zstd"] }
 solana-address-lookup-table-interface = { workspace = true, features = [
-    "bincode",
-    "bytemuck",
+  "bincode",
+  "bytemuck",
 ] }
 solana-clock = { workspace = true }
 solana-config-interface = { workspace = true, features = ["bincode"] }

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -1,20 +1,16 @@
 [package]
 name = "solana-accounts-cluster-bench"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -32,7 +28,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
-solana-message = { workspace = true, features = ["serde", "blake3", "wincode"] }
+solana-message = { workspace = true, features = ["blake3", "serde", "wincode"] }
 solana-net-utils = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-pubkey = { workspace = true }
@@ -47,18 +43,31 @@ solana-version = { workspace = true }
 spl-generic-token = { workspace = true }
 spl-token-interface = { workspace = true }
 
-[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
-
 [dev-dependencies]
 solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api"] }
 solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-local-cluster = {
+  path = "../local-cluster",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+solana-test-validator = {
+  path = "../test-validator",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/accounts-cluster-bench/Cargo.toml
+++ b/accounts-cluster-bench/Cargo.toml
@@ -51,14 +51,31 @@ spl-token-interface = { workspace = true }
 jemallocator = { workspace = true }
 
 [dev-dependencies]
-solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api"] }
-solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-local-cluster = { path = "../local-cluster", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-accounts-db = { path = "../accounts-db", features = [
+  "agave-unstable-api",
+] }
+solana-core = { path = "../core", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-faucet = { path = "../faucet", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-local-cluster = { path = "../local-cluster", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-native-token = { workspace = true }
 solana-poh-config = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-test-validator = { path = "../test-validator", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-accounts-db"
-description = "Solana accounts db"
-documentation = "https://docs.rs/solana-accounts-db"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana accounts db"
+documentation = "https://docs.rs/solana-accounts-db"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,32 +19,36 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_accounts_db"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-keypair",
-    "dep:solana-rent",
-    "dep:solana-signer",
-    "dep:solana-stake-interface",
-    "dep:solana-vote-program",
-    "solana-account/wincode",
-    "solana-transaction/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-fee-calculator/frozen-abi",
-    "solana-nonce/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "accounts_index"
+
+[[bench]]
+harness = false
+name = "bench_accounts_file"
+
+[[bench]]
+harness = false
+name = "bench_hashing"
+
+[[bench]]
+harness = false
+name = "read_only_accounts_cache"
+
+[[bench]]
+harness = false
+name = "bench_serde"
+
+[[bench]]
+harness = false
+name = "bench_lock_accounts"
 
 [dependencies]
 agave-fs = { workspace = true }
 ahash = { workspace = true }
 blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
-dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+dashmap = { workspace = true, features = ["raw-api", "rayon"] }
 itertools = { workspace = true }
 log = { workspace = true }
 modular-bitfield = { workspace = true }
@@ -56,21 +60,32 @@ seqlock = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 smallvec = { workspace = true, features = ["const_generics"] }
 solana-account = { workspace = true, features = ["serde"] }
-solana-address-lookup-table-interface = { workspace = true, features = [
+solana-address-lookup-table-interface = {
+  workspace = true,
+  features = [
     "bincode",
     "bytemuck",
-] }
+  ]
+}
 solana-bucket-map = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true, features = ["serde", "wincode"] }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-hash = { workspace = true, features = ["serde", "wincode", "rand"] }
+  ],
+  optional = true
+}
+solana-hash = { workspace = true, features = ["rand", "serde", "wincode"] }
 solana-keypair = { workspace = true, optional = true }
 solana-lattice-hash = { workspace = true }
 solana-measure = { workspace = true }
@@ -84,10 +99,14 @@ solana-rent = { workspace = true, optional = true }
 solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true, optional = true }
 solana-slot-hashes = { workspace = true }
-solana-stake-interface = { workspace = true, optional = true, features = [
+solana-stake-interface = {
+  workspace = true,
+  features = [
     "serde",
     "wincode",
-] }
+  ],
+  optional = true
+}
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = { workspace = true }
@@ -103,7 +122,10 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  features = ["agave-unstable-api"]
+}
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
@@ -124,29 +146,25 @@ test-case = { workspace = true }
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[[bench]]
-name = "accounts_index"
-harness = false
-
-[[bench]]
-name = "bench_accounts_file"
-harness = false
-
-[[bench]]
-name = "bench_hashing"
-harness = false
-
-[[bench]]
-name = "read_only_accounts_cache"
-harness = false
-
-[[bench]]
-name = "bench_serde"
-harness = false
-
-[[bench]]
-name = "bench_lock_accounts"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "dep:qualifier_attr",
+  "dep:solana-keypair",
+  "dep:solana-rent",
+  "dep:solana-signer",
+  "dep:solana-stake-interface",
+  "dep:solana-vote-program",
+  "solana-account/wincode",
+  "solana-transaction/dev-context-only-utils",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-fee-calculator/frozen-abi",
+  "solana-nonce/frozen-abi",
+  "solana-vote-program/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -22,22 +22,22 @@ name = "solana_accounts_db"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-keypair",
-    "dep:solana-rent",
-    "dep:solana-signer",
-    "dep:solana-stake-interface",
-    "dep:solana-vote-program",
-    "solana-account/wincode",
-    "solana-transaction/dev-context-only-utils",
+  "dep:qualifier_attr",
+  "dep:solana-keypair",
+  "dep:solana-rent",
+  "dep:solana-signer",
+  "dep:solana-stake-interface",
+  "dep:solana-vote-program",
+  "solana-account/wincode",
+  "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dev-context-only-utils",
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-fee-calculator/frozen-abi",
-    "solana-nonce/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dev-context-only-utils",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-fee-calculator/frozen-abi",
+  "solana-nonce/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 
 [dependencies]
@@ -58,18 +58,18 @@ serde = { workspace = true, features = ["rc"] }
 smallvec = { workspace = true, features = ["const_generics"] }
 solana-account = { workspace = true, features = ["serde"] }
 solana-address-lookup-table-interface = { workspace = true, features = [
-    "bincode",
-    "bytemuck",
+  "bincode",
+  "bytemuck",
 ] }
 solana-bucket-map = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true, features = ["serde", "wincode"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true, features = ["serde", "wincode", "rand"] }
 solana-keypair = { workspace = true, optional = true }
@@ -86,8 +86,8 @@ solana-reward-info = { workspace = true, features = ["serde"] }
 solana-signer = { workspace = true, optional = true }
 solana-slot-hashes = { workspace = true }
 solana-stake-interface = { workspace = true, optional = true, features = [
-    "serde",
-    "wincode",
+  "serde",
+  "wincode",
 ] }
 solana-svm-transaction = { workspace = true }
 solana-system-interface = { workspace = true }
@@ -104,14 +104,19 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = [
+  "agave-unstable-api",
+] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 memoffset = { workspace = true }
 rand_chacha = { workspace = true }
 serde_bytes = { workspace = true }
-solana-accounts-db = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-accounts-db = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-instruction = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }

--- a/accounts-db/store-histogram/Cargo.toml
+++ b/accounts-db/store-histogram/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "agave-store-histogram"
-description = "Tool to calculate account storage histogram"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
+description = "Tool to calculate account storage histogram"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [dependencies]
 clap = { workspace = true }
 solana-version = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/accounts-db/store-tool/Cargo.toml
+++ b/accounts-db/store-tool/Cargo.toml
@@ -1,20 +1,14 @@
 [package]
 name = "agave-store-tool"
-description = "Tool for account storage files"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Tool for account storage files"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 workspace = "../../dev-bins"
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-dummy-for-ci-check = []
-frozen-abi = []
+publish = false
 
 [dependencies]
 ahash = { workspace = true }
@@ -25,6 +19,12 @@ solana-accounts-db = { workspace = true, features = ["dev-context-only-utils"] }
 solana-pubkey = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-version = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+dummy-for-ci-check = []
+frozen-abi = []
 
 [lints]
 workspace = true

--- a/banking-stage-ingress-types/Cargo.toml
+++ b/banking-stage-ingress-types/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "agave-banking-stage-ingress-types"
-description = "Agave banking stage ingress types"
-documentation = "https://docs.rs/agave-banking-stage-ingress-types"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave banking stage ingress types"
+documentation = "https://docs.rs/agave-banking-stage-ingress-types"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["dep:wincode"]
-
 [dependencies]
 crossbeam-channel = { workspace = true }
 solana-perf = { workspace = true }
 wincode = { workspace = true, optional = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["dep:wincode"]
 
 [lints]
 workspace = true

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-banks-client"
-description = "Solana banks client"
-documentation = "https://docs.rs/solana-banks-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana banks client"
+documentation = "https://docs.rs/solana-banks-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_banks_client"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 borsh = { workspace = true }
@@ -48,9 +45,15 @@ wincode = { workspace = true }
 [dev-dependencies]
 solana-banks-server = { path = "../banks-server", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/banks-client/Cargo.toml
+++ b/banks-client/Cargo.toml
@@ -46,9 +46,14 @@ tokio-serde = { workspace = true, features = ["bincode"] }
 wincode = { workspace = true }
 
 [dev-dependencies]
-solana-banks-server = { path = "../banks-server", features = ["agave-unstable-api"] }
+solana-banks-server = { path = "../banks-server", features = [
+  "agave-unstable-api",
+] }
 solana-pubkey = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 

--- a/banks-interface/Cargo.toml
+++ b/banks-interface/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-banks-interface"
-description = "Solana banks RPC interface"
-documentation = "https://docs.rs/solana-banks-interface"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana banks RPC interface"
+documentation = "https://docs.rs/solana-banks-interface"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_banks_interface"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 serde = { workspace = true }
@@ -35,6 +32,9 @@ solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-context = { workspace = true, features = ["serde"] }
 solana-transaction-error = { workspace = true, features = ["serde"] }
 tarpc = { workspace = true, features = ["full"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/banks-server/Cargo.toml
+++ b/banks-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-banks-server"
-description = "Solana banks server"
-documentation = "https://docs.rs/solana-banks-server"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana banks server"
+documentation = "https://docs.rs/solana-banks-server"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_banks_server"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 bincode = { workspace = true }
@@ -41,6 +38,9 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 tarpc = { workspace = true, features = ["full"] }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-bloom"
-description = "Solana bloom filter"
-documentation = "https://docs.rs/solana-bloom"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana bloom filter"
+documentation = "https://docs.rs/solana-bloom"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,25 +19,28 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_bloom"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-hash/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "bloom"
 
 [dependencies]
 bv = { workspace = true }
 fnv = { workspace = true }
 rand = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-sanitize = { workspace = true }
 solana-time-utils = { workspace = true }
 wincode = { workspace = true, features = ["bv"] }
@@ -50,9 +53,14 @@ solana-hash = { workspace = true, features = ["atomic", "wincode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signature = { workspace = true, features = ["std"] }
 
-[[bench]]
-name = "bloom"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-hash/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/bloom/Cargo.toml
+++ b/bloom/Cargo.toml
@@ -23,9 +23,9 @@ name = "solana_bloom"
 agave-unstable-api = []
 dev-context-only-utils = []
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-hash/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-hash/frozen-abi",
 ]
 
 [dependencies]
@@ -33,10 +33,10 @@ bv = { workspace = true }
 fnv = { workspace = true }
 rand = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
 solana-time-utils = { workspace = true }
@@ -45,7 +45,10 @@ wincode = { workspace = true, features = ["bv"] }
 [dev-dependencies]
 bencher = { workspace = true }
 rayon = { workspace = true }
-solana-bloom = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-bloom = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-hash = { workspace = true, features = ["atomic", "wincode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signature = { workspace = true, features = ["std"] }

--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "agave-bls-cert-verify"
-description = "The BLS cert verify logic shared between sigverify and block marker consumption"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The BLS cert verify logic shared between sigverify and block marker consumption"
+readme = "../README.md"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["agave-votor-messages/dev-context-only-utils"]
+[[bench]]
+harness = false
+name = "cert_verify"
 
 [dependencies]
 agave-votor-messages = { workspace = true }
@@ -35,9 +35,9 @@ criterion = { workspace = true }
 rand = { workspace = true }
 solana-hash = { workspace = true }
 
-[[bench]]
-name = "cert_verify"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["agave-votor-messages/dev-context-only-utils"]
 
 [lints]
 workspace = true

--- a/bls-cert-verify/Cargo.toml
+++ b/bls-cert-verify/Cargo.toml
@@ -30,7 +30,10 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-bls-cert-verify = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+agave-bls-cert-verify = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 criterion = { workspace = true }
 rand = { workspace = true }
 solana-hash = { workspace = true }

--- a/bls-sigverify/Cargo.toml
+++ b/bls-sigverify/Cargo.toml
@@ -1,29 +1,23 @@
 [package]
 name = "agave-bls-sigverify"
-description = "Logic to process incoming alpenglow consensus messages"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Logic to process incoming alpenglow consensus messages"
+readme = "../README.md"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-bls-cert-verify/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "agave-votor-transport/dev-context-only-utils",
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-]
+[[bench]]
+harness = false
+name = "bls_vote_sigverify"
 
 [dependencies]
 agave-bls-cert-verify = { workspace = true }
@@ -67,9 +61,15 @@ solana-perf = { workspace = true }
 solana-signer = { workspace = true }
 tokio = { workspace = true }
 
-[[bench]]
-name = "bls_vote_sigverify"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-bls-cert-verify/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "agave-votor-transport/dev-context-only-utils",
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+]
 
 [lints]
 workspace = true

--- a/bls-sigverify/Cargo.toml
+++ b/bls-sigverify/Cargo.toml
@@ -18,11 +18,11 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-bls-cert-verify/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "agave-votor-transport/dev-context-only-utils",
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
+  "agave-bls-cert-verify/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "agave-votor-transport/dev-context-only-utils",
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
 ]
 
 [dependencies]
@@ -53,7 +53,10 @@ thiserror = { workspace = true }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-bls-sigverify = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+agave-bls-sigverify = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 agave-logger = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-bucket-map"
-description = "solana-bucket-map"
-documentation = "https://docs.rs/solana-bucket-map"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "solana-bucket-map"
+documentation = "https://docs.rs/solana-bucket-map"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,10 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_bucket_map"
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 ahash = { workspace = true }
@@ -41,6 +37,10 @@ tempfile = { workspace = true }
 rayon = { workspace = true }
 solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -39,7 +39,10 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 rayon = { workspace = true }
-solana-bucket-map = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-bucket-map = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 
 [lints]

--- a/builtins-default-costs/Cargo.toml
+++ b/builtins-default-costs/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-builtins-default-costs"
-description = "Solana builtins default costs"
-documentation = "https://docs.rs/solana-builtins-default-costs"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana builtins default costs"
+documentation = "https://docs.rs/solana-builtins-default-costs"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -20,10 +20,6 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_builtins_default_costs"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["dep:qualifier_attr"]
-
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
@@ -34,6 +30,10 @@ solana-sdk-ids = { workspace = true }
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["std"] }
 static_assertions = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["dep:qualifier_attr"]
 
 [lints]
 workspace = true

--- a/builtins/Cargo.toml
+++ b/builtins/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "solana-builtins"
-description = "Solana builtin programs"
-documentation = "https://docs.rs/solana-builtins"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana builtin programs"
+documentation = "https://docs.rs/solana-builtins"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -31,6 +27,10 @@ solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-zk-elgamal-proof-program = { workspace = true }
 solana-zk-token-proof-program = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -84,10 +84,11 @@ RUN \
   rustup component add llvm-tools-preview --toolchain=$RUST_NIGHTLY_VERSION && \
   cargo install cargo-audit && \
   cargo install cargo-hack && \
-  cargo install cargo-sort@2.0.2 && \
   cargo install rustfilt && \
   cargo install cargo-build-sbf@4.1.0 --locked && \
   cargo install cargo-deny@0.20.2 --locked && \
+  # tombi v1.5.0
+  cargo install --git https://github.com/tombi-toml/tombi.git --rev e735f817881f328daee6f9f0f458ba1ac4328a44 --locked tombi-cli && \
   rustup show && \
   rustc --version && \
   cargo --version && \

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -88,6 +88,7 @@ RUN \
   cargo install rustfilt && \
   cargo install cargo-build-sbf@4.1.0 --locked && \
   cargo install cargo-deny@0.20.2 --locked && \
+  cargo install taplo-cli@0.10.0 --locked && \
   rustup show && \
   rustc --version && \
   cargo --version && \

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -17,13 +17,8 @@ CHANNEL="$(jq -r '.CHANNEL' <<<"$channel_info")"
 export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings -A incomplete_features"
 
-# sort
-if [[ -n $CI ]]; then
-  # exclude from printing "Checking xxx ..."
-  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check > /dev/null
-else
-  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check
-fi
+# format and sort TOML files
+tombi format --check --diff
 
 # check dev-context-only-utils isn't used in normal dependencies
 _ scripts/check-dev-context-only-utils.sh tree

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -25,6 +25,9 @@ else
   _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check
 fi
 
+# format toml files
+taplo fmt --check --diff
+
 # check dev-context-only-utils isn't used in normal dependencies
 _ scripts/check-dev-context-only-utils.sh tree
 

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -20,9 +20,9 @@ export RUSTFLAGS="-D warnings -A incomplete_features"
 # sort
 if [[ -n $CI ]]; then
   # exclude from printing "Checking xxx ..."
-  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check > /dev/null
+  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check --no-format > /dev/null
 else
-  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check
+  _ scripts/cargo-for-all-lock-files.sh -- sort --workspace --check --no-format
 fi
 
 # format toml files

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -12,12 +12,6 @@ publish = false
 # Prevents auto-detection of parent workspace (ie. git worktrees).
 [workspace]
 
-[features]
-agave-unstable-api = []
-dummy-for-ci-check = []
-frozen-abi = []
-integration-tests = []
-
 [dependencies]
 anyhow = "1.0.104"
 clap = { version = "4.6.6", features = ["derive"] }
@@ -38,12 +32,11 @@ xtask_shared = { package = "anza-xtask", version = "0.2.2" }
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 
-[profile.dev]
-debug = "line-tables-only"
-
-[profile.full-dev]
-inherits = "dev"
-debug = "full"
+[features]
+agave-unstable-api = []
+dummy-for-ci-check = []
+frozen-abi = []
+integration-tests = []
 
 # Keep in sync with the root [workspace.lints.clippy].
 [lints.clippy]
@@ -56,3 +49,10 @@ used_underscore_binding = "deny"
 
 # Allowed lints
 new_without_default = "allow"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.full-dev]
+inherits = "dev"
+debug = "full"

--- a/ci/xtask/Cargo.toml
+++ b/ci/xtask/Cargo.toml
@@ -26,7 +26,9 @@ futures-util = "0.3.31"
 log = "0.4.28"
 octocrab = { version = "0.54.1", features = ["stream"] }
 regex = "1.13.1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "rustls-tls",
+] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.145"

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-clap-utils"
-description = "Solana utilities for the clap"
-documentation = "https://docs.rs/solana-clap-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana utilities for the clap"
+documentation = "https://docs.rs/solana-clap-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -17,9 +17,6 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 name = "solana_clap_utils"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 bip39 = { workspace = true }
@@ -52,6 +49,9 @@ assert_matches = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/clap-utils/Cargo.toml
+++ b/clap-utils/Cargo.toml
@@ -25,7 +25,9 @@ agave-unstable-api = []
 bip39 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["default"] }
-clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
+clap = { version = "2.33.0", default-features = false, features = [
+  "suggestions",
+] }
 rpassword = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-cli-config = { workspace = true }

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-clap-v3-utils"
-description = "Solana utilities for the clap v3"
-documentation = "https://docs.rs/solana-clap-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana utilities for the clap v3"
+documentation = "https://docs.rs/solana-clap-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -17,10 +17,6 @@ rustdoc-args = ["--cfg=docsrs"]
 
 [lib]
 name = "solana_clap_v3_utils"
-
-[features]
-agave-unstable-api = []
-elgamal = ["dep:solana-zk-sdk"]
 
 [dependencies]
 bip39 = { workspace = true }
@@ -56,6 +52,10 @@ solana-clap-v3-utils = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 tempfile = { workspace = true }
+
+[features]
+agave-unstable-api = []
+elgamal = ["dep:solana-zk-sdk"]
 
 [lints]
 workspace = true

--- a/clap-v3-utils/Cargo.toml
+++ b/clap-v3-utils/Cargo.toml
@@ -25,7 +25,11 @@ elgamal = ["dep:solana-zk-sdk"]
 [dependencies]
 bip39 = { workspace = true }
 chrono = { workspace = true, features = ["default"] }
-clap = { version = "3.2.23", default-features = false, features = ["cargo", "std", "suggestions"] }
+clap = { version = "3.2.23", default-features = false, features = [
+  "cargo",
+  "std",
+  "suggestions",
+] }
 five8 = { workspace = true }
 rpassword = { workspace = true }
 solana-cli-config = { workspace = true }

--- a/cli-config/Cargo.toml
+++ b/cli-config/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-cli-config"
-documentation = "https://docs.rs/solana-cli-config"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-cli-config"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 dirs-next = { workspace = true }
@@ -27,6 +24,9 @@ url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-cli-output"
-documentation = "https://docs.rs/solana-cli-output"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-cli-output"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 Inflector = { workspace = true }
@@ -63,7 +60,13 @@ spl-memo-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = ["agave-unstable-api", "bincode"]
+}
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/cli-output/Cargo.toml
+++ b/cli-output/Cargo.toml
@@ -25,7 +25,9 @@ agave-votor-messages = { workspace = true }
 base64 = { workspace = true }
 bitvec = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
-clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
+clap = { version = "2.33.0", default-features = false, features = [
+  "suggestions",
+] }
 console = { workspace = true }
 humantime = { workspace = true }
 indicatif = { workspace = true }
@@ -63,7 +65,10 @@ spl-memo-interface = { workspace = true }
 solana-keypair = { workspace = true }
 solana-seed-derivable = { workspace = true }
 solana-signer = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+] }
 
 [lints]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-cli"
-documentation = "https://docs.rs/solana-cli"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-cli"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -21,16 +21,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [[bin]]
 name = "solana"
 path = "src/main.rs"
-
-[features]
-default = ["remote-wallet-hidraw"]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "solana-faucet/dev-context-only-utils",
-    "solana-client/dev-context-only-utils",
-]
-remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
-remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -48,7 +38,18 @@ humantime = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pretty-hex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "rustls-tls-native-roots", "json"] }
+reqwest = {
+  workspace = true,
+  features = [
+    "blocking",
+    "brotli",
+    "deflate",
+    "gzip",
+    "json",
+    "rustls-tls",
+    "rustls-tls-native-roots"
+  ]
+}
 serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true, features = ["wincode"] }
@@ -121,9 +122,22 @@ solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = {
+  path = "../test-validator",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+default = ["remote-wallet-hidraw"]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "solana-client/dev-context-only-utils",
+  "solana-faucet/dev-context-only-utils",
+]
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [lints]
 workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,8 +26,8 @@ path = "src/main.rs"
 default = ["remote-wallet-hidraw"]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "solana-faucet/dev-context-only-utils",
-    "solana-client/dev-context-only-utils",
+  "solana-faucet/dev-context-only-utils",
+  "solana-client/dev-context-only-utils",
 ]
 remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
 remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
@@ -48,7 +48,15 @@ humantime = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pretty-hex = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "rustls-tls-native-roots", "json"] }
+reqwest = { workspace = true, features = [
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "rustls-tls-native-roots",
+  "json",
+] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account = { workspace = true, features = ["wincode"] }
@@ -96,7 +104,9 @@ solana-stake-interface = { workspace = true, features = ["wincode"] }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-tpu-client = { workspace = true, features = ["default"] }
-solana-tpu-client-next = { workspace = true, features = ["websocket-node-address-service"] }
+solana-tpu-client-next = { workspace = true, features = [
+  "websocket-node-address-service",
+] }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-transaction-status = { workspace = true }
@@ -112,7 +122,10 @@ wincode = { workspace = true }
 assert_matches = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
-solana-faucet = { path = "../faucet", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-faucet = { path = "../faucet", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
@@ -121,7 +134,10 @@ solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-presigner = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -1,21 +1,18 @@
 [package]
 name = "solana-client-test"
-description = "Solana RPC Test"
-documentation = "https://docs.rs/solana-client-test"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC Test"
+documentation = "https://docs.rs/solana-client-test"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 futures-util = { workspace = true }
@@ -49,10 +46,19 @@ log = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-packet = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+solana-test-validator = {
+  path = "../test-validator",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
 spl-memo-interface = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/client-test/Cargo.toml
+++ b/client-test/Cargo.toml
@@ -48,10 +48,21 @@ async-trait = { workspace = true }
 log = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-packet = { workspace = true }
-solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
+solana-rpc = { path = "../rpc", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-test-validator = { path = "../test-validator", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-tpu-client-next = { workspace = true, features = [
+  "dev-context-only-utils",
+] }
 spl-memo-interface = { workspace = true }
 
 [lints]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "solana-client"
-description = "Solana Client"
-documentation = "https://docs.rs/solana-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Client"
+documentation = "https://docs.rs/solana-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 async-trait = { workspace = true }
@@ -53,6 +49,10 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 crossbeam-channel = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,12 +2,27 @@ too-many-arguments-threshold = 9
 
 # Disallow specific methods from being used
 disallowed-methods = [
-    { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
-    { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
+  {
+    path = "std::net::UdpSocket::bind",
+    reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration."
+  },
+  {
+    path = "tokio::net::UdpSocket::bind",
+    reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration."
+  },
+  {
+    path = "lazy_static::initialize",
+    reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate."
+  }
 ]
 
 disallowed-macros = [
-    { path = "solana_sdk::saturating_add_assign", reason = "Deprecated. Use std::num::Saturating<T> instead." },
-    { path = "lazy_static::lazy_static", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
+  {
+    path = "solana_sdk::saturating_add_assign",
+    reason = "Deprecated. Use std::num::Saturating<T> instead."
+  },
+  {
+    path = "lazy_static::lazy_static",
+    reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate."
+  },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,28 +1,15 @@
+#:tombi toml-version = "v1.0.0"
+
 too-many-arguments-threshold = 9
 
 # Disallow specific methods from being used
 disallowed-methods = [
-  {
-    path = "std::net::UdpSocket::bind",
-    reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration."
-  },
-  {
-    path = "tokio::net::UdpSocket::bind",
-    reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration."
-  },
-  {
-    path = "lazy_static::initialize",
-    reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate."
-  }
+  { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
+  { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
+  { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
 ]
 
 disallowed-macros = [
-  {
-    path = "solana_sdk::saturating_add_assign",
-    reason = "Deprecated. Use std::num::Saturating<T> instead."
-  },
-  {
-    path = "lazy_static::lazy_static",
-    reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate."
-  },
+  { path = "solana_sdk::saturating_add_assign", reason = "Deprecated. Use std::num::Saturating<T> instead." },
+  { path = "lazy_static::lazy_static", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,12 +2,12 @@ too-many-arguments-threshold = 9
 
 # Disallow specific methods from being used
 disallowed-methods = [
-    { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
-    { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
-    { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." }
+  { path = "std::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_with_config, bind_to, etc instead for proper socket configuration." },
+  { path = "tokio::net::UdpSocket::bind", reason = "Use solana_net_utils::bind_to_async or bind_to_with_config_non_blocking instead for proper socket configuration." },
+  { path = "lazy_static::initialize", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
 ]
 
 disallowed-macros = [
-    { path = "solana_sdk::saturating_add_assign", reason = "Deprecated. Use std::num::Saturating<T> instead." },
-    { path = "lazy_static::lazy_static", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
+  { path = "solana_sdk::saturating_add_assign", reason = "Deprecated. Use std::num::Saturating<T> instead." },
+  { path = "lazy_static::lazy_static", reason = "Deprecated. Use std::{cell::{LazyCell, OnceCell}, sync::{LazyLock, OnceLock}} as appropriate." },
 ]

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-compute-budget-instruction"
-description = "Solana Compute Budget Instruction"
-documentation = "https://docs.rs/solana-compute-budget-instruction"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Compute Budget Instruction"
+documentation = "https://docs.rs/solana-compute-budget-instruction"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,9 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_compute_budget_instruction"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
+[[bench]]
+harness = false
+name = "process_compute_budget_instructions"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -39,7 +39,10 @@ solana-transaction-error = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { path = "../builtins-default-costs", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-builtins-default-costs = {
+  path = "../builtins-default-costs",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-compute-budget-instruction = { path = ".", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
@@ -49,9 +52,9 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
 
-[[bench]]
-name = "process_compute_budget_instructions"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/compute-budget-instruction/Cargo.toml
+++ b/compute-budget-instruction/Cargo.toml
@@ -39,8 +39,13 @@ solana-transaction-error = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-builtins-default-costs = { path = "../builtins-default-costs", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-compute-budget-instruction = { path = ".", features = ["agave-unstable-api"] }
+solana-builtins-default-costs = { path = "../builtins-default-costs", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-compute-budget-instruction = { path = ".", features = [
+  "agave-unstable-api",
+] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }

--- a/compute-budget/Cargo.toml
+++ b/compute-budget/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "solana-compute-budget"
-description = "Solana compute budget"
-documentation = "https://docs.rs/solana-compute-budget"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana compute budget"
+documentation = "https://docs.rs/solana-compute-budget"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[dependencies]
+solana-fee-structure = { workspace = true }
+solana-program-runtime = { workspace = true }
+
 [features]
 agave-unstable-api = []
 conf-stack-frame-size = ["solana-program-runtime/conf-stack-frame-size"]
 dev-context-only-utils = []
-
-[dependencies]
-solana-fee-structure = { workspace = true }
-solana-program-runtime = { workspace = true }
 
 [lints]
 workspace = true

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -1,27 +1,21 @@
 [package]
 name = "agave-conformance"
-description = "Cross-domain conformance harnesses for Agave"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Cross-domain conformance harnesses for Agave"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 workspace = "../dev-bins"
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
 bench = false
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-dummy-for-ci-check = ["ffi"]
-ffi = ["dep:prost", "dep:protosol", "agave-unstable-api"]
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bv = { workspace = true, features = ["serde"] }
@@ -41,6 +35,12 @@ solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-vote-program = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+dummy-for-ci-check = ["ffi"]
+ffi = ["agave-unstable-api", "dep:prost", "dep:protosol"]
 
 [lints]
 workspace = true

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-connection-cache"
-description = "Solana Connection Cache"
-documentation = "https://docs.rs/solana-connection-cache"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Connection Cache"
+documentation = "https://docs.rs/solana-connection-cache"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 async-trait = { workspace = true }
@@ -35,6 +32,9 @@ thiserror = { workspace = true }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 rand_chacha = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,51 +1,27 @@
 [package]
 name = "solana-core"
-documentation = "https://docs.rs/solana-core"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-core"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-banking-stage-ingress-types/dev-context-only-utils",
-    "agave-bls-sigverify/dev-context-only-utils",
-    "agave-votor/dev-context-only-utils",
-    "solana-entry/dev-context-only-utils",
-    "solana-ledger/dev-context-only-utils",
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-    "solana-streamer/dev-context-only-utils",
-    "solana-tpu-client-next/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-accounts-db/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-frozen-abi/frozen-abi",
-    "solana-gossip/frozen-abi",
-    "solana-hash/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-packet/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-signature/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "sigverify_stage"
+
+[[bench]]
+harness = false
+name = "shredder"
 
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
@@ -73,7 +49,7 @@ bitvec = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true, features = ["default", "serde"] }
 crossbeam-channel = { workspace = true }
-dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+dashmap = { workspace = true, features = ["raw-api", "rayon"] }
 futures = { workspace = true }
 histogram = { workspace = true }
 itertools = { workspace = true }
@@ -112,12 +88,20 @@ solana-epoch-schedule = { workspace = true }
 solana-fee = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
 solana-geyser-plugin-manager = { workspace = true }
@@ -185,31 +169,41 @@ tokio-util = { workspace = true }
 trees = { workspace = true }
 wincode = { workspace = true }
 
-[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemalloc-ctl = { workspace = true }
-
-[target."cfg(unix)".dependencies]
-sysctl = { workspace = true }
-
 [dev-dependencies]
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  features = ["agave-unstable-api"]
+}
 bencher = { workspace = true }
 bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["bincode", "wincode"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
+solana-bpf-loader-program = {
+  path = "../programs/bpf_loader",
+  default-features = false,
+  features = ["agave-unstable-api", "svm-internal"]
+}
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget-program = {
+  path = "../programs/compute-budget",
+  features = ["agave-unstable-api"]
+}
 solana-core = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-cost-model = { path = "../cost-model", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-cost-model = {
+  path = "../cost-model",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-keypair = { workspace = true }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-loader-v3-interface = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-poh = { path = "../poh", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
@@ -217,23 +211,59 @@ solana-rent = { workspace = true }
 solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signer-store = { workspace = true }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = {
+  path = "../unified-scheduler-pool",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-vote-program = { path = "../programs/vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-vote-program = {
+  path = "../programs/vote",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemalloc-ctl = { workspace = true }
+
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[[bench]]
-name = "sigverify_stage"
-harness = false
+[target."cfg(unix)".dependencies]
+sysctl = { workspace = true }
 
-[[bench]]
-name = "shredder"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-banking-stage-ingress-types/dev-context-only-utils",
+  "agave-bls-sigverify/dev-context-only-utils",
+  "agave-votor/dev-context-only-utils",
+  "solana-entry/dev-context-only-utils",
+  "solana-ledger/dev-context-only-utils",
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+  "solana-streamer/dev-context-only-utils",
+  "solana-tpu-client-next/dev-context-only-utils",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-accounts-db/frozen-abi",
+  "solana-cost-model/frozen-abi",
+  "solana-frozen-abi/frozen-abi",
+  "solana-gossip/frozen-abi",
+  "solana-hash/frozen-abi",
+  "solana-ledger/frozen-abi",
+  "solana-packet/frozen-abi",
+  "solana-perf/frozen-abi",
+  "solana-pubkey/frozen-abi",
+  "solana-runtime/frozen-abi",
+  "solana-signature/frozen-abi",
+  "solana-svm/frozen-abi",
+  "solana-vote-program/frozen-abi",
+  "solana-vote/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,33 +18,33 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-banking-stage-ingress-types/dev-context-only-utils",
-    "agave-bls-sigverify/dev-context-only-utils",
-    "agave-votor/dev-context-only-utils",
-    "solana-entry/dev-context-only-utils",
-    "solana-ledger/dev-context-only-utils",
-    "solana-perf/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-    "solana-streamer/dev-context-only-utils",
-    "solana-tpu-client-next/dev-context-only-utils",
+  "agave-banking-stage-ingress-types/dev-context-only-utils",
+  "agave-bls-sigverify/dev-context-only-utils",
+  "agave-votor/dev-context-only-utils",
+  "solana-entry/dev-context-only-utils",
+  "solana-ledger/dev-context-only-utils",
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+  "solana-streamer/dev-context-only-utils",
+  "solana-tpu-client-next/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-accounts-db/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-frozen-abi/frozen-abi",
-    "solana-gossip/frozen-abi",
-    "solana-hash/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-packet/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-signature/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-accounts-db/frozen-abi",
+  "solana-cost-model/frozen-abi",
+  "solana-frozen-abi/frozen-abi",
+  "solana-gossip/frozen-abi",
+  "solana-hash/frozen-abi",
+  "solana-ledger/frozen-abi",
+  "solana-packet/frozen-abi",
+  "solana-perf/frozen-abi",
+  "solana-pubkey/frozen-abi",
+  "solana-runtime/frozen-abi",
+  "solana-signature/frozen-abi",
+  "solana-svm/frozen-abi",
+  "solana-vote/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 
 [dependencies]
@@ -114,10 +114,10 @@ solana-fee = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
@@ -193,34 +193,75 @@ jemalloc-ctl = { workspace = true }
 sysctl = { workspace = true }
 
 [dev-dependencies]
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = [
+  "agave-unstable-api",
+] }
 bencher = { workspace = true }
 bitvec = { workspace = true }
 criterion = { workspace = true }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["bincode", "wincode"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api", "svm-internal"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = [
+  "agave-unstable-api",
+  "svm-internal",
+] }
 solana-client = { path = "../client", features = ["dev-context-only-utils"] }
 solana-compute-budget = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
-solana-core = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-cost-model = { path = "../cost-model", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = [
+  "agave-unstable-api",
+] }
+solana-core = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-cost-model = { path = "../cost-model", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-gossip = { path = "../gossip", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-keypair = { workspace = true }
-solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-ledger = { path = "../ledger", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-loader-v3-interface = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
-solana-poh = { path = "../poh", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
+solana-poh = { path = "../poh", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-program-binaries = { path = "../program-binaries", features = [
+  "agave-unstable-api",
+] }
 solana-rent = { workspace = true }
-solana-rpc = { path = "../rpc", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-rpc = { path = "../rpc", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signer-store = { workspace = true }
-solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-vote-program = { path = "../programs/vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-system-program = { path = "../programs/system", features = [
+  "agave-unstable-api",
+] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-vote = { path = "../vote", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-vote-program = { path = "../programs/vote", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 spl-memo-interface = { workspace = true }
 static_assertions = { workspace = true }
 test-case = { workspace = true }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-cost-model"
-description = "Solana cost model"
-documentation = "https://docs.rs/solana-cost-model"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana cost model"
+documentation = "https://docs.rs/solana-cost-model"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,34 +19,26 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_cost_model"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "dep:solana-hash",
-    "dep:solana-message",
-    "dep:solana-signature",
-    "dep:solana-transaction",
-    "solana-compute-budget-interface/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-pubkey/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-
 [dependencies]
 agave-feature-set = { workspace = true }
 ahash = { workspace = true }
 log = { workspace = true }
 solana-bincode = { workspace = true }
 solana-compute-budget = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true, optional = true }
 solana-message = { workspace = true, optional = true }
 solana-packet = { workspace = true }
@@ -62,7 +54,10 @@ solana-vote-program = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  features = ["agave-unstable-api"]
+}
 itertools = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
@@ -70,10 +65,29 @@ solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = {
+  path = "../runtime-transaction",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "dep:solana-hash",
+  "dep:solana-message",
+  "dep:solana-signature",
+  "dep:solana-transaction",
+  "solana-compute-budget-interface/dev-context-only-utils",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-pubkey/frozen-abi",
+  "solana-vote-program/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -22,17 +22,17 @@ name = "solana_cost_model"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "dep:solana-hash",
-    "dep:solana-message",
-    "dep:solana-signature",
-    "dep:solana-transaction",
-    "solana-compute-budget-interface/dev-context-only-utils",
+  "dep:solana-hash",
+  "dep:solana-message",
+  "dep:solana-signature",
+  "dep:solana-transaction",
+  "solana-compute-budget-interface/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-pubkey/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-pubkey/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 
 [dependencies]
@@ -43,10 +43,10 @@ solana-bincode = { workspace = true }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true, optional = true }
 solana-message = { workspace = true, optional = true }
@@ -64,15 +64,23 @@ solana-vote-program = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = [
+  "agave-unstable-api",
+] }
 itertools = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
-solana-cost-model = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-cost-model = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }

--- a/cpu-utils/Cargo.toml
+++ b/cpu-utils/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "agave-cpu-utils"
-description = "Agave CPU Utils"
 version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave CPU Utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 libc = { workspace = true }
+
+[features]
+agave-unstable-api = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,5 @@
 [bans]
 deny = [
-    { crate = "solana-sdk", reason = "Deprecated; use the standalone Solana crates instead" },
+  { crate = "solana-sdk", reason = "Deprecated; use the standalone Solana crates instead" },
 ]
 multiple-versions = "allow"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members = [
-    "../accounts-db/store-tool",
-    "../conformance",
-    "../ledger-tool",
-    "../svm-conformance",
+  "../accounts-db/store-tool",
+  "../conformance",
+  "../ledger-tool",
+  "../svm-conformance",
 ]
 
 resolver = "2"
@@ -11,37 +11,34 @@ resolver = "2"
 [workspace.package]
 version = "4.4.0-alpha.2"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-description = "Blockchain, Rebuilt for Scale"
-repository = "https://github.com/anza-xyz/agave"
-homepage = "https://anza.xyz/"
-license = "Apache-2.0"
 edition = "2024"
-
-[workspace.lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
-]
-
-# Clippy lint configuration that can not be applied in clippy.toml
-[workspace.lints.clippy]
-# Denied lints
-arithmetic_side_effects = "deny"
-default_trait_access = "deny"
-manual_let_else = "deny"
-uninlined_format_args = "deny"
-used_underscore_binding = "deny"
-
-# Allowed lints
-new_without_default = "allow"
+description = "Blockchain, Rebuilt for Scale"
+homepage = "https://anza.xyz/"
+repository = "https://github.com/anza-xyz/agave"
+license = "Apache-2.0"
 
 [workspace.dependencies]
-agave-feature-set = { path = "../feature-set", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-feature-set = {
+  path = "../feature-set",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-logger = { path = "../logger", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "../precompiles", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "../snapshots", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+agave-precompiles = {
+  path = "../precompiles",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+agave-snapshots = {
+  path = "../snapshots",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 agave-transaction-view = "6.1.0"
 agave-votor = { path = "../votor", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 ahash = "0.8.11"
@@ -58,9 +55,13 @@ env_logger = "0.11.11"
 futures = "0.3.34"
 histogram = "0.6.9"
 itertools = "0.15.0"
-jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
+jemallocator = {
+  package = "tikv-jemallocator",
+  version = "0.6.0",
+  features = [
     "unprefixed_malloc_on_supported_platforms",
-] }
+  ]
+}
 log = "0.4.28"
 num_cpus = "1.17.0"
 pretty-hex = "0.4.2"
@@ -77,61 +78,158 @@ serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
 solana-account = "4.6.0"
-solana-account-decoder = { path = "../account-decoder", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-accounts-db = { path = "../accounts-db", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-account-decoder = {
+  path = "../account-decoder",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-accounts-db = {
+  path = "../accounts-db",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-bloom = { path = "../bloom", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-bls-signatures = { version = "3.3.0", features = ["serde"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-builtins = { path = "../builtins", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "../clap-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = {
+  path = "../programs/bpf_loader",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-builtins = {
+  path = "../builtins",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-clap-utils = {
+  path = "../clap-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-cli-config = { path = "../cli-config", version = "=4.4.0-alpha.2" }
-solana-cli-output = { path = "../cli-output", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-cli-output = {
+  path = "../cli-output",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-client = { path = "../client", version = "=4.4.0-alpha.2" }
 solana-clock = "3.2.0"
 solana-cluster-type = "3.2.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "../compute-budget", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-compute-budget = {
+  path = "../compute-budget",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-compute-budget-interface = "3.1.0"
-solana-compute-budget-program = { path = "../programs/compute-budget", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-connection-cache = { path = "../connection-cache", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-compute-budget-program = {
+  path = "../programs/compute-budget",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-connection-cache = {
+  path = "../connection-cache",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-core = { path = "../core", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "../cost-model", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-cost-model = {
+  path = "../cost-model",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-entry = { path = "../entry", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-epoch-schedule = "3.2.0"
-solana-faucet = { path = "../faucet", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-faucet = {
+  path = "../faucet",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-feature-gate-interface = "4.0.0"
 solana-fee-calculator = "3.2.2"
-solana-genesis = { path = "../genesis", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-genesis = {
+  path = "../genesis",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-genesis-config = "4.1.0"
-solana-genesis-utils = { path = "../genesis-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-gossip = { path = "../gossip", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-genesis-utils = {
+  path = "../genesis-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-geyser-plugin-manager = {
+  path = "../geyser-plugin-manager",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-gossip = {
+  path = "../gossip",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-hash = "4.5.0"
 solana-inflation = "3.1.1"
 solana-instruction = "3.4.0"
 solana-instruction-error = "2.4.0"
 solana-keypair = "3.1.2"
-solana-ledger = { path = "../ledger", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-ledger = {
+  path = "../ledger",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
-solana-local-cluster = { path = "../local-cluster", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-measure = { path = "../measure", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-local-cluster = {
+  path = "../local-cluster",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-measure = {
+  path = "../measure",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-message = "4.1.0"
-solana-metrics = { path = "../metrics", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-metrics = {
+  path = "../metrics",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "../net-utils", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-net-utils = {
+  path = "../net-utils",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-nonce = "3.2.1"
 solana-packet = "4.2.0"
 solana-precompile-error = "3.0.0"
-solana-program-runtime = { path = "../program-runtime", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-program-runtime = {
+  path = "../program-runtime",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-pubkey = { version = "4.2.0", default-features = false }
-solana-quic-client = { path = "../quic-client", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-quic-client = {
+  path = "../quic-client",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-rent = "4.2.1"
 solana-rpc = { path = "../rpc", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
 solana-rpc-client = { path = "../rpc-client", version = "=4.4.0-alpha.2", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.4.0-alpha.2" }
-solana-runtime = { path = "../runtime", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-runtime = {
+  path = "../runtime",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-runtime-transaction = {
+  path = "../runtime-transaction",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-sanitize = "3.0.1"
 solana-sbpf = { version = "=0.24.0", default-features = false }
 solana-sdk-ids = "3.1.0"
@@ -140,33 +238,120 @@ solana-signature = { version = "3.4.1", default-features = false }
 solana-signer = "3.0.1"
 solana-signer-store = "0.1.0"
 solana-stake-interface = "4.3.0"
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-storage-bigtable = {
+  path = "../storage-bigtable",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-streamer = {
+  path = "../streamer",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-svm = { path = "../svm", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "../svm-callback", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-svm-timings = { path = "../svm-timings", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-svm-callback = {
+  path = "../svm-callback",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-feature-set = {
+  path = "../svm-feature-set",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-log-collector = {
+  path = "../svm-log-collector",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-svm-timings = {
+  path = "../svm-timings",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-svm-transaction = "5.0.0"
-solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-syscalls = {
+  path = "../syscalls",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-system-interface = "3.2"
-solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-system-program = {
+  path = "../programs/system",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.4.0-alpha.2" }
 solana-time-utils = "3.0.0"
-solana-tpu-client = { path = "../tpu-client", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client = {
+  path = "../tpu-client",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-transaction = "4.1.0"
-solana-transaction-context = { path = "../transaction-context", version = "=4.4.0-alpha.2", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api", "bincode"]
+}
 solana-transaction-error = "3.3.1"
-solana-transaction-status = { path = "../transaction-status", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-version = { path = "../version", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
+solana-transaction-status = {
+  path = "../transaction-status",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-unified-scheduler-pool = {
+  path = "../unified-scheduler-pool",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
+solana-version = {
+  path = "../version",
+  version = "=4.4.0-alpha.2",
+  features = ["agave-unstable-api"]
+}
 solana-vote = { path = "../vote", version = "=4.4.0-alpha.2", features = ["agave-unstable-api"] }
-solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.2", default-features = false, features = ["agave-unstable-api"] }
+solana-vote-program = {
+  path = "../programs/vote",
+  version = "=4.4.0-alpha.2",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"
 wincode = { version = "0.6.1", features = ["derive"] }
+
+# Clippy lint configuration that can not be applied in clippy.toml
+[workspace.lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+]
+
+[patch.crates-io]
+librocksdb-sys = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
+rocksdb = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
 
 [profile.dev]
 debug = "line-tables-only"
@@ -188,6 +373,10 @@ opt-level = 3
 [profile.dev.package.solana-ed25519]
 opt-level = 3
 
+[profile.release]
+split-debuginfo = "unpacked"
+lto = "thin"
+
 [profile.full-dev]
 inherits = "dev"
 debug = "full"
@@ -195,18 +384,10 @@ debug = "full"
 [profile.release-with-debug]
 inherits = "release"
 debug = true
-strip = false
 split-debuginfo = "off"
-
-[profile.release]
-split-debuginfo = "unpacked"
-lto = "thin"
+strip = false
 
 [profile.release-with-lto]
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-[patch.crates-io]
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2024"
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("frozen-abi", "no-entrypoint"))',
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("frozen-abi", "no-entrypoint"))',
 ]
 
 # Clippy lint configuration that can not be applied in clippy.toml
@@ -32,19 +32,33 @@ used_underscore_binding = "deny"
 new_without_default = "allow"
 
 [workspace.dependencies]
-agave-feature-set = { path = "../feature-set", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-logger = { path = "../logger", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-precompiles = { path = "../precompiles", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-agave-snapshots = { path = "../snapshots", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-feature-set = { path = "../feature-set", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-logger = { path = "../logger", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-precompiles = { path = "../precompiles", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+agave-snapshots = { path = "../snapshots", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 agave-transaction-view = "6.1.0"
-agave-votor = { path = "../votor", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+agave-votor = { path = "../votor", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 ahash = "0.8.11"
 assert_cmd = "2.2.2"
 bincode = "1.3.3"
 bytes = "1.12.1"
 chrono = { version = "0.4.42", default-features = false }
-clap = { version = "2.33.1", default-features = false, features = ["suggestions"] }
+clap = { version = "2.33.1", default-features = false, features = [
+  "suggestions",
+] }
 crossbeam-channel = "0.5.16"
 csv = "1.4.0"
 dashmap = "5.5.3"
@@ -53,7 +67,7 @@ futures = "0.3.33"
 histogram = "0.6.9"
 itertools = "0.14.0"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
-    "unprefixed_malloc_on_supported_platforms",
+  "unprefixed_malloc_on_supported_platforms",
 ] }
 log = "0.4.28"
 num_cpus = "1.17.0"
@@ -71,58 +85,110 @@ serde_yaml = "0.9.34"
 serial_test = "3.2.0"
 signal-hook = "0.4.4"
 solana-account = "4.6.0"
-solana-account-decoder = { path = "../account-decoder", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-accounts-db = { path = "../accounts-db", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "../account-decoder", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-accounts-db = { path = "../accounts-db", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-bls-signatures = { version = "3.3.0", features = ["serde"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-builtins = { path = "../builtins", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-clap-utils = { path = "../clap-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-builtins = { path = "../builtins", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-clap-utils = { path = "../clap-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-cli-config = { path = "../cli-config", version = "=4.4.0-alpha.0" }
-solana-cli-output = { path = "../cli-output", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-cli-output = { path = "../cli-output", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-client = { path = "../client", version = "=4.4.0-alpha.0" }
 solana-clock = "3.1.1"
 solana-cluster-type = "3.2.0"
 solana-commitment-config = "3.0.0"
-solana-compute-budget = { path = "../compute-budget", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "../compute-budget", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-compute-budget-interface = "3.1.0"
-solana-compute-budget-program = { path = "../programs/compute-budget", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-connection-cache = { path = "../connection-cache", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
-solana-core = { path = "../core", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-cost-model = { path = "../cost-model", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-entry = { path = "../entry", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "../programs/compute-budget", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-connection-cache = { path = "../connection-cache", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
+solana-core = { path = "../core", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-cost-model = { path = "../cost-model", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-entry = { path = "../entry", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-epoch-schedule = "3.2.0"
-solana-faucet = { path = "../faucet", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-faucet = { path = "../faucet", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-feature-gate-interface = "4.0.0"
 solana-fee-calculator = "3.2.2"
-solana-genesis = { path = "../genesis", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-genesis = { path = "../genesis", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-genesis-config = "4.1.0"
-solana-genesis-utils = { path = "../genesis-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-genesis-utils = { path = "../genesis-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-geyser-plugin-manager = { path = "../geyser-plugin-manager", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-hash = "4.5.0"
 solana-inflation = "3.1.1"
 solana-instruction = "3.4.0"
 solana-instruction-error = "2.4.0"
 solana-keypair = "3.1.2"
-solana-ledger = { path = "../ledger", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-ledger = { path = "../ledger", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-loader-v3-interface = "7.0.0"
 solana-loader-v4-interface = "3.1.0"
-solana-local-cluster = { path = "../local-cluster", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-measure = { path = "../measure", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-local-cluster = { path = "../local-cluster", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-measure = { path = "../measure", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-message = "4.1.0"
-solana-metrics = { path = "../metrics", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-metrics = { path = "../metrics", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-native-token = "3.0.0"
-solana-net-utils = { path = "../net-utils", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-net-utils = { path = "../net-utils", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-nonce = "3.2.1"
 solana-precompile-error = "3.0.0"
-solana-program-runtime = { path = "../program-runtime", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-pubkey = { version = "4.2.0", default-features = false }
-solana-quic-client = { path = "../quic-client", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-quic-client = { path = "../quic-client", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-rent = "4.2.1"
-solana-rpc = { path = "../rpc", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-rpc = { path = "../rpc", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-rpc-client = { path = "../rpc-client", version = "=4.4.0-alpha.0", default-features = false }
 solana-rpc-client-api = { path = "../rpc-client-api", version = "=4.4.0-alpha.0" }
-solana-runtime = { path = "../runtime", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-runtime = { path = "../runtime", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-runtime-transaction = { path = "../runtime-transaction", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-sbpf = { version = "=0.23.0", default-features = false }
 solana-sdk-ids = "3.1.0"
 solana-shred-version = "3.0.1"
@@ -130,29 +196,62 @@ solana-signature = { version = "3.4.1", default-features = false }
 solana-signer = "3.0.1"
 solana-signer-store = "0.1.0"
 solana-stake-interface = "4.3.0"
-solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm = { path = "../svm", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-callback = { path = "../svm-callback", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-svm-timings = { path = "../svm-timings", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-storage-bigtable = { path = "../storage-bigtable", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-streamer = { path = "../streamer", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm = { path = "../svm", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-callback = { path = "../svm-callback", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-feature-set = { path = "../svm-feature-set", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-log-collector = { path = "../svm-log-collector", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-svm-timings = { path = "../svm-timings", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-svm-transaction = "5.0.0"
-solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-syscalls = { path = "../syscalls", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-system-interface = "3.2"
-solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
+solana-system-program = { path = "../programs/system", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
 solana-sysvar-id = "3.1.0"
 solana-test-validator = { path = "../test-validator", version = "=4.4.0-alpha.0" }
 solana-time-utils = "3.0.0"
-solana-tpu-client = { path = "../tpu-client", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-tpu-client = { path = "../tpu-client", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
 solana-transaction = "4.1.0"
-solana-transaction-context = { path = "../transaction-context", version = "=4.4.0-alpha.0", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "../transaction-context", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+  "bincode",
+] }
 solana-transaction-error = "3.3.1"
-solana-transaction-status = { path = "../transaction-status", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-version = { path = "../version", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote = { path = "../vote", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
-solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
+solana-transaction-status = { path = "../transaction-status", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-version = { path = "../version", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-vote = { path = "../vote", version = "=4.4.0-alpha.0", features = [
+  "agave-unstable-api",
+] }
+solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.0", default-features = false, features = [
+  "agave-unstable-api",
+] }
 tempfile = "3.23.0"
 thiserror = "2.0.17"
 tokio = "1.48.0"

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-download-utils"
-description = "Solana Download Utils"
-documentation = "https://docs.rs/solana-download-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Download Utils"
+documentation = "https://docs.rs/solana-download-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,6 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_download_utils"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 agave-snapshots = { workspace = true }
 log = { workspace = true }
@@ -31,7 +28,13 @@ solana-genesis-config = { workspace = true }
 solana-runtime = { workspace = true }
 
 [dev-dependencies]
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/download-utils/Cargo.toml
+++ b/download-utils/Cargo.toml
@@ -31,7 +31,10 @@ solana-genesis-config = { workspace = true }
 solana-runtime = { workspace = true }
 
 [dev-dependencies]
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-entry"
-description = "Solana Entry"
-documentation = "https://docs.rs/solana-poh"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Entry"
+documentation = "https://docs.rs/solana-poh"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,9 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_entry"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
+[[bench]]
+harness = false
+name = "verify_signatures"
 
 [dependencies]
 agave-transaction-view = { workspace = true }
@@ -51,7 +51,10 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  features = ["agave-unstable-api"]
+}
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
@@ -67,9 +70,9 @@ solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["verify"] }
 test-case = { workspace = true }
 
-[[bench]]
-name = "verify_signatures"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/entry/Cargo.toml
+++ b/entry/Cargo.toml
@@ -52,15 +52,23 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = [
+  "agave-unstable-api",
+] }
 assert_matches = { workspace = true }
 criterion = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
-solana-entry = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-entry = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-keypair = { workspace = true }
 solana-message = { workspace = true }
-solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }

--- a/faucet-cli/Cargo.toml
+++ b/faucet-cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-faucet-cli"
-description = "Solana Faucet command-line tool"
-documentation = "https://docs.rs/solana-faucet-cli"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Faucet command-line tool"
+documentation = "https://docs.rs/solana-faucet-cli"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-faucet"
-description = "Solana Faucet"
-documentation = "https://docs.rs/solana-faucet"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Faucet"
+documentation = "https://docs.rs/solana-faucet"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,10 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_faucet"
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 crossbeam-channel = { workspace = true }
@@ -46,6 +42,10 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 solana-faucet = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -45,7 +45,10 @@ tokio = { workspace = true, features = ["full"] }
 wincode = { workspace = true }
 
 [dev-dependencies]
-solana-faucet = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-faucet = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -1,39 +1,47 @@
 [package]
 name = "agave-feature-set"
-description = "Solana runtime feature declarations"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana runtime feature declarations"
 readme = false
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-dev-context-only-utils = []
-
 [dependencies]
 ahash = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-svm-feature-set = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]
 workspace = true

--- a/feature-set/Cargo.toml
+++ b/feature-set/Cargo.toml
@@ -24,10 +24,10 @@ dev-context-only-utils = []
 ahash = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }

--- a/fee/Cargo.toml
+++ b/fee/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "solana-fee"
-description = "Solana fee calculation"
-documentation = "https://docs.rs/solana-fee"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana fee calculation"
+documentation = "https://docs.rs/solana-fee"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 solana-fee-structure = { workspace = true }
 solana-svm-transaction = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "agave-fs"
-description = "Agave file system utils"
-documentation = "https://docs.rs/agave-fs"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave file system utils"
+documentation = "https://docs.rs/agave-fs"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,6 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "agave_fs"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 libc = { workspace = true }
 log = { workspace = true }
@@ -29,15 +26,18 @@ slab = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+rand = { workspace = true }
+tempfile = { workspace = true }
+test-case = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 agave-io-uring = { workspace = true }
 io-uring = { workspace = true }
 tempfile = { workspace = true }
 
-[dev-dependencies]
-rand = { workspace = true }
-tempfile = { workspace = true }
-test-case = { workspace = true }
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/genesis-utils/Cargo.toml
+++ b/genesis-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-genesis-utils"
-description = "Solana Genesis Utils"
-documentation = "https://docs.rs/solana-download-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Genesis Utils"
+documentation = "https://docs.rs/solana-download-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,6 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_genesis_utils"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 agave-snapshots = { workspace = true }
 log = { workspace = true }
@@ -30,6 +27,9 @@ solana-genesis-config = { workspace = true }
 solana-hash = { workspace = true }
 solana-rpc-client = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-genesis"
-documentation = "https://docs.rs/solana-genesis"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-genesis"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -22,10 +22,6 @@ name = "solana_genesis"
 name = "solana-genesis"
 path = "src/main.rs"
 required-features = ["agave-unstable-api"]
-
-[features]
-default = ["agave-unstable-api"]
-agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -75,9 +71,16 @@ bs58 = { workspace = true, features = ["std"] }
 solana-borsh = { workspace = true }
 solana-genesis = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
+
+[features]
+default = ["agave-unstable-api"]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/genesis/Cargo.toml
+++ b/genesis/Cargo.toml
@@ -75,7 +75,10 @@ bs58 = { workspace = true, features = ["std"] }
 solana-borsh = { workspace = true }
 solana-genesis = { path = ".", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
 

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-geyser-plugin-interface"
-description = "The Solana Geyser plugin interface."
-documentation = "https://docs.rs/agave-geyser-plugin-interface"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The Solana Geyser plugin interface."
+documentation = "https://docs.rs/agave-geyser-plugin-interface"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 log = { workspace = true, features = ["std"] }
@@ -28,6 +25,9 @@ solana-signature = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-geyser-plugin-manager"
-description = "The Solana Geyser plugin manager."
-documentation = "https://docs.rs/solana-geyser-plugin-manager"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The Solana Geyser plugin manager."
+documentation = "https://docs.rs/solana-geyser-plugin-manager"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-geyser-plugin-interface = { workspace = true }
@@ -51,6 +48,9 @@ tokio = { workspace = true }
 agave-votor-messages = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-entry = { path = "../entry", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/gossip-cli/Cargo.toml
+++ b/gossip-cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-gossip-cli"
-documentation = "https://docs.rs/solana-gossip-cli"
 version = { workspace = true }
 authors = { workspace = true }
-description = "Binary crate providing the Solana Gossip command-line tool."
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Binary crate providing the Solana Gossip command-line tool."
+documentation = "https://docs.rs/solana-gossip-cli"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -16,12 +16,9 @@ all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
 [[bin]]
+bench = false
 name = "solana-gossip"
 path = "src/main.rs"
-bench = false
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -32,6 +29,9 @@ solana-gossip = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-pubkey = { version = "=4.3.0", features = ["rand"] }
 solana-version = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-gossip"
-documentation = "https://docs.rs/solana-gossip"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-gossip"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,28 +18,21 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 bench = false
 
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-bloom/frozen-abi",
-    "solana-hash/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-signature/frozen-abi",
-    "solana-transaction/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "dep:qualifier_attr",
-    "solana-bloom/dev-context-only-utils",
-]
+[[bench]]
+harness = false
+name = "crds"
+
+[[bench]]
+harness = false
+name = "crds_gossip_pull"
+
+[[bench]]
+harness = false
+name = "crds_shards"
+
+[[bench]]
+harness = false
+name = "weighted_shuffle"
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -65,12 +58,20 @@ solana-bloom = { workspace = true }
 solana-clock = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-ledger = { workspace = true }
@@ -105,9 +106,15 @@ criterion = { workspace = true }
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
 solana-gossip = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signature = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-vote-interface = { workspace = true }
@@ -117,21 +124,28 @@ strum_macros = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 
-[[bench]]
-name = "crds"
-harness = false
-
-[[bench]]
-name = "crds_gossip_pull"
-harness = false
-
-[[bench]]
-name = "crds_shards"
-harness = false
-
-[[bench]]
-name = "weighted_shuffle"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-votor-messages/dev-context-only-utils",
+  "dep:qualifier_attr",
+  "solana-bloom/dev-context-only-utils",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-bloom/frozen-abi",
+  "solana-hash/frozen-abi",
+  "solana-ledger/frozen-abi",
+  "solana-perf/frozen-abi",
+  "solana-pubkey/frozen-abi",
+  "solana-short-vec/frozen-abi",
+  "solana-signature/frozen-abi",
+  "solana-transaction/frozen-abi",
+  "solana-version/frozen-abi",
+  "solana-vote-program/frozen-abi",
+  "solana-vote/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/gossip/Cargo.toml
+++ b/gossip/Cargo.toml
@@ -20,24 +20,24 @@ bench = false
 
 [features]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-bloom/frozen-abi",
-    "solana-hash/frozen-abi",
-    "solana-ledger/frozen-abi",
-    "solana-perf/frozen-abi",
-    "solana-pubkey/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-signature/frozen-abi",
-    "solana-transaction/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-bloom/frozen-abi",
+  "solana-hash/frozen-abi",
+  "solana-ledger/frozen-abi",
+  "solana-perf/frozen-abi",
+  "solana-pubkey/frozen-abi",
+  "solana-short-vec/frozen-abi",
+  "solana-signature/frozen-abi",
+  "solana-transaction/frozen-abi",
+  "solana-version/frozen-abi",
+  "solana-vote/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-bloom/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-bloom/dev-context-only-utils",
 ]
 conformance = ["dep:prost", "dep:protosol", "dev-context-only-utils"]
 dummy-for-ci-check = ["conformance"]
@@ -68,10 +68,10 @@ solana-clock = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
@@ -106,10 +106,23 @@ bs58 = { workspace = true }
 criterion = { workspace = true }
 num_cpus = { workspace = true }
 serial_test = { workspace = true }
-solana-gossip = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "conformance"] }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-gossip = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+  "conformance",
+] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-perf = { path = "../perf", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
 solana-vote-interface = { workspace = true }

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-install"
-description = "The solana cluster software installer"
-documentation = "https://docs.rs/agave-install"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The solana cluster software installer"
+documentation = "https://docs.rs/agave-install"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -28,14 +25,17 @@ ctrlc = { workspace = true, features = ["termination"] }
 dirs-next = { workspace = true }
 indicatif = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
-reqwest = { workspace = true, features = [
+reqwest = {
+  workspace = true,
+  features = [
     "blocking",
     "brotli",
     "deflate",
     "gzip",
-    "rustls-tls",
     "json",
-] }
+    "rustls-tls",
+  ]
+}
 scopeguard = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -50,6 +50,9 @@ url = { workspace = true }
 [target."cfg(windows)".dependencies]
 winapi = { workspace = true, features = ["minwindef", "winuser"] }
 winreg = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -29,12 +29,12 @@ dirs-next = { workspace = true }
 indicatif = { workspace = true }
 nix = { workspace = true, features = ["signal"] }
 reqwest = { workspace = true, features = [
-    "blocking",
-    "brotli",
-    "deflate",
-    "gzip",
-    "rustls-tls",
-    "json",
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "json",
 ] }
 scopeguard = { workspace = true }
 semver = { workspace = true }

--- a/io-uring/Cargo.toml
+++ b/io-uring/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-io-uring"
-description = "Agave io_uring wrapper"
-documentation = "https://docs.rs/agave-io-uring"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave io_uring wrapper"
+documentation = "https://docs.rs/agave-io-uring"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 libc = { workspace = true }
@@ -26,6 +23,9 @@ smallvec = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-keygen"
-description = "Solana key generation utility"
-documentation = "https://docs.rs/solana-keygen"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana key generation utility"
+documentation = "https://docs.rs/solana-keygen"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -21,12 +21,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [[bin]]
 name = "solana-keygen"
 path = "src/keygen.rs"
-
-[features]
-default = ["remote-wallet-hidraw"]
-agave-unstable-api = []
-remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
-remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 agave-votor-messages = { workspace = true }
@@ -52,6 +46,12 @@ solana-version = { workspace = true }
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
+
+[features]
+default = ["remote-wallet-hidraw"]
+agave-unstable-api = []
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [lints]
 workspace = true

--- a/keygen/Cargo.toml
+++ b/keygen/Cargo.toml
@@ -32,7 +32,11 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 agave-votor-messages = { workspace = true }
 bip39 = { workspace = true }
 bs58 = { workspace = true, features = ["std"] }
-clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }
+clap = { version = "3.1.5", default-features = false, features = [
+  "cargo",
+  "std",
+  "suggestions",
+] }
 dirs-next = { workspace = true }
 num_cpus = { workspace = true }
 serde_json = { workspace = true }

--- a/lattice-hash/Cargo.toml
+++ b/lattice-hash/Cargo.toml
@@ -1,21 +1,26 @@
 [package]
 name = "solana-lattice-hash"
-description = "Solana Lattice Hash"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Lattice Hash"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "bench_lt_hash"
+
+[[bench]]
+harness = false
+name = "bench_batch"
 
 [dependencies]
 base64 = { workspace = true }
@@ -29,13 +34,8 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 solana-lattice-hash = { path = ".", features = ["agave-unstable-api"] }
 
-[[bench]]
-name = "bench_lt_hash"
-harness = false
-
-[[bench]]
-name = "bench_batch"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/leader-schedule/Cargo.toml
+++ b/leader-schedule/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-leader-schedule"
-description = "Solana leader schedule"
-documentation = "https://docs.rs/solana-leader-schedule"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana leader schedule"
+documentation = "https://docs.rs/solana-leader-schedule"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_leader_schedule"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-random = { workspace = true }
@@ -35,6 +32,9 @@ rand = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/leader-schedule/Cargo.toml
+++ b/leader-schedule/Cargo.toml
@@ -33,7 +33,10 @@ solana-vote = { workspace = true }
 [dev-dependencies]
 rand = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
-solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-vote = { path = "../vote", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 
 [lints]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -1,23 +1,17 @@
 [package]
 name = "agave-ledger-tool"
-documentation = "https://docs.rs/agave-ledger-tool"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/agave-ledger-tool"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 workspace = "../dev-bins"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-dummy-for-ci-check = []
-frozen-abi = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -41,7 +35,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-solana-account  = { workspace = true, features = ["wincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
@@ -60,7 +54,7 @@ solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-ledger = { workspace = true, features = ["dev-context-only-utils", "agave-unstable-api"] }
+solana-ledger = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-loader-v3-interface = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
@@ -94,16 +88,22 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 wincode = { workspace = true }
 
+[dev-dependencies]
+assert_cmd = { workspace = true }
+solana-bls-signatures = { workspace = true }
+tempfile = { workspace = true }
+
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
 jemallocator = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 signal-hook = { workspace = true }
 
-[dev-dependencies]
-assert_cmd = { workspace = true }
-solana-bls-signatures = { workspace = true }
-tempfile = { workspace = true }
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+dummy-for-ci-check = []
+frozen-abi = []
 
 [lints]
 workspace = true

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -41,7 +41,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-solana-account  = { workspace = true, features = ["wincode"] }
+solana-account = { workspace = true, features = ["wincode"] }
 solana-account-decoder = { workspace = true }
 solana-accounts-db = { workspace = true }
 solana-clap-utils = { workspace = true }
@@ -60,12 +60,18 @@ solana-hash = { workspace = true }
 solana-inflation = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-ledger = { workspace = true, features = ["dev-context-only-utils", "agave-unstable-api"] }
+solana-ledger = { workspace = true, features = [
+  "dev-context-only-utils",
+  "agave-unstable-api",
+] }
 solana-loader-v3-interface = { workspace = true }
 solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-native-token = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils", "metrics"] }
+solana-program-runtime = { workspace = true, features = [
+  "dev-context-only-utils",
+  "metrics",
+] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-rpc = { workspace = true, features = ["dev-context-only-utils"] }
@@ -86,7 +92,9 @@ solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-context = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
+solana-unified-scheduler-pool = { workspace = true, features = [
+  "dev-context-only-utils",
+] }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-ledger"
-description = "Solana ledger"
-documentation = "https://docs.rs/solana-ledger"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana ledger"
+documentation = "https://docs.rs/solana-ledger"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,15 +19,12 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_ledger"
 
-[features]
-dev-context-only-utils = ["solana-perf/dev-context-only-utils", "solana-runtime/dev-context-only-utils"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-runtime/frozen-abi",
-]
-agave-unstable-api = []
-shuttle-test = ["dep:shuttle"]
+[[bench]]
+name = "blockstore"
+
+[[bench]]
+harness = false
+name = "make_shreds_from_entries"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -45,7 +42,7 @@ chrono = { workspace = true, features = ["default"] }
 chrono-humanize = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-utils = { workspace = true }
-dashmap = { workspace = true, features = ["rayon", "raw-api"] }
+dashmap = { workspace = true, features = ["raw-api", "rayon"] }
 eager = { workspace = true }
 fs_extra = { workspace = true }
 futures = { workspace = true }
@@ -74,12 +71,20 @@ solana-clock = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
 solana-hash = { workspace = true }
@@ -142,24 +147,39 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bls-signatures = { workspace = true }
-solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-ledger = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signature = { workspace = true, features = ["rand"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = {
+  path = "../unified-scheduler-pool",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
 spl-generic-token = { workspace = true }
 test-case = { workspace = true }
 
-[[bench]]
-name = "blockstore"
-
-[[bench]]
-name = "make_shreds_from_entries"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils"
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-runtime/frozen-abi",
+]
+shuttle-test = ["dep:shuttle"]
 
 [lints]
 workspace = true

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -20,11 +20,14 @@ crate-type = ["lib"]
 name = "solana_ledger"
 
 [features]
-dev-context-only-utils = ["solana-perf/dev-context-only-utils", "solana-runtime/dev-context-only-utils"]
+dev-context-only-utils = [
+  "solana-perf/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-runtime/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-runtime/frozen-abi",
 ]
 agave-unstable-api = []
 
@@ -65,16 +68,18 @@ serde = { workspace = true }
 smallvec = { workspace = true }
 solana-account = { workspace = true }
 solana-accounts-db = { workspace = true }
-solana-address-lookup-table-interface = { workspace = true, features = ["wincode"] }
+solana-address-lookup-table-interface = { workspace = true, features = [
+  "wincode",
+] }
 solana-clock = { workspace = true }
 solana-cost-model = { workspace = true }
 solana-entry = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-genesis-config = { workspace = true }
 solana-genesis-utils = { workspace = true }
@@ -138,15 +143,33 @@ criterion = { workspace = true }
 proptest = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-bls-signatures = { workspace = true }
-solana-ledger = { path = ".", features = ["dev-context-only-utils", "agave-unstable-api"] }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-ledger = { path = ".", features = [
+  "dev-context-only-utils",
+  "agave-unstable-api",
+] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-perf = { path = "../perf", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signature = { workspace = true, features = ["rand"] }
-solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-vote = { path = "../vote", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = { path = "../unified-scheduler-pool", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-vote = { path = "../vote", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 spl-generic-token = { workspace = true }
 test-case = { workspace = true }
 

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -1,29 +1,19 @@
 [package]
 name = "solana-local-cluster"
-documentation = "https://docs.rs/solana-local-cluster"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-local-cluster"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-votor/dev-context-only-utils",
-    "solana-core/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-tpu-client-next/dev-context-only-utils",
-    "agave-votor-transport/dev-context-only-utils",
-]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -105,7 +95,20 @@ solana-download-utils = { path = "../download-utils", features = ["agave-unstabl
 solana-genesis-utils = { path = "../genesis-utils", features = ["agave-unstable-api"] }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-local-cluster = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-votor-messages/dev-context-only-utils",
+  "agave-votor-transport/dev-context-only-utils",
+  "agave-votor/dev-context-only-utils",
+  "solana-core/dev-context-only-utils",
+  "solana-tpu-client-next/dev-context-only-utils",
+]
 
 [lints]
 workspace = true

--- a/local-cluster/Cargo.toml
+++ b/local-cluster/Cargo.toml
@@ -18,11 +18,11 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-votor/dev-context-only-utils",
-    "solana-core/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-tpu-client-next/dev-context-only-utils",
-    "agave-votor-transport/dev-context-only-utils",
+  "agave-votor/dev-context-only-utils",
+  "solana-core/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-tpu-client-next/dev-context-only-utils",
+  "agave-votor-transport/dev-context-only-utils",
 ]
 
 [dependencies]
@@ -99,12 +99,28 @@ assert_matches = { workspace = true }
 fs_extra = { workspace = true }
 gag = { workspace = true }
 serial_test = { workspace = true }
-solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-download-utils = { path = "../download-utils", features = ["agave-unstable-api"] }
-solana-genesis-utils = { path = "../genesis-utils", features = ["agave-unstable-api"] }
-solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-local-cluster = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-core = { path = "../core", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-download-utils = { path = "../download-utils", features = [
+  "agave-unstable-api",
+] }
+solana-genesis-utils = { path = "../genesis-utils", features = [
+  "agave-unstable-api",
+] }
+solana-ledger = { path = "../ledger", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-local-cluster = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "agave-logger"
-description = "Agave Logger"
-documentation = "https://docs.rs/agave-logger"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave Logger"
+documentation = "https://docs.rs/agave-logger"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "agave_logger"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 env_logger = { workspace = true }
 log = { workspace = true }
@@ -28,6 +25,9 @@ log = { workspace = true }
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }
 signal-hook = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/math-utils/Cargo.toml
+++ b/math-utils/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-math-utils"
-description = "Math utilities for Agave"
-readme = "../README.md"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Math utilities for Agave"
+readme = "../README.md"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 num-traits = { workspace = true }
@@ -25,6 +22,9 @@ num-traits = { workspace = true }
 agave-math-utils = { path = ".", features = ["agave-unstable-api"] }
 rand = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/measure/Cargo.toml
+++ b/measure/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-measure"
-documentation = "https://docs.rs/solana-measure"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-measure"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-merkle-tree"
-description = "Solana Merkle Tree"
-documentation = "https://docs.rs/solana-merkle-tree"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Merkle Tree"
+documentation = "https://docs.rs/solana-merkle-tree"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,15 +19,15 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_merkle_tree"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 solana-hash = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-metrics"
-description = "Solana Metrics"
-documentation = "https://docs.rs/solana-metrics"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Metrics"
+documentation = "https://docs.rs/solana-metrics"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,14 +18,18 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "solana_metrics"
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "metrics"
 
 [dependencies]
 crossbeam-channel = { workspace = true }
 gethostname = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = {
+  workspace = true,
+  features = ["blocking", "brotli", "deflate", "gzip", "json", "rustls-tls"]
+}
 solana-cluster-type = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-time-utils = { workspace = true }
@@ -39,9 +43,8 @@ serial_test = { workspace = true }
 solana-metrics = { path = ".", features = ["agave-unstable-api"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 
-[[bench]]
-name = "metrics"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -25,7 +25,14 @@ agave-unstable-api = []
 crossbeam-channel = { workspace = true }
 gethostname = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = [
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "json",
+] }
 solana-cluster-type = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-time-utils = { workspace = true }

--- a/net-utils/Cargo.toml
+++ b/net-utils/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-net-utils"
-description = "Solana Network Utilities"
-documentation = "https://docs.rs/solana-net-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Network Utilities"
+documentation = "https://docs.rs/solana-net-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,10 +18,9 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "solana_net_utils"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["dep:anyhow", "dep:pcap-file", "dep:hxdmp"]
-shuttle-test = ["dep:shuttle", "solana-svm-type-overrides/shuttle-test"]
+[[bench]]
+harness = false
+name = "token_bucket"
 
 [dependencies]
 agave-xdp = { workspace = true }
@@ -33,7 +32,7 @@ dashmap = { workspace = true, features = ["raw-api"] }
 hxdmp = { version = "0.2.1", optional = true }
 itertools = { workspace = true }
 log = { workspace = true }
-nix = { workspace = true, features = ["socket", "fs", "mman", "signal"] }
+nix = { workspace = true, features = ["fs", "mman", "signal", "socket"] }
 pcap-file = { version = "2.0.0", optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
@@ -49,9 +48,10 @@ url = { workspace = true }
 agave-logger = { workspace = true }
 solana-net-utils = { path = ".", features = ["agave-unstable-api"] }
 
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["dep:anyhow", "dep:hxdmp", "dep:pcap-file"]
+shuttle-test = ["dep:shuttle", "solana-svm-type-overrides/shuttle-test"]
+
 [lints]
 workspace = true
-
-[[bench]]
-name = "token_bucket"
-harness = false

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-notifier"
-description = "Solana Notifier"
-documentation = "https://docs.rs/solana-notifier"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Notifier"
+documentation = "https://docs.rs/solana-notifier"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,14 +18,17 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "solana_notifier"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = {
+  workspace = true,
+  features = ["blocking", "brotli", "deflate", "gzip", "json", "rustls-tls"]
+}
 serde_json = { workspace = true }
-solana-hash = { workspace = true, features = ["std", "decode"] }
+solana-hash = { workspace = true, features = ["decode", "std"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/notifier/Cargo.toml
+++ b/notifier/Cargo.toml
@@ -23,7 +23,14 @@ agave-unstable-api = []
 
 [dependencies]
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = [
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "json",
+] }
 serde_json = { workspace = true }
 solana-hash = { workspace = true, features = ["std", "decode"] }
 

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-perf"
-description = "Solana Performance APIs"
-documentation = "https://docs.rs/solana-perf"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Performance APIs"
+documentation = "https://docs.rs/solana-perf"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,27 +18,21 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "solana_perf"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "dep:solana-clock",
-    "dep:solana-keypair",
-    "dep:solana-signer",
-    "dep:solana-system-interface",
-    "dep:solana-system-transaction",
-    "dep:solana-transaction",
-    "dep:solana-vote-program",
-    "dep:solana-vote",
-    "solana-hash/atomic",
-    "solana-transaction/wincode",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-packet/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "dedup"
+
+[[bench]]
+harness = false
+name = "recycler"
+
+[[bench]]
+harness = false
+name = "reset"
+
+[[bench]]
+harness = false
+name = "sigverify"
 
 [dependencies]
 agave-transaction-view = { workspace = true }
@@ -52,12 +46,20 @@ rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
 solana-clock = { workspace = true, optional = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true, optional = true }
 solana-message = { workspace = true }
@@ -72,16 +74,11 @@ solana-signer = { workspace = true, optional = true }
 solana-system-interface = { workspace = true, optional = true }
 solana-system-transaction = { workspace = true, optional = true }
 solana-time-utils = { workspace = true }
-solana-transaction = { workspace = true, optional = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["serde"], optional = true }
 solana-transaction-context = { workspace = true }
 solana-vote = { workspace = true, optional = true }
 solana-vote-program = { workspace = true, optional = true }
 wincode = { workspace = true }
-
-[target."cfg(target_os = \"linux\")".dependencies]
-caps = { workspace = true }
-libc = { workspace = true }
-nix = { workspace = true, features = ["user"] }
 
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
@@ -96,25 +93,32 @@ wincode = { workspace = true }
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[[bench]]
-name = "dedup"
-harness = false
+[target."cfg(target_os = \"linux\")".dependencies]
+caps = { workspace = true }
+libc = { workspace = true }
+nix = { workspace = true, features = ["user"] }
 
-[[bench]]
-name = "recycler"
-harness = false
-
-[[bench]]
-name = "reset"
-harness = false
-
-[[bench]]
-name = "sigverify"
-harness = false
-
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = ['cfg(build_target_feature_avx)', 'cfg(build_target_feature_avx2)']
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "dep:solana-clock",
+  "dep:solana-keypair",
+  "dep:solana-signer",
+  "dep:solana-system-interface",
+  "dep:solana-system-transaction",
+  "dep:solana-transaction",
+  "dep:solana-vote",
+  "dep:solana-vote-program",
+  "solana-hash/atomic",
+  "solana-transaction/wincode",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-packet/frozen-abi",
+  "solana-short-vec/frozen-abi",
+  "solana-vote-program/frozen-abi",
+]
 
 # Duplicated from the root [workspace.lints.clippy]. This crate defines its own
 # [lints.rust.unexpected_cfgs] above, and cargo does not support combining
@@ -130,3 +134,7 @@ used_underscore_binding = "deny"
 
 # Allowed lints
 new_without_default = "allow"
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ["cfg(build_target_feature_avx)", "cfg(build_target_feature_avx2)"]

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -21,23 +21,23 @@ name = "solana_perf"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "dep:solana-clock",
-    "dep:solana-keypair",
-    "dep:solana-signer",
-    "dep:solana-system-interface",
-    "dep:solana-system-transaction",
-    "dep:solana-transaction",
-    "dep:solana-vote-program",
-    "dep:solana-vote",
-    "solana-hash/atomic",
-    "solana-transaction/wincode",
+  "dep:solana-clock",
+  "dep:solana-keypair",
+  "dep:solana-signer",
+  "dep:solana-system-interface",
+  "dep:solana-system-transaction",
+  "dep:solana-transaction",
+  "dep:solana-vote-program",
+  "dep:solana-vote",
+  "solana-hash/atomic",
+  "solana-transaction/wincode",
 ]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-packet/frozen-abi",
-    "solana-short-vec/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-packet/frozen-abi",
+  "solana-short-vec/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 
 [dependencies]
@@ -53,17 +53,19 @@ rayon = { workspace = true }
 serde = { workspace = true }
 solana-clock = { workspace = true, optional = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true, optional = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-packet = { workspace = true, features = ["bincode"] }
-solana-pubkey = { workspace = true, default-features = false, features = ["rand"] }
+solana-pubkey = { workspace = true, default-features = false, features = [
+  "rand",
+] }
 solana-runtime-transaction = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-short-vec = { workspace = true }
@@ -89,7 +91,10 @@ agave-random = { path = "../random", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 rand_chacha = { workspace = true }
-solana-perf = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-perf = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 wincode = { workspace = true }
 

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -1,20 +1,17 @@
 [package]
 name = "solana-poh-bench"
-documentation = "https://docs.rs/solana-poh-bench"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+documentation = "https://docs.rs/solana-poh-bench"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-logger = { workspace = true }
@@ -25,6 +22,9 @@ solana-entry = { workspace = true }
 solana-measure = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-version = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/poh-bench/Cargo.toml
+++ b/poh-bench/Cargo.toml
@@ -18,7 +18,11 @@ agave-unstable-api = []
 
 [dependencies]
 agave-logger = { workspace = true }
-clap = { version = "3.1.5", default-features = false, features = ["cargo", "std", "suggestions"] }
+clap = { version = "3.1.5", default-features = false, features = [
+  "cargo",
+  "std",
+  "suggestions",
+] }
 num_cpus = { workspace = true }
 rayon = { workspace = true }
 solana-entry = { workspace = true }

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-poh"
-description = "Solana PoH"
-documentation = "https://docs.rs/solana-poh"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana PoH"
+documentation = "https://docs.rs/solana-poh"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,10 +19,17 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_poh"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-shuttle-test = ["dep:shuttle"]
+[[bench]]
+harness = false
+name = "poh"
+
+[[bench]]
+harness = false
+name = "poh_verify"
+
+[[bench]]
+harness = false
+name = "transaction_recorder"
 
 [dependencies]
 agave-cpu-utils = { workspace = true }
@@ -56,7 +63,10 @@ solana-entry = { path = "../entry", features = ["agave-unstable-api", "dev-conte
 solana-keypair = { workspace = true }
 solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-poh = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
@@ -64,17 +74,10 @@ solana-system-transaction = { workspace = true }
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[[bench]]
-name = "poh"
-harness = false
-
-[[bench]]
-name = "poh_verify"
-harness = false
-
-[[bench]]
-name = "transaction_recorder"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+shuttle-test = ["dep:shuttle"]
 
 [lints]
 workspace = true

--- a/poh/Cargo.toml
+++ b/poh/Cargo.toml
@@ -51,11 +51,23 @@ assert_matches = { workspace = true }
 bincode = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-entry = { path = "../entry", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-entry = { path = "../entry", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-keypair = { workspace = true }
-solana-perf = { path = "../perf", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-poh = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-perf = { path = "../perf", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-poh = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-precompiles"
-description = "Solana precompiled programs."
-documentation = "https://docs.rs/agave-precompiles"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana precompiled programs."
+documentation = "https://docs.rs/agave-precompiles"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -41,6 +38,9 @@ hex = { workspace = true }
 rand = { workspace = true }
 solana-instruction = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/program-binaries/Cargo.toml
+++ b/program-binaries/Cargo.toml
@@ -1,21 +1,18 @@
 [package]
 name = "solana-program-binaries"
-description = "Prebuilt SPL and Core BPF programs"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Prebuilt SPL and Core BPF programs"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 bincode = { workspace = true }
@@ -25,6 +22,9 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 spl-generic-token = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/program-binaries/Cargo.toml
+++ b/program-binaries/Cargo.toml
@@ -20,7 +20,10 @@ agave-unstable-api = []
 [dependencies]
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-loader-v3-interface = { workspace = true, features = ["bincode", "serde"] }
+solana-loader-v3-interface = { workspace = true, features = [
+  "bincode",
+  "serde",
+] }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-program-runtime"
-description = "Solana program runtime"
-documentation = "https://docs.rs/solana-program-runtime"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana program runtime"
+documentation = "https://docs.rs/solana-program-runtime"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,21 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_program_runtime"
-
-[features]
-agave-unstable-api = []
-conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-message",
-    "solana-epoch-schedule/wincode",
-]
-dummy-for-ci-check = ["metrics"]
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-metrics = []
-sbpf-debugger = ["solana-sbpf/debugger"]
-shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
-svm-internal = ["dep:qualifier_attr"]
 
 [dependencies]
 base64 = { workspace = true }
@@ -49,12 +34,20 @@ solana-clock = { workspace = true }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-structure = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-last-restart-slot = { workspace = true }
@@ -98,12 +91,30 @@ solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = [
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = [
     "agave-unstable-api",
     "bincode",
     "dev-context-only-utils",
-] }
+  ]
+}
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
+conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
+dev-context-only-utils = [
+  "dep:qualifier_attr",
+  "dep:solana-message",
+  "solana-epoch-schedule/wincode",
+]
+dummy-for-ci-check = ["metrics"]
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
+metrics = []
+sbpf-debugger = ["solana-sbpf/debugger"]
+shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
+svm-internal = ["dep:qualifier_attr"]
 
 [lints]
 workspace = true

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -23,15 +23,18 @@ name = "solana_program_runtime"
 agave-unstable-api = []
 conf-stack-frame-size = ["solana-sbpf/conf-stack-frame-size"]
 dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:solana-message",
-    "solana-epoch-schedule/wincode",
+  "dep:qualifier_attr",
+  "dep:solana-message",
+  "solana-epoch-schedule/wincode",
 ]
 dummy-for-ci-check = ["metrics"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 metrics = []
 sbpf-debugger = ["solana-sbpf/debugger"]
-shuttle-test = ["solana-sbpf/shuttle-test", "solana-svm-type-overrides/shuttle-test"]
+shuttle-test = [
+  "solana-sbpf/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
+]
 svm-internal = ["dep:qualifier_attr"]
 
 [dependencies]
@@ -50,10 +53,10 @@ solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
@@ -92,16 +95,19 @@ solana-instruction = { workspace = true, features = ["bincode"] }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-keypair = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-secp256r1-program = { workspace = true, features = ["openssl-vendored"] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction-context = { path = "../transaction-context", features = [
-    "agave-unstable-api",
-    "bincode",
-    "dev-context-only-utils",
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
 ] }
 test-case = { workspace = true }
 

--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -1,21 +1,18 @@
 [package]
-description = "Solana Program Test Framework"
 name = "solana-program-test"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Program Test Framework"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -80,6 +77,9 @@ solana-cpi = { workspace = true }
 solana-program = { workspace = true }
 solana-program-test = { path = ".", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -3,27 +3,28 @@
 
 [package]
 name = "solana-bpf-loader-program-tests"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-bpf-loader-program = { path = "../bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = {
+  path = "../bpf_loader",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-clock = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
@@ -36,6 +37,9 @@ solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/bpf-loader-tests/Cargo.toml
+++ b/programs/bpf-loader-tests/Cargo.toml
@@ -23,12 +23,16 @@ agave-feature-set = { workspace = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
 solana-account = { workspace = true }
-solana-bpf-loader-program = { path = "../bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../bpf_loader", default-features = false, features = [
+  "agave-unstable-api",
+] }
 solana-clock = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
+solana-program-test = { path = "../../program-test", features = [
+  "agave-unstable-api",
+] }
 solana-pubkey = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-bpf-loader-program"
-description = "Solana BPF loader"
-documentation = "https://docs.rs/solana-bpf-loader-program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana BPF loader"
+documentation = "https://docs.rs/solana-bpf-loader-program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,18 +19,13 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_bpf_loader_program"
 
-[features]
-default = ["metrics"]
-agave-unstable-api = []
-metrics = ["solana-syscalls/metrics", "solana-program-runtime/metrics"]
-sbpf-debugger = ["solana-program-runtime/sbpf-debugger", "solana-sbpf/debugger"]
-shuttle-test = [
-    "dep:shuttle",
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
-]
-svm-internal = []
+[[bench]]
+harness = false
+name = "serialization"
+
+[[bench]]
+harness = false
+name = "bpf_loader_upgradeable"
 
 [dependencies]
 bincode = { workspace = true }
@@ -65,23 +60,34 @@ solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
-solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = {
+  path = "../../program-runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true, features = ["wincode"] }
 solana-slot-hashes = { workspace = true }
 solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
 solana-system-program = { workspace = true }
 solana-sysvar-id = { workspace = true }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = {
+  path = "../../transaction-context",
+  features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]
+}
 wincode = { workspace = true }
 
-[[bench]]
-name = "serialization"
-harness = false
-
-[[bench]]
-name = "bpf_loader_upgradeable"
-harness = false
+[features]
+default = ["metrics"]
+agave-unstable-api = []
+metrics = ["solana-program-runtime/metrics", "solana-syscalls/metrics"]
+sbpf-debugger = ["solana-program-runtime/sbpf-debugger", "solana-sbpf/debugger"]
+shuttle-test = [
+  "dep:shuttle",
+  "solana-program-runtime/shuttle-test",
+  "solana-sbpf/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = []
 
 [lints]
 workspace = true

--- a/programs/bpf_loader/Cargo.toml
+++ b/programs/bpf_loader/Cargo.toml
@@ -25,10 +25,10 @@ agave-unstable-api = []
 metrics = ["solana-syscalls/metrics", "solana-program-runtime/metrics"]
 sbpf-debugger = ["solana-program-runtime/sbpf-debugger", "solana-sbpf/debugger"]
 shuttle-test = [
-    "dep:shuttle",
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
+  "dep:shuttle",
+  "solana-program-runtime/shuttle-test",
+  "solana-sbpf/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
 ]
 svm-internal = []
 
@@ -59,20 +59,32 @@ assert_matches = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
-solana-bpf-loader-program = { path = ".", features = ["agave-unstable-api", "svm-internal"] }
+solana-bpf-loader-program = { path = ".", features = [
+  "agave-unstable-api",
+  "svm-internal",
+] }
 solana-clock = { workspace = true, features = ["wincode"] }
 solana-epoch-rewards = { workspace = true }
 solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
-solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true, features = ["wincode"] }
 solana-slot-hashes = { workspace = true }
-solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../../svm-callback", features = [
+  "agave-unstable-api",
+] }
 solana-system-program = { workspace = true }
 solana-sysvar-id = { workspace = true }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
+] }
 wincode = { workspace = true }
 
 [[bench]]

--- a/programs/compute-budget-bench/Cargo.toml
+++ b/programs/compute-budget-bench/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "solana-compute-budget-program-bench"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "compute_budget"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -25,9 +26,8 @@ solana-message = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-svm-transaction = { workspace = true }
 
-[[bench]]
-name = "compute_budget"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/compute-budget/Cargo.toml
+++ b/programs/compute-budget/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-compute-budget-program"
-description = "Solana Compute Budget program"
-documentation = "https://docs.rs/solana-compute-budget-program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Compute Budget program"
+documentation = "https://docs.rs/solana-compute-budget-program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,11 +19,11 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_compute_budget_program"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 solana-program-runtime = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -1,19 +1,16 @@
 [package]
 name = "solana-ed25519-program-tests"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -26,6 +23,9 @@ solana-program-test = { path = "../../program-test", features = ["agave-unstable
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/ed25519-tests/Cargo.toml
+++ b/programs/ed25519-tests/Cargo.toml
@@ -22,7 +22,9 @@ solana-ed25519-program = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
+solana-program-test = { path = "../../program-test", features = [
+  "agave-unstable-api",
+] }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,105 +1,86 @@
 [package]
 name = "solana-sbf-programs"
-documentation = "https://docs.rs/solana"
-readme = "README.md"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana"
+readme = "README.md"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [workspace]
 members = [
-    "rust/128bit",
-    "rust/128bit_dep",
-    "rust/account_mem",
-    "rust/account_mem_deprecated",
-    "rust/alloc",
-    "rust/alt_bn128",
-    "rust/alt_bn128_compression",
-    "rust/big_mod_exp",
-    "rust/call_args",
-    "rust/call_depth",
-    "rust/caller_access",
-    "rust/curve25519",
-    "rust/custom_heap",
-    "rust/dep_crate",
-    "rust/deprecated_loader",
-    "rust/direct_account_pointers_in_program_input",
-    "rust/divide_by_zero",
-    "rust/dup_accounts",
-    "rust/error_handling",
-    "rust/external_spend",
-    "rust/inner_instruction_alignment_check",
-    "rust/instruction_introspection",
-    "rust/invoke",
-    "rust/invoke_and_error",
-    "rust/invoke_and_ok",
-    "rust/invoke_and_return",
-    "rust/invoked",
-    "rust/iter",
-    "rust/log_data",
-    "rust/many_args",
-    "rust/many_args_dep",
-    "rust/mem",
-    "rust/mem_dep",
-    "rust/membuiltins",
-    "rust/noop",
-    "rust/panic",
-    "rust/param_passing",
-    "rust/param_passing_dep",
-    "rust/poseidon",
-    "rust/r2_instruction_data_pointer",
-    "rust/rand",
-    "rust/realloc",
-    "rust/realloc_invoke",
-    "rust/remaining_compute_units",
-    "rust/ro_account_modify",
-    "rust/ro_modify",
-    "rust/sanity",
-    "rust/secp256k1_recover",
-    "rust/sha",
-    "rust/sibling_inner_instructions",
-    "rust/sibling_instructions",
-    "rust/simulation",
-    "rust/spoof1",
-    "rust/spoof1_system",
-    "rust/syscall-get-epoch-stake",
-    "rust/sysvar",
-    "rust/upgradeable",
-    "rust/upgraded",
+  "rust/128bit",
+  "rust/128bit_dep",
+  "rust/account_mem",
+  "rust/account_mem_deprecated",
+  "rust/alloc",
+  "rust/alt_bn128",
+  "rust/alt_bn128_compression",
+  "rust/big_mod_exp",
+  "rust/call_args",
+  "rust/call_depth",
+  "rust/caller_access",
+  "rust/curve25519",
+  "rust/custom_heap",
+  "rust/dep_crate",
+  "rust/deprecated_loader",
+  "rust/direct_account_pointers_in_program_input",
+  "rust/divide_by_zero",
+  "rust/dup_accounts",
+  "rust/error_handling",
+  "rust/external_spend",
+  "rust/inner_instruction_alignment_check",
+  "rust/instruction_introspection",
+  "rust/invoke",
+  "rust/invoke_and_error",
+  "rust/invoke_and_ok",
+  "rust/invoke_and_return",
+  "rust/invoked",
+  "rust/iter",
+  "rust/log_data",
+  "rust/many_args",
+  "rust/many_args_dep",
+  "rust/mem",
+  "rust/mem_dep",
+  "rust/membuiltins",
+  "rust/noop",
+  "rust/panic",
+  "rust/param_passing",
+  "rust/param_passing_dep",
+  "rust/poseidon",
+  "rust/r2_instruction_data_pointer",
+  "rust/rand",
+  "rust/realloc",
+  "rust/realloc_invoke",
+  "rust/remaining_compute_units",
+  "rust/ro_account_modify",
+  "rust/ro_modify",
+  "rust/sanity",
+  "rust/secp256k1_recover",
+  "rust/sha",
+  "rust/sibling_inner_instructions",
+  "rust/sibling_instructions",
+  "rust/simulation",
+  "rust/spoof1",
+  "rust/spoof1_system",
+  "rust/syscall-get-epoch-stake",
+  "rust/sysvar",
+  "rust/upgradeable",
+  "rust/upgraded",
 ]
+
 [workspace.package]
 version = "4.4.0-alpha.2"
-description = "Solana SBF test program written in Rust"
 authors = ["Anza Maintainers <maintainers@anza.xyz>"]
-repository = "https://github.com/anza-xyz/agave"
-homepage = "https://anza.xyz"
-license = "Apache-2.0"
 edition = "2024"
-
-[workspace.lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("custom-panic", "custom-heap", "sbpf-v3"))',
-    'cfg(target_feature, values("dynamic-frames"))',
-]
-
-# Keep in sync with the root [workspace.lints.clippy].
-[workspace.lints.clippy]
-# Denied lints
-arithmetic_side_effects = "deny"
-default_trait_access = "deny"
-manual_let_else = "deny"
-uninlined_format_args = "deny"
-used_underscore_binding = "deny"
-
-# Allowed lints
-new_without_default = "allow"
+description = "Solana SBF test program written in Rust"
+homepage = "https://anza.xyz"
+repository = "https://github.com/anza-xyz/agave"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 agave-feature-set = { path = "../../feature-set", version = "=4.4.0-alpha.2" }
@@ -124,7 +105,10 @@ solana-blake3-hasher = { version = "=3.1.0", features = ["blake3"] }
 solana-bn254 = "=3.2.1"
 solana-clock = { version = "=3.2.0", features = ["serde", "sysvar"] }
 solana-compute-budget = { path = "../../compute-budget", version = "=4.4.0-alpha.2" }
-solana-compute-budget-instruction = { path = "../../compute-budget-instruction", version = "=4.4.0-alpha.2" }
+solana-compute-budget-instruction = {
+  path = "../../compute-budget-instruction",
+  version = "=4.4.0-alpha.2"
+}
 solana-cpi = "=3.1.0"
 solana-curve25519 = "=4.0.1"
 solana-define-syscall = "=3.0.0"
@@ -151,7 +135,10 @@ solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=4.4.0
 solana-sbf-rust-mem-dep = { path = "rust/mem_dep", version = "=4.4.0-alpha.2" }
 solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=4.4.0-alpha.2" }
 solana-sbf-rust-realloc-dep = { path = "rust/realloc_dep", version = "=4.4.0-alpha.2" }
-solana-sbf-rust-realloc-invoke-dep = { path = "rust/realloc_invoke_dep", version = "=4.4.0-alpha.2" }
+solana-sbf-rust-realloc-invoke-dep = {
+  path = "rust/realloc_invoke_dep",
+  version = "=4.4.0-alpha.2"
+}
 solana-sdk-ids = "=3.1.0"
 solana-secp256k1-recover = "=3.3.0"
 solana-sha256-hasher = { version = "=3.1.0", features = ["sha2"] }
@@ -172,14 +159,25 @@ test-case = "3.3.1"
 thiserror = "2.0"
 wincode = { version = "0.6.1", default-features = false }
 
-[features]
-sbf_c = []
-sbf_rust = []
-sbf_sanity_list = []
-sbpf-v3 = []
-dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list", "sbpf-v3"]
-# This was needed for ci
-frozen-abi = []
+# Keep in sync with the root [workspace.lints.clippy].
+[workspace.lints.clippy]
+# Denied lints
+arithmetic_side_effects = "deny"
+default_trait_access = "deny"
+manual_let_else = "deny"
+uninlined_format_args = "deny"
+used_underscore_binding = "deny"
+
+# Allowed lints
+new_without_default = "allow"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-panic", "custom-heap", "sbpf-v3"))',
+  'cfg(target_feature, values("dynamic-frames"))',
+]
 
 [dev-dependencies]
 agave-feature-set = { workspace = true }
@@ -194,9 +192,12 @@ solana-client-traits = "4.0.0"
 solana-clock = { workspace = true }
 solana-cluster-type = "3.0.0"
 solana-compute-budget = { workspace = true }
-solana-compute-budget-instruction = { workspace = true, features = [
+solana-compute-budget-instruction = {
+  workspace = true,
+  features = [
     "dev-context-only-utils",
-] }
+  ]
+}
 solana-compute-budget-interface = "3.1.0"
 solana-fee = { workspace = true }
 solana-fee-calculator = "3.2.0"
@@ -211,9 +212,12 @@ solana-program-runtime = { workspace = true, features = ["dev-context-only-utils
 solana-pubkey = "4.2.0"
 solana-rent = "4.1.0"
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-solana-runtime-transaction = { workspace = true, features = [
+solana-runtime-transaction = {
+  workspace = true,
+  features = [
     "dev-context-only-utils",
-] }
+  ]
+}
 solana-sbf-rust-invoke-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sbf-rust-realloc-invoke-dep = { workspace = true }
@@ -227,7 +231,10 @@ solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.3.0"
-solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = {
+  workspace = true,
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-transaction = "4.1.0"
 solana-transaction-error = "3.3.0"
 solana-vote = { workspace = true }
@@ -235,26 +242,41 @@ solana-vote-interface = { workspace = true }
 solana-vote-program = { workspace = true }
 test-case = { workspace = true }
 
+[features]
+dummy-for-ci-check = ["sbf_c", "sbf_rust", "sbf_sanity_list", "sbpf-v3"]
+# This was needed for ci
+frozen-abi = []
+sbf_c = []
+sbf_rust = []
+sbf_sanity_list = []
+sbpf-v3 = []
+
+[lints]
+workspace = true
+
+[patch.crates-io]
+librocksdb-sys = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
+rocksdb = {
+  git = "https://github.com/anza-xyz/rust-rocksdb",
+  rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
+}
+
 [profile.dev]
 debug = "line-tables-only"
-
-[profile.full-dev]
-inherits = "dev"
-debug = "full"
-
-# Enable basic optimizations for unittests to trigger const propagation and inlining
-[profile.ci]
-inherits = "test"
-opt-level = 1
 
 [profile.release]
 # The test programs are build in release mode
 # Minimize their file size so that they fit into the account size limit
 strip = true
 
-[lints]
-workspace = true
+# Enable basic optimizations for unittests to trigger const propagation and inlining
+[profile.ci]
+inherits = "test"
+opt-level = 1
 
-[patch.crates-io]
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
+[profile.full-dev]
+inherits = "dev"
+debug = "full"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -13,64 +13,64 @@ edition = { workspace = true }
 
 [workspace]
 members = [
-    "rust/128bit",
-    "rust/128bit_dep",
-    "rust/account_mem",
-    "rust/account_mem_deprecated",
-    "rust/alloc",
-    "rust/alt_bn128",
-    "rust/alt_bn128_compression",
-    "rust/big_mod_exp",
-    "rust/call_args",
-    "rust/call_depth",
-    "rust/caller_access",
-    "rust/curve25519",
-    "rust/custom_heap",
-    "rust/dep_crate",
-    "rust/deprecated_loader",
-    "rust/direct_account_pointers_in_program_input",
-    "rust/divide_by_zero",
-    "rust/dup_accounts",
-    "rust/error_handling",
-    "rust/external_spend",
-    "rust/inner_instruction_alignment_check",
-    "rust/instruction_introspection",
-    "rust/invoke",
-    "rust/invoke_and_error",
-    "rust/invoke_and_ok",
-    "rust/invoke_and_return",
-    "rust/invoked",
-    "rust/iter",
-    "rust/log_data",
-    "rust/many_args",
-    "rust/many_args_dep",
-    "rust/mem",
-    "rust/mem_dep",
-    "rust/membuiltins",
-    "rust/noop",
-    "rust/panic",
-    "rust/param_passing",
-    "rust/param_passing_dep",
-    "rust/poseidon",
-    "rust/r2_instruction_data_pointer",
-    "rust/rand",
-    "rust/realloc",
-    "rust/realloc_invoke",
-    "rust/remaining_compute_units",
-    "rust/ro_account_modify",
-    "rust/ro_modify",
-    "rust/sanity",
-    "rust/secp256k1_recover",
-    "rust/sha",
-    "rust/sibling_inner_instructions",
-    "rust/sibling_instructions",
-    "rust/simulation",
-    "rust/spoof1",
-    "rust/spoof1_system",
-    "rust/syscall-get-epoch-stake",
-    "rust/sysvar",
-    "rust/upgradeable",
-    "rust/upgraded",
+  "rust/128bit",
+  "rust/128bit_dep",
+  "rust/account_mem",
+  "rust/account_mem_deprecated",
+  "rust/alloc",
+  "rust/alt_bn128",
+  "rust/alt_bn128_compression",
+  "rust/big_mod_exp",
+  "rust/call_args",
+  "rust/call_depth",
+  "rust/caller_access",
+  "rust/curve25519",
+  "rust/custom_heap",
+  "rust/dep_crate",
+  "rust/deprecated_loader",
+  "rust/direct_account_pointers_in_program_input",
+  "rust/divide_by_zero",
+  "rust/dup_accounts",
+  "rust/error_handling",
+  "rust/external_spend",
+  "rust/inner_instruction_alignment_check",
+  "rust/instruction_introspection",
+  "rust/invoke",
+  "rust/invoke_and_error",
+  "rust/invoke_and_ok",
+  "rust/invoke_and_return",
+  "rust/invoked",
+  "rust/iter",
+  "rust/log_data",
+  "rust/many_args",
+  "rust/many_args_dep",
+  "rust/mem",
+  "rust/mem_dep",
+  "rust/membuiltins",
+  "rust/noop",
+  "rust/panic",
+  "rust/param_passing",
+  "rust/param_passing_dep",
+  "rust/poseidon",
+  "rust/r2_instruction_data_pointer",
+  "rust/rand",
+  "rust/realloc",
+  "rust/realloc_invoke",
+  "rust/remaining_compute_units",
+  "rust/ro_account_modify",
+  "rust/ro_modify",
+  "rust/sanity",
+  "rust/secp256k1_recover",
+  "rust/sha",
+  "rust/sibling_inner_instructions",
+  "rust/sibling_instructions",
+  "rust/simulation",
+  "rust/spoof1",
+  "rust/spoof1_system",
+  "rust/syscall-get-epoch-stake",
+  "rust/sysvar",
+  "rust/upgradeable",
+  "rust/upgraded",
 ]
 [workspace.package]
 version = "4.4.0-alpha.0"
@@ -84,9 +84,9 @@ edition = "2024"
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-    'cfg(target_os, values("solana"))',
-    'cfg(feature, values("custom-panic", "custom-heap", "sbpf-v3"))',
-    'cfg(target_feature, values("dynamic-frames"))',
+  'cfg(target_os, values("solana"))',
+  'cfg(feature, values("custom-panic", "custom-heap", "sbpf-v3"))',
+  'cfg(target_feature, values("dynamic-frames"))',
 ]
 
 # Keep in sync with the root [workspace.lints.clippy].
@@ -195,7 +195,7 @@ solana-clock = "3.0.0"
 solana-cluster-type = "3.0.0"
 solana-compute-budget = { workspace = true }
 solana-compute-budget-instruction = { workspace = true, features = [
-    "dev-context-only-utils",
+  "dev-context-only-utils",
 ] }
 solana-compute-budget-interface = "3.1.0"
 solana-fee = { workspace = true }
@@ -206,13 +206,17 @@ solana-instruction = { workspace = true }
 solana-keypair = "3.1.2"
 solana-loader-v3-interface = "7.0.0"
 solana-message = "4.1.0"
-solana-program-binaries = { workspace = true, features = ["agave-unstable-api"] }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-binaries = { workspace = true, features = [
+  "agave-unstable-api",
+] }
+solana-program-runtime = { workspace = true, features = [
+  "dev-context-only-utils",
+] }
 solana-pubkey = "4.2.0"
 solana-rent = "4.1.0"
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-runtime-transaction = { workspace = true, features = [
-    "dev-context-only-utils",
+  "dev-context-only-utils",
 ] }
 solana-sbf-rust-invoke-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
@@ -227,7 +231,10 @@ solana-svm-transaction = { workspace = true }
 solana-svm-type-overrides = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-sysvar = "4.3.0"
-solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-transaction = "4.1.0"
 solana-transaction-error = "3.3.0"
 solana-vote = { workspace = true }

--- a/programs/sbf/rust/128bit/Cargo.toml
+++ b/programs/sbf/rust/128bit/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-128bit"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/128bit_dep/Cargo.toml
+++ b/programs/sbf/rust/128bit_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-128bit-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 

--- a/programs/sbf/rust/account_mem/Cargo.toml
+++ b/programs/sbf/rust/account_mem/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-account-mem"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/account_mem_deprecated/Cargo.toml
+++ b/programs/sbf/rust/account_mem_deprecated/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-account-mem-deprecated"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/alloc/Cargo.toml
+++ b/programs/sbf/rust/alloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-alloc"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/alt_bn128/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-alt-bn128"
-description = "Solana BPF test program written in Rust"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Solana BPF test program written in Rust"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/alt_bn128_compression/Cargo.toml
+++ b/programs/sbf/rust/alt_bn128_compression/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-alt-bn128-compression"
-description = "Solana BPF test program written in Rust"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Solana BPF test program written in Rust"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/big_mod_exp/Cargo.toml
+++ b/programs/sbf/rust/big_mod_exp/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-big-mod-exp"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/call_args/Cargo.toml
+++ b/programs/sbf/rust/call_args/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-call-args"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/call_depth/Cargo.toml
+++ b/programs/sbf/rust/call_depth/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-call-depth"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/caller_access/Cargo.toml
+++ b/programs/sbf/rust/caller_access/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-caller-access"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/curve25519/Cargo.toml
+++ b/programs/sbf/rust/curve25519/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-curve25519"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/custom_heap/Cargo.toml
+++ b/programs/sbf/rust/custom_heap/Cargo.toml
@@ -1,19 +1,15 @@
 [package]
 name = "solana-sbf-rust-custom-heap"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[features]
-default = ["custom-heap"]
-custom-heap = []
 
 [dependencies]
 solana-account-info = { workspace = true }
@@ -21,6 +17,10 @@ solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
+
+[features]
+default = ["custom-heap"]
+custom-heap = []
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/dep_crate/Cargo.toml
+++ b/programs/sbf/rust/dep_crate/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-dep-crate"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/deprecated_loader/Cargo.toml
+++ b/programs/sbf/rust/deprecated_loader/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-deprecated-loader"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
+++ b/programs/sbf/rust/direct_account_pointers_in_program_input/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-direct-account-pointers"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/divide_by_zero/Cargo.toml
+++ b/programs/sbf/rust/divide_by_zero/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-divide-by-zero"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/dup_accounts/Cargo.toml
+++ b/programs/sbf/rust/dup_accounts/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-dup-accounts"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/error_handling/Cargo.toml
+++ b/programs/sbf/rust/error_handling/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-error-handling"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/external_spend/Cargo.toml
+++ b/programs/sbf/rust/external_spend/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-external-spend"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
+++ b/programs/sbf/rust/inner_instruction_alignment_check/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/instruction_introspection/Cargo.toml
+++ b/programs/sbf/rust/instruction_introspection/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-instruction-introspection"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/invoke/Cargo.toml
+++ b/programs/sbf/rust/invoke/Cargo.toml
@@ -1,18 +1,15 @@
 [package]
 name = "solana-sbf-rust-invoke"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[features]
-sbpf-v3 = []
 
 [dependencies]
 solana-account-info = { workspace = true }
@@ -28,6 +25,9 @@ solana-sbf-rust-invoked-dep = { workspace = true }
 solana-sbf-rust-realloc-dep = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
+
+[features]
+sbpf-v3 = []
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/invoke_and_error/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_error/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-invoke-and-error"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/invoke_and_ok/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_ok/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-invoke-and-ok"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/invoke_and_return/Cargo.toml
+++ b/programs/sbf/rust/invoke_and_return/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-invoke-and-return"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/invoke_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-invoke-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/rust/invoked/Cargo.toml
+++ b/programs/sbf/rust/invoked/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-invoked"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/invoked_dep/Cargo.toml
+++ b/programs/sbf/rust/invoked_dep/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "solana-sbf-rust-invoked-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+[lib]
+crate-type = ["lib"]
 
 [dependencies]
 solana-instruction = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/iter/Cargo.toml
+++ b/programs/sbf/rust/iter/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-iter"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/log_data/Cargo.toml
+++ b/programs/sbf/rust/log_data/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-log-data"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/many_args/Cargo.toml
+++ b/programs/sbf/rust/many_args/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-many-args"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/many_args_dep/Cargo.toml
+++ b/programs/sbf/rust/many_args_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-many-args-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 solana-msg = { workspace = true }

--- a/programs/sbf/rust/mem/Cargo.toml
+++ b/programs/sbf/rust/mem/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-mem"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/mem_dep/Cargo.toml
+++ b/programs/sbf/rust/mem_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-mem-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/rust/membuiltins/Cargo.toml
+++ b/programs/sbf/rust/membuiltins/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-membuiltins"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/noop/Cargo.toml
+++ b/programs/sbf/rust/noop/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-noop"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/panic/Cargo.toml
+++ b/programs/sbf/rust/panic/Cargo.toml
@@ -1,19 +1,15 @@
 [package]
 name = "solana-sbf-rust-panic"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]
-
-[features]
-default = ["custom-panic"]
-custom-panic = []
 
 [dependencies]
 solana-account-info = { workspace = true }
@@ -21,6 +17,10 @@ solana-msg = { workspace = true }
 solana-program-entrypoint = { workspace = true }
 solana-program-error = { workspace = true }
 solana-pubkey = { workspace = true }
+
+[features]
+default = ["custom-panic"]
+custom-panic = []
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/param_passing/Cargo.toml
+++ b/programs/sbf/rust/param_passing/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-param-passing"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/param_passing_dep/Cargo.toml
+++ b/programs/sbf/rust/param_passing_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-param-passing-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 

--- a/programs/sbf/rust/poseidon/Cargo.toml
+++ b/programs/sbf/rust/poseidon/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-poseidon"
-description = "Solana SBF test program written in Rust"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Solana SBF test program written in Rust"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/r2_instruction_data_pointer/Cargo.toml
+++ b/programs/sbf/rust/r2_instruction_data_pointer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-r2-instruction-data-pointer"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/rand/Cargo.toml
+++ b/programs/sbf/rust/rand/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-rand"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/realloc/Cargo.toml
+++ b/programs/sbf/rust/realloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-realloc"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/realloc_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_dep/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "solana-sbf-rust-realloc-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+[lib]
+crate-type = ["lib"]
 
 [dependencies]
 solana-instruction = { workspace = true }
 solana-pubkey = { workspace = true }
-
-[lib]
-crate-type = ["lib"]
 
 [lints]
 workspace = true

--- a/programs/sbf/rust/realloc_invoke/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-realloc-invoke"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
+++ b/programs/sbf/rust/realloc_invoke_dep/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-realloc-invoke-dep"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/programs/sbf/rust/remaining_compute_units/Cargo.toml
+++ b/programs/sbf/rust/remaining_compute_units/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-remaining-compute-units"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/ro_account_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_account_modify/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-ro-account_modify"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/ro_modify/Cargo.toml
+++ b/programs/sbf/rust/ro_modify/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-ro-modify"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/sanity/Cargo.toml
+++ b/programs/sbf/rust/sanity/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-sanity"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/secp256k1_recover/Cargo.toml
+++ b/programs/sbf/rust/secp256k1_recover/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-secp256k1-recover"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/sha/Cargo.toml
+++ b/programs/sbf/rust/sha/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-sha"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_inner_instructions/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-sibling-inner-instructions"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/sibling_instructions/Cargo.toml
+++ b/programs/sbf/rust/sibling_instructions/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-sibling-instructions"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/simulation/Cargo.toml
+++ b/programs/sbf/rust/simulation/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-simulation"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/spoof1/Cargo.toml
+++ b/programs/sbf/rust/spoof1/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-spoof1"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/spoof1_system/Cargo.toml
+++ b/programs/sbf/rust/spoof1_system/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-spoof1-system"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
+++ b/programs/sbf/rust/syscall-get-epoch-stake/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-syscall-get-epoch-stake"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/sysvar/Cargo.toml
+++ b/programs/sbf/rust/sysvar/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "solana-sbf-rust-sysvar"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/programs/sbf/rust/upgradeable/Cargo.toml
+++ b/programs/sbf/rust/upgradeable/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "solana-sbf-rust-upgradeable"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
-name = "solana_sbf_rust_upgradeable"
 crate-type = ["cdylib"]
+name = "solana_sbf_rust_upgradeable"
 
 [dependencies]
 solana-account-info = { workspace = true }

--- a/programs/sbf/rust/upgraded/Cargo.toml
+++ b/programs/sbf/rust/upgraded/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "solana-sbf-rust-upgraded"
 version = { workspace = true }
-description = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
-name = "solana_sbf_rust_upgraded"
 crate-type = ["cdylib"]
+name = "solana_sbf_rust_upgraded"
 
 [dependencies]
 solana-account-info = { workspace = true }

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-system-program"
-description = "Solana System program"
-documentation = "https://docs.rs/solana-system-program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana System program"
+documentation = "https://docs.rs/solana-system-program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,8 +19,9 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_system_program"
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "system"
 
 [dependencies]
 bincode = { workspace = true }
@@ -54,12 +55,14 @@ solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-un
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-sysvar-id = { workspace = true }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = {
+  path = "../../transaction-context",
+  features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]
+}
 wincode = { workspace = true }
 
-[[bench]]
-name = "system"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/system/Cargo.toml
+++ b/programs/system/Cargo.toml
@@ -45,16 +45,26 @@ assert_matches = { workspace = true }
 criterion = { workspace = true }
 solana-account = { workspace = true, features = ["bincode", "wincode"] }
 solana-hash = { workspace = true }
-solana-program-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+solana-program-runtime = { workspace = true, features = [
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-solana-svm-callback = { path = "../../svm-callback", features = ["agave-unstable-api"] }
-solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../../svm-callback", features = [
+  "agave-unstable-api",
+] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = [
+  "agave-unstable-api",
+] }
 solana-system-program = { path = ".", features = ["agave-unstable-api"] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-sysvar-id = { workspace = true }
-solana-transaction-context = { path = "../../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
+] }
 wincode = { workspace = true }
 
 [[bench]]

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-vote-program"
-description = "Solana Vote program"
-documentation = "https://docs.rs/solana-vote-program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Vote program"
+documentation = "https://docs.rs/solana-vote-program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,15 +19,13 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_vote_program"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["dep:qualifier_attr"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
-    "solana-vote-interface/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "vote_instructions"
+
+[[bench]]
+harness = false
+name = "process_vote"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -39,12 +37,20 @@ solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-packet = { workspace = true }
@@ -67,7 +73,10 @@ solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
-solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = {
+  path = "../../program-runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
@@ -80,13 +89,15 @@ solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-conte
 test-case = { workspace = true }
 wincode = { workspace = true }
 
-[[bench]]
-name = "vote_instructions"
-harness = false
-
-[[bench]]
-name = "process_vote"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["dep:qualifier_attr"]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-program-runtime/frozen-abi",
+  "solana-vote-interface/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -23,10 +23,10 @@ name = "solana_vote_program"
 agave-unstable-api = []
 dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
-    "solana-vote-interface/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-program-runtime/frozen-abi",
+  "solana-vote-interface/frozen-abi",
 ]
 
 [dependencies]
@@ -40,10 +40,10 @@ solana-bls-signatures = { workspace = true }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
@@ -67,16 +67,26 @@ solana-epoch-schedule = { workspace = true, features = ["wincode"] }
 solana-fee-calculator = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
-solana-program-runtime = { path = "../../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = { path = "../../program-runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true, features = ["wincode"] }
 solana-sdk-ids = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-slot-hashes = { workspace = true, features = ["wincode"] }
-solana-svm-feature-set = { path = "../../svm-feature-set", features = ["agave-unstable-api"] }
-solana-system-program = { path = "../system", features = ["agave-unstable-api"] }
+solana-svm-feature-set = { path = "../../svm-feature-set", features = [
+  "agave-unstable-api",
+] }
+solana-system-program = { path = "../system", features = [
+  "agave-unstable-api",
+] }
 solana-sysvar-id = { workspace = true }
-solana-vote-program = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-vote-program = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 wincode = { workspace = true }
 

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "solana-zk-elgamal-proof-program-tests"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-
-[features]
-agave-unstable-api = []
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [dev-dependencies]
 bytemuck = { workspace = true }
@@ -26,6 +23,9 @@ solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 solana-zk-elgamal-proof-interface = { workspace = true }
 solana-zk-sdk = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/zk-elgamal-proof-tests/Cargo.toml
+++ b/programs/zk-elgamal-proof-tests/Cargo.toml
@@ -14,11 +14,15 @@ agave-unstable-api = []
 [dev-dependencies]
 bytemuck = { workspace = true }
 solana-account = { workspace = true }
-solana-compute-budget = { path = "../../compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "../../compute-budget", features = [
+  "agave-unstable-api",
+] }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
-solana-program-test = { path = "../../program-test", features = ["agave-unstable-api"] }
+solana-program-test = { path = "../../program-test", features = [
+  "agave-unstable-api",
+] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }

--- a/programs/zk-elgamal-proof/Cargo.toml
+++ b/programs/zk-elgamal-proof/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name = "solana-zk-elgamal-proof-program"
-description = "Solana Zk ElGamal Proof Program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Zk ElGamal Proof Program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "verify_proofs"
 
 [dependencies]
 bytemuck = { workspace = true }
@@ -29,9 +30,8 @@ solana-zk-sdk = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 
-[[bench]]
-name = "verify_proofs"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/programs/zk-token-proof/Cargo.toml
+++ b/programs/zk-token-proof/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "solana-zk-token-proof-program"
-description = "Solana Zk Token Proof Program"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Zk Token Proof Program"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 solana-program-runtime = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/pubsub-client/Cargo.toml
+++ b/pubsub-client/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-pubsub-client"
-description = "Solana Pubsub Client"
-documentation = "https://docs.rs/solana-pubsub-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Pubsub Client"
+documentation = "https://docs.rs/solana-pubsub-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 crossbeam-channel = { workspace = true }
@@ -40,6 +37,9 @@ url = { workspace = true }
 anyhow = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-quic-client"
-description = "Solana Quic Client"
-documentation = "https://docs.rs/solana-quic-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Quic Client"
+documentation = "https://docs.rs/solana-quic-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 async-lock = { workspace = true }
@@ -41,12 +38,21 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 crossbeam-channel = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-packet = { workspace = true }
 solana-perf = { path = "../perf", features = ["agave-unstable-api"] }
 solana-quic-client = { path = ".", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-streamer = {
+  path = "../streamer",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 tokio-util = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -41,11 +41,17 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 crossbeam-channel = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-packet = { workspace = true }
 solana-perf = { path = "../perf", features = ["agave-unstable-api"] }
 solana-quic-client = { path = ".", features = ["agave-unstable-api"] }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 tokio-util = { workspace = true }
 
 [lints]

--- a/random/Cargo.toml
+++ b/random/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "agave-random"
-description = "Agave randomization utils"
-documentation = "https://docs.rs/agave-random"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave randomization utils"
+documentation = "https://docs.rs/agave-random"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,6 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "agave_random"
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 rand = { workspace = true }
 
@@ -31,6 +28,9 @@ rand_chacha = { workspace = true }
 solana-hash = { workspace = true, features = ["decode"] }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/rayon-threadlimit/Cargo.toml
+++ b/rayon-threadlimit/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-rayon-threadlimit"
-description = "solana-rayon-threadlimit"
-documentation = "https://docs.rs/solana-rayon-threadlimit"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "solana-rayon-threadlimit"
+documentation = "https://docs.rs/solana-rayon-threadlimit"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 log = { workspace = true }
@@ -24,6 +21,9 @@ num_cpus = { workspace = true }
 
 [dev-dependencies]
 solana-rayon-threadlimit = { path = ".", features = ["agave-unstable-api"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/rbpf-cli/Cargo.toml
+++ b/rbpf-cli/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "rbpf-cli"
-description = "Decommissioned CLI to test and analyze SBF programs"
-keywords = ["SBF", "interpreter", "JIT"]
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Decommissioned CLI to test and analyze SBF programs"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+keywords = ["JIT", "SBF", "interpreter"]
+publish = false
+
+[dependencies]
 
 [features]
 agave-unstable-api = []
-
-[dependencies]
 
 [lints]
 workspace = true

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-remote-wallet"
-documentation = "https://docs.rs/solana-remote-wallet"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-remote-wallet"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -17,21 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 # Document the default backend plus the unstable API instead.
 features = ["agave-unstable-api"]
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["linux-static-hidraw"]
-agave-unstable-api = []
-keystone = [
-    "dep:hex",
-    "dep:rusb",
-    "dep:serde_json",
-    "dep:ur-parse-lib",
-    "dep:ur-registry",
-]
-linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
-linux-shared-libusb = ["hidapi/linux-shared-libusb"]
-linux-static-hidraw = ["hidapi/linux-static-hidraw"]
-linux-static-libusb = ["hidapi/linux-static-libusb"]
 
 [dependencies]
 console = { workspace = true }
@@ -60,6 +45,21 @@ uriparse = { workspace = true }
 assert_matches = { workspace = true }
 serial_test = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+default = ["linux-static-hidraw"]
+agave-unstable-api = []
+keystone = [
+  "dep:hex",
+  "dep:rusb",
+  "dep:serde_json",
+  "dep:ur-parse-lib",
+  "dep:ur-registry",
+]
+linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
+linux-shared-libusb = ["hidapi/linux-shared-libusb"]
+linux-static-hidraw = ["hidapi/linux-static-hidraw"]
+linux-static-libusb = ["hidapi/linux-static-libusb"]
 
 [lints]
 workspace = true

--- a/remote-wallet/Cargo.toml
+++ b/remote-wallet/Cargo.toml
@@ -22,11 +22,11 @@ rustdoc-args = ["--cfg=docsrs"]
 default = ["linux-static-hidraw"]
 agave-unstable-api = []
 keystone = [
-    "dep:hex",
-    "dep:rusb",
-    "dep:serde_json",
-    "dep:ur-parse-lib",
-    "dep:ur-registry",
+  "dep:hex",
+  "dep:rusb",
+  "dep:serde_json",
+  "dep:ur-parse-lib",
+  "dep:ur-registry",
 ]
 linux-shared-hidraw = ["hidapi/linux-shared-hidraw"]
 linux-shared-libusb = ["hidapi/linux-shared-libusb"]

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -1,32 +1,36 @@
 [package]
 name = "agave-reserved-account-keys"
-description = "Reserved Solana account keys"
-documentation = "https://docs.rs/agave-reserved-account-keys"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Reserved Solana account keys"
+documentation = "https://docs.rs/agave-reserved-account-keys"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
 [dependencies]
 agave-feature-set = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-pubkey = { workspace = true, default-features = false }
 solana-sdk-ids = { workspace = true }
 
@@ -34,6 +38,10 @@ solana-sdk-ids = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
 solana-sysvar = { workspace = true }
+
+[features]
+agave-unstable-api = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]
 workspace = true

--- a/reserved-account-keys/Cargo.toml
+++ b/reserved-account-keys/Cargo.toml
@@ -22,17 +22,19 @@ frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 [dependencies]
 agave-feature-set = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-pubkey = { workspace = true, default-features = false }
 solana-sdk-ids = { workspace = true }
 
 [dev-dependencies]
 solana-message = { workspace = true }
-solana-pubkey = { workspace = true, default-features = false, features = ["std"] }
+solana-pubkey = { workspace = true, default-features = false, features = [
+  "std",
+] }
 solana-sysvar = { workspace = true }
 
 [lints]

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-rpc-client-api"
-description = "Solana Client Common Utilities"
-documentation = "https://docs.rs/solana-rpc-client-api"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Client Common Utilities"
+documentation = "https://docs.rs/solana-rpc-client-api"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -34,6 +31,9 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/rpc-client-api/Cargo.toml
+++ b/rpc-client-api/Cargo.toml
@@ -21,7 +21,9 @@ agave-unstable-api = []
 [dependencies]
 anyhow = { workspace = true }
 jsonrpc-core = { workspace = true }
-reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
+reqwest = { workspace = true, default-features = false, features = [
+  "rustls-tls",
+] }
 reqwest-middleware = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -1,24 +1,19 @@
 [package]
 name = "solana-rpc-client-nonce-utils"
-description = "Solana RPC Client Nonce Utilities"
-documentation = "https://docs.rs/solana-rpc-client-nonce-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC Client Nonce Utilities"
+documentation = "https://docs.rs/solana-rpc-client-nonce-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = []
-agave-unstable-api = []
-clap = ["dep:clap", "dep:solana-clap-utils"]
 
 [dependencies]
 clap = { version = "2.33.0", default-features = false, features = ["suggestions"], optional = true }
@@ -47,6 +42,11 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+default = []
+agave-unstable-api = []
+clap = ["dep:clap", "dep:solana-clap-utils"]
 
 [lints]
 workspace = true

--- a/rpc-client-nonce-utils/Cargo.toml
+++ b/rpc-client-nonce-utils/Cargo.toml
@@ -21,7 +21,9 @@ agave-unstable-api = []
 clap = ["dep:clap", "dep:solana-clap-utils"]
 
 [dependencies]
-clap = { version = "2.33.0", default-features = false, features = ["suggestions"], optional = true }
+clap = { version = "2.33.0", default-features = false, features = [
+  "suggestions",
+], optional = true }
 solana-account = { workspace = true }
 solana-clap-utils = { workspace = true, optional = true }
 solana-commitment-config = { workspace = true }
@@ -38,7 +40,9 @@ wincode = { workspace = true }
 anyhow = { workspace = true }
 futures = { workspace = true }
 serde_json = { workspace = true }
-solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "../account-decoder", features = [
+  "agave-unstable-api",
+] }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-rpc-client-api = { path = "../rpc-client-api" }

--- a/rpc-client-types/Cargo.toml
+++ b/rpc-client-types/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-rpc-client-types"
-description = "Solana RPC Client Types"
-documentation = "https://docs.rs/solana-rpc-client-types"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC Client Types"
+documentation = "https://docs.rs/solana-rpc-client-types"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 base64 = { workspace = true }
@@ -41,6 +38,9 @@ thiserror = { workspace = true }
 const_format = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-signature = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -1,26 +1,19 @@
 [package]
 name = "solana-rpc-client"
-description = "Solana RPC Client"
-documentation = "https://docs.rs/solana-rpc-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC Client"
+documentation = "https://docs.rs/solana-rpc-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["spinner"]
-agave-unstable-api = []
-# Support rpc-client methods that feature a spinner progress bar for
-# command-line interfaces
-spinner = ["dep:indicatif"]
 
 [dependencies]
 agave-votor-messages = { workspace = true }
@@ -31,7 +24,10 @@ bs58 = { workspace = true }
 futures = { workspace = true }
 indicatif = { workspace = true, optional = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = {
+  workspace = true,
+  features = ["blocking", "brotli", "deflate", "gzip", "json", "rustls-tls"]
+}
 reqwest-middleware = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -73,6 +69,13 @@ solana-signer = { workspace = true }
 solana-system-interface = { workspace = true, features = ["bincode"] }
 solana-system-transaction = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+default = ["spinner"]
+agave-unstable-api = []
+# Support rpc-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = ["dep:indicatif"]
 
 [lints]
 workspace = true

--- a/rpc-client/Cargo.toml
+++ b/rpc-client/Cargo.toml
@@ -31,7 +31,14 @@ bs58 = { workspace = true }
 futures = { workspace = true }
 indicatif = { workspace = true, optional = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = [
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "json",
+] }
 reqwest-middleware = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
@@ -65,7 +72,9 @@ crossbeam-channel = { workspace = true }
 futures = { workspace = true }
 jsonrpc-core = { workspace = true }
 jsonrpc-http-server = { workspace = true }
-solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
+solana-account-decoder = { path = "../account-decoder", features = [
+  "agave-unstable-api",
+] }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -1,21 +1,18 @@
 [package]
 name = "solana-rpc-test"
-description = "Solana RPC Test"
-documentation = "https://docs.rs/solana-rpc-test"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC Test"
+documentation = "https://docs.rs/solana-rpc-test"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 bincode = { workspace = true }
@@ -23,7 +20,10 @@ bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = {
+  workspace = true,
+  features = ["blocking", "brotli", "deflate", "gzip", "json", "rustls-tls"]
+}
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-net-utils = { workspace = true }
@@ -45,10 +45,16 @@ solana-rent = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = {
+  workspace = true,
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-tpu-client-next = { workspace = true, features = ["dev-context-only-utils"] }
 solana-transaction = { workspace = true }
 tokio-util = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/rpc-test/Cargo.toml
+++ b/rpc-test/Cargo.toml
@@ -24,14 +24,23 @@ bs58 = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["blocking", "brotli", "deflate", "gzip", "rustls-tls", "json"] }
+reqwest = { workspace = true, features = [
+  "blocking",
+  "brotli",
+  "deflate",
+  "gzip",
+  "rustls-tls",
+  "json",
+] }
 serde_json = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-net-utils = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
-solana-tpu-client-next = { workspace = true, features = ["websocket-node-address-service"] }
+solana-tpu-client-next = { workspace = true, features = [
+  "websocket-node-address-service",
+] }
 solana-transaction-status = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
@@ -46,7 +55,10 @@ solana-rent = { workspace = true }
 solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-test-validator = { workspace = true, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { workspace = true, features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-transaction = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-rpc"
-description = "Solana RPC"
-documentation = "https://docs.rs/solana-rpc"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana RPC"
+documentation = "https://docs.rs/solana-rpc"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,16 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_rpc"
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "dep:solana-unified-scheduler-pool",
-    "solana-ledger/dev-context-only-utils",
-    "solana-rpc/dev-context-only-utils",
-    "solana-unified-scheduler-pool/dev-context-only-utils",
-]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -109,7 +99,10 @@ tokio-util = { workspace = true, features = ["codec", "compat"] }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = {
+  path = "../reserved-account-keys",
+  features = ["agave-unstable-api"]
+}
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-address-lookup-table-interface = { workspace = true }
@@ -127,16 +120,35 @@ solana-program-option = { workspace = true }
 solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
 solana-rent = { workspace = true }
 solana-rpc = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+solana-runtime-transaction = {
+  path = "../runtime-transaction",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-sdk-ids = { workspace = true }
-solana-send-transaction-service = { path = "../send-transaction-service", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-send-transaction-service = {
+  path = "../send-transaction-service",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
 solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true, features = ["wincode"] }
 symlink = { workspace = true }
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-votor-messages/dev-context-only-utils",
+  "dep:solana-unified-scheduler-pool",
+  "solana-ledger/dev-context-only-utils",
+  "solana-rpc/dev-context-only-utils",
+  "solana-unified-scheduler-pool/dev-context-only-utils",
+]
 
 [lints]
 workspace = true

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -22,11 +22,11 @@ name = "solana_rpc"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "dep:solana-unified-scheduler-pool",
-    "solana-ledger/dev-context-only-utils",
-    "solana-rpc/dev-context-only-utils",
-    "solana-unified-scheduler-pool/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "dep:solana-unified-scheduler-pool",
+  "solana-ledger/dev-context-only-utils",
+  "solana-rpc/dev-context-only-utils",
+  "solana-unified-scheduler-pool/dev-context-only-utils",
 ]
 
 [dependencies]
@@ -109,7 +109,9 @@ tokio-util = { workspace = true, features = ["codec", "compat"] }
 wincode = { workspace = true }
 
 [dev-dependencies]
-agave-reserved-account-keys = { path = "../reserved-account-keys", features = ["agave-unstable-api"] }
+agave-reserved-account-keys = { path = "../reserved-account-keys", features = [
+  "agave-unstable-api",
+] }
 serial_test = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
 solana-address-lookup-table-interface = { workspace = true }
@@ -118,21 +120,40 @@ solana-cluster-type = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-fee-structure = { workspace = true }
-solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-gossip = { path = "../gossip", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-instruction = { workspace = true }
 solana-nonce = { workspace = true, features = ["wincode"] }
 solana-nonce-account = { workspace = true, features = ["wincode"] }
 solana-program-option = { workspace = true }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api"] }
+solana-program-runtime = { path = "../program-runtime", features = [
+  "agave-unstable-api",
+] }
 solana-rent = { workspace = true }
-solana-rpc = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-rpc = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-sdk-ids = { workspace = true }
-solana-send-transaction-service = { path = "../send-transaction-service", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-send-transaction-service = { path = "../send-transaction-service", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-sha256-hasher = { workspace = true }
 solana-stake-interface = { workspace = true }
-solana-svm-log-collector = { path = "../svm-log-collector", features = ["agave-unstable-api"] }
+solana-svm-log-collector = { path = "../svm-log-collector", features = [
+  "agave-unstable-api",
+] }
 solana-vote-interface = { workspace = true, features = ["wincode"] }
 symlink = { workspace = true }
 test-case = { workspace = true }

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-runtime-transaction"
-description = "Solana runtime-transaction"
-documentation = "https://docs.rs/solana-runtime-transaction"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana runtime-transaction"
+documentation = "https://docs.rs/solana-runtime-transaction"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,9 +19,9 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_runtime_transaction"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
+[[bench]]
+harness = false
+name = "get_signature_details"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -46,7 +46,10 @@ agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-compute-budget-instruction = {
+  path = "../compute-budget-instruction",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-compute-budget-interface = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }
@@ -58,9 +61,9 @@ solana-system-interface = { workspace = true, features = ["wincode"] }
 solana-system-transaction = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3"] }
 
-[[bench]]
-name = "get_signature_details"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
 
 [lints]
 workspace = true

--- a/runtime-transaction/Cargo.toml
+++ b/runtime-transaction/Cargo.toml
@@ -21,7 +21,9 @@ name = "solana_runtime_transaction"
 
 [features]
 agave-unstable-api = []
-dev-context-only-utils = ["solana-compute-budget-instruction/dev-context-only-utils"]
+dev-context-only-utils = [
+  "solana-compute-budget-instruction/dev-context-only-utils",
+]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -46,7 +48,10 @@ agave-feature-set = { workspace = true }
 agave-reserved-account-keys = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
-solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-compute-budget-instruction = { path = "../compute-budget-instruction", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-compute-budget-interface = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
 solana-instruction = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-runtime"
-description = "Solana runtime"
-documentation = "https://docs.rs/solana-runtime"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana runtime"
+documentation = "https://docs.rs/solana-runtime"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,46 +19,12 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_runtime"
 
-[features]
-agave-unstable-api = []
-conformance = [
-    "agave-unstable-api",
-    "dep:prost",
-    "dep:protosol",
-    "dev-context-only-utils",
-    "solana-svm/conformance",
-]
-dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-accounts-db/dev-context-only-utils",
-    "solana-entry/dev-context-only-utils",
-    "solana-program-binaries",
-    "solana-svm/dev-context-only-utils",
-    "solana-runtime-transaction/dev-context-only-utils",
-    "solana-vote/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-account/frozen-abi",
-    "solana-accounts-db/frozen-abi",
-    "solana-bls-signatures/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-epoch-schedule/frozen-abi",
-    "solana-hard-forks/frozen-abi",
-    "solana-inflation/frozen-abi",
-    "solana-instruction/frozen-abi",
-    "solana-instruction-error/frozen-abi",
-    "solana-program-runtime/frozen-abi",
-    "solana-rent/frozen-abi",
-    "solana-stake-interface/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-transaction-error/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
-]
-shuttle-test = ["dep:shuttle"]
+[[bench]]
+name = "prioritization_fee_cache"
+
+[[bench]]
+harness = false
+name = "epoch_turnover"
 
 [dependencies]
 agave-bls-cert-verify = { workspace = true }
@@ -81,7 +47,7 @@ bytes = { workspace = true }
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { workspace = true }
 crossbeam-utils = { workspace = true }
-dashmap = { workspace = true, features = ["rayon", "raw-api", "serde"] }
+dashmap = { workspace = true, features = ["raw-api", "rayon", "serde"] }
 imbl = { workspace = true, features = ["rayon", "serde"] }
 itertools = { workspace = true }
 libc = { workspace = true }
@@ -127,15 +93,23 @@ solana-feature-gate-interface = { workspace = true, features = ["bincode"] }
 solana-fee = { workspace = true }
 solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-fee-structure = { workspace = true, features = ["serde"] }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-genesis-config = { workspace = true, features = ["serde"] }
 solana-hard-forks = { workspace = true, features = ["serde", "wincode"] }
-solana-hash = { workspace = true, features = ["atomic", "wincode", "rand"] }
+solana-hash = { workspace = true, features = ["atomic", "rand", "wincode"] }
 solana-inflation = { workspace = true, features = ["serde", "wincode"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true, features = ["seed-derivable"] }
@@ -206,31 +180,81 @@ bytes = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 proptest = { workspace = true }
-solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-builtins = { path = "../builtins", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-accounts-db = {
+  path = "../accounts-db",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+solana-builtins = {
+  path = "../builtins",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-instruction-error = { workspace = true }
 solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = {
+  path = "../runtime-transaction",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-sdk-ids = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-signature = { workspace = true, features = ["std"] }
 solana-signer-store = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode"] }
 solana-svm = { path = "../svm", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
-solana-vote-program = { path = "../programs/vote", default-features = false, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]
+}
+solana-vote-program = {
+  path = "../programs/vote",
+  default-features = false,
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 
 [target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
 jemallocator = { workspace = true }
 
-[[bench]]
-name = "prioritization_fee_cache"
-
-[[bench]]
-name = "epoch_turnover"
-harness = false
+[features]
+agave-unstable-api = []
+conformance = [
+  "agave-unstable-api",
+  "dep:prost",
+  "dep:protosol",
+  "dev-context-only-utils",
+  "solana-svm/conformance",
+]
+dev-context-only-utils = [
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-accounts-db/dev-context-only-utils",
+  "solana-entry/dev-context-only-utils",
+  "solana-program-binaries",
+  "solana-runtime-transaction/dev-context-only-utils",
+  "solana-svm/dev-context-only-utils",
+  "solana-vote/dev-context-only-utils",
+]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-account/frozen-abi",
+  "solana-accounts-db/frozen-abi",
+  "solana-bls-signatures/frozen-abi",
+  "solana-cost-model/frozen-abi",
+  "solana-epoch-schedule/frozen-abi",
+  "solana-hard-forks/frozen-abi",
+  "solana-inflation/frozen-abi",
+  "solana-instruction-error/frozen-abi",
+  "solana-instruction/frozen-abi",
+  "solana-program-runtime/frozen-abi",
+  "solana-rent/frozen-abi",
+  "solana-stake-interface/frozen-abi",
+  "solana-svm/frozen-abi",
+  "solana-transaction-error/frozen-abi",
+  "solana-version/frozen-abi",
+  "solana-vote-program/frozen-abi",
+  "solana-vote/frozen-abi",
+]
+shuttle-test = ["dep:shuttle"]
 
 [lints]
 workspace = true

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,41 +22,41 @@ name = "solana_runtime"
 [features]
 agave-unstable-api = []
 conformance = [
-    "agave-unstable-api",
-    "dep:prost",
-    "dep:protosol",
-    "dev-context-only-utils",
-    "solana-svm/conformance",
+  "agave-unstable-api",
+  "dep:prost",
+  "dep:protosol",
+  "dev-context-only-utils",
+  "solana-svm/conformance",
 ]
 dev-context-only-utils = [
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-accounts-db/dev-context-only-utils",
-    "solana-entry/dev-context-only-utils",
-    "solana-program-binaries",
-    "solana-svm/dev-context-only-utils",
-    "solana-runtime-transaction/dev-context-only-utils",
-    "solana-vote/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-accounts-db/dev-context-only-utils",
+  "solana-entry/dev-context-only-utils",
+  "solana-program-binaries",
+  "solana-svm/dev-context-only-utils",
+  "solana-runtime-transaction/dev-context-only-utils",
+  "solana-vote/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-account/frozen-abi",
-    "solana-accounts-db/frozen-abi",
-    "solana-bls-signatures/frozen-abi",
-    "solana-cost-model/frozen-abi",
-    "solana-epoch-schedule/frozen-abi",
-    "solana-hard-forks/frozen-abi",
-    "solana-inflation/frozen-abi",
-    "solana-instruction/frozen-abi",
-    "solana-instruction-error/frozen-abi",
-    "solana-program-runtime/frozen-abi",
-    "solana-rent/frozen-abi",
-    "solana-stake-interface/frozen-abi",
-    "solana-svm/frozen-abi",
-    "solana-transaction-error/frozen-abi",
-    "solana-version/frozen-abi",
-    "solana-vote/frozen-abi",
-    "solana-vote-program/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-account/frozen-abi",
+  "solana-accounts-db/frozen-abi",
+  "solana-bls-signatures/frozen-abi",
+  "solana-cost-model/frozen-abi",
+  "solana-epoch-schedule/frozen-abi",
+  "solana-hard-forks/frozen-abi",
+  "solana-inflation/frozen-abi",
+  "solana-instruction/frozen-abi",
+  "solana-instruction-error/frozen-abi",
+  "solana-program-runtime/frozen-abi",
+  "solana-rent/frozen-abi",
+  "solana-stake-interface/frozen-abi",
+  "solana-svm/frozen-abi",
+  "solana-transaction-error/frozen-abi",
+  "solana-version/frozen-abi",
+  "solana-vote/frozen-abi",
+  "solana-vote-program/frozen-abi",
 ]
 shuttle-test = ["dep:shuttle"]
 
@@ -128,10 +128,10 @@ solana-fee = { workspace = true }
 solana-fee-calculator = { workspace = true, features = ["wincode"] }
 solana-fee-structure = { workspace = true, features = ["serde"] }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-genesis-config = { workspace = true, features = ["serde"] }
 solana-hard-forks = { workspace = true, features = ["serde", "wincode"] }
@@ -206,19 +206,41 @@ bytes = { workspace = true }
 criterion = { workspace = true }
 libsecp256k1 = { workspace = true }
 proptest = { workspace = true }
-solana-accounts-db = { path = "../accounts-db", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-builtins = { path = "../builtins", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-accounts-db = { path = "../accounts-db", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-builtins = { path = "../builtins", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-instruction-error = { workspace = true }
-solana-runtime = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-sdk-ids = { workspace = true }
 solana-secp256k1-program = { workspace = true, features = ["bincode"] }
 solana-signature = { workspace = true, features = ["std"] }
 solana-signer-store = { workspace = true }
 solana-stake-interface = { workspace = true, features = ["bincode"] }
-solana-svm = { path = "../svm", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
-solana-vote-program = { path = "../programs/vote", default-features = false, features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-svm = { path = "../svm", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-transaction-context = { path = "../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
+] }
+solana-vote-program = { path = "../programs/vote", default-features = false, features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 static_assertions = { workspace = true }
 test-case = { workspace = true }
 

--- a/scheduling-utils/Cargo.toml
+++ b/scheduling-utils/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "agave-scheduling-utils"
-description = "Common utilities for building Agave scheduler implementations"
-documentation = "https://docs.rs/agave-scheduling-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Common utilities for building Agave scheduler implementations"
+documentation = "https://docs.rs/agave-scheduling-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["dep:wincode", "dep:solana-transaction"]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -30,21 +26,25 @@ slotmap = { workspace = true }
 solana-fee = { workspace = true, features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-runtime-transaction = { workspace = true }
-solana-transaction = { workspace = true, optional = true, features = ["serde"] }
+solana-transaction = { workspace = true, features = ["serde"], optional = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true, optional = true }
-
-[target."cfg(unix)".dependencies]
-libc = { workspace = true }
-nix = { workspace = true, features = ["socket", "uio"] }
 
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
 
+[target."cfg(unix)".dependencies]
+libc = { workspace = true }
+nix = { workspace = true, features = ["socket", "uio"] }
+
 [target."cfg(unix)".dev-dependencies]
 agave-scheduler-bindings = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["dep:solana-transaction", "dep:wincode"]
 
 [lints]
 workspace = true

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "solana-send-transaction-service"
-description = "Solana send transaction service"
-documentation = "https://docs.rs/solana-send-transaction-service"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana send transaction service"
+documentation = "https://docs.rs/solana-send-transaction-service"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["solana-net-utils"]
 
 [dependencies]
 crossbeam-channel = { workspace = true }
@@ -45,10 +41,17 @@ solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["solana-net-utils"]
 
 [lints]
 workspace = true

--- a/send-transaction-service/Cargo.toml
+++ b/send-transaction-service/Cargo.toml
@@ -46,7 +46,10 @@ solana-fee-calculator = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-nonce = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-transaction = { workspace = true }

--- a/snapshots/Cargo.toml
+++ b/snapshots/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "agave-snapshots"
-description = "Agave snapshot utils"
-documentation = "https://docs.rs/agave-snapshots"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave snapshot utils"
+documentation = "https://docs.rs/agave-snapshots"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "agave_snapshots"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-fs = { workspace = true }
@@ -51,6 +48,9 @@ zstd = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 solana-hash = { workspace = true, features = ["atomic"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-stake-accounts"
-documentation = "https://docs.rs/solana-stake-accounts"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-stake-accounts"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -17,12 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 # (hidraw) backend plus the unstable API.
 features = ["agave-unstable-api"]
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["remote-wallet-hidraw"]
-agave-unstable-api = []
-remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
-remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 clap = { workspace = true }
@@ -53,7 +47,16 @@ wincode = { workspace = true }
 [dev-dependencies]
 solana-client-traits = { workspace = true }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+
+[features]
+default = ["remote-wallet-hidraw"]
+agave-unstable-api = []
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [lints]
 workspace = true

--- a/stake-accounts/Cargo.toml
+++ b/stake-accounts/Cargo.toml
@@ -52,8 +52,13 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 solana-client-traits = { workspace = true }
-solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = [
+  "agave-unstable-api",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-storage-bigtable"
-description = "Solana Storage BigTable"
-documentation = "https://docs.rs/solana-storage-bigtable"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Storage BigTable"
+documentation = "https://docs.rs/solana-storage-bigtable"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,16 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_storage_bigtable"
-
-[features]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-signature/frozen-abi",
-    "solana-transaction/frozen-abi",
-    "solana-transaction-error/frozen-abi",
-]
-agave-unstable-api = []
 
 [dependencies]
 agave-reserved-account-keys = { workspace = true }
@@ -46,12 +36,20 @@ serde = { workspace = true }
 smpl_jwt = { workspace = true }
 solana-clock = { workspace = true }
 solana-entry = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-pubkey = { workspace = true }
@@ -74,7 +72,20 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = ["agave-unstable-api", "bincode"]
+}
+
+[features]
+agave-unstable-api = []
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-signature/frozen-abi",
+  "solana-transaction-error/frozen-abi",
+  "solana-transaction/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/storage-bigtable/Cargo.toml
+++ b/storage-bigtable/Cargo.toml
@@ -21,11 +21,11 @@ name = "solana_storage_bigtable"
 
 [features]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-signature/frozen-abi",
-    "solana-transaction/frozen-abi",
-    "solana-transaction-error/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-signature/frozen-abi",
+  "solana-transaction/frozen-abi",
+  "solana-transaction-error/frozen-abi",
 ]
 agave-unstable-api = []
 
@@ -47,10 +47,10 @@ smpl_jwt = { workspace = true }
 solana-clock = { workspace = true }
 solana-entry = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
@@ -74,7 +74,10 @@ solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-transaction = { workspace = true }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+] }
 
 [lints]
 workspace = true

--- a/storage-bigtable/build-proto/Cargo.toml
+++ b/storage-bigtable/build-proto/Cargo.toml
@@ -1,17 +1,14 @@
 [package]
 name = "proto"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-
-[features]
-agave-unstable-api = []
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [dependencies]
 tonic-prost-build = { workspace = true }
@@ -20,6 +17,9 @@ tonic-prost-build = { workspace = true }
 # envar to point to the installed binary
 [target."cfg(not(windows))".dependencies]
 protobuf-src = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-storage-proto"
-description = "Solana Storage Protobuf Definitions"
-documentation = "https://docs.rs/solana-storage-proto"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Storage Protobuf Definitions"
+documentation = "https://docs.rs/solana-storage-proto"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,9 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_storage_proto"
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 bs58 = { workspace = true }
@@ -40,6 +37,11 @@ solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }
 
+[dev-dependencies]
+enum-iterator = { workspace = true }
+solana-hash = { workspace = true, features = ["atomic"] }
+test-case = { workspace = true }
+
 [build-dependencies]
 tonic-prost-build = { workspace = true }
 
@@ -48,10 +50,8 @@ tonic-prost-build = { workspace = true }
 [target."cfg(not(windows))".build-dependencies]
 protobuf-src = { workspace = true }
 
-[dev-dependencies]
-enum-iterator = { workspace = true }
-solana-hash = { workspace = true, features = ["atomic"] }
-test-case = { workspace = true }
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/storage-proto/Cargo.toml
+++ b/storage-proto/Cargo.toml
@@ -34,7 +34,10 @@ solana-pubkey = { workspace = true }
 solana-serde = { workspace = true }
 solana-signature = { workspace = true, features = ["std"] }
 solana-transaction = { workspace = true }
-solana-transaction-context = { workspace = true, features = ["serde", "wincode"] }
+solana-transaction-context = { workspace = true, features = [
+  "serde",
+  "wincode",
+] }
 solana-transaction-error = { workspace = true, features = ["wincode"] }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-streamer"
-description = "Solana Streamer"
-documentation = "https://docs.rs/solana-streamer"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Streamer"
+documentation = "https://docs.rs/solana-streamer"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,10 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_streamer"
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 agave-xdp = { workspace = true }
@@ -61,9 +57,16 @@ assert_matches = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 solana-message = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -61,9 +61,15 @@ assert_matches = { workspace = true }
 chrono = { workspace = true, features = ["now"] }
 clap = { version = "4.5.31", features = ["cargo", "derive", "error-context"] }
 solana-message = { workspace = true }
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-streamer = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-streamer = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/svm-callback/Cargo.toml
+++ b/svm-callback/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "solana-svm-callback"
-description = "Solana SVM callback"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana SVM callback"
 readme = false
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 solana-account = { workspace = true }
 solana-clock = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-pubkey = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-svm-conformance"
-description = "Conformance harnesses for the Solana SVM"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "Conformance harnesses for the Solana SVM"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 workspace = "../dev-bins"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -38,28 +38,6 @@ name = "test_exec_vm_syscall"
 path = "src/bin/test_exec_vm_syscall.rs"
 required-features = ["cli", "ffi"]
 
-[features]
-default = ["cli", "ffi"]
-agave-unstable-api = []
-cli = ["dep:clap"]
-dev-context-only-utils = []
-dummy-for-ci-check = []
-ffi = [
-    "dep:agave-feature-set",
-    "dep:agave-precompiles",
-    "dep:prost",
-    "dep:protosol",
-    "dep:solana-compute-budget",
-    "dep:solana-instruction",
-    "dep:solana-program-runtime",
-    "dep:solana-pubkey",
-    "dep:solana-svm",
-    "dep:solana-syscalls",
-    "dep:solana-transaction-error",
-    "solana-svm/conformance",
-]
-frozen-abi = []
-
 [dependencies]
 agave-feature-set = { workspace = true, optional = true }
 agave-precompiles = { workspace = true, optional = true }
@@ -83,6 +61,28 @@ solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-system-program = { workspace = true }
+
+[features]
+default = ["cli", "ffi"]
+agave-unstable-api = []
+cli = ["dep:clap"]
+dev-context-only-utils = []
+dummy-for-ci-check = []
+ffi = [
+  "dep:agave-feature-set",
+  "dep:agave-precompiles",
+  "dep:prost",
+  "dep:protosol",
+  "dep:solana-compute-budget",
+  "dep:solana-instruction",
+  "dep:solana-program-runtime",
+  "dep:solana-pubkey",
+  "dep:solana-svm",
+  "dep:solana-syscalls",
+  "dep:solana-transaction-error",
+  "solana-svm/conformance",
+]
+frozen-abi = []
 
 [lints]
 workspace = true

--- a/svm-conformance/Cargo.toml
+++ b/svm-conformance/Cargo.toml
@@ -45,18 +45,18 @@ cli = ["dep:clap"]
 dev-context-only-utils = []
 dummy-for-ci-check = []
 ffi = [
-    "dep:agave-feature-set",
-    "dep:agave-precompiles",
-    "dep:prost",
-    "dep:protosol",
-    "dep:solana-compute-budget",
-    "dep:solana-instruction",
-    "dep:solana-program-runtime",
-    "dep:solana-pubkey",
-    "dep:solana-svm",
-    "dep:solana-syscalls",
-    "dep:solana-transaction-error",
-    "solana-svm/conformance",
+  "dep:agave-feature-set",
+  "dep:agave-precompiles",
+  "dep:prost",
+  "dep:protosol",
+  "dep:solana-compute-budget",
+  "dep:solana-instruction",
+  "dep:solana-program-runtime",
+  "dep:solana-pubkey",
+  "dep:solana-svm",
+  "dep:solana-syscalls",
+  "dep:solana-transaction-error",
+  "solana-svm/conformance",
 ]
 frozen-abi = []
 

--- a/svm-feature-set/Cargo.toml
+++ b/svm-feature-set/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
 name = "solana-svm-feature-set"
-description = "Solana SVM Feature Set"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana SVM Feature Set"
 readme = false
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
+[dependencies]
+
 [features]
 agave-unstable-api = []
-
-[dependencies]
 
 [lints]
 workspace = true

--- a/svm-log-collector/Cargo.toml
+++ b/svm-log-collector/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "solana-svm-log-collector"
-description = "Solana log collector"
-documentation = "https://docs.rs/solana-svm-log-collector"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana log collector"
+documentation = "https://docs.rs/solana-svm-log-collector"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-
 [dependencies]
 log = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/svm-measure/Cargo.toml
+++ b/svm-measure/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-svm-measure"
-description = "Timing measurement utilities for SVM"
-documentation = "https://docs.rs/solana-svm-measure"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Timing measurement utilities for SVM"
+documentation = "https://docs.rs/solana-svm-measure"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/svm-timings/Cargo.toml
+++ b/svm-timings/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-svm-timings"
-description = "Solana Execution Timings"
-documentation = "https://docs.rs/solana-svm-timings"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Execution Timings"
+documentation = "https://docs.rs/solana-svm-timings"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 eager = { workspace = true }
@@ -25,6 +22,9 @@ solana-pubkey = { workspace = true }
 
 [dev-dependencies]
 solana-pubkey = { workspace = true, features = ["rand"] }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/svm-type-overrides/Cargo.toml
+++ b/svm-type-overrides/Cargo.toml
@@ -1,28 +1,28 @@
 [package]
 name = "solana-svm-type-overrides"
-description = "Type overrides for specialized testing"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Type overrides for specialized testing"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-shuttle-test = ["dep:shuttle"]
-executor = ["dep:futures"]
-
 [dependencies]
 futures = { workspace = true, optional = true }
 rand = { workspace = true }
 shuttle = { workspace = true, optional = true }
+
+[features]
+agave-unstable-api = []
+executor = ["dep:futures"]
+shuttle-test = ["dep:shuttle"]
 
 [lints]
 workspace = true

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-svm"
-description = "Solana SVM"
-documentation = "https://docs.rs/solana-svm"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana SVM"
+documentation = "https://docs.rs/solana-svm"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,57 +18,6 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 crate-type = ["lib"]
 name = "solana_svm"
-
-[features]
-default = ["metrics"]
-agave-unstable-api = []
-conformance = [
-    "dep:agave-precompiles",
-    "dep:prost",
-    "dep:protosol",
-    "dep:solana-poseidon",
-    "dep:solana-signature",
-    "dep:solana-transaction",
-    "dep:solana-vote-program",
-    "dep:solana-zk-elgamal-proof-program",
-    "dep:xxhash-rust",
-    "dev-context-only-utils",
-    "solana-instruction-error/serde",
-    "solana-pubkey/default",
-    "solana-transaction-error/serde",
-]
-dev-context-only-utils = [
-    "dep:agave-feature-set",
-    "dep:qualifier_attr",
-    "dep:solana-address-lookup-table-interface",
-    "dep:solana-bpf-loader-program",
-    "dep:solana-compute-budget",
-    "dep:solana-compute-budget-instruction",
-    "dep:solana-compute-budget-program",
-    "dep:solana-instruction-error",
-    "dep:solana-precompile-error",
-    "dep:solana-slot-hashes",
-    "dep:solana-syscalls",
-    "dep:solana-system-program",
-    "solana-program-runtime/dev-context-only-utils",
-]
-dummy-for-ci-check = ["conformance", "metrics"]
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
-]
-metrics = [
-    "solana-bpf-loader-program/metrics",
-    "solana-program-runtime/metrics",
-]
-shuttle-test = [
-    "dep:shuttle",
-    "solana-bpf-loader-program/shuttle-test",
-    "solana-program-runtime/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
-]
-svm-internal = ["dep:qualifier_attr"]
 
 [dependencies]
 agave-feature-set = { workspace = true, optional = true }
@@ -82,22 +31,34 @@ qualifier_attr = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 shuttle = { workspace = true, optional = true }
 solana-account = { workspace = true, features = ["wincode"] }
-solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
+solana-address-lookup-table-interface = {
+  workspace = true,
+  features = [
     "bincode",
     "bytemuck",
-] }
+  ],
+  optional = true
+}
 solana-bpf-loader-program = { workspace = true, optional = true }
 solana-clock = { workspace = true }
 solana-compute-budget = { workspace = true, optional = true }
 solana-compute-budget-instruction = { workspace = true, optional = true }
 solana-compute-budget-program = { workspace = true, optional = true }
 solana-fee-structure = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
 solana-instruction-error = { workspace = true, optional = true }
@@ -116,7 +77,7 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, optional = true }
-solana-slot-hashes = { workspace = true, optional = true, features = ["wincode"] }
+solana-slot-hashes = { workspace = true, features = ["wincode"], optional = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
@@ -135,7 +96,7 @@ solana-vote-program = { workspace = true, optional = true }
 solana-zk-elgamal-proof-program = { workspace = true, optional = true }
 spl-generic-token = { workspace = true }
 thiserror = { workspace = true }
-xxhash-rust = { workspace = true, optional = true, features = ["xxh64"] }
+xxhash-rust = { workspace = true, features = ["xxh64"], optional = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
@@ -143,33 +104,100 @@ env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = {
+  path = "../programs/bpf_loader",
+  default-features = false,
+  features = ["agave-unstable-api"]
+}
 solana-clock = { workspace = true }
 solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget-program = {
+  path = "../programs/compute-budget",
+  features = ["agave-unstable-api"]
+}
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = {
+  path = "../program-runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
-solana-svm = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "svm-internal"] }
+solana-svm = {
+  path = ".",
+  features = ["agave-unstable-api", "dev-context-only-utils", "svm-internal"]
+}
 solana-syscalls = { path = "../syscalls", features = ["agave-unstable-api"] }
 solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]
+}
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
 wincode = { workspace = true }
+
+[features]
+default = ["metrics"]
+agave-unstable-api = []
+conformance = [
+  "dep:agave-precompiles",
+  "dep:prost",
+  "dep:protosol",
+  "dep:solana-poseidon",
+  "dep:solana-signature",
+  "dep:solana-transaction",
+  "dep:solana-vote-program",
+  "dep:solana-zk-elgamal-proof-program",
+  "dep:xxhash-rust",
+  "dev-context-only-utils",
+  "solana-instruction-error/serde",
+  "solana-pubkey/default",
+  "solana-transaction-error/serde",
+]
+dev-context-only-utils = [
+  "dep:agave-feature-set",
+  "dep:qualifier_attr",
+  "dep:solana-address-lookup-table-interface",
+  "dep:solana-bpf-loader-program",
+  "dep:solana-compute-budget",
+  "dep:solana-compute-budget-instruction",
+  "dep:solana-compute-budget-program",
+  "dep:solana-instruction-error",
+  "dep:solana-precompile-error",
+  "dep:solana-slot-hashes",
+  "dep:solana-syscalls",
+  "dep:solana-system-program",
+  "solana-program-runtime/dev-context-only-utils",
+]
+dummy-for-ci-check = ["conformance", "metrics"]
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-program-runtime/frozen-abi",
+]
+metrics = [
+  "solana-bpf-loader-program/metrics",
+  "solana-program-runtime/metrics",
+]
+shuttle-test = [
+  "dep:shuttle",
+  "solana-bpf-loader-program/shuttle-test",
+  "solana-program-runtime/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = ["dep:qualifier_attr"]
 
 [lints]
 workspace = true

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -23,50 +23,50 @@ name = "solana_svm"
 default = ["metrics"]
 agave-unstable-api = []
 conformance = [
-    "dep:agave-precompiles",
-    "dep:prost",
-    "dep:protosol",
-    "dep:solana-poseidon",
-    "dep:solana-signature",
-    "dep:solana-transaction",
-    "dep:solana-vote-program",
-    "dep:solana-zk-elgamal-proof-program",
-    "dep:xxhash-rust",
-    "dev-context-only-utils",
-    "solana-instruction-error/serde",
-    "solana-pubkey/default",
-    "solana-transaction-error/serde",
+  "dep:agave-precompiles",
+  "dep:prost",
+  "dep:protosol",
+  "dep:solana-poseidon",
+  "dep:solana-signature",
+  "dep:solana-transaction",
+  "dep:solana-vote-program",
+  "dep:solana-zk-elgamal-proof-program",
+  "dep:xxhash-rust",
+  "dev-context-only-utils",
+  "solana-instruction-error/serde",
+  "solana-pubkey/default",
+  "solana-transaction-error/serde",
 ]
 dev-context-only-utils = [
-    "dep:agave-feature-set",
-    "dep:qualifier_attr",
-    "dep:solana-address-lookup-table-interface",
-    "dep:solana-bpf-loader-program",
-    "dep:solana-compute-budget",
-    "dep:solana-compute-budget-instruction",
-    "dep:solana-compute-budget-program",
-    "dep:solana-instruction-error",
-    "dep:solana-precompile-error",
-    "dep:solana-slot-hashes",
-    "dep:solana-syscalls",
-    "dep:solana-system-program",
-    "solana-program-runtime/dev-context-only-utils",
+  "dep:agave-feature-set",
+  "dep:qualifier_attr",
+  "dep:solana-address-lookup-table-interface",
+  "dep:solana-bpf-loader-program",
+  "dep:solana-compute-budget",
+  "dep:solana-compute-budget-instruction",
+  "dep:solana-compute-budget-program",
+  "dep:solana-instruction-error",
+  "dep:solana-precompile-error",
+  "dep:solana-slot-hashes",
+  "dep:solana-syscalls",
+  "dep:solana-system-program",
+  "solana-program-runtime/dev-context-only-utils",
 ]
 dummy-for-ci-check = ["conformance", "metrics"]
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-program-runtime/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-program-runtime/frozen-abi",
 ]
 metrics = [
-    "solana-bpf-loader-program/metrics",
-    "solana-program-runtime/metrics",
+  "solana-bpf-loader-program/metrics",
+  "solana-program-runtime/metrics",
 ]
 shuttle-test = [
-    "dep:shuttle",
-    "solana-bpf-loader-program/shuttle-test",
-    "solana-program-runtime/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
+  "dep:shuttle",
+  "solana-bpf-loader-program/shuttle-test",
+  "solana-program-runtime/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
 ]
 svm-internal = ["dep:qualifier_attr"]
 
@@ -83,8 +83,8 @@ serde = { workspace = true, features = ["rc"] }
 shuttle = { workspace = true, optional = true }
 solana-account = { workspace = true, features = ["wincode"] }
 solana-address-lookup-table-interface = { workspace = true, optional = true, features = [
-    "bincode",
-    "bytemuck",
+  "bincode",
+  "bytemuck",
 ] }
 solana-bpf-loader-program = { workspace = true, optional = true }
 solana-clock = { workspace = true }
@@ -93,10 +93,10 @@ solana-compute-budget-instruction = { workspace = true, optional = true }
 solana-compute-budget-program = { workspace = true, optional = true }
 solana-fee-structure = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
@@ -116,7 +116,9 @@ solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, optional = true }
-solana-slot-hashes = { workspace = true, optional = true, features = ["wincode"] }
+solana-slot-hashes = { workspace = true, optional = true, features = [
+  "wincode",
+] }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
@@ -143,30 +145,51 @@ env_logger = { workspace = true }
 libsecp256k1 = { workspace = true }
 rand = { workspace = true }
 solana-account = { workspace = true, features = ["bincode"] }
-solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { path = "../programs/bpf_loader", default-features = false, features = [
+  "agave-unstable-api",
+] }
 solana-clock = { workspace = true }
-solana-compute-budget = { path = "../compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget = { path = "../compute-budget", features = [
+  "agave-unstable-api",
+] }
 solana-compute-budget-interface = { workspace = true }
-solana-compute-budget-program = { path = "../programs/compute-budget", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { path = "../programs/compute-budget", features = [
+  "agave-unstable-api",
+] }
 solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-keypair = { workspace = true }
 solana-native-token = { workspace = true }
 solana-precompile-error = { workspace = true }
-solana-program-binaries = { path = "../program-binaries", features = ["agave-unstable-api"] }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-binaries = { path = "../program-binaries", features = [
+  "agave-unstable-api",
+] }
+solana-program-runtime = { path = "../program-runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-rent = { workspace = true }
 solana-sbpf = { workspace = true, features = ["jit"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
-solana-svm = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils", "svm-internal"] }
+solana-svm = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+  "svm-internal",
+] }
 solana-syscalls = { path = "../syscalls", features = ["agave-unstable-api"] }
-solana-system-program = { path = "../programs/system", features = ["agave-unstable-api"] }
+solana-system-program = { path = "../programs/system", features = [
+  "agave-unstable-api",
+] }
 solana-system-transaction = { workspace = true }
 solana-sysvar = { workspace = true, features = ["wincode"] }
 solana-transaction = { workspace = true, features = ["dev-context-only-utils"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
+] }
 spl-token-interface = { workspace = true }
 test-case = { workspace = true }
 wincode = { workspace = true }

--- a/svm/tests/example-programs/clock-sysvar/Cargo.toml
+++ b/svm/tests/example-programs/clock-sysvar/Cargo.toml
@@ -3,9 +3,9 @@ name = "clock-sysvar-program"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/svm/tests/example-programs/complex-transfer/Cargo.toml
+++ b/svm/tests/example-programs/complex-transfer/Cargo.toml
@@ -3,9 +3,9 @@ name = "complex-transfer-program"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/svm/tests/example-programs/hello-solana/Cargo.toml
+++ b/svm/tests/example-programs/hello-solana/Cargo.toml
@@ -3,9 +3,9 @@ name = "hello-solana-program"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/svm/tests/example-programs/simple-transfer/Cargo.toml
+++ b/svm/tests/example-programs/simple-transfer/Cargo.toml
@@ -3,9 +3,9 @@ name = "simple-transfer-program"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/svm/tests/example-programs/transfer-from-account/Cargo.toml
+++ b/svm/tests/example-programs/transfer-from-account/Cargo.toml
@@ -3,9 +3,9 @@ name = "transfer-from-account"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/svm/tests/example-programs/write-to-account/Cargo.toml
+++ b/svm/tests/example-programs/write-to-account/Cargo.toml
@@ -3,9 +3,9 @@ name = "write-to-account"
 version = "4.4.0-alpha.2"
 edition = "2021"
 
-[dependencies]
+[workspace]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[workspace]
+[dependencies]

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -1,30 +1,19 @@
 [package]
 name = "solana-syscalls"
-description = "Solana syscalls."
-documentation = "https://docs.rs/solana-syscalls"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana syscalls."
+documentation = "https://docs.rs/solana-syscalls"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["metrics"]
-agave-unstable-api = []
-metrics = ["solana-program-runtime/metrics"]
-shuttle-test = [
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
-]
-svm-internal = []
 
 [dependencies]
 bincode = { workspace = true }
@@ -70,13 +59,30 @@ solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = {
+  path = "../program-runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-slot-hashes = { workspace = true }
 solana-svm-callback = { path = "../svm-callback", features = ["agave-unstable-api"] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = {
+  path = "../transaction-context",
+  features = ["agave-unstable-api", "bincode", "dev-context-only-utils"]
+}
 test-case = { workspace = true }
+
+[features]
+default = ["metrics"]
+agave-unstable-api = []
+metrics = ["solana-program-runtime/metrics"]
+shuttle-test = [
+  "solana-program-runtime/shuttle-test",
+  "solana-sbpf/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
+]
+svm-internal = []
 
 [lints]
 workspace = true

--- a/syscalls/Cargo.toml
+++ b/syscalls/Cargo.toml
@@ -20,9 +20,9 @@ default = ["metrics"]
 agave-unstable-api = []
 metrics = ["solana-program-runtime/metrics"]
 shuttle-test = [
-    "solana-program-runtime/shuttle-test",
-    "solana-sbpf/shuttle-test",
-    "solana-svm-type-overrides/shuttle-test",
+  "solana-program-runtime/shuttle-test",
+  "solana-sbpf/shuttle-test",
+  "solana-svm-type-overrides/shuttle-test",
 ]
 svm-internal = []
 
@@ -70,12 +70,21 @@ solana-epoch-schedule = { workspace = true }
 solana-fee-calculator = { workspace = true }
 solana-last-restart-slot = { workspace = true }
 solana-program = { workspace = true }
-solana-program-runtime = { path = "../program-runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-program-runtime = { path = "../program-runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-slot-hashes = { workspace = true }
-solana-svm-callback = { path = "../svm-callback", features = ["agave-unstable-api"] }
+solana-svm-callback = { path = "../svm-callback", features = [
+  "agave-unstable-api",
+] }
 solana-sysvar = { workspace = true, features = ["wincode"] }
-solana-transaction-context = { path = "../transaction-context", features = ["agave-unstable-api", "bincode", "dev-context-only-utils"] }
+solana-transaction-context = { path = "../transaction-context", features = [
+  "agave-unstable-api",
+  "bincode",
+  "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 
 [lints]

--- a/syscalls/gen-syscall-list/Cargo.toml
+++ b/syscalls/gen-syscall-list/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "gen-syscall-list"
-publish = false
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-
-[features]
-agave-unstable-api = []
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+publish = false
 
 [build-dependencies]
 regex = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -2,25 +2,17 @@
 name = "solana-test-validator"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "solana-core/dev-context-only-utils",
-    "solana-ledger/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -77,6 +69,14 @@ tokio = { workspace = true, features = ["full"] }
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
 solana-test-validator = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "solana-core/dev-context-only-utils",
+  "solana-ledger/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+]
 
 [lints]
 workspace = true

--- a/test-validator/Cargo.toml
+++ b/test-validator/Cargo.toml
@@ -17,9 +17,9 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "solana-core/dev-context-only-utils",
-    "solana-ledger/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
+  "solana-core/dev-context-only-utils",
+  "solana-ledger/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
 ]
 
 [dependencies]
@@ -76,7 +76,10 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-sdk-ids = { workspace = true }
-solana-test-validator = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/tls-utils/Cargo.toml
+++ b/tls-utils/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-tls-utils"
-description = "Solana TLS utilities"
-documentation = "https://docs.rs/solana-tls-utils"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana TLS utilities"
+documentation = "https://docs.rs/solana-tls-utils"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 quinn = { workspace = true }
@@ -25,6 +22,9 @@ rustls-webpki = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-tokens"
-documentation = "https://docs.rs/solana-tokens"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-tokens"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -17,12 +17,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 # (hidraw) backend plus the unstable API.
 features = ["agave-unstable-api"]
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["remote-wallet-hidraw"]
-agave-unstable-api = []
-remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
-remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 chrono = { workspace = true, features = ["default", "serde"] }
@@ -70,8 +64,17 @@ thiserror = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = {
+  path = "../test-validator",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-transaction-error = { workspace = true }
+
+[features]
+default = ["remote-wallet-hidraw"]
+agave-unstable-api = []
+remote-wallet-hidraw = ["solana-remote-wallet/linux-static-hidraw"]
+remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [lints]
 workspace = true

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -26,7 +26,9 @@ remote-wallet-libusb = ["solana-remote-wallet/linux-static-libusb"]
 
 [dependencies]
 chrono = { workspace = true, features = ["default", "serde"] }
-clap = { version = "2.33.0", default-features = false, features = ["suggestions"] }
+clap = { version = "2.33.0", default-features = false, features = [
+  "suggestions",
+] }
 console = { workspace = true }
 csv = { workspace = true }
 ctrlc = { workspace = true, features = ["termination"] }
@@ -70,7 +72,10 @@ thiserror = { workspace = true }
 agave-logger = { path = "../logger", features = ["agave-unstable-api"] }
 assert_matches = { workspace = true }
 bincode = { workspace = true }
-solana-test-validator = { path = "../test-validator", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-test-validator = { path = "../test-validator", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-transaction-error = { workspace = true }
 
 [lints]

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,4 @@
+toml-version = "v1.1.0"
+
+[format.rules]
+line-width = 100

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -1,25 +1,18 @@
 [package]
 name = "solana-tpu-client-next"
-description = "Client code to send transaction to TPU."
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Client code to send transaction to TPU."
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-metrics = ["dep:solana-metrics"]
-tracing = ["dep:tracing"]
-websocket-node-address-service = ["dep:solana-pubsub-client", "dep:tokio-stream"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -59,8 +52,21 @@ solana-commitment-config = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-tpu-client-next = { path = ".", features = ["agave-unstable-api", "websocket-node-address-service", "dev-context-only-utils"] }
+solana-streamer = {
+  path = "../streamer",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+solana-tpu-client-next = {
+  path = ".",
+  features = ["agave-unstable-api", "dev-context-only-utils", "websocket-node-address-service"]
+}
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+metrics = ["dep:solana-metrics"]
+tracing = ["dep:tracing"]
+websocket-node-address-service = ["dep:solana-pubsub-client", "dep:tokio-stream"]
 
 [lints]
 workspace = true

--- a/tpu-client-next/Cargo.toml
+++ b/tpu-client-next/Cargo.toml
@@ -19,7 +19,10 @@ agave-unstable-api = []
 dev-context-only-utils = []
 metrics = ["dep:solana-metrics"]
 tracing = ["dep:tracing"]
-websocket-node-address-service = ["dep:solana-pubsub-client", "dep:tokio-stream"]
+websocket-node-address-service = [
+  "dep:solana-pubsub-client",
+  "dep:tokio-stream",
+]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -58,8 +61,15 @@ solana-commitment-config = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-pubkey = { workspace = true }
 solana-signer = { workspace = true }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-tpu-client-next = { path = ".", features = ["agave-unstable-api", "websocket-node-address-service", "dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-tpu-client-next = { path = ".", features = [
+  "agave-unstable-api",
+  "websocket-node-address-service",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/tpu-client/Cargo.toml
+++ b/tpu-client/Cargo.toml
@@ -1,26 +1,19 @@
 [package]
 name = "solana-tpu-client"
-description = "Solana TPU Client"
-documentation = "https://docs.rs/solana-tpu-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana TPU Client"
+documentation = "https://docs.rs/solana-tpu-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-default = ["spinner"]
-agave-unstable-api = []
-# Support tpu-client methods that feature a spinner progress bar for
-# command-line interfaces
-spinner = ["dep:indicatif", "dep:solana-message", "solana-rpc-client/spinner"]
 
 [dependencies]
 futures-util = { workspace = true }
@@ -45,6 +38,13 @@ solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 wincode = { workspace = true }
+
+[features]
+default = ["spinner"]
+agave-unstable-api = []
+# Support tpu-client methods that feature a spinner progress bar for
+# command-line interfaces
+spinner = ["dep:indicatif", "dep:solana-message", "solana-rpc-client/spinner"]
 
 [lints]
 workspace = true

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -1,26 +1,19 @@
 [package]
 name = "solana-transaction-context"
-description = "Solana data shared between program runtime and built-in programs as well as SBF programs."
-documentation = "https://docs.rs/solana-transaction-context"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana data shared between program runtime and built-in programs as well as SBF programs."
+documentation = "https://docs.rs/solana-transaction-context"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-bincode = ["dep:bincode", "serde"]
-dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
-serde = ["serde/derive", "solana-pubkey/serde"]
-wincode = ["dep:wincode", "solana-pubkey/wincode"]
 
 [dependencies]
 solana-account = { workspace = true }
@@ -28,6 +21,20 @@ solana-instruction = { workspace = true, features = ["std"] }
 solana-instructions-sysvar = { workspace = true }
 solana-pubkey = { workspace = true }
 wincode = { workspace = true, optional = true }
+
+[dev-dependencies]
+solana-account-info = { workspace = true }
+solana-program-entrypoint = { workspace = true }
+solana-pubkey = { workspace = true, features = ["rand"] }
+solana-system-interface = { workspace = true }
+solana-transaction-context = {
+  path = ".",
+  features = [
+    "agave-unstable-api",
+    "dev-context-only-utils",
+  ]
+}
+static_assertions = { workspace = true }
 
 [target.'cfg(not(any(target_arch = "sbf", target_arch = "bpf")))'.dependencies]
 bincode = { workspace = true, optional = true }
@@ -38,16 +45,12 @@ solana-sbpf = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-signature = { workspace = true, optional = true }
 
-[dev-dependencies]
-solana-account-info = { workspace = true }
-solana-program-entrypoint = { workspace = true }
-solana-pubkey = { workspace = true, features = ["rand"] }
-solana-system-interface = { workspace = true }
-solana-transaction-context = { path = ".", features = [
-    "agave-unstable-api",
-    "dev-context-only-utils",
-] }
-static_assertions = { workspace = true }
+[features]
+agave-unstable-api = []
+bincode = ["dep:bincode", "serde"]
+dev-context-only-utils = ["bincode", "dep:qualifier_attr"]
+serde = ["serde/derive", "solana-pubkey/serde"]
+wincode = ["dep:wincode", "solana-pubkey/wincode"]
 
 [lints]
 workspace = true

--- a/transaction-context/Cargo.toml
+++ b/transaction-context/Cargo.toml
@@ -44,8 +44,8 @@ solana-program-entrypoint = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-system-interface = { workspace = true }
 solana-transaction-context = { path = ".", features = [
-    "agave-unstable-api",
-    "dev-context-only-utils",
+  "agave-unstable-api",
+  "dev-context-only-utils",
 ] }
 static_assertions = { workspace = true }
 

--- a/transaction-status-client-types/Cargo.toml
+++ b/transaction-status-client-types/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-transaction-status-client-types"
-description = "Core RPC client types for solana-transaction-status"
-documentation = "https://docs.rs/solana-transaction-status-client-types"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Core RPC client types for solana-transaction-status"
+documentation = "https://docs.rs/solana-transaction-status-client-types"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 base64 = { workspace = true }
@@ -38,6 +35,9 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -1,22 +1,23 @@
 [package]
 name = "solana-transaction-status"
-description = "Solana transaction status types"
-documentation = "https://docs.rs/solana-transaction-status"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana transaction status types"
+documentation = "https://docs.rs/solana-transaction-status"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "extract_memos"
 
 [dependencies]
 Inflector = { workspace = true }
@@ -64,9 +65,8 @@ solana-pubkey = { workspace = true, features = ["rand"] }
 solana-transaction-status = { path = ".", features = ["agave-unstable-api"] }
 spl-token-confidential-transfer-proof-extraction = { workspace = true }
 
-[[bench]]
-name = "extract_memos"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/transaction-status/Cargo.toml
+++ b/transaction-status/Cargo.toml
@@ -48,7 +48,9 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-vote-interface = { workspace = true }
 solana-zk-sdk-pod = { workspace = true }
-spl-associated-token-account-interface = { workspace = true, features = ["borsh"] }
+spl-associated-token-account-interface = { workspace = true, features = [
+  "borsh",
+] }
 spl-memo-interface = { workspace = true }
 spl-token-2022-interface = { workspace = true }
 spl-token-group-interface = { workspace = true }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -1,22 +1,27 @@
 [package]
 name = "solana-turbine"
-documentation = "https://docs.rs/solana-turbine"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/solana-turbine"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
+[[bench]]
+harness = false
+name = "cluster_info"
+
+[[bench]]
+harness = false
+name = "cluster_nodes"
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -69,19 +74,17 @@ bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }
 solana-turbine = { path = ".", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
 
-[[bench]]
-name = "cluster_info"
-harness = false
-
-[[bench]]
-name = "cluster_nodes"
-harness = false
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -62,14 +62,25 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 agave-logger = { workspace = true }
-agave-votor-messages = { path = "../votor-messages", features = ["dev-context-only-utils"] }
+agave-votor-messages = { path = "../votor-messages", features = [
+  "dev-context-only-utils",
+] }
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
 solana-genesis-config = { workspace = true }
-solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-gossip = { path = "../gossip", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-ledger = { path = "../ledger", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }
 solana-turbine = { path = ".", features = ["agave-unstable-api"] }

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -1,23 +1,19 @@
 [package]
 name = "solana-udp-client"
-description = "Solana UDP Client"
-documentation = "https://docs.rs/solana-udp-client"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana UDP Client"
+documentation = "https://docs.rs/solana-udp-client"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
 
 [dependencies]
 async-trait = { workspace = true }
@@ -28,9 +24,19 @@ solana-streamer = { workspace = true }
 solana-transaction-error = { workspace = true }
 
 [dev-dependencies]
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = {
+  path = "../net-utils",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-packet = { workspace = true }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-streamer = {
+  path = "../streamer",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/udp-client/Cargo.toml
+++ b/udp-client/Cargo.toml
@@ -28,9 +28,15 @@ solana-streamer = { workspace = true }
 solana-transaction-error = { workspace = true }
 
 [dev-dependencies]
-solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-net-utils = { path = "../net-utils", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-packet = { workspace = true }
-solana-streamer = { path = "../streamer", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-streamer = { path = "../streamer", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [lints]
 workspace = true

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "solana-unified-scheduler-logic"
-description = "The Solana unified scheduler logic"
-documentation = "https://docs.rs/solana-unified-scheduler-logic"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The Solana unified scheduler logic"
+documentation = "https://docs.rs/solana-unified-scheduler-logic"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 assert_matches = { workspace = true }
@@ -33,11 +30,17 @@ bytes = { workspace = true }
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = {
+  path = "../runtime-transaction",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
 test-case = { workspace = true }
 wincode = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -34,7 +34,10 @@ static_assertions = { workspace = true }
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
-solana-runtime-transaction = { path = "../runtime-transaction", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime-transaction = { path = "../runtime-transaction", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-signature = { workspace = true }
 solana-transaction = { workspace = true, features = ["wincode"] }
 test-case = { workspace = true }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -1,31 +1,27 @@
 [package]
 name = "solana-unified-scheduler-pool"
-description = "The Solana unified scheduler pool"
-documentation = "https://docs.rs/solana-unified-scheduler-pool"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "The Solana unified scheduler pool"
+documentation = "https://docs.rs/solana-unified-scheduler-pool"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
-
 [dependencies]
 agave-banking-stage-ingress-types = { workspace = true }
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
-derive-where = { workspace = true }
 derive_more = { workspace = true }
+derive-where = { workspace = true }
 log = { workspace = true }
 scopeguard = { workspace = true }
 solana-clock = { workspace = true }
@@ -48,10 +44,20 @@ solana-clock = { workspace = true }
 solana-entry = { path = "../entry", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-system-transaction = { workspace = true }
-solana-unified-scheduler-pool = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = {
+  path = ".",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 test-case = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = ["solana-runtime/dev-context-only-utils"]
 
 [lints]
 workspace = true

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -49,9 +49,15 @@ solana-clock = { workspace = true }
 solana-entry = { path = "../entry", features = ["agave-unstable-api"] }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-system-transaction = { workspace = true }
-solana-unified-scheduler-pool = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-unified-scheduler-pool = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 test-case = { workspace = true }
 
 [lints]

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -1,24 +1,21 @@
 [package]
 name = "agave-validator"
-readme = "../README.md"
-documentation = "https://docs.rs/agave-validator"
-default-run = "agave-validator"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/agave-validator"
+readme = "../README.md"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+default-run = "agave-validator"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-cpu-utils = { workspace = true }
@@ -99,15 +96,6 @@ symlink = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
-[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
-jemallocator = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-caps = { workspace = true }
-
-[target."cfg(unix)".dependencies]
-libc = { workspace = true }
-
 [dev-dependencies]
 assert_cmd = { workspace = true }
 assert_matches = { workspace = true }
@@ -118,10 +106,25 @@ solana-account-decoder = { path = "../account-decoder", features = ["agave-unsta
 solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dependencies]
+jemallocator = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = { workspace = true }
+
+[target."cfg(unix)".dependencies]
+libc = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -114,11 +114,19 @@ assert_matches = { workspace = true }
 predicates = { workspace = true }
 pretty_assertions = { workspace = true }
 scopeguard = { workspace = true }
-solana-account-decoder = { path = "../account-decoder", features = ["agave-unstable-api"] }
-solana-core = { path = "../core", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-account-decoder = { path = "../account-decoder", features = [
+  "agave-unstable-api",
+] }
+solana-core = { path = "../core", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-program-option = { workspace = true }
 solana-program-pack = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 solana-time-utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-version"
-description = "Solana Version"
-documentation = "https://docs.rs/solana-version"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana Version"
+documentation = "https://docs.rs/solana-version"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -18,22 +18,25 @@ rustdoc-args = ["--cfg=docsrs"]
 [lib]
 name = "solana_version"
 
-[features]
-agave-unstable-api = []
-dummy-for-ci-check = []
-frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
-
 [dependencies]
 agave-feature-set = { workspace = true }
 rand = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-sanitize = { workspace = true }
 solana-serde-varint = { workspace = true }
 solana-wincode-varint = { workspace = true }
@@ -41,6 +44,11 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 bincode = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dummy-for-ci-check = []
+frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 
 [lints]
 workspace = true

--- a/version/Cargo.toml
+++ b/version/Cargo.toml
@@ -29,10 +29,10 @@ rand = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-sanitize = { workspace = true }
 solana-serde-varint = { workspace = true }

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "solana-vote"
-description = "Solana vote"
-documentation = "https://docs.rs/solana-vote"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Solana vote"
+documentation = "https://docs.rs/solana-vote"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -19,24 +19,9 @@ rustdoc-args = ["--cfg=docsrs"]
 crate-type = ["lib"]
 name = "solana_vote"
 
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:rand",
-    "dep:bincode",
-    "dep:solana-bls-signatures",
-    "solana-bls-signatures/solana-signer-derive",
-]
-frozen-abi = [
-    "dep:solana-bls-signatures",
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-account/frozen-abi",
-    "solana-bls-signatures/solana-signer-derive",
-    "solana-pubkey/frozen-abi",
-    "solana-vote-interface/frozen-abi",
-]
+[[bench]]
+harness = false
+name = "vote_account"
 
 [dependencies]
 bincode = { workspace = true, optional = true }
@@ -48,12 +33,20 @@ solana-account = { workspace = true, features = ["serde", "wincode"] }
 solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-hash = { workspace = true, features = ["copy"] }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
@@ -78,13 +71,28 @@ solana-keypair = { workspace = true }
 solana-sha256-hasher = { workspace = true, features = ["sha2"] }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-transaction = { workspace = true, features = ["wincode", "dev-context-only-utils"] }
+solana-transaction = { workspace = true, features = ["dev-context-only-utils", "wincode"] }
 solana-vote = { path = ".", features = ["agave-unstable-api"] }
 solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
 
-[[bench]]
-name = "vote_account"
-harness = false
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "dep:bincode",
+  "dep:qualifier_attr",
+  "dep:rand",
+  "dep:solana-bls-signatures",
+  "solana-bls-signatures/solana-signer-derive",
+]
+frozen-abi = [
+  "dep:solana-bls-signatures",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-account/frozen-abi",
+  "solana-bls-signatures/solana-signer-derive",
+  "solana-pubkey/frozen-abi",
+  "solana-vote-interface/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/vote/Cargo.toml
+++ b/vote/Cargo.toml
@@ -22,20 +22,20 @@ name = "solana_vote"
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "dep:qualifier_attr",
-    "dep:rand",
-    "dep:bincode",
-    "dep:solana-bls-signatures",
-    "solana-bls-signatures/solana-signer-derive",
+  "dep:qualifier_attr",
+  "dep:rand",
+  "dep:bincode",
+  "dep:solana-bls-signatures",
+  "solana-bls-signatures/solana-signer-derive",
 ]
 frozen-abi = [
-    "dep:solana-bls-signatures",
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-account/frozen-abi",
-    "solana-bls-signatures/solana-signer-derive",
-    "solana-pubkey/frozen-abi",
-    "solana-vote-interface/frozen-abi",
+  "dep:solana-bls-signatures",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-account/frozen-abi",
+  "solana-bls-signatures/solana-signer-derive",
+  "solana-pubkey/frozen-abi",
+  "solana-vote-interface/frozen-abi",
 ]
 
 [dependencies]
@@ -49,10 +49,10 @@ solana-bincode = { workspace = true }
 solana-bls-signatures = { workspace = true, optional = true }
 solana-clock = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-hash = { workspace = true, features = ["copy"] }
 solana-instruction = { workspace = true }
@@ -78,9 +78,15 @@ solana-keypair = { workspace = true }
 solana-sha256-hasher = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-transaction = { workspace = true }
-solana-transaction = { workspace = true, features = ["wincode", "dev-context-only-utils"] }
+solana-transaction = { workspace = true, features = [
+  "wincode",
+  "dev-context-only-utils",
+] }
 solana-vote = { path = ".", features = ["agave-unstable-api"] }
-solana-vote-interface = { workspace = true, features = ["bincode", "dev-context-only-utils"] }
+solana-vote-interface = { workspace = true, features = [
+  "bincode",
+  "dev-context-only-utils",
+] }
 
 [[bench]]
 name = "vote_account"

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -1,29 +1,19 @@
 [package]
 name = "agave-votor-messages"
-documentation = "https://docs.rs/agave-votor-messages"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/agave-votor-messages"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-hash/frozen-abi",
-    "solana-bls-signatures/frozen-abi",
-]
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -33,25 +23,46 @@ log = { workspace = true }
 serde = { workspace = true }
 smallvec = { workspace = true }
 solana-address = { workspace = true, features = ["curve25519"] }
-solana-bls-signatures = { workspace = true, features = [
+solana-bls-signatures = {
+  workspace = true,
+  features = [
     "bytemuck",
     "solana-signer-derive",
-] }
+  ]
+}
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode", "atomic"] }
+  ],
+  optional = true
+}
+solana-hash = { workspace = true, features = ["atomic", "copy", "decode", "serde", "wincode"] }
 solana-leader-schedule = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-short-vec = { workspace = true, features = ["wincode"] }
 solana-signer-store = { workspace = true }
 thiserror = { workspace = true }
 wincode = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
+frozen-abi = [
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-bls-signatures/frozen-abi",
+  "solana-hash/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/votor-messages/Cargo.toml
+++ b/votor-messages/Cargo.toml
@@ -19,10 +19,10 @@ rustdoc-args = ["--cfg=docsrs"]
 agave-unstable-api = []
 dev-context-only-utils = []
 frozen-abi = [
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-hash/frozen-abi",
-    "solana-bls-signatures/frozen-abi",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-hash/frozen-abi",
+  "solana-bls-signatures/frozen-abi",
 ]
 
 [dependencies]
@@ -34,18 +34,24 @@ serde = { workspace = true }
 smallvec = { workspace = true }
 solana-address = { workspace = true, features = ["curve25519"] }
 solana-bls-signatures = { workspace = true, features = [
-    "bytemuck",
-    "solana-signer-derive",
+  "bytemuck",
+  "solana-signer-derive",
 ] }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
-solana-hash = { workspace = true, features = ["serde", "copy", "decode", "wincode", "atomic"] }
+solana-hash = { workspace = true, features = [
+  "serde",
+  "copy",
+  "decode",
+  "wincode",
+  "atomic",
+] }
 solana-leader-schedule = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-short-vec = { workspace = true, features = ["wincode"] }

--- a/votor-transport/Cargo.toml
+++ b/votor-transport/Cargo.toml
@@ -1,19 +1,15 @@
 [package]
 name = "agave-votor-transport"
-description = "QUIC datagram transport for Solana consensus traffic"
-documentation = "https://docs.rs/agave-votor-transport"
 version = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
+description = "QUIC datagram transport for Solana consensus traffic"
+documentation = "https://docs.rs/agave-votor-transport"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [lib]
-
-[features]
-dev-context-only-utils = []
-agave-unstable-api = []
 
 [dependencies]
 arrayvec = { workspace = true }
@@ -28,7 +24,7 @@ solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-tls-utils = { workspace = true, features = ["agave-unstable-api"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
@@ -36,6 +32,10 @@ quinn-proto = "0.11"
 solana-keypair = { workspace = true }
 solana-net-utils = { workspace = true, features = ["dev-context-only-utils"] }
 tokio = { workspace = true, features = ["full"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/votor-transport/Cargo.toml
+++ b/votor-transport/Cargo.toml
@@ -28,7 +28,12 @@ solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true, features = ["rand"] }
 solana-tls-utils = { workspace = true, features = ["agave-unstable-api"] }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { workspace = true, features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "time",
+] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -1,37 +1,19 @@
 [package]
 name = "agave-votor"
-documentation = "https://docs.rs/agave-votor"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/agave-votor"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = [
-    "agave-bls-sigverify/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
-]
-frozen-abi = [
-    "dep:serde",
-    "dep:serde_bytes",
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-ledger/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-signature/frozen-abi",
-    "agave-votor-messages/frozen-abi",
-]
 
 [dependencies]
 agave-bls-sigverify = { workspace = true }
@@ -52,12 +34,20 @@ smallvec = { workspace = true }
 solana-bls-signatures = { workspace = true, features = ["solana-signer-derive"] }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
-solana-frozen-abi = { workspace = true, optional = true, features = [
+solana-frozen-abi = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
-solana-frozen-abi-macro = { workspace = true, optional = true, features = [
+  ],
+  optional = true
+}
+solana-frozen-abi-macro = {
+  workspace = true,
+  features = [
     "frozen-abi",
-] }
+  ],
+  optional = true
+}
 solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
 solana-keypair = { workspace = true }
@@ -77,7 +67,7 @@ solana-tls-utils = { workspace = true, features = ["agave-unstable-api"] }
 solana-transaction = { workspace = true }
 solana-validator-exit = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
 wincode = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
@@ -86,10 +76,31 @@ agave-votor-transport = { workspace = true, features = ["dev-context-only-utils"
 rand = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-perf = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = {
+  path = "../runtime",
+  features = ["agave-unstable-api", "dev-context-only-utils"]
+}
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio-util = { workspace = true }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = [
+  "agave-bls-sigverify/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
+]
+frozen-abi = [
+  "agave-votor-messages/frozen-abi",
+  "dep:serde",
+  "dep:serde_bytes",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-ledger/frozen-abi",
+  "solana-runtime/frozen-abi",
+  "solana-signature/frozen-abi",
+]
 
 [lints]
 workspace = true

--- a/votor/Cargo.toml
+++ b/votor/Cargo.toml
@@ -18,19 +18,19 @@ rustdoc-args = ["--cfg=docsrs"]
 [features]
 agave-unstable-api = []
 dev-context-only-utils = [
-    "agave-bls-sigverify/dev-context-only-utils",
-    "agave-votor-messages/dev-context-only-utils",
-    "solana-runtime/dev-context-only-utils",
+  "agave-bls-sigverify/dev-context-only-utils",
+  "agave-votor-messages/dev-context-only-utils",
+  "solana-runtime/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dep:serde",
-    "dep:serde_bytes",
-    "dep:solana-frozen-abi",
-    "dep:solana-frozen-abi-macro",
-    "solana-ledger/frozen-abi",
-    "solana-runtime/frozen-abi",
-    "solana-signature/frozen-abi",
-    "agave-votor-messages/frozen-abi",
+  "dep:serde",
+  "dep:serde_bytes",
+  "dep:solana-frozen-abi",
+  "dep:solana-frozen-abi-macro",
+  "solana-ledger/frozen-abi",
+  "solana-runtime/frozen-abi",
+  "solana-signature/frozen-abi",
+  "agave-votor-messages/frozen-abi",
 ]
 
 [dependencies]
@@ -49,14 +49,16 @@ parking_lot = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
 smallvec = { workspace = true }
-solana-bls-signatures = { workspace = true, features = ["solana-signer-derive"] }
+solana-bls-signatures = { workspace = true, features = [
+  "solana-signer-derive",
+] }
 solana-clock = { workspace = true }
 solana-epoch-schedule = { workspace = true }
 solana-frozen-abi = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-frozen-abi-macro = { workspace = true, optional = true, features = [
-    "frozen-abi",
+  "frozen-abi",
 ] }
 solana-gossip = { workspace = true }
 solana-hash = { workspace = true }
@@ -82,11 +84,16 @@ wincode = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
 agave-votor = { path = ".", features = ["dev-context-only-utils"] }
-agave-votor-transport = { workspace = true, features = ["dev-context-only-utils"] }
+agave-votor-transport = { workspace = true, features = [
+  "dev-context-only-utils",
+] }
 rand = { workspace = true }
 solana-net-utils = { path = "../net-utils", features = ["agave-unstable-api"] }
 solana-perf = { workspace = true }
-solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-runtime = { path = "../runtime", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio-util = { workspace = true }

--- a/watchtower/Cargo.toml
+++ b/watchtower/Cargo.toml
@@ -1,22 +1,19 @@
 [package]
 name = "agave-watchtower"
-documentation = "https://docs.rs/agave-watchtower"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = { workspace = true }
+documentation = "https://docs.rs/agave-watchtower"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
 
 [dependencies]
 agave-feature-set = { workspace = true }
@@ -36,6 +33,9 @@ solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-interface = { workspace = true }
+
+[features]
+agave-unstable-api = []
 
 [lints]
 workspace = true

--- a/xdp-ebpf/Cargo.toml
+++ b/xdp-ebpf/Cargo.toml
@@ -2,13 +2,13 @@
 name = "agave-xdp-ebpf"
 version = { workspace = true }
 authors = { workspace = true }
-description = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
-include = ["Cargo.toml", "src/**", "README", "agave-xdp-prog"]
+description = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+include = ["Cargo.toml", "README", "agave-xdp-prog", "src/**"]
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
@@ -20,12 +20,12 @@ name = "agave-xdp-prog"
 path = "src/bin/agave-xdp-prog.rs"
 required-features = ["ebpf"]
 
-[features]
-ebpf = []
-agave-unstable-api = []
-
 [target.'cfg(target_arch = "bpf")'.dependencies]
 aya-ebpf = { workspace = true }
+
+[features]
+agave-unstable-api = []
+ebpf = []
 
 [lints]
 workspace = true

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -1,44 +1,17 @@
 [package]
 name = "agave-xdp"
-description = "Agave XDP implementation"
 version = { workspace = true }
-repository = { workspace = true }
-homepage = { workspace = true }
-license = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }
+description = "Agave XDP implementation"
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 all-features = true
 rustdoc-args = ["--cfg=docsrs"]
-
-[features]
-agave-unstable-api = []
-dev-context-only-utils = []
-
-[dependencies]
-agave-cpu-utils = { workspace = true }
-arc-swap = { workspace = true }
-bytes = { workspace = true }
-crossbeam-channel = { workspace = true }
-libc = { workspace = true }
-log = { workspace = true }
-thiserror = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-agave-xdp-ebpf = { workspace = true }
-arrayvec = { workspace = true }
-aya = { workspace = true }
-caps = { workspace = true }
-crossbeam-queue = { workspace = true }
-
-[dev-dependencies]
-agave-xdp = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-aya = { workspace = true, features = ["test-helpers"] }
-nix = { workspace = true, features = ["net", "poll", "socket"] }
 
 [[test]]
 name = "netlink_snapshot"
@@ -59,6 +32,33 @@ required-features = ["agave-unstable-api"]
 name = "transmitter_smoke"
 path = "tests/transmitter_smoke.rs"
 required-features = ["agave-unstable-api"]
+
+[dependencies]
+agave-cpu-utils = { workspace = true }
+arc-swap = { workspace = true }
+bytes = { workspace = true }
+crossbeam-channel = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+agave-xdp = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+agave-xdp-ebpf = { workspace = true }
+arrayvec = { workspace = true }
+aya = { workspace = true }
+caps = { workspace = true }
+crossbeam-queue = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+aya = { workspace = true, features = ["test-helpers"] }
+nix = { workspace = true, features = ["net", "poll", "socket"] }
+
+[features]
+agave-unstable-api = []
+dev-context-only-utils = []
 
 [lints]
 workspace = true

--- a/xdp/Cargo.toml
+++ b/xdp/Cargo.toml
@@ -34,7 +34,10 @@ caps = { workspace = true }
 crossbeam-queue = { workspace = true }
 
 [dev-dependencies]
-agave-xdp = { path = ".", features = ["agave-unstable-api", "dev-context-only-utils"] }
+agave-xdp = { path = ".", features = [
+  "agave-unstable-api",
+  "dev-context-only-utils",
+] }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 aya = { workspace = true, features = ["test-helpers"] }


### PR DESCRIPTION
#### Problem
We don't have formatting of `.toml` files enforced on CI. 

See main motivation from [slack discussion:](https://anza-xyz.slack.com/archives/C08D0FL5Q4T/p1786503861159119)
> I think many of us probably have one auto-enabled via the vscode toml plugin, and have to remind ourselves to save without formatting when making any toml changes (adding/removing deps)...which is a bit annoying. It also pops up in reviews occasionally where we get unrelated toml formatting changes, and just adds an extra human step.

#### Summary of Changes
This PR adds a formatting check to toml files on CI using [tombi](https://github.com/tombi-toml/tombi).

File changes:
- install `tombi` in CI dockerfile
- replace `cargo-sort` from CI with `tombi` as `tombi` does both formatting and sorting.

#### Testing
CI