### PR TITLE
chore(packet): Remove Vec requiremenet for new_with_recycler_data

### DIFF
--- a/core/src/repair/repair_handler.rs
+++ b/core/src/repair/repair_handler.rs
@@ -46,7 +46,7 @@ where
     let serialized_response = serialize(response).ok()?;
     let packet =
         repair_response::repair_response_packet_from_bytes(serialized_response, from_addr, nonce)?;
-    Some(RecycledPacketBatch::new_with_recycler_data(recycler, debug_label, vec![packet]).into())
+    Some(RecycledPacketBatch::new_with_recycler_data(recycler, debug_label, [packet]).into())
 }
 
 pub trait RepairHandler {
@@ -71,12 +71,8 @@ pub trait RepairHandler {
         // Try to find the requested index in one of the slots
         let packet = self.repair_response_packet(slot, shred_index, from_addr, nonce)?;
         Some(
-            RecycledPacketBatch::new_with_recycler_data(
-                recycler,
-                "run_window_request",
-                vec![packet],
-            )
-            .into(),
+            RecycledPacketBatch::new_with_recycler_data(recycler, "run_window_request", [packet])
+                .into(),
         )
     }
 
@@ -98,7 +94,7 @@ pub trait RepairHandler {
             RecycledPacketBatch::new_with_recycler_data(
                 recycler,
                 "run_window_request_for_block_id",
-                vec![packet],
+                [packet],
             )
             .into(),
         )
@@ -121,7 +117,7 @@ pub trait RepairHandler {
                 RecycledPacketBatch::new_with_recycler_data(
                     recycler,
                     "run_highest_window_request",
-                    vec![packet],
+                    [packet],
                 )
                 .into(),
             );

--- a/perf/src/packet.rs
+++ b/perf/src/packet.rs
@@ -678,10 +678,11 @@ impl RecycledPacketBatch {
     pub fn new_with_recycler_data(
         recycler: &PacketBatchRecycler,
         name: &'static str,
-        mut packets: Vec<Packet>,
+        packets: impl IntoIterator<Item = Packet, IntoIter: ExactSizeIterator>,
     ) -> Self {
+        let packets = packets.into_iter();
         let mut batch = Self::new_with_recycler(recycler, packets.len(), name);
-        batch.packets.append(&mut packets);
+        batch.packets.extend(packets);
         batch
     }
 

--- a/perf/src/recycled_vec.rs
+++ b/perf/src/recycled_vec.rs
@@ -49,6 +49,13 @@ impl<'a, T: Clone + Default + Sized> IntoIterator for &'a RecycledVec<T> {
     }
 }
 
+impl<T: Clone + Default + Sized> Extend<T> for RecycledVec<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.x.extend(iter);
+    }
+}
+
 impl<T: Clone + Default + Sized, I: SliceIndex<[T]>> Index<I> for RecycledVec<T> {
     type Output = I::Output;
 


### PR DESCRIPTION
#### Problem
`RecycledPacketBatch::new_with_recycler_data` takes `packets` as a `Vec<Packet>`, forcing a `Vec` allocation, even though all call-sites pass a single `Packet`.

#### Summary of Changes
Update the signature of `RecycledPacketBatch::new_with_recycler_data` to accept `impl IntoIterator<Item = Packet, IntoIter: ExactSizeIterator>`, allowing callers to pass an array literal.
