### PR TITLE
ci: update lockfiles before manifests in dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -59,9 +59,13 @@ jobs:
         run: |
           echo "crate_name: $CRATE_NAME, old_version: $OLD_VERSION, new_version: $NEW_VERSION"
 
-          cargo anza-xtask update-crate --package "$CRATE_NAME" --from "$OLD_VERSION" --to "$NEW_VERSION"
-
+          # Bump lockfiles before manifests: while the manifests still request the old
+          # version, cargo swaps just this node; a manifest-first edit leaves the locked
+          # version unsatisfiable, which unlocks all of crates.io and rewrites unrelated
+          # resolution choices. No-ops for semver-major bumps, handled by `tree` below.
           ./scripts/cargo-for-all-lock-files.sh --ignore-exit-code -- update -p "$CRATE_NAME:$OLD_VERSION" --precise "$NEW_VERSION"
+
+          cargo anza-xtask update-crate --package "$CRATE_NAME" --from "$OLD_VERSION" --to "$NEW_VERSION"
 
           ./scripts/cargo-for-all-lock-files.sh tree
 


### PR DESCRIPTION
#### Problem
The dependabot PR automation bumps the workspace manifests before touching the lockfiles. Once a manifest requests a version the lockfile cannot satisfy, cargo poisons the whole crates.io source and re-resolves the entire graph, so the PRs carry unrelated resolution changes. The io-uring 0.7.14 bump, for instance, also moved hyper-util and quinn onto socket2 0.6.5, rustix and tempfile onto windows-sys 0.61.0, and bindgen onto itertools 0.13.0.

#### Summary of Changes
Run the per-lockfile precise update before update-crate, so the manifests still request the old version while cargo swaps just that one node. Semver-major bumps are not admitted by the old requirement, so the precise update no-ops for them (already tolerated via --ignore-exit-code) and the trailing tree performs the update as before.

#### Testing
* checked that this generates cleaned lockfile diff on io-uring bump
* checked that major version bump gracefully gets updated by  the `tree` command