### PR TITLE
accounts-db: Skips timing update_secondary_index_cached_accounts() if secondary indexes are not enabled

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4594,21 +4594,23 @@ impl AccountsDb {
         let write_accounts_us = write_accounts_time.end_as_us();
 
         // Update the secondary index
-        let update_secondary_index_time = Measure::start("update_secondary_index");
-        self.update_secondary_index_cached_accounts(
-            &accounts,
-            &store_account,
-            update_index_thread_selection,
-        );
-        let update_secondary_index_us = update_secondary_index_time.end_as_us();
+        if !self.account_indexes.is_empty() {
+            let update_secondary_index_time = Measure::start("update_secondary_index");
+            self.update_secondary_index_cached_accounts(
+                &accounts,
+                &store_account,
+                update_index_thread_selection,
+            );
+            let update_secondary_index_us = update_secondary_index_time.end_as_us();
+            self.store_accounts_unfrozen_stats
+                .update_secondary_index_us
+                .fetch_add(update_secondary_index_us, Ordering::Relaxed);
+        }
 
         let stats = &self.store_accounts_unfrozen_stats;
         stats
             .write_to_cache_us
             .fetch_add(write_accounts_us, Ordering::Relaxed);
-        stats
-            .update_secondary_index_us
-            .fetch_add(update_secondary_index_us, Ordering::Relaxed);
         stats
             .num_initial_accounts_to_store
             .fetch_add(write_stats.num_initial_accounts_to_store, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

When storing accounts in `store_accounts_unfrozen()`, we unconditionally measure how long it takes to update the secondary indexes, even if none are enabled. And then we also update its timing stat, which is an atomic update. This is unnecessary work.


#### Summary of Changes

Only measure how long it takes to update the secondary indexes if they are enabled.
