### PR TITLE
Shrink naming generic

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -144,7 +144,7 @@ pub(crate) struct AliveAccounts<'a> {
 
 /// separate alive accounts by whether a newer duplicate of the account exists
 #[derive(Debug)]
-pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
+pub(crate) struct AliveAccountsSeparated<'a> {
     /// can be packed into any slot
     pub(crate) no_duplicates: AliveAccounts<'a>,
     /// can only be packed into a slot >= this one
@@ -199,7 +199,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     }
 }
 
-impl<'a> ShrinkCollector<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
+impl<'a> ShrinkCollector<'a> for AliveAccountsSeparated<'a> {
     fn collect(&mut self, other: Self) {
         self.no_duplicates.collect(other.no_duplicates);
         self.newest_duplicate.collect(other.newest_duplicate);

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -153,7 +153,7 @@ pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
     pub(crate) not_newest_duplicate: AliveAccounts<'a>,
 }
 
-pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
+pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
     fn add(
@@ -167,7 +167,7 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
 }
 
-impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
+impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     fn collect(&mut self, mut other: Self) {
         self.bytes = self.bytes.saturating_add(other.bytes);
         self.accounts.append(&mut other.accounts);
@@ -199,7 +199,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     }
 }
 
-impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
+impl<'a> ShrinkCollector<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn collect(&mut self, other: Self) {
         self.no_duplicates.collect(other.no_duplicates);
         self.newest_duplicate.collect(other.newest_duplicate);
@@ -1936,7 +1936,7 @@ impl AccountsDb {
     /// load the account index entry for the first `count` items in `accounts`
     /// store a reference to all alive accounts in `alive_accounts`
     /// return sum of account size for all alive accounts
-    fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
+    fn load_accounts_index_for_shrink<'a, T: ShrinkCollector<'a>>(
         &self,
         accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
@@ -2040,7 +2040,7 @@ impl AccountsDb {
 
     /// shared code for shrinking normal slots and combining into ancient append vecs
     /// note 'unique_accounts' is passed by ref so we can return references to data within it, avoiding self-references
-    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
+    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollector<'b>>(
         &self,
         store: &'a AccountStorageEntry,
         unique_accounts: &'b mut GetUniqueAccountsResult,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -142,15 +142,15 @@ pub(crate) struct AliveAccounts<'a> {
     pub(crate) bytes: usize,
 }
 
-/// separate pubkeys into those with a single refcount and those with > 1 refcount
+/// separate alive accounts by whether a newer duplicate of the account exists
 #[derive(Debug)]
 pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
-    /// accounts where ref_count = 1
-    pub(crate) one_ref: AliveAccounts<'a>,
-    /// account where ref_count > 1, but this slot contains the alive entry with the highest slot
-    pub(crate) many_refs_this_is_newest_alive: AliveAccounts<'a>,
-    /// account where ref_count > 1, and this slot is NOT the highest alive entry in the index for the pubkey
-    pub(crate) many_refs_old_alive: AliveAccounts<'a>,
+    /// can be packed into any slot
+    pub(crate) no_duplicates: AliveAccounts<'a>,
+    /// can only be packed into a slot >= this one
+    pub(crate) newest_duplicate: AliveAccounts<'a>,
+    /// must stay in this slot
+    pub(crate) not_newest_duplicate: AliveAccounts<'a>,
 }
 
 pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
@@ -201,16 +201,16 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
 
 impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn collect(&mut self, other: Self) {
-        self.one_ref.collect(other.one_ref);
-        self.many_refs_this_is_newest_alive
-            .collect(other.many_refs_this_is_newest_alive);
-        self.many_refs_old_alive.collect(other.many_refs_old_alive);
+        self.no_duplicates.collect(other.no_duplicates);
+        self.newest_duplicate.collect(other.newest_duplicate);
+        self.not_newest_duplicate
+            .collect(other.not_newest_duplicate);
     }
     fn with_capacity(capacity: usize, slot: Slot) -> Self {
         Self {
-            one_ref: AliveAccounts::with_capacity(capacity, slot),
-            many_refs_this_is_newest_alive: AliveAccounts::with_capacity(0, slot),
-            many_refs_old_alive: AliveAccounts::with_capacity(0, slot),
+            no_duplicates: AliveAccounts::with_capacity(capacity, slot),
+            newest_duplicate: AliveAccounts::with_capacity(0, slot),
+            not_newest_duplicate: AliveAccounts::with_capacity(0, slot),
         }
     }
     fn add(
@@ -220,32 +220,32 @@ impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
         slot_list: &[(Slot, AccountInfo)],
     ) {
         let other = if ref_count == 1 {
-            &mut self.one_ref
+            &mut self.no_duplicates
         } else if slot_list.len() == 1
             || !slot_list
                 .iter()
-                .any(|(slot_list_slot, _info)| slot_list_slot > &self.many_refs_old_alive.slot)
+                .any(|(slot_list_slot, _info)| slot_list_slot > &self.not_newest_duplicate.slot)
         {
             // this entry is alive but is newer than any other slot in the index
-            &mut self.many_refs_this_is_newest_alive
+            &mut self.newest_duplicate
         } else {
             // This entry is alive but is older than at least one other slot in the index.
             // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
-            &mut self.many_refs_old_alive
+            &mut self.not_newest_duplicate
         };
         other.add(ref_count, account, slot_list);
     }
     fn len(&self) -> usize {
-        self.one_ref
+        self.no_duplicates
             .len()
-            .saturating_add(self.many_refs_old_alive.len())
-            .saturating_add(self.many_refs_this_is_newest_alive.len())
+            .saturating_add(self.not_newest_duplicate.len())
+            .saturating_add(self.newest_duplicate.len())
     }
     fn alive_bytes(&self) -> usize {
-        self.one_ref
+        self.no_duplicates
             .alive_bytes()
-            .saturating_add(self.many_refs_old_alive.alive_bytes())
-            .saturating_add(self.many_refs_this_is_newest_alive.alive_bytes())
+            .saturating_add(self.not_newest_duplicate.alive_bytes())
+            .saturating_add(self.newest_duplicate.alive_bytes())
     }
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage> {
         unimplemented!("illegal use");

--- a/accounts-db/src/accounts_db/stats.rs
+++ b/accounts-db/src/accounts_db/stats.rs
@@ -313,9 +313,9 @@ pub struct ShrinkAncientStats {
     pub bytes_from_must_shrink: AtomicU64,
     pub bytes_from_smallest_storages: AtomicU64,
     pub bytes_from_newest_storages: AtomicU64,
-    pub many_ref_slots_skipped: AtomicU64,
+    pub newest_duplicate_slots_skipped: AtomicU64,
     pub slots_cannot_move_count: AtomicU64,
-    pub many_refs_old_alive: AtomicU64,
+    pub not_newest_duplicate: AtomicU64,
     pub slots_eligible_to_shrink: AtomicU64,
     pub total_dead_bytes: AtomicU64,
     pub total_alive_bytes: AtomicU64,
@@ -753,8 +753,9 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "many_ref_slots_skipped",
-                self.many_ref_slots_skipped.swap(0, Ordering::Relaxed),
+                "newest_duplicate_slots_skipped",
+                self.newest_duplicate_slots_skipped
+                    .swap(0, Ordering::Relaxed),
                 i64
             ),
             (
@@ -763,8 +764,8 @@ impl ShrinkAncientStats {
                 i64
             ),
             (
-                "many_refs_old_alive",
-                self.many_refs_old_alive.swap(0, Ordering::Relaxed),
+                "not_newest_duplicate",
+                self.not_newest_duplicate.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("slot", self.slot.load(Ordering::Relaxed), i64),

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -258,8 +258,8 @@ impl AncientSlotInfos {
             // It will take a lot of time for the pack algorithm to create that many, and that is bad for system performance.
             // This should be a limit that only affects extreme testing environments.
             // We do not stop including entries until we have dealt with all the high slot #s. This allows the algorithm to continue
-            // to make progress each time it is called. There are exceptions that can cause the pack to fail, such as accounts with multiple
-            // refs.
+            // to make progress each time it is called. There are exceptions that can cause the pack to fail, such as accounts with duplicates.
+
             if !info.is_high_slot
                 && (storages_remaining + ancient_storages_required < low_threshold
                     || ancient_storages_required as u64 > u64::from(tuning.max_resulting_storages))
@@ -461,7 +461,7 @@ impl AccountsDb {
             })
             .collect::<Vec<_>>();
 
-        // Sort highest slot to lowest slot. This way, we will put the multi ref accounts with the highest slots in the highest
+        // Sort highest slot to lowest slot. This way, we will put the `newest_duplicate` accounts with the highest slots in the highest
         // packed slot.
         newest_duplicate.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
         metrics.newest_alive_packed_count += newest_duplicate.len();
@@ -480,8 +480,8 @@ impl AccountsDb {
             return;
         }
 
-        // for the accounts which are one ref and can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
-        // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other normal one ref accounts.
+        // for the accounts with no duplicates, which can be put anywhere, we want to put the accounts from the LARGEST storages at the end.
+        // This causes us to keep the accounts we're re-packing from already existing ancient storages together with other accounts that have no duplicates.
         // The alternative could cause us to mix newly ancient slots produced by flush (containing accounts touched more recently) with previously
         // packed ancient storages which over time contained enough dead accounts that the storage needed to be shrunk by being re-packed.
         // The end result of this sort should cause older, colder accounts (previously packed into large storages and then re-packed/shrunk) to
@@ -490,8 +490,8 @@ impl AccountsDb {
             .accounts_to_combine
             .sort_unstable_by_key(|a| a.written_bytes);
 
-        // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
-        // Note the `chain` below combining the 2 types of refs.
+        // pack the accounts with no duplicates, and those whose newest duplicate is the slot we're packing.
+        // Note the `chain` below combining them
         let pack = PackedAncientStorage::pack(
             newest_duplicate.iter().chain(
                 accounts_to_combine
@@ -691,7 +691,7 @@ impl AccountsDb {
 
         let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
 
-        // write new storages where contents were unable to move because ref_count > 1
+        // write new storages where contents were unable to move because a newer duplicate exists
         self.write_ancient_accounts_to_same_slot_not_newest_duplicate(
             accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
@@ -775,8 +775,8 @@ impl AccountsDb {
     /// given all accounts per ancient slot, in slots that we want to combine together:
     /// 1. Look up each pubkey in the index
     /// 2. separate, by slot, into:
-    ///    2a. pubkeys with refcount = 1. This means this pubkey exists NOWHERE else in accounts db.
-    ///    2b. pubkeys with refcount > 1
+    ///    2a. pubkeys with no duplicates. This means this pubkey exists NOWHERE else in accounts db.
+    ///    2b. pubkeys with duplicates
     ///
     /// Note that the return value can contain fewer items than 'accounts_per_storage' if we find storages which won't be affected.
     /// 'accounts_per_storage' should be sorted by slot
@@ -841,19 +841,19 @@ impl AccountsDb {
             {
                 let mut required_packed_slots = min_resulting_packed_slots;
                 if not_newest_duplicate.accounts.is_empty() {
-                    // if THIS slot can be used as a target slot, then even if we have multi refs
+                    // if THIS slot can be used as a target slot, then even if we have duplicates
                     // this is ok.
                     required_packed_slots = required_packed_slots.saturating_sub(1);
                 }
 
                 if (target_slots_sorted.len() as u64) >= required_packed_slots {
                     // we have prepared to pack enough normal target slots, that form now on we can safely pack
-                    // any 'many ref' slots.
+                    // any slots holding `newest_duplicate` accounts.
                     many_ref_slots = IncludeManyRefSlots::Include;
                 } else {
                     // Skip this because too few valid slots have been processed so far.
-                    // There are 'many ref newest' accounts in this slot. They must be packed into slots that are >= the current slot value.
-                    // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `many ref newest` accounts, then keep trying.
+                    // There are `newest_duplicate` accounts in this slot. They must be packed into slots that are >= the current slot value.
+                    // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `newest_duplicate` accounts, then keep trying.
                     // On the next pass, THIS slot will be older relative to newly ancient slot #s, so those newly ancient slots will be higher in this list.
                     self.shrink_ancient_stats
                         .many_ref_slots_skipped
@@ -894,14 +894,14 @@ impl AccountsDb {
                         .accounts
                         .is_empty()
                 {
-                    // all accounts in this append vec are alive and have > 1 ref, so nothing to be done for this append vec
+                    // all accounts in this append vec are alive and have a newer duplicate, so nothing to be done for this append vec
                     remove.push(i);
                     continue;
                 }
                 accounts_keep_slots
                     .insert(shrink_collect.slot, std::mem::take(not_newest_duplicate));
             } else {
-                // No alive accounts in this slot have a ref_count > 1. So, ALL alive accounts in this slot can be written to any other slot
+                // No alive accounts in this slot have duplicates. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
                 target_slots_sorted.push(shrink_collect.slot);
             }
@@ -954,10 +954,10 @@ impl AccountsDb {
 
     /// For each slot and alive accounts in 'accounts_to_combine'
     /// create a PackedAncientStorage that only contains the given alive accounts.
-    /// This will represent only the accounts with ref_count > 1 from the original storage.
+    /// This will represent only the `not_newest_duplicate` accounts from the original storage.
     /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
-    /// Other accounts would have ref_count = 1.
-    /// ref_count = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
+    /// Other accounts have no duplicates.
+    /// Those accounts will be combined together with other slots into larger append vecs elsewhere.
     fn write_ancient_accounts_to_same_slot_not_newest_duplicate<'a, 'b: 'a>(
         &'b self,
         accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
@@ -979,15 +979,15 @@ impl AccountsDb {
 struct AccountsToCombine<'a> {
     /// slots and alive accounts that must remain in the slot they are currently in
     /// because the account exists in more than 1 slot in accounts db
-    /// This hashmap contains an entry for each slot that contains at least one account with ref_count > 1.
-    /// The value of the entry is all alive accounts in that slot whose ref_count > 1.
-    /// Any OTHER accounts in that slot whose ref_count = 1 are in 'accounts_to_combine' because they can be moved
+    /// This hashmap contains an entry for each slot that contains at least one `not_newest_duplicate` account.
+    /// The value of the entry is all alive accounts in that slot that have a newer duplicate.
+    /// Any OTHER accounts in that slot with no duplicates are in 'accounts_to_combine' because they can be moved
     /// to any slot.
-    /// We want to keep the ref_count > 1 accounts by themselves, expecting the multiple ref_counts will be resolved
+    /// We want to keep those accounts by themselves, expecting the duplicates will be resolved
     /// soon and we can clean the duplicates up (which maybe THIS one).
     accounts_keep_slots: HashMap<Slot, AliveAccounts<'a>>,
     /// all the rest of alive accounts that can move slots and should be combined
-    /// This includes all accounts with ref_count = 1 from the slots in 'accounts_keep_slots'.
+    /// This includes all accounts with no duplicates from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
     accounts_to_combine: Vec<ShrinkCollect<ShrinkCollectAliveSeparatedByRefs<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
@@ -996,7 +996,7 @@ struct AccountsToCombine<'a> {
     /// The rest will become dead slots with no accounts in them.
     /// Sort order is lowest to highest.
     target_slots_sorted: Vec<Slot>,
-    /// when scanning, this many slots contained accounts that could not be packed because accounts with ref_count > 1 existed.
+    /// when scanning, this many slots contained accounts that could not be packed because `newest_duplicate` accounts existed.
     unpackable_slots_count: usize,
 }
 

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1127,7 +1127,7 @@ mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                AccountsDbConfig, ShrinkCollectRefs,
+                AccountsDbConfig, ShrinkCollector,
                 tests::{ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash},
             },
             accounts_index::{ReclaimsSlotList, UpsertReclaim},

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -335,11 +335,11 @@ struct WriteAncientAccounts<'a> {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-/// specify what to do with slots with accounts with many refs
-enum IncludeManyRefSlots {
+/// specify what to do with slots holding `newest_duplicate` accounts
+enum SlotsWithNewestDuplicate {
     /// include them in packing
     Include,
-    // skip them. ie. don't include them until sufficient slots of single refs have been created
+    // skip them. ie. don't include them until sufficient slots without duplicates have been created
     Skip,
 }
 
@@ -448,7 +448,7 @@ impl AccountsDb {
         let mut accounts_to_combine = self.calc_accounts_to_combine(
             &mut accounts_per_storage,
             &tuning,
-            IncludeManyRefSlots::Skip,
+            SlotsWithNewestDuplicate::Skip,
         );
         metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
 
@@ -784,7 +784,7 @@ impl AccountsDb {
         &self,
         accounts_per_storage: &'a mut [(&'a SlotInfo, GetUniqueAccountsResult)],
         tuning: &PackedAncientStorageTuning,
-        mut many_ref_slots: IncludeManyRefSlots,
+        mut slots_with_newest_duplicate: SlotsWithNewestDuplicate,
     ) -> AccountsToCombine<'a> {
         // reverse sort by slot #
         accounts_per_storage.sort_unstable_by_key(|b| cmp::Reverse(b.0.slot));
@@ -832,7 +832,7 @@ impl AccountsDb {
             last_slot = Some(shrink_collect.slot);
 
             let not_newest_duplicate = &mut shrink_collect.alive_accounts.not_newest_duplicate;
-            if many_ref_slots == IncludeManyRefSlots::Skip
+            if slots_with_newest_duplicate == SlotsWithNewestDuplicate::Skip
                 && !shrink_collect
                     .alive_accounts
                     .newest_duplicate
@@ -849,7 +849,7 @@ impl AccountsDb {
                 if (target_slots_sorted.len() as u64) >= required_packed_slots {
                     // we have prepared to pack enough normal target slots, that form now on we can safely pack
                     // any slots holding `newest_duplicate` accounts.
-                    many_ref_slots = IncludeManyRefSlots::Include;
+                    slots_with_newest_duplicate = SlotsWithNewestDuplicate::Include;
                 } else {
                     // Skip this because too few valid slots have been processed so far.
                     // There are `newest_duplicate` accounts in this slot. They must be packed into slots that are >= the current slot value.
@@ -1733,7 +1733,7 @@ mod tests {
                     let accounts_to_combine = db.calc_accounts_to_combine(
                         &mut accounts_per_storage,
                         &default_tuning(),
-                        IncludeManyRefSlots::Include,
+                        SlotsWithNewestDuplicate::Include,
                     );
                     let mut stats = SquashStatsSub::default();
                     let mut write_ancient_accounts = WriteAncientAccounts::default();
@@ -1795,7 +1795,10 @@ mod tests {
             ideal_storage_size: NonZeroU64::new(alive_bytes_per_slot * 2 + 1).unwrap(),
             ..default_tuning()
         };
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
+        for slots_with_newest_duplicate in [
+            SlotsWithNewestDuplicate::Skip,
+            SlotsWithNewestDuplicate::Include,
+        ] {
             for num_slots in 0..6 {
                 for unsorted_slots in [false, true] {
                     for two_slots in [false, true] {
@@ -1840,11 +1843,11 @@ mod tests {
                         let accounts_to_combine = db.calc_accounts_to_combine(
                             &mut accounts_per_storage,
                             &tuning,
-                            many_ref_slots,
+                            slots_with_newest_duplicate,
                         );
                         let expected_accounts_to_combine = if num_slots >= 3
                             && two_slots
-                            && many_ref_slots == IncludeManyRefSlots::Skip
+                            && slots_with_newest_duplicate == SlotsWithNewestDuplicate::Skip
                         {
                             // In this test setup, 2.5 regular slots fits into 1 ancient slot.
                             // When there are two_slots and when slots < 3, all regular slots can fit into one ancient slots.
@@ -1869,8 +1872,8 @@ mod tests {
 
                         log::debug!(
                             "output slots: {:?}, num_slots: {num_slots}, two_slots: {two_slots}, \
-                             many_refs: {many_ref_slots:?}, expected accounts to combine: \
-                             {expected_accounts_to_combine}, target slots: {:?}, \
+                             newest_duplicate: {slots_with_newest_duplicate:?}, expected accounts \
+                             to combine: {expected_accounts_to_combine}, target slots: {:?}, \
                              accounts_to_combine: {}",
                             accounts_to_combine.target_slots_sorted,
                             accounts_to_combine.target_slots_sorted,
@@ -1879,8 +1882,8 @@ mod tests {
                         assert_eq!(
                             accounts_to_combine.accounts_to_combine.len(),
                             expected_accounts_to_combine,
-                            "num_slots: {num_slots}, two_slots: {two_slots}, many_refs: \
-                             {many_ref_slots:?}"
+                            "num_slots: {num_slots}, two_slots: {two_slots}, newest_duplicate: \
+                             {slots_with_newest_duplicate:?}"
                         );
                     }
                 }
@@ -1902,7 +1905,10 @@ mod tests {
             ..default_tuning()
         };
 
-        for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
+        for slots_with_newest_duplicate in [
+            SlotsWithNewestDuplicate::Skip,
+            SlotsWithNewestDuplicate::Include,
+        ] {
             for add_dead_account in [true, false] {
                 for num_slots in 0..3 {
                     for unsorted_slots in [false, true] {
@@ -1978,19 +1984,22 @@ mod tests {
                             let accounts_to_combine = db.calc_accounts_to_combine(
                                 &mut accounts_per_storage,
                                 &tuning,
-                                many_ref_slots,
+                                slots_with_newest_duplicate,
                             );
                             // if we are only trying to pack a single slot of duplicates, it will succeed
                             // if num_slots = 2 and skip slots with duplicates, accounts_to_combine should contain
                             // one element (storage), because we don't count alive bytes of skipped accounts
                             // when we compute required target storages, and the second slot can be combined.
                             let expected_number_accounts_to_combine = if !two_slots
-                                || many_ref_slots == IncludeManyRefSlots::Include
+                                || slots_with_newest_duplicate == SlotsWithNewestDuplicate::Include
                                 || num_slots == 1
-                                || (num_slots == 2 && many_ref_slots != IncludeManyRefSlots::Skip)
+                                || (num_slots == 2
+                                    && slots_with_newest_duplicate
+                                        != SlotsWithNewestDuplicate::Skip)
                             {
                                 num_slots
-                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
+                            } else if num_slots == 2
+                                && slots_with_newest_duplicate == SlotsWithNewestDuplicate::Skip
                             {
                                 1
                             } else {
@@ -1999,12 +2008,12 @@ mod tests {
                             assert_eq!(
                                 accounts_to_combine.accounts_to_combine.len(),
                                 expected_number_accounts_to_combine,
-                                "num_slots: {num_slots}, two_slots: {two_slots}, many_refs: \
-                                 {many_ref_slots:?}"
+                                "num_slots: {num_slots}, two_slots: {two_slots}, \
+                                 newest_duplicate: {slots_with_newest_duplicate:?}"
                             );
 
                             let expected_target_slots_sorted = if !two_slots
-                                || many_ref_slots == IncludeManyRefSlots::Include
+                                || slots_with_newest_duplicate == SlotsWithNewestDuplicate::Include
                                 || num_slots == 1
                             {
                                 if unsorted_slots {
@@ -2012,7 +2021,8 @@ mod tests {
                                 } else {
                                     slots_vec.clone()
                                 }
-                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
+                            } else if num_slots == 2
+                                && slots_with_newest_duplicate == SlotsWithNewestDuplicate::Skip
                             {
                                 vec![1]
                             } else {
@@ -2147,7 +2157,7 @@ mod tests {
         let accounts_to_combine = db.calc_accounts_to_combine(
             &mut accounts_per_storage,
             &default_tuning(),
-            IncludeManyRefSlots::Include,
+            SlotsWithNewestDuplicate::Include,
         );
         let slots_vec = slots.collect::<Vec<_>>();
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
@@ -2325,7 +2335,7 @@ mod tests {
         let accounts_to_combine = db.calc_accounts_to_combine(
             &mut accounts_per_storage,
             &default_tuning(),
-            IncludeManyRefSlots::Include,
+            SlotsWithNewestDuplicate::Include,
         );
         let slots_vec = slots.collect::<Vec<_>>();
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1703,12 +1703,6 @@ mod tests {
         }
     }
 
-    #[derive(EnumIter, Debug, PartialEq, Eq)]
-    enum TestWriteMultipleRefs {
-        MultipleRefs,
-        PackedStorages,
-    }
-
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
     fn test_finish_combine_ancient_slots_packed_internal(accounts_db_config: AccountsDbConfig) {
         // n storages
@@ -1907,7 +1901,6 @@ mod tests {
 
         for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
             for add_dead_account in [true, false] {
-                for method in TestWriteMultipleRefs::iter() {
                     for num_slots in 0..3 {
                         for unsorted_slots in [false, true] {
                             for two_refs in [false, true] {
@@ -2006,8 +1999,8 @@ mod tests {
                                 assert_eq!(
                                     accounts_to_combine.accounts_to_combine.len(),
                                     expected_number_accounts_to_combine,
-                                    "method: {method:?}, num_slots: {num_slots}, two_refs: \
-                                     {two_refs}, many_refs: {many_ref_slots:?}"
+                                    "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
+                                     {many_ref_slots:?}"
                                 );
 
                                 let expected_target_slots_sorted = if !two_refs
@@ -2081,31 +2074,14 @@ mod tests {
                                     ));
                                 }
 
-                                // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
-                                let write_ancient_accounts = match method {
-                                    TestWriteMultipleRefs::MultipleRefs => {
-                                        let mut write_ancient_accounts =
-                                            WriteAncientAccounts::default();
-                                        db.write_ancient_accounts_to_same_slot_multiple_refs(
-                                            accounts_to_combine.accounts_keep_slots.values(),
-                                            &mut write_ancient_accounts,
-                                        );
-                                        write_ancient_accounts
-                                    }
-                                    TestWriteMultipleRefs::PackedStorages => {
-                                        let packed_contents = Vec::default();
-                                        db.write_packed_storages(
-                                            &accounts_to_combine,
-                                            packed_contents,
-                                        )
-                                    }
-                                };
+                                let packed_contents = Vec::default();
+                                let write_ancient_accounts =
+                                    db.write_packed_storages(&accounts_to_combine, packed_contents);
 
                                 assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
                             }
                         }
                     }
-                }
             }
         }
     }
@@ -2117,7 +2093,6 @@ mod tests {
         // 1 with 1 ref
         // 1 with 2 refs (and the other ref is from a newer slot)
         // So, the other alive ref will cause the account with 2 refs to be put into many_refs_old_alive and then accounts_keep_slots
-        for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
             // creating 1 more sample slot/storage, but effectively act like 1 slot
@@ -2248,21 +2223,9 @@ mod tests {
                         .is_empty())
             );
 
-            // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
-            let write_ancient_accounts = match method {
-                TestWriteMultipleRefs::MultipleRefs => {
-                    let mut write_ancient_accounts = WriteAncientAccounts::default();
-                    db.write_ancient_accounts_to_same_slot_multiple_refs(
-                        accounts_to_combine.accounts_keep_slots.values(),
-                        &mut write_ancient_accounts,
-                    );
-                    write_ancient_accounts
-                }
-                TestWriteMultipleRefs::PackedStorages => {
-                    let packed_contents = Vec::default();
-                    db.write_packed_storages(&accounts_to_combine, packed_contents)
-                }
-            };
+            let packed_contents = Vec::default();
+            let write_ancient_accounts =
+                db.write_packed_storages(&accounts_to_combine, packed_contents);
             assert_eq!(write_ancient_accounts.shrinks_in_progress.len(), num_slots);
             let mut shrinks_in_progress = write_ancient_accounts
                 .shrinks_in_progress
@@ -2308,7 +2271,6 @@ mod tests {
                 })
                 .unwrap();
             assert_eq!(account, account_shared_data_with_2_refs);
-        }
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -2318,7 +2280,6 @@ mod tests {
         // 1 with 1 ref
         // 1 with 2 refs, with the idea that the other ref is from an older slot, so this one is the newer index entry
         // The result will be that the account, even though it has refcount > 1, can be moved to a newer slot.
-        for method in TestWriteMultipleRefs::iter() {
             let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
             let num_slots = 1;
             let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
@@ -2430,21 +2391,9 @@ mod tests {
                         .is_empty())
             );
 
-            // test write_ancient_accounts_to_same_slot_multiple_refs since we built interesting 'AccountsToCombine'
-            let write_ancient_accounts = match method {
-                TestWriteMultipleRefs::MultipleRefs => {
-                    let mut write_ancient_accounts = WriteAncientAccounts::default();
-                    db.write_ancient_accounts_to_same_slot_multiple_refs(
-                        accounts_to_combine.accounts_keep_slots.values(),
-                        &mut write_ancient_accounts,
-                    );
-                    write_ancient_accounts
-                }
-                TestWriteMultipleRefs::PackedStorages => {
-                    let packed_contents = Vec::default();
-                    db.write_packed_storages(&accounts_to_combine, packed_contents)
-                }
-            };
+            let packed_contents = Vec::default();
+            let write_ancient_accounts =
+                db.write_packed_storages(&accounts_to_combine, packed_contents);
             assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
             // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
             let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
@@ -2465,7 +2414,6 @@ mod tests {
             assert_eq!(count, 2);
             assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
             assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
-        }
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -9,8 +9,8 @@ use {
         account_storage::ShrinkInProgress,
         account_storage_entry::AccountStorageEntry,
         accounts_db::{
-            AccountFromStorage, AccountsDb, AliveAccounts, GetUniqueAccountsResult, ShrinkCollect,
-            ShrinkCollectAliveSeparatedByRefs,
+            AccountFromStorage, AccountsDb, AliveAccounts, AliveAccountsSeparated,
+            GetUniqueAccountsResult, ShrinkCollect,
             stats::{ShrinkAncientStats, SquashStatsSub},
         },
         active_stats::ActiveStatItem,
@@ -802,7 +802,7 @@ impl AccountsDb {
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
-                self.shrink_collect::<ShrinkCollectAliveSeparatedByRefs<'_>>(
+                self.shrink_collect::<AliveAccountsSeparated<'_>>(
                     &info.storage,
                     unique_accounts,
                     &self.shrink_ancient_stats.shrink_stats,
@@ -989,7 +989,7 @@ struct AccountsToCombine<'a> {
     /// all the rest of alive accounts that can move slots and should be combined
     /// This includes all accounts with no duplicates from the slots in 'accounts_keep_slots'.
     /// There is one entry here for each storage we are processing. Even if all accounts are in 'accounts_keep_slots'.
-    accounts_to_combine: Vec<ShrinkCollect<ShrinkCollectAliveSeparatedByRefs<'a>>>,
+    accounts_to_combine: Vec<ShrinkCollect<AliveAccountsSeparated<'a>>>,
     /// slots that contain alive accounts that can move into ANY other ancient slot
     /// these slots will NOT be in 'accounts_keep_slots'
     /// Some of these slots will have ancient append vecs created at them to contain everything in 'accounts_to_combine'
@@ -3772,8 +3772,7 @@ mod tests {
                 let slot = 1;
                 let capacity = 0;
                 for i in 0..4usize {
-                    let mut alive_accounts =
-                        ShrinkCollectAliveSeparatedByRefs::with_capacity(capacity, slot);
+                    let mut alive_accounts = AliveAccountsSeparated::with_capacity(capacity, slot);
                     let lamports = 1;
 
                     match i {

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -383,16 +383,16 @@ impl AccountsDb {
         self.shrink_ancient_stats.report();
     }
 
-    /// return false if `many_refs_newest` accounts cannot be moved into `target_slots_sorted`.
+    /// return false if `newest_duplicate` accounts cannot be moved into `target_slots_sorted`.
     /// The slot # would be violated.
-    /// accounts in `many_refs_newest` must be moved a slot >= each account's current slot.
+    /// accounts in `newest_duplicate` must be moved a slot >= each account's current slot.
     /// If that can be done, this fn returns true
-    fn many_ref_accounts_can_be_moved(
-        many_refs_newest: &[AliveAccounts<'_>],
+    fn newest_duplicate_can_be_moved(
+        newest_duplicate: &[AliveAccounts<'_>],
         target_slots_sorted: &[Slot],
         tuning: &PackedAncientStorageTuning,
     ) -> bool {
-        let alive_bytes = many_refs_newest
+        let alive_bytes = newest_duplicate
             .iter()
             .map(|alive| alive.bytes)
             .sum::<usize>();
@@ -409,7 +409,7 @@ impl AccountsDb {
             .saturating_sub(required_ideal_packed);
 
         let highest_slot = target_slots_sorted[i_last];
-        many_refs_newest
+        newest_duplicate
             .iter()
             .all(|many| many.slot <= highest_slot)
     }
@@ -452,23 +452,22 @@ impl AccountsDb {
         );
         metrics.unpackable_slots_count += accounts_to_combine.unpackable_slots_count;
 
-        let mut many_refs_newest = accounts_to_combine
+        let mut newest_duplicate = accounts_to_combine
             .accounts_to_combine
             .iter_mut()
             .filter_map(|alive| {
-                let newest_alive =
-                    std::mem::take(&mut alive.alive_accounts.many_refs_this_is_newest_alive);
+                let newest_alive = std::mem::take(&mut alive.alive_accounts.newest_duplicate);
                 (!newest_alive.accounts.is_empty()).then_some(newest_alive)
             })
             .collect::<Vec<_>>();
 
         // Sort highest slot to lowest slot. This way, we will put the multi ref accounts with the highest slots in the highest
         // packed slot.
-        many_refs_newest.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
-        metrics.newest_alive_packed_count += many_refs_newest.len();
+        newest_duplicate.sort_unstable_by_key(|b| cmp::Reverse(b.slot));
+        metrics.newest_alive_packed_count += newest_duplicate.len();
 
-        if !Self::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        if !Self::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &accounts_to_combine.target_slots_sorted,
             &tuning,
         ) {
@@ -476,7 +475,7 @@ impl AccountsDb {
             log::info!(
                 "unable to ancient pack: highest available slot: {:?}, lowest required slot: {:?}",
                 accounts_to_combine.target_slots_sorted.last(),
-                many_refs_newest.last().map(|accounts| accounts.slot)
+                newest_duplicate.last().map(|accounts| accounts.slot)
             );
             return;
         }
@@ -494,11 +493,11 @@ impl AccountsDb {
         // pack the accounts with 1 ref or refs > 1 but the slot we're packing is the highest alive slot for the pubkey.
         // Note the `chain` below combining the 2 types of refs.
         let pack = PackedAncientStorage::pack(
-            many_refs_newest.iter().chain(
+            newest_duplicate.iter().chain(
                 accounts_to_combine
                     .accounts_to_combine
                     .iter()
-                    .map(|shrink_collect| &shrink_collect.alive_accounts.one_ref),
+                    .map(|shrink_collect| &shrink_collect.alive_accounts.no_duplicates),
             ),
             tuning.ideal_storage_size,
         );
@@ -693,7 +692,7 @@ impl AccountsDb {
         let mut write_ancient_accounts = write_ancient_accounts.into_inner().unwrap();
 
         // write new storages where contents were unable to move because ref_count > 1
-        self.write_ancient_accounts_to_same_slot_multiple_refs(
+        self.write_ancient_accounts_to_same_slot_not_newest_duplicate(
             accounts_to_combine.accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
@@ -795,11 +794,11 @@ impl AccountsDb {
 
         // `shrink_collect` all accounts in the append vecs we want to combine.
         // We are no longer doing eager unref in shrink_collect. Therefore, we will no longer need to iter them serially?
-        // There is a subtle difference for zero lamport accounts, which can lead to having more multi-refs than before?
+        // There is a subtle difference for zero lamport accounts, which can lead to more duplicates than before?
         // Consider account X in both slot x, and x+1 and x+2.
-        // With eager unref, we will only collect `one_ref`` X at slot x+2 after shrink.
-        // Without eager unref, we will collect X at `multi-ref` after shrink.
-        // Packing multi-ref is less efficient than `one_ref``. But it might be ok - in next round of clean, hopefully, it can turn this from multi-ref into one-ref.
+        // With eager unref, we will only collect `no_duplicates`` X at slot x+2 after shrink.
+        // Without eager unref, X keeps a duplicate after shrink.
+        // Packing duplicates is less efficient. But it might be ok - in the next round of clean, hopefully, the duplicate is resolved.
         let mut accounts_to_combine = accounts_per_storage
             .iter_mut()
             .map(|(info, unique_accounts)| {
@@ -816,7 +815,7 @@ impl AccountsDb {
             .map(|a| a.alive_total_bytes)
             .sum::<usize>();
 
-        let mut many_refs_old_alive_count = 0;
+        let mut not_newest_duplicate_count = 0;
 
         let mut remove = Vec::default();
         let mut last_slot = None;
@@ -832,16 +831,16 @@ impl AccountsDb {
             }
             last_slot = Some(shrink_collect.slot);
 
-            let many_refs_old_alive = &mut shrink_collect.alive_accounts.many_refs_old_alive;
+            let not_newest_duplicate = &mut shrink_collect.alive_accounts.not_newest_duplicate;
             if many_ref_slots == IncludeManyRefSlots::Skip
                 && !shrink_collect
                     .alive_accounts
-                    .many_refs_this_is_newest_alive
+                    .newest_duplicate
                     .accounts
                     .is_empty()
             {
                 let mut required_packed_slots = min_resulting_packed_slots;
-                if many_refs_old_alive.accounts.is_empty() {
+                if not_newest_duplicate.accounts.is_empty() {
                     // if THIS slot can be used as a target slot, then even if we have multi refs
                     // this is ok.
                     required_packed_slots = required_packed_slots.saturating_sub(1);
@@ -866,17 +865,17 @@ impl AccountsDb {
                 }
             }
 
-            if !many_refs_old_alive.accounts.is_empty() {
-                many_refs_old_alive_count += many_refs_old_alive.accounts.len();
-                many_refs_old_alive.accounts.iter().for_each(|account| {
+            if !not_newest_duplicate.accounts.is_empty() {
+                not_newest_duplicate_count += not_newest_duplicate.accounts.len();
+                not_newest_duplicate.accounts.iter().for_each(|account| {
                     // these accounts could indicate clean bugs or low memory conditions where we are forced to flush non-roots
                     log::info!(
                         "ancient append vec: found unpackable account: {}, {}",
-                        many_refs_old_alive.slot,
+                        not_newest_duplicate.slot,
                         account.pubkey()
                     );
                 });
-                // There are alive accounts with ref_count > 1, where the entry for the account in the index is NOT the highest slot. (`many_refs_old_alive`)
+                // There are alive accounts with a newer duplicate. (`not_newest_duplicate`)
                 // This means this account must remain IN this slot. There could be alive or dead references to this same account in any older slot.
                 // Moving it to a lower slot could move it before an alive or dead entry to this same account.
                 // Moving it to a higher slot could move it ahead of other slots where this account is also alive. We know a higher slot exists that contains this account.
@@ -884,10 +883,14 @@ impl AccountsDb {
                 // This would fail the invariant that the highest slot # where an account exists defines the most recent account.
                 // It could be a clean error or a transient condition that will resolve if we encounter this situation.
                 // The count of these accounts per call will be reported by metrics in `unpackable_slots_count`
-                if shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                if shrink_collect
+                    .alive_accounts
+                    .no_duplicates
+                    .accounts
+                    .is_empty()
                     && shrink_collect
                         .alive_accounts
-                        .many_refs_this_is_newest_alive
+                        .newest_duplicate
                         .accounts
                         .is_empty()
                 {
@@ -896,7 +899,7 @@ impl AccountsDb {
                     continue;
                 }
                 accounts_keep_slots
-                    .insert(shrink_collect.slot, std::mem::take(many_refs_old_alive));
+                    .insert(shrink_collect.slot, std::mem::take(not_newest_duplicate));
             } else {
                 // No alive accounts in this slot have a ref_count > 1. So, ALL alive accounts in this slot can be written to any other slot
                 // we find convenient. There is NO other instance of any account to conflict with.
@@ -916,7 +919,7 @@ impl AccountsDb {
             .fetch_add(accounts_keep_slots.len() as u64, Ordering::Relaxed);
         self.shrink_ancient_stats
             .many_refs_old_alive
-            .fetch_add(many_refs_old_alive_count as u64, Ordering::Relaxed);
+            .fetch_add(not_newest_duplicate_count as u64, Ordering::Relaxed);
         AccountsToCombine {
             accounts_to_combine,
             accounts_keep_slots,
@@ -955,7 +958,7 @@ impl AccountsDb {
     /// These accounts need to be rewritten in their same slot, Ideally with no other accounts in the slot.
     /// Other accounts would have ref_count = 1.
     /// ref_count = 1 accounts will be combined together with other slots into larger append vecs elsewhere.
-    fn write_ancient_accounts_to_same_slot_multiple_refs<'a, 'b: 'a>(
+    fn write_ancient_accounts_to_same_slot_not_newest_duplicate<'a, 'b: 'a>(
         &'b self,
         accounts_to_combine: impl Iterator<Item = &'a AliveAccounts<'a>>,
         write_ancient_accounts: &mut WriteAncientAccounts<'b>,
@@ -1405,13 +1408,13 @@ mod tests {
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_write_ancient_accounts_to_same_slot_multiple_refs_empty(
+    fn test_write_ancient_accounts_to_same_slot_not_newest_duplicate_empty(
         accounts_db_config: AccountsDbConfig,
     ) {
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config);
         let (_storages, _slots, _infos) = get_sample_storages(&db, 0, None);
         let mut write_ancient_accounts = WriteAncientAccounts::default();
-        db.write_ancient_accounts_to_same_slot_multiple_refs(
+        db.write_ancient_accounts_to_same_slot_not_newest_duplicate(
             AccountsToCombine::default().accounts_keep_slots.values(),
             &mut write_ancient_accounts,
         );
@@ -2015,7 +2018,7 @@ mod tests {
                             } else {
                                 vec![]
                             };
-                            // all accounts should be in one_ref and all slots are available as target slots
+                            // all accounts should be in no_duplicates and all slots are available as target slots
                             assert_eq!(
                                 accounts_to_combine.target_slots_sorted,
                                 expected_target_slots_sorted,
@@ -2025,7 +2028,7 @@ mod tests {
                                 |shrink_collect| {
                                     shrink_collect
                                         .alive_accounts
-                                        .many_refs_old_alive
+                                        .not_newest_duplicate
                                         .accounts
                                         .is_empty()
                                 }
@@ -2033,14 +2036,18 @@ mod tests {
                             if two_refs {
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
-                                        shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                                        shrink_collect
+                                            .alive_accounts
+                                            .no_duplicates
+                                            .accounts
+                                            .is_empty()
                                     }
                                 ));
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
                                         !shrink_collect
                                             .alive_accounts
-                                            .many_refs_this_is_newest_alive
+                                            .newest_duplicate
                                             .accounts
                                             .is_empty()
                                     }
@@ -2048,14 +2055,18 @@ mod tests {
                             } else {
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
-                                        !shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                                        !shrink_collect
+                                            .alive_accounts
+                                            .no_duplicates
+                                            .accounts
+                                            .is_empty()
                                     }
                                 ));
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
                                         shrink_collect
                                             .alive_accounts
-                                            .many_refs_this_is_newest_alive
+                                            .newest_duplicate
                                             .accounts
                                             .is_empty()
                                     }
@@ -2080,7 +2091,7 @@ mod tests {
         // with 2 accounts
         // 1 with 1 ref
         // 1 with 2 refs (and the other ref is from a newer slot)
-        // So, the other alive ref will cause the account with 2 refs to be put into many_refs_old_alive and then accounts_keep_slots
+        // So, the newer duplicate will put this account into not_newest_duplicate and then accounts_keep_slots
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
         let num_slots = 1;
         // creating 1 more sample slot/storage, but effectively act like 1 slot
@@ -2167,7 +2178,7 @@ mod tests {
             .first()
             .unwrap()
             .alive_accounts
-            .one_ref
+            .no_duplicates
             .accounts;
         let one_ref_accounts_account_shared_data = one_ref_accounts
             .iter()
@@ -2194,7 +2205,7 @@ mod tests {
                 .iter()
                 .all(|shrink_collect| shrink_collect
                     .alive_accounts
-                    .many_refs_this_is_newest_alive
+                    .newest_duplicate
                     .accounts
                     .is_empty())
         );
@@ -2206,7 +2217,7 @@ mod tests {
                 .iter()
                 .all(|shrink_collect| shrink_collect
                     .alive_accounts
-                    .many_refs_old_alive
+                    .not_newest_duplicate
                     .accounts
                     .is_empty())
         );
@@ -2318,7 +2329,7 @@ mod tests {
         );
         let slots_vec = slots.collect::<Vec<_>>();
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-        // all accounts should be in many_refs_this_is_newest_alive
+        // all accounts should be in newest_duplicate
         let mut accounts_keep = accounts_to_combine
             .accounts_keep_slots
             .keys()
@@ -2335,7 +2346,7 @@ mod tests {
                 .first()
                 .unwrap()
                 .alive_accounts
-                .many_refs_this_is_newest_alive
+                .newest_duplicate
                 .accounts
                 .iter()
                 .map(|meta| meta.pubkey())
@@ -2348,7 +2359,7 @@ mod tests {
             .first()
             .unwrap()
             .alive_accounts
-            .one_ref
+            .no_duplicates
             .accounts;
         let one_ref_accounts_account_shared_data = one_ref_accounts
             .iter()
@@ -2374,7 +2385,7 @@ mod tests {
                 .iter()
                 .all(|shrink_collect| !shrink_collect
                     .alive_accounts
-                    .many_refs_this_is_newest_alive
+                    .newest_duplicate
                     .accounts
                     .is_empty())
         );
@@ -3767,14 +3778,9 @@ mod tests {
                             // empty slot list (ignored anyway) because ref_count = 1
                             let slot_list = vec![];
                             alive_accounts.add(1, &account, &slot_list);
-                            assert!(!alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(!alive_accounts.no_duplicates.accounts.is_empty());
+                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
+                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         1 => {
                             // non-empty slot list (but ignored) because slot_list = 1
@@ -3786,17 +3792,12 @@ mod tests {
                                 ),
                             )];
                             alive_accounts.add(2, &account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                !alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
+                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
+                            assert!(!alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         2 => {
-                            // multiple slot list, ref_count=2, this is NOT newest alive, so many_refs_old_alive
+                            // multiple slot list, this is not the newest, so not_newest_duplicate
                             let slot_list = vec![
                                 (
                                     slot,
@@ -3814,14 +3815,9 @@ mod tests {
                                 ),
                             ];
                             alive_accounts.add(2, &account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(!alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
+                            assert!(!alive_accounts.not_newest_duplicate.accounts.is_empty());
+                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         3 => {
                             // multiple slot list, ref_count=2, this is newest
@@ -3842,14 +3838,9 @@ mod tests {
                                 ),
                             ];
                             alive_accounts.add(2, &account, &slot_list);
-                            assert!(alive_accounts.one_ref.accounts.is_empty());
-                            assert!(alive_accounts.many_refs_old_alive.accounts.is_empty());
-                            assert!(
-                                !alive_accounts
-                                    .many_refs_this_is_newest_alive
-                                    .accounts
-                                    .is_empty()
-                            );
+                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
+                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
+                            assert!(!alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         _ => {
                             panic!("unexpected");
@@ -3860,7 +3851,7 @@ mod tests {
     }
 
     #[test]
-    fn test_many_ref_accounts_can_be_moved() {
+    fn test_newest_duplicate_can_be_moved() {
         let tuning = PackedAncientStorageTuning {
             // only allow 10k slots old enough to be ancient
             max_ancient_slots: 10_000,
@@ -3871,58 +3862,58 @@ mod tests {
         };
 
         // nothing to move, so no problem fitting it
-        let many_refs_newest = vec![];
+        let newest_duplicate = vec![];
         let target_slots_sorted = vec![];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));
         // something to move, no target slots, so can't fit
         let slot = 1;
-        let many_refs_newest = vec![AliveAccounts {
+        let newest_duplicate = vec![AliveAccounts {
             bytes: 1,
             slot,
             accounts: Vec::default(),
         }];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));
 
         // something to move, 1 target slot, so can fit
         let target_slots_sorted = vec![slot];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));
 
         // too much to move to 1 target slot, so can't fit
-        let many_refs_newest = vec![AliveAccounts {
+        let newest_duplicate = vec![AliveAccounts {
             bytes: tuning.ideal_storage_size.get() as usize,
             slot,
             accounts: Vec::default(),
         }];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));
 
         // more than 1 slot to move, 2 target slots, so can fit
         let target_slots_sorted = vec![slot, slot + 1];
-        assert!(AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));
 
         // lowest target slot is below required slot
         let target_slots_sorted = vec![slot - 1, slot];
-        assert!(!AccountsDb::many_ref_accounts_can_be_moved(
-            &many_refs_newest,
+        assert!(!AccountsDb::newest_duplicate_can_be_moved(
+            &newest_duplicate,
             &target_slots_sorted,
             &tuning
         ));

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -856,7 +856,7 @@ impl AccountsDb {
                     // We require `min_resulting_packed_slots` target slots. If we have not encountered enough slots already without `newest_duplicate` accounts, then keep trying.
                     // On the next pass, THIS slot will be older relative to newly ancient slot #s, so those newly ancient slots will be higher in this list.
                     self.shrink_ancient_stats
-                        .many_ref_slots_skipped
+                        .newest_duplicate_slots_skipped
                         .fetch_add(1, Ordering::Relaxed);
                     // since we're skipping this one, we don't count it as required target storages
                     alive_bytes = alive_bytes.saturating_sub(shrink_collect.alive_total_bytes);
@@ -918,7 +918,7 @@ impl AccountsDb {
             .slots_cannot_move_count
             .fetch_add(accounts_keep_slots.len() as u64, Ordering::Relaxed);
         self.shrink_ancient_stats
-            .many_refs_old_alive
+            .not_newest_duplicate
             .fetch_add(not_newest_duplicate_count as u64, Ordering::Relaxed);
         AccountsToCombine {
             accounts_to_combine,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1901,187 +1901,175 @@ mod tests {
 
         for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
             for add_dead_account in [true, false] {
-                    for num_slots in 0..3 {
-                        for unsorted_slots in [false, true] {
-                            for two_refs in [false, true] {
-                                let db = AccountsDb::new_for_tests_with_config(
-                                    Vec::new(),
-                                    accounts_db_config.clone(),
-                                );
-                                let (mut storages, slots, mut infos) =
-                                    get_sample_storages(&db, num_slots, Some(data_size));
-                                infos
-                                    .iter_mut()
-                                    .for_each(|a| a.alive_bytes += alive_bytes_per_account);
+                for num_slots in 0..3 {
+                    for unsorted_slots in [false, true] {
+                        for two_refs in [false, true] {
+                            let db = AccountsDb::new_for_tests_with_config(
+                                Vec::new(),
+                                accounts_db_config.clone(),
+                            );
+                            let (mut storages, slots, mut infos) =
+                                get_sample_storages(&db, num_slots, Some(data_size));
+                            infos
+                                .iter_mut()
+                                .for_each(|a| a.alive_bytes += alive_bytes_per_account);
 
-                                let slots_vec;
-                                if unsorted_slots {
-                                    slots_vec = slots.rev().collect::<Vec<_>>();
-                                    storages = storages.into_iter().rev().collect();
-                                    infos = infos.into_iter().rev().collect();
-                                } else {
-                                    slots_vec = slots.collect::<Vec<_>>()
-                                }
+                            let slots_vec;
+                            if unsorted_slots {
+                                slots_vec = slots.rev().collect::<Vec<_>>();
+                                storages = storages.into_iter().rev().collect();
+                                infos = infos.into_iter().rev().collect();
+                            } else {
+                                slots_vec = slots.collect::<Vec<_>>()
+                            }
 
-                                if two_refs {
-                                    add_older_ref(&db, &storages);
-                                }
+                            if two_refs {
+                                add_older_ref(&db, &storages);
+                            }
 
-                                if add_dead_account {
-                                    storages.iter().for_each(|storage| {
-                                        let pk = solana_pubkey::new_rand();
-                                        let alive = false;
-                                        append_single_account_with_default_hash(
-                                            storage,
+                            if add_dead_account {
+                                storages.iter().for_each(|storage| {
+                                    let pk = solana_pubkey::new_rand();
+                                    let alive = false;
+                                    append_single_account_with_default_hash(
+                                        storage,
+                                        &pk,
+                                        &AccountSharedData::default(),
+                                        alive,
+                                        Some(&db.accounts_index),
+                                    );
+                                    // mark the account obsolete and remove it from the index,
+                                    // as clean does when it reclaims an account
+                                    let account_offset =
+                                        db.accounts_index.get_and_then(&pk, |entry| {
+                                            let slot_list = entry.unwrap().slot_list_read_lock();
+                                            (false, slot_list.first().unwrap().1.offset())
+                                        });
+                                    storage
+                                        .obsolete_accounts
+                                        .write()
+                                        .unwrap()
+                                        .mark_accounts_obsolete(
+                                            std::iter::once((account_offset, 0)),
+                                            storage.slot(),
+                                        );
+                                    assert!(
+                                        db.accounts_index.purge_exact(
                                             &pk,
-                                            &AccountSharedData::default(),
-                                            alive,
-                                            Some(&db.accounts_index),
-                                        );
-                                        // mark the account obsolete and remove it from the index,
-                                        // as clean does when it reclaims an account
-                                        let account_offset =
-                                            db.accounts_index.get_and_then(&pk, |entry| {
-                                                let slot_list =
-                                                    entry.unwrap().slot_list_read_lock();
-                                                (false, slot_list.first().unwrap().1.offset())
-                                            });
-                                        storage
-                                            .obsolete_accounts
-                                            .write()
-                                            .unwrap()
-                                            .mark_accounts_obsolete(
-                                                std::iter::once((account_offset, 0)),
-                                                storage.slot(),
-                                            );
-                                        assert!(
-                                            db.accounts_index.purge_exact(
-                                                &pk,
-                                                [storage.slot()]
-                                                    .into_iter()
-                                                    .collect::<std::collections::HashSet<Slot>>(),
-                                                &mut ReclaimsSlotList::new()
-                                            )
-                                        );
-                                    });
+                                            [storage.slot()]
+                                                .into_iter()
+                                                .collect::<std::collections::HashSet<Slot>>(),
+                                            &mut ReclaimsSlotList::new()
+                                        )
+                                    );
+                                });
+                            }
+                            let original_results = storages
+                                .iter()
+                                .map(|store| db.get_unique_accounts_from_storage(store))
+                                .collect::<Vec<_>>();
+
+                            let mut accounts_per_storage =
+                                infos.iter().zip(original_results).collect::<Vec<_>>();
+
+                            let accounts_to_combine = db.calc_accounts_to_combine(
+                                &mut accounts_per_storage,
+                                &tuning,
+                                many_ref_slots,
+                            );
+                            // if we are only trying to pack a single slot of multi-refs, it will succeed
+                            // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
+                            // one element (storage), because we don't count alive bytes of skipped accounts
+                            // when we compute required target storages, and the second slot can be combined.
+                            let expected_number_accounts_to_combine = if !two_refs
+                                || many_ref_slots == IncludeManyRefSlots::Include
+                                || num_slots == 1
+                                || (num_slots == 2 && many_ref_slots != IncludeManyRefSlots::Skip)
+                            {
+                                num_slots
+                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
+                            {
+                                1
+                            } else {
+                                0
+                            };
+                            assert_eq!(
+                                accounts_to_combine.accounts_to_combine.len(),
+                                expected_number_accounts_to_combine,
+                                "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
+                                 {many_ref_slots:?}"
+                            );
+
+                            let expected_target_slots_sorted = if !two_refs
+                                || many_ref_slots == IncludeManyRefSlots::Include
+                                || num_slots == 1
+                            {
+                                if unsorted_slots {
+                                    slots_vec.iter().cloned().rev().collect::<Vec<_>>()
+                                } else {
+                                    slots_vec.clone()
                                 }
-                                let original_results = storages
-                                    .iter()
-                                    .map(|store| db.get_unique_accounts_from_storage(store))
-                                    .collect::<Vec<_>>();
-
-                                let mut accounts_per_storage =
-                                    infos.iter().zip(original_results).collect::<Vec<_>>();
-
-                                let accounts_to_combine = db.calc_accounts_to_combine(
-                                    &mut accounts_per_storage,
-                                    &tuning,
-                                    many_ref_slots,
-                                );
-                                // if we are only trying to pack a single slot of multi-refs, it will succeed
-                                // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
-                                // one element (storage), because we don't count alive bytes of skipped accounts
-                                // when we compute required target storages, and the second slot can be combined.
-                                let expected_number_accounts_to_combine = if !two_refs
-                                    || many_ref_slots == IncludeManyRefSlots::Include
-                                    || num_slots == 1
-                                    || (num_slots == 2
-                                        && many_ref_slots != IncludeManyRefSlots::Skip)
-                                {
-                                    num_slots
-                                } else if num_slots == 2
-                                    && many_ref_slots == IncludeManyRefSlots::Skip
-                                {
-                                    1
-                                } else {
-                                    0
-                                };
-                                assert_eq!(
-                                    accounts_to_combine.accounts_to_combine.len(),
-                                    expected_number_accounts_to_combine,
-                                    "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
-                                     {many_ref_slots:?}"
-                                );
-
-                                let expected_target_slots_sorted = if !two_refs
-                                    || many_ref_slots == IncludeManyRefSlots::Include
-                                    || num_slots == 1
-                                {
-                                    if unsorted_slots {
-                                        slots_vec.iter().cloned().rev().collect::<Vec<_>>()
-                                    } else {
-                                        slots_vec.clone()
-                                    }
-                                } else if num_slots == 2
-                                    && many_ref_slots == IncludeManyRefSlots::Skip
-                                {
-                                    vec![1]
-                                } else {
-                                    vec![]
-                                };
-                                // all accounts should be in one_ref and all slots are available as target slots
-                                assert_eq!(
-                                    accounts_to_combine.target_slots_sorted,
-                                    expected_target_slots_sorted,
-                                );
-                                assert!(accounts_to_combine.accounts_keep_slots.is_empty());
+                            } else if num_slots == 2 && many_ref_slots == IncludeManyRefSlots::Skip
+                            {
+                                vec![1]
+                            } else {
+                                vec![]
+                            };
+                            // all accounts should be in one_ref and all slots are available as target slots
+                            assert_eq!(
+                                accounts_to_combine.target_slots_sorted,
+                                expected_target_slots_sorted,
+                            );
+                            assert!(accounts_to_combine.accounts_keep_slots.is_empty());
+                            assert!(accounts_to_combine.accounts_to_combine.iter().all(
+                                |shrink_collect| {
+                                    shrink_collect
+                                        .alive_accounts
+                                        .many_refs_old_alive
+                                        .accounts
+                                        .is_empty()
+                                }
+                            ));
+                            if two_refs {
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
-                                        shrink_collect
+                                        shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                                    }
+                                ));
+                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
+                                    |shrink_collect| {
+                                        !shrink_collect
                                             .alive_accounts
-                                            .many_refs_old_alive
+                                            .many_refs_this_is_newest_alive
                                             .accounts
                                             .is_empty()
                                     }
                                 ));
-                                if two_refs {
-                                    assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                        |shrink_collect| {
-                                            shrink_collect
-                                                .alive_accounts
-                                                .one_ref
-                                                .accounts
-                                                .is_empty()
-                                        }
-                                    ));
-                                    assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                        |shrink_collect| {
-                                            !shrink_collect
-                                                .alive_accounts
-                                                .many_refs_this_is_newest_alive
-                                                .accounts
-                                                .is_empty()
-                                        }
-                                    ));
-                                } else {
-                                    assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                        |shrink_collect| {
-                                            !shrink_collect
-                                                .alive_accounts
-                                                .one_ref
-                                                .accounts
-                                                .is_empty()
-                                        }
-                                    ));
-                                    assert!(accounts_to_combine.accounts_to_combine.iter().all(
-                                        |shrink_collect| {
-                                            shrink_collect
-                                                .alive_accounts
-                                                .many_refs_this_is_newest_alive
-                                                .accounts
-                                                .is_empty()
-                                        }
-                                    ));
-                                }
-
-                                let packed_contents = Vec::default();
-                                let write_ancient_accounts =
-                                    db.write_packed_storages(&accounts_to_combine, packed_contents);
-
-                                assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
+                            } else {
+                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
+                                    |shrink_collect| {
+                                        !shrink_collect.alive_accounts.one_ref.accounts.is_empty()
+                                    }
+                                ));
+                                assert!(accounts_to_combine.accounts_to_combine.iter().all(
+                                    |shrink_collect| {
+                                        shrink_collect
+                                            .alive_accounts
+                                            .many_refs_this_is_newest_alive
+                                            .accounts
+                                            .is_empty()
+                                    }
+                                ));
                             }
+
+                            let packed_contents = Vec::default();
+                            let write_ancient_accounts =
+                                db.write_packed_storages(&accounts_to_combine, packed_contents);
+
+                            assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
                         }
                     }
+                }
             }
         }
     }
@@ -2093,184 +2081,184 @@ mod tests {
         // 1 with 1 ref
         // 1 with 2 refs (and the other ref is from a newer slot)
         // So, the other alive ref will cause the account with 2 refs to be put into many_refs_old_alive and then accounts_keep_slots
-            let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
-            let num_slots = 1;
-            // creating 1 more sample slot/storage, but effectively act like 1 slot
-            let (mut storages, slots, infos) = get_sample_storages(&db, num_slots + 1, None);
-            let slots = slots.start..slots.start + 1;
-            let storage = storages.first().unwrap().clone();
-            let ignored_storage = storages.pop().unwrap();
-            let original_results = storages
-                .iter()
-                .map(|store| db.get_unique_accounts_from_storage(store))
-                .collect::<Vec<_>>();
-            let pk_with_1_ref = solana_pubkey::new_rand();
-            let slot1 = slots.start;
-            let account_with_2_refs = original_results
-                .first()
-                .unwrap()
-                .stored_accounts
-                .first()
-                .unwrap();
-            let account_shared_data_with_2_refs =
-                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-            let pk_with_2_refs = account_with_2_refs.pubkey();
-            let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-            account_with_1_ref.checked_add_lamports(1).unwrap();
-            append_single_account_with_default_hash(
-                &storage,
-                &pk_with_1_ref,
-                &account_with_1_ref,
-                true,
-                Some(&db.accounts_index),
-            );
-            // add the account with 2 refs into the storage we're ignoring.
-            // The storage we're ignoring has a higher slot.
-            // The index entry for pk_with_2_refs will have both slots in it.
-            // The slot of `storage` is lower than the slot of `ignored_storage`.
-            // But, both are 'alive', aka in the index.
-            append_single_account_with_default_hash(
-                &ignored_storage,
-                pk_with_2_refs,
-                &account_shared_data_with_2_refs,
-                true,
-                Some(&db.accounts_index),
-            );
+        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
+        let num_slots = 1;
+        // creating 1 more sample slot/storage, but effectively act like 1 slot
+        let (mut storages, slots, infos) = get_sample_storages(&db, num_slots + 1, None);
+        let slots = slots.start..slots.start + 1;
+        let storage = storages.first().unwrap().clone();
+        let ignored_storage = storages.pop().unwrap();
+        let original_results = storages
+            .iter()
+            .map(|store| db.get_unique_accounts_from_storage(store))
+            .collect::<Vec<_>>();
+        let pk_with_1_ref = solana_pubkey::new_rand();
+        let slot1 = slots.start;
+        let account_with_2_refs = original_results
+            .first()
+            .unwrap()
+            .stored_accounts
+            .first()
+            .unwrap();
+        let account_shared_data_with_2_refs =
+            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
+        let pk_with_2_refs = account_with_2_refs.pubkey();
+        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
+        account_with_1_ref.checked_add_lamports(1).unwrap();
+        append_single_account_with_default_hash(
+            &storage,
+            &pk_with_1_ref,
+            &account_with_1_ref,
+            true,
+            Some(&db.accounts_index),
+        );
+        // add the account with 2 refs into the storage we're ignoring.
+        // The storage we're ignoring has a higher slot.
+        // The index entry for pk_with_2_refs will have both slots in it.
+        // The slot of `storage` is lower than the slot of `ignored_storage`.
+        // But, both are 'alive', aka in the index.
+        append_single_account_with_default_hash(
+            &ignored_storage,
+            pk_with_2_refs,
+            &account_shared_data_with_2_refs,
+            true,
+            Some(&db.accounts_index),
+        );
 
-            // update to get both accounts in the storage
-            let original_results = storages
-                .iter()
-                .map(|store| db.get_unique_accounts_from_storage(store))
-                .collect::<Vec<_>>();
-            assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-            let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
+        // update to get both accounts in the storage
+        let original_results = storages
+            .iter()
+            .map(|store| db.get_unique_accounts_from_storage(store))
+            .collect::<Vec<_>>();
+        assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
+        let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
 
-            let accounts_to_combine = db.calc_accounts_to_combine(
-                &mut accounts_per_storage,
-                &default_tuning(),
-                IncludeManyRefSlots::Include,
-            );
-            let slots_vec = slots.collect::<Vec<_>>();
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-            // all accounts should be in many_refs
-            let mut accounts_keep = accounts_to_combine
+        let accounts_to_combine = db.calc_accounts_to_combine(
+            &mut accounts_per_storage,
+            &default_tuning(),
+            IncludeManyRefSlots::Include,
+        );
+        let slots_vec = slots.collect::<Vec<_>>();
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
+        // all accounts should be in many_refs
+        let mut accounts_keep = accounts_to_combine
+            .accounts_keep_slots
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        accounts_keep.sort_unstable();
+        assert_eq!(accounts_keep, slots_vec);
+        assert!(accounts_to_combine.target_slots_sorted.is_empty());
+        assert_eq!(accounts_to_combine.accounts_keep_slots.len(), num_slots);
+        assert_eq!(
+            accounts_to_combine
                 .accounts_keep_slots
-                .keys()
-                .cloned()
-                .collect::<Vec<_>>();
-            accounts_keep.sort_unstable();
-            assert_eq!(accounts_keep, slots_vec);
-            assert!(accounts_to_combine.target_slots_sorted.is_empty());
-            assert_eq!(accounts_to_combine.accounts_keep_slots.len(), num_slots);
-            assert_eq!(
-                accounts_to_combine
-                    .accounts_keep_slots
-                    .get(&slot1)
-                    .unwrap()
-                    .accounts
-                    .iter()
-                    .map(|meta| meta.pubkey())
-                    .collect::<Vec<_>>(),
-                vec![pk_with_2_refs]
-            );
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-            let one_ref_accounts = &accounts_to_combine
-                .accounts_to_combine
-                .first()
+                .get(&slot1)
                 .unwrap()
-                .alive_accounts
-                .one_ref
-                .accounts;
-            let one_ref_accounts_account_shared_data = one_ref_accounts
-                .iter()
-                .map(|account| get_account_from_account_from_storage(account, &db, slot1))
-                .collect::<Vec<_>>();
-
-            assert_eq!(
-                one_ref_accounts
-                    .iter()
-                    .map(|meta| meta.pubkey())
-                    .collect::<Vec<_>>(),
-                vec![&pk_with_1_ref]
-            );
-            assert_eq!(
-                one_ref_accounts_account_shared_data
-                    .iter()
-                    .map(create_account_shared_data)
-                    .collect::<Vec<_>>(),
-                vec![account_with_1_ref]
-            );
-            assert!(
-                accounts_to_combine
-                    .accounts_to_combine
-                    .iter()
-                    .all(|shrink_collect| shrink_collect
-                        .alive_accounts
-                        .many_refs_this_is_newest_alive
-                        .accounts
-                        .is_empty())
-            );
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-
-            assert!(
-                accounts_to_combine
-                    .accounts_to_combine
-                    .iter()
-                    .all(|shrink_collect| shrink_collect
-                        .alive_accounts
-                        .many_refs_old_alive
-                        .accounts
-                        .is_empty())
-            );
-
-            let packed_contents = Vec::default();
-            let write_ancient_accounts =
-                db.write_packed_storages(&accounts_to_combine, packed_contents);
-            assert_eq!(write_ancient_accounts.shrinks_in_progress.len(), num_slots);
-            let mut shrinks_in_progress = write_ancient_accounts
-                .shrinks_in_progress
-                .iter()
-                .collect::<Vec<_>>();
-            shrinks_in_progress.sort_unstable_by(|a, b| a.0.cmp(b.0));
-            assert_eq!(
-                shrinks_in_progress
-                    .iter()
-                    .map(|(slot, _)| **slot)
-                    .collect::<Vec<_>>(),
-                slots_vec
-            );
-            assert_eq!(
-                shrinks_in_progress
-                    .iter()
-                    .map(|(_, shrink_in_progress)| shrink_in_progress.old_storage().id())
-                    .collect::<Vec<_>>(),
-                storages
-                    .iter()
-                    .map(|storage| storage.id())
-                    .collect::<Vec<_>>()
-            );
-            let mut reader = append_vec::new_scan_accounts_reader();
-
-            // assert that we wrote the 2_ref account to the newly shrunk append vec
-            let shrink_in_progress = shrinks_in_progress.first().unwrap().1;
-            let mut count = 0;
-            shrink_in_progress
-                .new_storage()
                 .accounts
-                .scan_accounts(&mut reader, |_offset, _| {
-                    count += 1;
-                })
-                .expect("must scan accounts storage");
-            assert_eq!(count, 1);
-            let account = shrink_in_progress
-                .new_storage()
-                .accounts
-                .get_stored_account_callback(0, |account| {
-                    assert_eq!(account.pubkey(), pk_with_2_refs);
-                    create_account_shared_data(&account)
-                })
-                .unwrap();
-            assert_eq!(account, account_shared_data_with_2_refs);
+                .iter()
+                .map(|meta| meta.pubkey())
+                .collect::<Vec<_>>(),
+            vec![pk_with_2_refs]
+        );
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
+        let one_ref_accounts = &accounts_to_combine
+            .accounts_to_combine
+            .first()
+            .unwrap()
+            .alive_accounts
+            .one_ref
+            .accounts;
+        let one_ref_accounts_account_shared_data = one_ref_accounts
+            .iter()
+            .map(|account| get_account_from_account_from_storage(account, &db, slot1))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            one_ref_accounts
+                .iter()
+                .map(|meta| meta.pubkey())
+                .collect::<Vec<_>>(),
+            vec![&pk_with_1_ref]
+        );
+        assert_eq!(
+            one_ref_accounts_account_shared_data
+                .iter()
+                .map(create_account_shared_data)
+                .collect::<Vec<_>>(),
+            vec![account_with_1_ref]
+        );
+        assert!(
+            accounts_to_combine
+                .accounts_to_combine
+                .iter()
+                .all(|shrink_collect| shrink_collect
+                    .alive_accounts
+                    .many_refs_this_is_newest_alive
+                    .accounts
+                    .is_empty())
+        );
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
+
+        assert!(
+            accounts_to_combine
+                .accounts_to_combine
+                .iter()
+                .all(|shrink_collect| shrink_collect
+                    .alive_accounts
+                    .many_refs_old_alive
+                    .accounts
+                    .is_empty())
+        );
+
+        let packed_contents = Vec::default();
+        let write_ancient_accounts =
+            db.write_packed_storages(&accounts_to_combine, packed_contents);
+        assert_eq!(write_ancient_accounts.shrinks_in_progress.len(), num_slots);
+        let mut shrinks_in_progress = write_ancient_accounts
+            .shrinks_in_progress
+            .iter()
+            .collect::<Vec<_>>();
+        shrinks_in_progress.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        assert_eq!(
+            shrinks_in_progress
+                .iter()
+                .map(|(slot, _)| **slot)
+                .collect::<Vec<_>>(),
+            slots_vec
+        );
+        assert_eq!(
+            shrinks_in_progress
+                .iter()
+                .map(|(_, shrink_in_progress)| shrink_in_progress.old_storage().id())
+                .collect::<Vec<_>>(),
+            storages
+                .iter()
+                .map(|storage| storage.id())
+                .collect::<Vec<_>>()
+        );
+        let mut reader = append_vec::new_scan_accounts_reader();
+
+        // assert that we wrote the 2_ref account to the newly shrunk append vec
+        let shrink_in_progress = shrinks_in_progress.first().unwrap().1;
+        let mut count = 0;
+        shrink_in_progress
+            .new_storage()
+            .accounts
+            .scan_accounts(&mut reader, |_offset, _| {
+                count += 1;
+            })
+            .expect("must scan accounts storage");
+        assert_eq!(count, 1);
+        let account = shrink_in_progress
+            .new_storage()
+            .accounts
+            .get_stored_account_callback(0, |account| {
+                assert_eq!(account.pubkey(), pk_with_2_refs);
+                create_account_shared_data(&account)
+            })
+            .unwrap();
+        assert_eq!(account, account_shared_data_with_2_refs);
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -2280,140 +2268,140 @@ mod tests {
         // 1 with 1 ref
         // 1 with 2 refs, with the idea that the other ref is from an older slot, so this one is the newer index entry
         // The result will be that the account, even though it has refcount > 1, can be moved to a newer slot.
-            let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
-            let num_slots = 1;
-            let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
-            let original_results = storages
-                .iter()
-                .map(|store| db.get_unique_accounts_from_storage(store))
-                .collect::<Vec<_>>();
-            let storage = storages.first().unwrap().clone();
-            let pk_with_1_ref = solana_pubkey::new_rand();
-            let slot1 = slots.start;
-            let account_with_2_refs = original_results
-                .first()
-                .unwrap()
-                .stored_accounts
-                .first()
-                .unwrap();
-            let account_shared_data_with_2_refs =
-                get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-            let pk_with_2_refs = account_with_2_refs.pubkey();
-            let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-            _ = account_with_1_ref.checked_add_lamports(1);
-            append_single_account_with_default_hash(
-                &storage,
-                &pk_with_1_ref,
-                &account_with_1_ref,
-                true,
-                Some(&db.accounts_index),
-            );
-            original_results.iter().for_each(|results| {
-                results.stored_accounts.iter().for_each(|account| {
-                    db.accounts_index
-                        .get_and_then(account.pubkey(), |entry| (true, entry.unwrap().addref()));
-                })
-            });
+        let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
+        let num_slots = 1;
+        let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
+        let original_results = storages
+            .iter()
+            .map(|store| db.get_unique_accounts_from_storage(store))
+            .collect::<Vec<_>>();
+        let storage = storages.first().unwrap().clone();
+        let pk_with_1_ref = solana_pubkey::new_rand();
+        let slot1 = slots.start;
+        let account_with_2_refs = original_results
+            .first()
+            .unwrap()
+            .stored_accounts
+            .first()
+            .unwrap();
+        let account_shared_data_with_2_refs =
+            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
+        let pk_with_2_refs = account_with_2_refs.pubkey();
+        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
+        _ = account_with_1_ref.checked_add_lamports(1);
+        append_single_account_with_default_hash(
+            &storage,
+            &pk_with_1_ref,
+            &account_with_1_ref,
+            true,
+            Some(&db.accounts_index),
+        );
+        original_results.iter().for_each(|results| {
+            results.stored_accounts.iter().for_each(|account| {
+                db.accounts_index
+                    .get_and_then(account.pubkey(), |entry| (true, entry.unwrap().addref()));
+            })
+        });
 
-            // update to get both accounts in the storage
-            let original_results = storages
-                .iter()
-                .map(|store| db.get_unique_accounts_from_storage(store))
-                .collect::<Vec<_>>();
-            assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
-            let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
+        // update to get both accounts in the storage
+        let original_results = storages
+            .iter()
+            .map(|store| db.get_unique_accounts_from_storage(store))
+            .collect::<Vec<_>>();
+        assert_eq!(original_results.first().unwrap().stored_accounts.len(), 2);
+        let mut accounts_per_storage = infos.iter().zip(original_results).collect::<Vec<_>>();
 
-            let accounts_to_combine = db.calc_accounts_to_combine(
-                &mut accounts_per_storage,
-                &default_tuning(),
-                IncludeManyRefSlots::Include,
-            );
-            let slots_vec = slots.collect::<Vec<_>>();
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-            // all accounts should be in many_refs_this_is_newest_alive
-            let mut accounts_keep = accounts_to_combine
-                .accounts_keep_slots
-                .keys()
-                .cloned()
-                .collect::<Vec<_>>();
-            accounts_keep.sort_unstable();
-            assert_eq!(accounts_to_combine.target_slots_sorted, slots_vec);
-            assert!(accounts_keep.is_empty());
-            assert!(!accounts_to_combine.target_slots_sorted.is_empty());
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-            assert_eq!(
-                accounts_to_combine
-                    .accounts_to_combine
-                    .first()
-                    .unwrap()
-                    .alive_accounts
-                    .many_refs_this_is_newest_alive
-                    .accounts
-                    .iter()
-                    .map(|meta| meta.pubkey())
-                    .collect::<Vec<_>>(),
-                vec![pk_with_2_refs]
-            );
-            assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-            let one_ref_accounts = &accounts_to_combine
+        let accounts_to_combine = db.calc_accounts_to_combine(
+            &mut accounts_per_storage,
+            &default_tuning(),
+            IncludeManyRefSlots::Include,
+        );
+        let slots_vec = slots.collect::<Vec<_>>();
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
+        // all accounts should be in many_refs_this_is_newest_alive
+        let mut accounts_keep = accounts_to_combine
+            .accounts_keep_slots
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        accounts_keep.sort_unstable();
+        assert_eq!(accounts_to_combine.target_slots_sorted, slots_vec);
+        assert!(accounts_keep.is_empty());
+        assert!(!accounts_to_combine.target_slots_sorted.is_empty());
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
+        assert_eq!(
+            accounts_to_combine
                 .accounts_to_combine
                 .first()
                 .unwrap()
                 .alive_accounts
-                .one_ref
-                .accounts;
-            let one_ref_accounts_account_shared_data = one_ref_accounts
+                .many_refs_this_is_newest_alive
+                .accounts
                 .iter()
-                .map(|account| get_account_from_account_from_storage(account, &db, slot1))
-                .collect::<Vec<_>>();
-            assert_eq!(
-                one_ref_accounts
-                    .iter()
-                    .map(|meta| meta.pubkey())
-                    .collect::<Vec<_>>(),
-                vec![&pk_with_1_ref]
-            );
-            assert_eq!(
-                one_ref_accounts_account_shared_data
-                    .iter()
-                    .map(create_account_shared_data)
-                    .collect::<Vec<_>>(),
-                vec![account_with_1_ref]
-            );
-            assert!(
-                accounts_to_combine
-                    .accounts_to_combine
-                    .iter()
-                    .all(|shrink_collect| !shrink_collect
-                        .alive_accounts
-                        .many_refs_this_is_newest_alive
-                        .accounts
-                        .is_empty())
-            );
+                .map(|meta| meta.pubkey())
+                .collect::<Vec<_>>(),
+            vec![pk_with_2_refs]
+        );
+        assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
+        let one_ref_accounts = &accounts_to_combine
+            .accounts_to_combine
+            .first()
+            .unwrap()
+            .alive_accounts
+            .one_ref
+            .accounts;
+        let one_ref_accounts_account_shared_data = one_ref_accounts
+            .iter()
+            .map(|account| get_account_from_account_from_storage(account, &db, slot1))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            one_ref_accounts
+                .iter()
+                .map(|meta| meta.pubkey())
+                .collect::<Vec<_>>(),
+            vec![&pk_with_1_ref]
+        );
+        assert_eq!(
+            one_ref_accounts_account_shared_data
+                .iter()
+                .map(create_account_shared_data)
+                .collect::<Vec<_>>(),
+            vec![account_with_1_ref]
+        );
+        assert!(
+            accounts_to_combine
+                .accounts_to_combine
+                .iter()
+                .all(|shrink_collect| !shrink_collect
+                    .alive_accounts
+                    .many_refs_this_is_newest_alive
+                    .accounts
+                    .is_empty())
+        );
 
-            let packed_contents = Vec::default();
-            let write_ancient_accounts =
-                db.write_packed_storages(&accounts_to_combine, packed_contents);
-            assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
-            // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
-            let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
-            let accounts_shrunk_same_slot = storage
-                .accounts
-                .get_stored_account_callback(0, |account| {
-                    (*account.pubkey(), create_account_shared_data(&account))
-                })
-                .unwrap();
-            let mut reader = append_vec::new_scan_accounts_reader();
-            let mut count = 0;
-            storage
-                .accounts
-                .scan_accounts(&mut reader, |_, _| {
-                    count += 1;
-                })
-                .expect("must scan accounts storage");
-            assert_eq!(count, 2);
-            assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
-            assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
+        let packed_contents = Vec::default();
+        let write_ancient_accounts =
+            db.write_packed_storages(&accounts_to_combine, packed_contents);
+        assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
+        // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
+        let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
+        let accounts_shrunk_same_slot = storage
+            .accounts
+            .get_stored_account_callback(0, |account| {
+                (*account.pubkey(), create_account_shared_data(&account))
+            })
+            .unwrap();
+        let mut reader = append_vec::new_scan_accounts_reader();
+        let mut count = 0;
+        storage
+            .accounts
+            .scan_accounts(&mut reader, |_, _| {
+                count += 1;
+            })
+            .expect("must scan accounts storage");
+        assert_eq!(count, 2);
+        assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
+        assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1229,7 +1229,7 @@ mod tests {
     /// Give every account backing `storages` a second index entry at slot 0. Sample-storage
     /// slots start at 1, so slot 0 is older than all of them: each account ends up with
     /// slot_list.len() == 2 while its storage slot stays newest
-    fn add_older_ref(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
+    fn add_older_entry(db: &AccountsDb, storages: &[Arc<AccountStorageEntry>]) {
         storages.iter().for_each(|storage| {
             db.get_unique_accounts_from_storage(storage)
                 .stored_accounts
@@ -1710,7 +1710,7 @@ mod tests {
     fn test_finish_combine_ancient_slots_packed_internal(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref
+        // all accounts are in 1 slot
         // nothing shrunk, so all storages and roots should be removed
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {
@@ -1783,10 +1783,10 @@ mod tests {
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
-    fn test_calc_accounts_to_combine_many_refs(accounts_db_config: AccountsDbConfig) {
+    fn test_calc_accounts_to_combine_multiple(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
+        // all accounts are in 1 slot or all accounts are in 2 slots
         let data_size = 48;
         let alive_bytes_per_slot = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
@@ -1798,7 +1798,7 @@ mod tests {
         for many_ref_slots in [IncludeManyRefSlots::Skip, IncludeManyRefSlots::Include] {
             for num_slots in 0..6 {
                 for unsorted_slots in [false, true] {
-                    for two_refs in [false, true] {
+                    for two_slots in [false, true] {
                         let db = AccountsDb::new_for_tests_with_config(
                             Vec::new(),
                             accounts_db_config.clone(),
@@ -1819,7 +1819,7 @@ mod tests {
                             .iter()
                             .map(|store| db.get_unique_accounts_from_storage(store))
                             .collect::<Vec<_>>();
-                        if two_refs {
+                        if two_slots {
                             original_results.iter().for_each(|results| {
                                 results.stored_accounts.iter().for_each(|account| {
                                     db.accounts_index.get_and_then(account.pubkey(), |entry| {
@@ -1843,14 +1843,14 @@ mod tests {
                             many_ref_slots,
                         );
                         let expected_accounts_to_combine = if num_slots >= 3
-                            && two_refs
+                            && two_slots
                             && many_ref_slots == IncludeManyRefSlots::Skip
                         {
                             // In this test setup, 2.5 regular slots fits into 1 ancient slot.
-                            // When there are two_refs and when slots < 3, all regular slots can fit into one ancient slots.
+                            // When there are two_slots and when slots < 3, all regular slots can fit into one ancient slots.
                             // Therefore, we should have all slots that can be combined for slots < 3.
                             // However, when slots >=3, we need more than one ancient slots. The pack algorithm will need to first
-                            // find at least [ceiling(num_slots/2.5) - 1] slots that's don't have many_refs before we can pack slots with many_refs.
+                            // find at least [ceiling(num_slots/2.5) - 1] slots that don't have newest_duplicate accounts before we can pack slots with them.
                             // Since we decrease the number of alive bytes we'll be writing, when we encounter slots that can't be packed,
                             // we now reduce the number required ideal packed storages. As a result, the last
                             // slot can be packed, and the number of accounts to combine should be 2.
@@ -1868,7 +1868,7 @@ mod tests {
                             });
 
                         log::debug!(
-                            "output slots: {:?}, num_slots: {num_slots}, two_refs: {two_refs}, \
+                            "output slots: {:?}, num_slots: {num_slots}, two_slots: {two_slots}, \
                              many_refs: {many_ref_slots:?}, expected accounts to combine: \
                              {expected_accounts_to_combine}, target slots: {:?}, \
                              accounts_to_combine: {}",
@@ -1879,7 +1879,7 @@ mod tests {
                         assert_eq!(
                             accounts_to_combine.accounts_to_combine.len(),
                             expected_accounts_to_combine,
-                            "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
+                            "num_slots: {num_slots}, two_slots: {two_slots}, many_refs: \
                              {many_ref_slots:?}"
                         );
                     }
@@ -1892,7 +1892,7 @@ mod tests {
     fn test_calc_accounts_to_combine_simple(accounts_db_config: AccountsDbConfig) {
         // n storages
         // 1 account each
-        // all accounts have 1 ref or all accounts have 2 refs
+        // all accounts are in 1 slot or all accounts are in 2 slots
         let data_size = 48;
         let alive_bytes_per_account = AppendVec::calculate_stored_size(data_size as usize) as u64;
 
@@ -1906,7 +1906,7 @@ mod tests {
             for add_dead_account in [true, false] {
                 for num_slots in 0..3 {
                     for unsorted_slots in [false, true] {
-                        for two_refs in [false, true] {
+                        for two_slots in [false, true] {
                             let db = AccountsDb::new_for_tests_with_config(
                                 Vec::new(),
                                 accounts_db_config.clone(),
@@ -1926,8 +1926,8 @@ mod tests {
                                 slots_vec = slots.collect::<Vec<_>>()
                             }
 
-                            if two_refs {
-                                add_older_ref(&db, &storages);
+                            if two_slots {
+                                add_older_entry(&db, &storages);
                             }
 
                             if add_dead_account {
@@ -1980,11 +1980,11 @@ mod tests {
                                 &tuning,
                                 many_ref_slots,
                             );
-                            // if we are only trying to pack a single slot of multi-refs, it will succeed
-                            // if num_slots = 2 and skip multi-ref slots, accounts_to_combine should contain
+                            // if we are only trying to pack a single slot of duplicates, it will succeed
+                            // if num_slots = 2 and skip slots with duplicates, accounts_to_combine should contain
                             // one element (storage), because we don't count alive bytes of skipped accounts
                             // when we compute required target storages, and the second slot can be combined.
-                            let expected_number_accounts_to_combine = if !two_refs
+                            let expected_number_accounts_to_combine = if !two_slots
                                 || many_ref_slots == IncludeManyRefSlots::Include
                                 || num_slots == 1
                                 || (num_slots == 2 && many_ref_slots != IncludeManyRefSlots::Skip)
@@ -1999,11 +1999,11 @@ mod tests {
                             assert_eq!(
                                 accounts_to_combine.accounts_to_combine.len(),
                                 expected_number_accounts_to_combine,
-                                "num_slots: {num_slots}, two_refs: {two_refs}, many_refs: \
+                                "num_slots: {num_slots}, two_slots: {two_slots}, many_refs: \
                                  {many_ref_slots:?}"
                             );
 
-                            let expected_target_slots_sorted = if !two_refs
+                            let expected_target_slots_sorted = if !two_slots
                                 || many_ref_slots == IncludeManyRefSlots::Include
                                 || num_slots == 1
                             {
@@ -2033,7 +2033,7 @@ mod tests {
                                         .is_empty()
                                 }
                             ));
-                            if two_refs {
+                            if two_slots {
                                 assert!(accounts_to_combine.accounts_to_combine.iter().all(
                                     |shrink_collect| {
                                         shrink_collect
@@ -2089,8 +2089,8 @@ mod tests {
     fn test_calc_accounts_to_combine_older_dup(accounts_db_config: AccountsDbConfig) {
         // looking at 1 storage
         // with 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs (and the other ref is from a newer slot)
+        // 1 in a single slot
+        // 1 in 2 slots (and the other entry is from a newer slot)
         // So, the newer duplicate will put this account into not_newest_duplicate and then accounts_keep_slots
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
         let num_slots = 1;
@@ -2103,35 +2103,35 @@ mod tests {
             .iter()
             .map(|store| db.get_unique_accounts_from_storage(store))
             .collect::<Vec<_>>();
-        let pk_with_1_ref = solana_pubkey::new_rand();
+        let pk_with_1_slot = solana_pubkey::new_rand();
         let slot1 = slots.start;
-        let account_with_2_refs = original_results
+        let account_with_2_slots = original_results
             .first()
             .unwrap()
             .stored_accounts
             .first()
             .unwrap();
-        let account_shared_data_with_2_refs =
-            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-        let pk_with_2_refs = account_with_2_refs.pubkey();
-        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-        account_with_1_ref.checked_add_lamports(1).unwrap();
+        let account_shared_data_with_2_slots =
+            get_account_from_account_from_storage(account_with_2_slots, &db, slot1);
+        let pk_with_2_slots = account_with_2_slots.pubkey();
+        let mut account_with_1_slot = account_shared_data_with_2_slots.clone();
+        account_with_1_slot.checked_add_lamports(1).unwrap();
         append_single_account_with_default_hash(
             &storage,
-            &pk_with_1_ref,
-            &account_with_1_ref,
+            &pk_with_1_slot,
+            &account_with_1_slot,
             true,
             Some(&db.accounts_index),
         );
-        // add the account with 2 refs into the storage we're ignoring.
+        // add the account in 2 slots into the storage we're ignoring.
         // The storage we're ignoring has a higher slot.
-        // The index entry for pk_with_2_refs will have both slots in it.
+        // The index entry for pk_with_2_slots will have both slots in it.
         // The slot of `storage` is lower than the slot of `ignored_storage`.
         // But, both are 'alive', aka in the index.
         append_single_account_with_default_hash(
             &ignored_storage,
-            pk_with_2_refs,
-            &account_shared_data_with_2_refs,
+            pk_with_2_slots,
+            &account_shared_data_with_2_slots,
             true,
             Some(&db.accounts_index),
         );
@@ -2151,7 +2151,7 @@ mod tests {
         );
         let slots_vec = slots.collect::<Vec<_>>();
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), num_slots);
-        // all accounts should be in many_refs
+        // all accounts should be in newest_duplicate
         let mut accounts_keep = accounts_to_combine
             .accounts_keep_slots
             .keys()
@@ -2170,34 +2170,34 @@ mod tests {
                 .iter()
                 .map(|meta| meta.pubkey())
                 .collect::<Vec<_>>(),
-            vec![pk_with_2_refs]
+            vec![pk_with_2_slots]
         );
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-        let one_ref_accounts = &accounts_to_combine
+        let single_accounts = &accounts_to_combine
             .accounts_to_combine
             .first()
             .unwrap()
             .alive_accounts
             .no_duplicates
             .accounts;
-        let one_ref_accounts_account_shared_data = one_ref_accounts
+        let single_accounts_account_shared_data = single_accounts
             .iter()
             .map(|account| get_account_from_account_from_storage(account, &db, slot1))
             .collect::<Vec<_>>();
 
         assert_eq!(
-            one_ref_accounts
+            single_accounts
                 .iter()
                 .map(|meta| meta.pubkey())
                 .collect::<Vec<_>>(),
-            vec![&pk_with_1_ref]
+            vec![&pk_with_1_slot]
         );
         assert_eq!(
-            one_ref_accounts_account_shared_data
+            single_accounts_account_shared_data
                 .iter()
                 .map(create_account_shared_data)
                 .collect::<Vec<_>>(),
-            vec![account_with_1_ref]
+            vec![account_with_1_slot]
         );
         assert!(
             accounts_to_combine
@@ -2250,7 +2250,7 @@ mod tests {
         );
         let mut reader = append_vec::new_scan_accounts_reader();
 
-        // assert that we wrote the 2_ref account to the newly shrunk append vec
+        // assert that we wrote the 2 slot account to the newly shrunk append vec
         let shrink_in_progress = shrinks_in_progress.first().unwrap().1;
         let mut count = 0;
         shrink_in_progress
@@ -2265,20 +2265,20 @@ mod tests {
             .new_storage()
             .accounts
             .get_stored_account_callback(0, |account| {
-                assert_eq!(account.pubkey(), pk_with_2_refs);
+                assert_eq!(account.pubkey(), pk_with_2_slots);
                 create_account_shared_data(&account)
             })
             .unwrap();
-        assert_eq!(account, account_shared_data_with_2_refs);
+        assert_eq!(account, account_shared_data_with_2_slots);
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
     fn test_calc_accounts_to_combine_opposite(accounts_db_config: AccountsDbConfig) {
         // 1 storage
         // 2 accounts
-        // 1 with 1 ref
-        // 1 with 2 refs, with the idea that the other ref is from an older slot, so this one is the newer index entry
-        // The result will be that the account, even though it has refcount > 1, can be moved to a newer slot.
+        // 1 in a single slot
+        // 1 in 2 slots, with the idea that the other entry is from an older slot, so this one is the newer index entry
+        // The result will be that the account, even though it has a duplicate, can be moved to a newer slot.
         let db = AccountsDb::new_for_tests_with_config(Vec::new(), accounts_db_config.clone());
         let num_slots = 1;
         let (storages, slots, infos) = get_sample_storages(&db, num_slots, None);
@@ -2287,23 +2287,23 @@ mod tests {
             .map(|store| db.get_unique_accounts_from_storage(store))
             .collect::<Vec<_>>();
         let storage = storages.first().unwrap().clone();
-        let pk_with_1_ref = solana_pubkey::new_rand();
+        let pk_with_1_slot = solana_pubkey::new_rand();
         let slot1 = slots.start;
-        let account_with_2_refs = original_results
+        let account_with_2_slots = original_results
             .first()
             .unwrap()
             .stored_accounts
             .first()
             .unwrap();
-        let account_shared_data_with_2_refs =
-            get_account_from_account_from_storage(account_with_2_refs, &db, slot1);
-        let pk_with_2_refs = account_with_2_refs.pubkey();
-        let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
-        _ = account_with_1_ref.checked_add_lamports(1);
+        let account_shared_data_with_2_slots =
+            get_account_from_account_from_storage(account_with_2_slots, &db, slot1);
+        let pk_with_2_slots = account_with_2_slots.pubkey();
+        let mut account_with_1_slot = account_shared_data_with_2_slots.clone();
+        _ = account_with_1_slot.checked_add_lamports(1);
         append_single_account_with_default_hash(
             &storage,
-            &pk_with_1_ref,
-            &account_with_1_ref,
+            &pk_with_1_slot,
+            &account_with_1_slot,
             true,
             Some(&db.accounts_index),
         );
@@ -2351,33 +2351,33 @@ mod tests {
                 .iter()
                 .map(|meta| meta.pubkey())
                 .collect::<Vec<_>>(),
-            vec![pk_with_2_refs]
+            vec![pk_with_2_slots]
         );
         assert_eq!(accounts_to_combine.accounts_to_combine.len(), 1);
-        let one_ref_accounts = &accounts_to_combine
+        let single_accounts = &accounts_to_combine
             .accounts_to_combine
             .first()
             .unwrap()
             .alive_accounts
             .no_duplicates
             .accounts;
-        let one_ref_accounts_account_shared_data = one_ref_accounts
+        let single_accounts_account_shared_data = single_accounts
             .iter()
             .map(|account| get_account_from_account_from_storage(account, &db, slot1))
             .collect::<Vec<_>>();
         assert_eq!(
-            one_ref_accounts
+            single_accounts
                 .iter()
                 .map(|meta| meta.pubkey())
                 .collect::<Vec<_>>(),
-            vec![&pk_with_1_ref]
+            vec![&pk_with_1_slot]
         );
         assert_eq!(
-            one_ref_accounts_account_shared_data
+            single_accounts_account_shared_data
                 .iter()
                 .map(create_account_shared_data)
                 .collect::<Vec<_>>(),
-            vec![account_with_1_ref]
+            vec![account_with_1_slot]
         );
         assert!(
             accounts_to_combine
@@ -2394,7 +2394,7 @@ mod tests {
         let write_ancient_accounts =
             db.write_packed_storages(&accounts_to_combine, packed_contents);
         assert!(write_ancient_accounts.shrinks_in_progress.is_empty());
-        // assert that we wrote the 2_ref account (and the 1 ref account) to the newly shrunk append vec
+        // assert that we wrote the 2 slot account (and the 1 slot account) to the newly shrunk append vec
         let storage = db.storage.get_slot_storage_entry(slot1).unwrap();
         let accounts_shrunk_same_slot = storage
             .accounts
@@ -2411,8 +2411,11 @@ mod tests {
             })
             .expect("must scan accounts storage");
         assert_eq!(count, 2);
-        assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_refs);
-        assert_eq!(accounts_shrunk_same_slot.1, account_shared_data_with_2_refs);
+        assert_eq!(accounts_shrunk_same_slot.0, *pk_with_2_slots);
+        assert_eq!(
+            accounts_shrunk_same_slot.1,
+            account_shared_data_with_2_slots
+        );
     }
 
     #[test_case(ACCOUNTS_DB_CONFIG_APPEND_VEC)]
@@ -3775,7 +3778,7 @@ mod tests {
 
                     match i {
                         0 => {
-                            // empty slot list (ignored anyway) because ref_count = 1
+                            // empty slot list (ignored anyway) because there are no duplicates
                             let slot_list = vec![];
                             alive_accounts.add(1, &account, &slot_list);
                             assert!(!alive_accounts.no_duplicates.accounts.is_empty());
@@ -3820,7 +3823,7 @@ mod tests {
                             assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         3 => {
-                            // multiple slot list, ref_count=2, this is newest
+                            // multiple slot list, this is newest
                             let slot_list = vec![
                                 (
                                     slot,

--- a/accounts-db/src/storable_accounts.rs
+++ b/accounts-db/src/storable_accounts.rs
@@ -285,7 +285,7 @@ impl<'a> StorableAccountsBySlot<'a> {
         // This happens when we are just shrinking a single slot storage, which happens very often.
         // Note: we check the actual number of entries, not just whether slots differ,
         // because multiple entries can have the same slot value (e.g., when packing
-        // many_refs_newest and one_ref accounts from the same source slot).
+        // newest_duplicate and no_duplicates accounts from the same source slot).
         if self.slots_and_accounts.len() == 1 {
             return (0, index);
         }


### PR DESCRIPTION
#### Problem
Shrink currently bases all its naming and decisions on ref_count. This is specific (and will soon be incorrect).

#### Summary of Changes


#### Testing


Fixes #
