### PR TITLE
local-cluster: fix flaky alpenglow_basic_equivocation

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -6186,7 +6186,7 @@ fn test_alpenglow_basic_equivocation() {
         let total_duplicate_blocks_observed = (1..=last_duplicate)
             .filter(|slot| blockstore.has_duplicate_shreds_in_slot(*slot))
             .count();
-        if total_duplicate_blocks_observed == expected_duplicate_blocks {
+        if total_duplicate_blocks_observed >= expected_duplicate_blocks {
             break;
         }
         if start.elapsed() > Duration::from_secs(60) {


### PR DESCRIPTION
#### Problem
This test is sometimes flaky now that slot times have decreased. We require that we observe exactly 9 duplicate blocks, however the polling loop only runs once every 1 second. 

In failure we see that we jump from 8 to 10 duplicate blocks and the polling loop hangs.

#### Summary of Changes
Instead require that we observe at least 9 duplicate blocks

#### Testing
CI