### PR TITLE
Replace Rayon shred sigverify with dedicated workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11319,6 +11319,7 @@ dependencies = [
  "bencher",
  "bs58",
  "bytes",
+ "clap 2.33.3",
  "crossbeam-channel",
  "itertools 0.15.0",
  "lazy-lru",
@@ -11327,6 +11328,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
+ "scopeguard",
  "solana-clock",
  "solana-cluster-type",
  "solana-cost-model",
@@ -11344,6 +11346,7 @@ dependencies = [
  "solana-perf",
  "solana-poh",
  "solana-pubkey 4.3.0",
+ "solana-rayon-threadlimit",
  "solana-rpc",
  "solana-rpc-client-api",
  "solana-runtime",
@@ -11358,6 +11361,7 @@ dependencies = [
  "solana-turbine",
  "test-case",
  "thiserror 2.0.20",
+ "tikv-jemallocator",
  "wincode",
 ]
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -8833,6 +8833,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
+ "scopeguard",
  "solana-clock",
  "solana-cluster-type",
  "solana-cost-model",

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -1,11 +1,10 @@
 #![allow(clippy::implicit_hasher)]
 use {
     crate::shred,
-    rayon::prelude::*,
     solana_clock::Slot,
     solana_hash::Hash,
     solana_nohash_hasher::BuildNoHashHasher,
-    solana_perf::packet::{PacketBatch, PacketRef},
+    solana_perf::packet::PacketRef,
     solana_pubkey::Pubkey,
     solana_signature::Signature,
     std::{collections::HashMap, sync::RwLock},
@@ -55,20 +54,6 @@ pub fn verify_shred_cpu(
     }
 }
 
-pub fn par_verify_shreds(
-    batches: &mut [PacketBatch],
-    slot_leaders: &SlotPubkeys,
-    cache: &RwLock<LruCache>,
-) {
-    batches.par_iter_mut().for_each(|batch| {
-        batch.par_iter_mut().for_each(|mut packet| {
-            if !packet.meta().discard() && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache) {
-                packet.meta_mut().set_discard(true);
-            }
-        });
-    });
-}
-
 #[cfg(test)]
 fn sign_shred_cpu(keypair: &Keypair, packet: &mut PacketRefMut) {
     let sig = shred::layout::SIGNATURE_RANGE;
@@ -100,12 +85,11 @@ mod tests {
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{Rng, seq::SliceRandom},
-        rayon::{ThreadPool, ThreadPoolBuilder},
         solana_entry::entry::Entry,
         solana_hash::Hash,
         solana_keypair::Keypair,
         solana_packet::Packet,
-        solana_perf::packet::RecycledPacketBatch,
+        solana_perf::packet::{PacketBatch, RecycledPacketBatch},
         solana_signer::Signer,
         solana_system_transaction as system_transaction,
         solana_transaction::Transaction,
@@ -113,25 +97,28 @@ mod tests {
         test_case::test_case,
     };
 
-    fn verify_shreds(
-        thread_pool: &ThreadPool,
+    fn sign_shreds(keypair: &Keypair, batches: &mut [PacketBatch]) {
+        for batch in batches {
+            for mut packet in batch.iter_mut() {
+                sign_shred_cpu(keypair, &mut packet);
+            }
+        }
+    }
+
+    fn verify_batches(
         batches: &mut [PacketBatch],
         slot_leaders: &SlotPubkeys,
         cache: &RwLock<LruCache>,
     ) {
-        thread_pool.install(|| {
-            par_verify_shreds(batches, slot_leaders, cache);
-        });
-    }
-
-    fn sign_shreds(thread_pool: &ThreadPool, keypair: &Keypair, batches: &mut [PacketBatch]) {
-        thread_pool.install(|| {
-            batches.par_iter_mut().for_each(|batch| {
-                batch
-                    .par_iter_mut()
-                    .for_each(|mut p| sign_shred_cpu(keypair, &mut p));
-            });
-        });
+        for batch in batches {
+            for mut packet in batch.iter_mut() {
+                if !packet.meta().discard()
+                    && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache)
+                {
+                    packet.meta_mut().set_discard(true);
+                }
+            }
+        }
     }
 
     fn run_test_sigverify_shred_cpu(slot: Slot) {
@@ -171,149 +158,6 @@ mod tests {
     #[test]
     fn test_sigverify_shred_cpu() {
         run_test_sigverify_shred_cpu(0xdead_c0de);
-    }
-
-    fn run_test_sigverify_shreds_cpu(thread_pool: &ThreadPool, slot: Slot) {
-        agave_logger::setup();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let keypair = Keypair::new();
-
-        let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| !packet.meta().discard())
-        );
-
-        let wrong_keypair = Keypair::new();
-        let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-
-        let leader_slots: SlotPubkeys = HashMap::default();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        batches[0]
-            .iter_mut()
-            .for_each(|mut packet_ref| packet_ref.meta_mut().size = 0);
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-    }
-
-    #[test]
-    fn test_sigverify_shreds_cpu() {
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
-        run_test_sigverify_shreds_cpu(&thread_pool, 0xdead_c0de);
-    }
-
-    fn run_test_sigverify_shreds(thread_pool: &ThreadPool, slot: Slot) {
-        agave_logger::setup();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-
-        let keypair = Keypair::new();
-        let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
-            .into_iter()
-            .collect();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| !packet.meta().discard())
-        );
-
-        let wrong_keypair = Keypair::new();
-        let leader_slots: SlotPubkeys = [
-            (u64::MAX, Pubkey::default()),
-            (slot, wrong_keypair.pubkey()),
-        ]
-        .into_iter()
-        .collect();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-
-        let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default())].into_iter().collect();
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-
-        let mut batches = [make_packet_batch(&keypair, slot)];
-        batches[0]
-            .iter_mut()
-            .for_each(|mut pr| pr.meta_mut().size = 0);
-        let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
-            .into_iter()
-            .collect();
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
-        assert!(
-            batches
-                .iter()
-                .flatten()
-                .all(|packet| packet.meta().discard())
-        );
-    }
-
-    fn make_packet_batch(keypair: &Keypair, slot: u64) -> PacketBatch {
-        let mut batch = RecycledPacketBatch::default();
-        let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
-        let reed_solomon_cache = ReedSolomonCache::default();
-        let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
-            keypair,
-            &[],
-            true,
-            Hash::default(),
-            0,
-            0,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        );
-        batch.resize(shreds.len(), Packet::default());
-        for i in 0..shreds.len() {
-            batch[i].buffer_mut()[..shreds[i].payload().len()].copy_from_slice(shreds[i].payload());
-            batch[i].meta_mut().size = shreds[i].payload().len();
-        }
-        PacketBatch::from(batch)
-    }
-
-    #[test]
-    fn test_sigverify_shreds() {
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
-        run_test_sigverify_shreds(&thread_pool, 0xdead_c0de);
     }
 
     fn make_transaction<R: Rng>(rng: &mut R) -> Transaction {
@@ -421,7 +265,6 @@ mod tests {
     fn test_verify_shreds_fuzz(is_last_in_slot: bool) {
         let mut rng = rand::rng();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         let keypairs = repeat_with(|| rng.random_range(169_367_809..169_906_789))
             .map(|slot| (slot, Keypair::new()))
             .take(3)
@@ -433,13 +276,15 @@ mod tests {
             .chain(once((Slot::MAX, Pubkey::default())))
             .collect();
         let mut packets = make_packets(&mut rng, &shreds);
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+
+        verify_batches(&mut packets, &pubkeys, &cache);
         assert!(
             packets
                 .iter()
                 .flatten()
                 .all(|packet| !packet.meta().discard())
         );
+
         // Invalidate signatures for a random number of packets.
         let expected_discards = packets
             .iter_mut()
@@ -459,7 +304,8 @@ mod tests {
                     .collect::<Vec<bool>>()
             })
             .collect::<Vec<_>>();
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+
+        verify_batches(&mut packets, &pubkeys, &cache);
         assert!(
             packets
                 .iter()
@@ -478,7 +324,6 @@ mod tests {
     fn test_sign_shreds(is_last_in_slot: bool) {
         let mut rng = rand::rng();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         let shreds = {
             let keypairs = repeat_with(|| rng.random_range(169_367_809..169_906_789))
                 .map(|slot| (slot, Keypair::new()))
@@ -497,22 +342,25 @@ mod tests {
                 .collect()
         };
         let mut packets = make_packets(&mut rng, &shreds);
+
         // Assert that initially all signatures are invalid.
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        verify_batches(&mut packets, &pubkeys, &cache);
         assert!(
             packets
                 .iter()
                 .flatten()
                 .all(|packet| packet.meta().discard())
         );
-        // Sign and verify shreds signatures.
+
         packets.iter_mut().for_each(|batch| {
             batch
                 .iter_mut()
                 .for_each(|mut packet| packet.meta_mut().set_discard(false));
         });
-        sign_shreds(&thread_pool, &keypair, &mut packets);
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+
+        // Sign and verify shred signatures.
+        sign_shreds(&keypair, &mut packets);
+        verify_batches(&mut packets, &pubkeys, &cache);
         assert!(
             packets
                 .iter()

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9797,6 +9797,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
+ "scopeguard",
  "solana-clock",
  "solana-cluster-type",
  "solana-cost-model",

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -31,6 +31,7 @@ lru = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
+scopeguard = { workspace = true }
 solana-clock = { workspace = true }
 solana-cluster-type = { workspace = true }
 solana-cost-model = { workspace = true }
@@ -66,14 +67,19 @@ agave-votor-messages = { path = "../votor-messages", features = ["dev-context-on
 assert_matches = { workspace = true }
 bencher = { workspace = true }
 bs58 = { workspace = true }
+clap = { workspace = true }
 solana-genesis-config = { workspace = true }
 solana-gossip = { path = "../gossip", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-ledger = { path = "../ledger", features = ["agave-unstable-api", "dev-context-only-utils"] }
+solana-rayon-threadlimit = { workspace = true }
 solana-runtime = { path = "../runtime", features = ["agave-unstable-api", "dev-context-only-utils"] }
 solana-signature = { workspace = true, features = ["rand"] }
 solana-transaction = { workspace = true }
 solana-turbine = { path = ".", features = ["agave-unstable-api"] }
 test-case = { workspace = true }
+
+[target.'cfg(not(any(target_env = "msvc", target_os = "freebsd")))'.dev-dependencies]
+jemallocator = { workspace = true }
 
 [[bench]]
 name = "cluster_info"

--- a/turbine/examples/shred_sigverify.rs
+++ b/turbine/examples/shred_sigverify.rs
@@ -1,0 +1,1016 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+#[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+use {
+    clap::{App, Arg, ArgMatches, ErrorKind},
+    crossbeam_channel::{TrySendError, bounded},
+    rand::{Rng, SeedableRng},
+    rand_chacha::ChaCha8Rng,
+    solana_entry::entry::create_ticks,
+    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
+    solana_hash::Hash,
+    solana_keypair::Keypair,
+    solana_ledger::{
+        genesis_utils::create_genesis_config_with_leader,
+        leader_schedule_cache::LeaderScheduleCache,
+        shred::{
+            DATA_SHREDS_PER_FEC_BLOCK, MAX_CODE_SHREDS_PER_SLOT, MAX_DATA_SHREDS_PER_SLOT,
+            ProcessShredsStats, ReedSolomonCache, Shred, Shredder,
+            get_data_shred_bytes_per_batch_typical, max_ticks_per_n_shreds,
+        },
+    },
+    solana_net_utils::SocketAddrSpace,
+    solana_perf::packet::{PACKETS_PER_BATCH, Packet, PacketBatch, RecycledPacketBatch},
+    solana_rayon_threadlimit::get_thread_count,
+    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_signer::Signer,
+    solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
+    solana_time_utils::timestamp,
+    solana_turbine::sigverify_shreds::{RepairNonceLocationLookup, spawn_shred_sigverify},
+    std::{
+        fmt::{self, Display, Formatter},
+        num::NonZeroUsize,
+        sync::Arc,
+        thread,
+        time::{Duration, Instant},
+    },
+};
+
+const SHRED_FETCH_COALESCE: Duration = Duration::from_millis(5);
+
+// Keep the harness queue deliberately small so saturation mode reaches
+// backpressure without requiring the much larger production ingress queue.
+const CHANNEL_CAPACITY: usize = 1_024;
+
+const DEFAULT_NUM_SLOTS: usize = 50;
+const DEFAULT_SLOT_DURATION_MS: u64 = 400;
+// Preserve the old default workload volume: 500 batches * 64 packets.
+const DEFAULT_SHREDS_PER_SLOT: usize = 500 * PACKETS_PER_BATCH;
+const DEFAULT_INVALID_PACKETS_PER_SLOT: usize = 0;
+const DEFAULT_ARRIVAL_SEED: u64 = 1;
+
+const MAX_SHREDS_PER_SLOT: usize = MAX_DATA_SHREDS_PER_SLOT + MAX_CODE_SHREDS_PER_SLOT;
+const FIRST_SLOT: u64 = 1;
+
+#[derive(Clone, Copy, Debug)]
+enum ReplayMode {
+    Paced,
+    Saturate,
+}
+
+impl Display for ReplayMode {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Paced => "paced",
+            Self::Saturate => "saturate",
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ArrivalDistribution {
+    EvenlySpaced,
+    UniformRandom,
+}
+
+impl Display for ArrivalDistribution {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::EvenlySpaced => "evenly-spaced",
+            Self::UniformRandom => "uniform-random",
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Args {
+    mode: ReplayMode,
+    distribution: ArrivalDistribution,
+    slots: usize,
+    slot_duration_ms: u64,
+    shreds_per_slot: usize,
+    invalid_per_slot: usize,
+    arrival_seed: u64,
+    threads: Option<NonZeroUsize>,
+}
+
+impl Args {
+    fn parse() -> Result<Self, clap::Error> {
+        let matches = App::new("shred_sigverify")
+            .about("Replay a synthetic shred workload through shred sigverify")
+            .arg(
+                Arg::with_name("mode")
+                    .long("mode")
+                    .takes_value(true)
+                    .possible_values(&["paced", "saturate"])
+                    .default_value("paced")
+                    .help("Replay scheduled arrivals or saturate the input channel"),
+            )
+            .arg(
+                Arg::with_name("distribution")
+                    .long("distribution")
+                    .takes_value(true)
+                    .possible_values(&["evenly-spaced", "uniform-random"])
+                    .default_value("evenly-spaced")
+                    .help("Distribution of shred arrival times within each slot"),
+            )
+            .arg(
+                Arg::with_name("slots")
+                    .long("slots")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .help("Number of source slots to replay (default: 50)"),
+            )
+            .arg(
+                Arg::with_name("slot-duration-ms")
+                    .long("slot-duration-ms")
+                    .takes_value(true)
+                    .value_name("MILLISECONDS")
+                    .help("Synthetic duration of each source slot (default: 400 ms)"),
+            )
+            .arg(
+                Arg::with_name("shreds-per-slot")
+                    .long("shreds-per-slot")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .help("Shreds arriving per source slot (default: 500 packet batches)"),
+            )
+            .arg(
+                Arg::with_name("invalid-per-slot")
+                    .long("invalid-per-slot")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .help("Intentionally corrupted shred signatures per slot (default: 0)"),
+            )
+            .arg(
+                Arg::with_name("arrival-seed")
+                    .long("arrival-seed")
+                    .takes_value(true)
+                    .value_name("SEED")
+                    .help("Seed for random arrival times (default: 1)"),
+            )
+            .arg(
+                Arg::with_name("threads")
+                    .long("threads")
+                    .takes_value(true)
+                    .value_name("COUNT")
+                    .help("Number of sigverify workers (default: system thread count)"),
+            )
+            .get_matches_safe()?;
+
+        Ok(Self {
+            mode: match matches.value_of("mode") {
+                Some("paced") => ReplayMode::Paced,
+                Some("saturate") => ReplayMode::Saturate,
+                _ => unreachable!("clap validates --mode"),
+            },
+            distribution: match matches.value_of("distribution") {
+                Some("evenly-spaced") => ArrivalDistribution::EvenlySpaced,
+                Some("uniform-random") => ArrivalDistribution::UniformRandom,
+                _ => unreachable!("clap validates --distribution"),
+            },
+            slots: parse_optional(&matches, "slots")?.unwrap_or(DEFAULT_NUM_SLOTS),
+            slot_duration_ms: parse_optional(&matches, "slot-duration-ms")?
+                .unwrap_or(DEFAULT_SLOT_DURATION_MS),
+            shreds_per_slot: parse_optional(&matches, "shreds-per-slot")?
+                .unwrap_or(DEFAULT_SHREDS_PER_SLOT),
+            invalid_per_slot: parse_optional(&matches, "invalid-per-slot")?
+                .unwrap_or(DEFAULT_INVALID_PACKETS_PER_SLOT),
+            arrival_seed: parse_optional(&matches, "arrival-seed")?.unwrap_or(DEFAULT_ARRIVAL_SEED),
+            threads: parse_optional(&matches, "threads")?,
+        })
+    }
+}
+
+fn parse_optional<T>(matches: &ArgMatches<'_>, name: &str) -> Result<Option<T>, clap::Error>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    matches
+        .value_of(name)
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|error| argument_error(format!("invalid value for --{name}: {error}")))
+        })
+        .transpose()
+}
+
+struct ScheduledBatch {
+    batch: PacketBatch,
+    emit_offset: Duration,
+}
+
+struct HarnessConfig {
+    replay_mode: ReplayMode,
+    arrival_distribution: ArrivalDistribution,
+    num_slots: usize,
+    slot_duration: Duration,
+    shreds_per_slot: usize,
+    invalid_packets_per_slot: usize,
+    arrival_seed: u64,
+    num_sigverify_threads: NonZeroUsize,
+    expected_shreds: usize,
+    expected_invalid_shreds: usize,
+    expected_valid_shreds: usize,
+}
+
+impl HarnessConfig {
+    fn try_from_args(args: Args) -> Result<Self, clap::Error> {
+        if args.slots == 0 {
+            return Err(argument_error("--slots must be greater than zero"));
+        }
+        if args.slot_duration_ms == 0 {
+            return Err(argument_error(
+                "--slot-duration-ms must be greater than zero",
+            ));
+        }
+        if args.shreds_per_slot == 0 {
+            return Err(argument_error(
+                "--shreds-per-slot must be greater than zero",
+            ));
+        }
+        if args.shreds_per_slot > MAX_SHREDS_PER_SLOT {
+            return Err(argument_error(format!(
+                "--shreds-per-slot={} exceeds the current per-source-slot limit of \
+                 {MAX_SHREDS_PER_SLOT} ({MAX_DATA_SHREDS_PER_SLOT} data + \
+                 {MAX_CODE_SHREDS_PER_SLOT} coding shreds)",
+                args.shreds_per_slot,
+            )));
+        }
+        if args.invalid_per_slot > args.shreds_per_slot {
+            return Err(argument_error(
+                "--invalid-per-slot must not exceed --shreds-per-slot",
+            ));
+        }
+
+        let expected_shreds = args
+            .slots
+            .checked_mul(args.shreds_per_slot)
+            .ok_or_else(|| argument_error("configured workload is too large"))?;
+        let expected_invalid_shreds = args
+            .slots
+            .checked_mul(args.invalid_per_slot)
+            .ok_or_else(|| argument_error("configured invalid-shred count is too large"))?;
+        let expected_valid_shreds = expected_shreds
+            .checked_sub(expected_invalid_shreds)
+            .ok_or_else(|| argument_error("invalid-shred count exceeds total workload"))?;
+        let num_sigverify_threads = args.threads.unwrap_or_else(|| {
+            NonZeroUsize::new(get_thread_count())
+                .expect("system thread count must be greater than zero")
+        });
+
+        Ok(Self {
+            replay_mode: args.mode,
+            arrival_distribution: args.distribution,
+            num_slots: args.slots,
+            slot_duration: Duration::from_millis(args.slot_duration_ms),
+            shreds_per_slot: args.shreds_per_slot,
+            invalid_packets_per_slot: args.invalid_per_slot,
+            arrival_seed: args.arrival_seed,
+            num_sigverify_threads,
+            expected_shreds,
+            expected_invalid_shreds,
+            expected_valid_shreds,
+        })
+    }
+}
+
+impl Display for HarnessConfig {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "Shred sigverify configuration")?;
+        writeln!(formatter, "  mode:                 {}", self.replay_mode)?;
+        writeln!(
+            formatter,
+            "  distribution:         {}",
+            self.arrival_distribution
+        )?;
+        writeln!(formatter, "  slots:                {}", self.num_slots)?;
+        writeln!(
+            formatter,
+            "  slot duration:        {:?}",
+            self.slot_duration
+        )?;
+        writeln!(
+            formatter,
+            "  shreds per slot:      {}",
+            self.shreds_per_slot
+        )?;
+        writeln!(
+            formatter,
+            "  invalid per slot:     {}",
+            self.invalid_packets_per_slot
+        )?;
+        writeln!(
+            formatter,
+            "  sigverify threads:    {}",
+            self.num_sigverify_threads
+        )?;
+        writeln!(
+            formatter,
+            "  total shreds:         {}",
+            self.expected_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  intentionally invalid:{}",
+            self.expected_invalid_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  expected valid:       {}",
+            self.expected_valid_shreds
+        )?;
+        writeln!(formatter, "  maximum per slot:     {MAX_SHREDS_PER_SLOT}")?;
+        write!(formatter, "  arrival seed:         {}", self.arrival_seed)
+    }
+}
+
+fn argument_error(message: impl Into<String>) -> clap::Error {
+    clap::Error::with_description(&message.into(), ErrorKind::ValueValidation)
+}
+
+struct ReplayResult {
+    sent_shreds: usize,
+    verified_shreds: usize,
+    additional_discards: usize,
+    overflow_shreds: usize,
+    max_observed_input_queue_depth: usize,
+    ingress_elapsed: Duration,
+    end_to_end_elapsed: Duration,
+}
+
+struct BatchShapeStats {
+    total_batches: usize,
+    full_batches: usize,
+    partial_batches: usize,
+    min_partial_batch: usize,
+    max_partial_batch: usize,
+    partial_packets: usize,
+}
+
+impl BatchShapeStats {
+    fn from_workload(workload: &[ScheduledBatch]) -> Self {
+        let mut stats = Self {
+            total_batches: workload.len(),
+            full_batches: 0,
+            partial_batches: 0,
+            min_partial_batch: usize::MAX,
+            max_partial_batch: 0,
+            partial_packets: 0,
+        };
+
+        for scheduled_batch in workload {
+            let batch_len = scheduled_batch.batch.len();
+            assert!(batch_len > 0, "synthetic coalescer produced an empty batch");
+            assert!(
+                batch_len <= PACKETS_PER_BATCH,
+                "synthetic coalescer produced an oversized batch: {batch_len}"
+            );
+
+            if batch_len == PACKETS_PER_BATCH {
+                stats.full_batches += 1;
+            } else {
+                stats.partial_batches += 1;
+                stats.min_partial_batch = stats.min_partial_batch.min(batch_len);
+                stats.max_partial_batch = stats.max_partial_batch.max(batch_len);
+                stats.partial_packets += batch_len;
+            }
+        }
+
+        if stats.partial_batches == 0 {
+            stats.min_partial_batch = 0;
+        }
+
+        stats
+    }
+
+    fn full_batch_ratio(&self) -> f64 {
+        if self.total_batches == 0 {
+            0.0
+        } else {
+            self.full_batches as f64 / self.total_batches as f64
+        }
+    }
+
+    fn average_partial_batch(&self) -> f64 {
+        if self.partial_batches == 0 {
+            0.0
+        } else {
+            self.partial_packets as f64 / self.partial_batches as f64
+        }
+    }
+}
+
+struct WorkloadReport<'a> {
+    stats: &'a BatchShapeStats,
+    scheduled_replay: Duration,
+}
+
+impl Display for WorkloadReport<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "Generated packet batches")?;
+        writeln!(
+            formatter,
+            "  total:                {}",
+            self.stats.total_batches
+        )?;
+        writeln!(
+            formatter,
+            "  full:                 {} ({:.1}%)",
+            self.stats.full_batches,
+            self.stats.full_batch_ratio() * 100.0
+        )?;
+        writeln!(
+            formatter,
+            "  partial:              {}",
+            self.stats.partial_batches
+        )?;
+        writeln!(
+            formatter,
+            "  partial size:         {} / {:.1} / {} (min / avg / max)",
+            self.stats.min_partial_batch,
+            self.stats.average_partial_batch(),
+            self.stats.max_partial_batch
+        )?;
+        writeln!(
+            formatter,
+            "  coalesce window:      {SHRED_FETCH_COALESCE:?}"
+        )?;
+        write!(
+            formatter,
+            "  scheduled replay:     {:?}",
+            self.scheduled_replay
+        )
+    }
+}
+
+struct ReplayReport<'a> {
+    config: &'a HarnessConfig,
+    result: &'a ReplayResult,
+    nominal_replay: Duration,
+    scheduled_replay: Duration,
+}
+
+impl Display for ReplayReport<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let shreds_per_second =
+            self.result.sent_shreds as f64 / self.result.end_to_end_elapsed.as_secs_f64();
+        writeln!(formatter, "Shred sigverify result")?;
+        writeln!(
+            formatter,
+            "  mode:                 {}",
+            self.config.replay_mode
+        )?;
+        writeln!(
+            formatter,
+            "  sent:                 {}",
+            self.result.sent_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  intentionally invalid:{}",
+            self.config.expected_invalid_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  expected valid:       {}",
+            self.config.expected_valid_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  verified:             {}",
+            self.result.verified_shreds
+        )?;
+        writeln!(
+            formatter,
+            "  additional discards:  {}",
+            self.result.additional_discards
+        )?;
+        if matches!(self.config.replay_mode, ReplayMode::Paced) {
+            writeln!(
+                formatter,
+                "  input overflow:       {}",
+                self.result.overflow_shreds
+            )?;
+            writeln!(
+                formatter,
+                "  max input queue depth:{}",
+                self.result.max_observed_input_queue_depth
+            )?;
+        }
+        writeln!(
+            formatter,
+            "  ingress elapsed:      {:?}",
+            self.result.ingress_elapsed
+        )?;
+        writeln!(formatter, "  shreds/s:             {shreds_per_second:.0}")?;
+        write!(
+            formatter,
+            "  end-to-end elapsed:   {:?}",
+            self.result.end_to_end_elapsed
+        )?;
+        if matches!(self.config.replay_mode, ReplayMode::Paced) {
+            writeln!(formatter)?;
+            writeln!(
+                formatter,
+                "  nominal replay:       {:?}",
+                self.nominal_replay
+            )?;
+            write!(
+                formatter,
+                "  scheduled replay:     {:?}",
+                self.scheduled_replay
+            )?;
+        }
+        Ok(())
+    }
+}
+
+fn duration_fraction(duration: Duration, numerator: usize, denominator: usize) -> Duration {
+    assert!(denominator > 0);
+
+    let nanos = duration
+        .as_nanos()
+        .checked_mul(numerator as u128)
+        .expect("duration multiplication overflowed")
+        / denominator as u128;
+    Duration::from_nanos(u64::try_from(nanos).expect("duration does not fit in u64 nanoseconds"))
+}
+
+fn duration_mul(duration: Duration, factor: usize) -> Duration {
+    let nanos = duration
+        .as_nanos()
+        .checked_mul(factor as u128)
+        .expect("duration multiplication overflowed");
+    Duration::from_nanos(u64::try_from(nanos).expect("duration does not fit in u64 nanoseconds"))
+}
+
+fn shred_size_typical() -> usize {
+    let batch_payload = get_data_shred_bytes_per_batch_typical() as usize;
+    batch_payload / DATA_SHREDS_PER_FEC_BLOCK
+}
+
+fn should_corrupt_packet(
+    packet_index: usize,
+    packets_per_slot: usize,
+    invalid_packets_per_slot: usize,
+) -> bool {
+    if invalid_packets_per_slot == 0 {
+        return false;
+    }
+
+    packet_index * invalid_packets_per_slot / packets_per_slot
+        != (packet_index + 1) * invalid_packets_per_slot / packets_per_slot
+}
+
+fn corrupt_shred_signature(packet: &mut Packet) {
+    // The leader signature starts at the beginning of the shred payload.
+    // Flipping one signature byte keeps the shred layout intact while making
+    // signature verification fail.
+    packet.buffer_mut()[0] ^= 1;
+}
+
+fn make_slot_shreds(leader_keypair: &Keypair, slot: u64, shreds_per_slot: usize) -> Vec<Shred> {
+    // The current shred format uses 32 data + 32 coding shreds per FEC block.
+    // Split the synthetic source-slot workload between both kinds so the
+    // configured total cannot silently exceed either per-slot index limit.
+    let target_data_shreds = shreds_per_slot.div_ceil(2);
+    let target_coding_shreds = shreds_per_slot / 2;
+
+    assert!(target_data_shreds <= MAX_DATA_SHREDS_PER_SLOT);
+    assert!(target_coding_shreds <= MAX_CODE_SHREDS_PER_SLOT);
+
+    let shred_size = shred_size_typical();
+    let target_data_shreds_u64 =
+        u64::try_from(target_data_shreds).expect("data shred count does not fit in u64");
+    let num_ticks = max_ticks_per_n_shreds(target_data_shreds_u64, Some(shred_size));
+
+    let entries = create_ticks(num_ticks, 0, Hash::new_unique());
+    let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
+
+    // Use variants without retransmitter signatures so the workload primarily
+    // measures leader signature verification.
+    let (data_shreds, coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
+        leader_keypair,
+        &entries,
+        false,
+        Hash::new_unique(),
+        0,
+        0,
+        &ReedSolomonCache::default(),
+        &mut ProcessShredsStats::default(),
+    );
+
+    assert!(
+        data_shreds.len() >= target_data_shreds,
+        "shred generator produced {} data shreds, expected at least {}",
+        data_shreds.len(),
+        target_data_shreds,
+    );
+    assert!(
+        coding_shreds.len() >= target_coding_shreds,
+        "shred generator produced {} coding shreds, expected at least {}",
+        coding_shreds.len(),
+        target_coding_shreds,
+    );
+
+    // Interleave data and coding shreds instead of putting all data traffic
+    // first and all coding traffic second.
+    let mut coding_shreds = coding_shreds.into_iter().take(target_coding_shreds);
+    let mut shreds = Vec::with_capacity(shreds_per_slot);
+
+    for data_shred in data_shreds.into_iter().take(target_data_shreds) {
+        shreds.push(data_shred);
+        if let Some(coding_shred) = coding_shreds.next() {
+            shreds.push(coding_shred);
+        }
+    }
+
+    assert_eq!(shreds.len(), shreds_per_slot);
+    shreds
+}
+
+fn evenly_spaced_arrival_offsets(slot_duration: Duration, shreds_per_slot: usize) -> Vec<Duration> {
+    (0..shreds_per_slot)
+        .map(|packet_index| duration_fraction(slot_duration, packet_index, shreds_per_slot))
+        .collect()
+}
+
+fn uniform_random_arrival_offsets(
+    slot_duration: Duration,
+    shreds_per_slot: usize,
+    rng: &mut ChaCha8Rng,
+) -> Vec<Duration> {
+    let slot_nanos =
+        u64::try_from(slot_duration.as_nanos()).expect("slot duration must fit in u64 nanoseconds");
+
+    // Sample packet arrival times independently across the slot, then sort
+    // them into receive order. The arrival model intentionally knows nothing
+    // about the coalescer; batch boundaries are derived later.
+    let mut offsets = (0..shreds_per_slot)
+        .map(|_| Duration::from_nanos(rng.random_range(0..slot_nanos)))
+        .collect::<Vec<_>>();
+
+    offsets.sort_unstable();
+    offsets
+}
+
+fn slot_arrival_offsets(
+    distribution: ArrivalDistribution,
+    slot_duration: Duration,
+    shreds_per_slot: usize,
+    rng: &mut ChaCha8Rng,
+) -> Vec<Duration> {
+    match distribution {
+        ArrivalDistribution::EvenlySpaced => {
+            evenly_spaced_arrival_offsets(slot_duration, shreds_per_slot)
+        }
+        ArrivalDistribution::UniformRandom => {
+            uniform_random_arrival_offsets(slot_duration, shreds_per_slot, rng)
+        }
+    }
+}
+
+/// Stateful approximation of the shred-fetch UDP receive loop.
+///
+/// Production starts the coalescing deadline when it enters a receive cycle,
+/// not when the first packet arrives. Consequently, if the receiver blocks
+/// waiting for data past that deadline, its first successful read completes
+/// the batch immediately. This models that distinction while intentionally
+/// ignoring recv_mmsg/poll syscall details.
+struct BatchCoalescer {
+    workload: Vec<ScheduledBatch>,
+    batch: RecycledPacketBatch,
+    receive_deadline: Duration,
+    last_arrival_offset: Option<Duration>,
+}
+
+impl BatchCoalescer {
+    fn new(expected_packets: usize) -> Self {
+        Self {
+            workload: Vec::with_capacity(expected_packets.div_ceil(PACKETS_PER_BATCH)),
+            batch: RecycledPacketBatch::with_capacity(PACKETS_PER_BATCH),
+            receive_deadline: SHRED_FETCH_COALESCE,
+            last_arrival_offset: None,
+        }
+    }
+
+    fn push(&mut self, packet: Packet, arrival_offset: Duration) {
+        if let Some(previous_arrival) = self.last_arrival_offset {
+            assert!(
+                arrival_offset >= previous_arrival,
+                "packet arrivals must be ordered"
+            );
+        }
+        self.last_arrival_offset = Some(arrival_offset);
+
+        if !self.batch.is_empty() && arrival_offset >= self.receive_deadline {
+            self.flush(self.receive_deadline);
+            self.receive_deadline = self
+                .receive_deadline
+                .checked_add(SHRED_FETCH_COALESCE)
+                .expect("receive deadline overflowed");
+        }
+
+        // recv_from_coalesce receives at least one packet before checking an
+        // already-expired cycle deadline. Model that packet as being emitted
+        // at its actual arrival time.
+        if self.batch.is_empty() && arrival_offset >= self.receive_deadline {
+            self.batch.push(packet);
+            self.flush(arrival_offset);
+            self.receive_deadline = arrival_offset
+                .checked_add(SHRED_FETCH_COALESCE)
+                .expect("receive deadline overflowed");
+            return;
+        }
+
+        self.batch.push(packet);
+
+        if self.batch.len() == PACKETS_PER_BATCH {
+            self.flush(arrival_offset);
+            self.receive_deadline = arrival_offset
+                .checked_add(SHRED_FETCH_COALESCE)
+                .expect("receive deadline overflowed");
+        }
+    }
+
+    fn flush(&mut self, emit_offset: Duration) {
+        assert!(!self.batch.is_empty(), "cannot emit an empty packet batch");
+
+        let batch = std::mem::replace(
+            &mut self.batch,
+            RecycledPacketBatch::with_capacity(PACKETS_PER_BATCH),
+        );
+        self.workload.push(ScheduledBatch {
+            batch: PacketBatch::from(batch),
+            emit_offset,
+        });
+    }
+
+    fn finish(mut self) -> Vec<ScheduledBatch> {
+        if !self.batch.is_empty() {
+            self.flush(self.receive_deadline);
+        }
+        self.workload
+    }
+}
+
+fn make_workload(leader_keypair: &Keypair, config: &HarnessConfig) -> Vec<ScheduledBatch> {
+    let mut rng = ChaCha8Rng::seed_from_u64(config.arrival_seed);
+    let mut coalescer = BatchCoalescer::new(config.expected_shreds);
+
+    for slot_offset in 0..config.num_slots {
+        let slot = FIRST_SLOT
+            .checked_add(u64::try_from(slot_offset).expect("slot offset does not fit in u64"))
+            .expect("slot number overflowed");
+        let slot_start = duration_mul(config.slot_duration, slot_offset);
+
+        let shreds = make_slot_shreds(leader_keypair, slot, config.shreds_per_slot);
+        let arrivals = slot_arrival_offsets(
+            config.arrival_distribution,
+            config.slot_duration,
+            config.shreds_per_slot,
+            &mut rng,
+        );
+
+        assert_eq!(shreds.len(), arrivals.len());
+
+        let mut corrupted_packets = 0usize;
+
+        for (packet_index, (shred, slot_arrival)) in shreds.into_iter().zip(arrivals).enumerate() {
+            let mut packet = shred.payload().to_packet(None);
+
+            if should_corrupt_packet(
+                packet_index,
+                config.shreds_per_slot,
+                config.invalid_packets_per_slot,
+            ) {
+                corrupt_shred_signature(&mut packet);
+                corrupted_packets += 1;
+            }
+
+            coalescer.push(packet, slot_start + slot_arrival);
+        }
+
+        assert_eq!(corrupted_packets, config.invalid_packets_per_slot);
+    }
+
+    coalescer.finish()
+}
+
+fn sleep_until(deadline: Instant) {
+    loop {
+        let now = Instant::now();
+
+        if now >= deadline {
+            return;
+        }
+
+        thread::sleep(deadline - now);
+    }
+}
+
+type VerifiedShred = (
+    solana_ledger::shred::Payload,
+    bool,
+    solana_ledger::blockstore_meta::BlockLocation,
+);
+
+fn run_sigverify(
+    config: &HarnessConfig,
+    leader_keypair: &Keypair,
+    workload: Vec<ScheduledBatch>,
+) -> ReplayResult {
+    let leader_pubkey = leader_keypair.pubkey();
+
+    // The validator running sigverify must not be the leader.
+    let node_keypair = Arc::new(Keypair::new());
+    let node_pubkey = node_keypair.pubkey();
+
+    let bank = Bank::new_for_tests(
+        &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+    );
+    let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+    let bank_forks = BankForks::new_rw_arc(bank);
+    let cluster_info = Arc::new(ClusterInfo::new(
+        ContactInfo::new_localhost(&node_pubkey, timestamp()),
+        node_keypair,
+        SocketAddrSpace::Unspecified,
+    ));
+
+    let (shred_fetch_sender, shred_fetch_receiver) = bounded::<PacketBatch>(CHANNEL_CAPACITY);
+
+    let evicting_shred_fetch_sender =
+        EvictingSender::new(shred_fetch_sender.clone(), shred_fetch_receiver.clone());
+
+    // Retransmit output is intentionally ignored by this harness. EvictingSender
+    // retains the receiver it needs to evict old messages from a full channel.
+    let (retransmit_sender, _) = EvictingSender::new_bounded(1);
+
+    // Drain verified output continuously so sigverify cannot block on the
+    // downstream channel.
+    let (verified_sender, verified_receiver) = bounded::<Vec<VerifiedShred>>(CHANNEL_CAPACITY);
+    let verified_handle = thread::spawn(move || {
+        verified_receiver
+            .into_iter()
+            .map(|shreds| shreds.len())
+            .sum::<usize>()
+    });
+
+    let repair_nonce_location_lookup: Arc<RepairNonceLocationLookup> = Arc::new(|_| None);
+
+    // Worker creation is outside the measured section.
+    let sigverify_handle = spawn_shred_sigverify(
+        cluster_info,
+        bank_forks,
+        leader_schedule_cache,
+        shred_fetch_receiver,
+        retransmit_sender,
+        verified_sender,
+        repair_nonce_location_lookup,
+        config.num_sigverify_threads,
+    );
+
+    let replay_start = Instant::now();
+    let mut sent_shreds = 0usize;
+    let mut overflow_shreds = 0usize;
+    let mut max_observed_input_queue_depth = 0usize;
+
+    for ScheduledBatch { batch, emit_offset } in workload {
+        let batch_len = batch.len();
+
+        match config.replay_mode {
+            ReplayMode::Paced => {
+                sleep_until(replay_start + emit_offset);
+                match evicting_shred_fetch_sender.try_send(batch) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(evicted_batch)) => {
+                        overflow_shreds = overflow_shreds
+                            .checked_add(evicted_batch.len())
+                            .expect("input overflow shred count overflowed");
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        unreachable!("evicting sender retains the channel receiver")
+                    }
+                }
+                max_observed_input_queue_depth =
+                    max_observed_input_queue_depth.max(evicting_shred_fetch_sender.len());
+            }
+            ReplayMode::Saturate => {
+                shred_fetch_sender
+                    .send(batch)
+                    .expect("shred sigverify receiver disconnected");
+            }
+        }
+
+        sent_shreds = sent_shreds
+            .checked_add(batch_len)
+            .expect("sent shred count overflowed");
+    }
+
+    let ingress_elapsed = replay_start.elapsed();
+    assert_eq!(sent_shreds, config.expected_shreds);
+
+    // Closing ingress lets sigverify drain all queued batches and terminate.
+    drop(evicting_shred_fetch_sender);
+    drop(shred_fetch_sender);
+    sigverify_handle
+        .join()
+        .expect("shred sigverify thread panicked");
+    let verified_shreds = verified_handle
+        .join()
+        .expect("verified shred consumer panicked");
+    let end_to_end_elapsed = replay_start.elapsed();
+
+    assert!(
+        verified_shreds <= config.expected_valid_shreds,
+        "sigverify emitted {verified_shreds} shreds, but only {} input shreds had valid leader \
+         signatures",
+        config.expected_valid_shreds,
+    );
+
+    let additional_discards = config
+        .expected_valid_shreds
+        .checked_sub(verified_shreds)
+        .expect("verified shred count exceeds expected-valid count");
+
+    // Deduper false positives are expected, but dropping more than 1% of
+    // otherwise valid shreds beyond input overflow indicates a broken benchmark
+    // or sigverify regression. An evicted batch can contain intentionally invalid
+    // shreds, so overflow_shreds is a conservative upper bound here.
+    let max_additional_discards = config
+        .expected_valid_shreds
+        .div_ceil(100)
+        .checked_add(overflow_shreds)
+        .expect("maximum additional discard count overflowed");
+
+    assert!(
+        additional_discards <= max_additional_discards,
+        "lost {additional_discards} expected-valid shreds; maximum allowed is \
+         {max_additional_discards} ({overflow_shreds} input overflow + 1%)"
+    );
+
+    ReplayResult {
+        sent_shreds,
+        verified_shreds,
+        additional_discards,
+        overflow_shreds,
+        max_observed_input_queue_depth,
+        ingress_elapsed,
+        end_to_end_elapsed,
+    }
+}
+
+fn main() {
+    let args = Args::parse().unwrap_or_else(|error| error.exit());
+    let config = HarnessConfig::try_from_args(args).unwrap_or_else(|error| error.exit());
+
+    println!("{config}\n");
+
+    let leader_keypair = Keypair::new();
+
+    // Generate and coalesce all input before entering the measured section.
+    let workload = make_workload(&leader_keypair, &config);
+    let batch_stats = BatchShapeStats::from_workload(&workload);
+    let scheduled_replay = workload
+        .last()
+        .map(|batch| batch.emit_offset)
+        .unwrap_or_default();
+    let generated_shreds = workload
+        .iter()
+        .map(|scheduled_batch| scheduled_batch.batch.len())
+        .sum::<usize>();
+
+    assert_eq!(generated_shreds, config.expected_shreds);
+
+    println!(
+        "{}\n",
+        WorkloadReport {
+            stats: &batch_stats,
+            scheduled_replay,
+        }
+    );
+
+    println!(
+        "Shred sigverify workload ready; attach profiler to pid {}\n",
+        std::process::id()
+    );
+
+    let result = run_sigverify(&config, &leader_keypair, workload);
+    let nominal_replay = duration_mul(config.slot_duration, config.num_slots);
+
+    println!(
+        "{}",
+        ReplayReport {
+            config: &config,
+            result: &result,
+            nominal_replay,
+            scheduled_replay,
+        }
+    );
+}

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -4,9 +4,8 @@ use {
         retransmit_stage::RetransmitStage,
     },
     agave_feature_set as feature_set,
-    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
-    itertools::{Either, Itertools},
-    rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
+    crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender, bounded},
+    scopeguard::defer,
     solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -15,27 +14,26 @@ use {
         leader_schedule_cache::LeaderScheduleCache,
         shred::{
             self,
-            layout::{get_shred, resign_packet},
-            wire::is_retransmitter_signed_variant,
+            layout::get_shred,
+            wire::{is_retransmitter_signed_variant, resign_packet},
         },
-        sigverify_shreds::{LruCache, SlotPubkeys, par_verify_shreds},
+        sigverify_shreds::{LruCache, SlotPubkeys, verify_shred_cpu},
     },
     solana_perf::{
-        self,
         deduper::Deduper,
         packet::{PacketBatch, PacketRef, PacketRefMut},
     },
     solana_pubkey::Pubkey,
-    solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_runtime::{
+        bank::Bank,
+        bank_forks::{BankForks, SharableBanks},
+    },
     solana_signer::Signer,
     solana_streamer::{evicting_sender::EvictingSender, streamer::ChannelSend},
     std::{
         num::NonZeroUsize,
-        sync::{
-            Arc, RwLock,
-            atomic::{AtomicUsize, Ordering},
-        },
-        thread::{Builder, JoinHandle},
+        sync::{Arc, RwLock},
+        thread::{self, Builder, JoinHandle},
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -76,101 +74,53 @@ enum ResignError {
 
 pub type RepairNonceLocationLookup = dyn Fn(shred::Nonce) -> Option<BlockLocation> + Send + Sync;
 
-pub fn spawn_shred_sigverify(
-    cluster_info: Arc<ClusterInfo>,
-    bank_forks: Arc<RwLock<BankForks>>,
-    leader_schedule_cache: Arc<LeaderScheduleCache>,
-    shred_fetch_receiver: Receiver<PacketBatch>,
-    retransmit_sender: EvictingSender<Vec<shred::Payload>>,
-    verified_sender: Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
-    repair_nonce_location_lookup: Arc<RepairNonceLocationLookup>,
-    num_sigverify_threads: NonZeroUsize,
-) -> JoinHandle<()> {
-    let mut stats = ShredSigVerifyStats::new(Instant::now());
-    let cache = RwLock::new(LruCache::new(SIGVERIFY_LRU_CACHE_CAPACITY));
-    let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
-        CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
-        CLUSTER_NODES_CACHE_TTL,
-    );
-    let thread_pool = ThreadPoolBuilder::new()
-        .num_threads(num_sigverify_threads.get())
-        .thread_name(|i| format!("solSvrfyShred{i:02}"))
-        .build()
-        .expect("new rayon threadpool");
-    let run_shred_sigverify = move || {
-        let mut rng = rand::rng();
-        let deduper = Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS);
-        let mut shred_buffer = Vec::with_capacity(SIGVERIFY_SHRED_BATCH_SIZE);
-        loop {
-            if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE) {
-                stats.num_deduper_saturations += 1;
-            }
-            // We can't store the keypair outside the loop
-            // because the identity might be hot swapped.
-            let keypair = cluster_info.keypair();
-            match run_shred_sigverify(
-                &thread_pool,
-                &keypair,
-                &cluster_info,
-                &bank_forks,
-                &leader_schedule_cache,
-                &deduper,
-                &shred_fetch_receiver,
-                &retransmit_sender,
-                &verified_sender,
-                &cluster_nodes_cache,
-                repair_nonce_location_lookup.as_ref(),
-                &cache,
-                &mut stats,
-                &mut shred_buffer,
-            ) {
-                Ok(()) => (),
-                Err(ShredSigverifyError::RecvTimeout) => (),
-                Err(ShredSigverifyError::RecvDisconnected) => break,
-                Err(ShredSigverifyError::SendError) => break,
-            }
-            stats.maybe_submit();
-        }
-    };
-    Builder::new()
-        .name("solShredVerifr".to_string())
-        .spawn(run_shred_sigverify)
-        .unwrap()
+#[derive(Default)]
+struct WorkerStats {
+    num_discards_post: usize,
+    num_duplicates: usize,
+    num_invalid_retransmitter: usize,
+    num_retranmitter_signature_skipped: usize,
+    num_retranmitter_signature_verified: usize,
+    num_unknown_slot_leader: usize,
+    num_unknown_turbine_parent: usize,
+}
+impl WorkerStats {
+    fn add_batch(&mut self, counters: WorkerCounters) {
+        self.num_discards_post += usize::from(counters.num_discards_post);
+        self.num_duplicates += usize::from(counters.num_duplicates);
+        self.num_invalid_retransmitter += usize::from(counters.num_invalid_retransmitter);
+        self.num_retranmitter_signature_skipped +=
+            usize::from(counters.num_retranmitter_signature_skipped);
+        self.num_retranmitter_signature_verified +=
+            usize::from(counters.num_retranmitter_signature_verified);
+        self.num_unknown_slot_leader += usize::from(counters.num_unknown_slot_leader);
+        self.num_unknown_turbine_parent += usize::from(counters.num_unknown_turbine_parent);
+    }
+}
+#[derive(Default)]
+struct WorkerCounters {
+    num_discards_post: u16,
+    num_duplicates: u16,
+    num_invalid_retransmitter: u16,
+    num_retranmitter_signature_skipped: u16,
+    num_retranmitter_signature_verified: u16,
+    num_unknown_slot_leader: u16,
+    num_unknown_turbine_parent: u16,
 }
 
-#[allow(clippy::too_many_arguments)]
-fn run_shred_sigverify<const K: usize>(
-    thread_pool: &ThreadPool,
-    keypair: &Keypair,
-    cluster_info: &ClusterInfo,
-    bank_forks: &RwLock<BankForks>,
-    leader_schedule_cache: &LeaderScheduleCache,
-    deduper: &Deduper<K, [u8]>,
-    shred_fetch_receiver: &Receiver<PacketBatch>,
-    retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
-    verified_sender: &Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
-    cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
-    repair_nonce_location_lookup: &RepairNonceLocationLookup,
-    cache: &RwLock<LruCache>,
-    stats: &mut ShredSigVerifyStats,
-    shred_buffer: &mut Vec<PacketBatch>,
-) -> Result<(), ShredSigverifyError> {
-    const RECV_TIMEOUT: Duration = Duration::from_secs(1);
-    let packets = shred_fetch_receiver.recv_timeout(RECV_TIMEOUT)?;
-    stats.num_packets += packets.len();
-    shred_buffer.push(packets);
-    for packets in shred_fetch_receiver
-        .try_iter()
-        .take(SIGVERIFY_SHRED_BATCH_SIZE - 1)
-    {
-        stats.num_packets += packets.len();
-        shred_buffer.push(packets);
-    }
+#[derive(Clone)]
+struct WorkerContext {
+    cache: Arc<RwLock<LruCache>>,
+    cluster_info: Arc<ClusterInfo>,
+    sharable_banks: SharableBanks,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
+    cluster_nodes_cache: Arc<ClusterNodesCache<RetransmitStage>>,
+    deduper: Arc<Deduper<2, [u8]>>,
+}
 
-    let now = Instant::now();
-    stats.num_iters += 1;
-    stats.num_batches += shred_buffer.len();
-    stats.num_discards_pre += count_discards(shred_buffer);
+fn verify_batch(batch: &mut PacketBatch, ctx: &WorkerContext, keypair: &Keypair) -> WorkerCounters {
+    let mut counters = WorkerCounters::default();
+
     // Repair shreds include a randomly generated u32 nonce, so it does not
     // make sense to deduplicate the entire packet payload (i.e. they are not
     // duplicate of any other packet.data(..)).
@@ -184,129 +134,402 @@ fn run_shred_sigverify<const K: usize>(
     // path once a shred is repaired.
     // For backward compatibility we need to allow trailing bytes in the packet
     // after the shred payload, but have to exclude them here from the deduper.
-    stats.num_duplicates += thread_pool.install(|| {
-        shred_buffer
-            .par_iter_mut()
-            .flatten()
-            .filter(|packet| {
-                !packet.meta().discard()
-                    && shred::wire::get_shred(packet.as_ref())
-                        .map(|shred| deduper.dedup(shred))
-                        .unwrap_or(true)
-                    && !packet.meta().repair()
-            })
-            .map(|mut packet| packet.meta_mut().set_discard(true))
-            .count()
-    });
-    let (working_bank, root_bank) = {
-        let bank_forks = bank_forks.read().unwrap();
-        (bank_forks.working_bank(), bank_forks.root_bank())
-    };
-    thread_pool.install(|| {
-        par_verify_packets(
-            &keypair.pubkey(),
-            &working_bank,
-            leader_schedule_cache,
-            shred_buffer,
-            cache,
+    for mut packet in batch.iter_mut() {
+        if packet.meta().discard() {
+            continue;
+        }
+
+        let duplicate = shred::wire::get_shred(packet.as_ref())
+            .map(|shred| ctx.deduper.dedup(shred))
+            .unwrap_or(true);
+
+        if duplicate && !packet.meta().repair() {
+            packet.meta_mut().set_discard(true);
+            counters.num_duplicates += 1;
+        }
+    }
+
+    let banks = ctx.sharable_banks.load();
+    let working_bank = banks.working_bank;
+    let root_bank = banks.root_bank;
+
+    let self_pubkey = keypair.pubkey();
+    let slot_leaders = get_slot_leaders(
+        &self_pubkey,
+        batch,
+        ctx.leader_schedule_cache.as_ref(),
+        working_bank.as_ref(),
+    )
+    .filter_map(|(slot, pubkey)| pubkey.map(|pubkey| (slot, pubkey)))
+    .chain(std::iter::once((Slot::MAX, Pubkey::default())))
+    .collect::<SlotPubkeys>();
+
+    for mut packet in batch.iter_mut() {
+        if packet.meta().discard() {
+            counters.num_discards_post += 1;
+            continue;
+        }
+
+        if !verify_shred_cpu(packet.as_ref(), &slot_leaders, ctx.cache.as_ref()) {
+            packet.meta_mut().set_discard(true);
+            counters.num_discards_post += 1;
+            continue;
+        }
+
+        if maybe_verify_and_resign_packet(
+            &mut packet,
+            root_bank.as_ref(),
+            working_bank.as_ref(),
+            ctx.cluster_info.as_ref(),
+            ctx.leader_schedule_cache.as_ref(),
+            ctx.cluster_nodes_cache.as_ref(),
+            &mut counters,
+            keypair,
         )
-    });
-    stats.num_discards_post += count_discards(shred_buffer);
-    // Verify retransmitter's signature, and resign shreds
-    // Merkle root as the retransmitter node.
-    let resign_start = Instant::now();
-    thread_pool.install(|| {
-        shred_buffer
-            .par_iter_mut()
-            .flatten()
-            .filter(|packet| !packet.meta().discard())
-            .for_each(|mut packet| {
-                if maybe_verify_and_resign_packet(
-                    &mut packet,
-                    &root_bank,
-                    &working_bank,
-                    cluster_info,
-                    leader_schedule_cache,
-                    cluster_nodes_cache,
-                    stats,
-                    keypair,
-                )
-                .is_err()
-                {
-                    packet.meta_mut().set_discard(true);
+        .is_err()
+        {
+            packet.meta_mut().set_discard(true);
+        }
+    }
+
+    counters
+}
+
+struct BatchJob {
+    batch: PacketBatch,
+    keypair: Arc<Keypair>,
+}
+
+#[derive(Debug)]
+struct WorkerPanicked;
+
+struct BatchResult {
+    batch: PacketBatch,
+    counters: WorkerCounters,
+}
+
+type WorkerResult = Result<BatchResult, WorkerPanicked>;
+
+struct WorkerHandles(Vec<JoinHandle<()>>);
+
+impl Drop for WorkerHandles {
+    fn drop(&mut self) {
+        for handle in self.0.drain(..) {
+            if let Err(err) = handle.join() {
+                error!("shred sigverify worker encountered unexpected error: {err:?}");
+            }
+        }
+    }
+}
+
+struct ShredSigverifyWorkers {
+    // Drop order is significant:
+    // 1. Disconnect the job channel so workers stop receiving new work.
+    // 2. Disconnect the result channel so workers cannot block sending results.
+    // 3. Drop WorkerHandles, whose Drop impl joins all worker threads.
+    job_sender: Sender<BatchJob>,
+    result_receiver: Receiver<WorkerResult>,
+    _worker_handles: WorkerHandles,
+}
+
+impl ShredSigverifyWorkers {
+    fn new(
+        num_workers: NonZeroUsize,
+        cache: Arc<RwLock<LruCache>>,
+        deduper: Arc<Deduper<2, [u8]>>,
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        cluster_nodes_cache: Arc<ClusterNodesCache<RetransmitStage>>,
+    ) -> Self {
+        let (job_sender, job_receiver) = bounded::<BatchJob>(SIGVERIFY_SHRED_BATCH_SIZE);
+        let (result_sender, result_receiver) = bounded::<WorkerResult>(SIGVERIFY_SHRED_BATCH_SIZE);
+
+        // Keep cheap lock-free handles to the current root and working banks.
+        let sharable_banks = bank_forks.read().unwrap().sharable_banks();
+
+        let worker_context = WorkerContext {
+            cache,
+            cluster_info,
+            sharable_banks,
+            leader_schedule_cache,
+            cluster_nodes_cache,
+            deduper,
+        };
+
+        let worker_handles = WorkerHandles(
+            (0..num_workers.get())
+                .map(|index| {
+                    let job_receiver = job_receiver.clone();
+                    let result_sender = result_sender.clone();
+                    let ctx = worker_context.clone();
+
+                    Builder::new()
+                        .name(format!("solSvrfyShred{index:02}"))
+                        .spawn(move || {
+                            defer! {
+                                if !thread::panicking() {
+                                    return;
+                                }
+
+                                let current_thread = thread::current();
+                                error!("shred sigverify worker is panicking: {current_thread:?}");
+
+                                if result_sender.send(Err(WorkerPanicked)).is_err() {
+                                    error!("failed to report shred sigverify worker panic");
+                                }
+                            }
+
+                            while let Ok(BatchJob { mut batch, keypair }) = job_receiver.recv() {
+                                let counters = verify_batch(&mut batch, &ctx, keypair.as_ref());
+
+                                if result_sender
+                                    .send(Ok(BatchResult { batch, counters }))
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                        })
+                        .unwrap()
+                })
+                .collect(),
+        );
+
+        Self {
+            job_sender,
+            result_receiver,
+            _worker_handles: worker_handles,
+        }
+    }
+
+    fn process_batches(
+        &self,
+        packets: &mut Vec<PacketBatch>,
+        keypair: &Arc<Keypair>,
+    ) -> WorkerStats {
+        if packets.is_empty() {
+            return WorkerStats::default();
+        }
+
+        debug_assert!(
+            packets.len() <= SIGVERIFY_SHRED_BATCH_SIZE,
+            "run_shred_sigverify collects one batch plus at most SIGVERIFY_SHRED_BATCH_SIZE - 1 \
+             additional batches"
+        );
+
+        let num_batches = packets.len();
+
+        for batch in packets.drain(..) {
+            self.job_sender
+                .send(BatchJob {
+                    batch,
+                    keypair: keypair.clone(),
+                })
+                .expect("shred sigverify workers must be alive");
+        }
+
+        let mut worker_stats = WorkerStats::default();
+
+        for _ in 0..num_batches {
+            match self.result_receiver.recv() {
+                Ok(Ok(BatchResult { batch, counters })) => {
+                    worker_stats.add_batch(counters);
+                    packets.push(batch);
                 }
-            })
-    });
-    stats.resign_micros += resign_start.elapsed().as_micros() as u64;
-    // Extract shred payload from packets, and separate out repaired shreds.
-    let (shreds, repairs): (Vec<_>, Vec<_>) = shred_buffer
+                Ok(Err(WorkerPanicked)) => {
+                    panic!("shred sigverify worker panicked");
+                }
+                Err(_) => {
+                    panic!("all shred sigverify workers died");
+                }
+            }
+        }
+
+        worker_stats
+    }
+}
+
+pub fn spawn_shred_sigverify(
+    cluster_info: Arc<ClusterInfo>,
+    bank_forks: Arc<RwLock<BankForks>>,
+    leader_schedule_cache: Arc<LeaderScheduleCache>,
+    shred_fetch_receiver: Receiver<PacketBatch>,
+    retransmit_sender: EvictingSender<Vec<shred::Payload>>,
+    verified_sender: Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
+    repair_nonce_location_lookup: Arc<RepairNonceLocationLookup>,
+    num_sigverify_threads: NonZeroUsize,
+) -> JoinHandle<()> {
+    let mut stats = ShredSigVerifyStats::new(Instant::now());
+
+    let cache = Arc::new(RwLock::new(LruCache::new(SIGVERIFY_LRU_CACHE_CAPACITY)));
+
+    let deduper = {
+        let mut rng = rand::rng();
+        Arc::new(Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS))
+    };
+
+    let cluster_nodes_cache = Arc::new(ClusterNodesCache::<RetransmitStage>::new(
+        CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
+        CLUSTER_NODES_CACHE_TTL,
+    ));
+
+    let workers = ShredSigverifyWorkers::new(
+        num_sigverify_threads,
+        cache,
+        deduper.clone(),
+        cluster_info.clone(),
+        bank_forks.clone(),
+        leader_schedule_cache.clone(),
+        cluster_nodes_cache,
+    );
+
+    let run_shred_sigverify = move || {
+        let mut rng = rand::rng();
+        let mut shred_buffer = Vec::with_capacity(SIGVERIFY_SHRED_BATCH_SIZE);
+
+        loop {
+            if deduper.maybe_reset(&mut rng, DEDUPER_FALSE_POSITIVE_RATE, DEDUPER_RESET_CYCLE) {
+                stats.num_deduper_saturations += 1;
+            }
+
+            // We can't store the keypair outside the loop
+            // because the identity might be hot swapped.
+            let keypair = cluster_info.keypair();
+
+            match run_shred_sigverify(
+                &workers,
+                &keypair,
+                &shred_fetch_receiver,
+                &retransmit_sender,
+                &verified_sender,
+                repair_nonce_location_lookup.as_ref(),
+                &mut stats,
+                &mut shred_buffer,
+            ) {
+                Ok(()) => (),
+                Err(ShredSigverifyError::RecvTimeout) => (),
+                Err(ShredSigverifyError::RecvDisconnected) => break,
+                Err(ShredSigverifyError::SendError) => break,
+            }
+
+            stats.maybe_submit();
+        }
+    };
+
+    Builder::new()
+        .name("solShredVerifr".to_string())
+        .spawn(run_shred_sigverify)
+        .unwrap()
+}
+fn run_shred_sigverify(
+    workers: &ShredSigverifyWorkers,
+    keypair: &Arc<Keypair>,
+    shred_fetch_receiver: &Receiver<PacketBatch>,
+    retransmit_sender: &EvictingSender<Vec<shred::Payload>>,
+    verified_sender: &Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
+    repair_nonce_location_lookup: &RepairNonceLocationLookup,
+    stats: &mut ShredSigVerifyStats,
+    shred_buffer: &mut Vec<PacketBatch>,
+) -> Result<(), ShredSigverifyError> {
+    const RECV_TIMEOUT: Duration = Duration::from_secs(1);
+
+    let packets = shred_fetch_receiver.recv_timeout(RECV_TIMEOUT)?;
+    stats.num_packets += packets.len();
+    shred_buffer.push(packets);
+
+    for packets in shred_fetch_receiver
+        .try_iter()
+        .take(SIGVERIFY_SHRED_BATCH_SIZE - 1)
+    {
+        stats.num_packets += packets.len();
+        shred_buffer.push(packets);
+    }
+
+    let now = Instant::now();
+
+    stats.num_iters += 1;
+    stats.num_batches += shred_buffer.len();
+    stats.num_discards_pre += count_discards(shred_buffer);
+
+    let verify_and_resign_start = Instant::now();
+
+    let worker_stats = workers.process_batches(shred_buffer, keypair);
+    stats.add_worker_stats(worker_stats);
+
+    stats.verify_and_resign_micros += verify_and_resign_start.elapsed().as_micros() as u64;
+
+    let mut retransmit_shreds = Vec::new();
+    let mut verified_shreds = Vec::new();
+
+    for packet in shred_buffer
         .iter()
         .flat_map(|batch| batch.iter())
         .filter(|packet| !packet.meta().discard())
-        .filter_map(|packet| {
+    {
+        let Some((shred, location)) =
             extract_shred_and_location(packet, repair_nonce_location_lookup, stats)
-        })
-        .partition_map(|(shred, location)| {
-            if let Some(location) = location {
-                // No need for Arc overhead here because repaired shreds are
-                // not retranmitted.
-                Either::Right((
-                    shred::Payload::from(shred),
-                    /* is_repaired */ true,
-                    location,
-                ))
-            } else {
-                // Share the payload between the retransmit-stage and the
-                // window-service.
-                Either::Left(shred::Payload::from(shred))
-            }
-        });
+        else {
+            continue;
+        };
 
-    // Repaired shreds are not retransmitted.
-    stats.num_retransmit_shreds += shreds.len();
-    if let Err(send_err) = retransmit_sender.try_send(shreds.clone()) {
+        if let Some(location) = location {
+            verified_shreds.push((shred, /* is_repaired */ true, location));
+        } else {
+            retransmit_shreds.push(shred.clone());
+            verified_shreds.push((shred, /* is_repaired */ false, BlockLocation::Original));
+        }
+    }
+
+    stats.num_retransmit_shreds += retransmit_shreds.len();
+
+    if let Err(send_err) = retransmit_sender.try_send(retransmit_shreds) {
         match send_err {
-            crossbeam_channel::TrySendError::Full(v) => {
-                stats.num_retransmit_stage_overflow_shreds += v.len();
+            crossbeam_channel::TrySendError::Full(shreds) => {
+                stats.num_retransmit_stage_overflow_shreds += shreds.len();
             }
             _ => unreachable!("EvictingSender holds on to both ends of the channel"),
         }
     }
-    // Send all shreds to window service to be inserted into blockstore.
-    let shreds = shreds
-        .into_iter()
-        .map(|shred| (shred, /*is_repaired:*/ false, BlockLocation::Original));
-    verified_sender.send(shreds.chain(repairs).collect())?;
+
+    verified_sender.send(verified_shreds)?;
+
     stats.elapsed_micros += now.elapsed().as_micros() as u64;
     shred_buffer.clear();
+
     Ok(())
 }
 
-/// Extracts shred bytes and, for repaired shreds, the location where the shred
-/// should be inserted into blockstore.
 fn extract_shred_and_location(
     packet: PacketRef,
     repair_nonce_location_lookup: &RepairNonceLocationLookup,
     stats: &mut ShredSigVerifyStats,
-) -> Option<(Vec<u8>, Option<BlockLocation>)> {
-    let (shred, nonce) = shred::layout::get_shred_and_repair_nonce(packet)?;
-    let Some(nonce) = nonce else {
-        // Turbine shred.
-        return Some((shred.to_vec(), None));
+) -> Option<(shred::Payload, Option<BlockLocation>)> {
+    let (shred_bytes, nonce) = shred::layout::get_shred_and_repair_nonce(packet)?;
+
+    let location = match nonce {
+        None => None,
+        Some(nonce) => match repair_nonce_location_lookup(nonce) {
+            Some(location) => Some(location),
+            None => {
+                stats.num_unknown_block_location += 1;
+                return None;
+            }
+        },
     };
 
-    // Repair shred.
-    if let Some(location) = repair_nonce_location_lookup(nonce) {
-        Some((shred.to_vec(), Some(location)))
-    } else {
-        // This indicates the request entry was evicted before consumption.
-        stats.num_unknown_block_location += 1;
-        None
-    }
-}
+    let payload = match packet {
+        PacketRef::Packet(_) => shred::Payload::from(shred_bytes.to_vec()),
+        PacketRef::Bytes(packet) => {
+            shred::Payload::from(packet.buffer().slice(..shred_bytes.len()))
+        }
+    };
 
-/// Checks whether the shred in the given `packet` is of resigned variant. If
-/// yes, it calls [`verify_and_resign_shred`].
+    Some((payload, location))
+}
+/// Checks whether the shred in `packet` uses a retransmitter-signed variant.
+/// For turbine shreds, checks the retransmitter signature, then resigns the
+/// packet with this node's keypair.
 fn maybe_verify_and_resign_packet(
     packet: &mut PacketRefMut,
     root_bank: &Bank,
@@ -314,45 +537,46 @@ fn maybe_verify_and_resign_packet(
     cluster_info: &ClusterInfo,
     leader_schedule_cache: &LeaderScheduleCache,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
-    stats: &ShredSigVerifyStats,
+    counters: &mut WorkerCounters,
     keypair: &Keypair,
 ) -> Result<(), ResignError> {
     let repair = packet.meta().repair();
     let shred = get_shred(packet.as_ref()).ok_or(shred::Error::InvalidPacketSize)?;
-    let is_signed = is_retransmitter_signed_variant(shred)?;
-    if is_signed {
-        // Repair packets do not follow turbine tree and
-        // are verified using the trailing nonce.
-        if !repair
-            && !verify_retransmitter_signature(
-                shred,
-                root_bank,
-                working_bank,
-                cluster_info,
-                leader_schedule_cache,
-                cluster_nodes_cache,
-                stats,
-            )
-        {
-            stats
-                .num_invalid_retransmitter
-                .fetch_add(1, Ordering::Relaxed);
-            if shred::layout::get_slot(shred)
-                .map(|slot| {
-                    shred::filter::check_feature_activation_from_bank(
-                        &feature_set::verify_retransmitter_signature::id(),
-                        slot,
-                        root_bank,
-                    )
-                })
-                .unwrap_or_default()
-            {
-                return Err(ResignError::VerifyRetransmitterSignature);
-            }
-        }
 
-        resign_packet(packet, keypair)?;
+    if !is_retransmitter_signed_variant(shred)? {
+        return Ok(());
     }
+
+    // Repair packets do not follow the turbine tree and are verified
+    // using the trailing repair nonce.
+    if !repair
+        && !verify_retransmitter_signature(
+            shred,
+            root_bank,
+            working_bank,
+            cluster_info,
+            leader_schedule_cache,
+            cluster_nodes_cache,
+            counters,
+        )
+    {
+        counters.num_invalid_retransmitter += 1;
+
+        if shred::layout::get_slot(shred)
+            .map(|slot| {
+                shred::filter::check_feature_activation_from_bank(
+                    &feature_set::verify_retransmitter_signature::id(),
+                    slot,
+                    root_bank,
+                )
+            })
+            .unwrap_or_default()
+        {
+            return Err(ResignError::VerifyRetransmitterSignature);
+        }
+    }
+
+    resign_packet(packet, keypair)?;
 
     Ok(())
 }
@@ -365,7 +589,7 @@ fn verify_retransmitter_signature(
     cluster_info: &ClusterInfo,
     leader_schedule_cache: &LeaderScheduleCache,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
-    stats: &ShredSigVerifyStats,
+    counters: &mut WorkerCounters,
 ) -> bool {
     let signature = match shred::layout::get_retransmitter_signature(shred) {
         Ok(signature) => signature,
@@ -374,60 +598,43 @@ fn verify_retransmitter_signature(
         Err(shred::Error::InvalidShredVariant) => return true,
         Err(_) => return false,
     };
+
     let Some(merkle_root) = shred::layout::get_merkle_root(shred) else {
         return false;
     };
+
     let Some(shred) = shred::layout::get_shred_id(shred) else {
         return false;
     };
+
     let Some(leader) = leader_schedule_cache.slot_leader_at(shred.slot(), Some(working_bank))
     else {
-        stats
-            .num_unknown_slot_leader
-            .fetch_add(1, Ordering::Relaxed);
+        counters.num_unknown_slot_leader += 1;
         return false;
     };
+
     let cluster_nodes =
         cluster_nodes_cache.get(shred.slot(), root_bank, working_bank, cluster_info);
+
     let parent = match cluster_nodes.get_retransmit_parent(&leader.id, &shred, DATA_PLANE_FANOUT) {
         Ok(Some(parent)) => parent,
         Ok(None) => {
-            stats
-                .num_retranmitter_signature_skipped
-                .fetch_add(1, Ordering::Relaxed);
+            counters.num_retranmitter_signature_skipped += 1;
             return true;
         }
         Err(err) => {
             error!("get_retransmit_parent: {err:?}");
-            stats
-                .num_unknown_turbine_parent
-                .fetch_add(1, Ordering::Relaxed);
+            counters.num_unknown_turbine_parent += 1;
             return false;
         }
     };
+
     if signature.verify(parent.as_ref(), merkle_root.as_ref()) {
-        stats
-            .num_retranmitter_signature_verified
-            .fetch_add(1, Ordering::Relaxed);
+        counters.num_retranmitter_signature_verified += 1;
         true
     } else {
         false
     }
-}
-
-fn par_verify_packets(
-    self_pubkey: &Pubkey,
-    working_bank: &Bank,
-    leader_schedule_cache: &LeaderScheduleCache,
-    packets: &mut [PacketBatch],
-    cache: &RwLock<LruCache>,
-) {
-    let leader_slots: SlotPubkeys =
-        get_slot_leaders(self_pubkey, packets, leader_schedule_cache, working_bank)
-            .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
-            .chain(std::iter::once((Slot::MAX, Pubkey::default())))
-            .collect();
-    par_verify_shreds(packets, &leader_slots, cache);
 }
 
 // Returns pubkey of leaders for shred slots referenced in the packets.
@@ -437,13 +644,12 @@ fn par_verify_packets(
 //   - slot leader is the node itself (circular transmission).
 fn get_slot_leaders<'a>(
     self_pubkey: &'a Pubkey,
-    batches: &'a mut [PacketBatch],
+    batch: &'a mut PacketBatch,
     leader_schedule_cache: &'a LeaderScheduleCache,
     bank: &'a Bank,
 ) -> impl Iterator<Item = (Slot, Option<Pubkey>)> + 'a {
-    batches
+    batch
         .iter_mut()
-        .flat_map(|batch| batch.iter_mut())
         .filter(|packet| !packet.meta().discard())
         .filter_map(move |mut packet| {
             let shred = shred::layout::get_shred(packet.as_ref());
@@ -452,9 +658,11 @@ fn get_slot_leaders<'a>(
                 .slot_leader_at(slot, Some(bank))
                 .map(|leader| leader.id)
                 .filter(|leader| leader != self_pubkey);
+
             if leader.is_none() {
                 packet.meta_mut().set_discard(true);
             }
+
             Some((slot, leader))
         })
 }
@@ -488,21 +696,15 @@ struct ShredSigVerifyStats {
     num_batches: usize,
     num_packets: usize,
     num_deduper_saturations: usize,
-    num_discards_post: usize,
     num_discards_pre: usize,
-    num_duplicates: usize,
-    num_invalid_retransmitter: AtomicUsize,
-    num_retranmitter_signature_skipped: AtomicUsize,
-    num_retranmitter_signature_verified: AtomicUsize,
+    worker_stats: WorkerStats,
     num_retransmit_stage_overflow_shreds: usize,
     num_retransmit_shreds: usize,
     /// This means the OutstandingRequests cache is saturated and we
     /// threw away a verified shred due to being unable to fetch the storage location
     num_unknown_block_location: usize,
-    num_unknown_slot_leader: AtomicUsize,
-    num_unknown_turbine_parent: AtomicUsize,
     elapsed_micros: u64,
-    resign_micros: u64,
+    verify_and_resign_micros: u64,
 }
 
 impl ShredSigVerifyStats {
@@ -511,30 +713,37 @@ impl ShredSigVerifyStats {
     fn new(now: Instant) -> Self {
         Self {
             since: now,
-            num_iters: 0usize,
-            num_batches: 0usize,
-            num_packets: 0usize,
-            num_discards_pre: 0usize,
-            num_deduper_saturations: 0usize,
-            num_discards_post: 0usize,
-            num_duplicates: 0usize,
-            num_invalid_retransmitter: AtomicUsize::default(),
-            num_retranmitter_signature_skipped: AtomicUsize::default(),
-            num_retranmitter_signature_verified: AtomicUsize::default(),
-            num_retransmit_stage_overflow_shreds: 0usize,
-            num_retransmit_shreds: 0usize,
-            num_unknown_block_location: 0usize,
-            num_unknown_slot_leader: AtomicUsize::default(),
-            num_unknown_turbine_parent: AtomicUsize::default(),
-            elapsed_micros: 0u64,
-            resign_micros: 0u64,
+            num_iters: 0,
+            num_batches: 0,
+            num_packets: 0,
+            num_deduper_saturations: 0,
+            num_discards_pre: 0,
+            worker_stats: WorkerStats::default(),
+            num_retransmit_stage_overflow_shreds: 0,
+            num_retransmit_shreds: 0,
+            num_unknown_block_location: 0,
+            elapsed_micros: 0,
+            verify_and_resign_micros: 0,
         }
+    }
+
+    fn add_worker_stats(&mut self, worker_stats: WorkerStats) {
+        self.worker_stats.num_discards_post += worker_stats.num_discards_post;
+        self.worker_stats.num_duplicates += worker_stats.num_duplicates;
+        self.worker_stats.num_invalid_retransmitter += worker_stats.num_invalid_retransmitter;
+        self.worker_stats.num_retranmitter_signature_skipped +=
+            worker_stats.num_retranmitter_signature_skipped;
+        self.worker_stats.num_retranmitter_signature_verified +=
+            worker_stats.num_retranmitter_signature_verified;
+        self.worker_stats.num_unknown_slot_leader += worker_stats.num_unknown_slot_leader;
+        self.worker_stats.num_unknown_turbine_parent += worker_stats.num_unknown_turbine_parent;
     }
 
     fn maybe_submit(&mut self) {
         if self.since.elapsed() <= Self::METRICS_SUBMIT_CADENCE {
             return;
         }
+
         datapoint_info!(
             "shred_sigverify",
             ("num_iters", self.num_iters, i64),
@@ -542,23 +751,25 @@ impl ShredSigVerifyStats {
             ("num_packets", self.num_packets, i64),
             ("num_discards_pre", self.num_discards_pre, i64),
             ("num_deduper_saturations", self.num_deduper_saturations, i64),
-            ("num_discards_post", self.num_discards_post, i64),
-            ("num_duplicates", self.num_duplicates, i64),
+            (
+                "num_discards_post",
+                self.worker_stats.num_discards_post,
+                i64
+            ),
+            ("num_duplicates", self.worker_stats.num_duplicates, i64),
             (
                 "num_invalid_retransmitter",
-                self.num_invalid_retransmitter.load(Ordering::Relaxed),
+                self.worker_stats.num_invalid_retransmitter,
                 i64
             ),
             (
                 "num_retranmitter_signature_skipped",
-                self.num_retranmitter_signature_skipped
-                    .load(Ordering::Relaxed),
+                self.worker_stats.num_retranmitter_signature_skipped,
                 i64
             ),
             (
                 "num_retranmitter_signature_verified",
-                self.num_retranmitter_signature_verified
-                    .load(Ordering::Relaxed),
+                self.worker_stats.num_retranmitter_signature_verified,
                 i64
             ),
             (
@@ -574,17 +785,22 @@ impl ShredSigVerifyStats {
             ),
             (
                 "num_unknown_slot_leader",
-                self.num_unknown_slot_leader.load(Ordering::Relaxed),
+                self.worker_stats.num_unknown_slot_leader,
                 i64
             ),
             (
                 "num_unknown_turbine_parent",
-                self.num_unknown_turbine_parent.load(Ordering::Relaxed),
+                self.worker_stats.num_unknown_turbine_parent,
                 i64
             ),
             ("elapsed_micros", self.elapsed_micros, i64),
-            ("resign_micros", self.resign_micros, i64),
+            (
+                "verify_and_resign_micros",
+                self.verify_and_resign_micros,
+                i64
+            ),
         );
+
         *self = Self::new(Instant::now());
     }
 }
@@ -610,37 +826,154 @@ mod tests {
         test_case::test_matrix,
     };
 
+    fn new_sigverify_workers(
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        num_workers: usize,
+    ) -> ShredSigverifyWorkers {
+        let cache = Arc::new(RwLock::new(LruCache::new(/*capacity:*/ 128)));
+
+        new_sigverify_workers_with_cache(
+            cluster_info,
+            bank_forks,
+            leader_schedule_cache,
+            cache,
+            num_workers,
+        )
+    }
+    // Allows panic-path tests to inject a poisoned cache.
+    fn new_sigverify_workers_with_cache(
+        cluster_info: Arc<ClusterInfo>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        leader_schedule_cache: Arc<LeaderScheduleCache>,
+        cache: Arc<RwLock<LruCache>>,
+        num_workers: usize,
+    ) -> ShredSigverifyWorkers {
+        let deduper = {
+            let mut rng = rand::rng();
+            Arc::new(Deduper::<2, [u8]>::new(&mut rng, DEDUPER_NUM_BITS))
+        };
+
+        let cluster_nodes_cache = Arc::new(ClusterNodesCache::<RetransmitStage>::new(
+            CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
+            CLUSTER_NODES_CACHE_TTL,
+        ));
+
+        ShredSigverifyWorkers::new(
+            NonZeroUsize::new(num_workers).unwrap(),
+            cache,
+            deduper,
+            cluster_info,
+            bank_forks,
+            leader_schedule_cache,
+            cluster_nodes_cache,
+        )
+    }
+    #[test]
+    #[should_panic(expected = "shred sigverify worker panicked")]
+    fn test_sigverify_worker_panic_is_propagated() {
+        let leader_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(Keypair::new());
+        let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair.pubkey();
+
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let cache = Arc::new(RwLock::new(LruCache::new(/*capacity:*/ 128)));
+        let cache_to_poison = cache.clone();
+
+        let poison_result = std::thread::spawn(move || {
+            let _guard = cache_to_poison.write().unwrap();
+            panic!("poison shred sigverify cache");
+        })
+        .join();
+
+        assert!(poison_result.is_err());
+
+        let workers = new_sigverify_workers_with_cache(
+            cluster_info,
+            bank_forks,
+            leader_schedule_cache,
+            cache,
+            1,
+        );
+
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(1, 0, 1, 0).unwrap();
+
+        let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            false,
+            Hash::new_unique(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        let shred = &shreds[0];
+        let mut batch = RecycledPacketBatch::with_capacity(1);
+        batch.resize(1, Packet::default());
+        batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[0].meta_mut().size = shred.payload().len();
+
+        let mut batches = vec![PacketBatch::from(batch)];
+
+        workers.process_batches(&mut batches, &node_keypair);
+    }
+
     #[test]
     fn test_sigverify_shreds_verify_batches() {
         let leader_keypair = Arc::new(Keypair::new());
         let wrong_keypair = Keypair::new();
+        let node_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair.pubkey();
+
         let bank = Bank::new_for_tests(
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
         );
-        let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let bank_forks = BankForks::new_rw_arc(bank);
-        let batch_size = 2;
-        let mut batch = RecycledPacketBatch::with_capacity(batch_size);
-        batch.resize(batch_size, Packet::default());
-        let mut batches = vec![batch];
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let workers = new_sigverify_workers(cluster_info, bank_forks, leader_schedule_cache, 3);
 
         let entries = create_ticks(1, 1, Hash::new_unique());
         let shredder = Shredder::new(1, 0, 1, 0).unwrap();
-        let (shreds_data, _shreds_code) = shredder.entries_to_merkle_shreds_for_tests(
+
+        let (valid_shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             &leader_keypair,
             &entries,
-            true,
+            false,
             Hash::new_unique(),
             0,
             0,
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         );
-        let (shreds_data_wrong, _shreds_code_wrong) = shredder.entries_to_merkle_shreds_for_tests(
+
+        let (invalid_shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
             &wrong_keypair,
             &entries,
-            true,
+            false,
             Hash::new_unique(),
             0,
             0,
@@ -648,57 +981,59 @@ mod tests {
             &mut ProcessShredsStats::default(),
         );
 
-        let shred = shreds_data[0].clone();
-        batches[0][0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][0].meta_mut().size = shred.payload().len();
+        let mut batch = RecycledPacketBatch::with_capacity(2);
+        batch.resize(2, Packet::default());
 
-        let shred = shreds_data_wrong[0].clone();
-        batches[0][1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
-        batches[0][1].meta_mut().size = shred.payload().len();
+        let shred = &valid_shreds[0];
+        batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[0].meta_mut().size = shred.payload().len();
 
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
-        let working_bank = bank_forks.read().unwrap().working_bank();
-        let mut batches = batches
-            .into_iter()
-            .map(PacketBatch::from)
-            .collect::<Vec<_>>();
-        thread_pool.install(|| {
-            par_verify_packets(
-                &Pubkey::new_unique(), // self_pubkey
-                &working_bank,
-                &leader_schedule_cache,
-                &mut batches,
-                &cache,
-            )
-        });
+        let shred = &invalid_shreds[0];
+        batch[1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+        batch[1].meta_mut().size = shred.payload().len();
+
+        let mut batches = vec![PacketBatch::from(batch)];
+
+        let worker_stats = workers.process_batches(&mut batches, &node_keypair);
+
+        assert_eq!(worker_stats.num_discards_post, 1);
         assert!(!batches[0].get(0).unwrap().meta().discard());
         assert!(batches[0].get(1).unwrap().meta().discard());
     }
 
-    #[test_matrix(
-        [true, false],
-        [true, false]
-    )]
+    #[test_matrix([true, false], [true, false])]
     fn test_maybe_verify_and_resign_packet(repaired: bool, is_last_in_slot: bool) {
         let mut rng = rand::rng();
 
         let leader_keypair = Arc::new(Keypair::new());
         let leader_pubkey = leader_keypair.pubkey();
+
         let bank = Bank::new_for_tests(
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
         );
-        let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
         let bank_forks = BankForks::new_rw_arc(bank);
+
         let (working_bank, root_bank) = {
             let bank_forks = bank_forks.read().unwrap();
             (bank_forks.working_bank(), bank_forks.root_bank())
         };
-        let chained_merkle_root = Hash::new_from_array(rng.random());
 
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&leader_pubkey, timestamp()),
+            leader_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
+            CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
+            CLUSTER_NODES_CACHE_TTL,
+        );
+
+        let chained_merkle_root = Hash::new_from_array(rng.random());
         let shredder = Shredder::new(root_bank.slot(), root_bank.parent_slot(), 0, 0).unwrap();
         let entries = vec![Entry::new(&Hash::default(), 0, vec![])];
-        let mut shreds = shredder.make_merkle_shreds_from_entries(
+        let shreds = shredder.make_merkle_shreds_from_entries(
             &leader_keypair,
             &entries,
             is_last_in_slot,
@@ -709,104 +1044,460 @@ mod tests {
             &mut ProcessShredsStats::default(),
         );
 
-        let cluster_info = ClusterInfo::new(
-            ContactInfo::new_localhost(&leader_pubkey, timestamp()),
-            leader_keypair,
-            SocketAddrSpace::Unspecified,
-        );
-
-        let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
-            CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
-            CLUSTER_NODES_CACHE_TTL,
-        );
-        let stats = ShredSigVerifyStats::new(Instant::now());
-
-        for shred in shreds.iter_mut() {
-            let keypair = Keypair::new();
+        for shred in &shreds {
+            let retransmitter_keypair = Keypair::new();
             let nonce = repaired.then(|| rng.random::<Nonce>());
+
+            let mut packet = shred.payload().to_packet(nonce);
+            if repaired {
+                packet.meta_mut().flags |= PacketFlags::REPAIR;
+            }
+
+            let mut packet_batch = RecycledPacketBatch::with_capacity(1);
+            packet_batch.push(packet);
+
+            let mut bytes_packet = shred.payload().to_bytes_packet(nonce);
+            if repaired {
+                bytes_packet.meta_mut().flags |= PacketFlags::REPAIR;
+            }
+
+            let bytes_buffer_address_before = bytes_packet.buffer().as_ptr().addr();
+
+            let mut batches = vec![
+                PacketBatch::from(packet_batch),
+                PacketBatch::Single(bytes_packet),
+            ];
+
+            let packet_buffer_before = batches[0].get(0).unwrap().data(..).unwrap().to_vec();
+
+            let mut counters = WorkerCounters::default();
+
+            for batch in &mut batches {
+                let mut packet = batch.get_mut(0).unwrap();
+
+                maybe_verify_and_resign_packet(
+                    &mut packet,
+                    root_bank.as_ref(),
+                    working_bank.as_ref(),
+                    cluster_info.as_ref(),
+                    leader_schedule_cache.as_ref(),
+                    &cluster_nodes_cache,
+                    &mut counters,
+                    &retransmitter_keypair,
+                )
+                .unwrap();
+            }
+
+            let packet = batches
+                .iter()
+                .find_map(|batch| match batch {
+                    PacketBatch::Single(_) => None,
+                    batch => batch.get(0),
+                })
+                .unwrap();
+
+            let bytes_packet = batches
+                .iter()
+                .find_map(|batch| match batch {
+                    PacketBatch::Single(packet) => Some(packet),
+                    _ => None,
+                })
+                .unwrap();
+
+            assert!(!packet.meta().discard());
+            assert!(!bytes_packet.meta().discard());
+
+            let packet_buffer_after = packet.data(..).unwrap();
+            let bytes_buffer_address_after = bytes_packet.buffer().as_ptr().addr();
+
             if is_last_in_slot {
-                let packet = &mut shred.payload().to_packet(nonce);
-                let buf_before = packet.buffer_mut().to_vec();
-                if repaired {
-                    packet.meta_mut().flags |= PacketFlags::REPAIR;
+                assert_ne!(packet_buffer_before.as_slice(), packet_buffer_after);
+                assert_ne!(bytes_buffer_address_before, bytes_buffer_address_after);
+
+                for batch in &batches {
+                    let packet = batch.get(0).unwrap();
+                    let shred = get_shred(packet).unwrap();
+                    let signature = shred::layout::get_retransmitter_signature(shred).unwrap();
+                    let merkle_root = shred::layout::get_merkle_root(shred).unwrap();
+
+                    assert!(signature.verify(
+                        retransmitter_keypair.pubkey().as_ref(),
+                        merkle_root.as_ref(),
+                    ));
                 }
-                maybe_verify_and_resign_packet(
-                    &mut packet.into(),
-                    &root_bank,
-                    &working_bank,
-                    &cluster_info,
-                    &leader_schedule_cache,
-                    &cluster_nodes_cache,
-                    &stats,
-                    &keypair,
-                )
-                .expect("packet should pass the verification");
-                assert!(!packet.meta().discard());
-
-                // Check whether the packet was modified.
-                assert_ne!(&buf_before, &packet.data(..).unwrap());
-
-                let mut bytes_packet = shred.payload().to_bytes_packet(nonce);
-                if repaired {
-                    bytes_packet.meta_mut().flags |= PacketFlags::REPAIR;
-                }
-                let buf_addr = bytes_packet.buffer().as_ptr().addr();
-                maybe_verify_and_resign_packet(
-                    &mut bytes_packet.as_mut(),
-                    &root_bank,
-                    &working_bank,
-                    &cluster_info,
-                    &leader_schedule_cache,
-                    &cluster_nodes_cache,
-                    &stats,
-                    &keypair,
-                )
-                .expect("packet should pass the verification");
-                assert!(!bytes_packet.meta().discard());
-
-                // Check whether the packet was modified.
-                let buf_addr_after = bytes_packet.buffer().as_ptr().addr();
-                assert_ne!(buf_addr, buf_addr_after);
             } else {
-                let packet = &mut shred.payload().to_packet(nonce);
-                if repaired {
-                    packet.meta_mut().flags |= PacketFlags::REPAIR;
-                }
-                maybe_verify_and_resign_packet(
-                    &mut packet.into(),
-                    &root_bank,
-                    &working_bank,
-                    &cluster_info,
-                    &leader_schedule_cache,
-                    &cluster_nodes_cache,
-                    &stats,
-                    &keypair,
-                )
-                .expect("packet should pass the verification");
-                assert!(!packet.meta().discard());
-
-                let mut bytes_packet = shred.payload().to_bytes_packet(nonce);
-                if repaired {
-                    bytes_packet.meta_mut().flags |= PacketFlags::REPAIR;
-                }
-                let buf_addr = bytes_packet.buffer().as_ptr().addr();
-                maybe_verify_and_resign_packet(
-                    &mut bytes_packet.as_mut(),
-                    &root_bank,
-                    &working_bank,
-                    &cluster_info,
-                    &leader_schedule_cache,
-                    &cluster_nodes_cache,
-                    &stats,
-                    &keypair,
-                )
-                .expect("packet should pass the verification");
-                assert!(!packet.meta().discard());
-
-                // Packet should not be modified.
-                let buf_addr_after = bytes_packet.buffer().as_ptr().addr();
-                assert_eq!(buf_addr, buf_addr_after);
+                assert_eq!(packet_buffer_before.as_slice(), packet_buffer_after);
+                assert_eq!(bytes_buffer_address_before, bytes_buffer_address_after);
             }
         }
+    }
+
+    #[test]
+    fn test_extract_shred_and_location_bytes_packet_is_zero_copy() {
+        let leader_keypair = Keypair::new();
+
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(1, 0, 1, 0).unwrap();
+
+        let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            false,
+            Hash::new_unique(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        let bytes_packet = shreds[0].payload().to_bytes_packet(None);
+
+        let buffer_ptr = bytes_packet.buffer().as_ptr();
+
+        let mut stats = ShredSigVerifyStats::new(Instant::now());
+        let repair_nonce_location_lookup = |_| None;
+
+        let (payload, location) = extract_shred_and_location(
+            PacketRef::Bytes(&bytes_packet),
+            &repair_nonce_location_lookup,
+            &mut stats,
+        )
+        .unwrap();
+
+        assert!(location.is_none());
+        assert_eq!(payload.bytes.as_ptr(), buffer_ptr);
+        assert_eq!(payload.bytes.as_ref(), shreds[0].payload().bytes.as_ref());
+    }
+
+    #[test]
+    fn test_sigverify_workers_fanout_aggregates_stats() {
+        const NUM_WORKERS: usize = 3;
+        const NUM_BATCHES: usize = SIGVERIFY_SHRED_BATCH_SIZE;
+
+        let leader_keypair = Arc::new(Keypair::new());
+        let wrong_keypair = Keypair::new();
+        let node_keypair = Arc::new(Keypair::new());
+        let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair.pubkey();
+
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let workers =
+            new_sigverify_workers(cluster_info, bank_forks, leader_schedule_cache, NUM_WORKERS);
+
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(1, 0, 1, 0).unwrap();
+        let reed_solomon_cache = ReedSolomonCache::default();
+
+        let mut batches = Vec::with_capacity(NUM_BATCHES);
+
+        for index in 0..NUM_BATCHES {
+            let signing_keypair = if index % 2 == 0 {
+                leader_keypair.as_ref()
+            } else {
+                &wrong_keypair
+            };
+
+            // Use a different chained Merkle root for every batch so that
+            // otherwise-valid shreds are not treated as duplicates.
+            let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+                signing_keypair,
+                &entries,
+                false,
+                Hash::new_unique(),
+                0,
+                0,
+                &reed_solomon_cache,
+                &mut ProcessShredsStats::default(),
+            );
+
+            let shred = &shreds[0];
+
+            let mut batch = RecycledPacketBatch::with_capacity(1);
+            batch.resize(1, Packet::default());
+            batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+            batch[0].meta_mut().size = shred.payload().len();
+
+            batches.push(PacketBatch::from(batch));
+        }
+
+        let worker_stats = workers.process_batches(&mut batches, &node_keypair);
+
+        assert_eq!(batches.len(), NUM_BATCHES);
+
+        let num_discards = batches
+            .iter()
+            .flat_map(|batch| batch.iter())
+            .filter(|packet| packet.meta().discard())
+            .count();
+
+        assert_eq!(num_discards, NUM_BATCHES / 2);
+        assert_eq!(worker_stats.num_discards_post, NUM_BATCHES / 2);
+        assert_eq!(worker_stats.num_duplicates, 0);
+    }
+    #[test]
+    fn test_sigverify_workers_dedup_across_batches() {
+        const NUM_WORKERS: usize = 8;
+        const NUM_BATCHES: usize = 64;
+
+        let leader_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(Keypair::new());
+        let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair.pubkey();
+
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let workers =
+            new_sigverify_workers(cluster_info, bank_forks, leader_schedule_cache, NUM_WORKERS);
+
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(1, 0, 1, 0).unwrap();
+
+        let (shreds, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            false,
+            Hash::new_unique(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        let shred = &shreds[0];
+
+        let mut batches = Vec::with_capacity(NUM_BATCHES);
+
+        for _ in 0..NUM_BATCHES {
+            let mut batch = RecycledPacketBatch::with_capacity(1);
+            batch.resize(1, Packet::default());
+
+            batch[0].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
+            batch[0].meta_mut().size = shred.payload().len();
+
+            batches.push(PacketBatch::from(batch));
+        }
+
+        let worker_stats = workers.process_batches(&mut batches, &node_keypair);
+
+        assert_eq!(batches.len(), NUM_BATCHES);
+
+        let num_discards = batches
+            .iter()
+            .flat_map(|batch| batch.iter())
+            .filter(|packet| packet.meta().discard())
+            .count();
+
+        let num_survivors = NUM_BATCHES - num_discards;
+
+        // Deduper<2> sets two atomic bits for each payload. Concurrent workers can
+        // race while setting those bits, so at most two copies may be accepted.
+        assert!((1..=2).contains(&num_survivors));
+
+        assert_eq!(worker_stats.num_duplicates, num_discards);
+        assert_eq!(worker_stats.num_discards_post, num_discards);
+    }
+    #[test]
+    fn test_sigverify_workers_repair_shreds_are_deduped_but_not_discarded() {
+        let leader_keypair = Arc::new(Keypair::new());
+        let node_keypair = Arc::new(Keypair::new());
+        let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair.pubkey();
+
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let workers = new_sigverify_workers(cluster_info, bank_forks, leader_schedule_cache, 3);
+
+        let entries = create_ticks(1, 1, Hash::new_unique());
+        let shredder = Shredder::new(1, 0, 1, 0).unwrap();
+        let reed_solomon_cache = ReedSolomonCache::default();
+
+        let (shreds_a, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            false,
+            Hash::new_unique(),
+            0,
+            0,
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
+
+        let (shreds_b, _) = shredder.entries_to_merkle_shreds_for_tests(
+            &leader_keypair,
+            &entries,
+            false,
+            Hash::new_unique(),
+            0,
+            0,
+            &reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
+
+        let shred_a = &shreds_a[0];
+        let shred_b = &shreds_b[0];
+
+        let mut batch = RecycledPacketBatch::with_capacity(4);
+        batch.resize(4, Packet::default());
+
+        // Turbine A: first time the deduper sees payload A.
+        batch[0].buffer_mut()[..shred_a.payload().len()].copy_from_slice(shred_a.payload());
+        batch[0].meta_mut().size = shred_a.payload().len();
+
+        // Repair A: duplicate of A, but repair packets are exempt from discard.
+        batch[1].buffer_mut()[..shred_a.payload().len()].copy_from_slice(shred_a.payload());
+        batch[1].meta_mut().size = shred_a.payload().len();
+        batch[1].meta_mut().flags |= PacketFlags::REPAIR;
+
+        // Repair B: first time the deduper sees payload B. It must still be fed
+        // into the deduper even though repair packets are exempt from discard.
+        batch[2].buffer_mut()[..shred_b.payload().len()].copy_from_slice(shred_b.payload());
+        batch[2].meta_mut().size = shred_b.payload().len();
+        batch[2].meta_mut().flags |= PacketFlags::REPAIR;
+
+        // Turbine B: must now be discarded because repair B inserted the same
+        // shred payload into the deduper.
+        batch[3].buffer_mut()[..shred_b.payload().len()].copy_from_slice(shred_b.payload());
+        batch[3].meta_mut().size = shred_b.payload().len();
+
+        let mut batches = vec![PacketBatch::from(batch)];
+
+        let worker_stats = workers.process_batches(&mut batches, &node_keypair);
+
+        let batch = &batches[0];
+
+        assert!(!batch.get(0).unwrap().meta().discard());
+        assert!(!batch.get(1).unwrap().meta().discard());
+        assert!(!batch.get(2).unwrap().meta().discard());
+        assert!(batch.get(3).unwrap().meta().discard());
+
+        assert_eq!(worker_stats.num_duplicates, 1);
+        assert_eq!(worker_stats.num_discards_post, 1);
+    }
+    #[test]
+    fn test_sigverify_workers_use_updated_keypair_across_rounds() {
+        let mut rng = rand::rng();
+
+        let leader_keypair = Arc::new(Keypair::new());
+        let node_keypair_a = Arc::new(Keypair::new());
+        let node_keypair_b = Arc::new(Keypair::new());
+
+        let leader_pubkey = leader_keypair.pubkey();
+        let node_pubkey = node_keypair_a.pubkey();
+
+        let bank = Bank::new_for_tests(
+            &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
+        );
+        let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(&bank));
+        let bank_forks = BankForks::new_rw_arc(bank);
+
+        let cluster_info = Arc::new(ClusterInfo::new(
+            ContactInfo::new_localhost(&node_pubkey, timestamp()),
+            node_keypair_a.clone(),
+            SocketAddrSpace::Unspecified,
+        ));
+
+        let workers = new_sigverify_workers(cluster_info, bank_forks, leader_schedule_cache, 3);
+
+        let entries = vec![Entry::new(&Hash::default(), 0, vec![])];
+        let shredder = Shredder::new(1, 0, 0, 0).unwrap();
+
+        // Round 1 uses node_keypair_a.
+        let shreds = shredder.make_merkle_shreds_from_entries(
+            &leader_keypair,
+            &entries,
+            true,
+            Hash::new_unique(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        let shred = &shreds[0];
+        let nonce = rng.random::<Nonce>();
+        let mut packet = shred.payload().to_packet(Some(nonce));
+        packet.meta_mut().flags |= PacketFlags::REPAIR;
+
+        let mut batch = RecycledPacketBatch::with_capacity(1);
+        batch.push(packet);
+
+        let mut batches = vec![PacketBatch::from(batch)];
+
+        workers.process_batches(&mut batches, &node_keypair_a);
+
+        let packet = batches[0].get(0).unwrap();
+        assert!(!packet.meta().discard());
+
+        let shred = get_shred(packet).unwrap();
+        let signature = shred::layout::get_retransmitter_signature(shred).unwrap();
+        let merkle_root = shred::layout::get_merkle_root(shred).unwrap();
+
+        assert!(signature.verify(node_keypair_a.pubkey().as_ref(), merkle_root.as_ref(),));
+
+        // Round 2 reuses the same workers but supplies node_keypair_b.
+        // Use a different shred so the shared deduper does not discard it.
+        let shreds = shredder.make_merkle_shreds_from_entries(
+            &leader_keypair,
+            &entries,
+            true,
+            Hash::new_unique(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
+
+        let shred = &shreds[0];
+        let nonce = rng.random::<Nonce>();
+        let mut packet = shred.payload().to_packet(Some(nonce));
+        packet.meta_mut().flags |= PacketFlags::REPAIR;
+
+        let mut batch = RecycledPacketBatch::with_capacity(1);
+        batch.push(packet);
+
+        let mut batches = vec![PacketBatch::from(batch)];
+
+        workers.process_batches(&mut batches, &node_keypair_b);
+
+        let packet = batches[0].get(0).unwrap();
+        assert!(!packet.meta().discard());
+
+        let shred = get_shred(packet).unwrap();
+        let signature = shred::layout::get_retransmitter_signature(shred).unwrap();
+        let merkle_root = shred::layout::get_merkle_root(shred).unwrap();
+
+        assert!(signature.verify(node_keypair_b.pubkey().as_ref(), merkle_root.as_ref(),));
+        assert!(!signature.verify(node_keypair_a.pubkey().as_ref(), merkle_root.as_ref(),));
     }
 }


### PR DESCRIPTION
`ShredSigVerify` currently uses a dedicated Rayon pool for shred verification and retransmitter verification/resigning.

This PR replaces Rayon with persistent dedicated worker threads operating on whole `PacketBatch`es.

#### Summary of Changes

- Replace the dedicated Rayon pool with persistent sigverify workers.
- Move deduplication, bank loading, slot-leader resolution, leader verification, retransmitter verification, and resigning into the workers.
- Share the deduper across workers.
- Load root and working banks through `SharableBanks`.
- Aggregate worker stats per batch before publishing to atomics.
- Preserve the zero-copy payload path for `Bytes` packets.

Completed batches are collected as workers finish, so batch ordering is not preserved.

`resign_micros` is renamed to `verify_and_resign_micros` and now measures the full worker processing section.

A paced benchmark is included in `turbine/benches/shred_sigverify.rs`.

#### Testing

Unit tests cover:

- valid and invalid shred verification;
- retransmitter verification and resigning;
- `Packet` and `Bytes` variants;
- zero-copy `Bytes` extraction;
- worker fan-out and stats aggregation;
- cross-batch deduplication;
- repair-shred dedup semantics;
- worker reuse with an updated node keypair.