### PR TITLE
Revert "ci: update dependabot.yml (#14709)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,11 @@ updates:
   - package-ecosystem: cargo
     directories:
       - "/"
-      - "/ci/xtask"
-      - "/programs/sbf"
     schedule:
       interval: daily
       time: "08:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 10
-    groups:
-      per-dependency:
-        group-by: dependency-name
+    open-pull-requests-limit: 6
     cooldown:
       default-days: 7
       # crates published by anza-team bypass the cooldown
@@ -28,6 +23,8 @@ updates:
   - package-ecosystem: cargo
     directories:
       - "/dev-bins"
+      - "/ci/xtask"
+      - "/programs/sbf"
     schedule:
       interval: daily
       time: "14:00"


### PR DESCRIPTION
This reverts commit 4144dc4714cfc5d63c183d548e7294c8455c963c.

#### Problem

looks a bit weird and we will need to update the dependabot PR pipeline
<img width="517" height="433" alt="Screenshot 2026-08-18 at 23 57 30" src="https://github.com/user-attachments/assets/a9a27c77-3fc4-4dea-9f8a-b0cd03b3c011" />

let's revert to original behavior for now and let me think about it


