### PR TITLE
repair slot-cache hoist

### DIFF
--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -18,7 +18,7 @@ use {
         },
     },
     agave_votor_messages::{VerifiedVoterSlotsReceiver, migration::MigrationStatus},
-    ahash::AHashMap,
+    ahash::{AHashMap, AHashSet},
     bytes::Bytes,
     crossbeam_channel::{Receiver as CrossbeamReceiver, Sender as CrossbeamSender},
     lazy_lru::LruCache,
@@ -31,7 +31,7 @@ use {
     solana_ledger::{
         blockstore::Blockstore,
         blockstore_db::DBPinnableSlice,
-        blockstore_meta::{BlockLocation, SlotMetaRepair},
+        blockstore_meta::{BlockLocation, NextSlots, SlotMetaRepair},
         shred,
     },
     solana_measure::measure::Measure,
@@ -588,6 +588,58 @@ impl RepairServiceChannels {
     }
 }
 
+/// Caches child links for slots known to be full across repair iterations.
+///
+/// Full slots do not need to be checked for missing shreds again, but their [`NextSlots`] can
+/// still change when Blockstore inserts or removes descendants. `slot_meta_topology_generation`
+/// records the Blockstore topology generation for which `entries` are valid. Before each
+/// traversal, [`Self::invalidate_if_stale`] clears all entries if Blockstore has advanced that
+/// generation. Root advancement prunes older entries separately through
+/// [`Self::retain_from_root`].
+struct FullSlotsCache {
+    /// Maps each cached full slot to its children in Blockstore.
+    entries: AHashMap<Slot, NextSlots>,
+    /// Blockstore metadata generation observed when `entries` was last validated.
+    slot_meta_topology_generation: u64,
+}
+
+impl FullSlotsCache {
+    fn new(blockstore: &Blockstore) -> Self {
+        Self {
+            entries: AHashMap::new(),
+            slot_meta_topology_generation: blockstore.slot_meta_topology_generation(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    fn retain_from_root(&mut self, root: Slot) {
+        self.entries.retain(|slot, _next_slots| *slot >= root);
+    }
+
+    /// Clears cached child links if Blockstore metadata changed since they were last validated.
+    ///
+    /// This must run before the cache is used for a repair traversal. Adopting the current
+    /// generation only after clearing the entries keeps the map and its generation synchronized.
+    fn invalidate_if_stale(&mut self, blockstore: &Blockstore) {
+        let current_generation = blockstore.slot_meta_topology_generation();
+        if current_generation != self.slot_meta_topology_generation {
+            self.entries.clear();
+            self.slot_meta_topology_generation = current_generation;
+        }
+    }
+
+    /// Exposes the validated entries for traversal lookups and cache population.
+    ///
+    /// [`Self::invalidate_if_stale`] must be called before using the returned map in a new repair
+    /// traversal.
+    fn entries_mut(&mut self) -> &mut AHashMap<Slot, NextSlots> {
+        &mut self.entries
+    }
+}
+
 struct RepairTracker {
     sharable_banks: SharableBanks,
     repair_weight: RepairWeight,
@@ -598,6 +650,7 @@ struct RepairTracker {
     // Maps a repair that may still be outstanding to the timestamp it was requested.
     outstanding_repairs: HashMap<ShredRepairType, u64>,
     repair_eligibility: RepairEligibility,
+    full_slots_cache: FullSlotsCache,
 }
 
 pub struct RepairService {
@@ -650,6 +703,7 @@ impl RepairService {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_weighting_heuristic(
         blockstore: &Blockstore,
         root_bank: Arc<Bank>,
@@ -659,17 +713,25 @@ impl RepairService {
         verified_voter_slots_receiver: &VerifiedVoterSlotsReceiver,
         migration_status: &MigrationStatus,
         repair_metrics: &mut RepairMetrics,
+        full_slots_cache: &mut FullSlotsCache,
     ) {
         if repair_weight.is_pruned_tree_tracking_enabled()
             && migration_status.is_alpenglow_enabled()
         {
             repair_weight.disable_pruned_tree_tracking();
             popular_pruned_forks_requests.clear();
+            // Migration purges all TowerBFT slots above the Alpenglow genesis without emitting
+            // individual dumped-slot notifications.
+            full_slots_cache.clear();
         }
 
         // Purge outdated slots from the weighting heuristic
         let mut set_root_us = Measure::start("set_root_us");
+        let old_root = repair_weight.root();
         repair_weight.set_root(root_bank.slot());
+        if repair_weight.root() != old_root {
+            full_slots_cache.retain_from_root(repair_weight.root());
+        }
         set_root_us.stop();
 
         // Remove dumped slots from the weighting heuristic
@@ -701,6 +763,8 @@ impl RepairService {
                 }
             });
         dump_slots_us.stop();
+
+        full_slots_cache.invalidate_if_stale(blockstore);
 
         // Add new votes to the weighting heuristic
         let mut get_votes_us = Measure::start("get_votes_us");
@@ -741,6 +805,7 @@ impl RepairService {
         repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
         repair_metrics: &mut RepairMetrics,
+        full_slots_cache: &mut AHashMap<Slot, NextSlots>,
     ) -> Vec<ShredRepairType> {
         let mut purge_outstanding_repairs_us = Measure::start("purge_outstanding_repairs_us");
         // Purge old entries. They've either completed or need to be retried.
@@ -763,6 +828,7 @@ impl RepairService {
             repair_eligibility,
             repair_metrics,
             outstanding_repairs,
+            full_slots_cache,
         )
     }
 
@@ -884,6 +950,7 @@ impl RepairService {
             popular_pruned_forks_requests,
             outstanding_repairs,
             repair_eligibility,
+            full_slots_cache,
         } = repair_tracker;
         let root_bank = sharable_banks.root();
 
@@ -896,6 +963,7 @@ impl RepairService {
             verified_voter_slots_receiver,
             migration_status,
             repair_metrics,
+            full_slots_cache,
         );
 
         let repairs = Self::identify_repairs(
@@ -907,6 +975,7 @@ impl RepairService {
             repair_eligibility,
             outstanding_repairs,
             repair_metrics,
+            full_slots_cache.entries_mut(),
         );
 
         if !migration_status.is_alpenglow_enabled() {
@@ -965,6 +1034,7 @@ impl RepairService {
             popular_pruned_forks_requests: HashSet::new(),
             outstanding_repairs: HashMap::new(),
             repair_eligibility: RepairEligibility::default(),
+            full_slots_cache: FullSlotsCache::new(&blockstore),
         };
 
         let mut pinnable_slice = blockstore.new_pinnable_slice();
@@ -1034,7 +1104,7 @@ impl RepairService {
         }
     }
 
-    /// Repairs any fork starting at the input slot (uses blockstore for fork info)
+    /// Repairs any fork starting at the input slot (uses blockstore for fork info).
     pub fn generate_repairs_for_fork<'db>(
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
@@ -1044,10 +1114,45 @@ impl RepairService {
         repair_eligibility: &mut RepairEligibility,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
     ) {
+        Self::generate_repairs_for_fork_with_cache(
+            blockstore,
+            pinnable_slice,
+            repairs,
+            max_repairs,
+            slot,
+            &mut AHashMap::new(),
+            &mut AHashSet::new(),
+            repair_eligibility,
+            outstanding_repairs,
+        );
+    }
+
+    /// Repairs a Blockstore fork starting at `slot`, reusing validated metadata for full slots.
+    ///
+    /// Full slots cannot need shred repair, so their child topology is retained across repair
+    /// iterations and they are recorded in `processed_slots` for the remaining repair strategies.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn generate_repairs_for_fork_with_cache<'db>(
+        blockstore: &'db Blockstore,
+        pinnable_slice: &mut DBPinnableSlice<'db>,
+        repairs: &mut Vec<ShredRepairType>,
+        max_repairs: usize,
+        slot: Slot,
+        full_slots_cache: &mut AHashMap<Slot, NextSlots>,
+        processed_slots: &mut AHashSet<Slot>,
+        repair_eligibility: &mut RepairEligibility,
+        outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
+    ) {
         let mut pending_slots = vec![slot];
         while repairs.len() < max_repairs && !pending_slots.is_empty() {
             let slot = pending_slots.pop().unwrap();
+            if let Some(next_slots) = full_slots_cache.get(&slot) {
+                processed_slots.insert(slot);
+                pending_slots.extend(next_slots.iter().copied());
+                continue;
+            }
             if let Some(slot_meta) = blockstore.meta_repair_into(slot, pinnable_slice).unwrap() {
+                let is_full = slot_meta.is_full();
                 let new_repairs = Self::generate_repairs_for_slot(
                     blockstore,
                     slot,
@@ -1058,7 +1163,13 @@ impl RepairService {
                 );
                 repairs.extend(new_repairs);
                 let next_slots = slot_meta.next_slots;
-                pending_slots.extend(next_slots);
+                if is_full {
+                    processed_slots.insert(slot);
+                    pending_slots.extend(next_slots.iter().copied());
+                    full_slots_cache.insert(slot, next_slots);
+                } else {
+                    pending_slots.extend(next_slots);
+                }
             } else {
                 break;
             }
@@ -1424,6 +1535,7 @@ mod test {
             blockstore::{
                 Blockstore, make_chaining_slot_entries, make_many_slot_entries, make_slot_entries,
             },
+            blockstore_meta::SlotMeta,
             genesis_utils::{GenesisConfigInfo, create_genesis_config},
             get_tmp_ledger_path_auto_delete,
             shred::max_ticks_per_n_shreds,
@@ -1440,6 +1552,115 @@ mod test {
         let keypair = Arc::new(Keypair::new());
         let contact_info = ContactInfo::new_localhost(&keypair.pubkey(), timestamp());
         ClusterInfo::new(contact_info, keypair, SocketAddrSpace::Unspecified)
+    }
+
+    #[test]
+    fn test_alpenglow_transition_clears_full_slots_cache() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let (root_bank, migration_status) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.migration_status())
+        };
+        migration_status.enable_alpenglow_for_tests();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (_dumped_slots_sender, dumped_slots_receiver) = crossbeam_channel::unbounded();
+        let (_verified_voter_slots_sender, verified_voter_slots_receiver) =
+            crossbeam_channel::unbounded();
+        let mut repair_weight = RepairWeight::new(root_bank.slot());
+        let mut full_slots_cache = FullSlotsCache::new(&blockstore);
+        full_slots_cache.entries = AHashMap::from([(1, vec![2].into()), (2, vec![].into())]);
+        let mut repair_metrics = RepairMetrics::default();
+
+        RepairService::update_weighting_heuristic(
+            &blockstore,
+            root_bank,
+            &mut repair_weight,
+            &mut HashSet::new(),
+            &dumped_slots_receiver,
+            &verified_voter_slots_receiver,
+            migration_status.as_ref(),
+            &mut repair_metrics,
+            &mut full_slots_cache,
+        );
+
+        assert!(full_slots_cache.entries.is_empty());
+        assert!(!repair_weight.is_pruned_tree_tracking_enabled());
+    }
+
+    #[test]
+    fn test_slot_meta_invalidation_clears_full_slots_cache() {
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
+        let (root_bank, migration_status) = {
+            let bank_forks = bank_forks.read().unwrap();
+            (bank_forks.root_bank(), bank_forks.migration_status())
+        };
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let (_dumped_slots_sender, dumped_slots_receiver) = crossbeam_channel::unbounded();
+        let (_verified_voter_slots_sender, verified_voter_slots_receiver) =
+            crossbeam_channel::unbounded();
+        let mut repair_weight = RepairWeight::new(root_bank.slot());
+        let mut full_slots_cache = FullSlotsCache::new(&blockstore);
+        full_slots_cache.entries = AHashMap::from([(0, vec![1].into()), (1, vec![].into())]);
+        let mut repair_metrics = RepairMetrics::default();
+
+        let meta = SlotMeta {
+            slot: 42,
+            ..SlotMeta::default()
+        };
+        blockstore.put_meta(42, &meta).unwrap();
+        RepairService::update_weighting_heuristic(
+            &blockstore,
+            root_bank.clone(),
+            &mut repair_weight,
+            &mut HashSet::new(),
+            &dumped_slots_receiver,
+            &verified_voter_slots_receiver,
+            migration_status.as_ref(),
+            &mut repair_metrics,
+            &mut full_slots_cache,
+        );
+
+        assert!(full_slots_cache.entries.is_empty());
+        full_slots_cache.entries.insert(0, NextSlots::new());
+        RepairService::update_weighting_heuristic(
+            &blockstore,
+            root_bank,
+            &mut repair_weight,
+            &mut HashSet::new(),
+            &dumped_slots_receiver,
+            &verified_voter_slots_receiver,
+            migration_status.as_ref(),
+            &mut repair_metrics,
+            &mut full_slots_cache,
+        );
+        assert_eq!(full_slots_cache.entries.len(), 1);
+    }
+
+    #[test]
+    fn test_full_slots_cache_retain_from_root() {
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+        let mut full_slots_cache = FullSlotsCache::new(&blockstore);
+        full_slots_cache.entries = AHashMap::from([
+            (1, NextSlots::new()),
+            (2, NextSlots::new()),
+            (3, NextSlots::new()),
+        ]);
+
+        full_slots_cache.retain_from_root(2);
+
+        assert_eq!(
+            full_slots_cache
+                .entries
+                .keys()
+                .copied()
+                .collect::<HashSet<_>>(),
+            HashSet::from([2, 3])
+        );
     }
 
     #[test]
@@ -1512,6 +1733,7 @@ mod test {
                 &mut RepairEligibility::default(),
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             vec![
                 ShredRepairType::Orphan(2),
@@ -1547,6 +1769,7 @@ mod test {
                 &mut RepairEligibility::default(),
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             vec![ShredRepairType::HighestShred(0, 0)]
         );
@@ -1605,6 +1828,7 @@ mod test {
                 &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             vec![]
         );
@@ -1623,6 +1847,7 @@ mod test {
                 &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             expected
         );
@@ -1640,6 +1865,7 @@ mod test {
                 &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             )[..],
             expected[0..expected.len() - 2]
         );
@@ -1782,6 +2008,7 @@ mod test {
                 &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             vec![]
         );
@@ -1800,6 +2027,7 @@ mod test {
                 &mut repair_eligibility,
                 &mut RepairMetrics::default(),
                 &mut HashMap::default(),
+                &mut AHashMap::default(),
             ),
             expected
         );

--- a/core/src/repair/repair_weight.rs
+++ b/core/src/repair/repair_weight.rs
@@ -14,14 +14,16 @@ use {
     solana_epoch_schedule::EpochSchedule,
     solana_hash::Hash,
     solana_ledger::{
-        ancestor_iterator::AncestorIterator, blockstore::Blockstore,
-        blockstore_db::DBPinnableSlice, blockstore_meta::SlotMetaRepair,
+        ancestor_iterator::AncestorIterator,
+        blockstore::Blockstore,
+        blockstore_db::DBPinnableSlice,
+        blockstore_meta::{NextSlots, SlotMetaRepair},
     },
     solana_measure::measure::Measure,
     solana_pubkey::Pubkey,
     solana_runtime::epoch_stakes::VersionedEpochStakes,
     std::{
-        collections::{HashMap, HashSet, VecDeque},
+        collections::{HashMap, HashSet, VecDeque, hash_map::Entry},
         iter,
     },
 };
@@ -230,6 +232,7 @@ impl RepairWeight {
         repair_eligibility: &mut RepairEligibility,
         repair_metrics: &mut RepairMetrics,
         outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
+        full_slots_cache: &mut AHashMap<Slot, NextSlots>,
     ) -> Vec<ShredRepairType> {
         let mut repairs = vec![];
         let mut processed_slots = AHashSet::from([self.root]);
@@ -258,6 +261,8 @@ impl RepairWeight {
             blockstore,
             pinnable_slice,
             &mut slot_meta_cache,
+            full_slots_cache,
+            &mut processed_slots,
             &mut best_shreds_repairs,
             max_new_shreds,
             repair_eligibility,
@@ -309,6 +314,16 @@ impl RepairWeight {
         repairs.extend(closest_completion_repairs);
         get_closest_completion_us.stop();
 
+        // Preserve only the stable part of the per-iteration metadata cache. Incomplete metadata
+        // must be fetched again because new shreds can change it at any time.
+        for (slot, slot_meta) in &slot_meta_cache {
+            if let Some(slot_meta) = slot_meta
+                && slot_meta.is_full()
+                && let Entry::Vacant(entry) = full_slots_cache.entry(*slot)
+            {
+                entry.insert(slot_meta.next_slots.clone());
+            }
+        }
         repair_metrics.best_repairs_stats.update(
             num_orphan_slots as u64,
             num_orphan_repairs as u64,
@@ -535,11 +550,14 @@ impl RepairWeight {
     }
 
     // Generate shred repairs for main subtree rooted at `self.root`
+    #[allow(clippy::too_many_arguments)]
     fn get_best_shreds<'db>(
         &mut self,
         blockstore: &'db Blockstore,
         pinnable_slice: &mut DBPinnableSlice<'db>,
         slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+        full_slots_cache: &mut AHashMap<Slot, NextSlots>,
+        processed_slots: &mut AHashSet<Slot>,
         repairs: &mut Vec<ShredRepairType>,
         max_new_shreds: usize,
         repair_eligibility: &mut RepairEligibility,
@@ -551,6 +569,8 @@ impl RepairWeight {
             blockstore,
             pinnable_slice,
             slot_meta_cache,
+            full_slots_cache,
+            processed_slots,
             repairs,
             max_new_shreds,
             repair_eligibility,

--- a/core/src/repair/repair_weighted_traversal.rs
+++ b/core/src/repair/repair_weighted_traversal.rs
@@ -10,7 +10,9 @@ use {
     solana_clock::Slot,
     solana_hash::Hash,
     solana_ledger::{
-        blockstore::Blockstore, blockstore_db::DBPinnableSlice, blockstore_meta::SlotMetaRepair,
+        blockstore::Blockstore,
+        blockstore_db::DBPinnableSlice,
+        blockstore_meta::{NextSlots, SlotMetaRepair},
     },
     std::collections::HashMap,
 };
@@ -85,11 +87,14 @@ impl Iterator for RepairWeightTraversal<'_> {
 /// Generate shred repairs for `tree` starting at `tree.root`.
 /// Prioritized by stake weight, additionally considers children not present in `tree` but in
 /// blockstore.
+#[allow(clippy::too_many_arguments)]
 pub fn get_best_repair_shreds<'db>(
     tree: &HeaviestSubtreeForkChoice,
     blockstore: &'db Blockstore,
     pinnable_slice: &mut DBPinnableSlice<'db>,
     slot_meta_cache: &mut AHashMap<Slot, Option<SlotMetaRepair>>,
+    full_slots_cache: &mut AHashMap<Slot, NextSlots>,
+    processed_slots: &mut AHashSet<Slot>,
     repairs: &mut Vec<ShredRepairType>,
     max_new_shreds: usize,
     repair_eligibility: &mut RepairEligibility,
@@ -107,53 +112,108 @@ pub fn get_best_repair_shreds<'db>(
             break;
         }
 
-        let slot_meta = slot_meta_cache.entry(next.slot()).or_insert_with(|| {
-            blockstore
-                .meta_repair_into(next.slot(), pinnable_slice)
-                .unwrap()
-        });
-
-        // May not exist if blockstore purged the SlotMeta due to something
-        // like duplicate slots. TODO: Account for duplicate slot may be in orphans, especially
-        // if earlier duplicate was already removed
-        if let Some(slot_meta) = slot_meta {
-            match next {
-                Visit::Unvisited(slot) => {
-                    let new_repairs = RepairService::generate_repairs_for_slot(
-                        blockstore,
-                        slot,
-                        slot_meta,
-                        repair_eligibility,
-                        max_repairs - repairs.len(),
-                        outstanding_repairs,
-                    );
-                    repairs.extend(new_repairs);
+        match next {
+            Visit::Unvisited(slot) => {
+                if full_slots_cache.contains_key(&slot) {
                     visited_set.insert(slot);
+                    processed_slots.insert(slot);
+                    continue;
                 }
-                Visit::Visited(_) => {
-                    // By the time we reach here, this means all the children of this slot
-                    // have been explored/repaired. Although this slot has already been visited,
-                    // this slot is still the heaviest slot left in the traversal. Thus any
-                    // remaining children that have not been explored should now be repaired.
-                    for new_child_slot in &slot_meta.next_slots {
-                        // If the `new_child_slot` has not been visited by now, it must
-                        // not exist in `tree`
-                        if !visited_set.contains(new_child_slot) {
-                            // Generate repairs for entire subtree rooted at `new_child_slot`
-                            RepairService::generate_repairs_for_fork(
-                                blockstore,
-                                pinnable_slice,
-                                repairs,
-                                max_repairs,
-                                *new_child_slot,
-                                repair_eligibility,
-                                outstanding_repairs,
-                            );
-                        }
-                        visited_set.insert(*new_child_slot);
+
+                let slot_meta = slot_meta_cache
+                    .entry(slot)
+                    .or_insert_with(|| blockstore.meta_repair_into(slot, pinnable_slice).unwrap());
+
+                // May not exist if blockstore purged the SlotMeta due to something
+                // like duplicate slots. TODO: Account for duplicate slot may be in orphans,
+                // especially if earlier duplicate was already removed.
+                if let Some(slot_meta) = slot_meta {
+                    visited_set.insert(slot);
+                    if slot_meta.is_full() {
+                        full_slots_cache.insert(slot, slot_meta.next_slots.clone());
+                        processed_slots.insert(slot);
+                    } else {
+                        let new_repairs = RepairService::generate_repairs_for_slot(
+                            blockstore,
+                            slot,
+                            slot_meta,
+                            repair_eligibility,
+                            max_repairs - repairs.len(),
+                            outstanding_repairs,
+                        );
+                        repairs.extend(new_repairs);
                     }
                 }
             }
+            Visit::Visited(slot) => {
+                if let Some(next_slots) = full_slots_cache.get(&slot) {
+                    let next_slots = next_slots.clone();
+                    repair_unvisited_children(
+                        blockstore,
+                        pinnable_slice,
+                        &next_slots,
+                        &mut visited_set,
+                        full_slots_cache,
+                        processed_slots,
+                        repairs,
+                        max_repairs,
+                        repair_eligibility,
+                        outstanding_repairs,
+                    );
+                } else if let Some(slot_meta) = slot_meta_cache
+                    .entry(slot)
+                    .or_insert_with(|| blockstore.meta_repair_into(slot, pinnable_slice).unwrap())
+                {
+                    if slot_meta.is_full() {
+                        full_slots_cache.insert(slot, slot_meta.next_slots.clone());
+                        processed_slots.insert(slot);
+                    }
+                    repair_unvisited_children(
+                        blockstore,
+                        pinnable_slice,
+                        &slot_meta.next_slots,
+                        &mut visited_set,
+                        full_slots_cache,
+                        processed_slots,
+                        repairs,
+                        max_repairs,
+                        repair_eligibility,
+                        outstanding_repairs,
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[inline]
+fn repair_unvisited_children<'db>(
+    blockstore: &'db Blockstore,
+    pinnable_slice: &mut DBPinnableSlice<'db>,
+    next_slots: &[Slot],
+    visited_set: &mut AHashSet<Slot>,
+    full_slots_cache: &mut AHashMap<Slot, NextSlots>,
+    processed_slots: &mut AHashSet<Slot>,
+    repairs: &mut Vec<ShredRepairType>,
+    max_repairs: usize,
+    repair_eligibility: &mut RepairEligibility,
+    outstanding_repairs: &mut HashMap<ShredRepairType, u64>,
+) {
+    // All weighted children have been explored. Repair any remaining Blockstore-only children.
+    for new_child_slot in next_slots {
+        if visited_set.insert(*new_child_slot) {
+            RepairService::generate_repairs_for_fork_with_cache(
+                blockstore,
+                pinnable_slice,
+                repairs,
+                max_repairs,
+                *new_child_slot,
+                full_slots_cache,
+                processed_slots,
+                repair_eligibility,
+                outstanding_repairs,
+            );
         }
     }
 }
@@ -248,6 +308,8 @@ pub mod test {
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
         let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         let last_shred = blockstore.meta(0).unwrap().unwrap().received;
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
@@ -257,6 +319,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             6,
             &mut repair_eligibility,
@@ -276,6 +340,7 @@ pub mod test {
         repairs = vec![];
         outstanding_repairs = HashMap::new();
         slot_meta_cache = AHashMap::default();
+        processed_slots.clear();
         let best_overall_slot = heaviest_subtree_fork_choice.best_overall_slot().0;
         assert_eq!(best_overall_slot, 4);
         blockstore.add_tree(
@@ -285,6 +350,7 @@ pub mod test {
             2,
             Hash::default(),
         );
+        full_slots_cache.clear();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
@@ -292,6 +358,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             6,
             &mut repair_eligibility,
@@ -310,6 +378,7 @@ pub mod test {
         repairs = vec![];
         outstanding_repairs = HashMap::new();
         slot_meta_cache = AHashMap::default();
+        processed_slots.clear();
         let keypair = Keypair::new();
         let reed_solomon_cache = ReedSolomonCache::default();
 
@@ -331,6 +400,7 @@ pub mod test {
             })
             .collect();
         blockstore.insert_shreds(completed_shreds, false).unwrap();
+        full_slots_cache.clear();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
@@ -338,6 +408,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             4,
             &mut repair_eligibility,
@@ -357,7 +429,9 @@ pub mod test {
         repairs = vec![];
         outstanding_repairs = HashMap::new();
         slot_meta_cache = AHashMap::default();
+        processed_slots.clear();
         blockstore.add_tree(tr(2) / (tr(8)), true, false, 2, Hash::default());
+        full_slots_cache.clear();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=8);
         get_best_repair_shreds(
@@ -365,6 +439,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             5,
             &mut repair_eligibility,
@@ -383,6 +459,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             1,
             &mut repair_eligibility,
@@ -403,6 +481,8 @@ pub mod test {
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
         let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
         get_best_repair_shreds(
@@ -410,6 +490,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             usize::MAX,
             &mut repair_eligibility,
@@ -427,12 +509,82 @@ pub mod test {
     }
 
     #[test]
+    fn test_get_best_repair_shreds_caches_full_blockstore_only_fork() {
+        let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
+        // Slots 6 and 7 are not in fork choice, so they are discovered only through SlotMeta.
+        blockstore.add_tree(tr(2) / (tr(6) / tr(7)), true, true, 2, Hash::default());
+
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut repairs = vec![];
+        let mut outstanding_repairs = HashMap::new();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=7);
+
+        get_best_repair_shreds(
+            &heaviest_subtree_fork_choice,
+            &blockstore,
+            &mut pinnable_slice,
+            &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
+            &mut repairs,
+            usize::MAX,
+            &mut repair_eligibility,
+            &mut outstanding_repairs,
+        );
+
+        assert_eq!(full_slots_cache.get(&6).unwrap().as_slice(), &[7]);
+        assert!(full_slots_cache.get(&7).unwrap().is_empty());
+        assert!(processed_slots.is_superset(&AHashSet::from([6, 7])));
+        let last_shred = blockstore.meta(0).unwrap().unwrap().received;
+        assert_eq!(
+            repairs,
+            [0, 1, 2, 4, 3, 5]
+                .into_iter()
+                .map(|slot| ShredRepairType::HighestShred(slot, last_shred))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_generate_repairs_for_fork_uses_cached_topology_without_meta() {
+        let ledger_path = get_tmp_ledger_path!();
+        let blockstore = Blockstore::open(&ledger_path).unwrap();
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut repairs = vec![];
+        let mut outstanding_repairs = HashMap::new();
+        let mut full_slots_cache = AHashMap::from([(6, vec![7].into()), (7, NextSlots::new())]);
+        let mut processed_slots = AHashSet::default();
+        let mut repair_eligibility = RepairEligibility::default();
+
+        RepairService::generate_repairs_for_fork_with_cache(
+            &blockstore,
+            &mut pinnable_slice,
+            &mut repairs,
+            usize::MAX,
+            6,
+            &mut full_slots_cache,
+            &mut processed_slots,
+            &mut repair_eligibility,
+            &mut outstanding_repairs,
+        );
+
+        assert!(repairs.is_empty());
+        assert_eq!(processed_slots, AHashSet::from([6, 7]));
+    }
+
+    #[test]
     fn test_get_best_repair_shreds_stops_at_limit() {
         let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
         let mut pinnable_slice = blockstore.new_pinnable_slice();
         let mut repairs = vec![];
         let mut outstanding_repairs = HashMap::new();
         let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache = AHashMap::default();
+        let mut processed_slots = AHashSet::default();
         let mut repair_eligibility =
             RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
 
@@ -441,6 +593,8 @@ pub mod test {
             &blockstore,
             &mut pinnable_slice,
             &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
             &mut repairs,
             1,
             &mut repair_eligibility,
@@ -450,6 +604,74 @@ pub mod test {
         assert_eq!(repairs.len(), 1);
         assert_eq!(repairs.len(), outstanding_repairs.len());
         assert_eq!(slot_meta_cache.len(), 1);
+    }
+
+    #[test]
+    fn test_get_best_repair_shreds_uses_full_slots_cache() {
+        let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut repairs = vec![];
+        let mut outstanding_repairs = HashMap::new();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache: AHashMap<Slot, NextSlots> =
+            AHashMap::from([(0, vec![1].into()), (1, vec![2, 3].into())]);
+        let mut processed_slots = AHashSet::default();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
+
+        get_best_repair_shreds(
+            &heaviest_subtree_fork_choice,
+            &blockstore,
+            &mut pinnable_slice,
+            &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
+            &mut repairs,
+            1,
+            &mut repair_eligibility,
+            &mut outstanding_repairs,
+        );
+
+        assert_eq!(repairs.len(), 1);
+        assert_eq!(repairs[0].slot(), 2);
+        assert_eq!(slot_meta_cache.keys().copied().collect::<Vec<_>>(), [2]);
+        assert!(processed_slots.is_superset(&AHashSet::from([0, 1])));
+    }
+
+    #[test]
+    fn test_get_best_repair_shreds_uses_cached_next_slots() {
+        let (blockstore, heaviest_subtree_fork_choice) = setup_forks();
+        let mut pinnable_slice = blockstore.new_pinnable_slice();
+        let mut repairs = vec![];
+        let mut outstanding_repairs = HashMap::new();
+        let mut slot_meta_cache = AHashMap::default();
+        let mut full_slots_cache: AHashMap<Slot, NextSlots> = AHashMap::from([
+            (0, vec![1].into()),
+            (1, vec![2, 3].into()),
+            (2, vec![4].into()),
+            (3, vec![5].into()),
+            (4, vec![].into()),
+            (5, vec![].into()),
+        ]);
+        let mut processed_slots = AHashSet::default();
+        let mut repair_eligibility =
+            RepairEligibility::elapsed_for_slots_for_tests(&blockstore, 0..=5);
+
+        get_best_repair_shreds(
+            &heaviest_subtree_fork_choice,
+            &blockstore,
+            &mut pinnable_slice,
+            &mut slot_meta_cache,
+            &mut full_slots_cache,
+            &mut processed_slots,
+            &mut repairs,
+            usize::MAX,
+            &mut repair_eligibility,
+            &mut outstanding_repairs,
+        );
+
+        assert!(slot_meta_cache.is_empty());
+        assert_eq!(processed_slots, AHashSet::from_iter(0..=5));
     }
 
     fn setup_forks() -> (Blockstore, HeaviestSubtreeForkChoice) {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -145,6 +145,22 @@ struct SignalUpdates {
     update_parent_signals: Vec<UpdateParentSignal>,
 }
 
+/// Effects produced while preparing SlotMeta chaining updates.
+///
+/// The caller must publish any reported topology change only after the write batch containing the
+/// corresponding metadata changes commits successfully.
+#[derive(Default)]
+struct ChainingEffects {
+    slot_meta_topology_changed: bool,
+}
+
+impl ChainingEffects {
+    #[inline]
+    fn merge(&mut self, other: Self) {
+        self.slot_meta_topology_changed |= other.slot_meta_topology_changed;
+    }
+}
+
 #[derive(Debug)]
 struct CertificateForwarder {
     /// The certificate along with the slot # of the block it was present in
@@ -388,6 +404,7 @@ pub struct Blockstore {
     switch_block_lock: SwitchBlockLock,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
+    slot_meta_topology_generation: AtomicU64,
     update_parent_signals: Mutex<Vec<UpdateParentSender>>,
     /// Stable shred-header parent for recent UpdateParent slots.
     ///
@@ -744,6 +761,7 @@ impl Blockstore {
 
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
+            slot_meta_topology_generation: AtomicU64::default(),
             update_parent_signals: Mutex::default(),
             update_parent_shred_parent_cache: Mutex::new(LruCache::new(
                 UPDATE_PARENT_SHRED_PARENT_CACHE_CAPACITY,
@@ -2291,7 +2309,7 @@ impl Blockstore {
         }
         // Handle chaining for the members of the slot_meta_working_set that
         // were inserted into, drop the others.
-        self.handle_chaining(
+        let chaining_effects = self.handle_chaining(
             shred_insertion_tracker.write_batch,
             &mut shred_insertion_tracker.slot_meta_working_set,
             metrics,
@@ -2313,6 +2331,10 @@ impl Blockstore {
         self.write_batch(&mut *shred_insertion_tracker.write_batch)?;
         start.stop();
         metrics.write_batch_elapsed_us += start.as_us();
+
+        if chaining_effects.slot_meta_topology_changed {
+            self.advance_slot_meta_topology_generation();
+        }
 
         if let Some(forwarder) = self.certificate_forwarder.get() {
             for (slot, last_index) in newly_completed_slots_with_last_index.iter() {
@@ -2416,6 +2438,18 @@ impl Blockstore {
 
     pub fn add_completed_slots_signal(&self, s: CompletedSlotsSender) {
         self.completed_slots_senders.lock().unwrap().push(s);
+    }
+
+    /// Returns the generation of structural changes to slot metadata.
+    #[inline]
+    pub fn slot_meta_topology_generation(&self) -> u64 {
+        self.slot_meta_topology_generation.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    fn advance_slot_meta_topology_generation(&self) {
+        self.slot_meta_topology_generation
+            .fetch_add(1, Ordering::Release);
     }
 
     pub fn add_update_parent_signal(&self, s: UpdateParentSender) {
@@ -3999,7 +4033,9 @@ impl Blockstore {
     /// Can interfere with automatic meta update and potentially break chaining.
     /// Dangerous. Use with care.
     pub fn put_meta_bytes(&self, slot: Slot, bytes: &[u8]) -> Result<()> {
-        self.meta_cf.put_bytes(slot, bytes)
+        self.meta_cf.put_bytes(slot, bytes)?;
+        self.advance_slot_meta_topology_generation();
+        Ok(())
     }
 
     /// Manually update the meta for a slot.
@@ -5744,21 +5780,26 @@ impl Blockstore {
     /// https://github.com/solana-labs/solana/pull/2253
     ///
     /// Arguments:
-    /// - `db`: the blockstore db that stores both shreds and their metadata.
-    /// - `write_batch`: the write batch which includes all the updates of the
-    ///   the current write and ensures their atomicity.
-    /// - `working_set`: a (location, slot-id) to SlotMetaWorkingSetEntry map.  This function
+    /// - `write_batch`: the write batch containing all updates from the current write and ensuring
+    ///   their atomicity.
+    /// - `working_set`: a (location, slot-id) to SlotMetaWorkingSetEntry map. This function
     ///   will remove all entries which insertion did not actually occur.
+    /// - `metrics`: insertion metrics updated with the time spent handling chaining.
+    ///
+    /// Returns the combined effects of all chaining updates staged in `write_batch`. A reported
+    /// topology change means at least one parent/child relationship changed. The caller must wait
+    /// until `write_batch` commits successfully before advancing the topology generation.
     fn handle_chaining(
         &self,
         write_batch: &mut WriteBatch,
         working_set: &mut HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         metrics: &mut BlockstoreInsertionMetrics,
-    ) -> Result<()> {
+    ) -> Result<ChainingEffects> {
         let mut start = Measure::start("Shred chaining");
         // Handle chaining for all the SlotMetas that were inserted into
         working_set.retain(|_, entry| entry.did_insert_occur);
         let mut new_chained_slots = HashMap::new();
+        let mut effects = ChainingEffects::default();
         for (location, slot) in working_set.keys() {
             if !matches!(location, BlockLocation::Original) {
                 // We do not perform SlotMeta chaining for alternate versions of slots.
@@ -5768,15 +5809,20 @@ impl Blockstore {
                 // handled separately.
                 continue;
             }
-            self.handle_chaining_for_slot(write_batch, working_set, &mut new_chained_slots, *slot)?;
+            effects.merge(self.handle_chaining_for_slot(
+                write_batch,
+                working_set,
+                &mut new_chained_slots,
+                *slot,
+            )?);
         }
 
         // Handle reparenting from UpdateParent markers
-        self.update_chaining_for_updated_parent_slots(
+        effects.merge(self.update_chaining_for_updated_parent_slots(
             write_batch,
             working_set,
             &mut new_chained_slots,
-        )?;
+        )?);
 
         // Write all the newly changed slots in new_chained_slots to the write_batch
         for (slot, meta) in new_chained_slots.iter() {
@@ -5785,7 +5831,7 @@ impl Blockstore {
         }
         start.stop();
         metrics.chaining_elapsed_us += start.as_us();
-        Ok(())
+        Ok(effects)
     }
 
     /// A helper function of handle_chaining which handles the chaining based
@@ -5813,26 +5859,29 @@ impl Blockstore {
     /// alternate versions is not supported.
     ///
     /// Arguments:
-    /// `db`: the underlying db for blockstore
-    /// `write_batch`: the write batch which includes all the updates of the
-    ///   the current write and ensures their atomicity.
-    /// `working_set`: the working set which include the specified `slot`
-    /// `new_chained_slots`: an output parameter which includes all the slots
-    ///   which connectivity have been updated.
-    /// `slot`: the slot which we want to handle its chaining effect.
+    /// - `write_batch`: the write batch containing all updates from the current write and ensuring
+    ///   their atomicity.
+    /// - `working_set`: the working set containing the specified `slot`.
+    /// - `new_chained_slots`: an output parameter containing all slots whose connectivity has
+    ///   changed.
+    /// - `slot`: the slot which we want to handle its chaining effect.
+    ///
+    /// Reports a topology change when `slot` is newly attached to its parent, which adds `slot` to
+    /// the parent's `next_slots`. Connectivity-only updates do not report a topology change.
     fn handle_chaining_for_slot(
         &self,
         write_batch: &mut WriteBatch,
         working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         new_chained_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
         slot: Slot,
-    ) -> Result<()> {
+    ) -> Result<ChainingEffects> {
         let slot_meta_entry = working_set
             .get(&(BlockLocation::Original, slot))
             .expect("Slot must exist in the working_set hashmap");
 
         let meta = &slot_meta_entry.new_slot_meta;
         let meta_backup = &slot_meta_entry.old_slot_meta;
+        let mut effects = ChainingEffects::default();
         {
             let mut meta_mut = meta.borrow_mut();
             let was_orphan_slot =
@@ -5859,6 +5908,7 @@ impl Blockstore {
                         slot,
                         &mut meta_mut,
                     );
+                    effects.slot_meta_topology_changed = true;
 
                     // If the parent of `slot` is a newly inserted orphan, insert it into the orphans
                     // column family
@@ -5887,7 +5937,7 @@ impl Blockstore {
             self.propagate_parent_connected_to_children(meta, working_set, new_chained_slots)?;
         }
 
-        Ok(())
+        Ok(effects)
     }
 
     /// Propagate `parent_connected` to children. Requires `slot_meta` to be connected.
@@ -5908,12 +5958,16 @@ impl Blockstore {
 
     /// Handles chaining updates when an `UpdateParent` marker overrides a
     /// previously set parent in `SlotMeta`.
+    ///
+    /// Reports a topology change when at least one slot is reparented because reparenting updates
+    /// both the old and new parents' `next_slots`.
     fn update_chaining_for_updated_parent_slots(
         &self,
         write_batch: &mut WriteBatch,
         working_set: &HashMap<(BlockLocation, u64), SlotMetaWorkingSetEntry>,
         new_chained_slots: &mut HashMap<u64, Rc<RefCell<SlotMeta>>>,
-    ) -> Result<()> {
+    ) -> Result<ChainingEffects> {
+        let mut effects = ChainingEffects::default();
         // Process only existing slots in Original whose parent was updated by UpdateParent.
         for (slot, slot_meta, old_parent_slot, new_parent_slot) in
             working_set
@@ -5948,6 +6002,7 @@ impl Blockstore {
                 .borrow_mut()
                 .next_slots
                 .retain(|s| *s != slot);
+            effects.slot_meta_topology_changed = true;
 
             // Add slot to new parent's next_slots.
             let new_parent_meta =
@@ -5988,7 +6043,7 @@ impl Blockstore {
             }
         }
 
-        Ok(())
+        Ok(effects)
     }
 
     /// Traverse all the children (direct and indirect) of `slot_meta`, and apply

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -173,6 +173,8 @@ impl Blockstore {
             error!("Error: {e:?} while submitting write batch for slot {slot:?}")
         })?;
 
+        self.advance_slot_meta_topology_generation();
+
         Ok(())
     }
 
@@ -215,6 +217,7 @@ impl Blockstore {
                  to_slot {to_slot}"
             )
         })?;
+        self.advance_slot_meta_topology_generation();
         write_timer.stop();
 
         let mut purge_files_in_range_timer = Measure::start("delete_file_in_range");
@@ -795,9 +798,23 @@ pub mod tests {
 
         let (shreds, _) = make_many_slot_entries(0, 50, 5);
         blockstore.insert_shreds(shreds, false).unwrap();
+        let mut slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
 
         blockstore.purge_slots(0, 5, PurgeType::Exact).unwrap();
+        assert_ne!(
+            slot_meta_topology_generation,
+            blockstore.slot_meta_topology_generation()
+        );
+        slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
         all_columns_empty_or_greater_than_slot(&blockstore, 6);
+
+        let slot = 6;
+        let meta = blockstore.meta(slot).unwrap().unwrap();
+        blockstore.put_meta(slot, &meta).unwrap();
+        assert_ne!(
+            slot_meta_topology_generation,
+            blockstore.slot_meta_topology_generation()
+        );
 
         blockstore.purge_slots(0, 50, PurgeType::Exact).unwrap();
         // min slot shouldn't matter, blockstore should be empty
@@ -1270,7 +1287,12 @@ pub mod tests {
         let (slot_12, _) = make_slot_entries(12, 5, 5);
         blockstore.insert_shreds(slot_12, false).unwrap();
 
+        let slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
         blockstore.purge_slot_cleanup_chaining(5).unwrap();
+        assert_ne!(
+            slot_meta_topology_generation,
+            blockstore.slot_meta_topology_generation()
+        );
 
         let slot_meta = blockstore.meta(5).unwrap().unwrap();
         let expected_slot_meta = SlotMeta {

--- a/ledger/src/blockstore/tests.rs
+++ b/ledger/src/blockstore/tests.rs
@@ -891,6 +891,7 @@ fn test_completed_shreds_signal_many() {
 fn test_handle_chaining_basic() {
     let ledger_path = get_tmp_ledger_path_auto_delete!();
     let blockstore = Blockstore::open(ledger_path.path()).unwrap();
+    let mut slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
 
     let entries_per_slot = 5;
     let num_slots = 3;
@@ -904,6 +905,11 @@ fn test_handle_chaining_basic() {
         .drain(shreds_per_slot..2 * shreds_per_slot)
         .collect_vec();
     blockstore.insert_shreds(shreds1, false).unwrap();
+    assert_ne!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
+    slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
     let meta1 = blockstore.meta(1).unwrap().unwrap();
     assert!(meta1.next_slots.is_empty());
     // Slot 1 is not connected because slot 0 hasn't been inserted yet
@@ -916,6 +922,11 @@ fn test_handle_chaining_basic() {
         .drain(shreds_per_slot..2 * shreds_per_slot)
         .collect_vec();
     blockstore.insert_shreds(shreds2, false).unwrap();
+    assert_ne!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
+    slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
     let meta2 = blockstore.meta(2).unwrap().unwrap();
     assert!(meta2.next_slots.is_empty());
     // Slot 2 is not connected because slot 0 hasn't been inserted yet
@@ -934,6 +945,10 @@ fn test_handle_chaining_basic() {
     // 3) Write to the zeroth slot, check that every slot
     // is now part of the trunk
     blockstore.insert_shreds(shreds, false).unwrap();
+    assert_eq!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
     for slot in 0..3 {
         let meta = blockstore.meta(slot).unwrap().unwrap();
         // The last slot will not chain to any other slots
@@ -6779,9 +6794,14 @@ fn test_block_id_reads_remain_consistent_after_switch() {
 
     assert_ne!(original_block_id, alternate_block_id);
 
+    let slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
     blockstore
         .switch_block_from_alternate(slot, temporary_alternate_location)
         .unwrap();
+    assert_ne!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
 
     assert_eq!(
         blockstore
@@ -7584,6 +7604,7 @@ fn test_multiple_children_reparenting() {
             .unwrap();
     }
     verify_next_slots(&blockstore, 35, &[40, 44, 48]);
+    let mut slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
 
     blockstore
         .insert_shreds(
@@ -7591,6 +7612,11 @@ fn test_multiple_children_reparenting() {
             true,
         )
         .unwrap();
+    assert_ne!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
+    slot_meta_topology_generation = blockstore.slot_meta_topology_generation();
     verify_next_slots(&blockstore, 35, &[40, 48]);
     verify_next_slots(&blockstore, 32, &[44]);
 
@@ -7600,6 +7626,10 @@ fn test_multiple_children_reparenting() {
             true,
         )
         .unwrap();
+    assert_ne!(
+        slot_meta_topology_generation,
+        blockstore.slot_meta_topology_generation()
+    );
     verify_next_slots(&blockstore, 35, &[48]);
     verify_next_slots(&blockstore, 33, &[40]);
 }


### PR DESCRIPTION
#### Problem

Best-shred repair traversal repeatedly reads metadata for slots that are already full. Full slots cannot require additional shred repair, so these repeated blockstore reads add unnecessary rocksdb load. 

#### Summary of Changes

This stores the child-slot data for full slots in a cache to avoid unnecessary loads in downstream repair traversals. The nontrivial part is that child-slot links can change when blockstore inserts, removes, or moves slot metadata. To handle this, the blockstore now increases an atomic generation value after each change to these links. Before a repair traversal uses the cache, it compares the current generation with the cached generation. If the values are different, it clears the cache. The service also removes old entries when the repair root advances. 

I had an initial design that was more surgical with removing cache entries when blockstore changed specific slots. Decided to simplify with the current implementation because being surgical about removal is significantly more complicated / error prone / hard to review. One metadata change can affect more than one cached entry -- a parent change affects the child, the old parent, and the new parent. A new child also changes the cached child list of its parent. This design also required signals, queues, locking, etc. Runtime measurements showed that the cache is typically small, invalidation is infrequent -- the generation system gave similar performance with substantially less code and a smaller surface area for bugs.

Some metrics gathered when testing both approaches:
Metric | Granular invalidation | Full-cache invalidation  |
|---|---:|---:|
| Repair calls | 1.86K | 1.84K 
| Metadata reads avoided | 59.24K | 58.7K
| Actual metadata reads | 331 | 389
| Estimated read avoidance | 99.44% | 99.34%
| Reads avoided per repair call | 31.8 | 31.9
| `get-best-shreds` time | 13.05 ms | 15.31 ms

Result: ~4x improvement to `get-best-shreds-us`

<img width="718" height="720" alt="image" src="https://github.com/user-attachments/assets/924960d4-9c42-4ed7-9957-c1f92b82a75e" />
<img width="709" height="672" alt="image" src="https://github.com/user-attachments/assets/e924efb0-2e77-4313-a4d8-24ca60e0a9e3" />



#### Testing

- coverage for cached weighted and Blockstore-only traversal
- cache-only topology reuse test that cannot fall back to Blockstore metadata
- generation assertions for UpdateParent reparenting, cleanup purge, and alternate-block switching
- cache root-retention and invalidation coverage