### PR TITLE
perf: do tx sanitization before verification

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5553,16 +5553,14 @@ impl Bank {
                 return Err(TransactionError::SanitizeFailure);
             }
 
-            // SIMD-0160, check instruction limit before signature verification
-            let number_of_instructions: usize = tx.num_instructions().into();
-            if number_of_instructions > solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH {
-                return Err(TransactionError::SanitizeFailure);
-            }
+            let sanitized_tx = tx
+                .sanitize(&solana_runtime_transaction::sanitize_config::sanitize_config())
+                .map_err(|_| TransactionError::SanitizeFailure)?;
 
             if verification_mode == TransactionVerificationMode::FullVerification {
-                let message_data = tx.message_data();
-                let keys = tx.static_account_keys().iter();
-                let signatures = tx.signatures().iter();
+                let message_data = sanitized_tx.message_data();
+                let keys = sanitized_tx.static_account_keys().iter();
+                let signatures = sanitized_tx.signatures().iter();
 
                 for (key, signature) in keys.zip(signatures) {
                     let valid_signature = signature.verify(key.as_ref(), message_data);
@@ -5571,10 +5569,6 @@ impl Bank {
                     }
                 }
             };
-
-            let sanitized_tx = tx
-                .sanitize(&solana_runtime_transaction::sanitize_config::sanitize_config())
-                .map_err(|_| TransactionError::SanitizeFailure)?;
 
             let sanitized_tx = RuntimeTransaction::<SanitizedTransactionView<_>>::try_new(
                 sanitized_tx,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -145,6 +145,7 @@ use {
         Transaction, TransactionVerificationMode, sanitized::SanitizedTransaction,
         versioned::VersionedTransaction,
     },
+    solana_transaction_context::MAX_INSTRUCTION_TRACE_LENGTH,
     solana_transaction_error::{TransactionError, TransactionResult as Result},
     solana_vote::vote_account::{VoteAccount, VoteAccounts},
     solana_vote_interface::state::{BLS_PUBLIC_KEY_COMPRESSED_SIZE, TowerSync},
@@ -9799,7 +9800,7 @@ fn test_verify_transactions_instruction_limit() {
     let recent_blockhash = Hash::new_unique();
     let keypair = Keypair::new();
     let pubkey = keypair.pubkey();
-    let ix_count = 65;
+    let ix_count = MAX_INSTRUCTION_TRACE_LENGTH + 1;
     let ixs: Vec<_> = std::iter::repeat_with(|| CompiledInstruction {
         program_id_index: 1,
         accounts: vec![0],


### PR DESCRIPTION
#### Problem
transaction is being veirifed before being sanitized.  See #14626 for why this is a perf problem

#### Summary of Changes
- move sanitization of before verification.
- remove `simd-0160` check, as sanitization covers it.
- updated `test_verify_transactions_instruction_limit` regression test to use `MAX_INSTRUCTION_TRACE_LENGTH` const.

#### Testing
`test_verify_transactions_instruction_limit` regression test exists.

Fixes #14626
