### PR TITLE
ci: group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,33 +3,17 @@ updates:
   - package-ecosystem: cargo
     directories:
       - "/"
-    schedule:
-      interval: daily
-      time: "08:00"
-      timezone: Etc/UTC
-    open-pull-requests-limit: 6
-    cooldown:
-      default-days: 7
-      # crates published by anza-team bypass the cooldown
-      exclude:
-        - "solana-*"
-        - "agave-*"
-        - "spl-*"
-        - "rts-alloc"
-        - "shaq"
-        - "wincode"
-
-  # split from root directory schedule to avoid duplicate checks
-  - package-ecosystem: cargo
-    directories:
       - "/dev-bins"
       - "/ci/xtask"
       - "/programs/sbf"
     schedule:
       interval: daily
-      time: "14:00"
+      time: "08:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 6
+    groups:
+      per-dependency:
+        group-by: dependency-name
+    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
       # crates published by anza-team bypass the cooldown


### PR DESCRIPTION
#### Problem

I split the dependabot config into the root dir + other dirs struct in https://github.com/anza-xyz/agave/pull/9825 because dependabot would generate duplicate PRs for the same crates when they live in multiple dirs.

TIL: https://github.com/dependabot/dependabot-core/issues/13284. it looks like it addresses the exact issue I originally ran into

#### Summary of Changes

try to use the new syntax

```
    groups:
      per-dependency:
        group-by: dependency-name
```