### PR TITLE
Cleanup - Removes `ProgramCache::merge()`

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -762,22 +762,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
         }
     }
 
-    pub fn merge(
-        &mut self,
-        program_runtime_environment: &ProgramRuntimeEnvironment,
-        current_slot: Slot,
-        modified_entries: &HashMap<Pubkey, Arc<ProgramCacheEntry>>,
-    ) {
-        modified_entries.iter().for_each(|(key, entry)| {
-            self.assign_program(
-                program_runtime_environment,
-                *key,
-                current_slot,
-                entry.clone(),
-            );
-        })
-    }
-
     /// Returns the list of entries which are verified and compiled.
     pub fn get_flattened_entries(&self) -> Vec<(Pubkey, Slot, Arc<ProgramCacheEntry>)> {
         match &self.index {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4420,31 +4420,6 @@ impl Bank {
         let ((), update_stakes_cache_us) =
             measure_us!(self.update_stakes_cache(sanitized_txs, &processing_results));
 
-        let ((), update_executors_us) = measure_us!({
-            let mut cache = None;
-            for processing_result in &processing_results {
-                if let Some(ProcessedTransaction::Executed(executed_tx)) =
-                    processing_result.processed_transaction()
-                {
-                    let programs_modified_by_tx = &executed_tx.programs_modified_by_tx;
-                    if executed_tx.was_successful() && !programs_modified_by_tx.is_empty() {
-                        cache
-                            .get_or_insert_with(|| {
-                                self.transaction_processor
-                                    .global_program_cache
-                                    .write()
-                                    .unwrap()
-                            })
-                            .merge(
-                                &self.transaction_processor.program_runtime_environment,
-                                self.slot,
-                                programs_modified_by_tx,
-                            );
-                    }
-                }
-            }
-        });
-
         let accounts_data_len_delta = processing_results
             .iter()
             .filter_map(|processing_result| processing_result.processed_transaction())
@@ -4468,7 +4443,6 @@ impl Bank {
             ExecuteTimingType::UpdateStakesCacheUs,
             update_stakes_cache_us,
         );
-        timings.saturating_add_in_place(ExecuteTimingType::UpdateExecutorsUs, update_executors_us);
         timings.saturating_add_in_place(
             ExecuteTimingType::UpdateTransactionStatuses,
             update_transaction_statuses_us,

--- a/runtime/src/bank/builtins/core_bpf_migration/mod.rs
+++ b/runtime/src/bank/builtins/core_bpf_migration/mod.rs
@@ -206,18 +206,6 @@ impl Bank {
             load_program_metrics.submit_datapoint(&mut dummy_invoke_context.timings);
         }
 
-        // Update the program cache by merging with `programs_modified`, which
-        // should have been updated by the deploy function.
-        self.transaction_processor
-            .global_program_cache
-            .write()
-            .unwrap()
-            .merge(
-                &self.transaction_processor.program_runtime_environment,
-                self.slot,
-                &program_cache_for_tx_batch.drain_modified_entries(),
-            );
-
         Ok(())
     }
 

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -41,10 +41,7 @@ use {
         },
         nonce_info::NonceInfo,
         transaction_execution_result::TransactionExecutionDetails,
-        transaction_processing_result::{
-            ProcessedTransaction, TransactionProcessingResult,
-            TransactionProcessingResultExtensions,
-        },
+        transaction_processing_result::{ProcessedTransaction, TransactionProcessingResult},
         transaction_processor::{
             ExecutionRecordingConfig, LoadAndExecuteSanitizedTransactionsOutput,
             TransactionBatchProcessor, TransactionProcessingConfig,
@@ -330,26 +327,6 @@ impl SvmTestEnvironment<'_> {
         // merge new account states into the bank for multi-batch tests
         let mut mock_bank_accounts = self.mock_bank.account_shared_data.write().unwrap();
         mock_bank_accounts.extend(final_accounts_actual);
-
-        // update global program cache
-        for processing_result in batch_output.processing_results.iter() {
-            if let Some(ProcessedTransaction::Executed(executed_tx)) =
-                processing_result.processed_transaction()
-            {
-                let programs_modified_by_tx = &executed_tx.programs_modified_by_tx;
-                if executed_tx.was_successful() && !programs_modified_by_tx.is_empty() {
-                    self.batch_processor
-                        .global_program_cache
-                        .write()
-                        .unwrap()
-                        .merge(
-                            &self.batch_processor.program_runtime_environment,
-                            self.batch_processor.slot,
-                            programs_modified_by_tx,
-                        );
-                }
-            }
-        }
 
         batch_output
     }

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -3271,7 +3271,6 @@ fn program_cache_stats() {
         &[&fee_payer_keypair],
         Hash::default(),
     ));
-    noop_tx_usage += 1;
 
     test_entry.drop_expected_account(buffer_address);
 
@@ -3304,6 +3303,7 @@ fn program_cache_stats() {
     );
 
     // third batch, this creates a delayed visibility tombstone
+    let mut noop_tx_usage = 0;
     let mut test_entry = SvmTestEntry {
         initial_accounts: env.test_entry.final_accounts.clone(),
         final_accounts: env.test_entry.final_accounts.clone(),


### PR DESCRIPTION
#### Problem
With #14630 the loader uplink to the **global** program cache won't be necessary anymore.
However, the loader uplink to the **local** program cache is still needed for updates inside the same TX and the same TX batch.

The only downside this has is that the usage statistics are reset implicitly on redeployments.

#### Summary of Changes

- Removes `ProgramCache::merge()`.
- Deletes the callsite in `Bank::commit_transactions()`.
- Deletes the callsite in `Bank::directly_invoke_loader_v3_deploy()`.

#### Testing

- Deletes the callsite in `SvmTestEnvironment::execute()`.
- Adjusts `program_cache_stats()`.

524:30:03 (21 days) of replay against mainnet-beta.