### PR TITLE
ci: split dev-bins in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: cargo
     directories:
       - "/"
-      - "/dev-bins"
       - "/ci/xtask"
       - "/programs/sbf"
     schedule:
@@ -14,6 +13,25 @@ updates:
       per-dependency:
         group-by: dependency-name
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      # crates published by anza-team bypass the cooldown
+      exclude:
+        - "solana-*"
+        - "agave-*"
+        - "spl-*"
+        - "rts-alloc"
+        - "shaq"
+        - "wincode"
+
+  - package-ecosystem: cargo
+    directories:
+      - "/dev-bins"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 6
     cooldown:
       default-days: 7
       # crates published by anza-team bypass the cooldown


### PR DESCRIPTION
#### Problem

I merged all dirs in https://github.com/anza-xyz/agave/pull/14691. however, I saw this: https://github.com/anza-xyz/agave/actions/runs/32114670348/job/95641385386#step:3:176

```
2026/08/18 08:12:54 INFO <job_1530606952> Updating the /dev-bins directory.
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Started process PID: 1652 with command: {} git reset --hard 18c2b38fe3f6463167e25758d615527b9fdbc079 {}
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Process PID: 1652 completed with status: pid 1652 exit 0
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Total execution time: 0.02 seconds
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Started process PID: 1659 with command: {} git clean -fx . {}
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Process PID: 1659 completed with status: pid 1659 exit 0
2026/08/18 08:12:54 INFO <job_1530606952> Total execution time: 0.0 seconds
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Started process PID: 1668 with command: {} git stash clear {}
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Process PID: 1668 completed with status: pid 1668 exit 0
updater | 2026/08/18 08:12:54 INFO <job_1530606952> Total execution time: 0.0 seconds
updater | 2026/08/18 08:12:54 ERROR <job_1530606952> No Cargo.toml!
```

it's super weird. sorry for debugging on master but let's give me a try 🥹

#### Summary of Changes

split dev-bins from the big group

