### PR TITLE
alpenglow: fix non-terminal fec sets under perfect equivocation

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -114,9 +114,9 @@ pub trait RepairHandler {
     ) -> Option<PacketBatch> {
         // Try to find the requested index in one of the slots
         let meta = self.blockstore().meta(slot).ok()??;
-        if meta.received > highest_index {
-            // meta.received must be at least 1 by this point
-            let packet = self.repair_response_packet(slot, meta.received - 1, from_addr, nonce)?;
+        let shred_index = meta.received.checked_sub(1)?;
+        if shred_index >= highest_index || meta.last_index == Some(shred_index) {
+            let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
             return Some(
                 RecycledPacketBatch::new_with_recycler_data(
                     recycler,

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -39,7 +39,7 @@ use {
         blockstore_meta::BlockLocation,
         shred::{
             self, DATA_SHREDS_PER_FEC_BLOCK, MAX_FEC_SETS_PER_SLOT, Nonce, SIZE_OF_NONCE,
-            ShredFetchStats, ShredType, layout::get_merkle_root, merkle_tree,
+            ShredFetchStats, ShredFlags, ShredType, layout::get_merkle_root, merkle_tree,
         },
     },
     solana_net_utils::{SocketAddrSpace, token_bucket::TokenBucket},
@@ -126,7 +126,8 @@ impl From<Hash> for FecSetRoot {
 pub enum ShredRepairType {
     /// Requesting `MAX_ORPHAN_REPAIR_RESPONSES ` parent shreds
     Orphan(Slot),
-    /// Requesting any shred with index greater than or equal to the particular index
+    /// Requesting any shred with index greater than or equal to the particular index,
+    /// or a lower shred marked as the last shred in its slot.
     HighestShred(Slot, u64),
     /// Requesting the missing shred at a particular index
     Shred(Slot, u64),
@@ -181,7 +182,12 @@ impl RequestResponse for ShredRepairType {
         match self {
             ShredRepairType::Orphan(slot) => shred_slot <= *slot,
             ShredRepairType::HighestShred(slot, index) => {
-                shred_slot == *slot && get_shred_index(shred) >= Some(*index)
+                shred_slot == *slot
+                    && get_shred_index(shred).is_some_and(|shred_index| {
+                        shred_index >= *index
+                            || shred::layout::get_flags(shred)
+                                .is_ok_and(|flags| flags.contains(ShredFlags::LAST_SHRED_IN_SLOT))
+                    })
             }
             ShredRepairType::Shred(slot, index) => {
                 shred_slot == *slot && get_shred_index(shred) == Some(*index)
@@ -2540,7 +2546,7 @@ mod tests {
             index + 1,
             nonce,
         );
-        assert!(rv.is_none());
+        assert!(rv.is_some());
     }
 
     #[test]

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -178,9 +178,18 @@ fn run_check_duplicate(
             &root_bank,
         );
 
-        let Some((shred1, shred2)) =
-            check_duplicate_shred(blockstore, shred, no_verify_chained_merkle_root)?
-        else {
+        let duplicate = check_duplicate_shred(blockstore, shred, no_verify_chained_merkle_root)?;
+
+        let should_mark_dead = migration_status
+            .genesis_block()
+            .is_some_and(|genesis| shred_slot > genesis.slot);
+        if should_mark_dead {
+            // Apart from Exists all existing cases mark dead inline in blockstore.
+            // Once Alpenglow is active we can fully remove this thread and move Exists to inline as well.
+            blockstore.set_dead_slot_if_duplicate_and_not_full(shred_slot)?;
+        }
+
+        let Some((shred1, shred2)) = duplicate else {
             return Ok(());
         };
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5365,6 +5365,17 @@ impl Blockstore {
         self.dead_slots_cf.put(slot, &true)
     }
 
+    /// Marks a duplicate slot dead unless it is full, for external use.
+    pub fn set_dead_slot_if_duplicate_and_not_full(&self, slot: Slot) -> Result<()> {
+        let _lock = self.insert_shreds_lock.lock().unwrap();
+        if self.has_duplicate_shreds_in_slot(slot)
+            && !self.meta(slot)?.is_some_and(|meta| meta.is_full())
+        {
+            self.set_dead_slot(slot)?;
+        }
+        Ok(())
+    }
+
     pub fn remove_dead_slot(&self, slot: Slot) -> Result<()> {
         self.dead_slots_cf.delete(slot)
     }


### PR DESCRIPTION
Combining https://github.com/anza-xyz/agave/pull/14625 and https://github.com/anza-xyz/agave/pull/14643 for ease of backporting

#### Problem
As found in the AG bug bounty report.

In Alpenglow we require that every block received through turbine/repair will eventually either:
- Be full
- Marked dead

This is critical for nodes to catchup in case of leader equivocation.
If a leader *perfectly* partitions Turbine, they can submit version A and B such that:
- Version A ends with the last shred correctly setting `LAST_SHRED_IN_SLOT`
- Version B is equal or longer in size does not have the `LAST_SHRED_IN_SLOT`

and no individual node sees shreds from both versions.

Victims who receive version B will send `HighestShred` repair requests to try to complete the block. 
They will not receive any valid responses since B is longer than A and they have all shreds of B.

Supposing for a minute they did receive shreds of A (e.g. if the repair bug was patched OR if the leader didn't _perfectly_ partition turbine), they reject it and emit `PossibleDuplicateShred::Exists`

`Exists` returns early and skips the rest of the checks:
https://github.com/anza-xyz/agave/blob/d71b6883792351a905cb0696b67ab41792246940/ledger/src/blockstore.rs#L2967

Unlike TowerBFT we don't take any action on `Exists`. All other `PossibleDuplicateShred` variants mark the slot as dead inline, but this one was forgotten.

Thus we violate the invariant, the block can never be full or dead and the victim stalls. 

#### Summary of Changes
Commit 1: Mark `PossibleDuplicateShredExists` as dead when Alpenglow is active. For simplicity we mark all successful variants of `PossibleDuplicateShred` as dead - the rest are already marked dead inline but it doesn't hurt. Once AG is active we can just remove this separate thread and mark all variants inline.

Commit 2: Allow for `HighestShred` to receive any lower shred that has `LAST_SHRED_IN_SLOT` set

