### PR TITLE
votor-transport: uniform reporting for datagram send errors

### DIFF
--- a/votor-transport/src/client.rs
+++ b/votor-transport/src/client.rs
@@ -352,17 +352,17 @@ impl OutboundLoop {
                     self.stats.connection_lost.fetch_add(1, Ordering::Relaxed);
                     dead_peers.push(*peer);
                 }
-                Err(SendDatagramError::UnsupportedByPeer) => {
-                    debug!("OutboundLoop: peer {peer} does not support datagrams.");
-                    // The wrong-direction reader holds a clone, so close explicitly before removal.
-                    close_codes::NORMAL_CLOSE.close(connection);
-                    // reconnecting is not likely to help, but it is the least we can do
-                    self.stats.connect_failed.fetch_add(1, Ordering::Relaxed);
-                    dead_peers.push(*peer);
-                }
-                Err(SendDatagramError::TooLarge) => {
-                    error!("Votor message too large and does not fit into transport MTU");
-                    debug_assert!(false, "Votor message too large ({} bytes)", message.len());
+                // The peer does not support datagrams or advertises a datagram size limit below
+                // message size. Both are likely remote misconfigurations, reconnecting is not
+                // likely to help, so we keep these connections to avoid churn.
+                Err(e @ (SendDatagramError::UnsupportedByPeer | SendDatagramError::TooLarge)) => {
+                    debug!(
+                        "OutboundLoop: peer {peer} refused a {} byte datagram: {e}",
+                        message.len()
+                    );
+                    self.stats
+                        .datagram_send_failed
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 Err(SendDatagramError::Disabled) => {
                     unreachable!("By construction (we enable datagrams)");

--- a/votor-transport/src/stats.rs
+++ b/votor-transport/src/stats.rs
@@ -21,6 +21,8 @@ pub struct ClientStats {
     pub(crate) connect_failed: AtomicU64,
     /// A peer in the peer_list had no resolvable address.
     pub(crate) connect_failed_no_address: AtomicU64,
+    /// Datagrams dropped because the peer configuration is incorrect.
+    pub(crate) datagram_send_failed: AtomicU64,
     /// Connections closed because the local identity changed.
     pub(crate) connection_closed_identity_changed: AtomicU64,
     /// Existing connection closed because the peer's gossip address changed.
@@ -163,6 +165,7 @@ impl ClientStats {
         let datagrams_sent = swap(&self.datagrams_sent);
         let connect_failed = swap(&self.connect_failed);
         let connect_failed_no_address = swap(&self.connect_failed_no_address);
+        let datagram_send_failed = swap(&self.datagram_send_failed);
         let connection_lost = swap(&self.connection_lost);
         let connection_closed_peer_moved = swap(&self.connection_closed_peer_moved);
         let connection_closed_not_in_peer_list = swap(&self.connection_closed_not_in_peer_list);
@@ -173,6 +176,7 @@ impl ClientStats {
             ("datagrams_sent", datagrams_sent, i64),
             ("connect_failed", connect_failed, i64),
             ("connect_failed_no_address", connect_failed_no_address, i64),
+            ("datagram_send_failed", datagram_send_failed, i64),
             ("connection_lost", connection_lost, i64),
             (
                 "connection_closed_peer_moved",


### PR DESCRIPTION
#### Problem

Inconsistent noisy stats

#### Summary of Changes

Consistently report peer datagram misconfiguration in metrics.

#### Testing
CI