### PR TITLE
Uses the older epoch stakes view for broadcasting certs

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -237,9 +237,10 @@ impl ConsensusPoolService {
     }
 
     fn is_current_identity_staked(ctx: &ConsensusPoolContext) -> bool {
-        ctx.sharable_banks
-            .root()
-            .current_epoch_staked_nodes()
+        let root_bank = ctx.sharable_banks.root();
+        root_bank
+            .epoch_staked_nodes(root_bank.epoch())
+            .expect("Root bank retains epoch_stakes for its own epoch")
             .get(&ctx.cluster_info.id())
             .is_some_and(|stake| *stake > 0)
     }


### PR DESCRIPTION
#### Problem

Currently, we are using an incorrect epoch stakes view to decide if we should broadcast a certificate or not.  `current_epoch_staked_nodes` returns the epoch stakes view computed at the start of this epoch.  This means that if I change my validator's identity from machine `A` to machine `B` in epoch E, in epoch E+1, `is_current_identity_staked` will start returning false on `A` and true on machine `B`.

However, all other services are using an older epoch stakes view so in epoch E+1, they will still be expecting to hear from `A` and not from `B`.  As a result, `A` will stop broadcasting its certs too early and `B` will start too early (which will simply be ignored).


#### Summary of change

`is_current_identity_staked` is updated to use use the older epoch stakes view i.e. `Bank::epoch_staked_nodes()`.  This will result in machine A continuing to participate in consensus till end of epoch E+1 and machine B taking over in epoch E+2.  This will be a simple fix.


#### Testing

No new tests added