### PR TITLE
gossip: replace f64 prune stake threshold with Fraction

### DIFF
--- a/gossip/src/crds_gossip_push.rs
+++ b/gossip/src/crds_gossip_push.rs
@@ -22,6 +22,7 @@ use {
         push_active_set::PushActiveSet,
         received_cache::ReceivedCache,
     },
+    agave_votor_messages::fraction::Fraction,
     itertools::Itertools,
     solana_keypair::Keypair,
     solana_net_utils::SocketAddrSpace,
@@ -46,7 +47,7 @@ const CRDS_GOSSIP_PUSH_FANOUT: usize = 9;
 // might need more time to receive values. 15 seconds should be plenty.
 pub const CRDS_GOSSIP_PUSH_MSG_TIMEOUT_MS: u64 = 15000;
 const CRDS_GOSSIP_PRUNE_MSG_TIMEOUT_MS: u64 = 500;
-const CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT: f64 = 0.15;
+const CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD: Fraction = Fraction::from_percentage(15);
 const CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES: usize = 2;
 const CRDS_GOSSIP_PUSH_ACTIVE_SET_SIZE: usize = CRDS_GOSSIP_PUSH_FANOUT + 3;
 
@@ -105,7 +106,7 @@ impl CrdsGossipPush {
                     .prune(
                         self_pubkey,
                         origin,
-                        CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT,
+                        CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD,
                         CRDS_GOSSIP_PRUNE_MIN_INGRESS_NODES,
                         stakes,
                     )

--- a/gossip/src/received_cache.rs
+++ b/gossip/src/received_cache.rs
@@ -1,4 +1,5 @@
 use {
+    agave_votor_messages::fraction::Fraction,
     itertools::Itertools,
     lazy_lru::LruCache,
     solana_pubkey::Pubkey,
@@ -38,7 +39,7 @@ impl ReceivedCache {
         &mut self,
         pubkey: &Pubkey, // This node.
         origin: Pubkey,  // CRDS value owner.
-        stake_threshold: f64,
+        stake_threshold: Fraction,
         min_ingress_nodes: usize,
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = Pubkey> + use<> {
@@ -90,17 +91,17 @@ impl ReceivedCacheEntry {
         self,
         pubkey: &Pubkey, // This node.
         origin: &Pubkey, // CRDS value owner.
-        stake_threshold: f64,
+        stake_threshold: Fraction,
         min_ingress_nodes: usize,
         stakes: &HashMap<Pubkey, u64>,
     ) -> impl Iterator<Item = Pubkey> + use<> {
-        debug_assert!((0.0..=1.0).contains(&stake_threshold));
+        debug_assert!(stake_threshold <= Fraction::from_percentage(100));
         debug_assert!(self.num_upserts >= ReceivedCache::MIN_NUM_UPSERTS);
         // Enforce a minimum aggregate ingress stake; see:
         // https://github.com/solana-labs/solana/issues/3214
         let min_ingress_stake = {
             let stake = stakes.get(pubkey).min(stakes.get(origin));
-            (stake.copied().unwrap_or_default() as f64 * stake_threshold) as u64
+            stake_threshold.mul_u64(stake.copied().unwrap_or_default())
         };
         self.nodes
             .into_iter()
@@ -175,14 +176,14 @@ mod tests {
         assert_eq!(
             cache
                 .mock_clone()
-                .prune(&pubkey, origin, 0.5, 2, &stakes)
+                .prune(&pubkey, origin, Fraction::from_percentage(50), 2, &stakes)
                 .collect::<HashSet<_>>(),
             prunes
         );
         let prunes: HashSet<Pubkey> = [nodes[0], nodes[2]].into_iter().collect();
         assert_eq!(
             cache
-                .prune(&pubkey, origin, 1.0, 0, &stakes)
+                .prune(&pubkey, origin, Fraction::from_percentage(100), 0, &stakes)
                 .collect::<HashSet<_>>(),
             prunes
         );

--- a/votor-messages/src/fraction.rs
+++ b/votor-messages/src/fraction.rs
@@ -36,6 +36,18 @@ impl Fraction {
     pub fn approx_f64(&self) -> f64 {
         self.numerator as f64 / self.denominator.get() as f64
     }
+
+    /// Multiplies `value` by this fraction, rounding down and saturating at
+    /// `u64::MAX`.
+    #[inline]
+    pub fn mul_u64(&self, value: u64) -> u64 {
+        // u64 * u64 always fits in u128, and the denominator is non-zero
+        let product = (value as u128)
+            .checked_mul(self.numerator as u128)
+            .and_then(|product| product.checked_div(self.denominator.get() as u128))
+            .unwrap();
+        u64::try_from(product).unwrap_or(u64::MAX)
+    }
 }
 
 impl PartialOrd for Fraction {
@@ -71,6 +83,22 @@ mod tests {
         assert!(frac(2, 4) <= frac(1, 2));
         assert!(frac(2, 4) >= frac(1, 2));
         assert!(frac(3, 4) > frac(2, 3));
+    }
+
+    #[test]
+    fn test_mul_u64() {
+        assert_eq!(frac(15, 100).mul_u64(1_000), 150);
+        assert_eq!(frac(1, 3).mul_u64(10), 3); // rounds down
+        assert_eq!(frac(1, 1).mul_u64(u64::MAX), u64::MAX);
+        assert_eq!(frac(3, 1).mul_u64(u64::MAX), u64::MAX); // saturates
+        assert_eq!(frac(0, 100).mul_u64(u64::MAX), 0);
+        // f64 rounds this one up, integer math does not
+        let stake = 999_999_999_999_999_999u64;
+        assert_eq!(
+            Fraction::from_percentage(15).mul_u64(stake),
+            149_999_999_999_999_999
+        );
+        assert_eq!((stake as f64 * 0.15) as u64, 150_000_000_000_000_000);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
`ReceivedCacheEntry::prune` derives the minimum ingress stake from an f64:
`(stake as f64 * 0.15) as u64`. f64 has 53 mantissa bits, so once
`min(self_stake, origin_stake)` exceeds 2^53 lamports (~9M SOL) the stake is
rounded before the multiply — at 9_007_199_254_740_999 lamports the threshold
comes out 1 lamport high.

#### Summary of Changes
- `CRDS_GOSSIP_PRUNE_STAKE_THRESHOLD_PCT: f64 = 0.15` -> `Fraction::from_percentage(15)`
- add `Fraction::mul_u64` (u128 intermediate, rounds down) and use it for `min_ingress_stake`

`Fraction` lives in votor-messages, which gossip already depends on. Prune
decisions are local propagation policy, so no feature gate.

#### Testing
`received_cache` tests pass with unchanged expectations. New `mul_u64` unit
test covers rounding, saturation, and the f64 case above.

Fixes #14624
