### PR TITLE
feat(banking): make block production scheduling slot-specific

### DIFF
--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -3004,6 +3004,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
+            slot: bank.slot(),
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -3046,6 +3047,7 @@ mod tests {
             )]);
             consume_sender
                 .send(ConsumeWork {
+                    slot: bank.slot(),
                     batch_id: TransactionBatchId::new(i as u64),
                     ids: vec![i],
                     transactions,
@@ -3112,6 +3114,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
+            slot: bank.slot(),
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -3167,6 +3170,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid,
                 ids: vec![id1, id2],
                 transactions: txs,
@@ -3233,6 +3237,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid1,
                 ids: vec![id1],
                 transactions: txs1,
@@ -3242,6 +3247,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: bid2,
                 ids: vec![id2],
                 transactions: txs2,
@@ -3359,6 +3365,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
+                slot: bank.slot(),
                 batch_id: TransactionBatchId::new(1),
                 ids: vec![0, 1, 2, 3, 4, 5],
                 transactions: txs,

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -112,6 +112,9 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         let bank = leader_state
             .working_bank()
             .expect("active_leader_state should only return an active bank");
+        if bank.slot() != work.slot {
+            return Ok(ProcessingStatus::CouldNotProcess(work));
+        }
         self.metrics
             .count_metrics
             .num_messages_processed
@@ -3073,6 +3076,64 @@ mod tests {
         }
 
         // Cleanup.
+        drop(test_frame);
+        let _ = worker_thread.join().unwrap();
+    }
+
+    #[test]
+    fn test_worker_consume_wrong_slot() {
+        let (mut test_frame, worker) = setup_test_frame();
+        let metrics = worker.metrics_handle();
+        let TestFrame {
+            mint_keypair,
+            genesis_config,
+            bank,
+            shared_leader_state,
+            consume_sender,
+            consumed_receiver,
+            ..
+        } = &mut test_frame;
+        shared_leader_state.store(Arc::new(LeaderState::new(
+            Some(bank.clone()),
+            bank.tick_height(),
+            None,
+            None,
+        )));
+        let worker_thread = std::thread::spawn(move || worker.run());
+
+        let transactions = sanitize_transactions(vec![system_transaction::transfer(
+            mint_keypair,
+            &Pubkey::new_unique(),
+            1,
+            genesis_config.hash(),
+        )]);
+        consume_sender
+            .send(ConsumeWork {
+                slot: bank.slot() + 1,
+                batch_id: TransactionBatchId::new(0),
+                ids: vec![0],
+                transactions,
+                max_ages: vec![MaxAge {
+                    sanitized_epoch: bank.epoch(),
+                    alt_invalidation_slot: bank.slot(),
+                }],
+            })
+            .unwrap();
+
+        let consumed = consumed_receiver.recv().unwrap();
+        assert_eq!(consumed.work.slot, bank.slot() + 1);
+        assert_eq!(
+            consumed.retryable_indexes,
+            vec![RetryableIndex::new(0, true)]
+        );
+        assert_eq!(
+            metrics
+                .count_metrics
+                .num_messages_processed
+                .load(Ordering::Relaxed),
+            0
+        );
+
         drop(test_frame);
         let _ = worker_thread.join().unwrap();
     }

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -112,7 +112,7 @@ impl<Tx: TransactionWithMeta> ConsumeWorker<Tx> {
         let bank = leader_state
             .working_bank()
             .expect("active_leader_state should only return an active bank");
-        if bank.slot() != work.slot {
+        if bank.slot() != work.target_slot {
             return Ok(ProcessingStatus::CouldNotProcess(work));
         }
         self.metrics
@@ -3007,7 +3007,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
-            slot: bank.slot(),
+            target_slot: bank.slot(),
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -3050,7 +3050,7 @@ mod tests {
             )]);
             consume_sender
                 .send(ConsumeWork {
-                    slot: bank.slot(),
+                    target_slot: bank.slot(),
                     batch_id: TransactionBatchId::new(i as u64),
                     ids: vec![i],
                     transactions,
@@ -3109,7 +3109,7 @@ mod tests {
         )]);
         consume_sender
             .send(ConsumeWork {
-                slot: bank.slot() + 1,
+                target_slot: bank.slot() + 1,
                 batch_id: TransactionBatchId::new(0),
                 ids: vec![0],
                 transactions,
@@ -3121,7 +3121,7 @@ mod tests {
             .unwrap();
 
         let consumed = consumed_receiver.recv().unwrap();
-        assert_eq!(consumed.work.slot, bank.slot() + 1);
+        assert_eq!(consumed.work.target_slot, bank.slot() + 1);
         assert_eq!(
             consumed.retryable_indexes,
             vec![RetryableIndex::new(0, true)]
@@ -3175,7 +3175,7 @@ mod tests {
             alt_invalidation_slot: bank.slot(),
         };
         let work = ConsumeWork {
-            slot: bank.slot(),
+            target_slot: bank.slot(),
             batch_id: bid,
             ids: vec![id],
             transactions,
@@ -3231,7 +3231,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
-                slot: bank.slot(),
+                target_slot: bank.slot(),
                 batch_id: bid,
                 ids: vec![id1, id2],
                 transactions: txs,
@@ -3298,7 +3298,7 @@ mod tests {
         };
         consume_sender
             .send(ConsumeWork {
-                slot: bank.slot(),
+                target_slot: bank.slot(),
                 batch_id: bid1,
                 ids: vec![id1],
                 transactions: txs1,
@@ -3308,7 +3308,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
-                slot: bank.slot(),
+                target_slot: bank.slot(),
                 batch_id: bid2,
                 ids: vec![id2],
                 transactions: txs2,
@@ -3426,7 +3426,7 @@ mod tests {
 
         consume_sender
             .send(ConsumeWork {
-                slot: bank.slot(),
+                target_slot: bank.slot(),
                 batch_id: TransactionBatchId::new(1),
                 ids: vec![0, 1, 2, 3, 4, 5],
                 transactions: txs,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -39,7 +39,6 @@ impl MaxAge {
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork<Tx> {
-    #[allow(dead_code)] // Read by consume workers in the follow-up change.
     pub slot: Slot,
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -39,6 +39,8 @@ impl MaxAge {
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork<Tx> {
+    #[allow(dead_code)] // Read by consume workers in the follow-up change.
+    pub slot: Slot,
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,
     pub transactions: Vec<Tx>,

--- a/core/src/banking_stage/scheduler_messages.rs
+++ b/core/src/banking_stage/scheduler_messages.rs
@@ -39,7 +39,7 @@ impl MaxAge {
 /// Message: [Scheduler -> Worker]
 /// Transactions to be consumed (i.e. executed, recorded, and committed)
 pub struct ConsumeWork<Tx> {
-    pub slot: Slot,
+    pub target_slot: Slot,
     pub batch_id: TransactionBatchId,
     pub ids: Vec<TransactionId>,
     pub transactions: Vec<Tx>,

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -17,6 +17,7 @@ use {
         ThreadAwareAccountLocks, ThreadId, ThreadSet, TryLockError,
     },
     crossbeam_channel::{Receiver, Sender},
+    solana_clock::Slot,
     solana_cost_model::block_cost_limits::MAX_BLOCK_UNITS,
     solana_ledger::shred::get_data_shred_bytes_per_batch_typical,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
@@ -82,6 +83,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
     fn schedule<S: StateContainer<Tx>>(
         &mut self,
         container: &mut S,
+        slot: Slot,
         budget: u64,
     ) -> Result<SchedulingSummary, SchedulerError> {
         // Subtract any in-flight compute units from the budget.
@@ -179,7 +181,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                     if self.common.batches.entry_bytes()[thread_id] + transaction_bytes
                         > self.config.target_entry_bytes_per_batch
                     {
-                        num_sent += self.common.send_batches()?;
+                        num_sent += self.common.send_batches(slot)?;
                     }
 
                     num_scheduled += 1;
@@ -199,7 +201,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
                         || self.common.batches.entry_bytes()[thread_id]
                             >= self.config.target_entry_bytes_per_batch
                     {
-                        num_sent += self.common.send_batches()?;
+                        num_sent += self.common.send_batches(slot)?;
                     }
 
                     // if the thread is at target_cu_per_thread, remove it from the schedulable threads
@@ -218,7 +220,7 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
             }
         }
 
-        num_sent += self.common.send_batches()?;
+        num_sent += self.common.send_batches(slot)?;
         let Saturating(num_scheduled) = num_scheduled;
         assert_eq!(
             num_scheduled, num_sent,
@@ -310,6 +312,8 @@ mod test {
         solana_transaction::{Transaction, sanitized::SanitizedTransaction},
         std::borrow::Borrow,
     };
+
+    const TEST_SLOT: Slot = 42;
 
     #[allow(clippy::type_complexity)]
     fn create_test_frame(
@@ -411,6 +415,7 @@ mod test {
         assert_matches!(
             scheduler.schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             ),
             Err(SchedulerError::DisconnectedSendChannel(_))
@@ -429,6 +434,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -449,6 +455,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 0, // zero budget
             )
             .unwrap();
@@ -473,6 +480,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -498,6 +506,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -523,6 +532,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -549,7 +559,9 @@ mod test {
             (&Keypair::new(), &[Pubkey::new_unique()], 3, 3),
         ]);
 
-        let scheduling_summary = scheduler.schedule(&mut container, u64::MAX).unwrap();
+        let scheduling_summary = scheduler
+            .schedule(&mut container, TEST_SLOT, u64::MAX)
+            .unwrap();
         assert_eq!(scheduling_summary.num_scheduled, 3);
         assert_eq!(scheduling_summary.num_unschedulable_conflicts, 0);
         assert_eq!(
@@ -579,6 +591,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -597,6 +610,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -636,6 +650,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();
@@ -671,6 +686,7 @@ mod test {
         let scheduling_summary = scheduler
             .schedule(
                 &mut container,
+                TEST_SLOT,
                 u64::MAX, // no budget
             )
             .unwrap();

--- a/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/greedy_scheduler.rs
@@ -242,6 +242,10 @@ impl<Tx: TransactionWithMeta> Scheduler<Tx> for GreedyScheduler<Tx> {
     fn scheduling_common_mut(&mut self) -> &mut SchedulingCommon<Tx> {
         &mut self.common
     }
+
+    fn has_in_flight_transactions(&self) -> bool {
+        self.common.in_flight_tracker.has_in_flight_transactions()
+    }
 }
 
 fn try_schedule_transaction<Tx: TransactionWithMeta>(

--- a/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
+++ b/core/src/banking_stage/transaction_scheduler/in_flight_tracker.rs
@@ -38,6 +38,11 @@ impl InFlightTracker {
         &self.cus_in_flight_per_thread
     }
 
+    /// Returns true if any batches are still in flight.
+    pub fn has_in_flight_transactions(&self) -> bool {
+        !self.batches.is_empty()
+    }
+
     /// Tracks number of transactions and CUs in-flight for the `thread_id`.
     /// Returns a `TransactionBatchId` that can be used to stop tracking the batch
     /// when it is complete.
@@ -98,9 +103,11 @@ mod tests {
     #[test]
     fn test_in_flight_tracker() {
         let mut in_flight_tracker = InFlightTracker::new(2);
+        assert!(!in_flight_tracker.has_in_flight_transactions());
 
         // Add a batch with 2 transactions, 10 kCUs to thread 0.
         let batch_id_0 = in_flight_tracker.track_batch(2, 10_000, 0);
+        assert!(in_flight_tracker.has_in_flight_transactions());
         assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[2, 0]);
         assert_eq!(in_flight_tracker.cus_in_flight_per_thread(), &[10_000, 0]);
 
@@ -117,6 +124,7 @@ mod tests {
         assert_eq!(in_flight_tracker.cus_in_flight_per_thread(), &[0, 15_000]);
 
         in_flight_tracker.complete_batch(batch_id_1);
+        assert!(!in_flight_tracker.has_in_flight_transactions());
         assert_eq!(in_flight_tracker.num_in_flight_per_thread(), &[0, 0]);
         assert_eq!(in_flight_tracker.cus_in_flight_per_thread(), &[0, 0]);
     }

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -3,6 +3,7 @@ use {
         scheduler_common::SchedulingCommon, scheduler_error::SchedulerError,
         transaction_state_container::StateContainer,
     },
+    solana_clock::Slot,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
     std::num::Saturating,
 };
@@ -14,6 +15,7 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
     fn schedule<S: StateContainer<Tx>>(
         &mut self,
         container: &mut S,
+        slot: Slot,
         budget: u64,
     ) -> Result<SchedulingSummary, SchedulerError>;
 

--- a/core/src/banking_stage/transaction_scheduler/scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler.rs
@@ -19,6 +19,10 @@ pub(crate) trait Scheduler<Tx: TransactionWithMeta> {
         budget: u64,
     ) -> Result<SchedulingSummary, SchedulerError>;
 
+    /// Returns true if any scheduled transactions have not yet been returned
+    /// by the consume workers.
+    fn has_in_flight_transactions(&self) -> bool;
+
     /// Receive completed batches of transactions without blocking.
     /// Returns (num_transactions, num_retryable_transactions) on success.
     fn receive_completed(

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -14,6 +14,7 @@ use {
     },
     crossbeam_channel::{Receiver, Sender, TryRecvError},
     itertools::izip,
+    solana_clock::Slot,
     solana_runtime_transaction::transaction_with_meta::TransactionWithMeta,
 };
 
@@ -196,7 +197,7 @@ impl<Tx> SchedulingCommon<Tx> {
 
     /// Send a batch of transactions to the given thread's `ConsumeWork` channel.
     /// Returns the number of transactions sent.
-    pub fn send_batch(&mut self, thread_index: usize) -> Result<usize, SchedulerError> {
+    pub fn send_batch(&mut self, thread_index: usize, slot: Slot) -> Result<usize, SchedulerError> {
         if self.batches.ids[thread_index].is_empty() {
             return Ok(0);
         }
@@ -209,6 +210,7 @@ impl<Tx> SchedulingCommon<Tx> {
 
         let num_scheduled = ids.len();
         let work = ConsumeWork {
+            slot,
             batch_id,
             ids,
             transactions,
@@ -223,9 +225,9 @@ impl<Tx> SchedulingCommon<Tx> {
 
     /// Send all batches of transactions to the worker threads.
     /// Returns the number of transactions sent.
-    pub fn send_batches(&mut self) -> Result<usize, SchedulerError> {
+    pub fn send_batches(&mut self, slot: Slot) -> Result<usize, SchedulerError> {
         (0..self.consume_work_senders.len())
-            .map(|thread_index| self.send_batch(thread_index))
+            .map(|thread_index| self.send_batch(thread_index, slot))
             .sum()
     }
 }
@@ -241,6 +243,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
             Ok(FinishedConsumeWork {
                 work:
                     ConsumeWork {
+                        slot: _,
                         batch_id,
                         mut ids,
                         mut transactions,
@@ -338,6 +341,7 @@ mod tests {
 
     const NUM_WORKERS: usize = 4;
     const DUMMY_COST: u64 = 1;
+    const TEST_SLOT: Slot = 42;
 
     fn simple_transaction() -> RuntimeTransaction<SanitizedTransaction> {
         RuntimeTransaction::from_transaction_for_tests(system_transaction::transfer(
@@ -493,7 +497,7 @@ mod tests {
 
         pop_and_add_transaction(&mut container, &mut common, 0);
         assert!(common.batches.entry_bytes()[0] > ENTRY_OVERHEAD_BYTES);
-        let num_scheduled = common.send_batch(0).unwrap();
+        let num_scheduled = common.send_batch(0, TEST_SLOT).unwrap();
         assert_eq!(num_scheduled, 1);
         assert_eq!(common.batches.entry_bytes()[0], ENTRY_OVERHEAD_BYTES);
         assert_eq!(work_receivers[0].len(), 1);
@@ -506,17 +510,18 @@ mod tests {
             &[DUMMY_COST, 0, 0, 0]
         );
 
-        let num_scheduled = common.send_batch(1).unwrap();
+        let num_scheduled = common.send_batch(1, TEST_SLOT).unwrap();
         assert_eq!(num_scheduled, 0);
         assert_eq!(work_receivers[1].len(), 0); // not actually sent since no transactions.
 
-        work_receivers[0].recv().unwrap();
+        let work = work_receivers[0].recv().unwrap();
+        assert_eq!(work.slot, TEST_SLOT);
 
         // Multiple batches.
         pop_and_add_transaction(&mut container, &mut common, 0);
         pop_and_add_transaction(&mut container, &mut common, 2);
 
-        common.send_batches().unwrap();
+        common.send_batches(TEST_SLOT).unwrap();
         assert_eq!(work_receivers[0].len(), 1);
         assert_eq!(work_receivers[1].len(), 0);
         assert_eq!(work_receivers[2].len(), 1);
@@ -543,7 +548,7 @@ mod tests {
 
         // Send a batch. Return completed work.
         pop_and_add_transaction(&mut container, &mut common, 0);
-        let num_scheduled = common.send_batch(0).unwrap();
+        let num_scheduled = common.send_batch(0, TEST_SLOT).unwrap();
 
         let work = work_receivers[0].try_recv().unwrap();
         assert_eq!(work.ids.len(), num_scheduled);
@@ -565,7 +570,7 @@ mod tests {
         pop_and_add_transaction(&mut container, &mut common, 0);
         pop_and_add_transaction(&mut container, &mut common, 0);
         pop_and_add_transaction(&mut container, &mut common, 0);
-        let num_scheduled = common.send_batch(0).unwrap();
+        let num_scheduled = common.send_batch(0, TEST_SLOT).unwrap();
         let work = work_receivers[0].try_recv().unwrap();
         assert_eq!(work.ids.len(), num_scheduled);
         let retryable_indexes = vec![
@@ -599,7 +604,7 @@ mod tests {
         add_transactions_to_container(&mut container, 2);
         pop_and_add_transaction(&mut container, &mut common, 0);
         pop_and_add_transaction(&mut container, &mut common, 0);
-        let num_scheduled = common.send_batch(0).unwrap();
+        let num_scheduled = common.send_batch(0, TEST_SLOT).unwrap();
         let work = work_receivers[0].try_recv().unwrap();
         assert_eq!(work.ids.len(), num_scheduled);
         let retryable_indexes = vec![RetryableIndex::new(1, true), RetryableIndex::new(0, true)];

--- a/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_common.rs
@@ -210,7 +210,7 @@ impl<Tx> SchedulingCommon<Tx> {
 
         let num_scheduled = ids.len();
         let work = ConsumeWork {
-            slot,
+            target_slot: slot,
             batch_id,
             ids,
             transactions,
@@ -243,7 +243,7 @@ impl<Tx: TransactionWithMeta> SchedulingCommon<Tx> {
             Ok(FinishedConsumeWork {
                 work:
                     ConsumeWork {
-                        slot: _,
+                        target_slot: _,
                         batch_id,
                         mut ids,
                         mut transactions,
@@ -515,7 +515,7 @@ mod tests {
         assert_eq!(work_receivers[1].len(), 0); // not actually sent since no transactions.
 
         let work = work_receivers[0].recv().unwrap();
-        assert_eq!(work.slot, TEST_SLOT);
+        assert_eq!(work.target_slot, TEST_SLOT);
 
         // Multiple batches.
         pop_and_add_transaction(&mut container, &mut common, 0);

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -962,7 +962,7 @@ mod tests {
         finished_consume_work_sender
             .send(FinishedConsumeWork {
                 work: ConsumeWork {
-                    slot: 0,
+                    target_slot: 0,
                     batch_id: TransactionBatchId::new(0),
                     ids: vec![],
                     transactions: vec![],
@@ -1024,7 +1024,7 @@ mod tests {
 
         test_receive_then_schedule(&mut scheduler_controller);
         let consume_work = consume_work_receivers[0].try_recv().unwrap();
-        assert_eq!(consume_work.slot, bank.slot());
+        assert_eq!(consume_work.target_slot, bank.slot());
         assert_eq!(consume_work.ids.len(), 2);
         assert_eq!(consume_work.transactions.len(), 2);
         let message_hashes = consume_work

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -21,7 +21,7 @@ use {
         validator::SchedulerPacing,
     },
     agave_banking_stage_ingress_types::SchedulerPriorityFloor,
-    solana_clock::DEFAULT_MS_PER_SLOT,
+    solana_clock::{DEFAULT_MS_PER_SLOT, Slot},
     solana_cost_model::cost_tracker::SharedBlockCost,
     solana_measure::measure_us,
     solana_runtime::bank_forks::SharableBanks,
@@ -44,6 +44,28 @@ const CHECK_CHUNK: usize = 128;
 const SATURATION_BUFFER_PCT: u8 = 99;
 /// Clear the priority floor once the retained buffer drains below this watermark.
 const DESATURATION_BUFFER_PCT: u8 = 95;
+
+#[derive(Debug, PartialEq, Eq)]
+enum SchedulingSlotStatus {
+    Ready,
+    Transitioned,
+    WaitingForInFlight,
+}
+
+fn update_scheduling_slot(
+    scheduling_slot: &mut Option<Slot>,
+    decision_slot: Option<Slot>,
+    has_in_flight_transactions: bool,
+) -> SchedulingSlotStatus {
+    if *scheduling_slot == decision_slot {
+        SchedulingSlotStatus::Ready
+    } else if has_in_flight_transactions {
+        SchedulingSlotStatus::WaitingForInFlight
+    } else {
+        *scheduling_slot = decision_slot;
+        SchedulingSlotStatus::Transitioned
+    }
+}
 
 #[derive(Clone)]
 pub struct SchedulerConfig {
@@ -187,7 +209,7 @@ where
     }
 
     pub fn run(&mut self) -> Result<(), SchedulerError> {
-        let mut most_recent_leader_slot = None;
+        let mut scheduling_slot = None;
         let mut cost_pacer = None;
 
         while !self.exit.load(Ordering::Relaxed) {
@@ -213,9 +235,16 @@ where
             self.timing_metrics
                 .maybe_report_and_reset_slot(new_leader_slot);
 
-            if most_recent_leader_slot != new_leader_slot {
+            self.receive_completed()?;
+            let scheduling_slot_status = update_scheduling_slot(
+                &mut scheduling_slot,
+                new_leader_slot,
+                self.scheduler.has_in_flight_transactions(),
+            );
+            let scheduling_enabled =
+                scheduling_slot_status != SchedulingSlotStatus::WaitingForInFlight;
+            if scheduling_slot_status == SchedulingSlotStatus::Transitioned {
                 self.container.flush_held_transactions();
-                most_recent_leader_slot = new_leader_slot;
                 cost_pacer = decision.bank().map(|b| {
                     let cost_tracker = b.read_cost_tracker().unwrap();
                     let block_limit = cost_tracker.get_block_limit();
@@ -251,9 +280,15 @@ where
                 });
             }
 
-            self.receive_completed()?;
             let mut receiving_stats = self.drain_check_results(&decision);
-            let _scheduled = self.process_transactions(&decision, cost_pacer.as_ref(), &now)?;
+            // A slot transition gates only new scheduling. Check-result processing,
+            // ingestion, buffering, and maintenance below continue while old work returns.
+            let _scheduled =
+                if scheduling_enabled || !matches!(decision, BufferedPacketsDecision::Consume(_)) {
+                    self.process_transactions(&decision, cost_pacer.as_ref(), &now)?
+                } else {
+                    0
+                };
             if decision.bank().is_none() {
                 let (_, clean_time_us) = measure_us!(self.incremental_recheck());
                 self.timing_metrics.update(|timing_metrics| {
@@ -585,6 +620,34 @@ mod tests {
             sync::{Arc, RwLock},
         },
     };
+
+    #[test]
+    fn test_scheduling_slot_waits_for_in_flight_and_adopts_latest_slot() {
+        let mut scheduling_slot = Some(10);
+
+        assert_eq!(
+            update_scheduling_slot(&mut scheduling_slot, Some(11), true),
+            SchedulingSlotStatus::WaitingForInFlight
+        );
+        assert_eq!(scheduling_slot, Some(10));
+
+        // Ingestion may observe a newer slot while old work is still in flight.
+        assert_eq!(
+            update_scheduling_slot(&mut scheduling_slot, Some(12), true),
+            SchedulingSlotStatus::WaitingForInFlight
+        );
+        assert_eq!(scheduling_slot, Some(10));
+
+        assert_eq!(
+            update_scheduling_slot(&mut scheduling_slot, Some(12), false),
+            SchedulingSlotStatus::Transitioned
+        );
+        assert_eq!(scheduling_slot, Some(12));
+        assert_eq!(
+            update_scheduling_slot(&mut scheduling_slot, Some(12), true),
+            SchedulingSlotStatus::Ready
+        );
+    }
 
     fn create_channels<T>(num: usize) -> (Vec<Sender<T>>, Vec<Receiver<T>>) {
         (0..num).map(|_| bounded(1024)).unzip()

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -210,6 +210,7 @@ where
 
     pub fn run(&mut self) -> Result<(), SchedulerError> {
         let mut scheduling_slot = None;
+        let mut scheduling_blocked_at = None;
         let mut cost_pacer = None;
 
         while !self.exit.load(Ordering::Relaxed) {
@@ -243,6 +244,16 @@ where
             );
             let scheduling_enabled =
                 scheduling_slot_status != SchedulingSlotStatus::WaitingForInFlight;
+            let scheduling_blocked =
+                !scheduling_enabled && matches!(decision, BufferedPacketsDecision::Consume(_));
+            if scheduling_blocked {
+                scheduling_blocked_at.get_or_insert_with(Instant::now);
+            } else if let Some(blocked_at) = scheduling_blocked_at.take() {
+                self.timing_metrics.update(|timing_metrics| {
+                    timing_metrics.scheduling_slot_transition_blocked_time_us +=
+                        blocked_at.elapsed().as_micros() as u64;
+                });
+            }
             if scheduling_slot_status == SchedulingSlotStatus::Transitioned {
                 self.container.flush_held_transactions();
                 cost_pacer = decision.bank().map(|b| {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -300,14 +300,15 @@ where
         now: &Instant,
     ) -> Result<usize, SchedulerError> {
         let scheduled = match decision {
-            BufferedPacketsDecision::Consume(_bank) => {
+            BufferedPacketsDecision::Consume(bank) => {
                 let scheduling_budget = cost_pacer
                     .expect("cost pacer must be set for Consume")
                     .scheduling_budget(now);
-                let (scheduling_summary, schedule_time_us) = measure_us!(
-                    self.scheduler
-                        .schedule(&mut self.container, scheduling_budget,)?
-                );
+                let (scheduling_summary, schedule_time_us) = measure_us!(self.scheduler.schedule(
+                    &mut self.container,
+                    bank.slot(),
+                    scheduling_budget,
+                )?);
 
                 self.count_metrics.update(|count_metrics| {
                     count_metrics.num_scheduled += scheduling_summary.num_scheduled;
@@ -898,6 +899,7 @@ mod tests {
         finished_consume_work_sender
             .send(FinishedConsumeWork {
                 work: ConsumeWork {
+                    slot: 0,
                     batch_id: TransactionBatchId::new(0),
                     ids: vec![],
                     transactions: vec![],
@@ -959,6 +961,7 @@ mod tests {
 
         test_receive_then_schedule(&mut scheduler_controller);
         let consume_work = consume_work_receivers[0].try_recv().unwrap();
+        assert_eq!(consume_work.slot, bank.slot());
         assert_eq!(consume_work.ids.len(), 2);
         assert_eq!(consume_work.transactions.len(), 2);
         let message_hashes = consume_work

--- a/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_metrics.rs
@@ -318,6 +318,8 @@ pub struct SchedulerTimingMetricsInner {
     pub clean_time_us: Saturating<u64>,
     /// Time spent receiving completed transactions.
     pub receive_completed_time_us: Saturating<u64>,
+    /// Time scheduling was blocked on in-flight transactions during slot transitions.
+    pub scheduling_slot_transition_blocked_time_us: Saturating<u64>,
 }
 
 impl IntervalSchedulerTimingMetrics {
@@ -356,6 +358,8 @@ impl SchedulerTimingMetricsInner {
             clear_time_us: Saturating(clear_time_us),
             clean_time_us: Saturating(clean_time_us),
             receive_completed_time_us: Saturating(receive_completed_time_us),
+            scheduling_slot_transition_blocked_time_us:
+                Saturating(scheduling_slot_transition_blocked_time_us),
         } = self;
         let mut datapoint = create_datapoint!(
             @point name,
@@ -368,6 +372,11 @@ impl SchedulerTimingMetricsInner {
             (
                 "receive_completed_time_us",
                 receive_completed_time_us,
+                i64
+            ),
+            (
+                "scheduling_slot_transition_blocked_time_us",
+                scheduling_slot_transition_blocked_time_us,
                 i64
             )
         );
@@ -385,6 +394,7 @@ impl SchedulerTimingMetricsInner {
         self.clear_time_us = Saturating(0);
         self.clean_time_us = Saturating(0);
         self.receive_completed_time_us = Saturating(0);
+        self.scheduling_slot_transition_blocked_time_us = Saturating(0);
     }
 }
 


### PR DESCRIPTION
#### Problem
- want to add more advanced cost-tracking in the scheduler
- cannot because we currently allow slot-rolling
	- i.e. txs are not scheduled for a specific slot. if bank changes by the time work is picked up by worker, we can still process it.
	- slot-rolling was in the original implementation because we had issues elsewhere, which are gone now.

#### Summary of Changes
- Make block-production scheduling for a specific slot
- Do not begin scheduling while previous slot has outstanding work

#### Testing
- CI
- bench-tps
- this is how external scheduler works

Fixes #
