### PR TITLE
conformance(cost): support v0 transactions with address table lookups

### DIFF
--- a/runtime/src/conformance/cost.rs
+++ b/runtime/src/conformance/cost.rs
@@ -8,8 +8,9 @@ use {
         SanitizedTransaction as ProtoSanitizedTransaction, TxnCostMode as ProtoTxnCostMode,
     },
     solana_cost_model::{cost_model::CostModel, transaction_cost::TransactionCost},
-    solana_message::SimpleAddressLoader,
+    solana_message::{SimpleAddressLoader, VersionedMessage, v0::LoadedAddresses},
     solana_packet::PACKET_DATA_SIZE,
+    solana_pubkey::Pubkey,
     solana_runtime_transaction::runtime_transaction::RuntimeTransaction,
     solana_signature::Signature,
     solana_svm::conformance::{
@@ -53,11 +54,35 @@ fn runtime_transaction_from_proto(
         "transaction exceeds max packet size",
     );
 
+    // Dummy loaded addresses, one per ALUT index. Cost tracking only
+    // tracks counts, so dummy pubkeys are fine.
+    let lookups = match &versioned_tx.message {
+        VersionedMessage::V0(message) => message.address_table_lookups.as_slice(),
+        _ => &[],
+    };
+    let num_writable_lookups: usize = lookups.iter().map(|l| l.writable_indexes.len()).sum();
+    let num_readonly_lookups: usize = lookups.iter().map(|l| l.readonly_indexes.len()).sum();
+    let dummy_key = |tag: u8, index: usize| {
+        let mut bytes = [0u8; 32];
+        bytes[0] = tag;
+        bytes[1] = index as u8;
+        bytes[2] = (index >> 8) as u8;
+        Pubkey::new_from_array(bytes)
+    };
+    let loaded_addresses = LoadedAddresses {
+        writable: (0..num_writable_lookups)
+            .map(|index| dummy_key(0xAA, index))
+            .collect(),
+        readonly: (0..num_readonly_lookups)
+            .map(|index| dummy_key(0xBB, index))
+            .collect(),
+    };
+
     RuntimeTransaction::try_create(
         versioned_tx,
         MessageHash::Compute,
         None,
-        SimpleAddressLoader::Disabled,
+        SimpleAddressLoader::Enabled(loaded_addresses),
         &std::collections::HashSet::new(),
     )
     .expect("failed to create RuntimeTransaction")

--- a/runtime/src/conformance/cost.rs
+++ b/runtime/src/conformance/cost.rs
@@ -184,6 +184,7 @@ mod tests {
         agave_feature_set::FEATURE_NAMES,
         protosol::protos::{
             CompiledInstruction as ProtoCompiledInstruction, FeatureSet as ProtoFeatureSet,
+            MessageAddressTableLookup as ProtoMessageAddressTableLookup,
             MessageHeader as ProtoMessageHeader, SanitizedTransaction as ProtoSanitizedTransaction,
             TransactionMessage as ProtoTransactionMessage,
         },
@@ -255,6 +256,30 @@ mod tests {
         }
     }
 
+    fn v0_tx(lookups: Vec<ProtoMessageAddressTableLookup>) -> ProtoSanitizedTransaction {
+        let msg = ProtoTransactionMessage {
+            is_legacy: false,
+            header: Some(ProtoMessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            }),
+            account_keys: vec![vec![1; 32], SYSTEM_PROGRAM_ID.to_vec()],
+            recent_blockhash: vec![0; 32],
+            instructions: vec![ProtoCompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![2, 0, 0, 0],
+            }],
+            address_table_lookups: lookups,
+        };
+        ProtoSanitizedTransaction {
+            message: Some(msg),
+            message_hash: vec![0; 32],
+            signatures: vec![vec![0; 64]],
+        }
+    }
+
     fn estimate_context(tx: ProtoSanitizedTransaction) -> ProtoCostContext {
         ProtoCostContext {
             tx: Some(tx),
@@ -291,6 +316,24 @@ mod tests {
         let result = assert_has_cost(&estimate_context(vote_tx()));
         assert!(result.total_cost > 0);
         assert!(result.signature_cost > 0);
+    }
+
+    #[test]
+    fn test_estimate_v0_with_lookups() {
+        let lookups = vec![ProtoMessageAddressTableLookup {
+            account_key: vec![3; 32],
+            writable_indexes: vec![0, 1],
+            readonly_indexes: vec![2],
+        }];
+        let with_lookups = assert_has_cost(&estimate_context(v0_tx(lookups)));
+        let without_lookups = assert_has_cost(&estimate_context(v0_tx(vec![])));
+
+        // Two writable lookups triple the write lock cost (payer + 2);
+        // the readonly lookup adds nothing.
+        assert_eq!(
+            with_lookups.write_lock_cost,
+            3 * without_lookups.write_lock_cost,
+        );
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
`runtime/src/conformance/cost.rs` passes `SimpleAddressLoader::Disabled`, so any v0 transaction carrying address table lookups fails `RuntimeTransaction::try_create` with `UnsupportedVersion` and panics the cost harness instead of being executed.

#### Summary of Changes
Build one dummy loaded address per ALUT index and pass `SimpleAddressLoader::Enabled`, which is safe because cost tracking only counts loaded addresses rather than reading them.