### PR TITLE
Remove unused add roots timing

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -3,8 +3,8 @@ use {
         account_locks::{AccountLocks, validate_account_locks},
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{
-            AccountsAddRootTiming, AccountsDb, LoadHint, LoadedAccount, PopulateReadCache,
-            ScanAccountStorageData, ScanStorageResult, UpdateIndexThreadSelection,
+            AccountsDb, LoadHint, LoadedAccount, PopulateReadCache, ScanAccountStorageData,
+            ScanStorageResult, UpdateIndexThreadSelection,
         },
         accounts_index::IndexKey,
         accounts_scan::{ScanConfig, ScanError, ScanResult},
@@ -572,7 +572,7 @@ impl Accounts {
     }
 
     /// Add a slot to root.  Root slots cannot be purged
-    pub fn add_root(&self, slot: Slot) -> AccountsAddRootTiming {
+    pub fn add_root(&self, slot: Slot) {
         self.accounts_db.add_root(slot)
     }
 }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -326,10 +326,6 @@ pub struct GetUniqueAccountsResult {
     pub written_bytes: u64,
 }
 
-pub struct AccountsAddRootTiming {
-    pub cache_us: u64,
-}
-
 /// Slots older the "number of slots in an epoch minus this number"
 /// than max root are treated as ancient and subject to packing.
 /// |  older  |<-          slots in an epoch          ->| max root
@@ -5055,16 +5051,9 @@ impl AccountsDb {
         }
     }
 
-    pub fn add_root(&self, slot: Slot) -> AccountsAddRootTiming {
-        let mut cache_time = Measure::start("cache_add_root");
+    pub fn add_root(&self, slot: Slot) {
         self.accounts_cache.add_root(slot);
-        cache_time.stop();
-
         self.max_root.fetch_max(slot, Ordering::Relaxed);
-
-        AccountsAddRootTiming {
-            cache_us: cache_time.as_us(),
-        }
     }
 
     /// Returns the largest slot that has been added as a root via `add_root`.


### PR DESCRIPTION
#### Problem
None of the callers use the timing value. It's also fast and not worth timing now. 

#### Summary of Changes
- Remove it

#### Testing


Fixes #
