### PR TITLE
core: prefer bank wrapper over load_with_fixed_root()

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -904,13 +904,8 @@ pub(crate) mod external {
                 );
 
                 let fee_payer_balance = working_bank
-                    .rc
-                    .accounts
-                    .load_with_fixed_root(
-                        &working_bank.ancestors,
-                        &transaction.static_account_keys()[0],
-                    )
-                    .map(|(account, _slot)| account.lamports())
+                    .get_account_with_fixed_root(&transaction.static_account_keys()[0])
+                    .map(|account| account.lamports())
                     .unwrap_or(0);
 
                 let response = &mut responses[transaction_index];

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -485,10 +485,8 @@ impl Consumer {
             transaction_configuration.priority_fee_lamports,
             bank.fee_features(),
         );
-        let (mut fee_payer_account, _slot) = bank
-            .rc
-            .accounts
-            .load_with_fixed_root(&bank.ancestors, fee_payer)
+        let mut fee_payer_account = bank
+            .get_account_with_fixed_root(fee_payer)
             .ok_or(TransactionError::AccountNotFound)?;
 
         validate_fee_payer(


### PR DESCRIPTION
#### Problem
we anticipate changing the signature of `load_with_fixed_root()` in https://github.com/anza-xyz/agave/pull/14540. we use it in core/ but dont need to

#### Summary of Changes
use the bank wrapper 
