### PR TITLE
Shrink classifier on master

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -47,7 +47,7 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, IndexKey, ReclaimsSlotList,
-            ReclaimsWithNewestSlot, RefCount, ScanFilter, Startup, UpsertReclaim,
+            ReclaimsWithNewestSlot, ScanFilter, Startup, UpsertReclaim,
             in_mem_accounts_index::StartupStats,
         },
         accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult, ScanTracker},
@@ -142,26 +142,21 @@ pub(crate) struct AliveAccounts<'a> {
     pub(crate) bytes: usize,
 }
 
-/// separate pubkeys into those with a single refcount and those with > 1 refcount
+/// separate pubkeys into those with a single slot and those with > 1 slot
 #[derive(Debug)]
 pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
-    /// accounts where ref_count = 1
+    /// accounts where slot_list_len = 1
     pub(crate) one_ref: AliveAccounts<'a>,
-    /// account where ref_count > 1, but this slot contains the alive entry with the highest slot
+    /// account where slot_list_len > 1, but this slot contains the alive entry with the highest slot
     pub(crate) many_refs_this_is_newest_alive: AliveAccounts<'a>,
-    /// account where ref_count > 1, and this slot is NOT the highest alive entry in the index for the pubkey
+    /// account where slot_list_len > 1, and this slot is NOT the highest alive entry in the index for the pubkey
     pub(crate) many_refs_old_alive: AliveAccounts<'a>,
 }
 
 pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
-    fn add(
-        &mut self,
-        ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        slot_list: &[(Slot, AccountInfo)],
-    );
+    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]);
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
@@ -179,12 +174,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
             slot,
         }
     }
-    fn add(
-        &mut self,
-        _ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        _slot_list: &[(Slot, AccountInfo)],
-    ) {
+    fn add(&mut self, account: &'a AccountFromStorage, _slot_list: &[(Slot, AccountInfo)]) {
         self.accounts.push(account);
         self.bytes = self.bytes.saturating_add(account.stored_size());
     }
@@ -213,18 +203,12 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             many_refs_old_alive: AliveAccounts::with_capacity(0, slot),
         }
     }
-    fn add(
-        &mut self,
-        ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        slot_list: &[(Slot, AccountInfo)],
-    ) {
-        let other = if ref_count == 1 {
+    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]) {
+        let other = if slot_list.len() == 1 {
             &mut self.one_ref
-        } else if slot_list.len() == 1
-            || !slot_list
-                .iter()
-                .any(|(slot_list_slot, _info)| slot_list_slot > &self.many_refs_old_alive.slot)
+        } else if !slot_list
+            .iter()
+            .any(|(slot_list_slot, _info)| slot_list_slot > &self.many_refs_old_alive.slot)
         {
             // this entry is alive but is newer than any other slot in the index
             &mut self.many_refs_this_is_newest_alive
@@ -233,7 +217,7 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
             // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
             &mut self.many_refs_old_alive
         };
-        other.add(ref_count, account, slot_list);
+        other.add(account, slot_list);
     }
     fn len(&self) -> usize {
         self.one_ref
@@ -1952,7 +1936,7 @@ impl AccountsDb {
             accounts.iter().map(|account| account.pubkey()),
             |_pubkey, slots_refs| {
                 let stored_account = &accounts[index];
-                if let Some((slot_list, ref_count)) = slots_refs {
+                if let Some((slot_list, _)) = slots_refs {
                     index_scan_returned_some_count += 1;
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
                         // if the accounts index contains an entry at this slot, then the append vec we're asking about contains this item and thus, it is alive at this slot
@@ -1961,17 +1945,16 @@ impl AccountsDb {
 
                     // All obsolete and tombstones have been filtered. Account MUST be alive in this slot
                     assert!(is_alive);
-                    alive_accounts.add(ref_count, stored_account, slot_list);
+                    alive_accounts.add(stored_account, slot_list);
                 } else {
                     index_scan_returned_none_count += 1;
-                    // getting None here means the account is 'normal' and was written to disk. This means it must have ref_count=1 and
+                    // getting None here means the account is 'normal' and was written to disk. This means it must have
                     // slot_list.len() = 1. This means it must be alive in this slot. This is by far the most common case.
                     // Note that we could get Some(...) here if the account is in the in mem index because it is hot.
                     // Note this could also mean the account isn't on disk either. That would indicate a bug in accounts db.
                     // Account is alive.
-                    let ref_count = 1;
                     let slot_list = [(slot_to_shrink, AccountInfo::default())];
-                    alive_accounts.add(ref_count, stored_account, &slot_list);
+                    alive_accounts.add(stored_account, &slot_list);
                 }
                 index += 1;
             },

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -144,7 +144,7 @@ pub(crate) struct AliveAccounts<'a> {
 
 /// separate pubkeys into those with a single slot and those with > 1 slot
 #[derive(Debug)]
-pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
+pub(crate) struct AliveAccountsSeparatedBySlots<'a> {
     /// the account is in this slot only
     pub(crate) single: AliveAccounts<'a>,
     /// the account is in multiple slots, and this slot is the newest of them
@@ -189,7 +189,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     }
 }
 
-impl<'a> ShrinkCollector<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
+impl<'a> ShrinkCollector<'a> for AliveAccountsSeparatedBySlots<'a> {
     fn collect(&mut self, other: Self) {
         self.single.collect(other.single);
         self.multiple_newest.collect(other.multiple_newest);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -146,11 +146,11 @@ pub(crate) struct AliveAccounts<'a> {
 #[derive(Debug)]
 pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
     /// accounts where slot_list_len = 1
-    pub(crate) one_ref: AliveAccounts<'a>,
+    pub(crate) single: AliveAccounts<'a>,
     /// account where slot_list_len > 1, but this slot contains the alive entry with the highest slot
-    pub(crate) many_refs_this_is_newest_alive: AliveAccounts<'a>,
+    pub(crate) multiple_newest: AliveAccounts<'a>,
     /// account where slot_list_len > 1, and this slot is NOT the highest alive entry in the index for the pubkey
-    pub(crate) many_refs_old_alive: AliveAccounts<'a>,
+    pub(crate) multiple_not_newest: AliveAccounts<'a>,
 }
 
 pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
@@ -191,45 +191,44 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
 
 impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn collect(&mut self, other: Self) {
-        self.one_ref.collect(other.one_ref);
-        self.many_refs_this_is_newest_alive
-            .collect(other.many_refs_this_is_newest_alive);
-        self.many_refs_old_alive.collect(other.many_refs_old_alive);
+        self.single.collect(other.single);
+        self.multiple_newest.collect(other.multiple_newest);
+        self.multiple_not_newest.collect(other.multiple_not_newest);
     }
     fn with_capacity(capacity: usize, slot: Slot) -> Self {
         Self {
-            one_ref: AliveAccounts::with_capacity(capacity, slot),
-            many_refs_this_is_newest_alive: AliveAccounts::with_capacity(0, slot),
-            many_refs_old_alive: AliveAccounts::with_capacity(0, slot),
+            single: AliveAccounts::with_capacity(capacity, slot),
+            multiple_newest: AliveAccounts::with_capacity(0, slot),
+            multiple_not_newest: AliveAccounts::with_capacity(0, slot),
         }
     }
     fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]) {
         let other = if slot_list.len() == 1 {
-            &mut self.one_ref
+            &mut self.single
         } else if !slot_list
             .iter()
-            .any(|(slot_list_slot, _info)| slot_list_slot > &self.many_refs_old_alive.slot)
+            .any(|(slot_list_slot, _info)| slot_list_slot > &self.multiple_not_newest.slot)
         {
             // this entry is alive but is newer than any other slot in the index
-            &mut self.many_refs_this_is_newest_alive
+            &mut self.multiple_newest
         } else {
             // This entry is alive but is older than at least one other slot in the index.
             // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
-            &mut self.many_refs_old_alive
+            &mut self.multiple_not_newest
         };
         other.add(account, slot_list);
     }
     fn len(&self) -> usize {
-        self.one_ref
+        self.single
             .len()
-            .saturating_add(self.many_refs_old_alive.len())
-            .saturating_add(self.many_refs_this_is_newest_alive.len())
+            .saturating_add(self.multiple_not_newest.len())
+            .saturating_add(self.multiple_newest.len())
     }
     fn alive_bytes(&self) -> usize {
-        self.one_ref
+        self.single
             .alive_bytes()
-            .saturating_add(self.many_refs_old_alive.alive_bytes())
-            .saturating_add(self.many_refs_this_is_newest_alive.alive_bytes())
+            .saturating_add(self.multiple_not_newest.alive_bytes())
+            .saturating_add(self.multiple_newest.alive_bytes())
     }
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         unimplemented!("illegal use");

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -145,11 +145,11 @@ pub(crate) struct AliveAccounts<'a> {
 /// separate pubkeys into those with a single slot and those with > 1 slot
 #[derive(Debug)]
 pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
-    /// accounts where slot_list_len = 1
+    /// the account is in this slot only
     pub(crate) single: AliveAccounts<'a>,
-    /// account where slot_list_len > 1, but this slot contains the alive entry with the highest slot
+    /// the account is in multiple slots, and this slot is the newest of them
     pub(crate) multiple_newest: AliveAccounts<'a>,
-    /// account where slot_list_len > 1, and this slot is NOT the highest alive entry in the index for the pubkey
+    /// the account is in multiple slots, and a newer slot also holds it
     pub(crate) multiple_not_newest: AliveAccounts<'a>,
 }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -153,7 +153,7 @@ pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
     pub(crate) multiple_not_newest: AliveAccounts<'a>,
 }
 
-pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
+pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
     fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]);
@@ -162,7 +162,7 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
 }
 
-impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
+impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     fn collect(&mut self, mut other: Self) {
         self.bytes = self.bytes.saturating_add(other.bytes);
         self.accounts.append(&mut other.accounts);
@@ -189,7 +189,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     }
 }
 
-impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
+impl<'a> ShrinkCollector<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn collect(&mut self, other: Self) {
         self.single.collect(other.single);
         self.multiple_newest.collect(other.multiple_newest);
@@ -1919,7 +1919,7 @@ impl AccountsDb {
     /// load the account index entry for the first `count` items in `accounts`
     /// store a reference to all alive accounts in `alive_accounts`
     /// return sum of account size for all alive accounts
-    fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
+    fn load_accounts_index_for_shrink<'a, T: ShrinkCollector<'a>>(
         &self,
         accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
@@ -2022,7 +2022,7 @@ impl AccountsDb {
 
     /// shared code for shrinking normal slots and combining into ancient append vecs
     /// note 'unique_accounts' is passed by ref so we can return references to data within it, avoiding self-references
-    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
+    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollector<'b>>(
         &self,
         store: &'a AccountStorageEntry,
         unique_accounts: &'b mut GetUniqueAccountsResult,

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -313,9 +313,9 @@ pub struct ShrinkAncientStats {
     pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
     pub bytes_from_newest_storages: AtomicU64,
-    pub many_ref_slots_skipped: AtomicU64,
+    pub multiple_newest_slots_skipped: AtomicU64,
     pub slots_cannot_move_count: AtomicU64,
-    pub many_refs_old_alive: AtomicU64,
+    pub multiple_not_newest: AtomicU64,
     pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
@@ -753,8 +753,9 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "many_ref_slots_skipped",
-                self.many_ref_slots_skipped.swap(0, Ordering::Relaxed),
+                "multiple_newest_slots_skipped",
+                self.multiple_newest_slots_skipped
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -763,8 +764,8 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "many_refs_old_alive",
-                self.many_refs_old_alive.swap(0, Ordering::Relaxed),
+                "multiple_not_newest",
+                self.multiple_not_newest.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("slot", self.slot.load(Ordering::Relaxed), i64),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1121,7 +1121,7 @@ mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                AccountsDbConfig, ShrinkCollectRefs,
+                AccountsDbConfig, ShrinkCollector,
                 tests::{ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash},
             },
             accounts_index::{ReclaimsSlotList, UpsertReclaim},

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1701,8 +1701,8 @@ mod tests {
     }
 
     #[derive(EnumIter, Debug, PartialEq, Eq)]
-    enum TestWriteMultipleRefs {
-        MultipleRefs,
+    enum TestWriteMultipleNotNewest {
+        MultipleNotNewest,
         PackedStorages,
     }
 
@@ -1900,7 +1900,7 @@ mod tests {
             IncludeMultipleNewestSlots::Include,
         ] {
             for add_dead_account in [true, false] {
-                for method in TestWriteMultipleRefs::iter() {
+                for method in TestWriteMultipleNotNewest::iter() {
                     for num_slots in 0..3 {
                         for unsorted_slots in [false, true] {
                             for two_slots in [false, true] {
@@ -2077,7 +2077,7 @@ mod tests {
 
                                 // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
                                 let write_ancient_accounts = match method {
-                                    TestWriteMultipleRefs::MultipleRefs => {
+                                    TestWriteMultipleNotNewest::MultipleNotNewest => {
                                         let mut write_ancient_accounts =
                                             WriteAncientAccounts::default();
                                         db.write_ancient_accounts_to_same_slot_multiple_not_newest(
@@ -2086,7 +2086,7 @@ mod tests {
                                         );
                                         write_ancient_accounts
                                     }
-                                    TestWriteMultipleRefs::PackedStorages => {
+                                    TestWriteMultipleNotNewest::PackedStorages => {
                                         let packed_contents = Vec::default();
                                         db.write_packed_storages(
                                             &accounts_to_combine,
@@ -2111,7 +2111,7 @@ mod tests {
         // 1 in a single slot
         // 1 in 2 slots (and the other entry is from a newer slot)
         // So, the other alive entry will cause the account in 2 slots to be put into multiple_not_newest and then accounts_keep_slots
-        for method in TestWriteMultipleRefs::iter() {
+        for method in TestWriteMultipleNotNewest::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
             // creating 1 more sample slot/storage, but effectively act like 1 slot
@@ -2244,7 +2244,7 @@ mod tests {
 
             // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
             let write_ancient_accounts = match method {
-                TestWriteMultipleRefs::MultipleRefs => {
+                TestWriteMultipleNotNewest::MultipleNotNewest => {
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
                     db.write_ancient_accounts_to_same_slot_multiple_not_newest(
                         accounts_to_combine.accounts_keep_slots.values(),
@@ -2252,7 +2252,7 @@ mod tests {
                     );
                     write_ancient_accounts
                 }
-                TestWriteMultipleRefs::PackedStorages => {
+                TestWriteMultipleNotNewest::PackedStorages => {
                     let packed_contents = Vec::default();
                     db.write_packed_storages(&accounts_to_combine, packed_contents)
                 }
@@ -2312,7 +2312,7 @@ mod tests {
         // 1 with a single slot list entry
         // 1 with 2 slot list entries, where the other entry is from an older slot, so this one is the newer index entry
         // The result will be that the account, even though it is in multiple slots, can be moved to a newer slot.
-        for method in TestWriteMultipleRefs::iter() {
+        for method in TestWriteMultipleNotNewest::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
             let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
@@ -2423,7 +2423,7 @@ mod tests {
 
             // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
             let write_ancient_accounts = match method {
-                TestWriteMultipleRefs::MultipleRefs => {
+                TestWriteMultipleNotNewest::MultipleNotNewest => {
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
                     db.write_ancient_accounts_to_same_slot_multiple_not_newest(
                         accounts_to_combine.accounts_keep_slots.values(),
@@ -2431,7 +2431,7 @@ mod tests {
                     );
                     write_ancient_accounts
                 }
-                TestWriteMultipleRefs::PackedStorages => {
+                TestWriteMultipleNotNewest::PackedStorages => {
                     let packed_contents = Vec::default();
                     db.write_packed_storages(&accounts_to_combine, packed_contents)
                 }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -854,7 +854,7 @@ impl AccountsDb {
                     // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `multiple_newest` accounts, then keep trying.
                     // On the next pass, THIS slot will be older relative to newly ancient slot #s, so those newly ancient slots will be higher in this list.
                     self.shrink_ancient_stats
-                        .many_ref_slots_skipped
+                        .multiple_newest_slots_skipped
                         .fetch_add(1, Ordering::Relaxed);
                     // since we're skipping this one, we don't count it as required target storages
                     alive_bytes = alive_bytes.saturating_sub(shrink_collect.alive_total_bytes);
@@ -912,7 +912,7 @@ impl AccountsDb {
             .slots_cannot_move_count
             .fetch_add(accounts_keep_slots.len() as u64, Ordering::Relaxed);
         self.shrink_ancient_stats
-            .many_refs_old_alive
+            .multiple_not_newest
             .fetch_add(multiple_not_newest_count as u64, Ordering::Relaxed);
         AccountsToCombine {
             accounts_to_combine,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -383,16 +383,16 @@ impl AccountsDb {
         self.shrink_ancient_stats.report();
     }
 
-    /// return false if `many_refs_newest` accounts cannot be moved into `target_slots_sorted`.
+    /// return false if `multiple_newest` accounts cannot be moved into `target_slots_sorted`.
     /// The slot # would be violated.
-    /// accounts in `many_refs_newest` must be moved a slot >= each account's current slot.
+    /// accounts in `multiple_newest` must be moved a slot >= each account's current slot.
     /// If that can be done, this fn returns true
-    fn many_ref_accounts_can_be_moved(
-        many_refs_newest: &[AliveAccounts<'_>],
+    fn multiple_newest_can_be_moved(
+        multiple_newest: &[AliveAccounts<'_>],
         target_slots_sorted: &[Slot],
         tuning: &PackedAncientStorageTuning,
     ) -> bool {
-        let alive_bytes = many_refs_newest
+        let alive_bytes = multiple_newest
             .iter()
             .map(|alive| alive.bytes)
             .sum::<usize>();
@@ -409,9 +409,7 @@ impl AccountsDb {
             .saturating_sub(required_ideal_packed);
 
         let highest_slot = target_slots_sorted[i_last];
-        many_refs_newest
-            .iter()
-            .all(|many| many.slot <= highest_slot)
+        multiple_newest.iter().all(|many| many.slot <= highest_slot)
     }
 
     fn combine_ancient_slots_packed_internal(
@@ -452,23 +450,22 @@ impl AccountsDb {
         );
         metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
 
-        let mut many_refs_newest = accounts_to_combine
+        let mut multiple_newest = accounts_to_combine
             .accounts_to_combine
             .iter_mut()
             .filter_map(|alive| {
-                let newest_alive =
-                    std::mem::take(&mut alive.alive_accounts.many_refs_this_is_newest_alive);
+                let newest_alive = std::mem::take(&mut alive.alive_accounts.multiple_newest);
                 (!newest_alive.accounts.is_empty()).then_some(newest_alive)
             })
             .collect::<Vec<_>>();
 
         // Sort highest slot to lowest slot. This way, we will put the multi ref accounts with the highest slots in the highest
         // packed slot.
-        many_refs_newest.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
-        metrics.newest_alive_packed_count += many_refs_newest.len();
+        multiple_newest.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
+        metrics.newest_alive_packed_count += multiple_newest.len();
 
-        if !Self::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        if !Self::multiple_newest_can_be_moved(
+            &multiple_newest,
             &accounts_to_combine.target_slots_sorted,
             &tuning,
         ) {
@@ -476,7 +473,7 @@ impl AccountsDb {
             log::info!(
                 "unable to ancient pack: highest available slot: {:?}, lowest required slot: {:?}",
                 accounts_to_combine.target_slots_sorted.last(),
-                many_refs_newest.last().map(|accounts| accounts.slot)
+                multiple_newest.last().map(|accounts| accounts.slot)
             );
             return;
         }
@@ -494,11 +491,11 @@ impl AccountsDb {
         // pack the accounts with slot_list_len = 1 or slot_list_len > 1 but the slot we're packing is the highest alive slot for the pubkey.
         // Note the `chain` below combining them
         let pack = PackedAncientStorage::pack(
-            many_refs_newest.iter().chain(
+            multiple_newest.iter().chain(
                 accounts_to_combine
                     .accounts_to_combine
                     .iter()
-                    .map(|shrink_collect| &shrink_collect.alive_accounts.one_ref),
+                    .map(|shrink_collect| &shrink_collect.alive_accounts.single),
             ),
             tuning.ideal_storage_size,
         );
@@ -693,7 +690,7 @@ impl AccountsDb {
         let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
 
         // write new storages where contents were unable to move because slot_list_len > 1
-        self.write_ancient_accounts_to_same_slot_multiple_refs(
+        self.write_ancient_accounts_to_same_slot_multiple_not_newest(
             accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
@@ -785,7 +782,7 @@ impl AccountsDb {
         &self,
         accounts_per_storage: &'a mut [(&'a SlotInfo, GetUniqueAccountsResult)],
         tuning: &PackedAncientStorageTuning,
-        mut many_ref_slots: IncludeManyRefSlots,
+        mut include_multiple_newest_slots: IncludeManyRefSlots,
     ) -> AccountsToCombine<'a> {
         // reverse sort by slot #
         accounts_per_storage.sort_unstable_by_key(|b| cmp::Reverse(b.0.slot));
@@ -797,9 +794,9 @@ impl AccountsDb {
         // We are no longer doing eager unref in shrink_collect. Therefore, we will no longer need to iter them serially?
         // There is a subtle difference for zero lamport accounts, which can lead to having more multi-refs than before?
         // Consider account X in both slot x, and x+1 and x+2.
-        // With eager unref, we will only collect `one_ref`` X at slot x+2 after shrink.
+        // With eager unref, we will only collect `single`` X at slot x+2 after shrink.
         // Without eager unref, we will collect X at `multi-ref` after shrink.
-        // Packing multi-ref is less efficient than `one_ref``. But it might be ok - in next round of clean, hopefully, it can turn this from multi-ref into one-ref.
+        // Packing multi-ref is less efficient than `single``. But it might be ok - in next round of clean, hopefully, it can turn this from multi-ref into one-ref.
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
@@ -816,7 +813,7 @@ impl AccountsDb {
             .map(|a| a.alive_total_bytes)
             .sum::<usize>();
 
-        let mut many_refs_old_alive_count = 0;
+        let mut multiple_not_newest_count = 0;
 
         let mut remove = Vec::default();
         let mut last_slot = None;
@@ -832,16 +829,16 @@ impl AccountsDb {
             }
             last_slot = Some(shrink_collect.slot);
 
-            let many_refs_old_alive = &mut shrink_collect.alive_accounts.many_refs_old_alive;
-            if many_ref_slots == IncludeManyRefSlots::Skip
+            let multiple_not_newest = &mut shrink_collect.alive_accounts.multiple_not_newest;
+            if include_multiple_newest_slots == IncludeManyRefSlots::Skip
                 && !shrink_collect
                     .alive_accounts
-                    .many_refs_this_is_newest_alive
+                    .multiple_newest
                     .accounts
                     .is_empty()
             {
                 let mut required_packed_slots = min_resulting_packed_slots;
-                if many_refs_old_alive.accounts.is_empty() {
+                if multiple_not_newest.accounts.is_empty() {
                     // if THIS slot can be used as a target slot, then even if we have multi refs
                     // this is ok.
                     required_packed_slots = required_packed_slots.saturating_sub(1);
@@ -850,7 +847,7 @@ impl AccountsDb {
                 if (target_slots_sorted.len() as u64) >= required_packed_slots {
                     // we have prepared to pack enough normal target slots, that form now on we can safely pack
                     // any 'many ref' slots.
-                    many_ref_slots = IncludeManyRefSlots::Include;
+                    include_multiple_newest_slots = IncludeManyRefSlots::Include;
                 } else {
                     // Skip this because too few valid slots have been processed so far.
                     // There are 'many ref newest' accounts in this slot. They must be packed into slots that are >= the current slot value.
@@ -866,17 +863,17 @@ impl AccountsDb {
                 }
             }
 
-            if !many_refs_old_alive.accounts.is_empty() {
-                many_refs_old_alive_count += many_refs_old_alive.accounts.len();
-                many_refs_old_alive.accounts.iter().for_each(|account| {
+            if !multiple_not_newest.accounts.is_empty() {
+                multiple_not_newest_count += multiple_not_newest.accounts.len();
+                multiple_not_newest.accounts.iter().for_each(|account| {
                     // these accounts could indicate clean bugs or low memory conditions where we are forced to flush non-roots
                     log::info!(
                         "ancient append vec: found unpackable account: {}, {}",
-                        many_refs_old_alive.slot,
+                        multiple_not_newest.slot,
                         account.pubkey()
                     );
                 });
-                // There are alive accounts with slot_list_len > 1, where the entry for the account in the index is NOT the highest slot. (`many_refs_old_alive`)
+                // There are alive accounts with slot_list_len > 1, where the entry for the account in the index is NOT the highest slot. (`multiple_not_newest`)
                 // This means this account must remain IN this slot. There could be alive or dead references to this same account in any older slot.
                 // Moving it to a lower slot could move it before an alive or dead entry to this same account.
                 // Moving it to a higher slot could move it ahead of other slots where this account is also alive. We know a higher slot exists that contains this account.
@@ -884,10 +881,10 @@ impl AccountsDb {
                 // This would fail the invariant that the highest slot # where an account exists defines the most recent account.
                 // It could be a clean error or a transient condition that will resolve if we encounter this situation.
                 // The count of these accounts per call will be reported by metrics in `unpackable_slots_count`
-                if shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                if shrink_collect.alive_accounts.single.accounts.is_empty()
                     && shrink_collect
                         .alive_accounts
-                        .many_refs_this_is_newest_alive
+                        .multiple_newest
                         .accounts
                         .is_empty()
                 {
@@ -896,7 +893,7 @@ impl AccountsDb {
                     continue;
                 }
                 accounts_keep_slots
-                    .insert(shrink_collect.slot, std::mem::take(many_refs_old_alive));
+                    .insert(shrink_collect.slot, std::mem::take(multiple_not_newest));
             } else {
                 // No alive accounts in this slot have a slot_list_len > 1. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
@@ -916,7 +913,7 @@ impl AccountsDb {
             .fetch_add(accounts_keep_slots.len() as u64, Ordering::Relaxed);
         self.shrink_ancient_stats
             .many_refs_old_alive
-            .fetch_add(many_refs_old_alive_count as u64, Ordering::Relaxed);
+            .fetch_add(multiple_not_newest_count as u64, Ordering::Relaxed);
         AccountsToCombine {
             accounts_to_combine,
             accounts_keep_slots,
@@ -955,7 +952,7 @@ impl AccountsDb {
     /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
     /// Other accounts would have slot_list_len = 1.
     /// slot_list_len = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
-    fn write_ancient_accounts_to_same_slot_multiple_refs<'a, 'b: 'a>(
+    fn write_ancient_accounts_to_same_slot_multiple_not_newest<'a, 'b: 'a>(
         &'b self,
         accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
         write_ancient_accounts: &mut WriteAncientAccounts<'b>,
@@ -1226,7 +1223,7 @@ mod tests {
     /// Give every account backing `storages` a second index entry at slot 0. Sample-storage
     /// slots start at 1, so slot 0 is older than all of them: each account ends up with
     /// slot_list.len() == 2 while its storage slot stays newest
-    fn add_older_ref(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
+    fn add_older_slot(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
         storages.iter().for_each(|storage| {
             db.get_unique_accounts_from_storage(storage)
                 .stored_accounts
@@ -1405,13 +1402,13 @@ mod tests {
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_write_ancient_accounts_to_same_slot_multiple_refs_empty(
+    fn test_write_ancient_accounts_to_same_slot_multiple_not_newest_empty(
         accounts_db_config: AccountsDbConfig,
     ) {
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
         let (_storages, _slots, _infos) = get_sample_storages(&db, 0, None);
         let mut write_ancient_accounts = WriteAncientAccounts::default();
-        db.write_ancient_accounts_to_same_slot_multiple_refs(
+        db.write_ancient_accounts_to_same_slot_multiple_not_newest(
             AccountsToCombine::default().accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
@@ -1786,7 +1783,7 @@ mod tests {
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_many_refs(accounts_db_config: AccountsDbConfig) {
+    fn test_calc_accounts_to_combine_multiple(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
         // all accounts have 1 ref or all accounts have 2 refs
@@ -1798,10 +1795,12 @@ mod tests {
             ideal_storage_size: NonZeroU64::new(alive_bytes_per_slot * 2 + 1).unwrap(),
             ..default_tuning()
         };
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
+        for include_multiple_newest_slots in
+            [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include]
+        {
             for num_slots in 0..6 {
                 for unsorted_slots in [false, true] {
-                    for two_refs in [false, true] {
+                    for two_slots in [false, true] {
                         let db = AccountsDb::new_for_tests_with_config(
                             Vec::new(),
                             accounts_db_config.clone(),
@@ -1818,8 +1817,8 @@ mod tests {
                             infos = infos.into_iter().rev().collect();
                         }
 
-                        if two_refs {
-                            add_older_ref(&db, &storages);
+                        if two_slots {
+                            add_older_slot(&db, &storages);
                         }
 
                         let original_results = storages
@@ -1833,17 +1832,17 @@ mod tests {
                         let accounts_to_combine = db.calc_accounts_to_combine(
                             &mut accounts_per_storage,
                             &tuning,
-                            many_ref_slots,
+                            include_multiple_newest_slots,
                         );
                         let expected_accounts_to_combine = if num_slots >= 3
-                            && two_refs
-                            && many_ref_slots == IncludeManyRefSlots::Skip
+                            && two_slots
+                            && include_multiple_newest_slots == IncludeManyRefSlots::Skip
                         {
                             // In this test setup, 2.5 regular slots fits into 1 ancient slot.
-                            // When there are two_refs and when slots < 3, all regular slots can fit into one ancient slots.
+                            // When there are two_slots and when slots < 3, all regular slots can fit into one ancient slots.
                             // Therefore, we should have all slots that can be combined for slots < 3.
                             // However, when slots >=3, we need more than one ancient slots. The pack algorithm will need to first
-                            // find at least [ceiling(num_slots/2.5) - 1] slots that's don't have many_refs before we can pack slots with many_refs.
+                            // find at least [ceiling(num_slots/2.5) - 1] slots that's don't have multiple before we can pack slots with multiple.
                             // Since we decrease the number of alive bytes we'll be writing, when we encounter slots that can't be packed,
                             // we now reduce the number required ideal packed storages. As a result, the last
                             // slot can be packed, and the number of accounts to combine should be 2.
@@ -1861,9 +1860,9 @@ mod tests {
                             });
 
                         log::debug!(
-                            "output slots: {:?}, num_slots: {num_slots}, two_refs: {two_refs}, \
-                             many_refs: {many_ref_slots:?}, expected accounts to combine: \
-                             {expected_accounts_to_combine}, target slots: {:?}, \
+                            "output slots: {:?}, num_slots: {num_slots}, two_slots: {two_slots}, \
+                             multiple: {include_multiple_newest_slots:?}, expected accounts to \
+                             combine: {expected_accounts_to_combine}, target slots: {:?}, \
                              accounts_to_combine: {}",
                             accounts_to_combine.target_slots_sorted,
                             accounts_to_combine.target_slots_sorted,
@@ -1872,8 +1871,8 @@ mod tests {
                         assert_eq!(
                             accounts_to_combine.accounts_to_combine.len(),
                             expected_accounts_to_combine,
-                            "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
-                             {many_ref_slots:?}"
+                            "num_slots: {num_slots}, two_slots: {two_slots}, multiple: \
+                             {include_multiple_newest_slots:?}"
                         );
                     }
                 }
@@ -1895,12 +1894,14 @@ mod tests {
             ..default_tuning()
         };
 
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
+        for include_multiple_newest_slots in
+            [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include]
+        {
             for add_dead_account in [true, false] {
                 for method in TestWriteMultipleRefs::iter() {
                     for num_slots in 0..3 {
                         for unsorted_slots in [false, true] {
-                            for two_refs in [false, true] {
+                            for two_slots in [false, true] {
                                 let db = AccountsDb::new_for_tests_with_config(
                                     Vec::new(),
                                     accounts_db_config.clone(),
@@ -1920,8 +1921,8 @@ mod tests {
                                     slots_vec = slots.collect::<Vec<_>>()
                                 }
 
-                                if two_refs {
-                                    add_older_ref(&db, &storages);
+                                if two_slots {
+                                    add_older_slot(&db, &storages);
                                 }
 
                                 if add_dead_account {
@@ -1973,21 +1974,22 @@ mod tests {
                                 let accounts_to_combine = db.calc_accounts_to_combine(
                                     &mut accounts_per_storage,
                                     &tuning,
-                                    many_ref_slots,
+                                    include_multiple_newest_slots,
                                 );
                                 // if we are only trying to pack a single slot of multi-refs, it will succeed
                                 // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
                                 // one element (storage), because we don't count alive bytes of skipped accounts
                                 // when we compute required target storages, and the second slot can be combined.
-                                let expected_number_accounts_to_combine = if !two_refs
-                                    || many_ref_slots == IncludeManyRefSlots::Include
+                                let expected_number_accounts_to_combine = if !two_slots
+                                    || include_multiple_newest_slots == IncludeManyRefSlots::Include
                                     || num_slots == 1
                                     || (num_slots == 2
-                                        && many_ref_slots != IncludeManyRefSlots::Skip)
+                                        && include_multiple_newest_slots
+                                            != IncludeManyRefSlots::Skip)
                                 {
                                     num_slots
                                 } else if num_slots == 2
-                                    && many_ref_slots == IncludeManyRefSlots::Skip
+                                    && include_multiple_newest_slots == IncludeManyRefSlots::Skip
                                 {
                                     1
                                 } else {
@@ -1996,12 +1998,12 @@ mod tests {
                                 assert_eq!(
                                     accounts_to_combine.accounts_to_combine.len(),
                                     expected_number_accounts_to_combine,
-                                    "method: {method:?}, num_slots: {num_slots}, two_refs: \
-                                     {two_refs}, many_refs: {many_ref_slots:?}"
+                                    "method: {method:?}, num_slots: {num_slots}, two_slots: \
+                                     {two_slots}, multiple: {include_multiple_newest_slots:?}"
                                 );
 
-                                let expected_target_slots_sorted = if !two_refs
-                                    || many_ref_slots == IncludeManyRefSlots::Include
+                                let expected_target_slots_sorted = if !two_slots
+                                    || include_multiple_newest_slots == IncludeManyRefSlots::Include
                                     || num_slots == 1
                                 {
                                     if unsorted_slots {
@@ -2010,13 +2012,13 @@ mod tests {
                                         slots_vec.clone()
                                     }
                                 } else if num_slots == 2
-                                    && many_ref_slots == IncludeManyRefSlots::Skip
+                                    && include_multiple_newest_slots == IncludeManyRefSlots::Skip
                                 {
                                     vec![1]
                                 } else {
                                     vec![]
                                 };
-                                // all accounts should be in one_ref and all slots are available as target slots
+                                // all accounts should be in single and all slots are available as target slots
                                 assert_eq!(
                                     accounts_to_combine.target_slots_sorted,
                                     expected_target_slots_sorted,
@@ -2026,26 +2028,22 @@ mod tests {
                                     |shrink_collect| {
                                         shrink_collect
                                             .alive_accounts
-                                            .many_refs_old_alive
+                                            .multiple_not_newest
                                             .accounts
                                             .is_empty()
                                     }
                                 ));
-                                if two_refs {
+                                if two_slots {
                                     assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                         |shrink_collect| {
-                                            shrink_collect
-                                                .alive_accounts
-                                                .one_ref
-                                                .accounts
-                                                .is_empty()
+                                            shrink_collect.alive_accounts.single.accounts.is_empty()
                                         }
                                     ));
                                     assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                         |shrink_collect| {
                                             !shrink_collect
                                                 .alive_accounts
-                                                .many_refs_this_is_newest_alive
+                                                .multiple_newest
                                                 .accounts
                                                 .is_empty()
                                         }
@@ -2055,7 +2053,7 @@ mod tests {
                                         |shrink_collect| {
                                             !shrink_collect
                                                 .alive_accounts
-                                                .one_ref
+                                                .single
                                                 .accounts
                                                 .is_empty()
                                         }
@@ -2064,19 +2062,19 @@ mod tests {
                                         |shrink_collect| {
                                             shrink_collect
                                                 .alive_accounts
-                                                .many_refs_this_is_newest_alive
+                                                .multiple_newest
                                                 .accounts
                                                 .is_empty()
                                         }
                                     ));
                                 }
 
-                                // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
+                                // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
                                 let write_ancient_accounts = match method {
                                     TestWriteMultipleRefs::MultipleRefs => {
                                         let mut write_ancient_accounts =
                                             WriteAncientAccounts::default();
-                                        db.write_ancient_accounts_to_same_slot_multiple_refs(
+                                        db.write_ancient_accounts_to_same_slot_multiple_not_newest(
                                             accounts_to_combine.accounts_keep_slots.values(),
                                             &mut write_ancient_accounts,
                                         );
@@ -2106,7 +2104,7 @@ mod tests {
         // with 2 accounts
         // 1 with 1 ref
         // 1 with 2 refs (and the other ref is from a newer slot)
-        // So, the other alive ref will cause the account with 2 refs to be put into many_refs_old_alive and then accounts_keep_slots
+        // So, the other alive ref will cause the account with 2 refs to be put into multiple_not_newest and then accounts_keep_slots
         for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
@@ -2119,35 +2117,35 @@ mod tests {
                 .iter()
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
-            let pk_with_1_ref = solana_pubkey::new_rand();
+            let pk_with_1_slot = solana_pubkey::new_rand();
             let slot1 = slots.start;
-            let account_with_2_refs = original_results
+            let account_with_2_slots = original_results
                 .first()
                 .unwrap()
                 .stored_accounts
                 .first()
                 .unwrap();
-            let account_shared_data_with_2_refs =
-                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-            let pk_with_2_refs = account_with_2_refs.pubkey();
-            let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-            account_with_1_ref.checked_add_lamports(1).unwrap();
+            let account_shared_data_with_2_slots =
+                get_account_from_account_from_storage(account_with_2_slots, &db, slot1);
+            let pk_with_2_slots = account_with_2_slots.pubkey();
+            let mut account_with_1_slot = account_shared_data_with_2_slots.clone();
+            account_with_1_slot.checked_add_lamports(1).unwrap();
             append_single_account_with_default_hash(
                 &storage,
-                &pk_with_1_ref,
-                &account_with_1_ref,
+                &pk_with_1_slot,
+                &account_with_1_slot,
                 true,
                 Some(&db.accounts_index),
             );
             // add the account with 2 refs into the storage we're ignoring.
             // The storage we're ignoring has a higher slot.
-            // The index entry for pk_with_2_refs will have both slots in it.
+            // The index entry for pk_with_2_slots will have both slots in it.
             // The slot of `storage` is lower than the slot of `ignored_storage`.
             // But, both are 'alive', aka in the index.
             append_single_account_with_default_hash(
                 &ignored_storage,
-                pk_with_2_refs,
-                &account_shared_data_with_2_refs,
+                pk_with_2_slots,
+                &account_shared_data_with_2_slots,
                 true,
                 Some(&db.accounts_index),
             );
@@ -2167,7 +2165,7 @@ mod tests {
             );
             let slots_vec = slots.collect::<Vec<_>>();
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-            // all accounts should be in many_refs
+            // all accounts should be in multiple
             let mut accounts_keep = accounts_to_combine
                 .accounts_keep_slots
                 .keys()
@@ -2186,34 +2184,34 @@ mod tests {
                     .iter()
                     .map(|meta| meta.pubkey())
                     .collect::<Vec<_>>(),
-                vec![pk_with_2_refs]
+                vec![pk_with_2_slots]
             );
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-            let one_ref_accounts = &accounts_to_combine
+            let one_slot_accounts = &accounts_to_combine
                 .accounts_to_combine
                 .first()
                 .unwrap()
                 .alive_accounts
-                .one_ref
+                .single
                 .accounts;
-            let one_ref_accounts_account_shared_data = one_ref_accounts
+            let one_slot_accounts_account_shared_data = one_slot_accounts
                 .iter()
                 .map(|account| get_account_from_account_from_storage(account, &db, slot1))
                 .collect::<Vec<_>>();
 
             assert_eq!(
-                one_ref_accounts
+                one_slot_accounts
                     .iter()
                     .map(|meta| meta.pubkey())
                     .collect::<Vec<_>>(),
-                vec![&pk_with_1_ref]
+                vec![&pk_with_1_slot]
             );
             assert_eq!(
-                one_ref_accounts_account_shared_data
+                one_slot_accounts_account_shared_data
                     .iter()
                     .map(create_account_shared_data)
                     .collect::<Vec<_>>(),
-                vec![account_with_1_ref]
+                vec![account_with_1_slot]
             );
             assert!(
                 accounts_to_combine
@@ -2221,7 +2219,7 @@ mod tests {
                     .iter()
                     .all(|shrink_collect| shrink_collect
                         .alive_accounts
-                        .many_refs_this_is_newest_alive
+                        .multiple_newest
                         .accounts
                         .is_empty())
             );
@@ -2233,16 +2231,16 @@ mod tests {
                     .iter()
                     .all(|shrink_collect| shrink_collect
                         .alive_accounts
-                        .many_refs_old_alive
+                        .multiple_not_newest
                         .accounts
                         .is_empty())
             );
 
-            // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
+            // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
             let write_ancient_accounts = match method {
                 TestWriteMultipleRefs::MultipleRefs => {
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
-                    db.write_ancient_accounts_to_same_slot_multiple_refs(
+                    db.write_ancient_accounts_to_same_slot_multiple_not_newest(
                         accounts_to_combine.accounts_keep_slots.values(),
                         &mut write_ancient_accounts,
                     );
@@ -2293,11 +2291,11 @@ mod tests {
                 .new_storage()
                 .accounts
                 .get_stored_account_callback(0, |account| {
-                    assert_eq!(account.pubkey(), pk_with_2_refs);
+                    assert_eq!(account.pubkey(), pk_with_2_slots);
                     create_account_shared_data(&account)
                 })
                 .unwrap();
-            assert_eq!(account, account_shared_data_with_2_refs);
+            assert_eq!(account, account_shared_data_with_2_slots);
         }
     }
 
@@ -2317,26 +2315,26 @@ mod tests {
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
             // add an older index entry for the sample account, giving it 2 refs.
-            // `pk_with_1_ref` is appended below, so it only gets the 1 ref.
-            add_older_ref(&db, &storages);
+            // `pk_with_1_slot` is appended below, so it only gets the 1 ref.
+            add_older_slot(&db, &storages);
             let storage = storages.first().unwrap().clone();
-            let pk_with_1_ref = solana_pubkey::new_rand();
+            let pk_with_1_slot = solana_pubkey::new_rand();
             let slot1 = slots.start;
-            let account_with_2_refs = original_results
+            let account_with_2_slots = original_results
                 .first()
                 .unwrap()
                 .stored_accounts
                 .first()
                 .unwrap();
-            let account_shared_data_with_2_refs =
-                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-            let pk_with_2_refs = account_with_2_refs.pubkey();
-            let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-            _ = account_with_1_ref.checked_add_lamports(1);
+            let account_shared_data_with_2_slots =
+                get_account_from_account_from_storage(account_with_2_slots, &db, slot1);
+            let pk_with_2_slots = account_with_2_slots.pubkey();
+            let mut account_with_1_slot = account_shared_data_with_2_slots.clone();
+            _ = account_with_1_slot.checked_add_lamports(1);
             append_single_account_with_default_hash(
                 &storage,
-                &pk_with_1_ref,
-                &account_with_1_ref,
+                &pk_with_1_slot,
+                &account_with_1_slot,
                 true,
                 Some(&db.accounts_index),
             );
@@ -2356,7 +2354,7 @@ mod tests {
             );
             let slots_vec = slots.collect::<Vec<_>>();
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-            // all accounts should be in many_refs_this_is_newest_alive
+            // all accounts should be in multiple_newest
             let mut accounts_keep = accounts_to_combine
                 .accounts_keep_slots
                 .keys()
@@ -2373,38 +2371,38 @@ mod tests {
                     .first()
                     .unwrap()
                     .alive_accounts
-                    .many_refs_this_is_newest_alive
+                    .multiple_newest
                     .accounts
                     .iter()
                     .map(|meta| meta.pubkey())
                     .collect::<Vec<_>>(),
-                vec![pk_with_2_refs]
+                vec![pk_with_2_slots]
             );
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-            let one_ref_accounts = &accounts_to_combine
+            let one_slot_accounts = &accounts_to_combine
                 .accounts_to_combine
                 .first()
                 .unwrap()
                 .alive_accounts
-                .one_ref
+                .single
                 .accounts;
-            let one_ref_accounts_account_shared_data = one_ref_accounts
+            let one_slot_accounts_account_shared_data = one_slot_accounts
                 .iter()
                 .map(|account| get_account_from_account_from_storage(account, &db, slot1))
                 .collect::<Vec<_>>();
             assert_eq!(
-                one_ref_accounts
+                one_slot_accounts
                     .iter()
                     .map(|meta| meta.pubkey())
                     .collect::<Vec<_>>(),
-                vec![&pk_with_1_ref]
+                vec![&pk_with_1_slot]
             );
             assert_eq!(
-                one_ref_accounts_account_shared_data
+                one_slot_accounts_account_shared_data
                     .iter()
                     .map(create_account_shared_data)
                     .collect::<Vec<_>>(),
-                vec![account_with_1_ref]
+                vec![account_with_1_slot]
             );
             assert!(
                 accounts_to_combine
@@ -2412,16 +2410,16 @@ mod tests {
                     .iter()
                     .all(|shrink_collect| !shrink_collect
                         .alive_accounts
-                        .many_refs_this_is_newest_alive
+                        .multiple_newest
                         .accounts
                         .is_empty())
             );
 
-            // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
+            // test write_ancient_accounts_to_same_slot_multiple_not_newest since we built interesting 'AccountsToCombine'
             let write_ancient_accounts = match method {
                 TestWriteMultipleRefs::MultipleRefs => {
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
-                    db.write_ancient_accounts_to_same_slot_multiple_refs(
+                    db.write_ancient_accounts_to_same_slot_multiple_not_newest(
                         accounts_to_combine.accounts_keep_slots.values(),
                         &mut write_ancient_accounts,
                     );
@@ -2450,8 +2448,11 @@ mod tests {
                 })
                 .expect("must scan accounts storage");
             assert_eq!(count, 2);
-            assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
-            assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
+            assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_slots);
+            assert_eq!(
+                accounts_shrunk_same_slot.1,
+                account_shared_data_with_2_slots
+            );
         }
     }
 
@@ -3824,17 +3825,12 @@ mod tests {
                                 ),
                             )];
                             alive_accounts.add(&account, &slot_list);
-                            assert!(!alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(!alive_accounts.single.accounts.is_empty());
+                            assert!(alive_accounts.multiple_not_newest.accounts.is_empty());
+                            assert!(alive_accounts.multiple_newest.accounts.is_empty());
                         }
                         1 => {
-                            // multiple slot list, this is NOT newest alive, so many_refs_old_alive
+                            // multiple slot list, this is NOT newest alive, so multiple_not_newest
                             let slot_list = vec![
                                 (
                                     slot,
@@ -3852,14 +3848,9 @@ mod tests {
                                 ),
                             ];
                             alive_accounts.add(&account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(!alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(alive_accounts.single.accounts.is_empty());
+                            assert!(!alive_accounts.multiple_not_newest.accounts.is_empty());
+                            assert!(alive_accounts.multiple_newest.accounts.is_empty());
                         }
                         2 => {
                             // multiple slot list, this is newest
@@ -3880,14 +3871,9 @@ mod tests {
                                 ),
                             ];
                             alive_accounts.add(&account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                !alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(alive_accounts.single.accounts.is_empty());
+                            assert!(alive_accounts.multiple_not_newest.accounts.is_empty());
+                            assert!(!alive_accounts.multiple_newest.accounts.is_empty());
                         }
                         _ => {
                             panic!("unexpected");
@@ -3898,7 +3884,7 @@ mod tests {
     }
 
     #[test]
-    fn test_many_ref_accounts_can_be_moved() {
+    fn test_multiple_newest_can_be_moved() {
         let tuning = PackedAncientStorageTuning {
             // only allow 10k slots old enough to be ancient
             max_ancient_slots: 10_000,
@@ -3909,58 +3895,58 @@ mod tests {
         };
 
         // nothing to move, so no problem fitting it
-        let many_refs_newest = vec![];
+        let multiple_newest = vec![];
         let target_slots_sorted = vec![];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));
         // something to move, no target slots, so can't fit
         let slot = 1;
-        let many_refs_newest = vec![AliveAccounts {
+        let multiple_newest = vec![AliveAccounts {
             bytes: 1,
             slot,
             accounts: Vec::default(),
         }];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));
 
         // something to move, 1 target slot, so can fit
         let target_slots_sorted = vec![slot];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));
 
         // too much to move to 1 target slot, so can't fit
-        let many_refs_newest = vec![AliveAccounts {
+        let multiple_newest = vec![AliveAccounts {
             bytes: tuning.ideal_storage_size.get() as usize,
             slot,
             accounts: Vec::default(),
         }];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));
 
         // more than 1 slot to move, 2 target slots, so can fit
         let target_slots_sorted = vec![slot, slot + 1];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));
 
         // lowest target slot is below required slot
         let target_slots_sorted = vec![slot - 1, slot];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::multiple_newest_can_be_moved(
+            &multiple_newest,
             &target_slots_sorted,
             &tuning
         ));

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -335,7 +335,7 @@ struct WriteAncientAccounts<'a> {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-/// specify what to do with slots with accounts with many refs
+/// specify what to do with slots holding accounts that are in multiple slots
 enum IncludeManyRefSlots {
     /// include them in packing
     Include,
@@ -459,7 +459,7 @@ impl AccountsDb {
             })
             .collect::<Vec<_>>();
 
-        // Sort highest slot to lowest slot. This way, we will put the multi ref accounts with the highest slots in the highest
+        // Sort highest slot to lowest slot. This way, we will put the accounts in multiple slots with the highest slots in the highest
         // packed slot.
         multiple_newest.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
         metrics.newest_alive_packed_count += multiple_newest.len();
@@ -478,8 +478,8 @@ impl AccountsDb {
             return;
         }
 
-        // for the accounts which are one ref and can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
-        // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other normal one ref accounts.
+        // for the accounts which are in a single slot and can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
+        // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other normal single slot accounts.
         // The alternative could cause us to mix newly ancient slots produced by flush (containing accounts touched more recently) with previously
         // packed ancient storages which over time contained enough dead accounts that the storage needed to be shrunk by being re-packed.
         // The end result of this sort should cause older, colder accounts (previously packed into large storages and then re-packed/shrunk) to
@@ -488,7 +488,7 @@ impl AccountsDb {
             .accounts_to_combine
             .sort_unstable_by_key(|a| a.written_bytes);
 
-        // pack the accounts with slot_list_len = 1 or slot_list_len > 1 but the slot we're packing is the highest alive slot for the pubkey.
+        // pack the accounts in a single slot, or in multiple slots but the slot we're packing is the highest alive slot for the pubkey.
         // Note the `chain` below combining them
         let pack = PackedAncientStorage::pack(
             multiple_newest.iter().chain(
@@ -689,7 +689,7 @@ impl AccountsDb {
 
         let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
 
-        // write new storages where contents were unable to move because slot_list_len > 1
+        // write new storages where contents were unable to move because they are in multiple slots
         self.write_ancient_accounts_to_same_slot_multiple_not_newest(
             accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
@@ -773,8 +773,8 @@ impl AccountsDb {
     /// given all accounts per ancient slot, in slots that we want to combine together:
     /// 1. Look up each pubkey in the index
     /// 2. separate, by slot, into:
-    ///    2a. pubkeys with slot_list_len = 1. This means this pubkey exists NOWHERE else in accounts db.
-    ///    2b. pubkeys with slot_list_len > 1
+    ///    2a. pubkeys in a single slot. This means this pubkey exists NOWHERE else in accounts db.
+    ///    2b. pubkeys in multiple slots
     ///
     /// Note that the return value can contain fewer items than 'accounts_per_storage' if we find storages which won't be affected.
     /// 'accounts_per_storage' should be sorted by slot
@@ -792,11 +792,11 @@ impl AccountsDb {
 
         // `shrink_collect` all accounts in the append vecs we want to combine.
         // We are no longer doing eager unref in shrink_collect. Therefore, we will no longer need to iter them serially?
-        // There is a subtle difference for zero lamport accounts, which can lead to having more multi-refs than before?
+        // There is a subtle difference for zero lamport accounts, which can lead to having more accounts in multiple slots than before?
         // Consider account X in both slot x, and x+1 and x+2.
-        // With eager unref, we will only collect `single`` X at slot x+2 after shrink.
-        // Without eager unref, we will collect X at `multi-ref` after shrink.
-        // Packing multi-ref is less efficient than `single``. But it might be ok - in next round of clean, hopefully, it can turn this from multi-ref into one-ref.
+        // With eager unref, we will only collect `single` X at slot x+2 after shrink.
+        // Without eager unref, we will collect X as `multiple` after shrink.
+        // Packing multiple is less efficient than `single`. But it might be ok - in next round of clean, hopefully, it can turn this from multiple into single.
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
@@ -839,19 +839,19 @@ impl AccountsDb {
             {
                 let mut required_packed_slots = min_resulting_packed_slots;
                 if multiple_not_newest.accounts.is_empty() {
-                    // if THIS slot can be used as a target slot, then even if we have multi refs
+                    // if THIS slot can be used as a target slot, then even if we have accounts in multiple slots
                     // this is ok.
                     required_packed_slots = required_packed_slots.saturating_sub(1);
                 }
 
                 if (target_slots_sorted.len() as u64) >= required_packed_slots {
                     // we have prepared to pack enough normal target slots, that form now on we can safely pack
-                    // any 'many ref' slots.
+                    // any slots holding accounts in multiple slots.
                     include_multiple_newest_slots = IncludeManyRefSlots::Include;
                 } else {
                     // Skip this because too few valid slots have been processed so far.
-                    // There are 'many ref newest' accounts in this slot. They must be packed into slots that are >= the current slot value.
-                    // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `many ref newest` accounts, then keep trying.
+                    // There are `multiple_newest` accounts in this slot. They must be packed into slots that are >= the current slot value.
+                    // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `multiple_newest` accounts, then keep trying.
                     // On the next pass, THIS slot will be older relative to newly ancient slot #s, so those newly ancient slots will be higher in this list.
                     self.shrink_ancient_stats
                         .many_ref_slots_skipped
@@ -873,7 +873,7 @@ impl AccountsDb {
                         account.pubkey()
                     );
                 });
-                // There are alive accounts with slot_list_len > 1, where the entry for the account in the index is NOT the highest slot. (`multiple_not_newest`)
+                // There are alive accounts in multiple slots, where the entry for the account in the index is NOT the highest slot. (`multiple_not_newest`)
                 // This means this account must remain IN this slot. There could be alive or dead references to this same account in any older slot.
                 // Moving it to a lower slot could move it before an alive or dead entry to this same account.
                 // Moving it to a higher slot could move it ahead of other slots where this account is also alive. We know a higher slot exists that contains this account.
@@ -888,14 +888,14 @@ impl AccountsDb {
                         .accounts
                         .is_empty()
                 {
-                    // all accounts in this append vec are alive and have > 1 ref, so nothing to be done for this append vec
+                    // all accounts in this append vec are alive and in multiple slots, so nothing to be done for this append vec
                     remove.push(i);
                     continue;
                 }
                 accounts_keep_slots
                     .insert(shrink_collect.slot, std::mem::take(multiple_not_newest));
             } else {
-                // No alive accounts in this slot have a slot_list_len > 1. So, ALL alive accounts in this slot can be written to any other slot
+                // No alive accounts in this slot are in multiple slots. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
                 target_slots_sorted.push(shrink_collect.slot);
             }
@@ -948,10 +948,10 @@ impl AccountsDb {
 
     /// For each slot and alive accounts in 'accounts_to_combine'
     /// create a PackedAncientStorage that only contains the given alive accounts.
-    /// This will represent only the accounts with slot_list_len > 1 from the original storage.
+    /// This will represent only the accounts in multiple slots from the original storage.
     /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
-    /// Other accounts would have slot_list_len = 1.
-    /// slot_list_len = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
+    /// Other accounts would be in a single slot.
+    /// Single slot accounts will be combined together with other slots into larger append vecs elsewhere.
     fn write_ancient_accounts_to_same_slot_multiple_not_newest<'a, 'b: 'a>(
         &'b self,
         accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
@@ -973,15 +973,15 @@ impl AccountsDb {
 struct AccountsToCombine<'a> {
     /// slots and alive accounts that must remain in the slot they are currently in
     /// because the account exists in more than 1 slot in accounts db
-    /// This hashmap contains an entry for each slot that contains at least one account with slot_list_len > 1.
-    /// The value of the entry is all alive accounts in that slot whose slot_list_len > 1.
-    /// Any OTHER accounts in that slot whose slot_list_len = 1 are in 'accounts_to_combine' because they can be moved
+    /// This hashmap contains an entry for each slot that contains at least one account in multiple slots.
+    /// The value of the entry is all alive accounts in that slot that are in multiple slots.
+    /// Any OTHER accounts in that slot that are in a single slot are in 'accounts_to_combine' because they can be moved
     /// to any slot.
-    /// We want to keep the slot_list_len > 1 accounts by themselves, expecting the multiple slot entries will be resolved
+    /// We want to keep the accounts in multiple slots by themselves, expecting the multiple slot entries will be resolved
     /// soon and we can clean the duplicates up (which maybe THIS one).
     accounts_keep_slots: HashMap<Slot, AliveAccounts<'a>>,
     /// all the rest of alive accounts that can move slots and should be combined
-    /// This includes all accounts with slot_list_len = 1 from the slots in 'accounts_keep_slots'.
+    /// This includes all accounts in a single slot from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
     accounts_to_combine: Vec<ShrinkCollect<ShrinkCollectAliveSeparatedByRefs<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
@@ -990,7 +990,7 @@ struct AccountsToCombine<'a> {
     /// The rest will become dead slots with no accounts in them.
     /// Sort order is lowest to highest.
     target_slots_sorted: Vec<Slot>,
-    /// when scanning, this many slots contained accounts that could not be packed because accounts with slot_list_len > 1 existed.
+    /// when scanning, this many slots contained accounts that could not be packed because accounts in multiple slots existed.
     unpackable_slots_count: usize,
 }
 
@@ -1710,7 +1710,7 @@ mod tests {
     fn test_finish_combine_ancient_slots_packed_internal(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref
+        // all accounts are in 1 slot
         // nothing shrunk, so all storages and roots should be removed
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {
@@ -1786,7 +1786,7 @@ mod tests {
     fn test_calc_accounts_to_combine_multiple(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
+        // all accounts are in 1 slot or all accounts are in 2 slots
         let data_size = 48;
         let alive_bytes_per_slot = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
@@ -1884,7 +1884,7 @@ mod tests {
     fn test_calc_accounts_to_combine_simple(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
+        // all accounts are in 1 slot or all accounts are in 2 slots
         let data_size = 48;
         let alive_bytes_per_account = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
@@ -1976,8 +1976,8 @@ mod tests {
                                     &tuning,
                                     include_multiple_newest_slots,
                                 );
-                                // if we are only trying to pack a single slot of multi-refs, it will succeed
-                                // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
+                                // if we are only trying to pack a single slot of accounts in multiple slots, it will succeed
+                                // if num_slots = 2 and skip slots with accounts in multiple slots, accounts_to_combine should contain
                                 // one element (storage), because we don't count alive bytes of skipped accounts
                                 // when we compute required target storages, and the second slot can be combined.
                                 let expected_number_accounts_to_combine = if !two_slots
@@ -2102,9 +2102,9 @@ mod tests {
     fn test_calc_accounts_to_combine_older_dup(accounts_db_config: AccountsDbConfig) {
         // looking at 1 storage
         // with 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs (and the other ref is from a newer slot)
-        // So, the other alive ref will cause the account with 2 refs to be put into multiple_not_newest and then accounts_keep_slots
+        // 1 in a single slot
+        // 1 in 2 slots (and the other entry is from a newer slot)
+        // So, the other alive entry will cause the account in 2 slots to be put into multiple_not_newest and then accounts_keep_slots
         for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
@@ -2137,7 +2137,7 @@ mod tests {
                 true,
                 Some(&db.accounts_index),
             );
-            // add the account with 2 refs into the storage we're ignoring.
+            // add the account in 2 slots into the storage we're ignoring.
             // The storage we're ignoring has a higher slot.
             // The index entry for pk_with_2_slots will have both slots in it.
             // The slot of `storage` is lower than the slot of `ignored_storage`.
@@ -2276,7 +2276,7 @@ mod tests {
             );
             let mut reader = append_vec::new_scan_accounts_reader();
 
-            // assert that we wrote the 2_ref account to the newly shrunk append vec
+            // assert that we wrote the 2 slot account to the newly shrunk append vec
             let shrink_in_progress = shrinks_in_progress.first().unwrap().1;
             let mut count = 0;
             shrink_in_progress
@@ -2305,7 +2305,7 @@ mod tests {
         // 2 accounts
         // 1 with a single slot list entry
         // 1 with 2 slot list entries, where the other entry is from an older slot, so this one is the newer index entry
-        // The result will be that the account, even though it has slot_list_len > 1, can be moved to a newer slot.
+        // The result will be that the account, even though it is in multiple slots, can be moved to a newer slot.
         for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
@@ -2314,8 +2314,8 @@ mod tests {
                 .iter()
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
-            // add an older index entry for the sample account, giving it 2 refs.
-            // `pk_with_1_slot` is appended below, so it only gets the 1 ref.
+            // add an older index entry for the sample account, putting it in 2 slots.
+            // `pk_with_1_slot` is appended below, so it stays in 1 slot.
             add_older_slot(&db, &storages);
             let storage = storages.first().unwrap().clone();
             let pk_with_1_slot = solana_pubkey::new_rand();
@@ -2431,7 +2431,7 @@ mod tests {
                 }
             };
             assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
-            // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
+            // assert that we wrote the 2 slot account (and the 1 slot account) to the newly shrunk append vec
             let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
             let accounts_shrunk_same_slot = storage
                 .accounts
@@ -3816,7 +3816,7 @@ mod tests {
 
                     match i {
                         0 => {
-                            // slot list with a single entry, so this account has one ref
+                            // slot list with a single entry, so this account is in a single slot
                             let slot_list = vec![(
                                 slot,
                                 AccountInfo::new(

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -491,8 +491,8 @@ impl AccountsDb {
             .accounts_to_combine
             .sort_unstable_by_key(|a| a.written_bytes);
 
-        // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
-        // Note the `chain` below combining the 2 types of refs.
+        // pack the accounts with slot_list_len = 1 or slot_list_len > 1 but the slot we're packing is the highest alive slot for the pubkey.
+        // Note the `chain` below combining them
         let pack = PackedAncientStorage::pack(
             many_refs_newest.iter().chain(
                 accounts_to_combine
@@ -692,7 +692,7 @@ impl AccountsDb {
 
         let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
 
-        // write new storages where contents were unable to move because ref_count > 1
+        // write new storages where contents were unable to move because slot_list_len > 1
         self.write_ancient_accounts_to_same_slot_multiple_refs(
             accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
@@ -776,8 +776,8 @@ impl AccountsDb {
     /// given all accounts per ancient slot, in slots that we want to combine together:
     /// 1. Look up each pubkey in the index
     /// 2. separate, by slot, into:
-    ///    2a. pubkeys with refcount = 1. This means this pubkey exists NOWHERE else in accounts db.
-    ///    2b. pubkeys with refcount > 1
+    ///    2a. pubkeys with slot_list_len = 1. This means this pubkey exists NOWHERE else in accounts db.
+    ///    2b. pubkeys with slot_list_len > 1
     ///
     /// Note that the return value can contain fewer items than 'accounts_per_storage' if we find storages which won't be affected.
     /// 'accounts_per_storage' should be sorted by slot
@@ -876,7 +876,7 @@ impl AccountsDb {
                         account.pubkey()
                     );
                 });
-                // There are alive accounts with ref_count > 1, where the entry for the account in the index is NOT the highest slot. (`many_refs_old_alive`)
+                // There are alive accounts with slot_list_len > 1, where the entry for the account in the index is NOT the highest slot. (`many_refs_old_alive`)
                 // This means this account must remain IN this slot. There could be alive or dead references to this same account in any older slot.
                 // Moving it to a lower slot could move it before an alive or dead entry to this same account.
                 // Moving it to a higher slot could move it ahead of other slots where this account is also alive. We know a higher slot exists that contains this account.
@@ -898,7 +898,7 @@ impl AccountsDb {
                 accounts_keep_slots
                     .insert(shrink_collect.slot, std::mem::take(many_refs_old_alive));
             } else {
-                // No alive accounts in this slot have a ref_count > 1. So, ALL alive accounts in this slot can be written to any other slot
+                // No alive accounts in this slot have a slot_list_len > 1. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
                 target_slots_sorted.push(shrink_collect.slot);
             }
@@ -951,10 +951,10 @@ impl AccountsDb {
 
     /// For each slot and alive accounts in 'accounts_to_combine'
     /// create a PackedAncientStorage that only contains the given alive accounts.
-    /// This will represent only the accounts with ref_count > 1 from the original storage.
+    /// This will represent only the accounts with slot_list_len > 1 from the original storage.
     /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
-    /// Other accounts would have ref_count = 1.
-    /// ref_count = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
+    /// Other accounts would have slot_list_len = 1.
+    /// slot_list_len = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
     fn write_ancient_accounts_to_same_slot_multiple_refs<'a, 'b: 'a>(
         &'b self,
         accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
@@ -976,15 +976,15 @@ impl AccountsDb {
 struct AccountsToCombine<'a> {
     /// slots and alive accounts that must remain in the slot they are currently in
     /// because the account exists in more than 1 slot in accounts db
-    /// This hashmap contains an entry for each slot that contains at least one account with ref_count > 1.
-    /// The value of the entry is all alive accounts in that slot whose ref_count > 1.
-    /// Any OTHER accounts in that slot whose ref_count = 1 are in 'accounts_to_combine' because they can be moved
+    /// This hashmap contains an entry for each slot that contains at least one account with slot_list_len > 1.
+    /// The value of the entry is all alive accounts in that slot whose slot_list_len > 1.
+    /// Any OTHER accounts in that slot whose slot_list_len = 1 are in 'accounts_to_combine' because they can be moved
     /// to any slot.
-    /// We want to keep the ref_count > 1 accounts by themselves, expecting the multiple ref_counts will be resolved
+    /// We want to keep the slot_list_len > 1 accounts by themselves, expecting the multiple slot entries will be resolved
     /// soon and we can clean the duplicates up (which maybe THIS one).
     accounts_keep_slots: HashMap<Slot, AliveAccounts<'a>>,
     /// all the rest of alive accounts that can move slots and should be combined
-    /// This includes all accounts with ref_count = 1 from the slots in 'accounts_keep_slots'.
+    /// This includes all accounts with slot_list_len = 1 from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
     accounts_to_combine: Vec<ShrinkCollect<ShrinkCollectAliveSeparatedByRefs<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
@@ -993,7 +993,7 @@ struct AccountsToCombine<'a> {
     /// The rest will become dead slots with no accounts in them.
     /// Sort order is lowest to highest.
     target_slots_sorted: Vec<Slot>,
-    /// when scanning, this many slots contained accounts that could not be packed because accounts with ref_count > 1 existed.
+    /// when scanning, this many slots contained accounts that could not be packed because accounts with slot_list_len > 1 existed.
     unpackable_slots_count: usize,
 }
 
@@ -1818,18 +1818,8 @@ mod tests {
                             infos = infos.into_iter().rev().collect();
                         }
 
-                        let original_results = storages
-                            .iter()
-                            .map(|store| db.get_unique_accounts_from_storage(store))
-                            .collect::<Vec<_>>();
                         if two_refs {
-                            original_results.iter().for_each(|results| {
-                                results.stored_accounts.iter().for_each(|account| {
-                                    db.accounts_index.get_and_then(account.pubkey(), |entry| {
-                                        (false, entry.unwrap().addref())
-                                    });
-                                })
-                            });
+                            add_older_ref(&db, &storages);
                         }
 
                         let original_results = storages
@@ -2315,9 +2305,9 @@ mod tests {
     fn test_calc_accounts_to_combine_opposite(accounts_db_config: AccountsDbConfig) {
         // 1 storage
         // 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs, with the idea that the other ref is from an older slot, so this one is the newer index entry
-        // The result will be that the account, even though it has refcount > 1, can be moved to a newer slot.
+        // 1 with a single slot list entry
+        // 1 with 2 slot list entries, where the other entry is from an older slot, so this one is the newer index entry
+        // The result will be that the account, even though it has slot_list_len > 1, can be moved to a newer slot.
         for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
@@ -2326,6 +2316,9 @@ mod tests {
                 .iter()
                 .map(|store| db.get_unique_accounts_from_storage(store))
                 .collect::<Vec<_>>();
+            // add an older index entry for the sample account, giving it 2 refs.
+            // `pk_with_1_ref` is appended below, so it only gets the 1 ref.
+            add_older_ref(&db, &storages);
             let storage = storages.first().unwrap().clone();
             let pk_with_1_ref = solana_pubkey::new_rand();
             let slot1 = slots.start;
@@ -2347,12 +2340,6 @@ mod tests {
                 true,
                 Some(&db.accounts_index),
             );
-            original_results.iter().for_each(|results| {
-                results.stored_accounts.iter().for_each(|account| {
-                    db.accounts_index
-                        .get_and_then(account.pubkey(), |entry| (true, entry.unwrap().addref()));
-                })
-            });
 
             // update to get both accounts in the storage
             let original_results = storages
@@ -3821,16 +3808,22 @@ mod tests {
                 let account = AccountFromStorage::new(offset, &stored_account);
                 let slot = 1;
                 let capacity = 0;
-                for i in 0..4usize {
+                for i in 0..3usize {
                     let mut alive_accounts =
                         ShrinkCollectAliveSeparatedByRefs::with_capacity(capacity, slot);
                     let lamports = 1;
 
                     match i {
                         0 => {
-                            // empty slot list (ignored anyway) because ref_count = 1
-                            let slot_list = vec![];
-                            alive_accounts.add(1, &account, &slot_list);
+                            // slot list with a single entry, so this account has one ref
+                            let slot_list = vec![(
+                                slot,
+                                AccountInfo::new(
+                                    StorageLocation::AccountsFile(0, 0),
+                                    lamports == 0,
+                                ),
+                            )];
+                            alive_accounts.add(&account, &slot_list);
                             assert!(!alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3841,26 +3834,7 @@ mod tests {
                             );
                         }
                         1 => {
-                            // non-empty slot list (but ignored) because slot_list = 1
-                            let slot_list = vec![(
-                                slot,
-                                AccountInfo::new(
-                                    StorageLocation::AccountsFile(0, 0),
-                                    lamports == 0,
-                                ),
-                            )];
-                            alive_accounts.add(2, &account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                !alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
-                        }
-                        2 => {
-                            // multiple slot list, ref_count=2, this is NOT newest alive, so many_refs_old_alive
+                            // multiple slot list, this is NOT newest alive, so many_refs_old_alive
                             let slot_list = vec![
                                 (
                                     slot,
@@ -3877,7 +3851,7 @@ mod tests {
                                     ),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(&account, &slot_list);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(!alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(
@@ -3887,8 +3861,8 @@ mod tests {
                                     .is_empty()
                             );
                         }
-                        3 => {
-                            // multiple slot list, ref_count=2, this is newest
+                        2 => {
+                            // multiple slot list, this is newest
                             let slot_list = vec![
                                 (
                                     slot,
@@ -3905,7 +3879,7 @@ mod tests {
                                     ),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(&account, &slot_list);
                             assert!(alive_accounts.one_ref.accounts.is_empty());
                             assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
                             assert!(

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -9,8 +9,8 @@ use {
         account_storage::ShrinkInProgress,
         account_storage_entry::AccountStorageEntry,
         accounts_db::{
-            AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
-            ShrinkCollectAliveSeparatedByRefs,
+            AccountFromStorage, AccountsDb, AliveAccounts, AliveAccountsSeparatedBySlots,
+            GetUniqueAccountsResult, ShrinkCollect,
             stats::{ShrinkAncientStats, SquashStatsSub},
         },
         active_stats::ActiveStatItem,
@@ -800,7 +800,7 @@ impl AccountsDb {
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
-                self.shrink_collect::<ShrinkCollectAliveSeparatedByRefs<'_>>(
+                self.shrink_collect::<AliveAccountsSeparatedBySlots<'_>>(
                     &info.storage,
                     unique_accounts,
                     &self.shrink_ancient_stats.shrink_stats,
@@ -983,7 +983,7 @@ struct AccountsToCombine<'a> {
     /// all the rest of alive accounts that can move slots and should be combined
     /// This includes all accounts in a single slot from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
-    accounts_to_combine: Vec<ShrinkCollect<ShrinkCollectAliveSeparatedByRefs<'a>>>,
+    accounts_to_combine: Vec<ShrinkCollect<AliveAccountsSeparatedBySlots<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
     /// these slots will NOT be in 'accounts_keep_slots'
     /// Some of these slots will have ancient append vecs created at them to contain everything in 'accounts_to_combine'
@@ -3811,7 +3811,7 @@ mod tests {
                 let capacity = 0;
                 for i in 0..3usize {
                     let mut alive_accounts =
-                        ShrinkCollectAliveSeparatedByRefs::with_capacity(capacity, slot);
+                        AliveAccountsSeparatedBySlots::with_capacity(capacity, slot);
                     let lamports = 1;
 
                     match i {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -336,7 +336,7 @@ struct WriteAncientAccounts<'a> {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 /// specify what to do with slots holding accounts that are in multiple slots
-enum IncludeManyRefSlots {
+enum IncludeMultipleNewestSlots {
     /// include them in packing
     Include,
     // skip them. ie. don't include them until sufficient slots of single refs have been created
@@ -446,7 +446,7 @@ impl AccountsDb {
         let mut accounts_to_combine = self.calc_accounts_to_combine(
             &mut accounts_per_storage,
             &tuning,
-            IncludeManyRefSlots::Skip,
+            IncludeMultipleNewestSlots::Skip,
         );
         metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
 
@@ -782,7 +782,7 @@ impl AccountsDb {
         &self,
         accounts_per_storage: &'a mut [(&'a SlotInfo, GetUniqueAccountsResult)],
         tuning: &PackedAncientStorageTuning,
-        mut include_multiple_newest_slots: IncludeManyRefSlots,
+        mut include_multiple_newest_slots: IncludeMultipleNewestSlots,
     ) -> AccountsToCombine<'a> {
         // reverse sort by slot #
         accounts_per_storage.sort_unstable_by_key(|b| cmp::Reverse(b.0.slot));
@@ -830,7 +830,7 @@ impl AccountsDb {
             last_slot = Some(shrink_collect.slot);
 
             let multiple_not_newest = &mut shrink_collect.alive_accounts.multiple_not_newest;
-            if include_multiple_newest_slots == IncludeManyRefSlots::Skip
+            if include_multiple_newest_slots == IncludeMultipleNewestSlots::Skip
                 && !shrink_collect
                     .alive_accounts
                     .multiple_newest
@@ -847,7 +847,7 @@ impl AccountsDb {
                 if (target_slots_sorted.len() as u64) >= required_packed_slots {
                     // we have prepared to pack enough normal target slots, that form now on we can safely pack
                     // any slots holding accounts in multiple slots.
-                    include_multiple_newest_slots = IncludeManyRefSlots::Include;
+                    include_multiple_newest_slots = IncludeMultipleNewestSlots::Include;
                 } else {
                     // Skip this because too few valid slots have been processed so far.
                     // There are `multiple_newest` accounts in this slot. They must be packed into slots that are >= the current slot value.
@@ -1733,7 +1733,7 @@ mod tests {
                     let accounts_to_combine = db.calc_accounts_to_combine(
                         &mut accounts_per_storage,
                         &default_tuning(),
-                        IncludeManyRefSlots::Include,
+                        IncludeMultipleNewestSlots::Include,
                     );
                     let mut stats = SquashStatsSub::default();
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
@@ -1795,9 +1795,10 @@ mod tests {
             ideal_storage_size: NonZeroU64::new(alive_bytes_per_slot * 2 + 1).unwrap(),
             ..default_tuning()
         };
-        for include_multiple_newest_slots in
-            [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include]
-        {
+        for include_multiple_newest_slots in [
+            IncludeMultipleNewestSlots::Skip,
+            IncludeMultipleNewestSlots::Include,
+        ] {
             for num_slots in 0..6 {
                 for unsorted_slots in [false, true] {
                     for two_slots in [false, true] {
@@ -1836,7 +1837,7 @@ mod tests {
                         );
                         let expected_accounts_to_combine = if num_slots >= 3
                             && two_slots
-                            && include_multiple_newest_slots == IncludeManyRefSlots::Skip
+                            && include_multiple_newest_slots == IncludeMultipleNewestSlots::Skip
                         {
                             // In this test setup, 2.5 regular slots fits into 1 ancient slot.
                             // When there are two_slots and when slots < 3, all regular slots can fit into one ancient slots.
@@ -1894,9 +1895,10 @@ mod tests {
             ..default_tuning()
         };
 
-        for include_multiple_newest_slots in
-            [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include]
-        {
+        for include_multiple_newest_slots in [
+            IncludeMultipleNewestSlots::Skip,
+            IncludeMultipleNewestSlots::Include,
+        ] {
             for add_dead_account in [true, false] {
                 for method in TestWriteMultipleRefs::iter() {
                     for num_slots in 0..3 {
@@ -1981,15 +1983,17 @@ mod tests {
                                 // one element (storage), because we don't count alive bytes of skipped accounts
                                 // when we compute required target storages, and the second slot can be combined.
                                 let expected_number_accounts_to_combine = if !two_slots
-                                    || include_multiple_newest_slots == IncludeManyRefSlots::Include
+                                    || include_multiple_newest_slots
+                                        == IncludeMultipleNewestSlots::Include
                                     || num_slots == 1
                                     || (num_slots == 2
                                         && include_multiple_newest_slots
-                                            != IncludeManyRefSlots::Skip)
+                                            != IncludeMultipleNewestSlots::Skip)
                                 {
                                     num_slots
                                 } else if num_slots == 2
-                                    && include_multiple_newest_slots == IncludeManyRefSlots::Skip
+                                    && include_multiple_newest_slots
+                                        == IncludeMultipleNewestSlots::Skip
                                 {
                                     1
                                 } else {
@@ -2003,7 +2007,8 @@ mod tests {
                                 );
 
                                 let expected_target_slots_sorted = if !two_slots
-                                    || include_multiple_newest_slots == IncludeManyRefSlots::Include
+                                    || include_multiple_newest_slots
+                                        == IncludeMultipleNewestSlots::Include
                                     || num_slots == 1
                                 {
                                     if unsorted_slots {
@@ -2012,7 +2017,8 @@ mod tests {
                                         slots_vec.clone()
                                     }
                                 } else if num_slots == 2
-                                    && include_multiple_newest_slots == IncludeManyRefSlots::Skip
+                                    && include_multiple_newest_slots
+                                        == IncludeMultipleNewestSlots::Skip
                                 {
                                     vec![1]
                                 } else {
@@ -2161,7 +2167,7 @@ mod tests {
             let accounts_to_combine = db.calc_accounts_to_combine(
                 &mut accounts_per_storage,
                 &default_tuning(),
-                IncludeManyRefSlots::Include,
+                IncludeMultipleNewestSlots::Include,
             );
             let slots_vec = slots.collect::<Vec<_>>();
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
@@ -2350,7 +2356,7 @@ mod tests {
             let accounts_to_combine = db.calc_accounts_to_combine(
                 &mut accounts_per_storage,
                 &default_tuning(),
-                IncludeManyRefSlots::Include,
+                IncludeMultipleNewestSlots::Include,
             );
             let slots_vec = slots.collect::<Vec<_>>();
             assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -285,7 +285,7 @@ impl<'a> StorableAccountsBySlot<'a> {
         // This happens when we are just shrinking a single slot storage, which happens very often.
         // Note: we check the actual number of entries, not just whether slots differ,
         // because multiple entries can have the same slot value (e.g., when packing
-        // many_refs_newest and one_ref accounts from the same source slot).
+        // multiple_newest and single accounts from the same source slot).
         if self.slots_and_accounts.len() == 1 {
             return (0, index);
         }


### PR DESCRIPTION
#### Problem
Shrink currently classifies based on ref_count, rather than slot_list_len. These are identical and ref_count is being removed. 

#### Summary of Changes
Classify based on slot_list_len instead. Separated into a few commits. 
1. The first commit is the only functional one: Classify based on slot_list instead of ref_count
2. Large, mechanical replacement of ref to slot
3. Touchups from the rename
4. Some associated type renames
5. Renaming stats.

#### Testing


Fixes #
