### PR TITLE
Adds agave-address-hasher crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-address-hasher"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "rand 0.9.4",
+ "solana-pubkey 4.3.0",
+]
+
+[[package]]
 name = "agave-banking-stage-ingress-types"
 version = "4.4.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "accounts-cluster-bench",
     "accounts-db",
     "accounts-db/store-histogram",
+    "address-hasher",
     "banking-stage-ingress-types",
     "banks-client",
     "banks-interface",
@@ -168,6 +169,7 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
+agave-address-hasher = { path = "address-hasher", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }

--- a/address-hasher/Cargo.toml
+++ b/address-hasher/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "agave-address-hasher"
+description = "Hasher for a solana address"
+documentation = "https://docs.rs/agave-address-hasher"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lib]
+crate-type = ["lib"]
+name = "agave_address_hasher"
+
+[features]
+agave-unstable-api = []
+
+[dependencies]
+rand = { workspace = true }
+
+[dev-dependencies]
+solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/address-hasher/src/hasher.rs
+++ b/address-hasher/src/hasher.rs
@@ -1,0 +1,248 @@
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    rand::Rng as _,
+    std::{
+        cell::Cell,
+        hash::{BuildHasher, Hasher},
+        thread_local,
+    },
+};
+
+/// Number of bytes in an address.
+///
+/// Mirrors `solana_pubkey::PUBKEY_BYTES` so `solana_pubkey` stays a dev-only dependency.
+/// (constant is kept in sync by asserts in tests)
+const ADDRESS_BYTES: usize = 32;
+
+/// A faster, but less collision resistant hasher for addresses.
+///
+/// Specialized hasher that uses an 8-byte slice
+/// of the address xor'd with a random u64 as the hash value.
+/// Should not be used when collisions might be used to mount DOS attacks.
+pub struct AddressHasher {
+    offset: usize,
+    random: u64,
+    state: u64,
+}
+
+impl Hasher for AddressHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        debug_assert_eq!(
+            bytes.len(),
+            ADDRESS_BYTES,
+            "This hasher is intended to be used with addresses and nothing else",
+        );
+        // This slice/unwrap can never panic since offset is < ADDRESS_BYTES - size_of::<u64>()
+        let chunk: &[u8; size_of::<u64>()] = bytes[self.offset..self.offset + size_of::<u64>()]
+            .try_into()
+            .unwrap();
+        self.state = u64::from_ne_bytes(*chunk) ^ self.random;
+    }
+}
+
+/// A builder for faster, but less collision resistant hasher for addresses.
+///
+/// Initializes `AddressHasher` instances that use an 8-byte slice
+/// of the address xor'd with a random u64 as the hash value.
+/// Should not be used when collisions might be used to mount DOS attacks.
+#[derive(Clone)]
+pub struct AddressHasherBuilder {
+    offset: usize,
+    random: u64,
+}
+
+impl AddressHasherBuilder {
+    /// Constructs a builder with a specific offset and random.
+    ///
+    /// Prefer `AddressHasherBuilder::default()` unless deterministic results are required.
+    pub fn with(offset: usize, random: u64) -> Self {
+        AddressHasherBuilder { offset, random }
+    }
+
+    /// Returns the offset used to construct this builder.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the random used to construct this builder.
+    pub fn random(&self) -> u64 {
+        self.random
+    }
+}
+
+impl Default for AddressHasherBuilder {
+    /// Default construct the AddressHasherBuilder.
+    ///
+    /// The position of the slice is determined initially
+    /// through random draw and then by incrementing a thread-local
+    /// This way each hashmap can be expected to use a slightly different
+    /// slice. This is essentially the same mechanism as what is used by
+    /// `RandomState`
+    fn default() -> Self {
+        thread_local! {
+            static OFFSET: Cell<usize>  = {
+                Cell::new(rand::rng().random_range(0..ADDRESS_BYTES - size_of::<u64>()))
+            };
+        }
+
+        let offset = OFFSET.with(|offset| {
+            let mut next_offset = offset.get() + 1;
+            if next_offset > ADDRESS_BYTES - size_of::<u64>() {
+                next_offset = 0;
+            }
+            offset.set(next_offset);
+            next_offset
+        });
+        let random = rand::rng().random();
+        AddressHasherBuilder { offset, random }
+    }
+}
+
+impl BuildHasher for AddressHasherBuilder {
+    type Hasher = AddressHasher;
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        AddressHasher {
+            offset: self.offset,
+            random: self.random,
+            state: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_pubkey::{PUBKEY_BYTES, Pubkey},
+    };
+
+    /// Ensure our ADDRESS_BYTES constant stays in sync with the solana-sdk
+    #[test]
+    fn test_address_bytes() {
+        assert_eq!(ADDRESS_BYTES, PUBKEY_BYTES);
+        assert_eq!(ADDRESS_BYTES, Pubkey::default().as_array().len());
+        assert_eq!(ADDRESS_BYTES, Pubkey::default().as_ref().len());
+    }
+
+    /// Ensure identical hashers with identical keys produce identical hashes
+    #[test]
+    fn test_identical_hashers_and_identical_keys() {
+        let mut hasher1 = AddressHasher {
+            offset: 7,
+            random: 42,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            offset: 7,
+            random: 42,
+            state: 0,
+        };
+
+        let key = Pubkey::new_unique();
+        hasher1.write(key.as_array());
+        hasher2.write(key.as_array());
+        assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure identical hashers with different keys produce different hashes
+    #[test]
+    fn test_identical_hashers_and_different_keys() {
+        let mut hasher1 = AddressHasher {
+            offset: 2,
+            random: 11,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            offset: 2,
+            random: 11,
+            state: 0,
+        };
+
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        hasher1.write(key1.as_array());
+        hasher2.write(key2.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different hashers with identical keys produce different hashes
+    #[test]
+    fn test_different_hashers_and_identical_keys() {
+        let mut hasher1 = AddressHasher {
+            offset: 3,
+            random: 123,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            offset: 4,
+            random: 456,
+            state: 0,
+        };
+
+        let key = Pubkey::new_unique();
+        hasher1.write(key.as_array());
+        hasher2.write(key.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different hashers with different keys produce different hashes
+    #[test]
+    fn test_different_hashers_and_different_keys() {
+        let mut hasher1 = AddressHasher {
+            offset: 20,
+            random: 321,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            offset: 10,
+            random: 987,
+            state: 0,
+        };
+
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        hasher1.write(key1.as_array());
+        hasher2.write(key2.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different builders are different
+    #[test]
+    fn test_builder_default() {
+        let builder1 = AddressHasherBuilder::default();
+        let builder2 = AddressHasherBuilder::default();
+
+        assert_ne!(builder1.offset(), builder2.offset());
+        assert_ne!(builder1.random(), builder2.random());
+    }
+
+    /// Ensure AddressHasherBuilder::with() is deterministic
+    #[test]
+    fn test_builder_with() {
+        let builder1 = AddressHasherBuilder::default();
+        let offset1 = builder1.offset();
+        let random1 = builder1.random();
+        let builder2 = AddressHasherBuilder::with(offset1, random1);
+
+        assert_eq!(offset1, builder2.offset());
+        assert_eq!(random1, builder2.random());
+    }
+
+    /// Ensure build_hasher() builds stable hashers
+    #[test]
+    fn test_build_hasher() {
+        let builder = AddressHasherBuilder::default();
+        let hasher1 = builder.build_hasher();
+        let hasher2 = builder.build_hasher();
+
+        assert_eq!(hasher1.offset, hasher2.offset);
+        assert_eq!(hasher1.random, hasher2.random);
+    }
+}

--- a/address-hasher/src/lib.rs
+++ b/address-hasher/src/lib.rs
@@ -1,0 +1,5 @@
+#![cfg(feature = "agave-unstable-api")]
+
+mod hasher;
+
+pub use hasher::{AddressHasher, AddressHasherBuilder};


### PR DESCRIPTION
#### Problem

No need for agave to depend on the solana sdk for a hasher of addresses.


#### Summary of Changes

Add one to agave.