### PR TITLE
Rename shrink collect trait

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -153,7 +153,7 @@ pub(crate) struct ShrinkCollectAliveSeparatedByRefs<'a> {
     pub(crate) many_refs_old_alive: AliveAccounts<'a>,
 }
 
-pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
+pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
     fn add(
@@ -167,7 +167,7 @@ pub(crate) trait ShrinkCollectRefs<'a>: Sync + Send {
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
 }
 
-impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
+impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     fn collect(&mut self, mut other: Self) {
         self.bytes = self.bytes.saturating_add(other.bytes);
         self.accounts.append(&mut other.accounts);
@@ -199,7 +199,7 @@ impl<'a> ShrinkCollectRefs<'a> for AliveAccounts<'a> {
     }
 }
 
-impl<'a> ShrinkCollectRefs<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
+impl<'a> ShrinkCollector<'a> for ShrinkCollectAliveSeparatedByRefs<'a> {
     fn collect(&mut self, other: Self) {
         self.one_ref.collect(other.one_ref);
         self.many_refs_this_is_newest_alive
@@ -1923,7 +1923,7 @@ impl AccountsDb {
     /// load the account index entry for the first `count` items in `accounts`
     /// store a reference to all alive accounts in `alive_accounts`
     /// return sum of account size for all alive accounts
-    fn load_accounts_index_for_shrink<'a, T: ShrinkCollectRefs<'a>>(
+    fn load_accounts_index_for_shrink<'a, T: ShrinkCollector<'a>>(
         &self,
         accounts: &'a [AccountFromStorage],
         stats: &ShrinkStats,
@@ -2027,7 +2027,7 @@ impl AccountsDb {
 
     /// shared code for shrinking normal slots and combining into ancient append vecs
     /// note 'unique_accounts' is passed by ref so we can return references to data within it, avoiding self-references
-    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollectRefs<'b>>(
+    pub(crate) fn shrink_collect<'a: 'b, 'b, T: ShrinkCollector<'b>>(
         &self,
         store: &'a AccountStorageEntry,
         unique_accounts: &'b mut GetUniqueAccountsResult,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1124,7 +1124,7 @@ mod tests {
         crate::{
             account_info::{AccountInfo, StorageLocation},
             accounts_db::{
-                AccountsDbConfig, ShrinkCollectRefs,
+                AccountsDbConfig, ShrinkCollector,
                 tests::{ACCOUNTS_DB_CONFIG_APPEND_VEC, append_single_account_with_default_hash},
             },
             accounts_index::{ReclaimsSlotList, UpsertReclaim},


### PR DESCRIPTION
#### Problem
ShrinkCollectRefs trait directly reference refcount, which is unneccessary. 

#### Summary of Changes
1. Change ShrinkCollectRefs Trait to ShrinkCollector. 
- No need to reference. Technically it can collect based on any criteria it chooses
- Trait now describes what functionality must be provided

#### Testing


Fixes #
