### PR TITLE
Cleanup - `syscall_parameter_address_restrictions`

### DIFF
--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -294,7 +294,6 @@ impl FeatureSet {
         let snapshot = &self.snapshot;
         SVMFeatureSet {
             move_precompile_verification_to_svm: snapshot.move_precompile_verification_to_svm,
-            syscall_parameter_address_restrictions: snapshot.syscall_parameter_address_restrictions,
             virtual_address_space_adjustments: snapshot.virtual_address_space_adjustments,
             account_data_direct_mapping: snapshot.account_data_direct_mapping,
             enable_bpf_loader_set_authority_checked_ix: snapshot

--- a/feature-set/src/lib.rs
+++ b/feature-set/src/lib.rs
@@ -29,7 +29,6 @@ pub struct FeatureSnapshot {
     pub simplify_alt_bn128_syscall_error_codes: bool,
     pub enable_big_mod_exp_syscall: bool,
     pub remove_bpf_loader_incorrect_program_id: bool,
-    pub syscall_parameter_address_restrictions: bool,
     pub virtual_address_space_adjustments: bool,
     pub account_data_direct_mapping: bool,
     pub last_restart_slot_sysvar: bool,
@@ -109,9 +108,6 @@ impl From<&AHashMap<Pubkey, u64>> for FeatureSnapshot {
             enable_big_mod_exp_syscall: is_active(&enable_big_mod_exp_syscall::ID),
             remove_bpf_loader_incorrect_program_id: is_active(
                 &remove_bpf_loader_incorrect_program_id::ID,
-            ),
-            syscall_parameter_address_restrictions: is_active(
-                &syscall_parameter_address_restrictions::ID,
             ),
             virtual_address_space_adjustments: is_active(&virtual_address_space_adjustments::ID),
             account_data_direct_mapping: is_active(&account_data_direct_mapping::ID),

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -263,6 +263,16 @@ pub struct CallerAccount<'a> {
 }
 
 impl<'a> CallerAccount<'a> {
+    /// Returns the length of the addres space reserved depending on the ABI version
+    pub fn address_space_reserved_for_account(&self, is_caller_loader_deprecated: bool) -> usize {
+        if is_caller_loader_deprecated {
+            self.original_data_len
+        } else {
+            self.original_data_len
+                .saturating_add(MAX_PERMITTED_DATA_INCREASE)
+        }
+    }
+
     /// # Safety
     ///
     /// * The caller must ensure that this function does not violate mutable reference uniqueness
@@ -1146,13 +1156,8 @@ unsafe fn update_caller_account_region(
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {
     let is_caller_loader_deprecated = !check_aligned;
-    let address_space_reserved_for_account = if is_caller_loader_deprecated {
-        caller_account.original_data_len
-    } else {
-        caller_account
-            .original_data_len
-            .saturating_add(MAX_PERMITTED_DATA_INCREASE)
-    };
+    let address_space_reserved_for_account =
+        caller_account.address_space_reserved_for_account(is_caller_loader_deprecated);
 
     if address_space_reserved_for_account > 0 {
         // We can trust vm_data_addr to point to the correct region because we
@@ -1190,10 +1195,6 @@ unsafe fn update_caller_account_region(
 //
 // This method updates caller_account so the CPI caller can see the callee's
 // changes.
-//
-// Safety: Once `syscall_parameter_address_restrictions` is enabled all fields of [CallerAccount] used
-// in this function should never point inside the address space reserved for
-// accounts (regardless of the current size of an account).
 fn update_caller_account(
     invoke_context: &InvokeContext,
     check_aligned: bool,
@@ -1208,13 +1209,8 @@ fn update_caller_account(
     let prev_len = *caller_account.ref_to_len_in_vm as usize;
     let post_len = callee_account.get_data().len();
     let is_caller_loader_deprecated = !check_aligned;
-    let address_space_reserved_for_account = if is_caller_loader_deprecated {
-        caller_account.original_data_len
-    } else {
-        caller_account
-            .original_data_len
-            .saturating_add(MAX_PERMITTED_DATA_INCREASE)
-    };
+    let address_space_reserved_for_account =
+        caller_account.address_space_reserved_for_account(is_caller_loader_deprecated);
 
     if post_len > address_space_reserved_for_account {
         let max_increase =

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1052,7 +1052,7 @@ where
             accounts.push(TranslatedAccount {
                 index_in_caller,
                 caller_account,
-                update_caller_account_region: true, // overwritten after calling update_callee_account() later
+                update_caller_account_region: true, // overwritten in `cpi_common` via `update_callee_acccount()`
                 update_caller_account_info: instruction_account.is_writable(),
             });
         } else {

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -275,7 +275,6 @@ impl<'a> CallerAccount<'a> {
         vm_addr: u64,
         original_data_len: usize,
         len: usize,
-        _syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) -> Result<&'a mut [u8], Error> {
@@ -419,7 +418,6 @@ impl<'a> CallerAccount<'a> {
                     data_slice.ptr(),
                     account_metadata.original_data_len,
                     *ref_to_len_in_vm as usize,
-                    true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
                 )?
@@ -520,7 +518,6 @@ impl<'a> CallerAccount<'a> {
                 account_info.data_addr,
                 account_metadata.original_data_len,
                 *ref_to_len_in_vm as usize,
-                true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )?
@@ -1124,7 +1121,6 @@ fn update_callee_account(
                         caller_account.vm_data_addr,
                         caller_account.original_data_len,
                         prev_len,
-                        true,
                         virtual_address_space_adjustments,
                         account_data_direct_mapping,
                     )?
@@ -1277,7 +1273,6 @@ fn update_caller_account(
                     caller_account.vm_data_addr,
                     caller_account.original_data_len,
                     post_len,
-                    true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
                 )?;
@@ -1950,7 +1945,6 @@ mod tests {
                     .len()
                     .saturating_add(MAX_PERMITTED_DATA_INCREASE)
                     .saturating_add(1),
-                true,  // syscall_parameter_address_restrictions
                 true,  // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
             )

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -332,9 +332,6 @@ impl<'a> CallerAccount<'a> {
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::{translate_type, translate_type_mut_for_cpi};
 
-        let _syscall_parameter_address_restrictions = invoke_context
-            .get_feature_set()
-            .syscall_parameter_address_restrictions;
         let virtual_address_space_adjustments = invoke_context
             .get_feature_set()
             .virtual_address_space_adjustments;
@@ -446,9 +443,6 @@ impl<'a> CallerAccount<'a> {
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::translate_type_mut_for_cpi;
 
-        let _syscall_parameter_address_restrictions = invoke_context
-            .get_feature_set()
-            .syscall_parameter_address_restrictions;
         let virtual_address_space_adjustments = invoke_context
             .get_feature_set()
             .virtual_address_space_adjustments;
@@ -796,9 +790,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     // changes so the callee can see them.
     let amount = invoke_context.get_execution_cost().invoke_units;
     invoke_context.compute_meter.consume_checked(amount)?;
-    let _syscall_parameter_address_restrictions = invoke_context
-        .get_feature_set()
-        .syscall_parameter_address_restrictions;
     let virtual_address_space_adjustments = invoke_context
         .get_feature_set()
         .virtual_address_space_adjustments;
@@ -914,10 +905,6 @@ fn translate_account_infos<T, R>(
     check_aligned: bool,
     cb: impl FnOnce(&[T], Vec<&Pubkey>) -> R,
 ) -> Result<R, Error> {
-    let _syscall_parameter_address_restrictions = invoke_context
-        .get_feature_set()
-        .syscall_parameter_address_restrictions;
-
     // In the same vein as the other check_account_info_pointer() checks, we don't lock
     // this pointer to a specific address but we don't want it to be inside accounts, or
     // callees might be able to write to the pointed memory.
@@ -990,14 +977,6 @@ where
         .memory_context_abi_v1()
         .unwrap()
         .accounts_metadata;
-
-    let _syscall_parameter_address_restrictions = invoke_context
-        .get_feature_set()
-        .syscall_parameter_address_restrictions;
-    let _virtual_address_space_adjustments = invoke_context
-        .get_feature_set()
-        .virtual_address_space_adjustments;
-    let _account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
 
     for (instruction_account_index, instruction_account) in
         next_instruction_accounts.iter().enumerate()

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -837,7 +837,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
             check_aligned,
             &translated_account.caller_account,
             callee_account,
-            true,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
         )?;
@@ -1097,7 +1096,6 @@ fn update_callee_account(
     check_aligned: bool,
     caller_account: &CallerAccount,
     mut callee_account: BorrowedInstructionAccount<'_, '_>,
-    _syscall_parameter_address_restrictions: bool,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
 ) -> Result<bool, Error> {
@@ -2210,12 +2208,10 @@ mod tests {
         assert_eq!(data_len, 0);
     }
 
-    #[case(false, false, false)]
-    #[case(true, false, false)]
-    #[case(true, true, false)]
-    #[case(true, true, true)]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
     fn test_update_callee_account_lamports_owner(
-        syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) {
@@ -2257,7 +2253,6 @@ mod tests {
             true, // check_aligned
             &caller_account,
             callee_account,
-            syscall_parameter_address_restrictions,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
         )
@@ -2268,12 +2263,10 @@ mod tests {
         assert_eq!(caller_account.owner, callee_account.get_owner());
     }
 
-    #[case(false, false, false)]
-    #[case(true, false, false)]
-    #[case(true, true, false)]
-    #[case(true, true, true)]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
     fn test_update_callee_account_data_writable(
-        syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) {
@@ -2314,7 +2307,6 @@ mod tests {
             true, // check_aligned
             &caller_account,
             callee_account,
-            false, // syscall_parameter_address_restrictions,
             false, // virtual_address_space_adjustments,
             false, // account_data_direct_mapping
         )
@@ -2332,7 +2324,6 @@ mod tests {
                 true, // check_aligned
                 &caller_account,
                 callee_account,
-                syscall_parameter_address_restrictions,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )
@@ -2351,7 +2342,6 @@ mod tests {
                 true, // check_aligned
                 &caller_account,
                 callee_account,
-                syscall_parameter_address_restrictions,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )
@@ -2371,7 +2361,6 @@ mod tests {
             true, // check_aligned
             &caller_account,
             callee_account,
-            syscall_parameter_address_restrictions,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
         )
@@ -2380,12 +2369,10 @@ mod tests {
         assert_eq!(callee_account.get_data(), b"");
     }
 
-    #[case(false, false, false)]
-    #[case(true, false, false)]
-    #[case(true, true, false)]
-    #[case(true, true, true)]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
     fn test_update_callee_account_data_readonly(
-        syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) {
@@ -2427,7 +2414,6 @@ mod tests {
                 true, // check_aligned
                 &caller_account,
                 callee_account,
-                false, // syscall_parameter_address_restrictions,
                 false, // virtual_address_space_adjustments,
                 false, // account_data_direct_mapping
             ),
@@ -2445,7 +2431,6 @@ mod tests {
                 true, // check_aligned
                 &caller_account,
                 callee_account,
-                syscall_parameter_address_restrictions,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             ),
@@ -2463,7 +2448,6 @@ mod tests {
                 true, // check_aligned
                 &caller_account,
                 callee_account,
-                syscall_parameter_address_restrictions,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             ),

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -865,7 +865,6 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
                 check_aligned,
                 &mut translated_account.caller_account,
                 &mut callee_account,
-                true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )?;
@@ -1221,7 +1220,6 @@ fn update_caller_account(
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
     callee_account: &mut BorrowedInstructionAccount<'_, '_>,
-    _syscall_parameter_address_restrictions: bool,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {
@@ -2007,12 +2005,10 @@ mod tests {
         assert_eq!(caller_account.serialized_data, account.data());
     }
 
-    #[case(false, false, false)]
-    #[case(true, false, false)]
-    #[case(true, true, false)]
-    #[case(true, true, true)]
+    #[case(false, false)]
+    #[case(true, false)]
+    #[case(true, true)]
     fn test_update_caller_account_lamports_owner(
-        syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) {
@@ -2064,7 +2060,6 @@ mod tests {
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
-            syscall_parameter_address_restrictions,
             virtual_address_space_adjustments,
             account_data_direct_mapping,
         )
@@ -2138,7 +2133,6 @@ mod tests {
                 true, // check_aligned
                 &mut caller_account,
                 &mut callee_account,
-                false, // syscall_parameter_address_restrictions
                 false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
             )
@@ -2164,7 +2158,6 @@ mod tests {
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
-            false, // syscall_parameter_address_restrictions
             false, // virtual_address_space_adjustments
             false, // account_data_direct_mapping
         )
@@ -2182,7 +2175,6 @@ mod tests {
                 true, // check_aligned
                 &mut caller_account,
                 &mut callee_account,
-                false, // syscall_parameter_address_restrictions
                 false, // virtual_address_space_adjustments
                 false, // account_data_direct_mapping
             ),
@@ -2199,7 +2191,6 @@ mod tests {
             true, // check_aligned
             &mut caller_account,
             &mut callee_account,
-            false, // syscall_parameter_address_restrictions
             false, // virtual_address_space_adjustments
             false, // account_data_direct_mapping
         )

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -281,16 +281,14 @@ impl<'a> CallerAccount<'a> {
     ) -> Result<&'a mut [u8], Error> {
         use crate::memory::translate_slice_mut_for_cpi;
 
-        if true {
-            let is_caller_loader_deprecated = !check_aligned;
-            let address_space_reserved_for_account = if is_caller_loader_deprecated {
-                original_data_len
-            } else {
-                original_data_len.saturating_add(MAX_PERMITTED_DATA_INCREASE)
-            };
-            if len > address_space_reserved_for_account {
-                return Err(InstructionError::InvalidRealloc.into());
-            }
+        let is_caller_loader_deprecated = !check_aligned;
+        let address_space_reserved_for_account = if is_caller_loader_deprecated {
+            original_data_len
+        } else {
+            original_data_len.saturating_add(MAX_PERMITTED_DATA_INCREASE)
+        };
+        if len > address_space_reserved_for_account {
+            return Err(InstructionError::InvalidRealloc.into());
         }
         if virtual_address_space_adjustments && account_data_direct_mapping {
             Ok(&mut [])
@@ -344,20 +342,18 @@ impl<'a> CallerAccount<'a> {
         let account_data_direct_mapping =
             invoke_context.get_feature_set().account_data_direct_mapping;
 
-        if true {
-            check_account_info_pointer(
-                invoke_context,
-                account_info.key_addr(),
-                account_metadata.vm_key_addr,
-                "key",
-            )?;
-            check_account_info_pointer(
-                invoke_context,
-                account_info.owner_addr(),
-                account_metadata.vm_owner_addr,
-                "owner",
-            )?;
-        }
+        check_account_info_pointer(
+            invoke_context,
+            account_info.key_addr(),
+            account_metadata.vm_key_addr,
+            "key",
+        )?;
+        check_account_info_pointer(
+            invoke_context,
+            account_info.owner_addr(),
+            account_metadata.vm_owner_addr,
+            "owner",
+        )?;
 
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
@@ -365,18 +361,17 @@ impl<'a> CallerAccount<'a> {
             // Double dereference lamports out
             let ptr =
                 translate_type::<u64>(memory_mapping, account_info.lamports_addr(), check_aligned)?;
-            if true {
-                if account_info.lamports_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
-                    return Err(Box::new(CpiError::InvalidPointer));
-                }
-
-                check_account_info_pointer(
-                    invoke_context,
-                    *ptr,
-                    account_metadata.vm_lamports_addr,
-                    "lamports",
-                )?;
+            if account_info.lamports_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
+                return Err(Box::new(CpiError::InvalidPointer));
             }
+
+            check_account_info_pointer(
+                invoke_context,
+                *ptr,
+                account_metadata.vm_lamports_addr,
+                "lamports",
+            )?;
+
             translate_type_mut_for_cpi::<u64>(memory_mapping, *ptr, check_aligned)?
         };
 
@@ -387,7 +382,7 @@ impl<'a> CallerAccount<'a> {
         )?;
 
         let (serialized_data, vm_data_addr, ref_to_len_in_vm) = {
-            if true && account_info.data_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
+            if account_info.data_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
                 return Err(Box::new(CpiError::InvalidPointer));
             }
 
@@ -399,30 +394,18 @@ impl<'a> CallerAccount<'a> {
                 account_info.data_addr(),
                 check_aligned,
             )?;
-            if true {
-                check_account_info_pointer(
-                    invoke_context,
-                    data_slice.ptr(),
-                    account_metadata.vm_data_addr,
-                    "data",
-                )?;
-            } else {
-                // Moved to translate_accounts_common() via feature gate.
-                invoke_context.compute_meter.consume_checked(
-                    data_slice
-                        .len()
-                        .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                        .unwrap_or(u64::MAX),
-                )?;
-            }
+            check_account_info_pointer(
+                invoke_context,
+                data_slice.ptr(),
+                account_metadata.vm_data_addr,
+                "data",
+            )?;
 
-            if true {
-                // In the same vein as the other check_account_info_pointer() checks, we don't lock
-                // this pointer to a specific address but we don't want it to be inside accounts, or
-                // callees might be able to write to the pointed memory.
-                if account_info.data_len_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
-                    return Err(Box::new(CpiError::InvalidPointer));
-                }
+            // In the same vein as the other check_account_info_pointer() checks, we don't lock
+            // this pointer to a specific address but we don't want it to be inside accounts, or
+            // callees might be able to write to the pointed memory.
+            if account_info.data_len_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
+                return Err(Box::new(CpiError::InvalidPointer));
             }
             let ref_to_len_in_vm = translate_type_mut_for_cpi::<u64>(
                 memory_mapping,
@@ -435,11 +418,7 @@ impl<'a> CallerAccount<'a> {
                     check_aligned,
                     data_slice.ptr(),
                     account_metadata.original_data_len,
-                    if true {
-                        *ref_to_len_in_vm as usize
-                    } else {
-                        data_slice.len() as usize
-                    },
+                    *ref_to_len_in_vm as usize,
                     true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
@@ -478,35 +457,33 @@ impl<'a> CallerAccount<'a> {
         let account_data_direct_mapping =
             invoke_context.get_feature_set().account_data_direct_mapping;
 
-        if true {
-            check_account_info_pointer(
-                invoke_context,
-                account_info.key_addr,
-                account_metadata.vm_key_addr,
-                "key",
-            )?;
+        check_account_info_pointer(
+            invoke_context,
+            account_info.key_addr,
+            account_metadata.vm_key_addr,
+            "key",
+        )?;
 
-            check_account_info_pointer(
-                invoke_context,
-                account_info.owner_addr,
-                account_metadata.vm_owner_addr,
-                "owner",
-            )?;
+        check_account_info_pointer(
+            invoke_context,
+            account_info.owner_addr,
+            account_metadata.vm_owner_addr,
+            "owner",
+        )?;
 
-            check_account_info_pointer(
-                invoke_context,
-                account_info.lamports_addr,
-                account_metadata.vm_lamports_addr,
-                "lamports",
-            )?;
+        check_account_info_pointer(
+            invoke_context,
+            account_info.lamports_addr,
+            account_metadata.vm_lamports_addr,
+            "lamports",
+        )?;
 
-            check_account_info_pointer(
-                invoke_context,
-                account_info.data_addr,
-                account_metadata.vm_data_addr,
-                "data",
-            )?;
-        }
+        check_account_info_pointer(
+            invoke_context,
+            account_info.data_addr,
+            account_metadata.vm_data_addr,
+            "data",
+        )?;
 
         // account_info points to host memory. The addresses used internally are
         // in vm space so they need to be translated.
@@ -521,16 +498,6 @@ impl<'a> CallerAccount<'a> {
             check_aligned,
         )?;
 
-        if !true {
-            // Moved to translate_accounts_common() via feature gate.
-            invoke_context.compute_meter.consume_checked(
-                account_info
-                    .data_len
-                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                    .unwrap_or(u64::MAX),
-            )?;
-        }
-
         // we already have the host addr we want: &mut account_info.data_len.
         // The account info might be read only in the vm though, so we translate
         // to ensure we can write. This is tested by programs/sbf/rust/ro_modify
@@ -538,13 +505,11 @@ impl<'a> CallerAccount<'a> {
         let vm_len_addr = vm_addr
             .saturating_add(&account_info.data_len as *const u64 as u64)
             .saturating_sub(account_info as *const _ as *const u64 as u64);
-        if true {
-            // In the same vein as the other check_account_info_pointer() checks, we don't lock
-            // this pointer to a specific address but we don't want it to be inside accounts, or
-            // callees might be able to write to the pointed memory.
-            if vm_len_addr >= solana_sbpf::ebpf::MM_INPUT_START {
-                return Err(Box::new(CpiError::InvalidPointer));
-            }
+        // In the same vein as the other check_account_info_pointer() checks, we don't lock
+        // this pointer to a specific address but we don't want it to be inside accounts, or
+        // callees might be able to write to the pointed memory.
+        if vm_len_addr >= solana_sbpf::ebpf::MM_INPUT_START {
+            return Err(Box::new(CpiError::InvalidPointer));
         }
         let ref_to_len_in_vm =
             translate_type_mut_for_cpi::<u64>(memory_mapping, vm_len_addr, false)?;
@@ -554,11 +519,7 @@ impl<'a> CallerAccount<'a> {
                 check_aligned,
                 account_info.data_addr,
                 account_metadata.original_data_len,
-                if true {
-                    *ref_to_len_in_vm as usize
-                } else {
-                    account_info.data_len as usize
-                },
+                *ref_to_len_in_vm as usize,
                 true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
@@ -864,30 +825,27 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     let mut accounts =
         S::translate_accounts(account_infos_addr, account_infos_len, invoke_context)?;
 
-    if true {
-        // before initiating CPI, the caller may have modified the
-        // account (caller_account). We need to update the corresponding
-        // BorrowedAccount (callee_account) so the callee can see the
-        // changes.
-        let transaction_context = &invoke_context.transaction_context;
-        let instruction_context = transaction_context.get_current_instruction_context()?;
-        let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
-        for translated_account in accounts.iter_mut() {
-            let callee_account = instruction_context
-                .try_borrow_instruction_account(translated_account.index_in_caller)?;
-            // update_callee_account() is moved from translate_accounts_common()
-            let update_caller = update_callee_account(
-                memory_mapping,
-                check_aligned,
-                &translated_account.caller_account,
-                callee_account,
-                true,
-                virtual_address_space_adjustments,
-                account_data_direct_mapping,
-            )?;
-            translated_account.update_caller_account_region =
-                translated_account.update_caller_account_info || update_caller;
-        }
+    // before initiating CPI, the caller may have modified the
+    // account (caller_account). We need to update the corresponding
+    // BorrowedAccount (callee_account) so the callee can see the
+    // changes.
+    let transaction_context = &invoke_context.transaction_context;
+    let instruction_context = transaction_context.get_current_instruction_context()?;
+    let memory_mapping = invoke_context.memory_contexts.memory_mapping()?;
+    for translated_account in accounts.iter_mut() {
+        let callee_account = instruction_context
+            .try_borrow_instruction_account(translated_account.index_in_caller)?;
+        let update_caller = update_callee_account(
+            memory_mapping,
+            check_aligned,
+            &translated_account.caller_account,
+            callee_account,
+            true,
+            virtual_address_space_adjustments,
+            account_data_direct_mapping,
+        )?;
+        translated_account.update_caller_account_region =
+            translated_account.update_caller_account_info || update_caller;
     }
 
     // Process the callee instruction
@@ -968,10 +926,9 @@ fn translate_account_infos<T, R>(
     // In the same vein as the other check_account_info_pointer() checks, we don't lock
     // this pointer to a specific address but we don't want it to be inside accounts, or
     // callees might be able to write to the pointed memory.
-    if true
-        && account_infos_addr
-            .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
-            >= ebpf::MM_INPUT_START
+    if account_infos_addr
+        .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
+        >= ebpf::MM_INPUT_START
     {
         return Err(CpiError::InvalidPointer.into());
     }
@@ -1042,10 +999,10 @@ where
     let _syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
-    let virtual_address_space_adjustments = invoke_context
+    let _virtual_address_space_adjustments = invoke_context
         .get_feature_set()
         .virtual_address_space_adjustments;
-    let account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
+    let _account_data_direct_mapping = invoke_context.get_feature_set().account_data_direct_mapping;
 
     for (instruction_account_index, instruction_account) in
         next_instruction_accounts.iter().enumerate()
@@ -1103,36 +1060,15 @@ where
                     serialized_metadata,
                 )?;
 
-            if true {
-                // Moved from do_translate() via feature gate.
-                let amount = (*caller_account.ref_to_len_in_vm)
-                    .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
-                    .unwrap_or(u64::MAX);
-                invoke_context.compute_meter.consume_checked(amount)?;
-            }
-            let update_caller = if true {
-                // update_callee_account() is moved to cpi_common()
-                true
-            } else {
-                // before initiating CPI, the caller may have modified the
-                // account (caller_account). We need to update the corresponding
-                // BorrowedAccount (callee_account) so the callee can see the
-                // changes.
-                update_callee_account(
-                    memory_mapping,
-                    check_aligned,
-                    &caller_account,
-                    callee_account,
-                    true,
-                    virtual_address_space_adjustments,
-                    account_data_direct_mapping,
-                )?
-            };
+            let amount = (*caller_account.ref_to_len_in_vm)
+                .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
+                .unwrap_or(u64::MAX);
+            invoke_context.compute_meter.consume_checked(amount)?;
 
             accounts.push(TranslatedAccount {
                 index_in_caller,
                 caller_account,
-                update_caller_account_region: instruction_account.is_writable() || update_caller,
+                update_caller_account_region: true, // overwritten after calling update_callee_account() later
                 update_caller_account_info: instruction_account.is_writable(),
             });
         } else {
@@ -1301,7 +1237,7 @@ fn update_caller_account(
     let prev_len = *caller_account.ref_to_len_in_vm as usize;
     let post_len = callee_account.get_data().len();
     let is_caller_loader_deprecated = !check_aligned;
-    let address_space_reserved_for_account = if true && is_caller_loader_deprecated {
+    let address_space_reserved_for_account = if is_caller_loader_deprecated {
         caller_account.original_data_len
     } else {
         caller_account
@@ -1309,7 +1245,7 @@ fn update_caller_account(
             .saturating_add(MAX_PERMITTED_DATA_INCREASE)
     };
 
-    if post_len > address_space_reserved_for_account && (true || prev_len != post_len) {
+    if post_len > address_space_reserved_for_account {
         let max_increase =
             address_space_reserved_for_account.saturating_sub(caller_account.original_data_len);
         ic_msg!(

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -1342,7 +1342,6 @@ mod tests {
                 .map(|a| (a.0, a.1))
                 .collect::<Vec<KeyedAccountSharedData>>();
             let mut feature_set = SVMFeatureSet::all_enabled();
-            feature_set.syscall_parameter_address_restrictions = false;
             feature_set.virtual_address_space_adjustments = false;
             feature_set.account_data_direct_mapping = false;
             let feature_set = &feature_set;

--- a/program-runtime/src/cpi.rs
+++ b/program-runtime/src/cpi.rs
@@ -275,13 +275,13 @@ impl<'a> CallerAccount<'a> {
         vm_addr: u64,
         original_data_len: usize,
         len: usize,
-        syscall_parameter_address_restrictions: bool,
+        _syscall_parameter_address_restrictions: bool,
         virtual_address_space_adjustments: bool,
         account_data_direct_mapping: bool,
     ) -> Result<&'a mut [u8], Error> {
         use crate::memory::translate_slice_mut_for_cpi;
 
-        if syscall_parameter_address_restrictions {
+        if true {
             let is_caller_loader_deprecated = !check_aligned;
             let address_space_reserved_for_account = if is_caller_loader_deprecated {
                 original_data_len
@@ -335,7 +335,7 @@ impl<'a> CallerAccount<'a> {
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::{translate_type, translate_type_mut_for_cpi};
 
-        let syscall_parameter_address_restrictions = invoke_context
+        let _syscall_parameter_address_restrictions = invoke_context
             .get_feature_set()
             .syscall_parameter_address_restrictions;
         let virtual_address_space_adjustments = invoke_context
@@ -344,7 +344,7 @@ impl<'a> CallerAccount<'a> {
         let account_data_direct_mapping =
             invoke_context.get_feature_set().account_data_direct_mapping;
 
-        if syscall_parameter_address_restrictions {
+        if true {
             check_account_info_pointer(
                 invoke_context,
                 account_info.key_addr(),
@@ -365,7 +365,7 @@ impl<'a> CallerAccount<'a> {
             // Double dereference lamports out
             let ptr =
                 translate_type::<u64>(memory_mapping, account_info.lamports_addr(), check_aligned)?;
-            if syscall_parameter_address_restrictions {
+            if true {
                 if account_info.lamports_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
                     return Err(Box::new(CpiError::InvalidPointer));
                 }
@@ -387,9 +387,7 @@ impl<'a> CallerAccount<'a> {
         )?;
 
         let (serialized_data, vm_data_addr, ref_to_len_in_vm) = {
-            if syscall_parameter_address_restrictions
-                && account_info.data_addr() >= solana_sbpf::ebpf::MM_INPUT_START
-            {
+            if true && account_info.data_addr() >= solana_sbpf::ebpf::MM_INPUT_START {
                 return Err(Box::new(CpiError::InvalidPointer));
             }
 
@@ -401,7 +399,7 @@ impl<'a> CallerAccount<'a> {
                 account_info.data_addr(),
                 check_aligned,
             )?;
-            if syscall_parameter_address_restrictions {
+            if true {
                 check_account_info_pointer(
                     invoke_context,
                     data_slice.ptr(),
@@ -418,7 +416,7 @@ impl<'a> CallerAccount<'a> {
                 )?;
             }
 
-            if syscall_parameter_address_restrictions {
+            if true {
                 // In the same vein as the other check_account_info_pointer() checks, we don't lock
                 // this pointer to a specific address but we don't want it to be inside accounts, or
                 // callees might be able to write to the pointed memory.
@@ -437,12 +435,12 @@ impl<'a> CallerAccount<'a> {
                     check_aligned,
                     data_slice.ptr(),
                     account_metadata.original_data_len,
-                    if syscall_parameter_address_restrictions {
+                    if true {
                         *ref_to_len_in_vm as usize
                     } else {
                         data_slice.len() as usize
                     },
-                    syscall_parameter_address_restrictions,
+                    true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
                 )?
@@ -471,7 +469,7 @@ impl<'a> CallerAccount<'a> {
     ) -> Result<CallerAccount<'a>, Error> {
         use crate::memory::translate_type_mut_for_cpi;
 
-        let syscall_parameter_address_restrictions = invoke_context
+        let _syscall_parameter_address_restrictions = invoke_context
             .get_feature_set()
             .syscall_parameter_address_restrictions;
         let virtual_address_space_adjustments = invoke_context
@@ -480,7 +478,7 @@ impl<'a> CallerAccount<'a> {
         let account_data_direct_mapping =
             invoke_context.get_feature_set().account_data_direct_mapping;
 
-        if syscall_parameter_address_restrictions {
+        if true {
             check_account_info_pointer(
                 invoke_context,
                 account_info.key_addr,
@@ -523,7 +521,7 @@ impl<'a> CallerAccount<'a> {
             check_aligned,
         )?;
 
-        if !syscall_parameter_address_restrictions {
+        if !true {
             // Moved to translate_accounts_common() via feature gate.
             invoke_context.compute_meter.consume_checked(
                 account_info
@@ -540,7 +538,7 @@ impl<'a> CallerAccount<'a> {
         let vm_len_addr = vm_addr
             .saturating_add(&account_info.data_len as *const u64 as u64)
             .saturating_sub(account_info as *const _ as *const u64 as u64);
-        if syscall_parameter_address_restrictions {
+        if true {
             // In the same vein as the other check_account_info_pointer() checks, we don't lock
             // this pointer to a specific address but we don't want it to be inside accounts, or
             // callees might be able to write to the pointed memory.
@@ -556,12 +554,12 @@ impl<'a> CallerAccount<'a> {
                 check_aligned,
                 account_info.data_addr,
                 account_metadata.original_data_len,
-                if syscall_parameter_address_restrictions {
+                if true {
                     *ref_to_len_in_vm as usize
                 } else {
                     account_info.data_len as usize
                 },
-                syscall_parameter_address_restrictions,
+                true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )?
@@ -840,7 +838,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     // changes so the callee can see them.
     let amount = invoke_context.get_execution_cost().invoke_units;
     invoke_context.compute_meter.consume_checked(amount)?;
-    let syscall_parameter_address_restrictions = invoke_context
+    let _syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
     let virtual_address_space_adjustments = invoke_context
@@ -866,7 +864,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
     let mut accounts =
         S::translate_accounts(account_infos_addr, account_infos_len, invoke_context)?;
 
-    if syscall_parameter_address_restrictions {
+    if true {
         // before initiating CPI, the caller may have modified the
         // account (caller_account). We need to update the corresponding
         // BorrowedAccount (callee_account) so the callee can see the
@@ -883,7 +881,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
                 check_aligned,
                 &translated_account.caller_account,
                 callee_account,
-                syscall_parameter_address_restrictions,
+                true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )?;
@@ -913,7 +911,7 @@ pub fn cpi_common<S: SyscallInvokeSigned>(
                 check_aligned,
                 &mut translated_account.caller_account,
                 &mut callee_account,
-                syscall_parameter_address_restrictions,
+                true,
                 virtual_address_space_adjustments,
                 account_data_direct_mapping,
             )?;
@@ -963,14 +961,14 @@ fn translate_account_infos<T, R>(
     check_aligned: bool,
     cb: impl FnOnce(&[T], Vec<&Pubkey>) -> R,
 ) -> Result<R, Error> {
-    let syscall_parameter_address_restrictions = invoke_context
+    let _syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
 
     // In the same vein as the other check_account_info_pointer() checks, we don't lock
     // this pointer to a specific address but we don't want it to be inside accounts, or
     // callees might be able to write to the pointed memory.
-    if syscall_parameter_address_restrictions
+    if true
         && account_infos_addr
             .saturating_add(account_infos_len.saturating_mul(std::mem::size_of::<T>() as u64))
             >= ebpf::MM_INPUT_START
@@ -1041,7 +1039,7 @@ where
         .unwrap()
         .accounts_metadata;
 
-    let syscall_parameter_address_restrictions = invoke_context
+    let _syscall_parameter_address_restrictions = invoke_context
         .get_feature_set()
         .syscall_parameter_address_restrictions;
     let virtual_address_space_adjustments = invoke_context
@@ -1105,14 +1103,14 @@ where
                     serialized_metadata,
                 )?;
 
-            if syscall_parameter_address_restrictions {
+            if true {
                 // Moved from do_translate() via feature gate.
                 let amount = (*caller_account.ref_to_len_in_vm)
                     .checked_div(invoke_context.get_execution_cost().cpi_bytes_per_unit)
                     .unwrap_or(u64::MAX);
                 invoke_context.compute_meter.consume_checked(amount)?;
             }
-            let update_caller = if syscall_parameter_address_restrictions {
+            let update_caller = if true {
                 // update_callee_account() is moved to cpi_common()
                 true
             } else {
@@ -1125,7 +1123,7 @@ where
                     check_aligned,
                     &caller_account,
                     callee_account,
-                    syscall_parameter_address_restrictions,
+                    true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
                 )?
@@ -1166,7 +1164,7 @@ fn update_callee_account(
     check_aligned: bool,
     caller_account: &CallerAccount,
     mut callee_account: BorrowedInstructionAccount<'_, '_>,
-    syscall_parameter_address_restrictions: bool,
+    _syscall_parameter_address_restrictions: bool,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
 ) -> Result<bool, Error> {
@@ -1190,7 +1188,7 @@ fn update_callee_account(
                         caller_account.vm_data_addr,
                         caller_account.original_data_len,
                         prev_len,
-                        syscall_parameter_address_restrictions,
+                        true,
                         virtual_address_space_adjustments,
                         account_data_direct_mapping,
                     )?
@@ -1293,7 +1291,7 @@ fn update_caller_account(
     check_aligned: bool,
     caller_account: &mut CallerAccount<'_>,
     callee_account: &mut BorrowedInstructionAccount<'_, '_>,
-    syscall_parameter_address_restrictions: bool,
+    _syscall_parameter_address_restrictions: bool,
     virtual_address_space_adjustments: bool,
     account_data_direct_mapping: bool,
 ) -> Result<(), Error> {
@@ -1303,18 +1301,15 @@ fn update_caller_account(
     let prev_len = *caller_account.ref_to_len_in_vm as usize;
     let post_len = callee_account.get_data().len();
     let is_caller_loader_deprecated = !check_aligned;
-    let address_space_reserved_for_account =
-        if syscall_parameter_address_restrictions && is_caller_loader_deprecated {
-            caller_account.original_data_len
-        } else {
-            caller_account
-                .original_data_len
-                .saturating_add(MAX_PERMITTED_DATA_INCREASE)
-        };
+    let address_space_reserved_for_account = if true && is_caller_loader_deprecated {
+        caller_account.original_data_len
+    } else {
+        caller_account
+            .original_data_len
+            .saturating_add(MAX_PERMITTED_DATA_INCREASE)
+    };
 
-    if post_len > address_space_reserved_for_account
-        && (syscall_parameter_address_restrictions || prev_len != post_len)
-    {
+    if post_len > address_space_reserved_for_account && (true || prev_len != post_len) {
         let max_increase =
             address_space_reserved_for_account.saturating_sub(caller_account.original_data_len);
         ic_msg!(
@@ -1346,7 +1341,7 @@ fn update_caller_account(
                     caller_account.vm_data_addr,
                     caller_account.original_data_len,
                     post_len,
-                    syscall_parameter_address_restrictions,
+                    true,
                     virtual_address_space_adjustments,
                     account_data_direct_mapping,
                 )?;

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4023,16 +4023,9 @@ fn test_cpi_account_ownership_writability() {
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
-            if virtual_address_space_adjustments {
-                // We move the data pointer, virtual_address_space_adjustments doesn't allow it
-                // anymore so it errors out earlier. See
-                // test_cpi_invalid_account_info_pointers.
-                TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
-            } else {
-                // We managed to make CPI write into the account data, but the
-                // usual checks still apply and we get an error.
-                TransactionError::InstructionError(0, InstructionError::ExternalAccountDataModified)
-            }
+            // We move the data pointer, syscall_parameter_address_restrictions doesn't allow it
+            // anymore so it errors out earlier. See test_cpi_invalid_account_info_pointers.
+            TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
         );
 
         // We're going to try and make CPI write ref_to_len_in_vm into a 2nd
@@ -4062,30 +4055,17 @@ fn test_cpi_account_ownership_writability() {
             let message = Message::new(&[instruction], Some(&mint_pubkey));
             let tx = Transaction::new(&[&mint_keypair], message.clone(), bank.last_blockhash());
             let (result, _, logs, _) = process_transaction_and_record_inner(&bank, tx);
-            if virtual_address_space_adjustments {
-                assert_eq!(
-                    result.unwrap_err(),
-                    TransactionError::InstructionError(
-                        0,
-                        InstructionError::ProgramFailedToComplete
-                    )
-                );
-                // We haven't moved the data pointer, but ref_to_len_vm _is_ in
-                // the account data vm range and that's not allowed either.
-                assert!(
-                    logs.iter().any(|log| log.contains("Invalid pointer")),
-                    "{logs:?}"
-                );
-            } else {
-                // we expect this to succeed as after updating `ref_to_len_in_vm`,
-                // CPI will sync the actual account data between the callee and the
-                // caller, _always_ writing over the location pointed by
-                // `ref_to_len_in_vm`. To verify this, we check that the account
-                // data is in fact all zeroes like it is in the callee.
-                result.unwrap();
-                let account = bank.get_account(&account_keypair.pubkey()).unwrap();
-                assert_eq!(account.data(), vec![0; 40]);
-            }
+            assert_eq!(
+                result.unwrap_err(),
+                TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete),
+            );
+            // We haven't moved the data pointer, but ref_to_len_vm _is_ in
+            // the account data vm range and that's not allowed either.
+            assert!(
+                logs.iter().any(|log| log.contains("Invalid pointer")),
+                "{logs:?}"
+            );
+            assert!(account.data().is_empty());
         }
 
         // Test that the caller can write to an account which it received from the callee
@@ -4191,8 +4171,8 @@ fn test_cpi_account_data_updates() {
                     if virtual_address_space_adjustments {
                         InstructionError::ProgramFailedToComplete
                     } else {
-                        InstructionError::ModifiedProgramId
-                    }
+                        InstructionError::InvalidRealloc
+                    },
                 )
             );
         } else {
@@ -4225,14 +4205,7 @@ fn test_cpi_account_data_updates() {
         } else if deprecated_caller {
             assert_eq!(
                 result.unwrap_err().unwrap(),
-                TransactionError::InstructionError(
-                    0,
-                    if virtual_address_space_adjustments {
-                        InstructionError::InvalidRealloc
-                    } else {
-                        InstructionError::ExternalAccountDataModified
-                    }
-                )
+                TransactionError::InstructionError(0, InstructionError::InvalidRealloc),
             );
         } else {
             assert!(result.is_ok(), "{result:?}");
@@ -4270,11 +4243,11 @@ fn test_cpi_account_data_updates() {
                 result.unwrap_err().unwrap(),
                 TransactionError::InstructionError(
                     0,
-                    if virtual_address_space_adjustments && deprecated_callee {
+                    if deprecated_callee {
                         InstructionError::InvalidRealloc
                     } else {
                         InstructionError::ExternalAccountDataModified
-                    }
+                    },
                 )
             );
         } else {
@@ -4312,8 +4285,8 @@ fn test_cpi_account_data_updates() {
                     if virtual_address_space_adjustments {
                         InstructionError::ProgramFailedToComplete
                     } else {
-                        InstructionError::ModifiedProgramId
-                    }
+                        InstructionError::InvalidRealloc
+                    },
                 )
             );
         } else {
@@ -4349,8 +4322,8 @@ fn test_cpi_account_data_updates() {
                     if virtual_address_space_adjustments {
                         InstructionError::ProgramFailedToComplete
                     } else {
-                        InstructionError::ModifiedProgramId
-                    }
+                        InstructionError::InvalidRealloc
+                    },
                 )
             );
         } else {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2638,7 +2638,6 @@ fn test_program_sbf_realloc() {
         // by default test banks have all features enabled, so we only need to
         // disable when needed
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -3923,7 +3922,6 @@ fn test_cpi_account_ownership_writability() {
         let mut bank = Bank::new_for_tests(&genesis_config);
         let mut feature_set = FeatureSet::all_enabled();
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -4121,7 +4119,6 @@ fn test_cpi_account_data_updates() {
         let mut bank = Bank::new_for_tests(&genesis_config);
         let mut feature_set = FeatureSet::all_enabled();
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -4626,7 +4623,6 @@ fn test_deny_access_beyond_current_length() {
         // by default test banks have all features enabled, so we only need to
         // disable when needed
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -4696,7 +4692,6 @@ fn test_deny_executable_write() {
         // by default test banks have all features enabled, so we only need to
         // disable when needed
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -4752,7 +4747,6 @@ fn test_update_callee_account() {
         // by default test banks have all features enabled, so we only need to
         // disable when needed
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -5023,7 +5017,6 @@ fn test_clone_account_data() {
         // by default test banks have all features enabled, so we only need to
         // disable when needed
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }
@@ -5374,7 +5367,6 @@ fn test_mem_syscalls_overlap_account_begin_or_end() {
         let mut bank = Bank::new_for_tests(&genesis_config);
         let mut feature_set = FeatureSet::all_enabled();
         if !virtual_address_space_adjustments {
-            feature_set.deactivate(&feature_set::syscall_parameter_address_restrictions::id());
             feature_set.deactivate(&feature_set::virtual_address_space_adjustments::id());
             feature_set.deactivate(&feature_set::account_data_direct_mapping::id());
         }

--- a/svm-feature-set/src/lib.rs
+++ b/svm-feature-set/src/lib.rs
@@ -2,7 +2,6 @@
 #[derive(Clone, Copy, Default)]
 pub struct SVMFeatureSet {
     pub move_precompile_verification_to_svm: bool,
-    pub syscall_parameter_address_restrictions: bool,
     pub virtual_address_space_adjustments: bool,
     pub account_data_direct_mapping: bool,
     pub enable_bpf_loader_set_authority_checked_ix: bool,
@@ -57,7 +56,6 @@ impl SVMFeatureSet {
     pub fn all_enabled() -> Self {
         Self {
             move_precompile_verification_to_svm: true,
-            syscall_parameter_address_restrictions: true,
             virtual_address_space_adjustments: true,
             account_data_direct_mapping: true,
             enable_bpf_loader_set_authority_checked_ix: true,

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -26,9 +26,7 @@ fn get_sysvar<T: SysvarId + Clone>(
     }
 
     if var_addr >= ebpf::MM_INPUT_START
-        && invoke_context
-            .get_feature_set()
-            .syscall_parameter_address_restrictions
+        && true
     {
         return Err(SyscallError::InvalidPointer.into());
     }
@@ -209,9 +207,7 @@ declare_builtin_function!(
         }
 
         if var_addr >= ebpf::MM_INPUT_START
-            && invoke_context
-                .get_feature_set()
-                .syscall_parameter_address_restrictions
+            && true
         {
             return Err(SyscallError::InvalidPointer.into());
         }

--- a/syscalls/src/sysvar.rs
+++ b/syscalls/src/sysvar.rs
@@ -25,9 +25,7 @@ fn get_sysvar<T: SysvarId + Clone>(
         return Err(SyscallError::UnalignedPointer.into());
     }
 
-    if var_addr >= ebpf::MM_INPUT_START
-        && true
-    {
+    if var_addr >= ebpf::MM_INPUT_START {
         return Err(SyscallError::InvalidPointer.into());
     }
 
@@ -206,9 +204,7 @@ declare_builtin_function!(
             return Err(SyscallError::UnalignedPointer.into());
         }
 
-        if var_addr >= ebpf::MM_INPUT_START
-            && true
-        {
+        if var_addr >= ebpf::MM_INPUT_START {
             return Err(SyscallError::InvalidPointer.into());
         }
 


### PR DESCRIPTION
#### Problem
https://github.com/anza-xyz/feature-gate-tracker/issues/116 was activated on all clusters.

#### Summary of Changes
- Replaces `syscall_parameter_address_restrictions` with `true`.
- Simplifies conditional code.
- Removes `syscall_parameter_address_restrictions` from `update_callee_account()`, `update_caller_account()` and `CallerAccount::get_serialized_data()`.
- Removes unused feature flag bindings.
- Removes deactivations of `syscall_parameter_address_restrictions` from mockups.
- Removes `SVMFeatureSet::syscall_parameter_address_restrictions`.
- Removes `FeatureSnapshot::syscall_parameter_address_restrictions`.

#### Testing
Adjusts:
- `test_cpi_account_ownership_writability()`
- `test_cpi_account_data_updates()`