### PR TITLE
chore(deps): bump rts-alloc from 4.0.0 to 5.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,12 +6066,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
+checksum = "279605f1b195cffab5534023f04f22831a30a048150a3339e46da69912074736"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ reqwest = { version = "0.12.28", default-features = false }
 reqwest-middleware = "0.4.2"
 rolling-file = "0.2.0"
 rpassword = "7.5"
-rts-alloc = { version = "4.0.0" }
+rts-alloc = { version = "5.0.0" }
 rusb = "0.9"
 rustls = { version = "0.23.43", features = ["std"], default-features = false }
 scopeguard = "1.2.0"

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -310,7 +310,7 @@ pub(crate) mod external {
             receiver: &mut shaq::spsc::Consumer<PackToWorkerMessage>,
             should_drain_executes: &mut bool,
         ) -> Result<IterationResult, ExternalConsumeWorkerError> {
-            self.allocator.clean_remote_free_lists();
+            self.allocator.clean_remote_frees();
             let capacity = NonZeroUsize::new(receiver.capacity())
                 .expect("shaq queue capacity must be non-zero");
             let Some(messages) = receiver.try_reserve_read_batch(capacity) else {

--- a/core/src/banking_stage/tpu_to_pack.rs
+++ b/core/src/banking_stage/tpu_to_pack.rs
@@ -87,7 +87,7 @@ fn handle_packet_batch(
 ) {
     // Clean all remote frees in allocator so we have as much
     // room as possible.
-    allocator.clean_remote_free_lists();
+    allocator.clean_remote_frees();
 
     let mut write_batch = producer.write_batch();
 

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -4998,12 +4998,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
+checksum = "279605f1b195cffab5534023f04f22831a30a048150a3339e46da69912074736"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4976,12 +4976,12 @@ dependencies = [
 
 [[package]]
 name = "rts-alloc"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddfcbcf855d5fa999ae18a991204dca661237b6e6fda7c4cb06bd97ad0b3af2"
+checksum = "279605f1b195cffab5534023f04f22831a30a048150a3339e46da69912074736"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]


### PR DESCRIPTION
#### Problem
- We've released https://github.com/anza-xyz/rts-alloc/releases/tag/v5.0.0

#### Summary of Changes
- Bump rts-alloc from 4.0.0 to 5.0.0
  - fix API changes
- Bump for bindings handshake version will be PR'd separately for agave v4.4 (other breaking changes coming) 

#### Testing
- CI

Fixes #
