### PR TITLE
global program cache: require exact deployment slot when extracting

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -614,12 +614,6 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                 search_for.retain(|program_to_load| {
                     if let Some(second_level) = entries.get(program_to_load.program_id) {
                         for entry in second_level.iter().rev() {
-                            // Second level is sorted by highest deployment slot.
-                            // If we're already past the target slot, it's not in here.
-                            if entry.deployment_slot < program_to_load.deployed_on_or_after_slot {
-                                break;
-                            }
-
                             // The entry must have been deployed in the slot reported by
                             // the caller's own program account, and by the same loader.
                             if program_to_load.deployed_on_or_after_slot != entry.deployment_slot

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -2138,16 +2138,16 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program1, 0, 12));
         assert!(match_slot(&extracted, &program2, 11, 12));
 
-        // Test the same fork, but request deployment slot 5 for both programs.
-        // program1 has no entry deployed in slot 5 and misses. program2 does,
-        // and gets it rather than its newer entry deployed in slot 11.
+        // Now try extractions that previously worked under the "deployed on
+        // or after" criteria, but won't work with exact matching.
         let mut missing = get_entries_to_load(&cache, 12, keys);
-        missing.get_mut(0).unwrap().deployed_on_or_after_slot = 5;
+        // Program 2's newest entry is at slot 11. Asking for 5 doesn't extract
+        // the latest (11) anymore. You get 5.
         missing.get_mut(1).unwrap().deployed_on_or_after_slot = 5;
         assert!(match_missing(&missing, &program3, false));
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
-        assert!(match_missing(&missing, &program1, true));
+        assert!(match_slot(&extracted, &program1, 0, 12));
         assert!(match_slot(&extracted, &program2, 5, 12));
     }
 

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -613,11 +613,16 @@ impl<FG: ForkGraph> ProgramCache<FG> {
             } => {
                 search_for.retain(|program_to_load| {
                     if let Some(second_level) = entries.get(program_to_load.program_id) {
-                        let mut filter_by_deployment_slot = None;
                         for entry in second_level.iter().rev() {
-                            let required_deployment_slot =
-                                filter_by_deployment_slot.unwrap_or(entry.deployment_slot);
-                            if required_deployment_slot != entry.deployment_slot
+                            // Second level is sorted by highest deployment slot.
+                            // If we're already past the target slot, it's not in here.
+                            if entry.deployment_slot < program_to_load.deployed_on_or_after_slot {
+                                break;
+                            }
+
+                            // The entry must have been deployed in the slot reported by
+                            // the caller's own program account, and by the same loader.
+                            if program_to_load.deployed_on_or_after_slot != entry.deployment_slot
                                 || program_to_load.loader != entry.account_owner
                             {
                                 continue;
@@ -639,22 +644,10 @@ impl<FG: ForkGraph> ProgramCache<FG> {
                                         entry,
                                         program_runtime_environment_for_execution,
                                     ) {
-                                        // We found an entry that would work, had its environment matched
-                                        // the one we're planning to use for this slot.
-                                        //
-                                        // At this point we know that whatever the "current version" of
-                                        // program is, it must have had a deployment slot equal to the
-                                        // program we're looking at in this iteration. We just have to find
-                                        // one with the correct environment and can skip entries for any
-                                        // other deployment slot while searching further.
-                                        filter_by_deployment_slot = filter_by_deployment_slot
-                                            .or(Some(entry.deployment_slot));
+                                        // We found an entry that would work, had its environment
+                                        // matched the one we're planning to use for this slot. A
+                                        // sibling compiled against that environment may follow.
                                         continue;
-                                    }
-                                    if entry.deployment_slot
-                                        < program_to_load.deployed_on_or_after_slot
-                                    {
-                                        break;
                                     }
                                     if let ProgramCacheEntryType::Unloaded(_environment) =
                                         &entry.program
@@ -1891,7 +1884,7 @@ pub(crate) mod tests {
                     .map(|(_program_id, entry)| ProgramToLoad {
                         program_id: key,
                         loader: entry.account_owner,
-                        deployed_on_or_after_slot: 0,
+                        deployed_on_or_after_slot: entry.deployment_slot,
                         last_modification_slot: entry.deployment_slot,
                     })
             })
@@ -2151,7 +2144,9 @@ pub(crate) mod tests {
         assert!(match_slot(&extracted, &program1, 0, 12));
         assert!(match_slot(&extracted, &program2, 11, 12));
 
-        // Test the same fork, but request the program modified at a later slot than what's in the cache.
+        // Test the same fork, but request deployment slot 5 for both programs.
+        // program1 has no entry deployed in slot 5 and misses. program2 does,
+        // and gets it rather than its newer entry deployed in slot 11.
         let mut missing = get_entries_to_load(&cache, 12, keys);
         missing.get_mut(0).unwrap().deployed_on_or_after_slot = 5;
         missing.get_mut(1).unwrap().deployed_on_or_after_slot = 5;
@@ -2159,7 +2154,7 @@ pub(crate) mod tests {
         let mut extracted = ProgramCacheForTxBatch::new(12);
         cache.extract(&mut missing, &mut extracted, &env, true, true);
         assert!(match_missing(&missing, &program1, true));
-        assert!(match_slot(&extracted, &program2, 11, 12));
+        assert!(match_slot(&extracted, &program2, 5, 12));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
Building on the back of #14484 and #14518, we can make the program cache's extraction explicitly require an _exact match_ on the program's deployment slot, rather than trying to choose its highest potential descendant.

As I described in #14484, older versions of the program cache did not have access to the underlying program and programdata accounts at all call sites, therefore inducing a load was costly. However, since we now have `AccountLoader` and the API surface of both transaction account loading and program cache extraction has changed, the underlying state is always available.

We can sharpen extraction's accuracy by changing it explicitly match on the provided deployment slot. A miss results in a reload, and there is no guesswork involved in determining which fork to relate an entry to.

#### Summary of Changes
Change the check inside of `extract` to require a specific match on deployment slot. Also eliminate the `filter_by_deployment_slot` drop-hatch, making it always implicitly true.

#### Testing
Change has existing coverage, but more is added in #14630 and follow-up work.