### PR TITLE
tpu-client-next: only advance cached estimated slot on send

### DIFF
--- a/tpu-client-next/src/node_address_service/slot_update_service.rs
+++ b/tpu-client-next/src/node_address_service/slot_update_service.rs
@@ -40,11 +40,13 @@ impl SlotUpdateService {
                         recent_slots.record(slot_event);
                         let estimated_slots = recent_slots.estimate_current_slot();
                         // Send update only if the estimated slot has advanced.
-                        if estimated_slots > cached_estimated_slot && slot_sender.send(estimated_slots).is_err() {
-                            info!("Stop SlotUpdateService: all slot receivers have been dropped.");
-                            break;
+                        if estimated_slots > cached_estimated_slot {
+                            cached_estimated_slot = estimated_slots;
+                            if slot_sender.send(estimated_slots).is_err() {
+                                info!("Stop SlotUpdateService: all slot receivers have been dropped.");
+                                break;
+                            }
                         }
-                        cached_estimated_slot = estimated_slots;
                     }
 
                     _ = cancel.cancelled() => {
@@ -84,4 +86,96 @@ pub enum Error {
 
     #[error("Failed to initialize WebsocketSlotUpdateService.")]
     InitializationFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        futures::{SinkExt, channel::mpsc},
+        std::time::Duration,
+        tokio::time,
+    };
+
+    /// Run a `SlotUpdateService` over `events`, feeding them one at a time with
+    /// backpressure so every published value on the watch channel is observed.
+    async fn collect_published_slots(
+        events: Vec<SlotEvent>,
+    ) -> (Vec<Slot>, SlotUpdateService) {
+        let cancel = CancellationToken::new();
+        // Capacity 1: each `send().await` completes only after the service has
+        // consumed the previous event, so each event is processed in turn.
+        let (mut tx, rx) = mpsc::channel(1);
+        let (mut slot_receiver, service) = SlotUpdateService::run(0, rx, cancel.clone())
+            .expect("SlotUpdateService should run");
+
+        let mut published = Vec::new();
+        for event in events {
+            tx.send(event).await.expect("service dropped the channel");
+            // Wait a short window for the service to publish an updated estimate.
+            // `changed()` resolves immediately if the value changed since the
+            // last observation; otherwise it times out.
+            match time::timeout(Duration::from_millis(100), slot_receiver.changed()).await {
+                Ok(Ok(())) => published.push(slot_receiver.slot()),
+                Ok(Err(_)) => break, // channel closed
+                Err(_) => {}         // no update for this event
+            }
+        }
+
+        (published, service)
+    }
+
+    fn backward_estimate_events() -> Vec<SlotEvent> {
+        let mut events = Vec::new();
+        // 1. Consecutive start events advance the estimate to 300.
+        for slot in 1..=300 {
+            events.push(SlotEvent::Start(slot));
+        }
+        // 2. A far-future start event within MAX_SLOT_SKIP_DISTANCE of the median
+        //    is adopted as the estimate and published: 332.
+        events.push(SlotEvent::Start(332));
+        // 3. Exactly 48 events with lower slots evict 332 from the 48-event window.
+        //    The raw estimate falls back to 297, below the last published 332.
+        for slot in 250..=297 {
+            events.push(SlotEvent::Start(slot));
+        }
+        // 4. The next event yields an estimate of 298: above the evicted cache
+        //    (297) but below the last published slot (332). Without the send
+        //    guard protecting the cache, this would be delivered as a backward
+        //    slot update.
+        events.push(SlotEvent::Start(298));
+        events
+    }
+
+    #[tokio::test]
+    async fn test_published_slots_are_monotonic() {
+        let (published, mut service) =
+            collect_published_slots(backward_estimate_events()).await;
+
+        assert_eq!(
+            published.first(),
+            Some(&1),
+            "expected first published slot to be the first recorded start event"
+        );
+        let mut last = 0;
+        for slot in &published {
+            assert!(*slot >= last, "slot went backward: {slot} < {last}");
+            last = *slot;
+        }
+
+        service.shutdown().await.expect("clean shutdown");
+    }
+
+    #[tokio::test]
+    async fn test_eviction_drops_estimate_without_regressing_published_slot() {
+        let (published, mut service) =
+            collect_published_slots(backward_estimate_events()).await;
+
+        let max = published.iter().copied().max().expect("published slots");
+        assert_eq!(max, 332, "far-future estimate should have been published");
+        // The last published value must remain the max; no backward delivery.
+        assert_eq!(*published.last().unwrap(), 332);
+
+        service.shutdown().await.expect("clean shutdown");
+    }
 }


### PR DESCRIPTION
## Summary

Fixes `SlotUpdateService` publishing a backward (non-monotonic) estimated slot.

`cached_estimated_slot` was updated unconditionally on every slot event, even when the estimate was not sent because it had not advanced past the last *published* value. The stated intent on the guard is "Send update only if the estimated slot has advanced", but the cache was advanced outside the guard, allowing a later estimate that is below the last published value to pass the check and be sent.

## Root cause

`RecentLeaderSlots::estimate_current_slot()` can legitimately decrease over time:

1. A slot event that is in the future but within `MAX_SLOT_SKIP_DISTANCE` of the median is adopted as the estimate (it satisfies the "reasonable" filter) and published.
2. Once that event is evicted from the 48-event window while real slot progression is still below it, the estimate drops.
3. Because `cached_estimated_slot = estimated_slots;` ran unconditionally (outside the guard), the cache dropped to the new lower estimate. Any subsequent estimate merely above that raw cache — but still below the last *published* value — passed the guard and was sent.

Net effect: the slot watch channel delivers a slot that is behind the last delivered value.

## Downstream impact

The backward slot is consumed by `LeaderTpuCacheService::run_loop` (`leader_tpu_cache_service.rs:154`; the slot is read at `slot_receiver.slot()` around lines 185–196), which recomputes the leader TPU socket list and forwards it to `ConnectionWorkersScheduler`. Although `leader_sockets` clamps `current_slot` to `max(first_slot, slot_leaders.first_slot)` (`leader_tpu_cache_service.rs:307`), that only guards against falling below the schedule's first slot — not against dropping below the last *delivered* slot. When the schedule's `first_slot` is lower than the previously published slot, the final leader list regresses, causing:
- extra QUIC connection handshakes (`ConnectionWorkersScheduler::run_with_broadcaster` at `connection_workers_scheduler.rs:206`),
- leader-set switches between transactions,
- spurious `extend` flag via `adjust_lookahead` (`leader_tpu_cache_service.rs:382`): `is_leader_last_consecutive_slot` returns `None` below `first_slot`, `unwrap_or(true)` → `lookahead_leaders.saturating_add(1)`).

## Real-world impact (external consumer)

`anza-xyz/tpu-tools` — the Anza maintenance suite for TPU latency investigation and TPU load generation — consumes `estimated_current_slot()` from this exact code path:

- `rate-latency-tool` reads `leader_updater.get_current_slot()` on every send tick (`rate-latency-tool/src/run_rate_latency_tool_scheduler.rs:52`) and embeds it as the transaction's `target_slot` in the memo (`rate-latency-tool/src/run_client.rs:216,281`), then records it as `sent_slot` (`rate-latency-tool/src/run_client.rs:225`).
- All three leader trackers reach the buggy watch channel. Note that the line references below are against the `v4.3.0-beta.0` tag that tpu-tools pins; the file layout on `master` has since been refactored (a `NodeAddressProvider` now exposes `estimated_current_slot()`, and `WebsocketNodeAddressService` no longer has a `current_slot()` method):
  - `WebsocketNodeAddressService::current_slot()` delegates to `estimated_current_slot()` (`websocket_node_address_service.rs:63-64`).
  - `YellowstoneNodeAddressService::get_current_slot()` delegates to `estimated_current_slot()` (`leader_updater.rs:151-152`).
  - `CustomGeyserNodeAddressService::get_current_slot()` delegates to `estimated_current_slot()` (`custom_geyser_node_address_service.rs:98-99`).
- tpu-tools pins `solana-tpu-client-next = 4.3.0-beta.0`, and the `v4.3.0-beta.0` tag contains the identical unconditional cache update.

With a backward slot, `slot_latency = landed_slot - target_slot` is inflated and `sent_slot` is misreported, corrupting the tool's primary latency measurement.

## Verification

**In-crate regression tests (this PR).** Two `#[tokio::test]` tests were added to `slot_update_service.rs` that drive a real `SlotUpdateService` over an mpsc stream and assert the watch channel never delivers a backward slot:

- `test_published_slots_are_monotonic`: publishes `1..=300`, spikes to `332` via a far-future event, evicts `332` from the 48-event window with 48 lower events (raw estimate drops to `297`), then feeds `Start(298)` — an estimate above the raw cache but below the last published `332`. Asserts every delivered slot is non-decreasing.
- `test_eviction_drops_estimate_without_regressing_published_slot`: same scenario; asserts the last published value stays `332`.

Verified against the exact code: the tests pass with this fix and **fail** on the pre-fix (unconditional cache update) variant with `slot went backward: 298 < 332`.

**Standalone harness.** A harness replicating the send loop plus the `LeaderTpuCacheService`/scheduler pipeline independently confirmed:

- Deterministic repro: watch channel observes `321` then `213` (backward).
- 20,000 randomized trials: buggy variant delivered 11,676 backward slots and 28,591 final-leader-list regressions; the fixed variant delivered **0** of each.
- Realistic real-time timeline (far-future event 25–48 slots ahead, within `MAX_SLOT_SKIP_DISTANCE`): buggy forced 6 extra QUIC handshakes and 5 extra leader-set switches per spike vs fixed.
- Spurious `extend` flags: 49 (buggy) vs 0 (fixed).

The fix is one logical change: advance `cached_estimated_slot` only when a value is actually sent, matching the comment's stated intent.

## Changes

- `tpu-client-next/src/node_address_service/slot_update_service.rs`: move `cached_estimated_slot = estimated_slots;` inside the send guard; add regression tests.

