### PR TITLE
ci: increase sanity timeout to 10 minutes

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -379,7 +379,7 @@ fn default_sanity_step() -> buildkite::Step {
         name: String::from("sanity"),
         command: String::from("ci/docker-run-default-image.sh ci/test-sanity.sh"),
         agents: Some(queue_agents()),
-        timeout_in_minutes: Some(5),
+        timeout_in_minutes: Some(10),
         ..Default::default()
     })
 }


### PR DESCRIPTION
#### Problem
sanity regularly times out and fails (all three of my most recent opened prs had this happen) because it has to download all these git submodules now. generally my experience is it hits the five minute limit, dies, retry finishes in one minute

#### Summary of Changes
increase the timeout to 10 minutes
