### PR TITLE
ci(dependabot): ignore major shaq and rts-alloc updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,13 @@ updates:
         - "rts-alloc"
         - "shaq"
         - "wincode"
+    ignore:
+      - dependency-name: "rts-alloc"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "shaq"
+        update-types:
+          - "version-update:semver-major"
 
   # split from root directory schedule to avoid duplicate checks
   - package-ecosystem: cargo
@@ -40,6 +47,13 @@ updates:
         - "rts-alloc"
         - "shaq"
         - "wincode"
+    ignore:
+      - dependency-name: "rts-alloc"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "shaq"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
#### Problem
- shaq and rts-alloc are part of the external scheduler interface	
	- a major bump including a ABI change would break schedulers
	- should be coordinated with bump of external scheduler handshake version

#### Summary of Changes
- Have dependabot ignore major version bumps for shaq/rts-alloc

#### Testing
- CI

Fixes #
