### PR TITLE
runtime: rewrite check_transactions.rs

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -2667,20 +2667,19 @@ mod tests {
         // all but one succeed. 6 for initial funding
         assert_eq!(bank.transaction_count(), 6 + 5);
 
-        let already_processed_results = bank
-            .check_transactions(
-                &sanitized_txs,
-                &vec![Ok(()); sanitized_txs.len()],
-                bank.max_processing_age(),
-                true,
-                &mut TransactionErrorMetrics::default(),
-            )
-            .into_iter()
-            .map(|r| match r {
-                Ok(_) => Ok(()),
-                Err(err) => Err(err),
-            })
-            .collect::<Vec<_>>();
+        let already_processed_results = Consumer::check_transactions_for_scheduling(
+            bank,
+            &sanitized_txs,
+            &vec![Ok(()); sanitized_txs.len()],
+            bank.max_processing_age(),
+            &mut TransactionErrorMetrics::default(),
+        )
+        .into_iter()
+        .map(|r| match r {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err),
+        })
+        .collect::<Vec<_>>();
         assert_eq!(
             already_processed_results,
             vec![

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -21,12 +21,12 @@ use {
         StaticMessageWithMeta, TransactionWithMeta,
     },
     solana_svm::{
-        account_loader::validate_fee_payer,
+        account_loader::{TransactionCheckResult, validate_fee_payer},
         transaction_error_metrics::TransactionErrorMetrics,
         transaction_processing_result::TransactionProcessingResultExtensions,
         transaction_processor::{ExecutionRecordingConfig, TransactionProcessingConfig},
     },
-    solana_transaction_error::TransactionError,
+    solana_transaction_error::{TransactionError, TransactionResult},
     solana_vote::vote_parser,
     std::num::Saturating,
 };
@@ -131,11 +131,11 @@ impl Consumer {
         let mut error_counters = TransactionErrorMetrics::default();
         let pre_results =
             SmallVec::<[_; TARGET_NUM_TRANSACTIONS_PER_BATCH]>::from_elem(Ok(()), txs.len());
-        let check_results = bank.check_transactions(
+        let check_results = Self::check_transactions_for_scheduling(
+            bank,
             txs,
             &pre_results,
             bank.max_processing_age(),
-            true,
             &mut error_counters,
         );
         let check_results = check_results
@@ -507,6 +507,17 @@ impl Consumer {
             execute_and_commit_timings,
             error_counters,
         }
+    }
+
+    pub(crate) fn check_transactions_for_scheduling<Tx: TransactionWithMeta>(
+        bank: &Bank,
+        txs: &[impl core::borrow::Borrow<Tx>],
+        lock_results: &[TransactionResult<()>],
+        max_age: usize,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> Vec<TransactionCheckResult> {
+        bank.check_transactions_external(txs, lock_results, max_age, false, error_counters)
+            .0
     }
 
     pub fn check_fee_payer_unlocked(

--- a/core/src/banking_stage/transaction_scheduler/check_worker.rs
+++ b/core/src/banking_stage/transaction_scheduler/check_worker.rs
@@ -157,11 +157,14 @@ pub(crate) mod external {
         },
         solana_runtime_transaction::{
             runtime_transaction::RuntimeTransaction, sanitize_config::sanitize_config,
-            transaction_meta::TransactionMeta,
+            transaction_meta::TransactionMeta, transaction_with_meta::TransactionWithMeta,
         },
-        solana_svm::transaction_error_metrics::TransactionErrorMetrics,
+        solana_svm::{
+            account_loader::TransactionCheckResult,
+            transaction_error_metrics::TransactionErrorMetrics,
+        },
         solana_svm_transaction::svm_message::{SVMMessage, SVMStaticMessage},
-        solana_transaction::TransactionError,
+        solana_transaction::{TransactionError, TransactionResult},
         std::{
             ptr::NonNull,
             sync::{
@@ -671,6 +674,16 @@ pub(crate) mod external {
             }
         }
 
+        fn check_transactions_with_processed_slots<Tx: TransactionWithMeta>(
+            bank: &Bank,
+            txs: &[impl core::borrow::Borrow<Tx>],
+            lock_results: &[TransactionResult<()>],
+            max_age: usize,
+            error_counters: &mut TransactionErrorMetrics,
+        ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
+            bank.check_transactions_external(txs, lock_results, max_age, true, error_counters)
+        }
+
         fn check_status_checks<D: TransactionData>(
             parsing_and_resolve_results: &[Result<(), PacketHandlingError>],
             txs: &[RuntimeTransaction<ResolvedTransactionView<D>>],
@@ -680,13 +693,12 @@ pub(crate) mod external {
             assert_eq!(parsing_and_resolve_results.len(), responses.len());
 
             let mut error_counters = TransactionErrorMetrics::default();
-            let (status_check_results, included_slots) = working_bank
-                .check_transactions_with_processed_slots(
+            let (status_check_results, included_slots) =
+                Self::check_transactions_with_processed_slots(
+                    working_bank,
                     txs,
                     &[const { Ok(()) }; MAX_TRANSACTIONS_PER_MESSAGE],
                     working_bank.max_processing_age(),
-                    true,
-                    true,
                     &mut error_counters,
                 );
             let included_slots = included_slots.expect("requested to collect processed slots");

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -12,6 +12,7 @@ use {
         banking_stage::{
             TOTAL_BUFFERED_PACKETS,
             consume_worker::ConsumeWorkerMetrics,
+            consumer::Consumer,
             decision_maker::{BufferedPacketsDecision, DecisionMaker},
             transaction_scheduler::{
                 receive_and_buffer::ReceivingStats, transaction_priority_id::TransactionPriorityId,
@@ -466,11 +467,11 @@ where
         };
         let lock_results = [const { Ok(()) }; CHECK_CHUNK];
         let mut error_counters = TransactionErrorMetrics::default();
-        let results = bank.check_transactions::<R::Transaction>(
+        let results = Consumer::check_transactions_for_scheduling::<R::Transaction>(
+            &bank,
             &txs,
             &lock_results[..txs.len()],
             bank.max_processing_age(),
-            true,
             &mut error_counters,
         );
 

--- a/core/src/banking_stage/vote_worker.rs
+++ b/core/src/banking_stage/vote_worker.rs
@@ -19,7 +19,9 @@ use {
     },
     crossbeam_channel::RecvTimeoutError,
     solana_accounts_db::account_locks::validate_account_locks,
-    solana_clock::FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
+    solana_clock::{
+        FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, MAX_TRANSACTION_FORWARDING_DELAY,
+    },
     solana_measure::{measure::Measure, measure_us},
     solana_perf::packet::bytes::Bytes,
     solana_poh::poh_recorder::PohRecorderError,
@@ -411,13 +413,35 @@ impl VoteWorker {
         let filter =
             Self::prepare_filter_for_pending_transactions(transactions.len(), pending_indexes);
 
-        let results = bank.check_transactions_with_forwarding_delay(
-            transactions,
-            &filter,
-            FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET,
-        );
+        let results = Self::check_transactions_with_forwarding_delay(bank, transactions, &filter);
 
         Self::filter_valid_transaction_indexes(&results)
+    }
+
+    /// A transaction batch check that truncates `max_age` to avoid forwarding soon-to-expire transactions.
+    fn check_transactions_with_forwarding_delay(
+        bank: &Bank,
+        txs: &[impl TransactionWithMeta],
+        lock_results: &[transaction::Result<()>],
+    ) -> Vec<TransactionCheckResult> {
+        // The following code also checks if the blockhash for a transaction is too old
+        // The check accounts for
+        //  1. Transaction forwarding delay
+        //  2. The slot at which the next leader will actually process the transaction
+        // Drop the transaction if it will expire by the time the next node receives and processes it
+        let notional_max_age = bank
+            .max_processing_age()
+            .saturating_sub(MAX_TRANSACTION_FORWARDING_DELAY)
+            .saturating_sub(FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET as usize);
+
+        bank.check_transactions_external(
+            txs,
+            lock_results,
+            notional_max_age,
+            false,
+            &mut TransactionErrorMetrics::default(),
+        )
+        .0
     }
 
     /// This function creates a filter of transaction results with Ok() for every pending

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -142,6 +142,7 @@ use {
     solana_message::{
         AccountKeys, SanitizedMessage, inner_instruction::InnerInstructions, v0::LoadedAddresses,
     },
+    solana_nonce_account::verify_nonce_account,
     solana_packet::PACKET_DATA_SIZE,
     solana_precompile_error::PrecompileError,
     solana_program_runtime::{
@@ -3488,8 +3489,10 @@ impl Bank {
             blockhash_queue.get_lamports_per_signature(message.recent_blockhash())
         }
         .or_else(|| {
-            self.load_message_nonce_data(message, false)
-                .map(|(_nonce_address, nonce_data)| nonce_data.get_lamports_per_signature())
+            let nonce_address = message.get_durable_nonce()?;
+            let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
+            verify_nonce_account(&nonce_account, message.recent_blockhash())
+                .map(|nonce_data| nonce_data.get_lamports_per_signature())
         })?;
 
         let transaction_configuration =
@@ -4202,11 +4205,10 @@ impl Bank {
     ) -> LoadAndExecuteTransactionsOutput {
         let sanitized_txs = batch.sanitized_transactions();
 
-        let (check_results, check_us) = measure_us!(self.check_transactions(
+        let (check_results, check_us) = measure_us!(self.check_transactions_before_execution(
             sanitized_txs,
             batch.lock_results(),
             max_age,
-            processing_config.strict_nonce_size_check,
             error_counters,
         ));
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_us);

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -1,9 +1,8 @@
 use {
     super::{Bank, BankStatusCache},
-    agave_feature_set::FeatureSet,
     solana_account::ReadableAccount,
     solana_accounts_db::blockhash_queue::BlockhashQueue,
-    solana_clock::{MAX_TRANSACTION_FORWARDING_DELAY, Slot},
+    solana_clock::Slot,
     solana_compute_budget::compute_budget::SVMTransactionExecutionBudget,
     solana_fee::calculate_fee_details,
     solana_nonce::{
@@ -26,279 +25,239 @@ use {
 };
 
 impl Bank {
-    /// Checks a batch of sanitized transactions again bank for age and status
-    pub fn check_transactions_with_forwarding_delay(
-        &self,
-        transactions: &[impl TransactionWithMeta],
-        filter: &[TransactionResult<()>],
-        forward_transactions_to_leader_at_slot_offset: u64,
-    ) -> Vec<TransactionCheckResult> {
-        let mut error_counters = TransactionErrorMetrics::default();
-        // The following code also checks if the blockhash for a transaction is too old
-        // The check accounts for
-        //  1. Transaction forwarding delay
-        //  2. The slot at which the next leader will actually process the transaction
-        // Drop the transaction if it will expire by the time the next node receives and processes it
-        let max_tx_fwd_delay = MAX_TRANSACTION_FORWARDING_DELAY;
-
-        self.check_transactions(
-            transactions,
-            filter,
-            self.max_processing_age()
-                .saturating_sub(max_tx_fwd_delay)
-                .saturating_sub(forward_transactions_to_leader_at_slot_offset as usize),
-            false,
-            &mut error_counters,
-        )
-    }
-
-    pub fn check_transactions<Tx: TransactionWithMeta>(
-        &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: &[TransactionResult<()>],
-        max_age: usize,
-        strict_nonce_size_check: bool,
-        error_counters: &mut TransactionErrorMetrics,
-    ) -> Vec<TransactionCheckResult> {
-        self.check_transactions_with_processed_slots(
-            sanitized_txs,
-            lock_results,
-            max_age,
-            false,
-            strict_nonce_size_check,
-            error_counters,
-        )
-        .0
-    }
-
-    /// Checks a sanitized transaction against the bank for age,
-    /// without checking the status cache. This is a leader-only
-    /// function and must not be used in replay without a feature gate.
+    /// A single-transaction check function that validates nonces with strict size and
+    /// authority, returning the validated nonce address, and does not check status cache.
     pub fn check_transaction_without_status_cache(
         &self,
-        tx: &impl SVMMessage,
+        tx: &impl TransactionWithMeta,
         max_age: usize,
         error_counters: &mut TransactionErrorMetrics,
     ) -> TransactionResult<Option<Pubkey>> {
-        let feature_set: &FeatureSet = &self.feature_set;
-        let feature_snapshot = feature_set.snapshot();
-        let enable_tx_v1 = feature_snapshot.enable_tx_v1;
+        self.check_v1_enabled(tx)?;
 
-        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
-            return Err(TransactionError::UnsupportedVersion);
-        }
+        self.check_compute_budget_and_limits(tx, error_counters)?;
 
         let hash_queue = self.blockhash_queue.read().unwrap();
         let next_durable_nonce = hash_queue.next_durable_nonce();
 
-        self.check_transaction_age(
-            tx,
-            max_age,
-            &next_durable_nonce,
-            &hash_queue,
-            error_counters,
-            true, // strict_nonce_size_check
-            true, // strict_nonce_authority_check
-        )
+        if self.check_blockhash_age(tx, max_age, &hash_queue) {
+            return Ok(None);
+        }
+
+        if let Some(nonce_address) = self.check_nonce_semantics(tx, &next_durable_nonce)
+            && self.check_nonce_account(tx, nonce_address, true).is_some()
+        {
+            return Ok(Some(nonce_address));
+        }
+
+        error_counters.blockhash_not_found += 1;
+        Err(TransactionError::BlockhashNotFound)
     }
 
-    pub fn check_transactions_with_processed_slots<Tx: TransactionWithMeta>(
+    /// The consensus check function that runs before SVM in both block-production and replay.
+    pub(super) fn check_transactions_before_execution<Tx: TransactionWithMeta>(
         &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
+        txs: &[impl core::borrow::Borrow<Tx>],
+        lock_results: &[TransactionResult<()>],
+        max_age: usize,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> Vec<TransactionCheckResult> {
+        self.check_transactions(txs, lock_results, max_age, false, false, error_counters)
+            .0
+    }
+
+    /// External interface for our check function, hiding `strict_nonce_checks`,
+    /// which is always true for non-consensus-related uses.
+    pub fn check_transactions_external<Tx: TransactionWithMeta>(
+        &self,
+        txs: &[impl core::borrow::Borrow<Tx>],
         lock_results: &[TransactionResult<()>],
         max_age: usize,
         collect_processed_slots: bool,
-        strict_nonce_size_check: bool,
         error_counters: &mut TransactionErrorMetrics,
     ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
-        let lock_results = self.filter_v1_transactions(sanitized_txs, lock_results);
-
-        let lock_results = self.check_age_and_compute_budget_limits(
-            sanitized_txs,
+        self.check_transactions(
+            txs,
             lock_results,
             max_age,
-            strict_nonce_size_check,
-            error_counters,
-        );
-        self.check_status_cache(
-            sanitized_txs,
-            lock_results,
             collect_processed_slots,
+            true,
             error_counters,
         )
     }
 
-    fn filter_v1_transactions<'a, Msg: SVMStaticMessage>(
+    // The heart of runtime transaction checking. We perform these operations, in sequence:
+    // * Reject V1 transactions until the feature is active.
+    //   This can be deleted after the feature is live on all clusters.
+    // * Parse and validate the compute budget and limits, producing the struct for SVM,
+    //   or reject the transaction if the compute budget is malformed.
+    // * Check the transaction lifetime specifier, in this order:
+    //   - First, check if the lifetime specifier is one of the last 151 blockhashes.
+    //     If so, the transaction is valid as a normal blockhash transaction.
+    //   - If not, check whether the transaction is structurally valid as a nonce transaction.
+    //     This depends on no account state but does depend on ALT resolution due to write demotion.
+    //     Then, load the nonce account and provisionally validate the nonce can be advanced.
+    //   - If neither condition holds, reject the transaction.
+    // * Check if the transaction message hash is present in the StatusCache.
+    //   Reject the transaction as AlreadyProcessed if present.
+    //
+    // The options collect_processed_slots and strict_nonce_checks are not part of consensus.
+    // We include everything in one omnibus function to have one clear implementation.
+    fn check_transactions<Tx: TransactionWithMeta>(
         &self,
-        messages: &'a [impl core::borrow::Borrow<Msg>],
-        lock_results: &'a [TransactionResult<()>],
-    ) -> impl Iterator<Item = TransactionResult<()>> + 'a {
+        txs: &[impl core::borrow::Borrow<Tx>],
+        lock_results: &[TransactionResult<()>],
+        max_age: usize,
+        collect_processed_slots: bool,
+        strict_nonce_checks: bool,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> (Vec<TransactionCheckResult>, Option<Vec<Option<Slot>>>) {
+        let check_results: Vec<TransactionCheckResult> = {
+            let hash_queue = self.blockhash_queue.read().unwrap();
+            let next_durable_nonce = hash_queue.next_durable_nonce();
+
+            txs.iter()
+                .zip(lock_results)
+                .map(|(tx, lock_result)| {
+                    let tx = tx.borrow();
+                    lock_result.clone()?;
+
+                    self.check_v1_enabled(tx)?;
+
+                    let compute_budget_and_limits =
+                        self.check_compute_budget_and_limits(tx, error_counters)?;
+
+                    if self.check_blockhash_age(tx, max_age, &hash_queue) {
+                        return Ok(CheckedTransactionDetails::new(
+                            None,
+                            compute_budget_and_limits,
+                        ));
+                    }
+
+                    if let Some(nonce_address) = self.check_nonce_semantics(tx, &next_durable_nonce)
+                        && self
+                            .check_nonce_account(tx, nonce_address, strict_nonce_checks)
+                            .is_some()
+                    {
+                        return Ok(CheckedTransactionDetails::new(
+                            Some(nonce_address),
+                            compute_budget_and_limits,
+                        ));
+                    }
+
+                    error_counters.blockhash_not_found += 1;
+                    Err(TransactionError::BlockhashNotFound)
+                })
+                .collect()
+        };
+
+        self.check_status_cache(txs, check_results, collect_processed_slots, error_counters)
+    }
+
+    fn check_v1_enabled(&self, tx: &impl SVMStaticMessage) -> TransactionResult<()> {
         let enable_tx_v1 = self.feature_set.snapshot().enable_tx_v1;
-        // Discard v1 transactions until feature gate is activated.
-        messages
-            .iter()
-            .zip(lock_results)
-            .map(move |(tx, lock_result)| match lock_result {
-                Err(err) => Err(err.clone()),
-                Ok(())
-                    if !enable_tx_v1 && tx.borrow().version() == TransactionVersion::Number(1) =>
-                {
-                    Err(TransactionError::UnsupportedVersion)
-                }
-                Ok(()) => Ok(()),
-            })
-    }
 
-    fn check_age_and_compute_budget_limits<Tx: TransactionWithMeta>(
-        &self,
-        sanitized_txs: &[impl core::borrow::Borrow<Tx>],
-        lock_results: impl IntoIterator<Item = TransactionResult<()>>,
-        max_age: usize,
-        strict_nonce_size_check: bool,
-        error_counters: &mut TransactionErrorMetrics,
-    ) -> Vec<TransactionCheckResult> {
-        let hash_queue = self.blockhash_queue.read().unwrap();
-        let next_durable_nonce = hash_queue.next_durable_nonce();
-
-        let feature_set: &FeatureSet = &self.feature_set;
-        let feature_snapshot = feature_set.snapshot();
-        let fee_features = self.fee_features();
-
-        let raise_cpi_limit = feature_snapshot.raise_cpi_nesting_limit_to_8;
-
-        sanitized_txs
-            .iter()
-            .zip(lock_results)
-            .map(|(tx, lock_res)| match lock_res {
-                Ok(()) => {
-                    let compute_budget_and_limits = tx
-                        .borrow()
-                        .transaction_configuration(feature_set)
-                        .map(|config| {
-                            let fee_details = calculate_fee_details(
-                                tx.borrow(),
-                                self.fee_structure.lamports_per_signature,
-                                config.priority_fee_lamports,
-                                fee_features,
-                            );
-                            if let Some(compute_budget) = self.compute_budget {
-                                // This block of code is only necessary to retain legacy behavior of the code.
-                                // It should be removed along with the change to favor transaction's compute budget limits
-                                // over configured compute budget in Bank.
-                                compute_budget.get_compute_budget_and_limits(
-                                    config.loaded_accounts_data_size_limit,
-                                    fee_details,
-                                )
-                            } else {
-                                SVMTransactionExecutionAndFeeBudgetLimits {
-                                    budget: SVMTransactionExecutionBudget {
-                                        compute_unit_limit: u64::from(config.compute_unit_limit),
-                                        heap_size: config.updated_heap_bytes,
-                                        ..SVMTransactionExecutionBudget::new_with_defaults(
-                                            raise_cpi_limit,
-                                        )
-                                    },
-                                    loaded_accounts_data_size_limit: config
-                                        .loaded_accounts_data_size_limit,
-                                    fee_details,
-                                }
-                            }
-                        })
-                        .inspect_err(|_err| {
-                            error_counters.invalid_compute_budget += 1;
-                        })?;
-
-                    let nonce_address = self.check_transaction_age(
-                        tx.borrow(),
-                        max_age,
-                        &next_durable_nonce,
-                        &hash_queue,
-                        error_counters,
-                        strict_nonce_size_check,
-                        false,
-                    )?;
-
-                    Ok(CheckedTransactionDetails::new(
-                        nonce_address,
-                        compute_budget_and_limits,
-                    ))
-                }
-                Err(e) => Err(e),
-            })
-            .collect()
-    }
-
-    fn check_transaction_age(
-        &self,
-        tx: &impl SVMMessage,
-        max_age: usize,
-        next_durable_nonce: &DurableNonce,
-        hash_queue: &BlockhashQueue,
-        error_counters: &mut TransactionErrorMetrics,
-        strict_nonce_size_check: bool,
-        strict_nonce_authority_check: bool,
-    ) -> TransactionResult<Option<Pubkey>> {
-        let recent_blockhash = tx.recent_blockhash();
-        if hash_queue
-            .get_hash_info_if_valid(recent_blockhash, max_age)
-            .is_some()
-        {
-            Ok(None)
-        } else if let Some((nonce_address, _)) = self.check_nonce_transaction_validity(
-            tx,
-            next_durable_nonce,
-            strict_nonce_size_check,
-            strict_nonce_authority_check,
-        ) {
-            Ok(Some(nonce_address))
+        if !enable_tx_v1 && tx.version() == TransactionVersion::Number(1) {
+            Err(TransactionError::UnsupportedVersion)
         } else {
-            error_counters.blockhash_not_found += 1;
-            Err(TransactionError::BlockhashNotFound)
+            Ok(())
         }
     }
 
-    pub(super) fn check_nonce_transaction_validity(
+    fn check_compute_budget_and_limits(
         &self,
-        message: &impl SVMMessage,
+        tx: &impl StaticMessageWithMeta,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> TransactionResult<SVMTransactionExecutionAndFeeBudgetLimits> {
+        let feature_set = &self.feature_set;
+        let feature_snapshot = feature_set.snapshot();
+        let fee_features = self.fee_features();
+        let raise_cpi_limit = feature_snapshot.raise_cpi_nesting_limit_to_8;
+
+        let compute_budget_and_limits = tx.transaction_configuration(feature_set).map(|config| {
+            let fee_details = calculate_fee_details(
+                tx,
+                self.fee_structure.lamports_per_signature,
+                config.priority_fee_lamports,
+                fee_features,
+            );
+            if let Some(compute_budget) = self.compute_budget {
+                // This block of code is only necessary to retain legacy behavior of the code.
+                // It should be removed along with the change to favor transaction's compute budget limits
+                // over configured compute budget in Bank.
+                compute_budget.get_compute_budget_and_limits(
+                    config.loaded_accounts_data_size_limit,
+                    fee_details,
+                )
+            } else {
+                SVMTransactionExecutionAndFeeBudgetLimits {
+                    budget: SVMTransactionExecutionBudget {
+                        compute_unit_limit: u64::from(config.compute_unit_limit),
+                        heap_size: config.updated_heap_bytes,
+                        ..SVMTransactionExecutionBudget::new_with_defaults(raise_cpi_limit)
+                    },
+                    loaded_accounts_data_size_limit: config.loaded_accounts_data_size_limit,
+                    fee_details,
+                }
+            }
+        });
+
+        if compute_budget_and_limits.is_err() {
+            error_counters.invalid_compute_budget += 1;
+        }
+
+        compute_budget_and_limits
+    }
+
+    fn check_blockhash_age(
+        &self,
+        tx: &impl SVMStaticMessage,
+        max_age: usize,
+        hash_queue: &BlockhashQueue,
+    ) -> bool {
+        let recent_blockhash = tx.recent_blockhash();
+        hash_queue
+            .get_hash_info_if_valid(recent_blockhash, max_age)
+            .is_some()
+    }
+
+    fn check_nonce_semantics(
+        &self,
+        tx: &impl SVMMessage,
         next_durable_nonce: &DurableNonce,
-        strict_nonce_size_check: bool,
-        strict_nonce_authority_check: bool,
-    ) -> Option<(Pubkey, u64)> {
-        let nonce_is_advanceable = message.recent_blockhash() != next_durable_nonce.as_hash();
+    ) -> Option<Pubkey> {
+        let nonce_is_advanceable = tx.recent_blockhash() != next_durable_nonce.as_hash();
         if !nonce_is_advanceable {
             return None;
         }
 
-        let (nonce_address, nonce_data) =
-            self.load_message_nonce_data(message, strict_nonce_size_check)?;
+        tx.get_durable_nonce().copied()
+    }
 
-        if strict_nonce_authority_check
-            && !message
+    fn check_nonce_account(
+        &self,
+        tx: &impl SVMStaticMessage,
+        nonce_address: Pubkey,
+        strict_nonce_checks: bool,
+    ) -> Option<NonceData> {
+        let nonce_account = self.get_account_with_fixed_root(&nonce_address)?;
+
+        if strict_nonce_checks && nonce_account.data().len() != NonceState::size() {
+            return None;
+        }
+
+        let nonce_data =
+            nonce_account::verify_nonce_account(&nonce_account, tx.recent_blockhash())?;
+
+        if strict_nonce_checks
+            && !tx
                 .get_ix_signers(NONCED_TX_MARKER_IX_INDEX as usize)
                 .any(|signer| signer == &nonce_data.authority)
         {
             return None;
         }
 
-        let previous_lamports_per_signature = nonce_data.get_lamports_per_signature();
-
-        Some((nonce_address, previous_lamports_per_signature))
-    }
-
-    pub(super) fn load_message_nonce_data(
-        &self,
-        message: &impl SVMMessage,
-        strict_nonce_size_check: bool,
-    ) -> Option<(Pubkey, NonceData)> {
-        let nonce_address = message.get_durable_nonce()?;
-        let nonce_account = self.get_account_with_fixed_root(nonce_address)?;
-        if strict_nonce_size_check && nonce_account.data().len() != NonceState::size() {
-            return None;
-        }
-        let nonce_data =
-            nonce_account::verify_nonce_account(&nonce_account, message.recent_blockhash())?;
-
-        Some((*nonce_address, nonce_data))
+        Some(nonce_data)
     }
 
     fn check_status_cache<Msg: StaticMessageWithMeta>(
@@ -364,6 +323,7 @@ mod tests {
             AccountSharedData, ReadableAccount, WritableAccount, state_traits::StateMutWincode as _,
         },
         solana_hash::Hash,
+        solana_instruction::{AccountMeta, Instruction},
         solana_keypair::Keypair,
         solana_message::{
             Message, MessageHeader, SanitizedMessage, SanitizedVersionedMessage,
@@ -376,6 +336,7 @@ mod tests {
         solana_runtime_transaction::{
             runtime_transaction::RuntimeTransaction, transaction_meta::TransactionMeta,
         },
+        solana_sdk_ids::sysvar,
         solana_signer::Signer,
         solana_svm_transaction::svm_message::SVMStaticMessage,
         solana_system_interface::{
@@ -419,14 +380,17 @@ mod tests {
             .unwrap();
         bank.store_account(&nonce_pubkey, &nonce_account);
 
+        let nonce_address = bank
+            .check_nonce_semantics(&message, &bank.next_durable_nonce())
+            .unwrap();
+        assert_eq!(nonce_address, nonce_pubkey);
+
+        let nonce_data = bank
+            .check_nonce_account(&message, nonce_address, false)
+            .unwrap();
         assert_eq!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                false,
-                false
-            ),
-            Some((nonce_pubkey, STALE_LAMPORTS_PER_SIGNATURE)),
+            nonce_data.get_lamports_per_signature(),
+            STALE_LAMPORTS_PER_SIGNATURE
         );
     }
 
@@ -447,18 +411,13 @@ mod tests {
             &nonce_hash,
         ));
         assert!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                false,
-                false
-            )
-            .is_none()
+            bank.check_nonce_semantics(&message, &bank.next_durable_nonce())
+                .is_none()
         );
     }
 
     #[test]
-    fn test_check_nonce_transaction_validity_strict_nonce_size_check_fail() {
+    fn test_check_nonce_transaction_validity_strict_nonce_checks_fail() {
         let (bank, _mint_keypair, custodian_keypair, nonce_keypair, _) =
             setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
         let custodian_pubkey = custodian_keypair.pubkey();
@@ -484,14 +443,12 @@ mod tests {
             .copy_from_slice(nonce_account.data());
         bank.store_account(&nonce_pubkey, &resized_nonce_account);
 
+        let nonce_address = bank
+            .check_nonce_semantics(&message, &bank.next_durable_nonce())
+            .unwrap();
         assert!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                true,
-                false
-            )
-            .is_none()
+            bank.check_nonce_account(&message, nonce_address, true)
+                .is_none()
         );
     }
 
@@ -513,13 +470,8 @@ mod tests {
         );
         message.instructions[0].accounts.clear();
         assert!(
-            bank.check_nonce_transaction_validity(
-                &new_sanitized_message(message),
-                &bank.next_durable_nonce(),
-                false,
-                false,
-            )
-            .is_none()
+            bank.check_nonce_semantics(&new_sanitized_message(message), &bank.next_durable_nonce())
+                .is_none()
         );
     }
 
@@ -541,14 +493,13 @@ mod tests {
             Some(&custodian_pubkey),
             &nonce_hash,
         ));
+        let nonce_address = bank
+            .check_nonce_semantics(&message, &bank.next_durable_nonce())
+            .unwrap();
+        assert_eq!(nonce_address, missing_pubkey);
         assert!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                false,
-                false
-            )
-            .is_none()
+            bank.check_nonce_account(&message, nonce_address, false)
+                .is_none()
         );
     }
 
@@ -567,14 +518,43 @@ mod tests {
             Some(&custodian_pubkey),
             &Hash::default(),
         ));
+        let nonce_address = bank
+            .check_nonce_semantics(&message, &bank.next_durable_nonce())
+            .unwrap();
         assert!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                false,
-                false
-            )
-            .is_none()
+            bank.check_nonce_account(&message, nonce_address, false)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_check_nonce_readonly_fail() {
+        let (bank, _mint_keypair, custodian_keypair, nonce_keypair, _) =
+            setup_nonce_with_bank(10_000_000, |_| {}, 5_000_000, 250_000, None).unwrap();
+        let custodian_pubkey = custodian_keypair.pubkey();
+        let nonce_pubkey = nonce_keypair.pubkey();
+
+        // an advance-nonce instruction whose nonce account is passed as read-only
+        let nonce_hash = get_nonce_blockhash(&bank, &nonce_pubkey).unwrap();
+        #[allow(deprecated)]
+        let nonce_instruction = Instruction::new_with_bincode(
+            system_program::id(),
+            &SystemInstruction::AdvanceNonceAccount,
+            vec![
+                AccountMeta::new_readonly(nonce_pubkey, false),
+                AccountMeta::new_readonly(sysvar::recent_blockhashes::id(), false),
+                AccountMeta::new_readonly(nonce_pubkey, true),
+            ],
+        );
+        let message = new_sanitized_message(Message::new_with_blockhash(
+            &[nonce_instruction],
+            Some(&custodian_pubkey),
+            &nonce_hash,
+        ));
+
+        assert!(
+            bank.check_nonce_semantics(&message, &bank.next_durable_nonce())
+                .is_none()
         );
     }
 
@@ -631,12 +611,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            bank.check_nonce_transaction_validity(
-                &message,
-                &bank.next_durable_nonce(),
-                false,
-                false
-            ),
+            bank.check_nonce_semantics(&message, &bank.next_durable_nonce()),
             None,
         );
     }
@@ -702,10 +677,11 @@ mod tests {
 
         let lock_results = [Ok(())];
         let mut error_counters = TransactionErrorMetrics::default();
-        let check_results = bank.check_transactions(
+        let (check_results, _) = bank.check_transactions(
             std::slice::from_ref(&tx),
             &lock_results,
             bank.max_processing_age(),
+            true,
             true,
             &mut error_counters,
         );
@@ -723,8 +699,26 @@ mod tests {
         assert_eq!(check_result, Ok(None));
     }
 
+    fn filter_v1_transactions<Tx: TransactionWithMeta>(
+        bank: &Bank,
+        txs: &[Tx],
+        lock_results: &[TransactionResult<()>],
+    ) -> Vec<TransactionResult<()>> {
+        bank.check_transactions_before_execution(
+            txs,
+            lock_results,
+            bank.max_processing_age(),
+            &mut TransactionErrorMetrics::default(),
+        )
+        .into_iter()
+        .map(|result| result.map(|_| ()))
+        .collect()
+    }
+
     #[test]
     fn test_filter_v1_transactions_keeps_existing_errors() {
+        let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
+        let bank = Bank::new_for_tests(&genesis_config);
         let txs = vec![
             make_test_tx(TransactionVersion::LEGACY),
             make_test_tx(TransactionVersion::Number(0)),
@@ -736,53 +730,65 @@ mod tests {
             Err(TransactionError::WouldExceedMaxBlockCostLimit),
         ];
 
-        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+        let filtered = filter_v1_transactions(&bank, &txs, &lock_results);
 
-        assert!(filtered.eq(lock_results.iter().cloned()));
+        assert_eq!(filtered, lock_results);
     }
 
     #[test]
     fn test_filter_v1_transactions_rejects_v1_with_ok_lock_result() {
+        let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
+        let bank = Bank::new_for_tests(&genesis_config);
         let txs = vec![make_test_tx(TransactionVersion::Number(1))];
         let lock_results = vec![Ok(())];
 
-        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+        let filtered = filter_v1_transactions(&bank, &txs, &lock_results);
 
-        assert!(filtered.eq([Err(TransactionError::UnsupportedVersion)]));
+        assert_eq!(filtered, [Err(TransactionError::UnsupportedVersion)]);
     }
 
     #[test]
     fn test_filter_v1_transactions_keeps_v1_when_feature_enabled() {
-        let txs = vec![make_test_tx(TransactionVersion::Number(1))];
-        let lock_results = vec![Ok(())];
-        let mut bank = Bank::default_for_tests();
+        let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
+        let mut bank = Bank::new_for_tests(&genesis_config);
         bank.activate_feature(&agave_feature_set::enable_tx_v1::id());
+        let txs = vec![make_test_tx_with_blockhash(
+            TransactionVersion::Number(1),
+            bank.last_blockhash(),
+        )];
+        let lock_results = vec![Ok(())];
 
-        let filtered = bank.filter_v1_transactions(&txs, &lock_results);
+        let filtered = filter_v1_transactions(&bank, &txs, &lock_results);
 
-        assert!(filtered.eq([Ok(())]));
+        assert_eq!(filtered, [Ok(())]);
     }
 
     #[test]
     fn test_filter_v1_transactions_keeps_legacy_and_v0_ok() {
+        let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let blockhash = bank.last_blockhash();
         let txs = vec![
-            make_test_tx(TransactionVersion::LEGACY),
-            make_test_tx(TransactionVersion::Number(0)),
+            make_test_tx_with_blockhash(TransactionVersion::LEGACY, blockhash),
+            make_test_tx_with_blockhash(TransactionVersion::Number(0), blockhash),
         ];
         let lock_results = vec![Ok(()), Ok(())];
 
-        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+        let filtered = filter_v1_transactions(&bank, &txs, &lock_results);
 
-        assert!(filtered.eq([Ok(()), Ok(())]));
+        assert_eq!(filtered, [Ok(()), Ok(())]);
     }
 
     #[test]
     fn test_filter_v1_transactions_mixed_results() {
+        let (genesis_config, _mint_keypair) = solana_genesis_config::create_genesis_config(1);
+        let bank = Bank::new_for_tests(&genesis_config);
+        let blockhash = bank.last_blockhash();
         let txs = vec![
-            make_test_tx(TransactionVersion::LEGACY),
-            make_test_tx(TransactionVersion::Number(1)),
-            make_test_tx(TransactionVersion::Number(0)),
-            make_test_tx(TransactionVersion::Number(1)),
+            make_test_tx_with_blockhash(TransactionVersion::LEGACY, blockhash),
+            make_test_tx_with_blockhash(TransactionVersion::Number(1), blockhash),
+            make_test_tx_with_blockhash(TransactionVersion::Number(0), blockhash),
+            make_test_tx_with_blockhash(TransactionVersion::Number(1), blockhash),
         ];
         let lock_results = vec![
             Ok(()),
@@ -791,13 +797,16 @@ mod tests {
             Err(TransactionError::TooManyAccountLocks),
         ];
 
-        let filtered = Bank::default_for_tests().filter_v1_transactions(&txs, &lock_results);
+        let filtered = filter_v1_transactions(&bank, &txs, &lock_results);
 
-        assert!(filtered.eq([
-            Ok(()),
-            Err(TransactionError::UnsupportedVersion),
-            Err(TransactionError::AccountInUse),
-            Err(TransactionError::TooManyAccountLocks),
-        ]));
+        assert_eq!(
+            filtered,
+            [
+                Ok(()),
+                Err(TransactionError::UnsupportedVersion),
+                Err(TransactionError::AccountInUse),
+                Err(TransactionError::TooManyAccountLocks),
+            ]
+        );
     }
 }

--- a/runtime/src/bank/check_transactions.rs
+++ b/runtime/src/bank/check_transactions.rs
@@ -35,8 +35,6 @@ impl Bank {
     ) -> TransactionResult<Option<Pubkey>> {
         self.check_v1_enabled(tx)?;
 
-        self.check_compute_budget_and_limits(tx, error_counters)?;
-
         let hash_queue = self.blockhash_queue.read().unwrap();
         let next_durable_nonce = hash_queue.next_durable_nonce();
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4766,15 +4766,6 @@ fn test_check_ro_durable_nonce_fails() {
         bank.process_transaction(&tx),
         Err(TransactionError::BlockhashNotFound)
     );
-    assert_eq!(
-        bank.check_nonce_transaction_validity(
-            &new_sanitized_message(tx.message().clone()),
-            &bank.next_durable_nonce(),
-            false,
-            false,
-        ),
-        None
-    );
 }
 
 #[test]


### PR DESCRIPTION
#### Problem
check_transactions.rs is quite unwieldy and hard to understand now that we have all these variants and bool options and so forth. i want to make some sensitive functionality changes such as not reading status cache for nonces and playing with the nonce validation in runtime itself. therefore it seems wise to refactor first to make it clear exactly what is going on

#### Summary of Changes
refactor to have two major check impls: `precheck_transaction_on_ingest()` which replaces `check_transaction_without_status_cache()` and `check_transactions_internal()`. everything else is now a wrapper on `check_transactions_internal()`. the most important of these is `check_transactions_before_execution()` which replaces `check_transactions()` in bank.rs, and is now `pub(super)` so nothing else can use it

instead of the nested helpers we had before, everything is one function and they can be laid out one after the other in the functions that use them: `check_v1_enabled()`, `check_compute_budget_and_limits()`, `check_blockhash_age()`, `check_nonce_semantics()` (this name im not particularly fond of but i really dont want to say "static"), and `check_nonce_account()`. this means whatever check logic something else needs can just chain together these pieces rather than weaving weird stuff through the layer cake we have presently

`check_status_cache()` and `get_processed_slot()` survive unchanged and are the only functions here i kept

i deliberately did not use the name `check_transactions()` for anything, partly to allay confusion and to not bless a "most proper" check function, and partly to force downstream projects building on this to read the code when they rebase instead of doing something wrong

this is a mostly no-effect refactor. the only changes are:
* the ingress filter `precheck_transaction_on_ingest()` now parses compute budget, it didnt before
* we ignore the `strict_nonce_size_check` setting in runtime and hide it from interfaces. the bank path treats it as always false, the various leader/scheduler paths treat it as always true. svm continues to use the config setting, so as to have the necessary differing behavior on leader vs replay. since svm enforces it, bank does not need to

the important thing about the second bullet above is replay behavior is identical: `strict_nonce_size_check` and `strict_nonce_authority_check` were both false before, `strict_nonce_checks` is false now

im getting cold feet on my planned stage magic to try to work around nonces for ALT resolution and will probably just do a small SIMD after to codify "nonces cannot be program ids" into consensus. ill add the 80 byte size rule to it too. if it is accepted then we can get rid of the leader/replay fussiness and collapse `check_transactions_before_execution()` and `check_transactions_for_scheduling()` back into one `check_transactions()`. perhaps `check_transactions_2022()`

#### Ok But Why

basically a clean plaform for edits, since every major check is a single-level helper instead of nested three or four deep:
* after nonce hardening SIMD, replace `get_durable_nonce()` usage with a new `get_durable_nonce_simd12345()` on `SVMStaticMessage`, loosening the _only_ constraint blocking us from taking `TransactionWithMeta` to `StaticTransactionWithMeta`
* remove nonce account checks from runtime. they are useless. i dont believe we _need_ to until SIMD-0297, since none of _them_ depend on ALT, but i think we probably should anyway to be more in line with firedancer
* only do the status cache check for blockhash transactions. i will not do this immediately, i dont think its _really_ needed until SIMD-0297, but it also gels with removing nonce account checks from runtime, otherwise we would check status for more invalid transactions

#### Testing
update various tests
