### PR TITLE
accounts-db: Removes UpdateIndexThreadSelection param from store_accounts_for_shrink()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2316,11 +2316,8 @@ impl AccountsDb {
         // mutating rooted slots; There should be no writers to them.
         let accounts = [(slot, &shrink_collect.alive_accounts.alive_accounts()[..])];
         let storable_accounts = StorableAccountsBySlot::new(slot, &accounts, self);
-        stats_sub.store_accounts_stats = self.store_accounts_for_shrink(
-            storable_accounts,
-            shrink_in_progress.new_storage(),
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        );
+        stats_sub.store_accounts_stats =
+            self.store_accounts_for_shrink(storable_accounts, shrink_in_progress.new_storage());
 
         let tombstone_refs: Vec<_> = shrink_collect.tombstones_to_carry_forward.iter().collect();
         let tombstone_accounts = [(slot, &tombstone_refs[..])];
@@ -4407,8 +4404,6 @@ impl AccountsDb {
         &self,
         infos: &[AccountInfo],
         accounts: &impl StorableAccounts<'a>,
-        update_index_thread_selection: UpdateIndexThreadSelection,
-        thread_pool: &ThreadPool,
     ) {
         let target_slot = accounts.target_slot();
         let len = std::cmp::min(accounts.len(), infos.len());
@@ -4424,11 +4419,8 @@ impl AccountsDb {
         };
 
         let threshold = 1;
-        if matches!(
-            update_index_thread_selection,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        ) && len > threshold
-        {
+        if len > threshold {
+            let thread_pool = &self.thread_pool_background;
             let chunk_size = len.div_ceil(thread_pool.current_num_threads());
             let batches = 1 + len / chunk_size;
             thread_pool.install(|| {
@@ -4707,11 +4699,7 @@ impl AccountsDb {
             0
         };
 
-        let store_accounts_for_shrink_stats = self.store_accounts_for_shrink(
-            accounts,
-            storage,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-        );
+        let store_accounts_for_shrink_stats = self.store_accounts_for_shrink(accounts, storage);
         StoreAccountsForSquashStats {
             store_accounts_for_shrink_stats,
             flush_read_cache_us,
@@ -4727,7 +4715,6 @@ impl AccountsDb {
         &self,
         accounts: impl StorableAccounts<'a>,
         storage: &AccountStorageEntry,
-        update_index_thread_selection: UpdateIndexThreadSelection,
     ) -> StoreAccountsForShrinkStats {
         let slot = accounts.target_slot();
         let num_accounts_stored = accounts.len();
@@ -4738,12 +4725,7 @@ impl AccountsDb {
         let write_accounts_us = write_accounts_time.end_as_us();
 
         let update_index_time = Measure::start("update_index");
-        self.update_index_for_shrink(
-            &infos,
-            &accounts,
-            update_index_thread_selection,
-            &self.thread_pool_background,
-        );
+        self.update_index_for_shrink(&infos, &accounts);
         let update_index_us = update_index_time.end_as_us();
 
         StoreAccountsForShrinkStats {

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -13,7 +13,7 @@ use {
     solana_account::ReadableAccount,
     solana_accounts_db::{
         account_storage_entry::AccountStorageEntry,
-        accounts_db::{AccountsDb, GetUniqueAccountsResult, UpdateIndexThreadSelection},
+        accounts_db::{AccountsDb, GetUniqueAccountsResult},
         storable_accounts::StorableAccountsBySlot,
     },
     solana_clock::Slot,
@@ -324,11 +324,8 @@ impl<'a> SnapshotMinimizer<'a> {
             let storable_accounts =
                 StorableAccountsBySlot::new(slot, &accounts, self.accounts_db());
 
-            self.accounts_db().store_accounts_for_shrink(
-                storable_accounts,
-                new_storage,
-                UpdateIndexThreadSelection::Inline,
-            );
+            self.accounts_db()
+                .store_accounts_for_shrink(storable_accounts, new_storage);
 
             new_storage.flush().unwrap();
         }


### PR DESCRIPTION
#### Problem

`store_accounts_for_shrink()` is always called from `shrink`, which is always called in the background from AccountsBackgroundService. Its `update_index_thread_selection` param is always `PoolWithThreshold` (not counting snapshot minimizer). Since the param is a constant, no need to have it.


#### Summary of Changes

Remove the param.