### PR TITLE
clippy: use as_chunks for constant-size slice chunking

### DIFF
--- a/ledger/src/shred/merkle_tree.rs
+++ b/ledger/src/shred/merkle_tree.rs
@@ -144,18 +144,16 @@ pub fn verify_merkle_proof(
     proof: &[u8],
     expected_root: Hash,
 ) -> Result<(), Error> {
-    let mut proof = proof.chunks_exact(SIZE_OF_MERKLE_PROOF_ENTRY);
-    if !proof.remainder().is_empty() {
+    let (proof, remainder) = proof.as_chunks::<SIZE_OF_MERKLE_PROOF_ENTRY>();
+    if !remainder.is_empty() {
         return Err(Error::InvalidMerkleProof);
     }
-    let other = proof.next().ok_or(Error::InvalidMerkleProof)?;
-    let other = <&MerkleProofEntry>::try_from(other).unwrap();
+    let (other, proof) = proof.split_first().ok_or(Error::InvalidMerkleProof)?;
     let parent = if index.is_multiple_of(2) {
         join_nodes(node, other)
     } else {
         join_nodes(other, node)
     };
-    let proof = proof.map(|entry| <&MerkleProofEntry>::try_from(entry).unwrap());
     let merkle_root = get_merkle_root(index >> 1, parent, proof)?;
 
     (merkle_root == expected_root)

--- a/runtime/src/conformance/block.rs
+++ b/runtime/src/conformance/block.rs
@@ -537,8 +537,9 @@ pub fn execute_block(context: &ProtoBlockContext) -> ProtoBlockEffects {
     );
 
     let mut parent_lthash = LtHash::identity();
-    for (i, chunk) in bank_ctx.parent_lt_hash.chunks_exact(2).enumerate() {
-        parent_lthash.0[i] = u16::from_le_bytes(chunk.try_into().unwrap());
+    let (chunks, _) = bank_ctx.parent_lt_hash.as_chunks::<2>();
+    for (i, chunk) in chunks.iter().enumerate() {
+        parent_lthash.0[i] = u16::from_le_bytes(*chunk);
     }
 
     assert!(bank_ctx.ns_per_slot.len() == 16);


### PR DESCRIPTION
#### Problem
Newer clippy adds `chunks_exact_to_as_chunks`, which flags `chunks_exact()` calls with a compile-time constant chunk size.

#### Summary of Changes
`as_chunks()` yields fixed-size arrays, so the fallible slice-to-array conversions at both call sites drop out along with the lint.

#### Testing
CI