### PR TITLE
rm shred::layout::get_reference_tick

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -511,8 +511,7 @@ impl ParentInfo {
             return None;
         }
 
-        let shred_bytes = current_shred.payload();
-        let payload = shred::layout::get_data(shred_bytes).ok()?;
+        let payload = current_shred.data().ok()?;
 
         if !BlockComponent::infer_is_block_marker(payload).unwrap_or(false) {
             return None;

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -1118,23 +1118,11 @@ mod tests {
         assert_eq!(layout::get_shred_id(data), Some(shred.id()));
         assert_eq!(layout::get_signature(data), Some(*shred.signature()));
         assert_eq!(layout::get_shred_type(data).unwrap(), shred.shred_type());
-        match shred.shred_type() {
-            ShredType::Code => {
-                assert_matches!(
-                    layout::get_reference_tick(data),
-                    Err(Error::InvalidShredType)
-                );
-            }
-            ShredType::Data => {
-                assert_eq!(
-                    layout::get_reference_tick(data).unwrap(),
-                    shred.reference_tick()
-                );
-                let parent_offset = layout::get_parent_offset(data).unwrap();
-                let slot = layout::get_slot(data).unwrap();
-                let parent = slot.checked_sub(Slot::from(parent_offset)).unwrap();
-                assert_eq!(parent, shred.parent().unwrap());
-            }
+        if shred.shred_type() == ShredType::Data {
+            let parent_offset = layout::get_parent_offset(data).unwrap();
+            let slot = layout::get_slot(data).unwrap();
+            let parent = slot.checked_sub(Slot::from(parent_offset)).unwrap();
+            assert_eq!(parent, shred.parent().unwrap());
         }
     }
 

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -1795,10 +1795,6 @@ mod test {
                     );
                     assert_eq!(shred::layout::get_flags(shred).unwrap(), data_header.flags);
                     assert_eq!(shred::layout::get_data(shred).unwrap(), data);
-                    assert_eq!(
-                        shred::layout::get_reference_tick(shred).unwrap(),
-                        reference_tick
-                    );
                     num_data_shreds += 1;
                 }
             }

--- a/ledger/src/shred/wire.rs
+++ b/ledger/src/shred/wire.rs
@@ -206,16 +206,6 @@ pub fn get_shred_id(shred: &[u8]) -> Option<ShredId> {
     ))
 }
 
-pub fn get_reference_tick(shred: &[u8]) -> Result<u8, Error> {
-    if get_shred_type(shred)? != ShredType::Data {
-        return Err(Error::InvalidShredType);
-    }
-    let Some(flags) = shred.get(85) else {
-        return Err(Error::InvalidPayloadSize(shred.len()));
-    };
-    Ok(flags & ShredFlags::SHRED_TICK_REFERENCE_MASK.bits())
-}
-
 pub fn get_merkle_root(shred: &[u8]) -> Option<Hash> {
     match get_shred_variant(shred).ok()? {
         ShredVariant::MerkleCode {
@@ -620,7 +610,6 @@ mod tests {
             if let shred::merkle::Shred::ShredCode(_) = shred {
                 assert_matches!(get_flags(bytes), Err(Error::InvalidShredType));
                 assert_matches!(get_data(bytes), Err(Error::InvalidShredType));
-                assert_matches!(get_reference_tick(bytes), Err(Error::InvalidShredType));
             }
             if let shred::merkle::Shred::ShredData(shred) = shred {
                 let shred_data_header = shred.data_header();
@@ -631,9 +620,6 @@ mod tests {
                 assert_eq!(get_flags(bytes).unwrap(), shred_data_header.flags);
                 assert_eq!(get_data_size(bytes).unwrap(), shred_data_header.size);
                 assert_eq!(get_data(bytes).unwrap(), shred.data().unwrap());
-                assert_eq!(get_reference_tick(bytes).unwrap(), {
-                    shred.reference_tick()
-                });
             }
         }
     }

--- a/ledger/src/shredder.rs
+++ b/ledger/src/shredder.rs
@@ -298,8 +298,7 @@ mod tests {
     use {
         super::*,
         crate::shred::{
-            self, CODING_SHREDS_PER_FEC_BLOCK, ShredType, max_ticks_per_n_shreds,
-            verify_test_data_shred,
+            CODING_SHREDS_PER_FEC_BLOCK, ShredType, max_ticks_per_n_shreds, verify_test_data_shred,
         },
         assert_matches::assert_matches,
         itertools::Itertools,
@@ -480,7 +479,6 @@ mod tests {
         );
         data_shreds.iter().for_each(|s| {
             assert_eq!(s.reference_tick(), 5);
-            assert_eq!(shred::layout::get_reference_tick(s.payload()).unwrap(), 5);
         });
 
         let deserialized_shred =
@@ -518,10 +516,6 @@ mod tests {
         data_shreds.iter().for_each(|s| {
             assert_eq!(
                 s.reference_tick(),
-                ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
-            );
-            assert_eq!(
-                shred::layout::get_reference_tick(s.payload()).unwrap(),
                 ShredFlags::SHRED_TICK_REFERENCE_MASK.bits()
             );
         });


### PR DESCRIPTION
#### Problem

get_reference_tick parser in wire.rs was only ever used in tests.

#### Summary of Changes

rm

#### Testing

CI