### PR TITLE
blockstore: reuse write batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -4449,7 +4449,7 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -6233,7 +6233,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -621,5 +621,5 @@ codegen-units = 1
 [patch.crates-io]
 # for details, see https://github.com/anza-xyz/crossbeam/commit/5ee1c6ec671d94db14ed9238eb99e59a84555aad
 crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "5ee1c6ec671d94db14ed9238eb99e59a84555aad" }
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
+librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
+rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2896,10 +2896,16 @@ fn cleanup_blockstore_incorrect_shred_versions(
             let mut num_slots_copied = 0;
             let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
             let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
+            let mut write_batch = backup_blockstore.get_write_batch();
             for (slot, _meta) in slot_meta_iterator {
                 let shreds = blockstore.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
-                let _ = backup_blockstore.insert_cow_shreds(shreds, true, &mut pinnable_slice);
+                let _ = backup_blockstore.insert_cow_shreds(
+                    shreds,
+                    true,
+                    &mut pinnable_slice,
+                    &mut write_batch,
+                );
                 num_slots_copied += 1;
 
                 if print_timer.elapsed() > PRINT_INTERVAL {

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -20,7 +20,7 @@ use {
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         blockstore::{Blockstore, BlockstoreInsertionMetrics, PossibleDuplicateShred},
-        blockstore_db::DBPinnableSlice,
+        blockstore_db::{DBPinnableSlice, WriteBatch},
         blockstore_meta::BlockLocation,
         shred::{self, ReedSolomonCache, Shred, filter::ShredRecoveryContext},
     },
@@ -222,6 +222,7 @@ fn run_insert<'db, F>(
     blockstore: &'db Blockstore,
     shred_recovery_context: &mut ShredRecoveryContext,
     pinnable_slice: &mut DBPinnableSlice<'db>,
+    write_batch: &mut WriteBatch,
     handle_duplicate: F,
     metrics: &mut BlockstoreInsertionMetrics,
     ws_metrics: &mut WindowServiceMetrics,
@@ -259,6 +260,7 @@ where
         false, // is_trusted
         shred_recovery_context,
         pinnable_slice,
+        write_batch,
         &handle_duplicate,
         metrics,
     )?;
@@ -449,6 +451,7 @@ impl WindowService {
                     shred_version,
                 );
                 let mut pinnable_slice = blockstore.new_pinnable_slice();
+                let mut write_batch = blockstore.get_write_batch();
 
                 while !exit.load(Ordering::Relaxed) {
                     shred_recovery_context.maybe_update(sharable_banks.root());
@@ -459,6 +462,7 @@ impl WindowService {
                         &blockstore,
                         &mut shred_recovery_context,
                         &mut pinnable_slice,
+                        &mut write_batch,
                         handle_duplicate,
                         &mut metrics,
                         &mut ws_metrics,

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5174,7 +5174,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/dev-bins/Cargo.toml
+++ b/dev-bins/Cargo.toml
@@ -196,5 +196,5 @@ lto = "fat"
 codegen-units = 1
 
 [patch.crates-io]
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
+librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
+rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -631,6 +631,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 AccessType::PrimaryForMaintenance,
             );
             let mut pinnable_slice = target.new_pinnable_slice();
+            let mut write_batch = target.get_write_batch();
 
             for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
                 if slot > ending_slot {
@@ -639,7 +640,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                 let shreds = shreds.into_iter().map(Cow::Owned);
                 if target
-                    .insert_cow_shreds(shreds, true, &mut pinnable_slice)
+                    .insert_cow_shreds(shreds, true, &mut pinnable_slice, &mut write_batch)
                     .is_err()
                 {
                     warn!("error inserting shreds for slot {slot}");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2446,11 +2446,13 @@ fn main() {
                                 AccessType::PrimaryForMaintenance,
                             ));
                             let mut pinnable_slice = backup_blockstore.new_pinnable_slice();
+                            let mut write_batch = backup_blockstore.get_write_batch();
                             let _ = backup_blockstore
                                 .insert_cow_shreds(
                                     shreds.into_iter().map(Cow::Owned),
                                     true,
                                     &mut pinnable_slice,
+                                    &mut write_batch,
                                 )
                                 .expect("Blockstore operation must succeed");
 
@@ -2492,8 +2494,9 @@ fn main() {
                             .map(Cow::Owned)
                             .collect();
                         let mut pinnable_slice = rw_blockstore.new_pinnable_slice();
+                        let mut write_batch = rw_blockstore.get_write_batch();
                         rw_blockstore
-                            .insert_cow_shreds(shreds, true, &mut pinnable_slice)
+                            .insert_cow_shreds(shreds, true, &mut pinnable_slice, &mut write_batch)
                             .expect("Blockstore operation must succeed");
                     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -425,7 +425,7 @@ pub struct SlotMetaWorkingSetEntry {
     did_insert_occur: bool,
 }
 
-struct ShredInsertionTracker<'a> {
+struct ShredInsertionTracker<'a, 'batch> {
     // Map which contains data shreds that have just been inserted. They will
     // later be written to `cf::ShredData` or `cf::AlternateShredData`
     just_inserted_shreds: HashMap<(BlockLocation, ShredId), Cow<'a, Shred>>,
@@ -444,15 +444,15 @@ struct ShredInsertionTracker<'a> {
     duplicate_shreds: Vec<PossibleDuplicateShred>,
     // Collection of the current blockstore writes which will be committed
     // atomically.
-    write_batch: WriteBatch,
+    write_batch: &'batch mut WriteBatch,
     // Time spent on loading or creating the index meta entry from the db
     index_meta_time_us: u64,
     // Collection of recently completed data sets (data portion of erasure batch)
     newly_completed_data_sets: Vec<CompletedDataSetInfo>,
 }
 
-impl ShredInsertionTracker<'_> {
-    fn new(shred_num: usize, write_batch: WriteBatch) -> Self {
+impl<'batch> ShredInsertionTracker<'_, 'batch> {
+    fn new(shred_num: usize, write_batch: &'batch mut WriteBatch) -> Self {
         Self {
             just_inserted_shreds: HashMap::with_capacity(shred_num),
             erasure_metas: BTreeMap::new(),
@@ -1629,7 +1629,7 @@ impl Blockstore {
         if mark_slot_dead {
             // If the slot is already full there is no reason to mark as dead
             self.dead_slots_cf.put_bytes_in_batch(
-                &mut shred_insertion_tracker.write_batch,
+                shred_insertion_tracker.write_batch,
                 slot,
                 &[true as u8],
             );
@@ -1646,7 +1646,7 @@ impl Blockstore {
         >,
         is_trusted: bool,
         pinnable_slice: &mut DBPinnableSlice<'db>,
-        shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
+        shred_insertion_tracker: &mut ShredInsertionTracker<'a, '_>,
         metrics: &mut BlockstoreInsertionMetrics,
     ) {
         let shreds = shreds.into_iter();
@@ -1938,7 +1938,7 @@ impl Blockstore {
                 meta.last_index.expect("Slot is full"),
                 &shred_insertion_tracker.slot_meta_working_set,
                 &shred_insertion_tracker.merkle_root_metas,
-                &mut shred_insertion_tracker.write_batch,
+                shred_insertion_tracker.write_batch,
             )?;
         }
         Ok(())
@@ -2116,7 +2116,7 @@ impl Blockstore {
         let mut start = Measure::start("Commit Working Sets");
         let signal_updates = self.commit_slot_meta_working_set(
             &shred_insertion_tracker.slot_meta_working_set,
-            &mut shred_insertion_tracker.write_batch,
+            shred_insertion_tracker.write_batch,
         )?;
 
         for (erasure_set, working_erasure_meta) in &shred_insertion_tracker.erasure_metas {
@@ -2126,7 +2126,7 @@ impl Blockstore {
             }
             let (slot, fec_set_index) = erasure_set.store_key();
             self.erasure_meta_cf.put_in_batch(
-                &mut shred_insertion_tracker.write_batch,
+                shred_insertion_tracker.write_batch,
                 (slot, u64::from(fec_set_index)),
                 working_erasure_meta.as_ref(),
             )?;
@@ -2140,7 +2140,7 @@ impl Blockstore {
                 continue;
             }
             self.put_merkle_root_meta_in_batch(
-                &mut shred_insertion_tracker.write_batch,
+                shred_insertion_tracker.write_batch,
                 erasure_set,
                 location,
                 working_merkle_root_meta.as_ref(),
@@ -2152,7 +2152,7 @@ impl Blockstore {
         {
             if index_working_set_entry.did_insert_occur {
                 self.put_index_in_batch(
-                    &mut shred_insertion_tracker.write_batch,
+                    shred_insertion_tracker.write_batch,
                     slot,
                     location,
                     &index_working_set_entry.index,
@@ -2204,6 +2204,7 @@ impl Blockstore {
     ///  - `shred_recovery_context`: recovery-time dependencies and policy for
     ///    erasure recovery. `None` disables recovery.
     ///  - `pinnable_slice`: reusable RocksDB pinnable slice.
+    ///  - `write_batch`: reusable RocksDB write batch.
     ///  - `metrics`: the metric for reporting detailed stats
     ///
     /// On success, the function returns an Ok result with a vector of
@@ -2223,9 +2224,11 @@ impl Blockstore {
         // recovered shreds.
         shred_recovery_context: Option<&mut ShredRecoveryContext>,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<InsertResults> {
         let mut total_start = Measure::start("Total elapsed");
+        write_batch.clear();
 
         // Acquire the insertion lock
         let mut start = Measure::start("Blockstore lock");
@@ -2239,8 +2242,10 @@ impl Blockstore {
             is_trusted,
             shred_recovery_context,
             pinnable_slice,
+            write_batch,
             metrics,
         );
+        write_batch.clear();
 
         // Roll up metrics
         total_start.stop();
@@ -2260,11 +2265,11 @@ impl Blockstore {
         is_trusted: bool,
         shred_recovery_context: Option<&mut ShredRecoveryContext>,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<InsertResults> {
         let shreds = shreds.into_iter();
-        let mut shred_insertion_tracker =
-            ShredInsertionTracker::new(shreds.len(), self.get_write_batch());
+        let mut shred_insertion_tracker = ShredInsertionTracker::new(shreds.len(), write_batch);
 
         self.attempt_shred_insertion(
             shreds,
@@ -2285,7 +2290,7 @@ impl Blockstore {
         // Handle chaining for the members of the slot_meta_working_set that
         // were inserted into, drop the others.
         self.handle_chaining(
-            &mut shred_insertion_tracker.write_batch,
+            shred_insertion_tracker.write_batch,
             &mut shred_insertion_tracker.slot_meta_working_set,
             metrics,
         )?;
@@ -2303,7 +2308,7 @@ impl Blockstore {
 
         // Write out the accumulated batch.
         let mut start = Measure::start("Write Batch");
-        self.write_batch(shred_insertion_tracker.write_batch)?;
+        self.write_batch(&mut *shred_insertion_tracker.write_batch)?;
         start.stop();
         metrics.write_batch_elapsed_us += start.as_us();
 
@@ -2348,6 +2353,7 @@ impl Blockstore {
         F: Fn(PossibleDuplicateShred),
     {
         let mut pinnable_slice = self.new_pinnable_slice();
+        let mut write_batch = self.get_write_batch();
         self.insert_shreds_at_location_handle_duplicate(
             shreds
                 .into_iter()
@@ -2355,6 +2361,7 @@ impl Blockstore {
             is_trusted,
             shred_recovery_context,
             &mut pinnable_slice,
+            &mut write_batch,
             handle_duplicate,
             metrics,
         )
@@ -2365,7 +2372,7 @@ impl Blockstore {
     /// Additionally attempts to recover and retransmit recovered shreds (also identifying
     /// and handling duplicate shreds). Broadcast stage should instead call
     /// Blockstore::insert_shreds when inserting own shreds during leader slots.
-    /// The pinnable slice can be reused across calls.
+    /// The pinnable slice and write batch can be reused across calls.
     pub fn insert_shreds_at_location_handle_duplicate<'a, 'db, F>(
         &'db self,
         shreds: impl IntoIterator<
@@ -2375,6 +2382,7 @@ impl Blockstore {
         is_trusted: bool,
         shred_recovery_context: &mut ShredRecoveryContext,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         handle_duplicate: &F,
         metrics: &mut BlockstoreInsertionMetrics,
     ) -> Result<Vec<CompletedDataSetInfo>>
@@ -2389,6 +2397,7 @@ impl Blockstore {
             is_trusted,
             Some(shred_recovery_context),
             pinnable_slice,
+            write_batch,
             metrics,
         )?;
 
@@ -2475,12 +2484,14 @@ impl Blockstore {
         let shreds = shreds.into_iter().map(|shred| {
             (Cow::Owned(shred), /*is_repaired:*/ false, to_location)
         });
+        let mut write_batch = self.get_write_batch();
         self.do_insert_shreds_locked(
             lock,
             shreds,
             true, // is_trusted
             None, // should_recover_shreds
             pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )?;
 
@@ -2588,6 +2599,7 @@ impl Blockstore {
         shreds: impl IntoIterator<Item = Cow<'a, Shred>, IntoIter: ExactSizeIterator>,
         is_trusted: bool,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let shreds = shreds
             .into_iter()
@@ -2597,6 +2609,7 @@ impl Blockstore {
             is_trusted,
             None, // Skip recovery for locally produced shreds.
             pinnable_slice,
+            write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )?;
         Ok(insert_results.completed_data_set_infos)
@@ -2609,13 +2622,15 @@ impl Blockstore {
         is_trusted: bool,
     ) -> Result<Vec<CompletedDataSetInfo>> {
         let mut pinnable_slice = self.new_pinnable_slice();
+        let mut write_batch = self.get_write_batch();
         let shreds = shreds.into_iter().map(Cow::Owned);
-        self.insert_cow_shreds(shreds, is_trusted, &mut pinnable_slice)
+        self.insert_cow_shreds(shreds, is_trusted, &mut pinnable_slice, &mut write_batch)
     }
 
     #[cfg(test)]
     fn insert_shred_return_duplicate(&self, shred: Shred) -> Vec<PossibleDuplicateShred> {
         let mut pinnable_slice = self.new_pinnable_slice();
+        let mut write_batch = self.get_write_batch();
         let insert_results = self
             .do_insert_shreds(
                 [(
@@ -2626,6 +2641,7 @@ impl Blockstore {
                 false,
                 None, // Skip recovery for this direct insertion path.
                 &mut pinnable_slice,
+                &mut write_batch,
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();
@@ -2656,7 +2672,7 @@ impl Blockstore {
     fn check_insert_coding_shred<'a, 'db>(
         &'db self,
         shred: Cow<'a, Shred>,
-        shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
+        shred_insertion_tracker: &mut ShredInsertionTracker<'a, '_>,
         is_trusted: bool,
         shred_source: ShredSource,
         pinnable_slice: &mut DBPinnableSlice<'db>,
@@ -2882,7 +2898,7 @@ impl Blockstore {
         &'db self,
         shred: Cow<'a, Shred>,
         location: BlockLocation,
-        shred_insertion_tracker: &mut ShredInsertionTracker<'a>,
+        shred_insertion_tracker: &mut ShredInsertionTracker<'a, '_>,
         is_trusted: bool,
         shred_source: ShredSource,
         pinnable_slice: &mut DBPinnableSlice<'db>,
@@ -6137,7 +6153,7 @@ impl Blockstore {
         self.db.batch()
     }
 
-    pub fn write_batch(&self, write_batch: WriteBatch) -> Result<()> {
+    pub fn write_batch<B: AsMut<WriteBatch>>(&self, write_batch: B) -> Result<()> {
         self.db.write(write_batch)
     }
 

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -1892,8 +1892,9 @@ fn test_merkle_root_metas_coding() {
     let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let coding_shred = coding_shreds[index as usize].clone();
 
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
-        ShredInsertionTracker::new(coding_shreds.len(), blockstore.get_write_batch());
+        ShredInsertionTracker::new(coding_shreds.len(), &mut write_batch);
     blockstore
         .check_insert_coding_shred(
             Cow::Borrowed(&coding_shred),
@@ -1948,8 +1949,9 @@ fn test_merkle_root_metas_coding() {
     let (_, coding_shreds) = setup_erasure_shreds(slot, parent_slot, 10);
     let new_coding_shred = coding_shreds[(index + 1) as usize].clone();
 
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
-        ShredInsertionTracker::new(coding_shreds.len(), blockstore.get_write_batch());
+        ShredInsertionTracker::new(coding_shreds.len(), &mut write_batch);
 
     assert!(matches!(
         blockstore.check_insert_coding_shred(
@@ -2082,8 +2084,9 @@ fn test_merkle_root_metas_data() {
     let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let data_shred = data_shreds[0].clone();
 
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
-        ShredInsertionTracker::new(data_shreds.len(), blockstore.get_write_batch());
+        ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
     blockstore
         .check_insert_data_shred(
             Cow::Borrowed(&data_shred),
@@ -2138,8 +2141,9 @@ fn test_merkle_root_metas_data() {
     let (data_shreds, _) = setup_erasure_shreds_with_index(slot, parent_slot, 10, fec_set_index);
     let new_data_shred = data_shreds[1].clone();
 
+    let mut write_batch = blockstore.get_write_batch();
     let mut shred_insertion_tracker =
-        ShredInsertionTracker::new(data_shreds.len(), blockstore.get_write_batch());
+        ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
 
     let insert_result = blockstore.check_insert_data_shred(
         Cow::Owned(new_data_shred),
@@ -2155,7 +2159,7 @@ fn test_merkle_root_metas_data() {
     );
     blockstore
         .dead_slots_cf
-        .put_in_batch(&mut shred_insertion_tracker.write_batch, slot, &true)
+        .put_in_batch(shred_insertion_tracker.write_batch, slot, &true)
         .unwrap();
     let ShredInsertionTracker {
         merkle_root_metas,
@@ -2233,8 +2237,9 @@ fn test_merkle_root_metas_data() {
         .next()
         .unwrap();
 
+    let mut write_batch = blockstore.db.batch();
     let mut shred_insertion_tracker =
-        ShredInsertionTracker::new(data_shreds.len(), blockstore.db.batch());
+        ShredInsertionTracker::new(data_shreds.len(), &mut write_batch);
     blockstore
         .check_insert_data_shred(
             Cow::Borrowed(&new_data_shred),
@@ -2308,7 +2313,8 @@ fn test_check_insert_coding_shred() {
         );
     let coding_shred = code_shreds[0].clone();
 
-    let mut shred_insertion_tracker = ShredInsertionTracker::new(1, blockstore.get_write_batch());
+    let mut write_batch = blockstore.get_write_batch();
+    let mut shred_insertion_tracker = ShredInsertionTracker::new(1, &mut write_batch);
     blockstore
         .check_insert_coding_shred(
             Cow::Borrowed(&coding_shred),
@@ -2437,7 +2443,8 @@ fn test_mark_slot_dead_if_not_full() {
         block_id: Hash::new_unique(),
     };
 
-    let mut shred_insertion_tracker = ShredInsertionTracker::new(1, blockstore.db.batch());
+    let mut write_batch = blockstore.db.batch();
+    let mut shred_insertion_tracker = ShredInsertionTracker::new(1, &mut write_batch);
 
     blockstore.mark_slot_dead_if_not_full(empty_slot, location, &mut shred_insertion_tracker);
     blockstore.mark_slot_dead_if_not_full(partial_slot, location, &mut shred_insertion_tracker);
@@ -4678,6 +4685,7 @@ fn test_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4703,6 +4711,7 @@ fn test_recovery() {
                 0, // shred_version
             )),
             &mut pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -4727,6 +4736,7 @@ fn test_skip_alt_recovery() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
 
     let slot = 1;
     let (data_shreds, coding_shreds) = setup_erasure_shreds(slot, 0, 100);
@@ -4747,6 +4757,7 @@ fn test_skip_alt_recovery() {
             false, // is_trusted
             None,
             &mut pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -4774,6 +4785,7 @@ fn test_skip_alt_recovery() {
                 0, // shred_version
             )),
             &mut pinnable_slice,
+            &mut write_batch,
             &mut metrics,
         )
         .unwrap();
@@ -4802,6 +4814,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
 
     let genesis_config = create_genesis_config(2).genesis_config;
     let root_bank = Arc::new(Bank::new_for_tests(&genesis_config));
@@ -4872,6 +4885,7 @@ fn test_recovery_discards_unexpected_data_complete_shreds() {
                 0, // shred_version
             )),
             &mut pinnable_slice,
+            &mut write_batch,
             &mut metrics,
         )
         .unwrap();
@@ -6413,6 +6427,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
 
     let parent_slot = 990;
     let parent_block_id = Hash::default();
@@ -6464,6 +6479,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
             false,
             None,
             &mut pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6561,6 +6577,7 @@ fn test_get_double_merkle_root(use_alternate_location: bool) {
             false,
             None,
             &mut pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6581,6 +6598,7 @@ fn insert_test_block_at_location(
     location: BlockLocation,
 ) -> (Vec<Shred>, Hash) {
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
     let (data_shreds, _) = setup_erasure_shreds(slot, parent_slot, 200);
     let is_repaired = location != BlockLocation::Original;
     let shreds = data_shreds
@@ -6592,6 +6610,7 @@ fn insert_test_block_at_location(
             false,
             None,
             &mut pinnable_slice,
+            &mut write_batch,
             &mut BlockstoreInsertionMetrics::default(),
         )
         .unwrap();
@@ -6695,6 +6714,7 @@ fn test_get_data_shreds_for_slot() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
     let mut pinnable_slice = blockstore.new_pinnable_slice();
+    let mut write_batch = blockstore.get_write_batch();
     let parent_slot = 990;
     let slot = 1000;
     let num_entries = 200;
@@ -6725,6 +6745,7 @@ fn test_get_data_shreds_for_slot() {
                 false,
                 None,
                 &mut pinnable_slice,
+                &mut write_batch,
                 &mut BlockstoreInsertionMetrics::default(),
             )
             .unwrap();

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -423,12 +423,13 @@ impl Rocks {
         }
     }
 
-    pub(crate) fn write(&self, batch: WriteBatch) -> Result<()> {
+    pub(crate) fn write<B: AsMut<WriteBatch>>(&self, mut batch: B) -> Result<()> {
+        let batch = batch.as_mut();
         let op_start_instant = maybe_enable_rocksdb_perf(
             self.column_options.rocks_perf_sample_interval,
             &self.write_batch_perf_status,
         );
-        let result = self.db.write(batch.write_batch);
+        let result = self.db.write(&mut batch.write_batch);
         if let Some(op_start_instant) = op_start_instant {
             report_rocksdb_write_perf(
                 PERF_METRIC_OP_NAME_WRITE_BATCH, // We use write_batch as cf_name for write batch.
@@ -542,6 +543,12 @@ pub struct WriteBatch {
     write_batch: RWriteBatch,
 }
 
+impl AsMut<Self> for WriteBatch {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 pub(crate) struct BlockstoreByteReference<'a> {
     slice: DBPinnableSlice<'a>,
 }
@@ -570,6 +577,10 @@ impl AsRef<[u8]> for BlockstoreByteReference<'_> {
 }
 
 impl WriteBatch {
+    pub(crate) fn clear(&mut self) {
+        self.write_batch.clear();
+    }
+
     fn put_cf<K: AsRef<[u8]>>(&mut self, cf: &ColumnFamily, key: K, value: &[u8]) {
         self.write_batch.put_cf(cf, key, value);
     }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3719,7 +3719,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 [[package]]
 name = "librocksdb-sys"
 version = "0.17.3+10.4.2"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5152,7 +5152,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3#2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3"
+source = "git+https://github.com/anza-xyz/rust-rocksdb?rev=4dba80dfe9434e595a971f5b2985ff9ba4fb31e7#4dba80dfe9434e595a971f5b2985ff9ba4fb31e7"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -256,5 +256,5 @@ strip = true
 workspace = true
 
 [patch.crates-io]
-librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
-rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "2c0ffd79c1b2e1f5220ee5f7c71af5080a5309e3" }
+librocksdb-sys = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }
+rocksdb = { git = "https://github.com/anza-xyz/rust-rocksdb", rev = "4dba80dfe9434e595a971f5b2985ff9ba4fb31e7" }

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -24,7 +24,7 @@ use {
     solana_leader_schedule::NUM_CONSECUTIVE_LEADER_SLOTS,
     solana_ledger::{
         blockstore::Blockstore,
-        blockstore_db::DBPinnableSlice,
+        blockstore_db::{DBPinnableSlice, WriteBatch},
         leader_schedule_cache::LeaderScheduleCache,
         shred::{MAX_FEC_SETS_PER_SLOT, Shred},
     },
@@ -221,6 +221,7 @@ trait BroadcastRun {
         keypair: &Keypair,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -237,6 +238,7 @@ trait BroadcastRun {
         receiver: &RecordReceiver,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
     ) -> Result<()>;
 }
 
@@ -273,11 +275,13 @@ impl BroadcastStage {
         mut broadcast_stage_run: impl BroadcastRun,
     ) -> BroadcastStageReturnType {
         let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut write_batch = blockstore.get_write_batch();
         loop {
             let res = broadcast_stage_run.run(
                 &cluster_info.keypair(),
                 blockstore,
                 &mut pinnable_slice,
+                &mut write_batch,
                 receiver,
                 socket_sender,
                 blockstore_sender,
@@ -423,11 +427,13 @@ impl BroadcastStage {
             let blockstore = blockstore.clone();
             let run_record = move || {
                 let mut pinnable_slice = blockstore.new_pinnable_slice();
+                let mut write_batch = blockstore.get_write_batch();
                 loop {
                     let res = broadcast_stage_run.record(
                         &blockstore_receiver,
                         &blockstore,
                         &mut pinnable_slice,
+                        &mut write_batch,
                     );
                     let res = Self::handle_error(res, "solana-broadcaster-record");
                     if let Some(res) = res {

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -93,6 +93,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         keypair: &Keypair,
         blockstore: &'db Blockstore,
         _pinnable_slice: &mut DBPinnableSlice<'db>,
+        _write_batch: &mut WriteBatch,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -448,10 +449,16 @@ impl BroadcastRun for BroadcastDuplicatesRun {
         receiver: &RecordReceiver,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
     ) -> Result<()> {
         let (all_shreds, _) = receiver.recv()?;
         blockstore
-            .insert_cow_shreds(all_shreds.iter().map(Cow::Borrowed), true, pinnable_slice)
+            .insert_cow_shreds(
+                all_shreds.iter().map(Cow::Borrowed),
+                true,
+                pinnable_slice,
+                write_batch,
+            )
             .expect("Failed to insert shreds in blockstore");
         Ok(())
     }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -323,10 +323,12 @@ impl StandardBroadcastRun {
         let (bsend, brecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let (ssend, srecv) = bounded(BROADCAST_CHANNEL_CAPACITY);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut write_batch = blockstore.get_write_batch();
         self.process_receive_results(
             keypair,
             blockstore,
             &mut pinnable_slice,
+            &mut write_batch,
             &ssend,
             &bsend,
             receive_results,
@@ -334,7 +336,7 @@ impl StandardBroadcastRun {
         )?;
         // Data and coding shreds are sent in a single batch.
         let _ = self.transmit(&srecv, cluster_info, BroadcastSocket::Udp(sock), bank_forks);
-        let _ = self.record(&brecv, blockstore, &mut pinnable_slice);
+        let _ = self.record(&brecv, blockstore, &mut pinnable_slice, &mut write_batch);
         Ok(())
     }
 
@@ -343,6 +345,7 @@ impl StandardBroadcastRun {
         keypair: &Keypair,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         receive_results: ReceiveResults,
@@ -459,6 +462,7 @@ impl StandardBroadcastRun {
                     [Cow::Borrowed(shred)],
                     true, // is_trusted
                     pinnable_slice,
+                    write_batch,
                 )
                 .expect("Failed to insert shreds in blockstore");
         }
@@ -533,6 +537,7 @@ impl StandardBroadcastRun {
         &mut self,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         shreds: Arc<Vec<Shred>>,
         broadcast_shred_batch_info: Option<BroadcastShredBatchInfo>,
     ) {
@@ -548,7 +553,12 @@ impl StandardBroadcastRun {
         let num_shreds = shreds.len();
         let shreds = shreds.iter().skip(offset).map(Cow::Borrowed);
         blockstore
-            .insert_cow_shreds(shreds, /*is_trusted:*/ true, pinnable_slice)
+            .insert_cow_shreds(
+                shreds,
+                /*is_trusted:*/ true,
+                pinnable_slice,
+                write_batch,
+            )
             .expect("Failed to insert shreds in blockstore");
         let insert_shreds_elapsed = insert_shreds_start.elapsed();
         let new_insert_shreds_stats = InsertShredsStats {
@@ -635,6 +645,7 @@ impl BroadcastRun for StandardBroadcastRun {
         keypair: &Keypair,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
         receiver: &Receiver<WorkingBankEntryOrMarker>,
         socket_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
         blockstore_sender: &Sender<(Arc<Vec<Shred>>, Option<BroadcastShredBatchInfo>)>,
@@ -651,6 +662,7 @@ impl BroadcastRun for StandardBroadcastRun {
             keypair,
             blockstore,
             pinnable_slice,
+            write_batch,
             socket_sender,
             blockstore_sender,
             receive_results,
@@ -672,9 +684,16 @@ impl BroadcastRun for StandardBroadcastRun {
         receiver: &RecordReceiver,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
+        write_batch: &mut WriteBatch,
     ) -> Result<()> {
         let (shreds, slot_start_ts) = receiver.recv()?;
-        self.insert(blockstore, pinnable_slice, shreds, slot_start_ts);
+        self.insert(
+            blockstore,
+            pinnable_slice,
+            write_batch,
+            shreds,
+            slot_start_ts,
+        );
         Ok(())
     }
 }
@@ -802,6 +821,7 @@ mod test {
         let (socket_sender, _socket_receiver) = bounded(1024);
         let (blockstore_sender, _blockstore_receiver) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut write_batch = blockstore.get_write_batch();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut standard_broadcast_run = StandardBroadcastRun::new(
             0,
@@ -815,6 +835,7 @@ mod test {
                 &Keypair::new(),
                 &blockstore,
                 &mut pinnable_slice,
+                &mut write_batch,
                 &socket_sender,
                 &blockstore_sender,
                 receive_results,
@@ -1039,6 +1060,7 @@ mod test {
         let (bsend, brecv) = bounded(1024);
         let (ssend, _srecv) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut write_batch = blockstore.get_write_batch();
         let (votor_event_sender, _votor_event_receiver) = bounded(1024);
         let mut last_tick_height = bank.tick_height();
         let mut standard_broadcast_run = StandardBroadcastRun::new(
@@ -1060,6 +1082,7 @@ mod test {
                     &leader_keypair,
                     &blockstore,
                     &mut pinnable_slice,
+                    &mut write_batch,
                     &ssend,
                     &bsend,
                     receive_results,
@@ -1170,6 +1193,7 @@ mod test {
         let (bsend, brecv) = bounded(1024);
         let (ssend, srecv) = bounded(1024);
         let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut write_batch = blockstore.get_write_batch();
 
         let ticks = create_ticks(1, 0, genesis_config.hash());
         let err = standard_broadcast_run
@@ -1177,6 +1201,7 @@ mod test {
                 &leader_keypair,
                 &blockstore,
                 &mut pinnable_slice,
+                &mut write_batch,
                 &ssend,
                 &bsend,
                 ReceiveResults {
@@ -1195,6 +1220,7 @@ mod test {
                 &leader_keypair,
                 &blockstore,
                 &mut pinnable_slice,
+                &mut write_batch,
                 &ssend,
                 &bsend,
                 ReceiveResults {
@@ -1218,6 +1244,7 @@ mod test {
                 &leader_keypair,
                 &blockstore,
                 &mut pinnable_slice,
+                &mut write_batch,
                 &ssend,
                 &bsend,
                 ReceiveResults {


### PR DESCRIPTION
Initially landed in b9687a87037c787fa3257dc62fa00ff4708f1879 and reverted in 12b5c7e4df705927b2f7f579f3aa606aa4bde1c0 because of a wrong submodule url.
