### PR TITLE
accounts-db: Removes UpdateIndexThreadSelection from store_accounts_unfrozen()

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -4,7 +4,7 @@ use {
         account_storage::stored_account_info::StoredAccountInfo,
         accounts_db::{
             AccountsAddRootTiming, AccountsDb, LoadHint, LoadedAccount, PopulateReadCache,
-            ScanAccountStorageData, ScanStorageResult, UpdateIndexThreadSelection,
+            ScanAccountStorageData, ScanStorageResult,
         },
         accounts_index::IndexKey,
         accounts_scan::{ScanConfig, ScanError, ScanResult},
@@ -511,13 +511,7 @@ impl Accounts {
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         ancestors: &Ancestors,
     ) {
-        self._store_accounts(
-            accounts,
-            bank_id,
-            transactions,
-            UpdateIndexThreadSelection::Inline,
-            ancestors,
-        );
+        self._store_accounts(accounts, bank_id, transactions, ancestors);
     }
 
     /// Store `accounts` into the DB
@@ -531,13 +525,7 @@ impl Accounts {
         transactions: Option<&'a [&'a SanitizedTransaction]>,
         ancestors: &Ancestors,
     ) {
-        self._store_accounts(
-            accounts,
-            bank_id,
-            transactions,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-            ancestors,
-        );
+        self._store_accounts(accounts, bank_id, transactions, ancestors);
     }
 
     /// Store `accounts` into the DB
@@ -550,7 +538,6 @@ impl Accounts {
         accounts: impl StorableAccounts<'a>,
         bank_id: BankId,
         transactions: Option<&'a [&'a SanitizedTransaction]>,
-        update_index_thread_selection: UpdateIndexThreadSelection,
         ancestors: &Ancestors,
     ) {
         let accounts_db = &self.accounts_db;
@@ -576,7 +563,7 @@ impl Accounts {
             }
         }
 
-        accounts_db.store_accounts_unfrozen(accounts, update_index_thread_selection, ancestors);
+        accounts_db.store_accounts_unfrozen(accounts, ancestors);
     }
 
     /// Add a slot to root.  Root slots cannot be purged

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4229,46 +4229,20 @@ impl AccountsDb {
         &self,
         accounts: &impl StorableAccounts<'a>,
         store_account: &BitVec,
-        update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         if !self.account_indexes.is_empty() {
-            let len = accounts.len();
             assert_eq!(accounts.len() as u64, store_account.len());
-
-            // Cache writes do not upsert the accounts index; it only ever holds storage entries,
-            // populated on flush. Readers find cache-only accounts through the write cache. Only
-            // the secondary indexes are updated here.
-            let update = |start, end| {
-                (start..end).for_each(|i| {
-                    if store_account[i as u64] {
-                        accounts.account(i, |account| {
-                            self.accounts_index.update_secondary_indexes(
-                                account.pubkey(),
-                                &account,
-                                &self.account_indexes,
-                            );
-                        });
-                    }
-                });
-            };
-
-            let threshold = 1;
-            if matches!(
-                update_index_thread_selection,
-                UpdateIndexThreadSelection::PoolWithThreshold,
-            ) && len > threshold
-            {
-                let chunk_size = len.div_ceil(self.thread_pool_foreground.current_num_threads());
-                let batches = 1 + len / chunk_size;
-                self.thread_pool_foreground.install(|| {
-                    (0..batches).into_par_iter().for_each(|batch| {
-                        let start = batch * chunk_size;
-                        let end = std::cmp::min(start + chunk_size, len);
-                        update(start, end)
-                    })
-                });
-            } else {
-                update(0, len);
+            for i in 0..accounts.len() {
+                if store_account[i as u64] {
+                    let pubkey = accounts.pubkey(i);
+                    accounts.account(i, |account| {
+                        self.accounts_index.update_secondary_indexes(
+                            pubkey,
+                            &account,
+                            &self.account_indexes,
+                        );
+                    });
+                }
             }
         }
     }
@@ -4576,7 +4550,6 @@ impl AccountsDb {
     pub(crate) fn store_accounts_unfrozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        update_index_thread_selection: UpdateIndexThreadSelection,
         ancestors: &Ancestors,
     ) {
         // If all transactions in a batch are errored,
@@ -4594,11 +4567,7 @@ impl AccountsDb {
         // Update the secondary index
         if !self.account_indexes.is_empty() {
             let update_secondary_index_time = Measure::start("update_secondary_index");
-            self.update_secondary_index_cached_accounts(
-                &accounts,
-                &store_account,
-                update_index_thread_selection,
-            );
+            self.update_secondary_index_cached_accounts(&accounts, &store_account);
             let update_secondary_index_us = update_secondary_index_time.end_as_us();
             self.store_accounts_unfrozen_stats
                 .update_secondary_index_us
@@ -5765,13 +5734,6 @@ enum MarkAccountsObsolete {
     No,
 }
 
-pub enum UpdateIndexThreadSelection {
-    /// Use current thread only
-    Inline,
-    /// Use a thread-pool if the number of updates exceeds a threshold
-    PoolWithThreshold,
-}
-
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
 #[cfg(feature = "dev-context-only-utils")]
 impl AccountStorageEntry {
@@ -5901,18 +5863,10 @@ impl AccountsDb {
         }
 
         // Pre-populate new zero-lamport accounts with single-lamport placeholders.
-        self.store_accounts_unfrozen(
-            (slot, pre_populate_zero_lamport.as_slice()),
-            UpdateIndexThreadSelection::PoolWithThreshold,
-            &ancestors,
-        );
+        self.store_accounts_unfrozen((slot, pre_populate_zero_lamport.as_slice()), &ancestors);
 
         // Then store the actual accounts provided by the caller.
-        self.store_accounts_unfrozen(
-            accounts,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-            &ancestors,
-        );
+        self.store_accounts_unfrozen(accounts, &ancestors);
     }
 
     #[allow(clippy::needless_range_loop)]

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4231,46 +4231,20 @@ impl AccountsDb {
         &self,
         accounts: &impl StorableAccounts<'a>,
         store_account: &BitVec,
-        update_index_thread_selection: UpdateIndexThreadSelection,
     ) {
         if !self.account_indexes.is_empty() {
-            let len = accounts.len();
             assert_eq!(accounts.len() as u64, store_account.len());
-
-            // Cache writes do not upsert the accounts index; it only ever holds storage entries,
-            // populated on flush. Readers find cache-only accounts through the write cache. Only
-            // the secondary indexes are updated here.
-            let update = |start, end| {
-                (start..end).for_each(|i| {
-                    if store_account[i as u64] {
-                        accounts.account(i, |account| {
-                            self.accounts_index.update_secondary_indexes(
-                                account.pubkey(),
-                                &account,
-                                &self.account_indexes,
-                            );
-                        });
-                    }
-                });
-            };
-
-            let threshold = 1;
-            if matches!(
-                update_index_thread_selection,
-                UpdateIndexThreadSelection::PoolWithThreshold,
-            ) && len > threshold
-            {
-                let chunk_size = len.div_ceil(self.thread_pool_foreground.current_num_threads());
-                let batches = 1 + len / chunk_size;
-                self.thread_pool_foreground.install(|| {
-                    (0..batches).into_par_iter().for_each(|batch| {
-                        let start = batch * chunk_size;
-                        let end = std::cmp::min(start + chunk_size, len);
-                        update(start, end)
-                    })
-                });
-            } else {
-                update(0, len);
+            for i in 0..accounts.len() {
+                if store_account[i as u64] {
+                    let pubkey = accounts.pubkey(i);
+                    accounts.account(i, |account| {
+                        self.accounts_index.update_secondary_indexes(
+                            pubkey,
+                            &account,
+                            &self.account_indexes,
+                        );
+                    });
+                }
             }
         }
     }
@@ -4578,7 +4552,6 @@ impl AccountsDb {
     pub(crate) fn store_accounts_unfrozen<'a>(
         &self,
         accounts: impl StorableAccounts<'a>,
-        update_index_thread_selection: UpdateIndexThreadSelection,
         ancestors: &Ancestors,
     ) {
         // If all transactions in a batch are errored,
@@ -4596,11 +4569,7 @@ impl AccountsDb {
         // Update the secondary index
         if !self.account_indexes.is_empty() {
             let update_secondary_index_time = Measure::start("update_secondary_index");
-            self.update_secondary_index_cached_accounts(
-                &accounts,
-                &store_account,
-                update_index_thread_selection,
-            );
+            self.update_secondary_index_cached_accounts(&accounts, &store_account);
             let update_secondary_index_us = update_secondary_index_time.end_as_us();
             self.store_accounts_unfrozen_stats
                 .update_secondary_index_us
@@ -5761,13 +5730,6 @@ enum MarkAccountsObsolete {
     No,
 }
 
-pub enum UpdateIndexThreadSelection {
-    /// Use current thread only
-    Inline,
-    /// Use a thread-pool if the number of updates exceeds a threshold
-    PoolWithThreshold,
-}
-
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
 #[cfg(feature = "dev-context-only-utils")]
 impl AccountStorageEntry {
@@ -5897,18 +5859,10 @@ impl AccountsDb {
         }
 
         // Pre-populate new zero-lamport accounts with single-lamport placeholders.
-        self.store_accounts_unfrozen(
-            (slot, pre_populate_zero_lamport.as_slice()),
-            UpdateIndexThreadSelection::PoolWithThreshold,
-            &ancestors,
-        );
+        self.store_accounts_unfrozen((slot, pre_populate_zero_lamport.as_slice()), &ancestors);
 
         // Then store the actual accounts provided by the caller.
-        self.store_accounts_unfrozen(
-            accounts,
-            UpdateIndexThreadSelection::PoolWithThreshold,
-            &ancestors,
-        );
+        self.store_accounts_unfrozen(accounts, &ancestors);
     }
 
     #[allow(clippy::needless_range_loop)]

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -6362,11 +6362,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     // 1. Insert a single zero-lamport account and verify it is not added to the index or the
     //    write cache. Since this is the first write to this slot, the slot cache should not be
     //    created.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey1, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey1, &zero_account)].as_slice()), &ancestors);
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(accounts_db.accounts_cache.slot_cache(slot).is_none());
 
@@ -6383,7 +6379,6 @@ fn test_new_zero_lamport_accounts_skipped() {
             ]
             .as_slice(),
         ),
-        UpdateIndexThreadSelection::Inline,
         &ancestors,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
@@ -6416,11 +6411,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     // 3. Insert a zero-lamport update for pubkey2, which already has a non-zero entry in the
     //    write cache. The update is stored rather than skipped, overwriting the cache entry
     //    with zero lamports.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey2, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey2, &zero_account)].as_slice()), &ancestors);
     assert_eq!(
         accounts_db
             .accounts_cache
@@ -6442,20 +6433,12 @@ fn test_new_zero_lamport_accounts_skipped() {
     //    (pubkey1) and verify the pubkey is added to the write cache.
     let slot = slot + 1;
     ancestors.insert(slot);
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey1, &account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey1, &account)].as_slice()), &ancestors);
     assert!(accounts_db.accounts_cache.contains_pubkey(&pubkey1));
 
     // 6. Set pubkey3 to zero lamports and flush. The flush deletes zero-lamport accounts from the
     // index, so pubkey3 is no longer present afterwards.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey3, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey3, &zero_account)].as_slice()), &ancestors);
     accounts_db.add_root_and_flush_write_cache(slot);
 
     // Verify pubkey3 is no longer in the index
@@ -6513,27 +6496,15 @@ fn test_write_accounts_to_cache_scenarios(
         }
         InitialState::WithLamports(lamports) => {
             let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account)].as_slice()), &ancestors);
         }
         InitialState::WithoutLamports => {
             let account = AccountSharedData::new(1, 0, &Pubkey::default());
             let account_zero = AccountSharedData::new(0, 0, &Pubkey::default());
             // Store a non-zero account first to create the index entry
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account)].as_slice()), &ancestors);
             // Overwrite with a zero-lamport account to simulate ephemeral setup
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account_zero)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account_zero)].as_slice()), &ancestors);
         }
     }
 
@@ -6546,11 +6517,7 @@ fn test_write_accounts_to_cache_scenarios(
         .collect();
     let batch: Vec<_> = accounts.iter().map(|account| (&key, account)).collect();
 
-    db.store_accounts_unfrozen(
-        (slot, batch.as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    db.store_accounts_unfrozen((slot, batch.as_slice()), &ancestors);
 
     // Verify results
     let loaded = db.do_load_for_tests(&ancestors, &key);

--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -6255,11 +6255,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     // 1. Insert a single zero-lamport account and verify it is not added to the index or the
     //    write cache. Since this is the first write to this slot, the slot cache should not be
     //    created.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey1, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey1, &zero_account)].as_slice()), &ancestors);
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
     assert!(accounts_db.accounts_cache.slot_cache(slot).is_none());
 
@@ -6276,7 +6272,6 @@ fn test_new_zero_lamport_accounts_skipped() {
             ]
             .as_slice(),
         ),
-        UpdateIndexThreadSelection::Inline,
         &ancestors,
     );
     assert!(!accounts_db.accounts_index.contains(&pubkey1));
@@ -6309,11 +6304,7 @@ fn test_new_zero_lamport_accounts_skipped() {
     // 3. Insert a zero-lamport update for pubkey2, which already has a non-zero entry in the
     //    write cache. The update is stored rather than skipped, overwriting the cache entry
     //    with zero lamports.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey2, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey2, &zero_account)].as_slice()), &ancestors);
     assert_eq!(
         accounts_db
             .accounts_cache
@@ -6335,20 +6326,12 @@ fn test_new_zero_lamport_accounts_skipped() {
     //    (pubkey1) and verify the pubkey is added to the write cache.
     let slot = slot + 1;
     ancestors.insert(slot);
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey1, &account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey1, &account)].as_slice()), &ancestors);
     assert!(accounts_db.accounts_cache.contains_pubkey(&pubkey1));
 
     // 6. Set pubkey3 to zero lamports and flush. The flush deletes zero-lamport accounts from the
     // index, so pubkey3 is no longer present afterwards.
-    accounts_db.store_accounts_unfrozen(
-        (slot, [(&pubkey3, &zero_account)].as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    accounts_db.store_accounts_unfrozen((slot, [(&pubkey3, &zero_account)].as_slice()), &ancestors);
     accounts_db.add_root_and_flush_write_cache(slot);
 
     // Verify pubkey3 is no longer in the index
@@ -6406,27 +6389,15 @@ fn test_write_accounts_to_cache_scenarios(
         }
         InitialState::WithLamports(lamports) => {
             let account = AccountSharedData::new(lamports, 0, &Pubkey::default());
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account)].as_slice()), &ancestors);
         }
         InitialState::WithoutLamports => {
             let account = AccountSharedData::new(1, 0, &Pubkey::default());
             let account_zero = AccountSharedData::new(0, 0, &Pubkey::default());
             // Store a non-zero account first to create the index entry
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account)].as_slice()), &ancestors);
             // Overwrite with a zero-lamport account to simulate ephemeral setup
-            db.store_accounts_unfrozen(
-                (slot, [(&key, &account_zero)].as_slice()),
-                UpdateIndexThreadSelection::Inline,
-                &ancestors,
-            );
+            db.store_accounts_unfrozen((slot, [(&key, &account_zero)].as_slice()), &ancestors);
         }
     }
 
@@ -6439,11 +6410,7 @@ fn test_write_accounts_to_cache_scenarios(
         .collect();
     let batch: Vec<_> = accounts.iter().map(|account| (&key, account)).collect();
 
-    db.store_accounts_unfrozen(
-        (slot, batch.as_slice()),
-        UpdateIndexThreadSelection::Inline,
-        &ancestors,
-    );
+    db.store_accounts_unfrozen((slot, batch.as_slice()), &ancestors);
 
     // Verify results
     let loaded = db.do_load_for_tests(&ancestors, &key);


### PR DESCRIPTION
#### Problem

The `UpdateIndexThreadSelection` on `store_accounts_unfrozen()` is a misnomer.

`store_accounts_unfrozen()` stores accounts into the accounts write cache. This no longer populates the main AccountsIndex. As such, we no longer update the index at all.

However, this param is _also_ plumbed into `update_secondary_index_cached_accounts()`, which updates the *secondary* indexes. Since the original impetus for *not* using a thread pool was for updating the main accounts index (and when the disk index was used/the default) (see PR https://github.com/solana-labs/solana/pull/31455), which we are no longer doing, we can also remove the param here.


#### Summary of Changes

* Remove the param from the fns.
* Simplify `update_secondary_index_cached_accounts()`, since it no longer uses a thread pool.
* This was the last usage of UpdateIndexThreadSelection, so remove the whole enum.

Note, purposely do _not_ change the `store_accounts_seq/par` fn. That'll be in the next PR.


#### Testing

I ran my dev box with the `spl-token-mint` secondary index enabled (since there are lots of tokens getting minted all the time) and compared the following three scenarios:

1. master
2. this pr, where updating the secondary indexes _never_ uses a thread pool
3. this pr, but modified to _always_ update the secondary indexes in a thread pool

It was quite telling!

Here's the metrics of updating the secondary indexes during `store_accounts_unfrozen()`. There are three distinct sections. The left maps to scenario 1 (master), the middle maps to scenario 3 (always thread pool), and the right maps to scenario 2 (never thread pool).

Note that the y-axis is log-scale as well, since the middle was so bad.

<img width="3771" height="1613" alt="Screenshot 2026-08-18 at 5 48 45 PM" src="https://github.com/user-attachments/assets/40b5b2b3-6187-4f9d-9a85-539bb7e5d414" />

Master and never-thread-pool are equivalent, at ~5 milliseconds to update the secondary indexes. The always-thread-pool is _so much worse_ at ~300 milliseconds to update the secondary indexes.