### PR TITLE
v4.3: Ignore h2 RUSTSEC-2026-258

### DIFF
--- a/ci/do-audit.sh
+++ b/ci/do-audit.sh
@@ -55,6 +55,16 @@ default_cargo_audit_extra_args=(
   # URL:       https://rustsec.org/advisories/RUSTSEC-2024-0376
   # Solution:  Upgrade to >=0.12.3
   --ignore RUSTSEC-2024-0376
+
+  # Crate:     h2
+  # Version:   0.4.13
+  # Title:     h2 unbounded empty DATA frames
+  # Date:      2026-08-17
+  # ID:        RUSTSEC-2026-0258
+  # URL:       https://rustsec.org/advisories/RUSTSEC-2026-0258
+  # Solution:  Upgrade to >=0.4.16
+  # Agave Ok:  Bigtable is the only use and is being considered a trusted peer
+  --ignore RUSTSEC-2026-0258
 )
 
 xtask_cargo_audit_extra_args=(


### PR DESCRIPTION
#### Problem
https://rustsec.org/advisories/RUSTSEC-2026-0258

#### Summary of Changes
We took the version bump on master, but ignore on this stabilization branch. Per the [GHSA](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h), 

> To determine if vulnerable, all these things must be true:
>
> - You are using HTTP/2, either as a server or a client.
> - Your application does not fully drain incoming request or response bodies (for example, a proxy applying backpressure, or a client that delays reading the body).
> - The direct remote peer is malicious and intentionally sends large numbers of empty DATA frames.

Our usage of this dependency pertains to Bigtable; we're considering this application a trusted peer. This issue has been around for a while and we haven't observed it so we have no reason to believe it will be a problem.

FWIW, Bigtable does comprise a pretty small fraction of uses cases

#### Testing
CI