### PR TITLE
accounts-db: Removes unnecessary AbiExample

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -32,7 +32,6 @@ dev-context-only-utils = [
     "solana-transaction/dev-context-only-utils",
 ]
 frozen-abi = [
-    "dev-context-only-utils",
     "dep:solana-frozen-abi",
     "dep:solana-frozen-abi-macro",
     "solana-fee-calculator/frozen-abi",

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -986,20 +986,6 @@ pub fn default_num_foreground_threads() -> usize {
     get_thread_count()
 }
 
-#[cfg(feature = "frozen-abi")]
-impl solana_frozen_abi::abi_example::AbiExample for AccountsDb {
-    fn example() -> Self {
-        let accounts_db = AccountsDb::default_for_tests();
-        let key = Pubkey::default();
-        let some_data_len = 5;
-        let some_slot: Slot = 0;
-        let account = AccountSharedData::new(1, some_data_len, &key);
-        accounts_db.store_for_tests((some_slot, [(&key, &account)].as_slice()));
-        accounts_db.add_root_and_flush_write_cache(0);
-        accounts_db
-    }
-}
-
 impl AccountsDb {
     // The default high and low watermark sizes for the accounts read cache.
     // If the cache size exceeds MAX_SIZE_HI, it'll evict entries until the size is <= MAX_SIZE_LO.

--- a/accounts-db/src/ancestors.rs
+++ b/accounts-db/src/ancestors.rs
@@ -4,7 +4,6 @@ use {
     solana_clock::Slot,
 };
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone, PartialEq)]
 pub struct Ancestors {
     ancestors: RollingBitField,

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -142,7 +142,6 @@ impl ReadWriteState {
 /// are serialized using `read_write_state`'s internal lock such that only one thread updates the
 /// file at a time. No restrictions are placed on reading. That is, one may read items from one
 /// thread while another is appending new items.
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Debug)]
 pub struct AppendVec {
     /// The file path where the data is stored.

--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -5,7 +5,6 @@
 mod iterators;
 use {bv::BitVec, iterators::RollingBitFieldOnesIter, solana_nohash_hasher::IntSet};
 
-#[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[derive(Clone)]
 pub struct RollingBitField {
     max_width: u64,


### PR DESCRIPTION
After moving over stuff to wincode, and cleaning up the snapshot fields, we no longer need to derive AbiExample on a bunch of types in accounts-db.