### PR TITLE
ledger: verify_shreds discard in place

### DIFF
--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -62,14 +62,20 @@ pub fn verify_shreds(
     cache: &RwLock<LruCache>,
 ) {
     thread_pool.install(|| {
-        batches.par_iter_mut().for_each(|batch| {
-            batch.par_iter_mut().for_each(|mut packet| {
-                if !packet.meta().discard()
-                    && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache)
-                {
-                    packet.meta_mut().set_discard(true);
-                }
-            });
+        par_verify_shreds(batches, slot_leaders, cache);
+    });
+}
+
+pub fn par_verify_shreds(
+    batches: &mut [PacketBatch],
+    slot_leaders: &SlotPubkeys,
+    cache: &RwLock<LruCache>,
+) {
+    batches.par_iter_mut().for_each(|batch| {
+        batch.par_iter_mut().for_each(|mut packet| {
+            if !packet.meta().discard() && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache) {
+                packet.meta_mut().set_discard(true);
+            }
         });
     });
 }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -57,21 +57,21 @@ pub fn verify_shred_cpu(
 
 pub fn verify_shreds(
     thread_pool: &ThreadPool,
-    batches: &[PacketBatch],
+    batches: &mut [PacketBatch],
     slot_leaders: &SlotPubkeys,
     cache: &RwLock<LruCache>,
-) -> Vec<Vec<u8>> {
+) {
     thread_pool.install(|| {
-        batches
-            .into_par_iter()
-            .map(|batch| {
-                batch
-                    .par_iter()
-                    .map(|packet| u8::from(verify_shred_cpu(packet, slot_leaders, cache)))
-                    .collect()
-            })
-            .collect()
-    })
+        batches.par_iter_mut().for_each(|batch| {
+            batch.par_iter_mut().for_each(|mut packet| {
+                if !packet.meta().discard()
+                    && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache)
+                {
+                    packet.meta_mut().set_discard(true);
+                }
+            });
+        });
+    });
 }
 
 #[cfg(test)]
@@ -171,28 +171,50 @@ mod tests {
         agave_logger::setup();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
-        let batch = make_packet_batch(&keypair, slot);
-        let mut batches = [batch];
 
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 1);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
+        );
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
         let leader_slots: SlotPubkeys = HashMap::default();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
+        let mut batches = [make_packet_batch(&keypair, slot)];
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
         batches[0]
             .iter_mut()
             .for_each(|mut packet_ref| packet_ref.meta_mut().size = 0);
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
     }
 
     #[test]
@@ -206,14 +228,17 @@ mod tests {
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
 
         let keypair = Keypair::new();
-        let batch = make_packet_batch(&keypair, slot);
-        let mut batches = [batch];
-
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 1);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
+        );
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [
@@ -222,21 +247,39 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
+        let mut batches = [make_packet_batch(&keypair, slot)];
         batches[0]
             .iter_mut()
             .for_each(|mut pr| pr.meta_mut().size = 0);
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
     }
 
     fn make_packet_batch(keypair: &Keypair, slot: u64) -> PacketBatch {
@@ -384,15 +427,15 @@ mod tests {
             .chain(once((Slot::MAX, Pubkey::default())))
             .collect();
         let mut packets = make_packets(&mut rng, &shreds);
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![1u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
         );
         // Invalidate signatures for a random number of packets.
-        let out: Vec<_> = packets
+        let expected_discards = packets
             .iter_mut()
             .map(|packets| {
                 let PacketBatch::Pinned(packets) = packets else {
@@ -405,12 +448,23 @@ mod tests {
                         if !coin_flip {
                             shred::layout::corrupt_packet(&mut rng, packet, &keypairs);
                         }
-                        u8::from(coin_flip)
+                        !coin_flip
                     })
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<bool>>()
             })
-            .collect();
-        assert_eq!(verify_shreds(&thread_pool, &packets, &pubkeys, &cache), out);
+            .collect::<Vec<_>>();
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
+            packets
+                .iter()
+                .zip(expected_discards.iter())
+                .all(|(batch, expected)| {
+                    batch
+                        .iter()
+                        .zip(expected)
+                        .all(|(packet, should_discard)| packet.meta().discard() == *should_discard)
+                })
+        );
     }
 
     #[test_case(true)]
@@ -438,21 +492,26 @@ mod tests {
         };
         let mut packets = make_packets(&mut rng, &shreds);
         // Assert that initially all signatures are invalid.
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![0u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| packet.meta().discard())
         );
         // Sign and verify shreds signatures.
+        packets.iter_mut().for_each(|batch| {
+            batch
+                .iter_mut()
+                .for_each(|mut packet| packet.meta_mut().set_discard(false));
+        });
         sign_shreds(&thread_pool, &keypair, &mut packets);
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![1u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
         );
     }
 }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::implicit_hasher)]
 use {
     crate::shred,
-    rayon::{ThreadPool, prelude::*},
+    rayon::prelude::*,
     solana_clock::Slot,
     solana_hash::Hash,
     solana_nohash_hasher::BuildNoHashHasher,
@@ -55,17 +55,6 @@ pub fn verify_shred_cpu(
     }
 }
 
-pub fn verify_shreds(
-    thread_pool: &ThreadPool,
-    batches: &mut [PacketBatch],
-    slot_leaders: &SlotPubkeys,
-    cache: &RwLock<LruCache>,
-) {
-    thread_pool.install(|| {
-        par_verify_shreds(batches, slot_leaders, cache);
-    });
-}
-
 pub fn par_verify_shreds(
     batches: &mut [PacketBatch],
     slot_leaders: &SlotPubkeys,
@@ -111,7 +100,7 @@ mod tests {
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{Rng, seq::SliceRandom},
-        rayon::ThreadPoolBuilder,
+        rayon::{ThreadPool, ThreadPoolBuilder},
         solana_entry::entry::Entry,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -123,6 +112,17 @@ mod tests {
         std::iter::{once, repeat_with},
         test_case::test_case,
     };
+
+    fn verify_shreds(
+        thread_pool: &ThreadPool,
+        batches: &mut [PacketBatch],
+        slot_leaders: &SlotPubkeys,
+        cache: &RwLock<LruCache>,
+    ) {
+        thread_pool.install(|| {
+            par_verify_shreds(batches, slot_leaders, cache);
+        });
+    }
 
     fn sign_shreds(thread_pool: &ThreadPool, keypair: &Keypair, batches: &mut [PacketBatch]) {
         thread_pool.install(|| {

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -132,16 +132,6 @@ pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool, ena
     }
 }
 
-pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
-    for (batch, v) in batches.iter_mut().zip(r) {
-        for (mut pkt, f) in batch.iter_mut().zip(v) {
-            if !pkt.meta().discard() {
-                pkt.meta_mut().set_discard(*f == 0);
-            }
-        }
-    }
-}
-
 #[cfg(feature = "dev-context-only-utils")]
 pub fn threadpool_for_tests() -> rayon::ThreadPool {
     // Four threads is sufficient for unit tests
@@ -218,19 +208,6 @@ mod tests {
         .unwrap();
 
         VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap()
-    }
-
-    #[test]
-    fn test_mark_disabled() {
-        let batch_size = 1;
-        let mut batch = BytesPacketBatch::with_capacity(batch_size);
-        batch.resize(batch_size, BytesPacket::empty());
-        let mut batches: Vec<PacketBatch> = vec![batch.into()];
-        mark_disabled(&mut batches, &[vec![0]]);
-        assert!(batches[0].get(0).unwrap().meta().discard());
-        batches[0].get_mut(0).unwrap().meta_mut().set_discard(false);
-        mark_disabled(&mut batches, &[vec![1]]);
-        assert!(!batches[0].get(0).unwrap().meta().discard());
     }
 
     fn packet_from_num_sigs(required_num_sigs: u8, actual_num_sigs: usize) -> BytesPacket {

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -427,8 +427,7 @@ fn verify_packets(
             .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
             .chain(std::iter::once((Slot::MAX, Pubkey::default())))
             .collect();
-    let out = verify_shreds(thread_pool, packets, &leader_slots, cache);
-    solana_perf::sigverify::mark_disabled(packets, &out);
+    verify_shreds(thread_pool, packets, &leader_slots, cache);
 }
 
 // Returns pubkey of leaders for shred slots referenced in the packets.

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -18,7 +18,7 @@ use {
             layout::{get_shred, resign_packet},
             wire::is_retransmitter_signed_variant,
         },
-        sigverify_shreds::{LruCache, SlotPubkeys, verify_shreds},
+        sigverify_shreds::{LruCache, SlotPubkeys, par_verify_shreds},
     },
     solana_perf::{
         self,
@@ -202,14 +202,15 @@ fn run_shred_sigverify<const K: usize>(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.working_bank(), bank_forks.root_bank())
     };
-    verify_packets(
-        thread_pool,
-        &keypair.pubkey(),
-        &working_bank,
-        leader_schedule_cache,
-        shred_buffer,
-        cache,
-    );
+    thread_pool.install(|| {
+        par_verify_packets(
+            &keypair.pubkey(),
+            &working_bank,
+            leader_schedule_cache,
+            shred_buffer,
+            cache,
+        )
+    });
     stats.num_discards_post += count_discards(shred_buffer);
     // Verify retransmitter's signature, and resign shreds
     // Merkle root as the retransmitter node.
@@ -414,8 +415,7 @@ fn verify_retransmitter_signature(
     }
 }
 
-fn verify_packets(
-    thread_pool: &ThreadPool,
+fn par_verify_packets(
     self_pubkey: &Pubkey,
     working_bank: &Bank,
     leader_schedule_cache: &LeaderScheduleCache,
@@ -427,7 +427,7 @@ fn verify_packets(
             .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
             .chain(std::iter::once((Slot::MAX, Pubkey::default())))
             .collect();
-    verify_shreds(thread_pool, packets, &leader_slots, cache);
+    par_verify_shreds(packets, &leader_slots, cache);
 }
 
 // Returns pubkey of leaders for shred slots referenced in the packets.
@@ -663,14 +663,15 @@ mod tests {
             .into_iter()
             .map(PacketBatch::from)
             .collect::<Vec<_>>();
-        verify_packets(
-            &thread_pool,
-            &Pubkey::new_unique(), // self_pubkey
-            &working_bank,
-            &leader_schedule_cache,
-            &mut batches,
-            &cache,
-        );
+        thread_pool.install(|| {
+            par_verify_packets(
+                &Pubkey::new_unique(), // self_pubkey
+                &working_bank,
+                &leader_schedule_cache,
+                &mut batches,
+                &cache,
+            )
+        });
         assert!(!batches[0].get(0).unwrap().meta().discard());
         assert!(batches[0].get(1).unwrap().meta().discard());
     }


### PR DESCRIPTION
#### Problem

`verify_shreds` returns `Vec<Vec<>>` that was historically needed to support cuda. Changes are split to commits to simplify review.

#### Summary of Changes

Make `verify_shreds` use preallocated buffer instead. Rename function `verify_shreds` to `par_verify_shreds`.


