### PR TITLE
ledger: Remove internal Merkle Shred enum

### DIFF
--- a/core/benches/shredder.rs
+++ b/core/benches/shredder.rs
@@ -65,7 +65,7 @@ fn bench_shredder_ticks(bencher: &mut Bencher) {
     let chained_merkle_root = Hash::new_from_array(rand::rng().random());
     bencher.iter(|| {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-        shredder.entries_to_merkle_shreds_for_tests(
+        shredder.make_merkle_shreds_from_entries(
             &kp,
             &entries,
             true,
@@ -150,6 +150,7 @@ fn bench_deserialize_hdr(bencher: &mut Bencher) {
             &reed_solomon_cache,
             &mut stats,
         )
+        .into_iter()
         .filter(Shred::is_data)
         .collect::<Vec<_>>();
     let shred = shreds.remove(0);
@@ -172,29 +173,7 @@ fn bench_shredder_coding(bencher: &mut Bencher) {
     let reed_solomon_cache = ReedSolomonCache::default();
     let merkle_root = Hash::new_from_array(rand::rng().random());
     bencher.iter(|| {
-        let result: Vec<_> = shredder
-            .make_merkle_shreds_from_entries(
-                &Keypair::new(),
-                &entries,
-                true, // is_last_in_slot
-                merkle_root,
-                0, // next_shred_index
-                0, // next_code_index
-                &reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
-            )
-            .collect();
-        black_box(result);
-    })
-}
-
-fn bench_shredder_decoding(bencher: &mut Bencher) {
-    let entries = make_entries();
-    let shredder = Shredder::new(1, 0, 0, 0).unwrap();
-    let reed_solomon_cache = ReedSolomonCache::default();
-    let merkle_root = Hash::new_from_array(rand::rng().random());
-    let (_data_shreds, mut coding_shreds): (Vec<_>, Vec<_>) = shredder
-        .make_merkle_shreds_from_entries(
+        let shreds = shredder.make_merkle_shreds_from_entries(
             &Keypair::new(),
             &entries,
             true, // is_last_in_slot
@@ -203,8 +182,26 @@ fn bench_shredder_decoding(bencher: &mut Bencher) {
             0, // next_code_index
             &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
-        )
-        .partition(Shred::is_data);
+        );
+        black_box(shreds);
+    })
+}
+
+fn bench_shredder_decoding(bencher: &mut Bencher) {
+    let entries = make_entries();
+    let shredder = Shredder::new(1, 0, 0, 0).unwrap();
+    let reed_solomon_cache = ReedSolomonCache::default();
+    let merkle_root = Hash::new_from_array(rand::rng().random());
+    let (_data_shreds, mut coding_shreds) = shredder.entries_to_merkle_shreds_for_tests(
+        &Keypair::new(),
+        &entries,
+        true, // is_last_in_slot
+        merkle_root,
+        0, // next_shred_index
+        0, // next_code_index
+        &reed_solomon_cache,
+        &mut ProcessShredsStats::default(),
+    );
     coding_shreds.truncate(CODING_SHREDS_PER_FEC_BLOCK);
     let mut shred_recovery_context = new_shred_recovery_context(&coding_shreds);
 

--- a/core/src/completed_data_sets_service.rs
+++ b/core/src/completed_data_sets_service.rs
@@ -661,7 +661,6 @@ pub mod test {
                     &ReedSolomonCache::default(),
                     &mut ProcessShredsStats::default(),
                 )
-                .collect::<Vec<_>>()
         };
         let mut shreds = make_marker_shreds(
             VersionedBlockMarker::from_block_header(BlockHeaderV1 {

--- a/core/src/repair/malicious_repair_handler.rs
+++ b/core/src/repair/malicious_repair_handler.rs
@@ -116,18 +116,16 @@ impl MaliciousRepairHandler {
         let chained_merkle_root = original_shred.chained_merkle_root().ok()?;
         let is_last_in_slot = original_shred.last_in_slot();
 
-        let shreds: Vec<Shred> = shredder
-            .make_merkle_shreds_from_entries(
-                &self.keypair,
-                &fake_entries,
-                is_last_in_slot,
-                chained_merkle_root,
-                shred_index as u32, // next_shred_index
-                0,                  // next_code_index
-                &self.reed_solomon_cache,
-                &mut ProcessShredsStats::default(),
-            )
-            .collect();
+        let shreds = shredder.make_merkle_shreds_from_entries(
+            &self.keypair,
+            &fake_entries,
+            is_last_in_slot,
+            chained_merkle_root,
+            shred_index as u32, // next_shred_index
+            0,                  // next_code_index
+            &self.reed_solomon_cache,
+            &mut ProcessShredsStats::default(),
+        );
 
         // Return the first data shred's payload
         shreds

--- a/core/src/replay_stage/tests.rs
+++ b/core/src/replay_stage/tests.rs
@@ -238,7 +238,6 @@ fn block_marker_shreds_with_last(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .collect()
 }
 
 fn insert_update_parent_slot(
@@ -1017,7 +1016,6 @@ fn test_dead_fork_entry_deserialize_failure() {
                 &mut ProcessShredsStats::default(),
             )
             .unwrap()
-            .collect()
     });
 
     assert_matches!(

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -381,18 +381,16 @@ fn append_component_shreds(
     chained_merkle_root: &mut Hash,
     reed_solomon_cache: &ReedSolomonCache,
 ) {
-    let shreds: Vec<_> = shredder
-        .make_merkle_shreds_from_component(
-            keypair,
-            component,
-            is_last_in_slot,
-            *chained_merkle_root,
-            *next_shred_index,
-            *next_code_index,
-            reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        )
-        .collect();
+    let shreds = shredder.make_merkle_shreds_from_component(
+        keypair,
+        component,
+        is_last_in_slot,
+        *chained_merkle_root,
+        *next_shred_index,
+        *next_code_index,
+        reed_solomon_cache,
+        &mut ProcessShredsStats::default(),
+    );
     if let Some(last_data_shred) = shreds.iter().filter(|shred| shred.is_data()).last() {
         *next_shred_index = last_data_shred.index() + 1;
         *chained_merkle_root = last_data_shred
@@ -592,6 +590,7 @@ async fn shreds(
                 &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             )
+            .into_iter()
             .filter(Shred::is_data)
             .collect();
         blockstore.insert_shreds(data_shreds, false)?;

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2490,6 +2490,7 @@ fn main() {
                                 &ReedSolomonCache::default(),
                                 &mut ProcessShredsStats::default(),
                             )
+                            .into_iter()
                             .filter(Shred::is_data)
                             .map(Cow::Owned)
                             .collect();

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -835,6 +835,7 @@ impl Blockstore {
                         &reed_solomon_cache,
                         &mut ProcessShredsStats::default(),
                     )
+                    .into_iter()
                     .filter(Shred::is_data)
                     .collect();
                 if let Some(last_shred) = shreds.last() {
@@ -6742,6 +6743,7 @@ pub fn entries_to_test_shreds(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
+        .into_iter()
         .filter(Shred::is_data)
         .collect()
 }

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -94,7 +94,6 @@ fn create_update_parent_shreds_with_shred_parent(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .collect()
 }
 
 fn create_block_header_shreds(slot: Slot, parent_slot: Slot, parent_block_id: Hash) -> Vec<Shred> {
@@ -126,7 +125,6 @@ fn create_block_header_shreds_with_shred_parent(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .collect()
 }
 
 fn verify_next_slots(blockstore: &Blockstore, parent_slot: Slot, expected: &[Slot]) {
@@ -185,7 +183,6 @@ fn create_block_footer_shreds_with_last(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .collect()
 }
 
 fn create_entry_batch_shreds(
@@ -209,7 +206,6 @@ fn create_entry_batch_shreds(
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
-        .collect()
 }
 
 fn data_shreds(shreds: Vec<Shred>) -> Vec<Shred> {
@@ -2237,6 +2233,7 @@ fn test_merkle_root_metas_data() {
             &mut ProcessShredsStats::default(),
         )
         .unwrap()
+        .into_iter()
         .next()
         .unwrap();
 
@@ -2630,7 +2627,7 @@ fn test_get_slot_entries_with_shred_count_corruption() {
     let keypair = Keypair::new();
     let reed_solomon_cache = ReedSolomonCache::default();
 
-    let shreds: Vec<Shred> = shredder
+    let mut shreds = shredder
         .make_shreds_from_data_slice(
             &keypair,
             &[1, 1, 1],
@@ -2641,9 +2638,8 @@ fn test_get_slot_entries_with_shred_count_corruption() {
             &reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         )
-        .unwrap()
-        .take(DATA_SHREDS_PER_FEC_BLOCK)
-        .collect();
+        .unwrap();
+    shreds.truncate(DATA_SHREDS_PER_FEC_BLOCK);
 
     // With the corruption, nothing should be returned, even though an
     // earlier data block was valid
@@ -3053,6 +3049,7 @@ fn test_get_complete_block_with_block_markers() {
             &ReedSolomonCache::default(),
             &mut ProcessShredsStats::default(),
         )
+        .into_iter()
         .filter(Shred::is_data)
         .collect_vec();
     let entry_end_index = entry_shreds.last().unwrap().index() + 1;
@@ -5647,33 +5644,29 @@ fn setup_duplicate_last_in_slot(
     let leader_keypair = Arc::new(Keypair::new());
     let reed_solomon_cache = ReedSolomonCache::default();
     let shredder = Shredder::new(slot, 0, 0, 0).unwrap();
-    let (shreds1, code1): (Vec<Shred>, Vec<Shred>) = shredder
-        .make_merkle_shreds_from_entries(
-            &leader_keypair,
-            &entries,
-            true,               // is_last_in_slot
-            Hash::new_unique(), // chained_merkle_root
-            0,                  // next_shred_index
-            0,                  // next_code_index,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        )
-        .partition(Shred::is_data);
+    let (shreds1, code1) = shredder.entries_to_merkle_shreds_for_tests(
+        &leader_keypair,
+        &entries,
+        true,               // is_last_in_slot
+        Hash::new_unique(), // chained_merkle_root
+        0,                  // next_shred_index
+        0,                  // next_code_index,
+        &reed_solomon_cache,
+        &mut ProcessShredsStats::default(),
+    );
     let last_data1 = shreds1.last().unwrap();
     let last_code1 = code1.last().unwrap();
 
-    let (shreds2, code2) = shredder
-        .make_merkle_shreds_from_entries(
-            &leader_keypair,
-            &entries,
-            true, // is_last_in_slot
-            last_data1.chained_merkle_root().unwrap(),
-            last_data1.index() + 1, // next_shred_index
-            last_code1.index() + 1, // next_code_index,
-            &reed_solomon_cache,
-            &mut ProcessShredsStats::default(),
-        )
-        .partition(Shred::is_data);
+    let (shreds2, code2) = shredder.entries_to_merkle_shreds_for_tests(
+        &leader_keypair,
+        &entries,
+        true, // is_last_in_slot
+        last_data1.chained_merkle_root().unwrap(),
+        last_data1.index() + 1, // next_shred_index
+        last_code1.index() + 1, // next_code_index,
+        &reed_solomon_cache,
+        &mut ProcessShredsStats::default(),
+    );
     ((shreds1, code1), (shreds2, code2))
 }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -5713,6 +5713,7 @@ pub mod tests {
                 &reed_solomon_cache,
                 &mut ProcessShredsStats::default(),
             )
+            .into_iter()
             .filter(Shred::is_data)
             .collect();
         next_shred_index = header_shreds.last().unwrap().index() + 1;
@@ -5731,6 +5732,7 @@ pub mod tests {
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
+                .into_iter()
                 .filter(Shred::is_data)
                 .collect();
             next_shred_index = footer_shreds.last().unwrap().index() + 1;
@@ -5746,6 +5748,7 @@ pub mod tests {
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
+                .into_iter()
                 .filter(Shred::is_data)
                 .collect();
 
@@ -5763,6 +5766,7 @@ pub mod tests {
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
+                .into_iter()
                 .filter(Shred::is_data)
                 .collect();
             next_shred_index = entry_shreds.last().unwrap().index() + 1;
@@ -5778,6 +5782,7 @@ pub mod tests {
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
+                .into_iter()
                 .filter(Shred::is_data)
                 .collect();
 
@@ -5967,6 +5972,7 @@ pub mod tests {
                         &ReedSolomonCache::default(),
                         &mut ProcessShredsStats::default(),
                     )
+                    .into_iter()
                     .filter(Shred::is_data)
                     .collect();
                 blockstore.insert_shreds(shreds, true).unwrap();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -54,7 +54,9 @@ pub(crate) use self::merkle_tree::PROOF_ENTRIES_FOR_32_32_BATCH;
 use rand::Rng;
 use {
     self::traits::{Shred as _, ShredData as _},
+    crate::shred::{merkle_tree::MerkleProofEntry, payload::PayloadMutGuard},
     bitflags::bitflags,
+    itertools::Either,
     num_enum::{IntoPrimitive, TryFromPrimitive},
     serde::{Deserialize, Serialize},
     solana_clock::Slot,
@@ -67,7 +69,7 @@ use {
     solana_sha256_hasher::hashv,
     solana_signature::{SIGNATURE_BYTES, Signature},
     static_assertions::const_assert_eq,
-    std::{fmt::Debug, mem::MaybeUninit},
+    std::{fmt::Debug, mem::MaybeUninit, ops::Range},
     thiserror::Error,
     wincode::{
         SchemaRead, SchemaWrite, TypeMeta,
@@ -297,7 +299,7 @@ struct CodingShredHeader {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Shred {
-    ShredCode(ShredCode),
+    ShredCode(merkle::ShredCode),
     ShredData(merkle::ShredData),
 }
 
@@ -417,29 +419,42 @@ macro_rules! dispatch {
     }
 }
 
-use {dispatch, wincode::config::ConfigCore};
+use wincode::config::ConfigCore;
 
 impl Shred {
     dispatch!(fn common_header(&self) -> &ShredCommonHeader);
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
     dispatch!(fn set_signature(&mut self, signature: Signature));
     dispatch!(fn signed_data(&self) -> Result<Hash, Error>);
-
-    dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
-    dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);
-    dispatch!(pub fn retransmitter_signature_offset(&self) -> Result<usize, Error>);
-
-    dispatch!(pub fn into_payload(self) -> Payload);
-    dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
-    dispatch!(pub fn payload(&self) -> &Payload);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
 
-    #[cfg(any(test, feature = "dev-context-only-utils"))]
-    pub fn copy_to_packet(&self, packet: &mut Packet) {
-        let payload = self.payload();
-        let size = payload.len();
-        packet.buffer_mut()[..size].copy_from_slice(&payload[..]);
-        packet.meta_mut().size = size;
+    dispatch!(pub fn chained_merkle_root(&self) -> Result<Hash, Error>);
+    dispatch!(fn set_chained_merkle_root(&mut self, chained_merkle_root: &Hash) -> Result<(), Error>);
+
+    dispatch!(pub fn retransmitter_signature_offset(&self) -> Result<usize, Error>);
+    dispatch!(pub(crate) fn retransmitter_signature(&self) -> Result<Signature, Error>);
+    dispatch!(fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error>);
+
+    dispatch!(pub fn payload(&self) -> &Payload);
+    dispatch!(pub fn into_payload(self) -> Payload);
+
+    dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
+    dispatch!(fn merkle_node(&self) -> Result<Hash, Error>);
+    #[cfg(test)]
+    dispatch!(pub(crate) fn proof_size(&self) -> Result<u8, Error>);
+
+    dispatch!(fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<'_, Range<usize>>, Error>);
+    dispatch!(fn erasure_shard_index(&self) -> Result<usize, Error>);
+    #[cfg(test)]
+    dispatch!(pub(crate) fn erasure_shard(&self) -> Result<&[u8], Error>);
+
+    pub(super) fn from_payload<T: AsRef<[u8]>>(shred: T) -> Result<Self, Error>
+    where
+        Payload: From<T>,
+    {
+        match layout::get_shred_variant(shred.as_ref())? {
+            ShredVariant::MerkleCode { .. } => Ok(Self::ShredCode(ShredCode::from_payload(shred)?)),
+            ShredVariant::MerkleData { .. } => Ok(Self::ShredData(ShredData::from_payload(shred)?)),
+        }
     }
 
     pub fn new_from_serialized_shred<T>(shred: T) -> Result<Self, Error>
@@ -447,16 +462,15 @@ impl Shred {
         T: AsRef<[u8]> + Into<Payload>,
         Payload: From<T>,
     {
-        Ok(match layout::get_shred_variant(shred.as_ref())? {
-            ShredVariant::MerkleCode { .. } => {
-                let shred = merkle::ShredCode::from_payload(shred)?;
-                Self::ShredCode(shred)
-            }
-            ShredVariant::MerkleData { .. } => {
-                let shred = merkle::ShredData::from_payload(shred)?;
-                Self::ShredData(shred)
-            }
-        })
+        Self::from_payload(shred)
+    }
+
+    #[cfg(any(test, feature = "dev-context-only-utils"))]
+    pub fn copy_to_packet(&self, packet: &mut Packet) {
+        let payload = self.payload();
+        let size = payload.len();
+        packet.buffer_mut()[..size].copy_from_slice(&payload[..]);
+        packet.meta_mut().size = size;
     }
 
     /// Unique identifier for each shred.
@@ -606,24 +620,23 @@ impl Shred {
         }
         get_payload(self) != get_payload(other)
     }
-}
 
-impl From<merkle::Shred> for Shred {
-    fn from(shred: merkle::Shred) -> Self {
-        match shred {
-            merkle::Shred::ShredCode(shred) => Self::ShredCode(shred),
-            merkle::Shred::ShredData(shred) => Self::ShredData(shred),
+    #[inline]
+    fn set_merkle_proof<'a, I>(&mut self, proof: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = Result<&'a MerkleProofEntry, Error>>,
+    {
+        match self {
+            Self::ShredCode(shred) => shred.set_merkle_proof(proof),
+            Self::ShredData(shred) => shred.set_merkle_proof(proof),
         }
     }
-}
 
-impl TryFrom<Shred> for merkle::Shred {
-    type Error = Error;
-
-    fn try_from(shred: Shred) -> Result<Self, Self::Error> {
-        match shred {
-            Shred::ShredCode(shred) => Ok(Self::ShredCode(shred)),
-            Shred::ShredData(shred) => Ok(Self::ShredData(shred)),
+    #[inline]
+    fn merkle_proof(&self) -> Result<impl Iterator<Item = &MerkleProofEntry>, Error> {
+        match self {
+            Self::ShredCode(shred) => shred.merkle_proof().map(Either::Left),
+            Self::ShredData(shred) => shred.merkle_proof().map(Either::Right),
         }
     }
 }
@@ -813,7 +826,7 @@ pub(crate) fn make_merkle_shreds_for_tests<R: Rng>(
     slot: Slot,
     data_size: usize,
     is_last_in_slot: bool,
-) -> Result<Vec<merkle::Shred>, Error> {
+) -> Result<Vec<Shred>, Error> {
     let chained_merkle_root = Hash::new_from_array(rng.random());
     let parent_offset = rng.random_range(1..=u16::try_from(slot).unwrap_or(u16::MAX));
     let parent_slot = slot.checked_sub(u64::from(parent_offset)).unwrap();
@@ -1190,6 +1203,7 @@ mod tests {
                 &mut ProcessShredsStats::default(),
             )
             .unwrap()
+            .into_iter()
             .next()
             .unwrap();
         shred.sign(&keypair);
@@ -1348,7 +1362,6 @@ mod tests {
         )
         .unwrap()
         .into_iter()
-        .map(Shred::from)
         .map(|shred| fill_retransmitter_signature(&mut rng, shred, is_last_in_slot))
         .collect();
         {

--- a/ledger/src/shred/filter.rs
+++ b/ledger/src/shred/filter.rs
@@ -7,7 +7,6 @@ use {
         ShredFlags, ShredType, ShredVariant, layout, merkle,
     },
     crate::blockstore,
-    assert_matches::debug_assert_matches,
     solana_clock::Slot,
     solana_epoch_schedule::EpochSchedule,
     solana_perf::packet::PacketRef,
@@ -494,17 +493,10 @@ impl ShredRecoveryContext {
         recovered_shreds: &mut Vec<Payload>,
         recovered_data_shreds: &mut Vec<Shred>,
     ) -> Result<(), Error> {
-        let shreds = shreds
+        let shreds: Vec<_> = shreds
             .into_iter()
             .filter(|shred| !self.shred_filter_ctx.should_discard_shred(shred.payload()))
-            .map(|shred| {
-                debug_assert_matches!(
-                    shred.common_header().shred_variant,
-                    ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. }
-                );
-                merkle::Shred::try_from(shred)
-            })
-            .collect::<Result<_, _>>()?;
+            .collect();
 
         // With Merkle shreds, leader signs the Merkle root of the erasure batch
         // and all shreds within the same erasure batch have the same signature.
@@ -515,7 +507,7 @@ impl ShredRecoveryContext {
         // same Merkle root.
         let shreds = merkle::recover(shreds, &self.reed_solomon_cache)?;
         shreds
-            .filter_map(|shred| shred.ok().map(Shred::from))
+            .filter_map(|shred| shred.ok())
             .filter(|shred| !self.should_discard_shred(shred))
             .for_each(|shred| {
                 // All shreds should be retransmitted, but because there are no
@@ -619,7 +611,6 @@ mod tests {
             is_last_in_slot,
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
 
         assert_matches!(shreds[0].shred_type(), ShredType::Data);
@@ -772,7 +763,6 @@ mod tests {
             false,    // is_last_in_slot
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         let coding_shreds: Vec<_> = shreds
             .into_iter()
             .filter(|shred| shred.shred_type() == ShredType::Code)
@@ -827,7 +817,7 @@ mod tests {
             false,    // is_last_in_slot
         )
         .unwrap();
-        let shred = Shred::from(shreds[0].clone());
+        let shred = shreds[0].clone();
         let shred_version = shred.common_header().version;
         let turbine_mode = TurbineMode::new(TurbineModeKind::TurbineDisabled);
         let mut packet = Packet::default();
@@ -867,7 +857,6 @@ mod tests {
             false,    // is_last_in_slot
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         assert_eq!(shreds.iter().map(Shred::fec_set_index).dedup().count(), 1);
 
         assert_matches!(shreds[0].shred_type(), ShredType::Data);
@@ -947,7 +936,6 @@ mod tests {
             true,     // is_last_in_slot
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         let shred_version = shreds[0].common_header().version;
         let data_shreds: Vec<_> = shreds
             .iter()
@@ -990,7 +978,6 @@ mod tests {
             false,    // is_last_in_slot
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
         let shred_version = shreds[0].common_header().version;
         let root_bank = new_test_bank(0);
 
@@ -1076,7 +1063,6 @@ mod tests {
             false,    // is_last_in_slot
         )
         .unwrap();
-        let shreds: Vec<_> = shreds.into_iter().map(Shred::from).collect();
 
         let data_shred = shreds
             .iter()

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1,14 +1,11 @@
-#[cfg(test)]
-use crate::shred::ShredType;
 use {
     crate::{
         shred::{
             self, CODING_SHREDS_PER_FEC_BLOCK, CodingShredHeader, DATA_SHREDS_PER_FEC_BLOCK,
             DataShredHeader, Error, ProcessShredsStats, SHREDS_PER_FEC_BLOCK,
             SIZE_OF_CODING_SHRED_HEADERS, SIZE_OF_DATA_SHRED_HEADERS, SIZE_OF_NONCE,
-            SIZE_OF_SIGNATURE, ShredCommonHeader, ShredFlags, ShredVariant,
+            SIZE_OF_SIGNATURE, Shred, ShredCommonHeader, ShredFlags, ShredVariant,
             common::impl_shred_common,
-            dispatch,
             merkle_tree::*,
             payload::{Payload, PayloadMutGuard},
             shred_code, shred_data,
@@ -19,12 +16,11 @@ use {
         shredder::ReedSolomonCache,
     },
     assert_matches::debug_assert_matches,
-    itertools::{Either, Itertools},
+    itertools::Itertools,
     reed_solomon_erasure::Error::{InvalidIndex, TooFewParityShards},
     solana_clock::Slot,
     solana_hash::Hash,
     solana_keypair::Keypair,
-    solana_pubkey::Pubkey,
     solana_sha256_hasher::hashv,
     solana_signature::Signature,
     solana_signer::Signer,
@@ -65,90 +61,6 @@ pub struct ShredCode {
     common_header: ShredCommonHeader,
     coding_header: CodingShredHeader,
     payload: Payload,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum Shred {
-    ShredCode(ShredCode),
-    ShredData(ShredData),
-}
-
-impl Shred {
-    dispatch!(fn erasure_shard_index(&self) -> Result<usize, Error>);
-    dispatch!(fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<'_, Range<usize>>, Error>);
-    dispatch!(fn merkle_node(&self) -> Result<Hash, Error>);
-    dispatch!(fn sanitize(&self) -> Result<(), Error>);
-    dispatch!(fn set_chained_merkle_root(&mut self, chained_merkle_root: &Hash) -> Result<(), Error>);
-    dispatch!(fn set_signature(&mut self, signature: Signature));
-    dispatch!(fn signed_data(&self) -> Result<Hash, Error>);
-    dispatch!(pub(super) fn common_header(&self) -> &ShredCommonHeader);
-    dispatch!(pub(super) fn payload(&self) -> &Payload);
-    dispatch!(pub(super) fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error>);
-
-    #[inline]
-    fn fec_set_index(&self) -> u32 {
-        self.common_header().fec_set_index
-    }
-
-    #[inline]
-    fn merkle_proof(&self) -> Result<impl Iterator<Item = &MerkleProofEntry>, Error> {
-        match self {
-            Self::ShredCode(shred) => shred.merkle_proof().map(Either::Left),
-            Self::ShredData(shred) => shred.merkle_proof().map(Either::Right),
-        }
-    }
-
-    #[inline]
-    fn set_merkle_proof<'a, I>(&mut self, proof: I) -> Result<(), Error>
-    where
-        I: IntoIterator<Item = Result<&'a MerkleProofEntry, Error>>,
-    {
-        match self {
-            Self::ShredCode(shred) => shred.set_merkle_proof(proof),
-            Self::ShredData(shred) => shred.set_merkle_proof(proof),
-        }
-    }
-
-    #[must_use]
-    fn verify(&self, pubkey: &Pubkey) -> bool {
-        match self.signed_data() {
-            Ok(data) => self.signature().verify(pubkey.as_ref(), data.as_ref()),
-            Err(_) => false,
-        }
-    }
-
-    #[inline]
-    fn signature(&self) -> &Signature {
-        &self.common_header().signature
-    }
-
-    pub(super) fn from_payload<T: AsRef<[u8]>>(shred: T) -> Result<Self, Error>
-    where
-        Payload: From<T>,
-    {
-        match shred::layout::get_shred_variant(shred.as_ref())? {
-            ShredVariant::MerkleCode { .. } => Ok(Self::ShredCode(ShredCode::from_payload(shred)?)),
-            ShredVariant::MerkleData { .. } => Ok(Self::ShredData(ShredData::from_payload(shred)?)),
-        }
-    }
-}
-
-#[cfg(test)]
-impl Shred {
-    dispatch!(fn erasure_shard(&self) -> Result<&[u8], Error>);
-    dispatch!(fn proof_size(&self) -> Result<u8, Error>);
-    dispatch!(pub(super) fn chained_merkle_root(&self) -> Result<Hash, Error>);
-    dispatch!(pub(super) fn merkle_root(&self) -> Result<Hash, Error>);
-    dispatch!(pub(super) fn retransmitter_signature(&self) -> Result<Signature, Error>);
-    dispatch!(pub(super) fn retransmitter_signature_offset(&self) -> Result<usize, Error>);
-
-    fn index(&self) -> u32 {
-        self.common_header().index
-    }
-
-    fn shred_type(&self) -> ShredType {
-        ShredType::from(self.common_header().shred_variant)
-    }
 }
 
 impl ShredData {
@@ -295,7 +207,7 @@ macro_rules! impl_merkle_shred {
     ($variant:ident) => {
         // proof_size is the number of merkle proof entries.
         #[inline]
-        fn proof_size(&self) -> Result<u8, Error> {
+        pub(super) fn proof_size(&self) -> Result<u8, Error> {
             match self.common_header.shred_variant {
                 ShredVariant::$variant { proof_size, .. } => Ok(proof_size),
                 _ => Err(Error::InvalidShredVariant),
@@ -367,7 +279,10 @@ macro_rules! impl_merkle_shred {
                 .ok_or(Error::InvalidPayloadSize(self.payload.len()))
         }
 
-        fn set_chained_merkle_root(&mut self, chained_merkle_root: &Hash) -> Result<(), Error> {
+        pub(super) fn set_chained_merkle_root(
+            &mut self,
+            chained_merkle_root: &Hash,
+        ) -> Result<(), Error> {
             let offset = self.chained_merkle_root_offset()?;
             let Some(mut buffer) = self.payload.get_mut(offset..offset + SIZE_OF_MERKLE_ROOT)
             else {
@@ -386,18 +301,20 @@ macro_rules! impl_merkle_shred {
             get_merkle_root(index, node, proof)
         }
 
-        fn merkle_proof(&self) -> Result<impl Iterator<Item = &MerkleProofEntry>, Error> {
+        pub(super) fn merkle_proof(
+            &self,
+        ) -> Result<impl Iterator<Item = &MerkleProofEntry>, Error> {
             let proof_size = self.proof_size()?;
             let proof_offset = self.proof_offset()?;
             get_merkle_proof(&self.payload, proof_offset, proof_size)
         }
 
-        fn merkle_node(&self) -> Result<Hash, Error> {
+        pub(super) fn merkle_node(&self) -> Result<Hash, Error> {
             let proof_offset = self.proof_offset()?;
             get_merkle_node(&self.payload, SIZE_OF_SIGNATURE..proof_offset)
         }
 
-        fn set_merkle_proof<'a, I>(&mut self, proof: I) -> Result<(), Error>
+        pub(super) fn set_merkle_proof<'a, I>(&mut self, proof: I) -> Result<(), Error>
         where
             I: IntoIterator<Item = Result<&'a MerkleProofEntry, Error>>,
         {
@@ -431,7 +348,10 @@ macro_rules! impl_merkle_shred {
                 .ok_or(Error::InvalidPayloadSize(self.payload.len()))
         }
 
-        fn set_retransmitter_signature(&mut self, signature: &Signature) -> Result<(), Error> {
+        pub(super) fn set_retransmitter_signature(
+            &mut self,
+            signature: &Signature,
+        ) -> Result<(), Error> {
             let offset = self.retransmitter_signature_offset()?;
             let Some(mut buffer) = self.payload.get_mut(offset..offset + SIZE_OF_SIGNATURE) else {
                 return Err(Error::InvalidPayloadSize(self.payload.len()));
@@ -486,7 +406,9 @@ macro_rules! impl_merkle_shred {
         }
 
         // Returns the erasure coded slice as a mutable reference.
-        fn erasure_shard_mut(&mut self) -> Result<PayloadMutGuard<'_, Range<usize>>, Error> {
+        pub(super) fn erasure_shard_mut(
+            &mut self,
+        ) -> Result<PayloadMutGuard<'_, Range<usize>>, Error> {
             let offsets = self.erasure_shard_offsets()?;
             let payload_size = self.payload.len();
             self.payload
@@ -1308,28 +1230,18 @@ fn finish_erasure_batch(
 #[cfg(test)]
 pub(crate) fn finish_erasure_batch_for_tests(
     keypair: &Keypair,
-    shreds: &mut [crate::shred::Shred],
+    shreds: &mut [Shred],
     chained_merkle_root: Hash,
     reed_solomon_cache: &ReedSolomonCache,
 ) -> Result<Hash, Error> {
-    let mut batch: Vec<_> = shreds
-        .iter()
-        .cloned()
-        .map(crate::shred::Shred::try_into)
-        .collect::<Result<_, _>>()?;
-    let chained_merkle_root =
-        finish_erasure_batch(keypair, &mut batch, chained_merkle_root, reed_solomon_cache)?;
-    for (dst, src) in shreds.iter_mut().zip(batch) {
-        *dst = crate::shred::Shred::from(src);
-    }
-    Ok(chained_merkle_root)
+    finish_erasure_batch(keypair, shreds, chained_merkle_root, reed_solomon_cache)
 }
 
 #[cfg(test)]
 mod test {
     use {
         super::*,
-        crate::shred::{ShredFlags, ShredId, merkle_tree::get_proof_size},
+        crate::shred::{ShredFlags, ShredId, ShredType, merkle_tree::get_proof_size},
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{CryptoRng, Rng, seq::SliceRandom},

--- a/ledger/src/shred/payload.rs
+++ b/ledger/src/shred/payload.rs
@@ -268,18 +268,16 @@ mod test {
         let shredder = Shredder::new(1, 0, 0, 0).unwrap();
         let entries = vec![Entry::new(&Hash::default(), 0, vec![])];
         let mut stats = crate::shred::ProcessShredsStats::default();
-        let shreds: Vec<_> = shredder
-            .make_merkle_shreds_from_entries(
-                &keypair,
-                &entries,
-                /*is_last_in_slot:*/ false,
-                Hash::default(),
-                0,
-                0,
-                &ReedSolomonCache::default(),
-                &mut stats,
-            )
-            .collect();
+        let shreds = shredder.make_merkle_shreds_from_entries(
+            &keypair,
+            &entries,
+            /*is_last_in_slot:*/ false,
+            Hash::default(),
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut stats,
+        );
         let shred = &shreds[0];
 
         // Create a BytesPacket with a trailing nonce and mark it as REPAIR.

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -8,7 +8,7 @@ use {
         blockstore_meta::ErasureConfig,
         shred::{
             self, Error, Nonce, SIZE_OF_COMMON_SHRED_HEADER, ShredFlags, ShredId, ShredType,
-            ShredVariant, merkle_tree::SIZE_OF_MERKLE_ROOT, traits::Shred,
+            ShredVariant, merkle_tree::SIZE_OF_MERKLE_ROOT, traits::Shred as ShredTrait,
         },
     },
     solana_clock::Slot,
@@ -404,7 +404,9 @@ pub(crate) fn corrupt_packet<R: Rng>(
 mod tests {
     use {
         super::*,
-        crate::shred::{SHREDS_PER_FEC_BLOCK, make_merkle_shreds_for_tests, traits::ShredData},
+        crate::shred::{
+            SHREDS_PER_FEC_BLOCK, Shred, make_merkle_shreds_for_tests, traits::ShredData,
+        },
         assert_matches::assert_matches,
         rand::Rng,
         solana_perf::packet::PacketFlags,
@@ -572,7 +574,7 @@ mod tests {
                     let signature = make_dummy_signature(&mut rng);
                     assert_matches!(set_retransmitter_signature(&mut bytes, &signature), Ok(()));
                     assert_eq!(get_retransmitter_signature(&bytes).unwrap(), signature);
-                    let shred = shred::merkle::Shred::from_payload(bytes).unwrap();
+                    let shred = Shred::from_payload(bytes).unwrap();
                     assert_eq!(shred.retransmitter_signature().unwrap(), signature);
                 }
                 {
@@ -581,7 +583,7 @@ mod tests {
                     let signature = keypair.sign_message(shred.merkle_root().unwrap().as_ref());
                     assert_matches!(resign_shred(&mut bytes, &keypair), Ok(()));
                     assert_eq!(get_retransmitter_signature(&bytes).unwrap(), signature);
-                    let shred = shred::merkle::Shred::from_payload(bytes).unwrap();
+                    let shred = Shred::from_payload(bytes).unwrap();
                     assert_eq!(shred.retransmitter_signature().unwrap(), signature);
                 }
             } else {
@@ -607,12 +609,12 @@ mod tests {
                 );
                 assert_eq!(bytes, shred.payload().as_ref());
             }
-            if let shred::merkle::Shred::ShredCode(_) = shred {
+            if let Shred::ShredCode(_) = shred {
                 assert_matches!(get_flags(bytes), Err(Error::InvalidShredType));
                 assert_matches!(get_data(bytes), Err(Error::InvalidShredType));
                 assert_matches!(get_reference_tick(bytes), Err(Error::InvalidShredType));
             }
-            if let shred::merkle::Shred::ShredData(shred) = shred {
+            if let Shred::ShredData(shred) = shred {
                 let shred_data_header = shred.data_header();
                 assert_eq!(
                     get_parent_offset(bytes).unwrap(),

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -64,7 +64,7 @@ impl Shredder {
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
-    ) -> impl Iterator<Item = Shred> + use<> {
+    ) -> Vec<Shred> {
         let now = Instant::now();
         let bytes = wincode::serialize(component).unwrap();
         stats.serialize_elapsed += now.elapsed().as_micros() as u64;
@@ -93,7 +93,7 @@ impl Shredder {
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
-    ) -> impl Iterator<Item = Shred> + use<> {
+    ) -> Vec<Shred> {
         stats.num_entries += entries.len();
         let now = Instant::now();
         let entries = wincode::serialize(entries).unwrap();
@@ -123,8 +123,8 @@ impl Shredder {
         next_code_index: u32,
         reed_solomon_cache: &ReedSolomonCache,
         stats: &mut ProcessShredsStats,
-    ) -> Result<impl Iterator<Item = Shred> + use<>, Error> {
-        let shreds = shred::merkle::make_shreds_from_data(
+    ) -> Result<Vec<Shred>, Error> {
+        shred::merkle::make_shreds_from_data(
             keypair,
             chained_merkle_root,
             data,
@@ -137,8 +137,7 @@ impl Shredder {
             next_code_index,
             reed_solomon_cache,
             stats,
-        )?;
-        Ok(shreds.into_iter().map(Shred::from))
+        )
     }
 
     pub fn entries_to_merkle_shreds_for_tests(
@@ -165,6 +164,7 @@ impl Shredder {
             reed_solomon_cache,
             stats,
         )
+        .into_iter()
         .partition(Shred::is_data)
     }
 
@@ -192,6 +192,7 @@ impl Shredder {
             reed_solomon_cache,
             stats,
         )
+        .into_iter()
         .partition(Shred::is_data)
     }
 

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -324,6 +324,7 @@ mod tests {
                     &reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 )
+                .into_iter()
             })
             .collect();
         shreds.shuffle(rng);

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -53,7 +53,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
     .unwrap();
 
     let entries = vec![Entry::new(&Hash::default(), 0, vec![])];
-    let data_shreds = shredder.make_merkle_shreds_from_entries(
+    let mut shreds = shredder.make_merkle_shreds_from_entries(
         &leader_keypair,
         &entries,
         true,            // is_last_in_slot
@@ -63,7 +63,7 @@ fn broadcast_shreds_bench(b: &mut Bencher) {
         &ReedSolomonCache::default(),
         &mut ProcessShredsStats::default(),
     );
-    let shreds: Vec<_> = data_shreds.take(NUM_SHREDS).collect();
+    shreds.truncate(NUM_SHREDS);
 
     let mut stakes = HashMap::new();
     const NUM_PEERS: usize = 200;

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -198,23 +198,23 @@ impl StandardBroadcastRun {
         }
         // Set the reference_tick as if the PoH completed for this slot
         let reference_tick = max_ticks_in_slot;
-        let shreds: Vec<_> =
-            Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
-                .unwrap()
-                .make_merkle_shreds_from_entries(
-                    keypair,
-                    &[],  // entries
-                    true, // is_last_in_slot,
-                    self.chained_merkle_root,
-                    self.next_shred_index,
-                    self.next_code_index,
-                    &self.reed_solomon_cache,
-                    &mut self.process_shreds_stats,
-                )
-                // These shreds will finish the slot so no need to update
-                // self.next_shred_index and self.next_code_index
-                .inspect(|shred| self.process_shreds_stats.record_shred(shred))
-                .collect();
+        let shreds = Shredder::new(self.slot, self.parent, reference_tick, self.shred_version)
+            .unwrap()
+            .make_merkle_shreds_from_entries(
+                keypair,
+                &[],  // entries
+                true, // is_last_in_slot,
+                self.chained_merkle_root,
+                self.next_shred_index,
+                self.next_code_index,
+                &self.reed_solomon_cache,
+                &mut self.process_shreds_stats,
+            );
+        // These shreds will finish the slot so no need to update
+        // self.next_shred_index and self.next_code_index
+        shreds.iter().for_each(|shred| {
+            self.process_shreds_stats.record_shred(shred);
+        });
         if let Some(shred) = shreds.last() {
             self.chained_merkle_root = shred.merkle_root().unwrap();
         }
@@ -243,16 +243,15 @@ impl StandardBroadcastRun {
                     self.next_code_index,
                     &self.reed_solomon_cache,
                     process_stats,
-                )
-                .inspect(|shred| {
-                    process_stats.record_shred(shred);
-                    let next_index = match shred.shred_type() {
-                        ShredType::Code => &mut self.next_code_index,
-                        ShredType::Data => &mut self.next_shred_index,
-                    };
-                    *next_index = (*next_index).max(shred.index() + 1);
-                })
-                .collect();
+                );
+        shreds.iter().for_each(|shred| {
+            process_stats.record_shred(shred);
+            let next_index = match shred.shred_type() {
+                ShredType::Code => &mut self.next_code_index,
+                ShredType::Data => &mut self.next_shred_index,
+            };
+            *next_index = (*next_index).max(shred.index() + 1);
+        });
 
         if self
             .migration_status

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -698,18 +698,16 @@ mod tests {
 
         let shredder = Shredder::new(root_bank.slot(), root_bank.parent_slot(), 0, 0).unwrap();
         let entries = vec![Entry::new(&Hash::default(), 0, vec![])];
-        let mut shreds: Vec<_> = shredder
-            .make_merkle_shreds_from_entries(
-                &leader_keypair,
-                &entries,
-                is_last_in_slot,
-                chained_merkle_root,
-                0,
-                0,
-                &ReedSolomonCache::default(),
-                &mut ProcessShredsStats::default(),
-            )
-            .collect();
+        let mut shreds = shredder.make_merkle_shreds_from_entries(
+            &leader_keypair,
+            &entries,
+            is_last_in_slot,
+            chained_merkle_root,
+            0,
+            0,
+            &ReedSolomonCache::default(),
+            &mut ProcessShredsStats::default(),
+        );
 
         let cluster_info = ClusterInfo::new(
             ContactInfo::new_localhost(&leader_pubkey, timestamp()),


### PR DESCRIPTION
#### Problem
When Merkle shreds were added to the codebase, support was added alongside the existing (Legacy) shreds. In order to support both, the different variants were covered with enum's:

**The "Public" Enum:**
https://github.com/anza-xyz/agave/blob/3dccb3e785ce8e7fc8370f983c81ee9cf4326de5/ledger/src/shred.rs#L237-L240

**Data Impl Enum:**
https://github.com/anza-xyz/agave/blob/3dccb3e785ce8e7fc8370f983c81ee9cf4326de5/ledger/src/shred/shred_data.rs#L14-L17

**Coding Impl Enum:**
https://github.com/anza-xyz/agave/blob/3dccb3e785ce8e7fc8370f983c81ee9cf4326de5/ledger/src/shred/shred_code.rs#L19-L22

Merkle shreds have since become the only supported option and the legacy variant support was removed. The "top level" enum contains merkle shred types as in the inner types:
https://github.com/anza-xyz/agave/blob/12b5c7e4df705927b2f7f579f3aa606aa4bde1c0/ledger/src/shred.rs#L299-L302

As do the Merkle shred implementation enum
https://github.com/anza-xyz/agave/blob/12b5c7e4df705927b2f7f579f3aa606aa4bde1c0/ledger/src/shred/merkle.rs#L71-L74

This second enum leads to some clunkiness like below where we will do a `.into_iter().map(...).collect()` on a `Vec`:
https://github.com/anza-xyz/agave/blob/12b5c7e4df705927b2f7f579f3aa606aa4bde1c0/ledger/src/shredder.rs#L141

#### Summary of Changes
Remove the second enum that lives in `merkle.rs` and update all calling code accordingly. One notable item is that `Shredder` functions now return `Vec<Shred>` instead of `Iterator<Shred>` since they don't have to convert from the "internal" to "public" enum types.

And FWIW, the `.into_iter().map(...).collect()` I referenced above occurs in `standard_broadcast_run.rs`. On the surface, this looks like an extra allocation but I remembered towards the end of this cleanup that Rust might/should be able to reuse the allocation in this instance via https://doc.rust-lang.org/nightly/src/alloc/vec/in_place_collect.rs.html. So, we may not have any perf wins but I think this is still progress towards making the codebase match current reality (Merkle shreds only) vs. the old (Legacy + Merkle)

#### Testing
CI