### PR TITLE
accounts-db: Replaces solana-sdk's PubkeyHasherBuilder with agave's AddressHasherBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6982,6 +6982,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-address-hasher",
  "agave-fs",
  "agave-logger",
  "agave-reserved-account-keys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-address-hasher"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "rand 0.9.4",
+ "solana-pubkey 4.3.0",
+]
+
+[[package]]
 name = "agave-banking-stage-ingress-types"
 version = "4.4.0-alpha.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "accounts-cluster-bench",
     "accounts-db",
     "accounts-db/store-histogram",
+    "address-hasher",
     "banking-stage-ingress-types",
     "banks-client",
     "banks-interface",
@@ -168,6 +169,7 @@ new_without_default = "allow"
 
 [workspace.dependencies]
 Inflector = "0.11.4"
+agave-address-hasher = { path = "address-hasher", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-banking-stage-ingress-types = { path = "banking-stage-ingress-types", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls-cert-verify = { path = "bls-cert-verify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }
 agave-bls-sigverify = { path = "bls-sigverify", version = "=4.4.0-alpha.0", features = ["agave-unstable-api"] }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -41,6 +41,7 @@ frozen-abi = [
 ]
 
 [dependencies]
+agave-address-hasher = { workspace = true }
 agave-fs = { workspace = true }
 ahash = { workspace = true }
 blake3 = { workspace = true }

--- a/accounts-db/src/accounts_cache.rs
+++ b/accounts-db/src/accounts_cache.rs
@@ -1,10 +1,11 @@
 use {
     crate::ancestors::Ancestors,
+    agave_address_hasher::AddressHasherBuilder,
     dashmap::{DashMap, mapref::entry::Entry},
     solana_account::{AccountSharedData, ReadableAccount},
     solana_clock::Slot,
     solana_nohash_hasher::BuildNoHashHasher,
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     std::{
         collections::BTreeSet,
         ops::Deref,
@@ -38,7 +39,7 @@ impl MaxFlushedRoot {
 
 #[derive(Debug)]
 pub struct SlotCache {
-    cache: DashMap<Pubkey, Arc<CachedAccount>, PubkeyHasherBuilder>,
+    cache: DashMap<Pubkey, Arc<CachedAccount>, AddressHasherBuilder>,
     same_account_writes: AtomicU64,
     same_account_writes_size: AtomicU64,
     unique_account_writes_size: AtomicU64,
@@ -158,7 +159,7 @@ impl SlotCache {
 }
 
 impl Deref for SlotCache {
-    type Target = DashMap<Pubkey, Arc<CachedAccount>, PubkeyHasherBuilder>;
+    type Target = DashMap<Pubkey, Arc<CachedAccount>, AddressHasherBuilder>;
     fn deref(&self) -> &Self::Target {
         &self.cache
     }
@@ -182,7 +183,7 @@ impl CachedAccount {
 /// look-up miss on max_slot by falling back to scanning all slots in the cache (see load_latest)
 #[derive(Debug, Default)]
 struct AccountsCacheIndex {
-    entries: DashMap<Pubkey, (Slot, u32), PubkeyHasherBuilder>,
+    entries: DashMap<Pubkey, (Slot, u32), AddressHasherBuilder>,
     // The number of unique pubkeys in the index, for reporting purposes. This is to avoid having to
     // lock each shard of the entries dashmap to count unique keys on demand
     num_unique_pubkeys: AtomicU64,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -63,6 +63,7 @@ use {
         u64_align,
         utils::{self, create_account_shared_data},
     },
+    agave_address_hasher::AddressHasherBuilder,
     agave_fs::buffered_reader::RequiredLenBufFileRead,
     ahash::HashMapExt,
     bv::BitVec,
@@ -80,7 +81,7 @@ use {
     },
     solana_measure::{measure::Measure, measure_us},
     solana_nohash_hasher::{BuildNoHashHasher, IntMap, IntSet},
-    solana_pubkey::{Pubkey, PubkeyHasherBuilder},
+    solana_pubkey::Pubkey,
     solana_rayon_threadlimit::get_thread_count,
     std::{
         borrow::Cow,
@@ -830,7 +831,7 @@ pub fn get_temp_accounts_paths(count: u32) -> io::Result<(Vec<TempDir>, Vec<Path
 }
 
 /// One accounts index bin's worth of pubkeys that are candidates for cleaning
-type CleaningCandidatesBin = HashSet<Pubkey, PubkeyHasherBuilder>;
+type CleaningCandidatesBin = HashSet<Pubkey, AddressHasherBuilder>;
 /// This is the return type of AccountsDb::construct_candidate_clean_keys.
 /// It's a collection of pubkeys that are candidates for cleaning
 type CleaningCandidates = Box<[RwLock<CleaningCandidatesBin>]>;
@@ -2729,8 +2730,10 @@ impl AccountsDb {
         // pubkey. Hold the Arc<CachedAccount> to keep the data alive even if the cache flushes
         // between now and step 3 (Arc clone is just a refcount bump).
         let cached_pubkeys = self.accounts_cache.cached_pubkeys();
-        let mut cached_versions =
-            HashMap::with_capacity_and_hasher(cached_pubkeys.len(), PubkeyHasherBuilder::default());
+        let mut cached_versions = HashMap::with_capacity_and_hasher(
+            cached_pubkeys.len(),
+            AddressHasherBuilder::default(),
+        );
         for pubkey in cached_pubkeys {
             if config.is_aborted() {
                 break;
@@ -3865,7 +3868,7 @@ impl AccountsDb {
             .and_then(|&root| self.accounts_cache.slot_cache(root))
             .map_or(0, |slot_cache| slot_cache.len() * 2);
         let mut written_accounts =
-            HashSet::with_capacity_and_hasher(dedup_capacity, PubkeyHasherBuilder::default());
+            HashSet::with_capacity_and_hasher(dedup_capacity, AddressHasherBuilder::default());
 
         // Iterate from newest root to oldest root being flushed in this batch
         for &root in flushed_roots.iter().rev() {
@@ -4867,7 +4870,8 @@ impl AccountsDb {
         ancestors: &Ancestors,
     ) -> (BitVec, WriteAccountsToCacheStats) {
         let len = accounts_and_meta_to_store.len();
-        let mut pubkey_set = HashSet::with_capacity_and_hasher(len, PubkeyHasherBuilder::default());
+        let mut pubkey_set =
+            HashSet::with_capacity_and_hasher(len, AddressHasherBuilder::default());
         let mut stats = WriteAccountsToCacheStats {
             num_initial_accounts_to_store: len as u64,
             ..Default::default()
@@ -5800,7 +5804,7 @@ enum PubkeysToStore {
     All,
     /// Store only these pubkeys (the newest version of each, per `select_pubkeys_to_store`),
     /// purging the rest from the index and reclaiming older versions.
-    Only(HashSet<Pubkey, PubkeyHasherBuilder>),
+    Only(HashSet<Pubkey, AddressHasherBuilder>),
 }
 
 /// Specify whether obsolete accounts should be marked or not during reclaims

--- a/address-hasher/Cargo.toml
+++ b/address-hasher/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "agave-address-hasher"
+description = "Hasher for a solana address"
+documentation = "https://docs.rs/agave-address-hasher"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+all-features = true
+rustdoc-args = ["--cfg=docsrs"]
+
+[lib]
+crate-type = ["lib"]
+name = "agave_address_hasher"
+
+[features]
+agave-unstable-api = []
+
+[dependencies]
+rand = { workspace = true }
+
+[dev-dependencies]
+solana-pubkey = { workspace = true, features = ["rand"] }
+
+[lints]
+workspace = true

--- a/address-hasher/src/hasher.rs
+++ b/address-hasher/src/hasher.rs
@@ -1,0 +1,248 @@
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    rand::Rng as _,
+    std::{
+        cell::Cell,
+        hash::{BuildHasher, Hasher},
+        thread_local,
+    },
+};
+
+/// Number of bytes in an address.
+///
+/// Mirrors `solana_pubkey::PUBKEY_BYTES` so `solana_pubkey` stays a dev-only dependency.
+/// (constant is kept in sync by asserts in tests)
+const ADDRESS_BYTES: usize = 32;
+
+/// A faster, but less collision resistant hasher for addresses.
+///
+/// Specialized hasher that uses a random 8 bytes subslice of the
+/// address as the hash value. Should not be used when collisions
+/// might be used to mount DOS attacks.
+pub struct AddressHasher {
+    random: u64,
+    offset: usize,
+    state: u64,
+}
+
+impl Hasher for AddressHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.state
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        debug_assert_eq!(
+            bytes.len(),
+            ADDRESS_BYTES,
+            "This hasher is intended to be used with addresses and nothing else",
+        );
+        // This slice/unwrap can never panic since offset is < ADDRESS_BYTES - size_of::<u64>()
+        let chunk: &[u8; size_of::<u64>()] = bytes[self.offset..self.offset + size_of::<u64>()]
+            .try_into()
+            .unwrap();
+        self.state = u64::from_ne_bytes(*chunk) ^ self.random;
+    }
+}
+
+/// A builder for faster, but less collision resistant hasher for addresses.
+///
+/// Initializes `AddressHasher` instances that use an 8-byte
+/// slice of the address as the hash value. Should not be used when
+/// collisions might be used to mount DOS attacks.
+#[derive(Clone)]
+pub struct AddressHasherBuilder {
+    random: u64,
+    offset: usize,
+}
+
+impl AddressHasherBuilder {
+    /// Constructs a builder with a specific random and offset.
+    ///
+    /// Prefer `AddressHasherBuilder::default()` unless deterministic results are required.
+    pub fn with(random: u64, offset: usize) -> Self {
+        AddressHasherBuilder { random, offset }
+    }
+
+    /// Returns the random used to construct this builder.
+    pub fn random(&self) -> u64 {
+        self.random
+    }
+
+    /// Returns the offset used to construct this builder.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+impl Default for AddressHasherBuilder {
+    /// Default construct the AddressHasherBuilder.
+    ///
+    /// The position of the slice is determined initially
+    /// through random draw and then by incrementing a thread-local
+    /// This way each hashmap can be expected to use a slightly different
+    /// slice. This is essentially the same mechanism as what is used by
+    /// `RandomState`
+    fn default() -> Self {
+        thread_local! {
+            static OFFSET: Cell<usize>  = {
+                Cell::new(rand::rng().random_range(0..ADDRESS_BYTES - size_of::<u64>()))
+            };
+        }
+
+        let random = rand::rng().random();
+        let offset = OFFSET.with(|offset| {
+            let mut next_offset = offset.get() + 1;
+            if next_offset > ADDRESS_BYTES - size_of::<u64>() {
+                next_offset = 0;
+            }
+            offset.set(next_offset);
+            next_offset
+        });
+        AddressHasherBuilder { random, offset }
+    }
+}
+
+impl BuildHasher for AddressHasherBuilder {
+    type Hasher = AddressHasher;
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        AddressHasher {
+            random: self.random,
+            offset: self.offset,
+            state: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_pubkey::{PUBKEY_BYTES, Pubkey},
+    };
+
+    /// Ensure our ADDRESS_BYTES constant stays in sync with the solana-sdk
+    #[test]
+    fn test_address_bytes() {
+        assert_eq!(ADDRESS_BYTES, PUBKEY_BYTES);
+        assert_eq!(ADDRESS_BYTES, Pubkey::default().as_array().len());
+        assert_eq!(ADDRESS_BYTES, Pubkey::default().as_ref().len());
+    }
+
+    /// Ensure identical hashers with identical keys produce identical hashes
+    #[test]
+    fn test_identical_hashers_and_identical_keys() {
+        let mut hasher1 = AddressHasher {
+            random: 42,
+            offset: 7,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            random: 42,
+            offset: 7,
+            state: 0,
+        };
+
+        let key = Pubkey::new_unique();
+        hasher1.write(key.as_array());
+        hasher2.write(key.as_array());
+        assert_eq!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure identical hashers with different keys produce different hashes
+    #[test]
+    fn test_identical_hashers_and_different_keys() {
+        let mut hasher1 = AddressHasher {
+            random: 11,
+            offset: 2,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            random: 11,
+            offset: 2,
+            state: 0,
+        };
+
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        hasher1.write(key1.as_array());
+        hasher2.write(key2.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different hashers with identical keys produce different hashes
+    #[test]
+    fn test_different_hashers_and_identical_keys() {
+        let mut hasher1 = AddressHasher {
+            random: 123,
+            offset: 3,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            random: 456,
+            offset: 4,
+            state: 0,
+        };
+
+        let key = Pubkey::new_unique();
+        hasher1.write(key.as_array());
+        hasher2.write(key.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different hashers with different keys produce different hashes
+    #[test]
+    fn test_different_hashers_and_different_keys() {
+        let mut hasher1 = AddressHasher {
+            random: 321,
+            offset: 20,
+            state: 0,
+        };
+        let mut hasher2 = AddressHasher {
+            random: 987,
+            offset: 10,
+            state: 0,
+        };
+
+        let key1 = Pubkey::new_unique();
+        let key2 = Pubkey::new_unique();
+        hasher1.write(key1.as_array());
+        hasher2.write(key2.as_array());
+        assert_ne!(hasher1.finish(), hasher2.finish());
+    }
+
+    /// Ensure different builders are different
+    #[test]
+    fn test_builder_default() {
+        let builder1 = AddressHasherBuilder::default();
+        let builder2 = AddressHasherBuilder::default();
+
+        assert_ne!(builder1.random(), builder2.random());
+        assert_ne!(builder1.offset(), builder2.offset());
+    }
+
+    /// Ensure AddressHasherBuilder::with() is deterministic
+    #[test]
+    fn test_builder_with() {
+        let builder1 = AddressHasherBuilder::default();
+        let random1 = builder1.random();
+        let offset1 = builder1.offset();
+        let builder2 = AddressHasherBuilder::with(random1, offset1);
+
+        assert_eq!(random1, builder2.random());
+        assert_eq!(offset1, builder2.offset());
+    }
+
+    /// Ensure build_hasher() builds stable hashers
+    #[test]
+    fn test_build_hasher() {
+        let builder = AddressHasherBuilder::default();
+        let hasher1 = builder.build_hasher();
+        let hasher2 = builder.build_hasher();
+
+        assert_eq!(hasher1.random, hasher2.random);
+        assert_eq!(hasher1.offset, hasher2.offset);
+    }
+}

--- a/address-hasher/src/lib.rs
+++ b/address-hasher/src/lib.rs
@@ -1,0 +1,5 @@
+#![cfg(feature = "agave-unstable-api")]
+
+mod hasher;
+
+pub use hasher::{AddressHasher, AddressHasherBuilder};

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -55,6 +55,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-address-hasher"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "agave-banking-stage-ingress-types"
 version = "4.4.0-alpha.0"
 dependencies = [
@@ -5722,6 +5729,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-address-hasher",
  "agave-fs",
  "ahash 0.8.12",
  "blake3",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -55,6 +55,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-address-hasher"
+version = "4.4.0-alpha.0"
+dependencies = [
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "agave-banking-stage-ingress-types"
 version = "4.4.0-alpha.0"
 dependencies = [
@@ -5746,6 +5753,7 @@ dependencies = [
 name = "solana-accounts-db"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-address-hasher",
  "agave-fs",
  "ahash 0.8.12",
  "blake3",


### PR DESCRIPTION
🚧 builds on https://github.com/anza-xyz/agave/pull/14684 🚧 

#### Problem

As of https://github.com/anza-xyz/agave/pull/14684, there is now an agave address hasher. No need to use solana sdk's.


#### Summary of Changes

Replaces solana-sdk's PubkeyHasherBuilder with agave's AddressHasherBuilder in accounts-db.
