### PR TITLE
wip: logger channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,8 @@ dependencies = [
 name = "agave-logger"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "agave-logger",
+ "crossbeam-channel",
  "env_logger",
  "libc",
  "log",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1914,7 +1914,7 @@ impl Validator {
                 && logrotate_flag.load(Ordering::Relaxed)
             {
                 info!("Received SIGUSR1, reopening {}", logfile.display());
-                agave_logger::redirect_stderr(logfile);
+                agave_logger::reopen(logfile);
                 // Reset the flag to `false` to allow detection of the
                 // signal again and to avoid hitting this case every
                 // iteration

--- a/dev-bins/Cargo.lock
+++ b/dev-bins/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
 name = "agave-logger"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "crossbeam-channel",
  "env_logger",
  "libc",
  "log",

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -22,12 +22,16 @@ name = "agave_logger"
 agave-unstable-api = []
 
 [dependencies]
+crossbeam-channel = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
 
 [target."cfg(unix)".dependencies]
 libc = { workspace = true }
 signal-hook = { workspace = true }
+
+[dev-dependencies]
+agave-logger = { path = ".", features = ["agave-unstable-api"] }
 
 [lints]
 workspace = true

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -1,5 +1,10 @@
 #![cfg(feature = "agave-unstable-api")]
 //! The `logger` module configures `env_logger`
+//!
+//! Records are filtered and formatted on the calling thread, then written to the log by a
+//! background thread. See [`writer`] for why, and for the guarantees that buys.
+mod writer;
+
 use std::{
     path::{Path, PathBuf},
     sync::{Arc, LazyLock, RwLock},
@@ -21,7 +26,13 @@ impl log::Log for LoggerShim {
         LOGGER.read().unwrap().log(record);
     }
 
-    fn flush(&self) {}
+    /// Never weaken this back to a no-op. Records are written by a background thread, so this is
+    /// the only barrier callers have; without it every `process::exit` silently truncates the log
+    /// at whatever was still queued. No test catches its removal: the writer normally drains
+    /// faster than a test can reach its assertions, so a stubbed-out flush still looks green.
+    fn flush(&self) {
+        writer::flush();
+    }
 }
 
 fn replace_logger(logger: env_logger::Logger) {
@@ -37,6 +48,7 @@ pub fn setup_with(filter: &str) {
     let logger =
         env_logger::Builder::from_env(env_logger::Env::new().filter_or("_RUST_LOG", filter))
             .format_timestamp_nanos()
+            .target(writer::target())
             .build();
     replace_logger(logger);
 }
@@ -45,6 +57,7 @@ pub fn setup_with(filter: &str) {
 pub fn setup_with_default(filter: &str) {
     let logger = env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(filter))
         .format_timestamp_nanos()
+        .target(writer::target())
         .build();
     replace_logger(logger);
 }
@@ -59,25 +72,8 @@ pub fn setup() {
     setup_with_default("error");
 }
 
-// Configures file logging with a default filter if RUST_LOG is not set
-#[cfg(not(unix))]
-fn setup_file_with_default_filter(logfile: &Path) {
-    let file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(logfile)
-        .unwrap();
-
-    let logger =
-        env_logger::Builder::from_env(env_logger::Env::new().default_filter_or(DEFAULT_FILTER))
-            .format_timestamp_nanos()
-            .target(env_logger::Target::Pipe(Box::new(file)))
-            .build();
-    replace_logger(logger);
-}
-
 #[cfg(unix)]
-pub fn redirect_stderr(filename: &Path) {
+fn redirect_stderr(filename: &Path) {
     use std::{fs::OpenOptions, os::unix::io::AsRawFd};
     match OpenOptions::new().create(true).append(true).open(filename) {
         Ok(file) => unsafe {
@@ -88,18 +84,25 @@ pub fn redirect_stderr(filename: &Path) {
 }
 
 pub fn initialize_logging(logfile: Option<PathBuf>) {
+    setup_with_default_filter();
     let Some(logfile) = logfile else {
-        setup_with_default_filter();
         return;
     };
+    point_at_logfile(&logfile);
+}
 
+/// Reopens the log file, for logrotate.
+pub fn reopen(logfile: &Path) {
+    // Drain records queued for the old file before either handle moves off it.
+    writer::flush();
+    point_at_logfile(logfile);
+}
+
+fn point_at_logfile(logfile: &Path) {
+    // Point fd 2 at the log file too, so output from code that writes to stderr directly (C
+    // libraries, the runtime's own abort messages) is captured alongside log records. Both
+    // handles are opened `O_APPEND`, so their writes interleave without tearing.
     #[cfg(unix)]
-    {
-        setup_with_default_filter();
-        redirect_stderr(&logfile);
-    }
-    #[cfg(not(unix))]
-    {
-        setup_file_with_default_filter(&logfile);
-    }
+    redirect_stderr(logfile);
+    writer::reopen(logfile);
 }

--- a/logger/src/writer.rs
+++ b/logger/src/writer.rs
@@ -1,0 +1,190 @@
+//! Off-thread log writer.
+//!
+//! Records are filtered and formatted on the calling thread, then handed to a bounded channel
+//! that a single background thread drains in batches. Callers never issue the write syscall, so
+//! a slow or stalled log sink cannot block a thread that holds a lock, and a burst of records
+//! costs one `write` for the whole batch instead of one per record.
+//!
+//! The queue is bounded and drops records when full rather than blocking the caller. Dropping
+//! log lines is preferable to stalling consensus, and drops are reported in-band so a gap in the
+//! log is never silent.
+
+use {
+    crossbeam_channel::{Receiver, Sender, TrySendError, bounded},
+    std::{
+        fs::{File, OpenOptions},
+        io::{self, Write},
+        path::{Path, PathBuf},
+        sync::{
+            LazyLock,
+            atomic::{AtomicU64, Ordering},
+        },
+        thread,
+        time::Duration,
+    },
+};
+
+/// Queue depth, in records. At ~200 bytes per record this bounds queued log memory to a few MB.
+const QUEUE_DEPTH: usize = 16 * 1024;
+/// Records coalesced into a single `write` call.
+const BATCH_RECORDS: usize = 1024;
+/// Byte target for one batch, so a burst of large records does not balloon the batch buffer.
+const BATCH_BYTES: usize = 256 * 1024;
+/// Batch buffer capacity above which it is shrunk back down after writing.
+const MAX_BATCH_CAPACITY: usize = 4 * BATCH_BYTES;
+/// Cap on how long callers wait on the writer, so a wedged sink cannot hang a panicking thread.
+const WRITER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Records dropped because the queue was full, awaiting report by the writer thread.
+static DROPPED: AtomicU64 = AtomicU64::new(0);
+
+static WRITER: LazyLock<Sender<Cmd>> = LazyLock::new(|| {
+    let (sender, receiver) = bounded(QUEUE_DEPTH);
+    thread::Builder::new()
+        .name("solLogWriter".to_string())
+        .spawn(move || run(receiver, Sink::Stderr))
+        .expect("log writer thread must spawn");
+    sender
+});
+
+enum Cmd {
+    /// One fully formatted log record, newline included.
+    Record(Vec<u8>),
+    /// Write everything queued ahead of this, then start writing to `PathBuf` instead.
+    Reopen(PathBuf),
+    /// Write everything queued ahead of this, then signal the waiter.
+    Flush(Sender<()>),
+}
+
+/// `env_logger` target that hands formatted records to the writer thread.
+struct ChannelSink;
+
+impl Write for ChannelSink {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match WRITER.try_send(Cmd::Record(buf.to_vec())) {
+            Ok(()) => (),
+            Err(TrySendError::Full(_)) => {
+                DROPPED.fetch_add(1, Ordering::Relaxed);
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                // No writer thread left to drain the queue, so write inline rather than lose
+                // the record.
+                io::stderr().write_all(buf)?;
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // `env_logger` flushes after every record. Waiting for the writer thread here would put
+        // the caller back on the syscall path this indirection exists to avoid; the real barrier
+        // is `writer::flush`, reached through `log::Log::flush`.
+        Ok(())
+    }
+}
+
+/// The `env_logger` target that routes records through the writer thread.
+pub(crate) fn target() -> env_logger::Target {
+    env_logger::Target::Pipe(Box::new(ChannelSink))
+}
+
+/// Blocks until every record queued before this call has been written.
+///
+/// Required before `process::exit`, which runs no destructors: without it the records explaining
+/// a shutdown or a panic are still sitting in the queue.
+pub(crate) fn flush() {
+    // Capacity 1 so the writer's send never blocks, even if this call has already timed out.
+    let (done, wait) = bounded(1);
+    if WRITER
+        .send_timeout(Cmd::Flush(done), WRITER_TIMEOUT)
+        .is_err()
+    {
+        return;
+    }
+    let _ = wait.recv_timeout(WRITER_TIMEOUT);
+}
+
+/// Writes everything already queued to the current file, then switches to `logfile`.
+pub(crate) fn reopen(logfile: &Path) {
+    let _ = WRITER.send_timeout(Cmd::Reopen(logfile.to_path_buf()), WRITER_TIMEOUT);
+}
+
+enum Sink {
+    Stderr,
+    File(File),
+}
+
+impl Sink {
+    fn open(logfile: &Path) -> Self {
+        // Append mode so this handle and the `dup2`ed stderr can share the file: the kernel
+        // makes each `write` to an `O_APPEND` fd atomic, so batches from either never tear.
+        match OpenOptions::new().create(true).append(true).open(logfile) {
+            Ok(file) => Sink::File(file),
+            Err(err) => {
+                eprintln!("Unable to open {}: {err}", logfile.display());
+                Sink::Stderr
+            }
+        }
+    }
+
+    fn write_all(&mut self, buf: &[u8]) {
+        let result = match self {
+            Sink::Stderr => io::stderr().write_all(buf),
+            Sink::File(file) => file.write_all(buf),
+        };
+        // A failed log write has nowhere left to report itself: logging the failure would go
+        // back through this same sink.
+        let _ = result;
+    }
+}
+
+fn run(receiver: Receiver<Cmd>, mut sink: Sink) {
+    let mut batch = Vec::with_capacity(BATCH_BYTES);
+    // `recv` parks until there is work; everything already queued behind it joins the batch.
+    while let Ok(first) = receiver.recv() {
+        let mut next = Some(first);
+        let mut records = 0usize;
+        let mut barrier = None;
+
+        while let Some(cmd) = next.take() {
+            match cmd {
+                Cmd::Record(record) => {
+                    batch.extend_from_slice(&record);
+                    records = records.saturating_add(1);
+                }
+                // `Reopen` and `Flush` are ordering barriers: every record queued ahead of them
+                // has to reach the sink first, so stop batching and act once `batch` is written.
+                other => {
+                    barrier = Some(other);
+                    break;
+                }
+            }
+            if records < BATCH_RECORDS && batch.len() < BATCH_BYTES {
+                next = receiver.try_recv().ok();
+            }
+        }
+
+        let dropped = DROPPED.swap(0, Ordering::Relaxed);
+        if dropped > 0 {
+            let _ = writeln!(
+                batch,
+                "{dropped} log records dropped, log writer fell behind"
+            );
+        }
+        if !batch.is_empty() {
+            sink.write_all(&batch);
+        }
+        batch.clear();
+        if batch.capacity() > MAX_BATCH_CAPACITY {
+            batch.shrink_to(BATCH_BYTES);
+        }
+
+        match barrier {
+            Some(Cmd::Reopen(logfile)) => sink = Sink::open(&logfile),
+            Some(Cmd::Flush(done)) => {
+                let _ = done.send(());
+            }
+            Some(Cmd::Record(_)) | None => (),
+        }
+    }
+}

--- a/logger/tests/smoke.rs
+++ b/logger/tests/smoke.rs
@@ -1,0 +1,123 @@
+//! End-to-end check that records reach the log file.
+//!
+//! The logger is process-global and `initialize_logging` repoints stderr, so all phases share a
+//! single test rather than racing each other under the default parallel harness.
+//!
+//! Linux only: the log files are written to `/dev/shm` to keep the test off the disk.
+#![cfg(all(target_os = "linux", feature = "agave-unstable-api"))]
+
+use {
+    log::info,
+    std::{fs, path::PathBuf, process, thread},
+};
+
+const THREADS: usize = 8;
+const RECORDS_PER_THREAD: usize = 200;
+/// Records the doomed thread writes before it panics.
+const RECORDS_BEFORE_PANIC: usize = 100;
+const RECORDS_AFTER_PANIC: usize = 50;
+/// Thread that panics partway through logging.
+const DOOMED: usize = 0;
+
+/// Removes the scratch directory even when an assertion unwinds.
+struct ScratchDir(PathBuf);
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn count_matching(log: &str, needle: &str) -> usize {
+    log.lines().filter(|line| line.contains(needle)).count()
+}
+
+#[test]
+fn smoke_logging_survives_a_panicking_thread() {
+    let dir = PathBuf::from(format!("/dev/shm/agave-logger-smoke-{}", process::id()));
+    fs::create_dir_all(&dir).expect("scratch dir in /dev/shm must be creatable");
+    let scratch = ScratchDir(dir.clone());
+    let first = dir.join("first.log");
+    let second = dir.join("second.log");
+
+    agave_logger::initialize_logging(Some(first.clone()));
+    // `DEFAULT_FILTER` only covers the `solana` and `agave` targets, and this test binary is
+    // neither, so widen the filter to let its own records through.
+    agave_logger::setup_with("info");
+
+    let writers: Vec<_> = (0..THREADS)
+        .map(|thread_id| {
+            thread::spawn(move || {
+                for record in 0..RECORDS_PER_THREAD {
+                    if thread_id == DOOMED && record == RECORDS_BEFORE_PANIC {
+                        panic!("deliberate panic from the smoke test");
+                    }
+                    info!("smoke t{thread_id} r{record}");
+                }
+            })
+        })
+        .collect();
+    let panicked: Vec<_> = writers
+        .into_iter()
+        .enumerate()
+        .filter_map(|(thread_id, writer)| writer.join().is_err().then_some(thread_id))
+        .collect();
+    assert_eq!(
+        panicked,
+        vec![DOOMED],
+        "only the doomed thread should have panicked"
+    );
+
+    // A panicking thread must not take the writer thread with it, so records logged afterwards
+    // still have to reach the file.
+    for record in 0..RECORDS_AFTER_PANIC {
+        info!("after panic r{record}");
+    }
+    log::logger().flush();
+
+    let logged = fs::read_to_string(&first).expect("log file must be readable");
+    for thread_id in 0..THREADS {
+        let expected = if thread_id == DOOMED {
+            RECORDS_BEFORE_PANIC
+        } else {
+            RECORDS_PER_THREAD
+        };
+        assert_eq!(
+            count_matching(&logged, &format!("smoke t{thread_id} r")),
+            expected,
+            "thread {thread_id} lost records"
+        );
+    }
+    assert_eq!(
+        count_matching(&logged, "after panic r"),
+        RECORDS_AFTER_PANIC,
+        "logger stopped working after a thread panicked"
+    );
+
+    // Reopening is an ordering barrier: records queued before it belong to the old file, and
+    // everything after it to the new one.
+    let lines_before_rotation = logged.lines().count();
+    agave_logger::reopen(&second);
+    info!("after rotation");
+    log::logger().flush();
+
+    let rotated_out = fs::read_to_string(&first).expect("log file must be readable");
+    let rotated_in = fs::read_to_string(&second).expect("rotated log file must be readable");
+    assert_eq!(
+        rotated_out.lines().count(),
+        lines_before_rotation,
+        "rotation must not add to the old file"
+    );
+    assert_eq!(
+        count_matching(&rotated_in, "after rotation"),
+        1,
+        "post-rotation record missing from the new file"
+    );
+    assert_eq!(
+        count_matching(&rotated_in, "smoke t"),
+        0,
+        "pre-rotation records leaked into the new file"
+    );
+
+    drop(scratch);
+}

--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -534,8 +534,19 @@ pub fn set_panic_hook(program: &'static str, version: Option<String>) {
     SET_HOOK.call_once(|| {
         let default_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |ono| {
-            default_hook(ono);
+            // Route the panic through the log pipeline instead of straight to stderr, so it
+            // lands after the records that led up to it rather than racing them. Falls back to
+            // the default hook when no logger is installed, which would swallow it entirely.
+            if log_enabled!(Level::Error) {
+                error!("{ono}\n{}", std::backtrace::Backtrace::capture());
+            } else {
+                default_hook(ono);
+            }
             submit_panic_datapoint(program, &version, ono);
+            // Never remove this. Log records are written by a background thread and the `exit`
+            // below runs no destructors, so this is what keeps the records explaining the panic
+            // from being discarded with the queue. It is not covered by any test.
+            log::logger().flush();
 
             // Exit cleanly so the process don't limp along in a half-dead state
             std::process::exit(1);

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
 name = "agave-logger"
 version = "4.4.0-alpha.0"
 dependencies = [
+ "crossbeam-channel",
  "env_logger",
  "libc",
  "log",


### PR DESCRIPTION
#### Problem

We probably do not want to be doing syscalls for every line we log. Not sure this is the right shape of the solution. Do not review seriously yet.

- This is not intended to make logging a lot faster or to incentivize to log more, just to move the IO/syscall work off the threads that are busy doing useful work
- Idea from @kskalski: We could use thread-local storage to avoid allocations. Thread local could be used as a buffer with limited life-time, we write to a file with a delay and only once all threads reported their state from time T, we log any line from <T. Would be better than current solution but more complex.

#### Summary of Changes

- send logged stuff via MPSC channel
- add dedicated worker to write to logfile (using buffered writes)
- add flush hook to make sure log is synced to disk when we panic/exit.

#### Testing

None yet.