### PR TITLE
fix(ledger-tool): handle malformed transactions in nonvote-slot checks

### DIFF
--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
+ "solana-svm-transaction",
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-transaction",
@@ -246,6 +247,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "tempfile",
+ "test-case",
  "thiserror 2.0.19",
  "tikv-jemallocator",
  "tokio",
@@ -9719,6 +9721,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.4",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "test-case-core",
+]
 
 [[package]]
 name = "textwrap"

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "solana-svm-callback",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
+ "solana-svm-transaction",
  "solana-syscalls",
  "solana-system-interface 3.3.0",
  "solana-transaction",
@@ -274,6 +275,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "tempfile",
+ "test-case",
  "thiserror 2.0.20",
  "tikv-jemallocator",
  "tokio",
@@ -9506,6 +9508,39 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if 1.0.4",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "test-case-core",
+]
 
 [[package]]
 name = "textwrap"

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -152,6 +152,7 @@ solana-version = { path = "../version", version = "=4.4.0-alpha.0", features = [
 solana-vote = { path = "../vote", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.0", default-features = false, features = ["agave-unstable-api"] }
 tempfile = "3.23.0"
+test-case = "3.3.1"
 thiserror = "2.0.17"
 tokio = "1.48.0"
 wincode = { version = "0.6.1", features = ["derive"] }

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -162,6 +162,7 @@ solana-version = { path = "../version", version = "=4.4.0-alpha.3", features = [
 solana-vote = { path = "../vote", version = "=4.4.0-alpha.3", features = ["agave-unstable-api"] }
 solana-vote-program = { path = "../programs/vote", version = "=4.4.0-alpha.3", default-features = false, features = ["agave-unstable-api"] }
 tempfile = "3.23.0"
+test-case = "3.3.1"
 thiserror = "2.0.17"
 tokio = "1.48.0"
 wincode = { version = "0.6.1", features = ["derive"] }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -81,6 +81,7 @@ solana-storage-bigtable = { workspace = true }
 solana-svm-callback = { workspace = true }
 solana-svm-feature-set = { workspace = true }
 solana-svm-log-collector = { workspace = true }
+solana-svm-transaction = { workspace = true }
 solana-syscalls = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-transaction = { workspace = true }
@@ -104,6 +105,7 @@ signal-hook = { workspace = true }
 assert_cmd = { workspace = true }
 solana-bls-signatures = { workspace = true }
 tempfile = { workspace = true }
+test-case = { workspace = true }
 
 [lints]
 workspace = true

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -4,7 +4,6 @@ use {
     crate::{
         error::{LedgerToolError, Result},
         ledger_path::canonicalize_ledger_path,
-        ledger_utils::get_program_ids,
         output::{CliDuplicateSlotProof, SlotBounds, SlotInfo, output_ledger, output_slot},
     },
     chrono::{DateTime, Utc},
@@ -27,6 +26,8 @@ use {
         blockstore_options::AccessType,
         shred::Shred,
     },
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_transaction::versioned::sanitized::SanitizedVersionedTransaction,
     std::{
         borrow::Cow,
         collections::{BTreeMap, BTreeSet, HashMap},
@@ -175,8 +176,13 @@ fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
     entries
         .iter()
         .flat_map(|entry| entry.transactions.iter())
-        .flat_map(get_program_ids)
-        .any(|program_id| *program_id != solana_vote_program::id())
+        .cloned()
+        .filter_map(|tx| SanitizedVersionedTransaction::try_new(tx).ok())
+        .any(|transaction| {
+            let mut instructions = transaction.program_instructions_iter();
+
+            instructions.any(|(program_id, _)| *program_id != solana_vote_program::id())
+        })
 }
 
 type OptimisticSlotInfo = (Slot, Option<(Hash, UnixTimestamp)>, bool);
@@ -984,8 +990,72 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
 pub mod tests {
     use {
         super::*,
-        solana_ledger::{blockstore::make_many_slot_entries, get_tmp_ledger_path_auto_delete},
+        solana_entry::entry::next_versioned_entry,
+        solana_instruction::Instruction,
+        solana_ledger::{
+            blockstore::{entries_to_test_shreds, make_many_slot_entries},
+            get_tmp_ledger_path_auto_delete,
+        },
+        solana_message::{Message, VersionedMessage, v0},
+        solana_pubkey::Pubkey,
+        solana_signature::Signature,
+        solana_transaction::versioned::VersionedTransaction,
+        test_case::{test_case, test_matrix},
     };
+
+    fn new_legacy_transaction(program_id: Pubkey) -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let instructions = [Instruction::new_with_bytes(program_id, &[], vec![])];
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::Legacy(Message::new(&instructions, Some(&payer))),
+        }
+    }
+
+    fn new_v0_transaction(program_id: Pubkey) -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let instructions = [Instruction::new_with_bytes(program_id, &[], vec![])];
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V0(
+                v0::Message::try_compile(&payer, &instructions, &[], Hash::default()).unwrap(),
+            ),
+        }
+    }
+
+    #[test_case(new_legacy_transaction(solana_vote_program::id()), false)]
+    #[test_case(new_legacy_transaction(Pubkey::new_unique()), true)]
+    #[test_case(new_v0_transaction(solana_vote_program::id()), false)]
+    #[test_case(new_v0_transaction(Pubkey::new_unique()), true)]
+    fn test_slot_contains_nonvote_tx(transaction: VersionedTransaction, is_nonvote: bool) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let entry = next_versioned_entry(&Hash::default(), 1, vec![transaction]);
+        let shreds = entries_to_test_shreds(&[entry], 1, 0, true, 0);
+
+        blockstore.insert_shreds(shreds, false).unwrap();
+
+        assert_eq!(slot_contains_nonvote_tx(&blockstore, 1), is_nonvote);
+    }
+
+    #[test_matrix([
+        new_legacy_transaction(Pubkey::new_unique()),
+        new_v0_transaction(Pubkey::new_unique()),
+    ])]
+    fn test_slot_contains_nonvote_tx_ignores_unsanitized_transaction(
+        mut transaction: VersionedTransaction,
+    ) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        transaction.signatures.clear();
+
+        let entry = next_versioned_entry(&Hash::default(), 1, vec![transaction]);
+        let shreds = entries_to_test_shreds(&[entry], 1, 0, true, 0);
+
+        blockstore.insert_shreds(shreds, false).unwrap();
+
+        assert!(!slot_contains_nonvote_tx(&blockstore, 1));
+    }
 
     #[test]
     fn test_latest_optimistic_ancestors() {

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -4,7 +4,6 @@ use {
     crate::{
         error::{LedgerToolError, Result},
         ledger_path::canonicalize_ledger_path,
-        ledger_utils::get_program_ids,
         output::{CliDuplicateSlotProof, SlotBounds, SlotInfo, output_ledger, output_slot},
     },
     chrono::{DateTime, Utc},
@@ -27,6 +26,8 @@ use {
         blockstore_options::AccessType,
         shred::Shred,
     },
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_transaction::versioned::sanitized::SanitizedVersionedTransaction,
     std::{
         borrow::Cow,
         collections::{BTreeMap, BTreeSet},
@@ -175,8 +176,22 @@ fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
     entries
         .iter()
         .flat_map(|entry| entry.transactions.iter())
-        .flat_map(get_program_ids)
-        .any(|program_id| *program_id != solana_vote_program::id())
+        .cloned()
+        .enumerate()
+        .any(
+            |(transaction_index, tx)| match SanitizedVersionedTransaction::try_new(tx) {
+                Ok(transaction) => transaction
+                    .program_instructions_iter()
+                    .any(|(program_id, _)| *program_id != solana_vote_program::id()),
+                Err(err) => {
+                    error!(
+                        "Failed to sanitize transaction {transaction_index} in slot {slot}: \
+                         {err:?}"
+                    );
+                    true
+                }
+            },
+        )
 }
 
 type OptimisticSlotInfo = (Slot, Option<(Hash, UnixTimestamp)>, bool);
@@ -980,8 +995,98 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
 pub mod tests {
     use {
         super::*,
-        solana_ledger::{blockstore::make_many_slot_entries, get_tmp_ledger_path_auto_delete},
+        solana_entry::entry::next_versioned_entry,
+        solana_instruction::Instruction,
+        solana_ledger::{
+            blockstore::{entries_to_test_shreds, make_many_slot_entries},
+            get_tmp_ledger_path_auto_delete,
+        },
+        solana_message::{Message, VersionedMessage, v0},
+        solana_pubkey::Pubkey,
+        solana_signature::Signature,
+        solana_transaction::versioned::VersionedTransaction,
+        test_case::{test_case, test_matrix},
     };
+
+    fn new_legacy_transaction(program_id: Pubkey) -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let instructions = [Instruction::new_with_bytes(program_id, &[], vec![])];
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::Legacy(Message::new(&instructions, Some(&payer))),
+        }
+    }
+
+    fn new_v0_transaction(program_id: Pubkey) -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let instructions = [Instruction::new_with_bytes(program_id, &[], vec![])];
+        VersionedTransaction {
+            signatures: vec![Signature::default()],
+            message: VersionedMessage::V0(
+                v0::Message::try_compile(&payer, &instructions, &[], Hash::default()).unwrap(),
+            ),
+        }
+    }
+
+    #[test_case(new_legacy_transaction(solana_vote_program::id()), false)]
+    #[test_case(new_legacy_transaction(Pubkey::new_unique()), true)]
+    #[test_case(new_v0_transaction(solana_vote_program::id()), false)]
+    #[test_case(new_v0_transaction(Pubkey::new_unique()), true)]
+    fn test_slot_contains_nonvote_tx(transaction: VersionedTransaction, is_nonvote: bool) {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let entry = next_versioned_entry(&Hash::default(), 1, vec![transaction]);
+        let shreds = entries_to_test_shreds(&[entry], 1, 0, true, 0);
+
+        blockstore.insert_shreds(shreds, false).unwrap();
+
+        assert_eq!(slot_contains_nonvote_tx(&blockstore, 1), is_nonvote);
+    }
+
+    enum SanitizationFailure {
+        MissingSignatures,
+        InvalidProgramIdIndex,
+    }
+
+    #[test_matrix(
+        [
+            new_legacy_transaction(Pubkey::new_unique()),
+            new_v0_transaction(Pubkey::new_unique()),
+        ],
+        [SanitizationFailure::MissingSignatures, SanitizationFailure::InvalidProgramIdIndex]
+    )]
+    fn test_slot_contains_nonvote_tx_includes_unsanitized_transaction(
+        mut transaction: VersionedTransaction,
+        failure: SanitizationFailure,
+    ) {
+        match failure {
+            SanitizationFailure::MissingSignatures => transaction.signatures.clear(),
+            SanitizationFailure::InvalidProgramIdIndex => {
+                let instructions = match &mut transaction.message {
+                    VersionedMessage::Legacy(message) => &mut message.instructions,
+                    VersionedMessage::V0(message) => &mut message.instructions,
+                    VersionedMessage::V1(message) => &mut message.instructions,
+                };
+                instructions[0].program_id_index = u8::MAX;
+            }
+        }
+
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let entry = next_versioned_entry(
+            &Hash::default(),
+            1,
+            vec![
+                new_legacy_transaction(solana_vote_program::id()),
+                transaction,
+            ],
+        );
+        let shreds = entries_to_test_shreds(&[entry], 1, 0, true, 0);
+
+        blockstore.insert_shreds(shreds, false).unwrap();
+
+        assert!(slot_contains_nonvote_tx(&blockstore, 1));
+    }
 
     #[test]
     fn test_latest_optimistic_ancestors() {

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -30,7 +30,6 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         use_snapshot_archives_at_startup::UseSnapshotArchivesAtStartup,
     },
-    solana_pubkey::Pubkey,
     solana_rpc::transaction_status_service::TransactionStatusService,
     solana_runtime::{
         accounts_background_service::{
@@ -43,7 +42,6 @@ use {
         transaction_execution::TransactionStatusSender,
     },
     solana_shred_version::compute_shred_version,
-    solana_transaction::versioned::VersionedTransaction,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{
         path::{Path, PathBuf},
@@ -604,16 +602,6 @@ pub fn open_genesis_config_by(ledger_path: &Path, matches: &ArgMatches<'_>) -> G
         eprintln!("Exiting. Failed to open genesis config: {err}");
         exit(1);
     })
-}
-
-pub fn get_program_ids(tx: &VersionedTransaction) -> impl Iterator<Item = &Pubkey> + '_ {
-    let message = &tx.message;
-    let account_keys = message.static_account_keys();
-
-    message
-        .instructions()
-        .iter()
-        .map(|ix| ix.program_id(account_keys))
 }
 
 /// Get the AccessType required, based on `process_options`

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        error::{LedgerToolError, Result},
-        ledger_utils::get_program_ids,
-    },
+    crate::error::{LedgerToolError, Result},
     itertools::Either,
     pretty_hex::PrettyHex,
     serde::{
@@ -32,7 +29,10 @@ use {
     solana_pubkey::Pubkey,
     solana_runtime::bank::Bank,
     solana_signer_store::{Decoded, decode},
-    solana_transaction::versioned::VersionedTransaction,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    solana_transaction::versioned::{
+        VersionedTransaction, sanitized::SanitizedVersionedTransaction,
+    },
     solana_transaction_status::{
         BlockEncodingOptions, ConfirmedBlock, Encodable, EncodedConfirmedBlock,
         EncodedTransactionWithStatusMeta, EntrySummary, Rewards, TransactionDetails,
@@ -981,15 +981,21 @@ pub fn output_slot(
                 .map(|entry| entry.hash)
                 .unwrap_or_default();
 
-            let mut num_transactions = 0;
+            let num_transactions = block_contents.transactions().count();
             let mut program_ids = HashMap::new();
 
-            for transaction in block_contents.transactions() {
-                num_transactions += 1;
-                for program_id in get_program_ids(transaction) {
-                    *program_ids.entry(*program_id).or_insert(0) += 1;
-                }
-            }
+            block_contents
+                .transactions()
+                .cloned()
+                .filter_map(|tx| SanitizedVersionedTransaction::try_new(tx).ok())
+                .for_each(|transaction| {
+                    transaction
+                        .program_instructions_iter()
+                        .for_each(|(program_id, _)| {
+                            *program_ids.entry(*program_id).or_insert(0) += 1;
+                        });
+                });
+
             println!(
                 "  Transactions: {num_transactions}, hashes: {num_hashes}, block_hash: {blockhash}",
             );

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -1,8 +1,13 @@
 use {
+    solana_entry::entry::next_versioned_entry,
+    solana_hash::Hash,
+    solana_instruction::Instruction,
     solana_ledger::{
         blockstore, blockstore::Blockstore, create_new_tmp_ledger_auto_delete,
         genesis_utils::create_genesis_config, get_tmp_ledger_path_auto_delete,
     },
+    solana_pubkey::Pubkey,
+    solana_transaction::Transaction,
     std::{
         path::Path,
         process::{Command, Output},
@@ -12,6 +17,7 @@ use {
 fn run_ledger_tool(args: &[&str]) -> Output {
     Command::new(assert_cmd::cargo::cargo_bin!(env!("CARGO_PKG_NAME")))
         .args(args)
+        .env("RUST_LOG", "error")
         .output()
         .unwrap()
 }
@@ -86,4 +92,40 @@ fn ledger_tool_copy_test() {
         assert!(dst_slot_output.status.success());
         assert!(!src_slot_output.stdout.is_empty());
     }
+}
+
+#[test]
+fn latest_optimistic_slots_reports_sanitization_errors() {
+    let instruction = Instruction::new_with_bytes(solana_vote_program::id(), &[], vec![]);
+    let vote_transaction = Transaction::new_with_payer(&[instruction], Some(&Pubkey::new_unique()));
+    let mut malformed_transaction = vote_transaction.clone();
+    malformed_transaction.message.instructions[0].program_id_index = u8::MAX;
+
+    let ledger_path = get_tmp_ledger_path_auto_delete!();
+    let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let entry = next_versioned_entry(
+        &Hash::default(),
+        1,
+        vec![vote_transaction.into(), malformed_transaction.into()],
+    );
+    let shreds = blockstore::entries_to_test_shreds(&[entry], 1, 0, true, 0);
+    blockstore.insert_shreds(shreds, false).unwrap();
+    blockstore
+        .insert_optimistic_slot(1, &Hash::default(), 0)
+        .unwrap();
+
+    let output = run_ledger_tool(&[
+        "-l",
+        ledger_path.path().to_str().unwrap(),
+        "latest-optimistic-slots",
+        "--exclude-vote-only-slots",
+    ]);
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("Failed to sanitize transaction 1 in slot 1: IndexOutOfBounds"),
+        "{stderr}"
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("Vote Only: false"), "{stdout}");
 }


### PR DESCRIPTION
#### Problem
See comment thread for more context;
https://github.com/anza-xyz/agave/pull/14356#discussion_r3782548678

The helper `get_program_ids` could potentially panic if it received a transaction with program_id_index > static_account_keys.len().

#### Summary of Changes
- removed helper `get_program_ids`
- call sites adopted to use `SVMStaticMessage::program_instructions_iter`

#### Testing
- Added unit tests to `slot_contains_nonvote_tx`
- Added integration tests to CLI that `--latest-optimistic-slots` prints error message if a transaction is malformed.