### PR TITLE
ci: use cargo-deny to ban usage of solana-sdk

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -87,6 +87,7 @@ RUN \
   cargo install cargo-sort@2.0.2 && \
   cargo install rustfilt && \
   cargo install cargo-build-sbf@4.1.0 --locked && \
+  cargo install cargo-deny@0.20.2 --locked && \
   rustup show && \
   rustc --version && \
   cargo --version && \

--- a/ci/test-sanity.sh
+++ b/ci/test-sanity.sh
@@ -71,16 +71,9 @@ EOF
 fi
 
 # Disallow (re)introduction of solana sdk dependencies
-(
-  if git diff "$target" | grep -v '+++' | grep '^+.*solana[-_]sdk[: =]'; then
-    cat <<'EOF' 1>&2
-
-Error: solana sdk crate dependencies (re)introduced.
-This crate is DEPRECATED. Please use the standalone crates for the corresponding modules
-EOF
-    exit 1
-  fi
-)
+cargo_deny_config="$PWD/deny.toml"
+scripts/cargo-for-all-lock-files.sh -- \
+  deny --config "$cargo_deny_config" --all-features check bans
 
 # Disallow adding new files under docs/ — docs now live in a separate repo
 (

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,5 @@
+[bans]
+deny = [
+    { crate = "solana-sdk", reason = "Deprecated; use the standalone Solana crates instead" },
+]
+multiple-versions = "allow"


### PR DESCRIPTION
#### Problem
We have a diff check to sanity check no usage of `solana-sdk`, however it has false positive where if a formatting change is made it treats it as introducing the dependency. See false positive in #14637:  https://anza-xyz.slack.com/archives/C08D0FL5Q4T/p1786968824950809?thread_ts=1786968559.427969&cid=C08D0FL5Q4T.

[`cargo-deny`](https://github.com/embarkstudios/cargo-deny) is a popular tool that can be used to ban dependencies by analyzing the lock files.

#### Summary of Changes
- use `cargo-deny` to ban `solana-sdk` dependency.

#### Testing
Ran it manually locally to sanity check:
```diff
agave on  dsharifi/use-cargo-deny [$!] is 📦 v4.4.0-alpha.0 via 🦀 v1.97.1 
❯ git diff svm/
diff --git a/svm/Cargo.toml b/svm/Cargo.toml
index aa1ad403cb..8e1816eacc 100644
--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
+solana-sdk = "4.1.0"
 ```

 ```log
❯ scripts/cargo-for-all-lock-files.sh -- \
        deny --config "$PWD/deny.toml" --all-features check bans
++ dirname Cargo.lock
+ cd .
+ cargo deny --config /Users/dsharifi/Dev/agave/deny.toml --all-features check bans
error[banned]: crate 'solana-sdk = 4.1.0' is explicitly banned
  ┌─ /Users/dsharifi/Dev/agave/deny.toml:3:16
  │
3 │     { crate = "solana-sdk", reason = "Deprecated; use the standalone Solana crates instead" },
  │                ━━━━━━━━━━             ──────────────────────────────────────────────────── reason
  │                │                       
  │                banned here
  │
```