### PR TITLE
chore(toolchain): bump rust toolchain to 1.98.0 and nightly=2026-07-03

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ repository = "https://github.com/anza-xyz/agave"
 homepage = "https://anza.xyz/"
 license = "Apache-2.0"
 edition = "2024"
-rust-version = "1.97.1"
+rust-version = "1.98.0"
 
 [workspace.lints.rust.unexpected_cfgs]
 level = "warn"

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n ${RUST_NIGHTLY_VERSION:-} ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2026-05-23
+  nightly_version=2026-07-03
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"


### PR DESCRIPTION
#### Problem
Rust 1.98.0 got released
https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/

#### Summary of Changes
* bump stable toolchain to 1.98.0
* bump nightly (for CI / checks) to 2026-07-03
* bump minimum rust version to 1.98.0

#### Testing
* CI
* running it on devbox without issues