### PR TITLE
gossip: retain unknown ContactInfo TLV extensions verbatim

### DIFF
--- a/gossip/src/contact_info.rs
+++ b/gossip/src/contact_info.rs
@@ -3,7 +3,7 @@ use {
     crate::{
         crds_data::MAX_WALLCLOCK,
         define_tlv_enum,
-        tlv::{self, TlvDecodeError, TlvRecord},
+        tlv::{TlvDecodeError, TlvRecord},
     },
     assert_matches::{assert_matches, debug_assert_matches},
     solana_net_utils::SocketAddrSpace,
@@ -105,8 +105,10 @@ pub struct ContactInfo {
     // All sockets have a unique key and a valid IP address index.
     #[wincode(with = "wincode::containers::Vec<SocketEntry, short_vec::ShortU16>")]
     sockets: Vec<SocketEntry>,
-    #[wincode(with = "wincode::containers::Vec<Extension, short_vec::ShortU16>")]
-    extensions: Vec<Extension>,
+    // Kept verbatim: signature and hash are taken over a re-serialization of
+    // this struct, so dropping unrecognized records would invalidate both.
+    #[wincode(with = "wincode::containers::Vec<TlvRecord, short_vec::ShortU16>")]
+    extensions: Vec<TlvRecord>,
     // Only sanitized socket-addrs can be cached!
     #[wincode(skip(default_val = EMPTY_SOCKET_ADDR_CACHE))]
     cache: [SocketAddr; SOCKET_CACHE_SIZE],
@@ -125,9 +127,10 @@ define_tlv_enum!(
     /// TLV encoded Extensions in ContactInfo messages
     ///
     /// On the wire each record is: [type: u8][len: varint][bytes]
-    /// Extensions with unknown types are skipped by tlv::parse,
-    /// so new types can be added without breaking legacy code,
-    /// and support by all clients is not required.
+    /// Unknown types are skipped by tlv::parse but kept verbatim in
+    /// ContactInfo::extensions, so new types can be added without breaking
+    /// legacy code. Never make decoding lossy: a dropped record makes the
+    /// value fail sigverify.
     ///
     /// Always add new TLV records to the end of this enum.
     /// Never reorder or reuse a type.
@@ -150,7 +153,6 @@ struct ContactInfoLite {
     addrs: Vec<IpAddr>,
     #[wincode(with = "wincode::containers::Vec<SocketEntry, short_vec::ShortU16>")]
     sockets: Vec<SocketEntry>,
-    #[allow(dead_code)]
     #[wincode(with = "wincode::containers::Vec<TlvRecord, short_vec::ShortU16>")]
     extensions: Vec<TlvRecord>,
 }
@@ -577,7 +579,7 @@ impl TryFrom<ContactInfoLite> for ContactInfo {
             version,
             addrs,
             sockets,
-            extensions: tlv::parse(&extensions),
+            extensions,
             cache: EMPTY_SOCKET_ADDR_CACHE,
         };
         // Populate node.cache.
@@ -1137,5 +1139,41 @@ mod tests {
             assert_eq!(node.overrides(&other), Some(false));
             assert_eq!(other.overrides(&node), Some(true));
         }
+    }
+
+    // Extensions are the last field, a short-vec, so an empty list is one
+    // trailing zero byte.
+    fn with_unknown_extension(node: &ContactInfo) -> Vec<u8> {
+        let mut bytes = wincode::serialize(node).unwrap();
+        assert_eq!(
+            bytes.pop(),
+            Some(0u8),
+            "expected empty extensions short-vec"
+        );
+        bytes.extend_from_slice(&[1u8, 200u8, 4u8, 1u8, 2u8, 3u8, 4u8]);
+        bytes
+    }
+
+    #[test]
+    fn test_unknown_extension_round_trip() {
+        let node = ContactInfo::new_localhost(&Pubkey::new_unique(), 1234);
+        let bytes = with_unknown_extension(&node);
+        let other: ContactInfo = wincode::deserialize(&bytes).unwrap();
+        assert_eq!(wincode::serialize(&other).unwrap(), bytes);
+    }
+
+    #[test]
+    fn test_unknown_extension_preserves_signature() {
+        use crate::{crds_data::CrdsData, crds_value::CrdsValue, sigverify_cache::SigVerifyCache};
+        let keypair = Keypair::new();
+        let node = ContactInfo::new_localhost(&keypair.pubkey(), 1234);
+        // Sign the payload carrying the extension, as its originator would.
+        let mut data = wincode::serialize(&CrdsData::ContactInfo(node)).unwrap();
+        assert_eq!(data.pop(), Some(0u8), "expected empty extensions short-vec");
+        data.extend_from_slice(&[1u8, 200u8, 4u8, 1u8, 2u8, 3u8, 4u8]);
+        let mut bytes = keypair.sign_message(&data).as_ref().to_vec();
+        bytes.extend_from_slice(&data);
+        let value: CrdsValue = wincode::deserialize(&bytes).unwrap();
+        assert!(value.verify_with_cache(&SigVerifyCache::new()));
     }
 }

--- a/gossip/src/tlv.rs
+++ b/gossip/src/tlv.rs
@@ -110,6 +110,13 @@ pub enum TlvEncodeError {
 
 /// Parses a slice of serialized TLV records into a provided type. Unsupported
 /// TLV records are ignored.
+///
+/// Re-serialize from the original records, not from the parsed output, or the
+/// records dropped here are lost.
+///
+/// Test-only while every Extension enum is empty; drop the cfg once decoding
+/// can return anything.
+#[cfg(test)]
 pub(crate) fn parse<'a, T: TryFrom<&'a TlvRecord>>(entries: &'a [TlvRecord]) -> Vec<T> {
     entries.iter().filter_map(|v| T::try_from(v).ok()).collect()
 }


### PR DESCRIPTION
#### Problem

ContactInfo stored its extensions as a parsed Vec<Extension> and tlv::parse silently drops records whose type the local build does not know. Both the CrdsValue signature and the CrdsValue hash are computed over a re-serialization of CrdsData, so a node that received a ContactInfo carrying an unknown extension re-serialized it without that record and then failed to verify a perfectly valid signature.

The TLV encoding exists precisely so that new extension types can be rolled out incrementally, but with lossy decoding the first node to publish an extension would have had its contact-info rejected by every peer that did not yet know the type, partitioning the cluster by version.

#### Summary of Changes

Keep the raw Vec<TlvRecord> as the field, which is what the wire format already was, and expose the decoded view through ContactInfo::extensions instead. The serialized form is unchanged; the frozen-abi digests for ContactInfo, CrdsData, CrdsValue and Protocol are all unaffected.

#### Testing

Both tests fail before this change: the round-trip one re-serializes to a shorter buffer, and the signature one rejects a correctly signed node.

Otherwise, tested by running the validator and checking for errors.