### PR TITLE
bcp: disallow block markers in towerbft blocks

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -1290,7 +1290,7 @@ pub mod formalize_loaded_transaction_data_size {
 }
 
 pub mod alpenglow {
-    solana_pubkey::declare_id!("A1PeNgLEYU9sdwWJH5SEcRGVVKXLQYnyq26kpL6G3iJH");
+    solana_pubkey::declare_id!("a1pEnGkb4MY7fPXcTnDSQoeQnK7pqD8ohS7dzKaiM72");
 }
 
 pub mod disable_zk_elgamal_proof_program {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -5538,9 +5538,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "5UrLWHi74qXWsyEHruqoz8g5XA31u4G7aADAt3Y81q5v"
+                    "2TxrpFi2FB6Cb1Gnwq8uYpEDUpCBcFZF7tze5mjz5hC2"
                 } else {
-                    "BSbYeY7uRBu3yoE5pJAJtunekoc6N9XjgDgek8uV3oZH"
+                    "637crtstLE19ykqsnQ3WeDZD1RHCgbp5EhFpDMakUBHc"
                 },
             );
         }
@@ -5549,9 +5549,9 @@ fn test_bank_hash_consistency(deprecate_rent_exemption_threshold: bool) {
             assert_eq!(
                 bank.hash().to_string(),
                 if deprecate_rent_exemption_threshold {
-                    "2umT1LU1YvfhfKsGDUah9ChnqSGfnJo4r9EHRKxiPbF2"
+                    "ETPRGYvvzhi9qBRSeSQvX7jU3RsCSMHyGRoV52F2oroQ"
                 } else {
-                    "FiredfFXh5u9GWcFfqDn9tG5mCEfnX8vAecJbgnwXKgC"
+                    "4GYXKxi4VuxrMtdyL7WxfFm5sthtYoqvr2GZFspyErbL"
                 },
             );
             break;
@@ -5852,11 +5852,8 @@ fn test_bank_hash_deterministic_with_stakes_cache() {
     bank2.freeze();
 
     assert_eq!(
-        bank2.hash().as_bytes(),
-        &[
-            167, 152, 211, 107, 117, 229, 2, 86, 15, 156, 174, 32, 113, 116, 240, 38, 14, 205, 174,
-            168, 10, 67, 5, 124, 73, 110, 6, 45, 149, 236, 149, 180
-        ]
+        bank2.hash().to_string(),
+        "LYFRXqcPwYrmWj3CaLSKhVSQhttzjZ8RyAjfazbT7NJ",
     );
 }
 

--- a/runtime/src/block_component_processor.rs
+++ b/runtime/src/block_component_processor.rs
@@ -326,9 +326,14 @@ impl BlockComponentProcessor {
         slot: Slot,
         parent_slot: Slot,
     ) -> Result<(), BlockComponentProcessorError> {
-        // Only require block markers (header/footer) for slots where they should be present
+        // Only allow block markers for slots where they should be present.
+        // TowerBFT blocks must not include block headers.
         if !migration_status.should_allow_block_markers(slot) {
-            return Ok(());
+            if self.stage == BlockComponentStage::PreParentMarker {
+                return Ok(());
+            } else {
+                return Err(BlockComponentProcessorError::BlockComponentPreMigration);
+            };
         }
 
         if Self::requires_genesis_certificate_marker(migration_status, parent_slot)
@@ -1030,6 +1035,37 @@ mod tests {
     }
 
     #[test]
+    fn test_header_during_tower_bft_slot() {
+        let migration_status = MigrationStatus::default();
+        migration_status.record_feature_activation(0);
+        let mut processor = BlockComponentProcessor::default();
+        let (parent, bank_forks) = create_test_bank();
+        let bank = create_child_bank(&bank_forks, &parent, 1);
+        let marker = VersionedBlockMarker::from_block_header(BlockHeaderV1 {
+            parent_slot: parent.slot(),
+            parent_block_id: Hash::default(),
+        });
+
+        assert!(!migration_status.should_allow_block_markers(bank.slot()));
+        processor
+            .on_marker(
+                bank.clone(),
+                parent,
+                rand::rng().random(),
+                marker,
+                false,
+                None,
+                &migration_status,
+            )
+            .unwrap();
+
+        assert_matches!(
+            processor.on_final(&migration_status, bank.slot(), bank.parent_slot()),
+            Err(BlockComponentProcessorError::BlockComponentPreMigration)
+        );
+    }
+
+    #[test]
     fn test_first_alpenglow_block_requires_genesis_certificate_marker() {
         let migration_status = post_migration_status_with_genesis_slot(1);
         let processor = processor_after_footer();
@@ -1532,6 +1568,9 @@ mod tests {
         // Even with slot full
         let result = processor.on_entry_batch::<Bytes>(&migration_status, 1, &[], false);
         assert!(result.is_ok());
+
+        // A Tower block with no markers is valid
+        assert!(processor.on_final(&migration_status, 1, 0).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
As stated by the alpenglow bug bounty report.

Once the alpenglow feature flag is active, we allow block headers in blocks as we don't know when the first Alpenglow block will arrive. This is so that lagging validators (or historical replay) can process the first Alpenglow block and enable Alpenglow.

However we missed the check in `on_final` to reject a block header on a TowerBFT block.

This means during the first 5000 slots of the epoch prior to the migration, a malicious leader could submit and finalize a TowerBFT block with an Alpenglow block header.

#### Summary of Changes
Disallow this behavior

#### Testing
Unit test