### PR TITLE
refactor(blockstore): use `filter_map` on components

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -5246,9 +5246,9 @@ impl Blockstore {
     ) -> Result<Vec<Entry>> {
         self.get_slot_data_in_block(slot, completed_ranges, slot_meta, |payload| {
             wincode::deserialize(&payload)
-                .map(|component| match component {
-                    BlockComponent::BlockMarker(_) => vec![],
-                    BlockComponent::EntryBatch(entries) => entries,
+                .filter_map(|component| match component {
+                    BlockComponent::BlockMarker(_) => None,
+                    BlockComponent::EntryBatch(entries) => Some(entries),
                 })
                 .map_err(|e| {
                     if BlockComponent::infer_is_empty_entry_batch(&payload) {
@@ -5272,9 +5272,9 @@ impl Blockstore {
             let is_empty_entry_batch = BlockComponent::infer_is_empty_entry_batch(&payload);
 
             block_component_parser::parse(payload)
-                .map(|component| match component {
-                    ParsedBlockComponent::BlockMarker(_) => vec![],
-                    ParsedBlockComponent::EntryBatch(entries) => entries,
+                .filter_map(|component| match component {
+                    ParsedBlockComponent::BlockMarker(_) => None,
+                    ParsedBlockComponent::EntryBatch(entries) => Some(entries),
                 })
                 .map_err(|error| {
                     if is_empty_entry_batch {


### PR DESCRIPTION
#### Problem
Originally discussed in https://github.com/anza-xyz/agave/pull/14356#discussion_r3780599569

`get_slot_entries_in_block` and `get_slot_entry_views_in_block` gets all entries by iterating over them, and mapping to empty vecs to on block markers. This can be rewritten as a filter_map.

#### Summary of Changes
Use `.filter_map` instead of mapping into empty vecs on block markers.

#### Testing
Regression tests.

Fixes #14670
