### PR TITLE
accounts-db: Makes AccountStorageEntry slot and id fields private

### DIFF
--- a/accounts-db/src/account_storage.rs
+++ b/accounts-db/src/account_storage.rs
@@ -191,7 +191,7 @@ impl AccountStorage {
             "shrink is in progress! slots: {:?}",
             self.shrink_in_progress_map.read().unwrap().keys(),
         );
-        assert!(self.map.insert(store.slot, store).is_none());
+        assert!(self.map.insert(store.slot(), store).is_none());
     }
 
     /// called when shrinking begins on a slot and append vec.

--- a/accounts-db/src/account_storage_entry.rs
+++ b/accounts-db/src/account_storage_entry.rs
@@ -21,9 +21,9 @@ use {
 /// Persistent storage structure holding the accounts
 #[derive(Debug)]
 pub struct AccountStorageEntry {
-    pub(crate) id: AccountsFileId,
+    id: AccountsFileId,
 
-    pub(crate) slot: Slot,
+    slot: Slot,
 
     /// storage holding the accounts
     pub accounts: AccountsFile,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5207,7 +5207,7 @@ impl AccountsDb {
         let mut total_time = Measure::start("generate_index");
 
         let mut storages = self.storage.all_storages();
-        storages.sort_unstable_by_key(|storage| storage.slot);
+        storages.sort_unstable_by_key(|storage| storage.slot());
         if let Some(limit) = limit_load_slot_count_from_snapshot {
             storages.truncate(limit); // get rid of the newer slots and keep just the older
         }


### PR DESCRIPTION
These fields are unnecessarily public.