### PR TITLE
Continued minimal cleanup

### DIFF
--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1351,7 +1351,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         let m = Measure::start("evict");
         self.evict_from_cache(&candidates_to_evict.0, current_age, ages_to_scan);
-        Self::update_time_stat(&self.stats().flush_evict_us, m);
+        Self::update_time_stat(&self.stats().evict_us, m);
 
         if iterate_for_age {
             // completed iteration of the buckets at the current age

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1314,7 +1314,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         debug_assert!(!startup);
 
         if !iterate_for_age {
-            // no need to age, so no need to flush this bucket
+            // no need to age, so no need to scan this bucket
             return;
         }
 
@@ -1346,7 +1346,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
 
         Self::update_stat(&self.stats().buckets_scanned, 1);
 
-        // scan in-mem map for candidates to flush/evict
+        // scan in-mem map for candidates to evict
         let candidates_to_evict = self.evict_scan(current_age, flush_guard, ages_to_scan);
 
         let m = Measure::start("evict");
@@ -1475,7 +1475,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 }
 
-/// State of reservoir sampling algorithm for flush/eviction candidates.
+/// State of reservoir sampling algorithm for eviction candidates.
 #[derive(Debug)]
 struct ReservoirState {
     samples: Vec<Pubkey>,
@@ -1730,7 +1730,7 @@ mod tests {
         assert!(accounts_index.load_from_disk(&pubkey_dirty_new).is_none());
         assert!(accounts_index.load_from_disk(&pubkey_dirty_old).is_none());
 
-        // A clean entry that is *not* in the flush/eviction window.
+        // A clean entry that is *not* in the eviction window.
         // This entry should *not* be eligible for eviction.
         let entry_clean_new = AccountMapEntry::new(
             SlotList::from([(slot, info)]),
@@ -1739,7 +1739,7 @@ mod tests {
         );
         assert!(!entry_clean_new.dirty());
 
-        // A clean entry that *is* in the flush/eviction window.
+        // A clean entry that *is* in the eviction window.
         // This entry *should* be eligible for eviction.
         let entry_clean_old = AccountMapEntry::new(
             SlotList::from([(slot + 1, info + 1)]),
@@ -1749,8 +1749,8 @@ mod tests {
         entry_clean_old.set_age(accounts_index.storage.current_age());
         assert!(!entry_clean_old.dirty());
 
-        // A dirty entry that is *not* in the flush/eviction window.
-        // This entry should *not* be eligible for flush.
+        // A dirty entry that is *not* in the eviction window.
+        // This entry should *not* be eligible for eviction.
         let entry_dirty_new = AccountMapEntry::new(
             SlotList::from([(slot + 2, info + 2)]),
             1,
@@ -1758,8 +1758,8 @@ mod tests {
         );
         assert!(entry_dirty_new.dirty());
 
-        // A dirty entry that *is* in the flush/eviction window.
-        // This entry *should* be eligible for flush.
+        // A dirty entry that *is* in the eviction window.
+        // The caller asserts the outcome for this entry.
         let entry_dirty_old = AccountMapEntry::new(
             SlotList::from([(slot + 3, info + 3)]),
             1,
@@ -1845,7 +1845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gather_possible_flush_and_evict_candidates_with_max_evictions() {
+    fn test_gather_possible_evict_candidates_with_max_evictions() {
         let ref_count = 1;
         let current_age = 100;
         let ages_to_scan = 0;
@@ -1894,7 +1894,7 @@ mod tests {
     }
 
     #[test]
-    fn test_gather_possible_evict_candidates_no_flush() {
+    fn test_gather_possible_evict_candidates_skips_dirty() {
         let accounts_index = new_disk_buckets_for_test::<u64>();
         let current_age = accounts_index.storage.current_age();
         let ages_to_scan = accounts_index.num_ages_to_distribute_scans;

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -48,14 +48,14 @@ pub struct InMemAccountsIndex<T: IndexValue, U: DiskIndexValue + From<T> + Into<
     /// info to streamline initial index generation
     startup_info: StartupInfo<T, U>,
 
-    /// how many more ages to skip before this bucket is flushed (as opposed to being skipped).
-    /// When this reaches 0, this bucket is flushed.
-    remaining_ages_to_skip_flushing: AtomicAge,
+    /// how many more ages to skip before this bucket is scanned.
+    /// When this reaches 0, this bucket is scanned.
+    ages_to_skip_before_scan: AtomicAge,
 
-    /// an individual bucket will evict its entries and write to disk every 1/NUM_AGES_TO_DISTRIBUTE_FLUSHES ages
-    /// Higher numbers mean we flush less buckets/s
-    /// Lower numbers mean we flush more buckets/s
-    num_ages_to_distribute_flushes: Age,
+    /// an individual bucket will scan for evictions every 1/num_ages_to_distribute_scans ages
+    /// Higher numbers mean we scan less buckets/s
+    /// Lower numbers mean we scan more buckets/s
+    num_ages_to_distribute_scans: Age,
 
     /// stats related to starting up
     pub(crate) startup_stats: Arc<StartupStats>,
@@ -116,7 +116,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         bin: usize,
         num_initial_accounts: Option<usize>,
     ) -> Self {
-        let num_ages_to_distribute_flushes = Age::MAX - storage.ages_to_stay_in_cache;
+        let num_ages_to_distribute_scans = Age::MAX - storage.ages_to_stay_in_cache;
 
         let map_internal = if let Some(num_initial_accounts) = num_initial_accounts {
             let capacity_per_bin = num_initial_accounts / storage.bins;
@@ -143,10 +143,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             startup_info: StartupInfo::default(),
             // Spread out the scanning across all ages within the window.
             // This causes us to scan 1/N of the bins each 'Age'
-            remaining_ages_to_skip_flushing: AtomicAge::new(
-                rng().random_range(0..num_ages_to_distribute_flushes),
+            ages_to_skip_before_scan: AtomicAge::new(
+                rng().random_range(0..num_ages_to_distribute_scans),
             ),
-            num_ages_to_distribute_flushes,
+            num_ages_to_distribute_scans,
             startup_stats: Arc::clone(&storage.startup_stats),
             should_write_through: storage.should_write_through(),
         }
@@ -1009,9 +1009,9 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     fn should_evict_based_on_age(
         current_age: Age,
         entry: &AccountMapEntry<T>,
-        ages_flushing_now: Age,
+        ages_to_scan: Age,
     ) -> bool {
-        current_age.wrapping_sub(entry.age()) <= ages_flushing_now
+        current_age.wrapping_sub(entry.age()) <= ages_to_scan
     }
 
     /// Collect candidates to evict from `iter` by checking age
@@ -1019,7 +1019,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     fn gather_possible_evict_candidates<'a>(
         iter: impl Iterator<Item = (&'a Pubkey, &'a Box<AccountMapEntry<T>>)>,
         current_age: Age,
-        ages_evicting_now: Age,
+        ages_to_scan: Age,
         max_evictions: NonZeroUsize,
     ) -> CandidatesToEvict {
         let mut rng = rng();
@@ -1030,8 +1030,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             max_samples: max_evictions,
         };
         for (k, v) in iter {
-            if !Self::should_evict_based_on_age(current_age, v, ages_evicting_now) {
-                // not planning to evict this item from memory within 'ages_evicting_now' ages
+            if !Self::should_evict_based_on_age(current_age, v, ages_to_scan) {
+                // not planning to evict this item from memory within 'ages_to_scan' ages
                 continue;
             }
 
@@ -1057,7 +1057,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         &self,
         current_age: Age,
         _flush_guard: &FlushGuard,
-        ages_evicting_now: Age,
+        ages_to_scan: Age,
     ) -> CandidatesToEvict {
         let (possible_evictions, m) = {
             let map = self.map_internal.read().unwrap();
@@ -1066,7 +1066,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             let possible_evictions = Self::gather_possible_evict_candidates(
                 map.iter(),
                 current_age,
-                ages_evicting_now,
+                ages_to_scan,
                 max_evictions,
             );
             (possible_evictions, m)
@@ -1328,29 +1328,29 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
             return;
         }
 
-        let ages_flushing_now = {
+        let ages_to_scan = {
             let old_value = self
-                .remaining_ages_to_skip_flushing
+                .ages_to_skip_before_scan
                 .fetch_sub(1, Ordering::AcqRel);
             if old_value == 0 {
-                self.remaining_ages_to_skip_flushing
-                    .store(self.num_ages_to_distribute_flushes, Ordering::Release);
+                self.ages_to_skip_before_scan
+                    .store(self.num_ages_to_distribute_scans, Ordering::Release);
             } else {
                 // skipping iteration of the buckets at the current age, but mark the bucket as having aged
                 assert_eq!(current_age, self.storage.current_age());
                 self.set_has_aged(current_age, can_advance_age);
                 return;
             }
-            self.num_ages_to_distribute_flushes
+            self.num_ages_to_distribute_scans
         };
 
         Self::update_stat(&self.stats().buckets_scanned, 1);
 
         // scan in-mem map for candidates to flush/evict
-        let candidates_to_evict = self.evict_scan(current_age, flush_guard, ages_flushing_now);
+        let candidates_to_evict = self.evict_scan(current_age, flush_guard, ages_to_scan);
 
         let m = Measure::start("evict");
-        self.evict_from_cache(&candidates_to_evict.0, current_age, ages_flushing_now);
+        self.evict_from_cache(&candidates_to_evict.0, current_age, ages_to_scan);
         Self::update_time_stat(&self.stats().flush_evict_us, m);
 
         if iterate_for_age {
@@ -1397,7 +1397,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     }
 
     // evict keys in 'evictions' from in-mem cache, likely due to age
-    fn evict_from_cache(&self, evictions: &[Pubkey], current_age: Age, ages_flushing_now: Age) {
+    fn evict_from_cache(&self, evictions: &[Pubkey], current_age: Age, ages_to_scan: Age) {
         if evictions.is_empty() {
             return;
         }
@@ -1414,7 +1414,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                     let v = occupied.get();
 
                     if v.dirty()
-                        || !Self::should_evict_based_on_age(current_age, v, ages_flushing_now)
+                        || !Self::should_evict_based_on_age(current_age, v, ages_to_scan)
                     {
                         // marked dirty or bumped in age after we looked above
                         // these evictions will be handled in later passes (at later ages)
@@ -1776,7 +1776,7 @@ mod tests {
         ]);
 
         accounts_index
-            .remaining_ages_to_skip_flushing
+            .ages_to_skip_before_scan
             .store(0, Ordering::Release);
 
         accounts_index.flush(false);
@@ -1848,7 +1848,7 @@ mod tests {
     fn test_gather_possible_flush_and_evict_candidates_with_max_evictions() {
         let ref_count = 1;
         let current_age = 100;
-        let ages_flushing_now = 0;
+        let ages_to_scan = 0;
         let total_entries = 256;
         let max_evictions = NonZeroUsize::new(5).unwrap();
 
@@ -1873,7 +1873,7 @@ mod tests {
         let to_evict = InMemAccountsIndex::<u64, u64>::gather_possible_evict_candidates(
             map.iter(),
             current_age,
-            ages_flushing_now,
+            ages_to_scan,
             max_evictions,
         );
 
@@ -1885,7 +1885,7 @@ mod tests {
             assert!(InMemAccountsIndex::<u64, u64>::should_evict_based_on_age(
                 current_age,
                 entry,
-                ages_flushing_now,
+                ages_to_scan,
             ));
         }
         for key in &to_evict.0 {
@@ -1897,7 +1897,7 @@ mod tests {
     fn test_gather_possible_evict_candidates_no_flush() {
         let accounts_index = new_disk_buckets_for_test::<u64>();
         let current_age = accounts_index.storage.current_age();
-        let ages_flushing_now = accounts_index.num_ages_to_distribute_flushes;
+        let ages_to_scan = accounts_index.num_ages_to_distribute_scans;
         let slot = 1;
 
         // Clean entry in the eviction window.
@@ -1925,7 +1925,7 @@ mod tests {
         let to_evict = InMemAccountsIndex::<u64, u64>::gather_possible_evict_candidates(
             map.iter(),
             current_age,
-            ages_flushing_now,
+            ages_to_scan,
             max_evictions,
         );
 

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1244,7 +1244,8 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         std::mem::take(&mut duplicates.duplicates_from_in_memory_only)
     }
 
-    /// Decide whether this bin needs flushing/eviction. Returns true if the caller should proceed.
+    /// Returns true when the bin's occupancy has crossed its configured thresholds and
+    /// the caller should reduce it.
     ///
     /// Fires on either of two conditions:
     /// - Free-entry headroom is below the configured overhead. Tombstones left by prior evictions
@@ -1255,7 +1256,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     ///   would not fire on its own.
     ///
     /// Returns false for bins still in initial growth (capacity below `high_water_mark`).
-    fn check_flush_trigger(&self) -> bool {
+    fn exceeds_thresholds(&self) -> bool {
         let (entries_in_bin, capacity) = {
             let map = self.map_internal.read().unwrap();
             (map.len(), map.capacity())
@@ -1320,7 +1321,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         // from this point forward, we know iterate_for_age == true
         debug_assert!(iterate_for_age);
 
-        if !self.check_flush_trigger() {
+        if !self.exceeds_thresholds() {
             // Still mark as aged to avoid infinite scanning
             assert_eq!(current_age, self.storage.current_age());
             self.set_has_aged(current_age, can_advance_age);
@@ -1365,7 +1366,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
     /// the hashmap to double in capacity.
     ///
     /// Only called in Threshold mode, where `capacity >= target_entries` is guaranteed
-    /// by the time eviction runs (`check_flush_trigger` gates on `high_water_mark`).
+    /// by the time eviction runs (`exceeds_thresholds` gates on `high_water_mark`).
     fn reallocate_to_clear_tombstones(&self) {
         let stats = self.stats();
         let m = Measure::start("reallocate_hashmap");
@@ -2661,10 +2662,10 @@ mod tests {
     }
 
     /// While the bin's hashmap is still in initial growth (capacity below `high_water_mark`),
-    /// the growth gate short-circuits check_flush_trigger to false even when the
+    /// the growth gate short-circuits exceeds_thresholds to false even when the
     /// low-free-entries check would otherwise fire.
     #[test]
-    fn test_check_flush_trigger_below_hwm_gate() {
+    fn test_exceeds_thresholds_below_hwm_gate() {
         // 56 entries fill hashbrown's raw=64 table exactly: capacity=56 (below HWM=100)
         // and free_entries=0 (below overhead=1, so low_free_entries would fire).
         let hwm = 100;
@@ -2693,15 +2694,15 @@ mod tests {
                 .should_evict_based_on_free_entries(free_entries)
         );
 
-        // But with the gate, check_flush_trigger returns false
-        assert!(!index.check_flush_trigger());
+        // But with the gate, exceeds_thresholds returns false
+        assert!(!index.exceeds_thresholds());
     }
 
-    /// Once capacity has cleared the low-water mark, check_flush_trigger must still return
+    /// Once capacity has cleared the low-water mark, exceeds_thresholds must still return
     /// false when the entry count is below the high-water mark and free-entry headroom exceeds
     /// the configured overhead.
     #[test]
-    fn test_check_flush_trigger_below_thresholds() {
+    fn test_exceeds_thresholds_below_thresholds() {
         // 60 entries push capacity to 112 (above LWM=50), len stays below HWM=100,
         // and free_entries (52) far exceeds overhead (1) — both conditions report false.
         let hwm = 100;
@@ -2718,13 +2719,13 @@ mod tests {
         }
         assert!(index.map_internal.read().unwrap().capacity() > lwm);
 
-        assert!(!index.check_flush_trigger());
+        assert!(!index.exceeds_thresholds());
     }
 
-    /// When the entry count crosses the high-water mark, check_flush_trigger returns true
+    /// When the entry count crosses the high-water mark, exceeds_thresholds returns true
     /// and the count-based trigger stat is incremented.
     #[test]
-    fn test_check_flush_trigger_high_count() {
+    fn test_exceeds_thresholds_high_count() {
         let hwm = 2;
         let lwm = 1;
         // high_water_mark=2: inserting 4 entries puts the bin past the count threshold.
@@ -2739,7 +2740,7 @@ mod tests {
             index.map_internal.write().unwrap().insert(pubkey, entry);
         }
 
-        assert!(index.check_flush_trigger());
+        assert!(index.exceeds_thresholds());
     }
 
     /// reallocate_to_clear_tombstones must rebuild the bin's hashmap so that all

--- a/accounts-db/src/accounts_index/in_mem_accounts_index.rs
+++ b/accounts-db/src/accounts_index/in_mem_accounts_index.rs
@@ -1329,9 +1329,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
         }
 
         let ages_to_scan = {
-            let old_value = self
-                .ages_to_skip_before_scan
-                .fetch_sub(1, Ordering::AcqRel);
+            let old_value = self.ages_to_skip_before_scan.fetch_sub(1, Ordering::AcqRel);
             if old_value == 0 {
                 self.ages_to_skip_before_scan
                     .store(self.num_ages_to_distribute_scans, Ordering::Release);
@@ -1413,9 +1411,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> InMemAccountsIndex<T,
                 if let Entry::Occupied(occupied) = map.entry(*k) {
                     let v = occupied.get();
 
-                    if v.dirty()
-                        || !Self::should_evict_based_on_age(current_age, v, ages_to_scan)
-                    {
+                    if v.dirty() || !Self::should_evict_based_on_age(current_age, v, ages_to_scan) {
                         // marked dirty or bumped in age after we looked above
                         // these evictions will be handled in later passes (at later ages)
                         failed += 1;

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -49,7 +49,7 @@ pub struct Stats {
     last_age: AtomicAge,
     last_ages_flushed: AtomicU64,
     pub evict_scan_us: AtomicU64,
-    pub flush_evict_us: AtomicU64,
+    pub evict_us: AtomicU64,
     pub flush_grow_us: AtomicU64,
     last_was_startup: AtomicBool,
     last_time: AtomicInterval,
@@ -384,8 +384,8 @@ impl Stats {
                     i64
                 ),
                 (
-                    "flush_evict_us",
-                    self.flush_evict_us.swap(0, Ordering::Relaxed),
+                    "evict_us",
+                    self.evict_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
                 (

--- a/accounts-db/src/accounts_index/stats.rs
+++ b/accounts-db/src/accounts_index/stats.rs
@@ -383,11 +383,7 @@ impl Stats {
                     self.flush_grow_us.swap(0, Ordering::Relaxed),
                     i64
                 ),
-                (
-                    "evict_us",
-                    self.evict_us.swap(0, Ordering::Relaxed),
-                    i64
-                ),
+                ("evict_us", self.evict_us.swap(0, Ordering::Relaxed), i64),
                 (
                     "num_hashmap_reallocates",
                     self.num_hashmap_reallocates.swap(0, Ordering::Relaxed),


### PR DESCRIPTION
#### Problem
Minimal was removed, but lots of the comments/names still refer to the flush functionality that it used. Changing terminology to be more generic. 

#### Summary of Changes
5 commits
1. Rename check_flush_trigger to exceeds_threshold
2. Rename ages_flushing_now to ages_to_scan
3. Rename flush_evict_us to evict_us
4. Stray flush comment cleanup
5. Format cleanup

#### Testing


Fixes #
