### PR TITLE
remove lru cache from shred sigverify

### DIFF
--- a/core/src/repair/repair_response.rs
+++ b/core/src/repair/repair_response.rs
@@ -49,20 +49,18 @@ mod test {
         solana_keypair::Keypair,
         solana_ledger::{
             shred::Shredder,
-            sigverify_shreds::{LruCache, SlotPubkeys, verify_shred_cpu},
+            sigverify_shreds::{SlotPubkeys, verify_shred_cpu},
         },
         solana_packet::PacketFlags,
         solana_signer::Signer,
         std::{
             collections::HashMap,
             net::{IpAddr, Ipv4Addr},
-            sync::RwLock,
         },
     };
 
     fn run_test_sigverify_shred_cpu_repair(slot: Slot) {
         agave_logger::setup();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
         let shred = Shredder::single_shred_for_tests(slot, &keypair);
 
@@ -77,14 +75,14 @@ mod test {
         packet.meta_mut().flags |= PacketFlags::REPAIR;
 
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        assert!(verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(verify_shred_cpu((&packet).into(), &leader_slots));
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots));
 
         let leader_slots: SlotPubkeys = HashMap::default();
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots));
     }
 
     #[test]

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -18,6 +18,37 @@ pub type LruCache = lazy_lru::LruCache<(Signature, Pubkey, /*merkle root:*/ Hash
 pub type SlotPubkeys = HashMap<Slot, Pubkey, BuildNoHashHasher<Slot>>;
 
 #[must_use]
+pub fn verify_shred_with_leader(
+    packet: PacketRef,
+    leader: &Pubkey,
+    cache: &RwLock<LruCache>,
+) -> bool {
+    if packet.meta().discard() {
+        return false;
+    }
+    let Some(shred) = shred::layout::get_shred(packet) else {
+        return false;
+    };
+    let Some(signature) = shred::layout::get_signature(shred) else {
+        return false;
+    };
+    trace!("signature {signature}");
+    let Some(merkle_root) = shred::layout::get_merkle_root(shred) else {
+        return false;
+    };
+
+    let key = (signature, *leader, merkle_root);
+    if cache.read().unwrap().get(&key).is_some() {
+        true
+    } else if key.0.verify(key.1.as_ref(), key.2.as_ref()) {
+        cache.write().unwrap().put(key, ());
+        true
+    } else {
+        false
+    }
+}
+
+#[must_use]
 pub fn verify_shred_cpu(
     packet: PacketRef,
     slot_leaders: &SlotPubkeys,
@@ -36,23 +67,7 @@ pub fn verify_shred_cpu(
     let Some(pubkey) = slot_leaders.get(&slot) else {
         return false;
     };
-    let Some(signature) = shred::layout::get_signature(shred) else {
-        return false;
-    };
-    trace!("signature {signature}");
-    let Some(data) = shred::layout::get_merkle_root(shred) else {
-        return false;
-    };
-
-    let key = (signature, *pubkey, data);
-    if cache.read().unwrap().get(&key).is_some() {
-        true
-    } else if key.0.verify(key.1.as_ref(), key.2.as_ref()) {
-        cache.write().unwrap().put(key, ());
-        true
-    } else {
-        false
-    }
+    verify_shred_with_leader(packet, pubkey, cache)
 }
 
 pub fn par_verify_shreds(

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -62,14 +62,20 @@ pub fn verify_shreds(
     cache: &RwLock<LruCache>,
 ) {
     thread_pool.install(|| {
-        batches.par_iter_mut().for_each(|batch| {
-            batch.par_iter_mut().for_each(|mut packet| {
-                if !packet.meta().discard()
-                    && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache)
-                {
-                    packet.meta_mut().set_discard(true);
-                }
-            });
+        par_verify_shreds(batches, slot_leaders, cache);
+    });
+}
+
+pub fn par_verify_shreds(
+    batches: &mut [PacketBatch],
+    slot_leaders: &SlotPubkeys,
+    cache: &RwLock<LruCache>,
+) {
+    batches.par_iter_mut().for_each(|batch| {
+        batch.par_iter_mut().for_each(|mut packet| {
+            if !packet.meta().discard() && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache) {
+                packet.meta_mut().set_discard(true);
+            }
         });
     });
 }

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::implicit_hasher)]
 use {
     crate::shred,
-    rayon::{ThreadPool, prelude::*},
+    rayon::prelude::*,
     solana_clock::Slot,
     solana_hash::Hash,
     solana_nohash_hasher::BuildNoHashHasher,
@@ -55,17 +55,6 @@ pub fn verify_shred_cpu(
     }
 }
 
-pub fn verify_shreds(
-    thread_pool: &ThreadPool,
-    batches: &mut [PacketBatch],
-    slot_leaders: &SlotPubkeys,
-    cache: &RwLock<LruCache>,
-) {
-    thread_pool.install(|| {
-        par_verify_shreds(batches, slot_leaders, cache);
-    });
-}
-
 pub fn par_verify_shreds(
     batches: &mut [PacketBatch],
     slot_leaders: &SlotPubkeys,
@@ -111,7 +100,7 @@ mod tests {
         assert_matches::assert_matches,
         itertools::Itertools,
         rand::{Rng, seq::SliceRandom},
-        rayon::ThreadPoolBuilder,
+        rayon::{ThreadPool, ThreadPoolBuilder},
         solana_entry::entry::Entry,
         solana_hash::Hash,
         solana_keypair::Keypair,
@@ -123,6 +112,17 @@ mod tests {
         std::iter::{once, repeat_with},
         test_case::test_case,
     };
+
+    fn verify_shreds(
+        thread_pool: &ThreadPool,
+        batches: &mut [PacketBatch],
+        slot_leaders: &SlotPubkeys,
+        cache: &RwLock<LruCache>,
+    ) {
+        thread_pool.install(|| {
+            par_verify_shreds(batches, slot_leaders, cache);
+        });
+    }
 
     fn sign_shreds(thread_pool: &ThreadPool, keypair: &Keypair, batches: &mut [PacketBatch]) {
         thread_pool.install(|| {

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -3,26 +3,18 @@ use {
     crate::shred,
     rayon::prelude::*,
     solana_clock::Slot,
-    solana_hash::Hash,
     solana_nohash_hasher::BuildNoHashHasher,
     solana_perf::packet::{PacketBatch, PacketRef},
     solana_pubkey::Pubkey,
-    solana_signature::Signature,
-    std::{collections::HashMap, sync::RwLock},
+    std::collections::HashMap,
 };
 #[cfg(test)]
 use {solana_keypair::Keypair, solana_perf::packet::PacketRefMut, solana_signer::Signer};
 
-pub type LruCache = lazy_lru::LruCache<(Signature, Pubkey, /*merkle root:*/ Hash), ()>;
-
 pub type SlotPubkeys = HashMap<Slot, Pubkey, BuildNoHashHasher<Slot>>;
 
 #[must_use]
-pub fn verify_shred_with_leader(
-    packet: PacketRef,
-    leader: &Pubkey,
-    cache: &RwLock<LruCache>,
-) -> bool {
+pub fn verify_shred_with_leader(packet: PacketRef, leader: &Pubkey) -> bool {
     if packet.meta().discard() {
         return false;
     }
@@ -37,23 +29,11 @@ pub fn verify_shred_with_leader(
         return false;
     };
 
-    let key = (signature, *leader, merkle_root);
-    if cache.read().unwrap().get(&key).is_some() {
-        true
-    } else if key.0.verify(key.1.as_ref(), key.2.as_ref()) {
-        cache.write().unwrap().put(key, ());
-        true
-    } else {
-        false
-    }
+    signature.verify(leader.as_ref(), merkle_root.as_ref())
 }
 
 #[must_use]
-pub fn verify_shred_cpu(
-    packet: PacketRef,
-    slot_leaders: &SlotPubkeys,
-    cache: &RwLock<LruCache>,
-) -> bool {
+pub fn verify_shred_cpu(packet: PacketRef, slot_leaders: &SlotPubkeys) -> bool {
     if packet.meta().discard() {
         return false;
     }
@@ -67,17 +47,13 @@ pub fn verify_shred_cpu(
     let Some(pubkey) = slot_leaders.get(&slot) else {
         return false;
     };
-    verify_shred_with_leader(packet, pubkey, cache)
+    verify_shred_with_leader(packet, pubkey)
 }
 
-pub fn par_verify_shreds(
-    batches: &mut [PacketBatch],
-    slot_leaders: &SlotPubkeys,
-    cache: &RwLock<LruCache>,
-) {
+pub fn par_verify_shreds(batches: &mut [PacketBatch], slot_leaders: &SlotPubkeys) {
     batches.par_iter_mut().for_each(|batch| {
         batch.par_iter_mut().for_each(|mut packet| {
-            if !packet.meta().discard() && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache) {
+            if !packet.meta().discard() && !verify_shred_cpu(packet.as_ref(), slot_leaders) {
                 packet.meta_mut().set_discard(true);
             }
         });
@@ -132,10 +108,9 @@ mod tests {
         thread_pool: &ThreadPool,
         batches: &mut [PacketBatch],
         slot_leaders: &SlotPubkeys,
-        cache: &RwLock<LruCache>,
     ) {
         thread_pool.install(|| {
-            par_verify_shreds(batches, slot_leaders, cache);
+            par_verify_shreds(batches, slot_leaders);
         });
     }
 
@@ -152,7 +127,6 @@ mod tests {
     fn run_test_sigverify_shred_cpu(slot: Slot) {
         agave_logger::setup();
         let mut packet = Packet::default();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let shredder = Shredder::new(slot, slot.saturating_sub(1), 0, 0).unwrap();
         let keypair = Keypair::new();
         let reed_solomon_cache = ReedSolomonCache::default();
@@ -173,14 +147,14 @@ mod tests {
         packet.meta_mut().size = shred.payload().len();
 
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        assert!(verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(verify_shred_cpu((&packet).into(), &leader_slots));
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots));
 
         let leader_slots: SlotPubkeys = HashMap::default();
-        assert!(!verify_shred_cpu((&packet).into(), &leader_slots, &cache));
+        assert!(!verify_shred_cpu((&packet).into(), &leader_slots));
     }
 
     #[test]
@@ -190,12 +164,11 @@ mod tests {
 
     fn run_test_sigverify_shreds_cpu(thread_pool: &ThreadPool, slot: Slot) {
         agave_logger::setup();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
 
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -206,7 +179,7 @@ mod tests {
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -216,7 +189,7 @@ mod tests {
 
         let leader_slots: SlotPubkeys = HashMap::default();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -229,7 +202,7 @@ mod tests {
         batches[0]
             .iter_mut()
             .for_each(|mut packet_ref| packet_ref.meta_mut().size = 0);
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -246,14 +219,13 @@ mod tests {
 
     fn run_test_sigverify_shreds(thread_pool: &ThreadPool, slot: Slot) {
         agave_logger::setup();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
 
         let keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -269,7 +241,7 @@ mod tests {
         .into_iter()
         .collect();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -279,7 +251,7 @@ mod tests {
 
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default())].into_iter().collect();
         let mut batches = [make_packet_batch(&keypair, slot)];
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -294,7 +266,7 @@ mod tests {
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
-        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        verify_shreds(thread_pool, &mut batches, &leader_slots);
         assert!(
             batches
                 .iter()
@@ -434,7 +406,6 @@ mod tests {
     #[test_case(false)]
     fn test_verify_shreds_fuzz(is_last_in_slot: bool) {
         let mut rng = rand::rng();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         let keypairs = repeat_with(|| rng.random_range(169_367_809..169_906_789))
             .map(|slot| (slot, Keypair::new()))
@@ -447,7 +418,7 @@ mod tests {
             .chain(once((Slot::MAX, Pubkey::default())))
             .collect();
         let mut packets = make_packets(&mut rng, &shreds);
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        verify_shreds(&thread_pool, &mut packets, &pubkeys);
         assert!(
             packets
                 .iter()
@@ -473,7 +444,7 @@ mod tests {
                     .collect::<Vec<bool>>()
             })
             .collect::<Vec<_>>();
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        verify_shreds(&thread_pool, &mut packets, &pubkeys);
         assert!(
             packets
                 .iter()
@@ -491,7 +462,6 @@ mod tests {
     #[test_case(false)]
     fn test_sign_shreds(is_last_in_slot: bool) {
         let mut rng = rand::rng();
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         let shreds = {
             let keypairs = repeat_with(|| rng.random_range(169_367_809..169_906_789))
@@ -512,7 +482,7 @@ mod tests {
         };
         let mut packets = make_packets(&mut rng, &shreds);
         // Assert that initially all signatures are invalid.
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        verify_shreds(&thread_pool, &mut packets, &pubkeys);
         assert!(
             packets
                 .iter()
@@ -526,7 +496,7 @@ mod tests {
                 .for_each(|mut packet| packet.meta_mut().set_discard(false));
         });
         sign_shreds(&thread_pool, &keypair, &mut packets);
-        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        verify_shreds(&thread_pool, &mut packets, &pubkeys);
         assert!(
             packets
                 .iter()

--- a/ledger/src/sigverify_shreds.rs
+++ b/ledger/src/sigverify_shreds.rs
@@ -57,21 +57,21 @@ pub fn verify_shred_cpu(
 
 pub fn verify_shreds(
     thread_pool: &ThreadPool,
-    batches: &[PacketBatch],
+    batches: &mut [PacketBatch],
     slot_leaders: &SlotPubkeys,
     cache: &RwLock<LruCache>,
-) -> Vec<Vec<u8>> {
+) {
     thread_pool.install(|| {
-        batches
-            .into_par_iter()
-            .map(|batch| {
-                batch
-                    .par_iter()
-                    .map(|packet| u8::from(verify_shred_cpu(packet, slot_leaders, cache)))
-                    .collect()
-            })
-            .collect()
-    })
+        batches.par_iter_mut().for_each(|batch| {
+            batch.par_iter_mut().for_each(|mut packet| {
+                if !packet.meta().discard()
+                    && !verify_shred_cpu(packet.as_ref(), slot_leaders, cache)
+                {
+                    packet.meta_mut().set_discard(true);
+                }
+            });
+        });
+    });
 }
 
 #[cfg(test)]
@@ -171,28 +171,50 @@ mod tests {
         agave_logger::setup();
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let keypair = Keypair::new();
-        let batch = make_packet_batch(&keypair, slot);
-        let mut batches = [batch];
 
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 1);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
+        );
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [(slot, wrong_keypair.pubkey())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
         let leader_slots: SlotPubkeys = HashMap::default();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
+        let mut batches = [make_packet_batch(&keypair, slot)];
         let leader_slots: SlotPubkeys = [(slot, keypair.pubkey())].into_iter().collect();
         batches[0]
             .iter_mut()
             .for_each(|mut packet_ref| packet_ref.meta_mut().size = 0);
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
     }
 
     #[test]
@@ -206,14 +228,17 @@ mod tests {
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
 
         let keypair = Keypair::new();
-        let batch = make_packet_batch(&keypair, slot);
-        let mut batches = [batch];
-
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 1);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
+        );
 
         let wrong_keypair = Keypair::new();
         let leader_slots: SlotPubkeys = [
@@ -222,21 +247,39 @@ mod tests {
         ]
         .into_iter()
         .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default())].into_iter().collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        let mut batches = [make_packet_batch(&keypair, slot)];
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
 
+        let mut batches = [make_packet_batch(&keypair, slot)];
         batches[0]
             .iter_mut()
             .for_each(|mut pr| pr.meta_mut().size = 0);
         let leader_slots: SlotPubkeys = [(u64::MAX, Pubkey::default()), (slot, keypair.pubkey())]
             .into_iter()
             .collect();
-        let rv = verify_shreds(thread_pool, &batches, &leader_slots, &cache);
-        assert_eq!(rv.into_iter().flatten().all_equal_value().unwrap(), 0);
+        verify_shreds(thread_pool, &mut batches, &leader_slots, &cache);
+        assert!(
+            batches
+                .iter()
+                .flatten()
+                .all(|packet| packet.meta().discard())
+        );
     }
 
     fn make_packet_batch(keypair: &Keypair, slot: u64) -> PacketBatch {
@@ -383,15 +426,15 @@ mod tests {
             .chain(once((Slot::MAX, Pubkey::default())))
             .collect();
         let mut packets = make_packets(&mut rng, &shreds);
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![1u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
         );
         // Invalidate signatures for a random number of packets.
-        let out: Vec<_> = packets
+        let expected_discards = packets
             .iter_mut()
             .map(|packets| {
                 let PacketBatch::Pinned(packets) = packets else {
@@ -404,12 +447,23 @@ mod tests {
                         if !coin_flip {
                             shred::layout::corrupt_packet(&mut rng, packet, &keypairs);
                         }
-                        u8::from(coin_flip)
+                        !coin_flip
                     })
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<bool>>()
             })
-            .collect();
-        assert_eq!(verify_shreds(&thread_pool, &packets, &pubkeys, &cache), out);
+            .collect::<Vec<_>>();
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
+            packets
+                .iter()
+                .zip(expected_discards.iter())
+                .all(|(batch, expected)| {
+                    batch
+                        .iter()
+                        .zip(expected)
+                        .all(|(packet, should_discard)| packet.meta().discard() == *should_discard)
+                })
+        );
     }
 
     #[test_case(true)]
@@ -437,21 +491,26 @@ mod tests {
         };
         let mut packets = make_packets(&mut rng, &shreds);
         // Assert that initially all signatures are invalid.
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![0u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| packet.meta().discard())
         );
         // Sign and verify shreds signatures.
+        packets.iter_mut().for_each(|batch| {
+            batch
+                .iter_mut()
+                .for_each(|mut packet| packet.meta_mut().set_discard(false));
+        });
         sign_shreds(&thread_pool, &keypair, &mut packets);
-        assert_eq!(
-            verify_shreds(&thread_pool, &packets, &pubkeys, &cache),
+        verify_shreds(&thread_pool, &mut packets, &pubkeys, &cache);
+        assert!(
             packets
                 .iter()
-                .map(|batch| vec![1u8; batch.len()])
-                .collect::<Vec<_>>()
+                .flatten()
+                .all(|packet| !packet.meta().discard())
         );
     }
 }

--- a/perf/src/sigverify.rs
+++ b/perf/src/sigverify.rs
@@ -132,16 +132,6 @@ pub fn ed25519_verify_serial(batch: &mut PacketBatch, reject_non_vote: bool, ena
     }
 }
 
-pub fn mark_disabled(batches: &mut [PacketBatch], r: &[Vec<u8>]) {
-    for (batch, v) in batches.iter_mut().zip(r) {
-        for (mut pkt, f) in batch.iter_mut().zip(v) {
-            if !pkt.meta().discard() {
-                pkt.meta_mut().set_discard(*f == 0);
-            }
-        }
-    }
-}
-
 #[cfg(feature = "dev-context-only-utils")]
 pub fn threadpool_for_tests() -> rayon::ThreadPool {
     // Four threads is sufficient for unit tests
@@ -218,19 +208,6 @@ mod tests {
         .unwrap();
 
         VersionedTransaction::try_new(VersionedMessage::V1(message), &[&payer]).unwrap()
-    }
-
-    #[test]
-    fn test_mark_disabled() {
-        let batch_size = 1;
-        let mut batch = BytesPacketBatch::with_capacity(batch_size);
-        batch.resize(batch_size, BytesPacket::empty());
-        let mut batches: Vec<PacketBatch> = vec![batch.into()];
-        mark_disabled(&mut batches, &[vec![0]]);
-        assert!(batches[0].get(0).unwrap().meta().discard());
-        batches[0].get_mut(0).unwrap().meta_mut().set_discard(false);
-        mark_disabled(&mut batches, &[vec![1]]);
-        assert!(!batches[0].get(0).unwrap().meta().discard());
     }
 
     fn packet_from_num_sigs(required_num_sigs: u8, actual_num_sigs: usize) -> BytesPacket {

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -5,7 +5,6 @@ use {
     },
     agave_feature_set as feature_set,
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
-    itertools::{Either, Itertools},
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
@@ -188,66 +187,144 @@ fn run_shred_sigverify<const K: usize>(
         (bank_forks.working_bank(), bank_forks.root_bank())
     };
     let self_pubkey = keypair.pubkey();
-    let (num_duplicates, num_discards_post, resign_micros) = thread_pool.install(|| {
+    let (
+        num_duplicates,
+        num_discards_post,
+        resign_micros,
+        num_unknown_block_location,
+        shreds,
+        repairs,
+    ) = thread_pool.install(|| {
         shred_buffer
             .par_iter_mut()
             .flatten()
-            .map(|mut packet| {
-                if packet.meta().discard() {
-                    return (0, 1, 0);
-                }
-                let mut num_duplicates = 0;
-                let duplicate = shred::wire::get_shred(packet.as_ref())
-                    .map(|shred| deduper.dedup(shred))
-                    .unwrap_or(true);
-                if duplicate && !packet.meta().repair() {
-                    packet.meta_mut().set_discard(true);
-                    num_duplicates = 1;
-                }
-                if !packet.meta().discard()
-                    && !verify_packet_signature(
-                        &self_pubkey,
-                        packet.as_ref(),
+            .fold(
+                || (0, 0, 0, 0, Vec::new(), Vec::new()),
+                |(
+                    mut num_duplicates_acc,
+                    mut num_discards_post_acc,
+                    mut resign_micros_acc,
+                    mut num_unknown_block_location_acc,
+                    mut shreds_acc,
+                    mut repairs_acc,
+                ),
+                 mut packet| {
+                    if packet.meta().discard() {
+                        num_discards_post_acc += 1;
+                        return (
+                            num_duplicates_acc,
+                            num_discards_post_acc,
+                            resign_micros_acc,
+                            num_unknown_block_location_acc,
+                            shreds_acc,
+                            repairs_acc,
+                        );
+                    }
+                    let duplicate = shred::wire::get_shred(packet.as_ref())
+                        .map(|shred| deduper.dedup(shred))
+                        .unwrap_or(true);
+                    if duplicate && !packet.meta().repair() {
+                        packet.meta_mut().set_discard(true);
+                        num_duplicates_acc += 1;
+                    }
+                    if !packet.meta().discard()
+                        && !verify_packet_signature(
+                            &self_pubkey,
+                            packet.as_ref(),
+                            &working_bank,
+                            leader_schedule_cache,
+                            cache,
+                        )
+                    {
+                        packet.meta_mut().set_discard(true);
+                    }
+                    if packet.meta().discard() {
+                        num_discards_post_acc += 1;
+                        return (
+                            num_duplicates_acc,
+                            num_discards_post_acc,
+                            resign_micros_acc,
+                            num_unknown_block_location_acc,
+                            shreds_acc,
+                            repairs_acc,
+                        );
+                    }
+                    let resign_start = Instant::now();
+                    if maybe_verify_and_resign_packet(
+                        &mut packet,
+                        &root_bank,
                         &working_bank,
+                        cluster_info,
                         leader_schedule_cache,
-                        cache,
+                        cluster_nodes_cache,
+                        stats,
+                        keypair,
                     )
-                {
-                    packet.meta_mut().set_discard(true);
-                }
-                let num_discards_post = usize::from(packet.meta().discard());
-                if packet.meta().discard() {
-                    return (num_duplicates, num_discards_post, 0);
-                }
-                let resign_start = Instant::now();
-                if maybe_verify_and_resign_packet(
-                    &mut packet,
-                    &root_bank,
-                    &working_bank,
-                    cluster_info,
-                    leader_schedule_cache,
-                    cluster_nodes_cache,
-                    stats,
-                    keypair,
-                )
-                .is_err()
-                {
-                    packet.meta_mut().set_discard(true);
-                }
-                (
-                    num_duplicates,
-                    num_discards_post,
-                    resign_start.elapsed().as_micros() as u64,
-                )
-            })
+                    .is_err()
+                    {
+                        packet.meta_mut().set_discard(true);
+                    }
+                    resign_micros_acc += resign_start.elapsed().as_micros() as u64;
+                    if !packet.meta().discard()
+                        && let Some((shred, nonce)) =
+                            shred::layout::get_shred_and_repair_nonce(packet.as_ref())
+                    {
+                        let shred = shred::Payload::from(shred.to_vec());
+                        match nonce {
+                            None => {
+                                // Share the payload between the retransmit-stage and the
+                                // window-service.
+                                shreds_acc.push(shred);
+                            }
+                            Some(nonce) => {
+                                if let Some(location) = repair_nonce_location_lookup(nonce) {
+                                    // No need for Arc overhead here because repaired shreds
+                                    // are not retranmitted.
+                                    repairs_acc
+                                        .push((shred, /* is_repaired */ true, location));
+                                } else {
+                                    num_unknown_block_location_acc += 1;
+                                }
+                            }
+                        }
+                    }
+                    (
+                        num_duplicates_acc,
+                        num_discards_post_acc,
+                        resign_micros_acc,
+                        num_unknown_block_location_acc,
+                        shreds_acc,
+                        repairs_acc,
+                    )
+                },
+            )
             .reduce(
-                || (0, 0, 0),
-                |(num_duplicates_a, num_discards_post_a, resign_micros_a),
-                 (num_duplicates_b, num_discards_post_b, resign_micros_b)| {
+                || (0, 0, 0, 0, Vec::new(), Vec::new()),
+                |(
+                    num_duplicates_a,
+                    num_discards_post_a,
+                    resign_micros_a,
+                    num_unknown_block_location_a,
+                    mut shreds_a,
+                    mut repairs_a,
+                ),
+                 (
+                    num_duplicates_b,
+                    num_discards_post_b,
+                    resign_micros_b,
+                    num_unknown_block_location_b,
+                    shreds_b,
+                    repairs_b,
+                )| {
+                    shreds_a.extend(shreds_b);
+                    repairs_a.extend(repairs_b);
                     (
                         num_duplicates_a + num_duplicates_b,
                         num_discards_post_a + num_discards_post_b,
                         resign_micros_a + resign_micros_b,
+                        num_unknown_block_location_a + num_unknown_block_location_b,
+                        shreds_a,
+                        repairs_a,
                     )
                 },
             )
@@ -255,30 +332,7 @@ fn run_shred_sigverify<const K: usize>(
     stats.num_duplicates += num_duplicates;
     stats.num_discards_post += num_discards_post;
     stats.resign_micros += resign_micros;
-    // Extract shred payload from packets, and separate out repaired shreds.
-    let (shreds, repairs): (Vec<_>, Vec<_>) = shred_buffer
-        .iter()
-        .flat_map(|batch| batch.iter())
-        .filter(|packet| !packet.meta().discard())
-        .filter_map(|packet| {
-            extract_shred_and_location(packet, repair_nonce_location_lookup, stats)
-        })
-        .partition_map(|(shred, location)| {
-            if let Some(location) = location {
-                // No need for Arc overhead here because repaired shreds are
-                // not retranmitted.
-                Either::Right((
-                    shred::Payload::from(shred),
-                    /* is_repaired */ true,
-                    location,
-                ))
-            } else {
-                // Share the payload between the retransmit-stage and the
-                // window-service.
-                Either::Left(shred::Payload::from(shred))
-            }
-        });
-
+    stats.num_unknown_block_location += num_unknown_block_location;
     // Repaired shreds are not retransmitted.
     stats.num_retransmit_shreds += shreds.len();
     if let Err(send_err) = retransmit_sender.try_send(shreds.clone()) {
@@ -297,29 +351,6 @@ fn run_shred_sigverify<const K: usize>(
     stats.elapsed_micros += now.elapsed().as_micros() as u64;
     shred_buffer.clear();
     Ok(())
-}
-
-/// Extracts shred bytes and, for repaired shreds, the location where the shred
-/// should be inserted into blockstore.
-fn extract_shred_and_location(
-    packet: PacketRef,
-    repair_nonce_location_lookup: &RepairNonceLocationLookup,
-    stats: &mut ShredSigVerifyStats,
-) -> Option<(Vec<u8>, Option<BlockLocation>)> {
-    let (shred, nonce) = shred::layout::get_shred_and_repair_nonce(packet)?;
-    let Some(nonce) = nonce else {
-        // Turbine shred.
-        return Some((shred.to_vec(), None));
-    };
-
-    // Repair shred.
-    if let Some(location) = repair_nonce_location_lookup(nonce) {
-        Some((shred.to_vec(), Some(location)))
-    } else {
-        // This indicates the request entry was evicted before consumption.
-        stats.num_unknown_block_location += 1;
-        None
-    }
 }
 
 /// Checks whether the shred in the given `packet` is of resigned variant. If

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -7,7 +7,6 @@ use {
     crossbeam_channel::{Receiver, RecvTimeoutError, SendError, Sender},
     itertools::{Either, Itertools},
     rayon::{ThreadPool, ThreadPoolBuilder, prelude::*},
-    solana_clock::Slot,
     solana_gossip::cluster_info::ClusterInfo,
     solana_keypair::Keypair,
     solana_ledger::{
@@ -18,7 +17,7 @@ use {
             layout::{get_shred, resign_packet},
             wire::is_retransmitter_signed_variant,
         },
-        sigverify_shreds::{LruCache, SlotPubkeys, par_verify_shreds},
+        sigverify_shreds::{LruCache, verify_shred_with_leader},
     },
     solana_perf::{
         self,
@@ -184,43 +183,43 @@ fn run_shred_sigverify<const K: usize>(
     // path once a shred is repaired.
     // For backward compatibility we need to allow trailing bytes in the packet
     // after the shred payload, but have to exclude them here from the deduper.
-    stats.num_duplicates += thread_pool.install(|| {
-        shred_buffer
-            .par_iter_mut()
-            .flatten()
-            .filter(|packet| {
-                !packet.meta().discard()
-                    && shred::wire::get_shred(packet.as_ref())
-                        .map(|shred| deduper.dedup(shred))
-                        .unwrap_or(true)
-                    && !packet.meta().repair()
-            })
-            .map(|mut packet| packet.meta_mut().set_discard(true))
-            .count()
-    });
     let (working_bank, root_bank) = {
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.working_bank(), bank_forks.root_bank())
     };
-    thread_pool.install(|| {
-        par_verify_packets(
-            &keypair.pubkey(),
-            &working_bank,
-            leader_schedule_cache,
-            shred_buffer,
-            cache,
-        )
-    });
-    stats.num_discards_post += count_discards(shred_buffer);
-    // Verify retransmitter's signature, and resign shreds
-    // Merkle root as the retransmitter node.
-    let resign_start = Instant::now();
-    thread_pool.install(|| {
+    let self_pubkey = keypair.pubkey();
+    let (num_duplicates, num_discards_post, resign_micros) = thread_pool.install(|| {
         shred_buffer
             .par_iter_mut()
             .flatten()
-            .filter(|packet| !packet.meta().discard())
-            .for_each(|mut packet| {
+            .map(|mut packet| {
+                if packet.meta().discard() {
+                    return (0, 1, 0);
+                }
+                let mut num_duplicates = 0;
+                let duplicate = shred::wire::get_shred(packet.as_ref())
+                    .map(|shred| deduper.dedup(shred))
+                    .unwrap_or(true);
+                if duplicate && !packet.meta().repair() {
+                    packet.meta_mut().set_discard(true);
+                    num_duplicates = 1;
+                }
+                if !packet.meta().discard()
+                    && !verify_packet_signature(
+                        &self_pubkey,
+                        packet.as_ref(),
+                        &working_bank,
+                        leader_schedule_cache,
+                        cache,
+                    )
+                {
+                    packet.meta_mut().set_discard(true);
+                }
+                let num_discards_post = usize::from(packet.meta().discard());
+                if packet.meta().discard() {
+                    return (num_duplicates, num_discards_post, 0);
+                }
+                let resign_start = Instant::now();
                 if maybe_verify_and_resign_packet(
                     &mut packet,
                     &root_bank,
@@ -235,9 +234,27 @@ fn run_shred_sigverify<const K: usize>(
                 {
                     packet.meta_mut().set_discard(true);
                 }
+                (
+                    num_duplicates,
+                    num_discards_post,
+                    resign_start.elapsed().as_micros() as u64,
+                )
             })
+            .reduce(
+                || (0, 0, 0),
+                |(num_duplicates_a, num_discards_post_a, resign_micros_a),
+                 (num_duplicates_b, num_discards_post_b, resign_micros_b)| {
+                    (
+                        num_duplicates_a + num_duplicates_b,
+                        num_discards_post_a + num_discards_post_b,
+                        resign_micros_a + resign_micros_b,
+                    )
+                },
+            )
     });
-    stats.resign_micros += resign_start.elapsed().as_micros() as u64;
+    stats.num_duplicates += num_duplicates;
+    stats.num_discards_post += num_discards_post;
+    stats.resign_micros += resign_micros;
     // Extract shred payload from packets, and separate out repaired shreds.
     let (shreds, repairs): (Vec<_>, Vec<_>) = shred_buffer
         .iter()
@@ -415,48 +432,30 @@ fn verify_retransmitter_signature(
     }
 }
 
-fn par_verify_packets(
+fn verify_packet_signature(
     self_pubkey: &Pubkey,
+    packet: PacketRef,
     working_bank: &Bank,
     leader_schedule_cache: &LeaderScheduleCache,
-    packets: &mut [PacketBatch],
     cache: &RwLock<LruCache>,
-) {
-    let leader_slots: SlotPubkeys =
-        get_slot_leaders(self_pubkey, packets, leader_schedule_cache, working_bank)
-            .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
-            .chain(std::iter::once((Slot::MAX, Pubkey::default())))
-            .collect();
-    par_verify_shreds(packets, &leader_slots, cache);
-}
-
-// Returns pubkey of leaders for shred slots referenced in the packets.
-// Marks packets as discard if:
-//   - fails to deserialize the shred slot.
-//   - slot leader is unknown.
-//   - slot leader is the node itself (circular transmission).
-fn get_slot_leaders<'a>(
-    self_pubkey: &'a Pubkey,
-    batches: &'a mut [PacketBatch],
-    leader_schedule_cache: &'a LeaderScheduleCache,
-    bank: &'a Bank,
-) -> impl Iterator<Item = (Slot, Option<Pubkey>)> + 'a {
-    batches
-        .iter_mut()
-        .flat_map(|batch| batch.iter_mut())
-        .filter(|packet| !packet.meta().discard())
-        .filter_map(move |mut packet| {
-            let shred = shred::layout::get_shred(packet.as_ref());
-            let slot = shred.and_then(shred::layout::get_slot)?;
-            let leader = leader_schedule_cache
-                .slot_leader_at(slot, Some(bank))
-                .map(|leader| leader.id)
-                .filter(|leader| leader != self_pubkey);
-            if leader.is_none() {
-                packet.meta_mut().set_discard(true);
-            }
-            Some((slot, leader))
-        })
+) -> bool {
+    if packet.meta().discard() {
+        return false;
+    }
+    let Some(shred) = shred::layout::get_shred(packet) else {
+        return false;
+    };
+    let Some(slot) = shred::layout::get_slot(shred) else {
+        return false;
+    };
+    let Some(leader) = leader_schedule_cache
+        .slot_leader_at(slot, Some(working_bank))
+        .map(|leader| leader.id)
+        .filter(|leader| leader != self_pubkey)
+    else {
+        return false;
+    };
+    verify_shred_with_leader(packet, &leader, cache)
 }
 
 fn count_discards(packets: &[PacketBatch]) -> usize {
@@ -611,7 +610,7 @@ mod tests {
     };
 
     #[test]
-    fn test_sigverify_shreds_verify_batches() {
+    fn test_verify_packet_signature() {
         let leader_keypair = Arc::new(Keypair::new());
         let wrong_keypair = Keypair::new();
         let leader_pubkey = leader_keypair.pubkey();
@@ -657,23 +656,25 @@ mod tests {
         batches[0][1].meta_mut().size = shred.payload().len();
 
         let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
-        let thread_pool = ThreadPoolBuilder::new().num_threads(3).build().unwrap();
         let working_bank = bank_forks.read().unwrap().working_bank();
-        let mut batches = batches
+        let batches = batches
             .into_iter()
             .map(PacketBatch::from)
             .collect::<Vec<_>>();
-        thread_pool.install(|| {
-            par_verify_packets(
-                &Pubkey::new_unique(), // self_pubkey
-                &working_bank,
-                &leader_schedule_cache,
-                &mut batches,
-                &cache,
-            )
-        });
-        assert!(!batches[0].get(0).unwrap().meta().discard());
-        assert!(batches[0].get(1).unwrap().meta().discard());
+        assert!(verify_packet_signature(
+            &Pubkey::new_unique(), // self_pubkey
+            batches[0].get(0).unwrap(),
+            &working_bank,
+            &leader_schedule_cache,
+            &cache,
+        ));
+        assert!(!verify_packet_signature(
+            &Pubkey::new_unique(), // self_pubkey
+            batches[0].get(1).unwrap(),
+            &working_bank,
+            &leader_schedule_cache,
+            &cache,
+        ));
     }
 
     #[test_matrix(

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -16,7 +16,7 @@ use {
             layout::{get_shred, resign_packet},
             wire::is_retransmitter_signed_variant,
         },
-        sigverify_shreds::{LruCache, verify_shred_with_leader},
+        sigverify_shreds::verify_shred_with_leader,
     },
     solana_perf::{
         self,
@@ -38,9 +38,6 @@ use {
     },
     thiserror::Error,
 };
-
-// 34MB where each cache entry is 136 bytes.
-const SIGVERIFY_LRU_CACHE_CAPACITY: usize = 1 << 18;
 
 const DEDUPER_FALSE_POSITIVE_RATE: f64 = 0.001;
 const DEDUPER_NUM_BITS: u64 = 637_534_199; // 76MB
@@ -85,7 +82,6 @@ pub fn spawn_shred_sigverify(
     num_sigverify_threads: NonZeroUsize,
 ) -> JoinHandle<()> {
     let mut stats = ShredSigVerifyStats::new(Instant::now());
-    let cache = RwLock::new(LruCache::new(SIGVERIFY_LRU_CACHE_CAPACITY));
     let cluster_nodes_cache = ClusterNodesCache::<RetransmitStage>::new(
         CLUSTER_NODES_CACHE_NUM_EPOCH_CAP,
         CLUSTER_NODES_CACHE_TTL,
@@ -118,7 +114,6 @@ pub fn spawn_shred_sigverify(
                 &verified_sender,
                 &cluster_nodes_cache,
                 repair_nonce_location_lookup.as_ref(),
-                &cache,
                 &mut stats,
                 &mut shred_buffer,
             ) {
@@ -149,7 +144,6 @@ fn run_shred_sigverify<const K: usize>(
     verified_sender: &Sender<Vec<(shred::Payload, /*is_repaired:*/ bool, BlockLocation)>>,
     cluster_nodes_cache: &ClusterNodesCache<RetransmitStage>,
     repair_nonce_location_lookup: &RepairNonceLocationLookup,
-    cache: &RwLock<LruCache>,
     stats: &mut ShredSigVerifyStats,
     shred_buffer: &mut Vec<PacketBatch>,
 ) -> Result<(), ShredSigverifyError> {
@@ -233,7 +227,6 @@ fn run_shred_sigverify<const K: usize>(
                             packet.as_ref(),
                             &working_bank,
                             leader_schedule_cache,
-                            cache,
                         )
                     {
                         packet.meta_mut().set_discard(true);
@@ -468,7 +461,6 @@ fn verify_packet_signature(
     packet: PacketRef,
     working_bank: &Bank,
     leader_schedule_cache: &LeaderScheduleCache,
-    cache: &RwLock<LruCache>,
 ) -> bool {
     if packet.meta().discard() {
         return false;
@@ -486,7 +478,7 @@ fn verify_packet_signature(
     else {
         return false;
     };
-    verify_shred_with_leader(packet, &leader, cache)
+    verify_shred_with_leader(packet, &leader)
 }
 
 fn count_discards(packets: &[PacketBatch]) -> usize {
@@ -686,7 +678,6 @@ mod tests {
         batches[0][1].buffer_mut()[..shred.payload().len()].copy_from_slice(shred.payload());
         batches[0][1].meta_mut().size = shred.payload().len();
 
-        let cache = RwLock::new(LruCache::new(/*capacity:*/ 128));
         let working_bank = bank_forks.read().unwrap().working_bank();
         let batches = batches
             .into_iter()
@@ -697,14 +688,12 @@ mod tests {
             batches[0].get(0).unwrap(),
             &working_bank,
             &leader_schedule_cache,
-            &cache,
         ));
         assert!(!verify_packet_signature(
             &Pubkey::new_unique(), // self_pubkey
             batches[0].get(1).unwrap(),
             &working_bank,
             &leader_schedule_cache,
-            &cache,
         ));
     }
 

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -427,8 +427,7 @@ fn verify_packets(
             .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
             .chain(std::iter::once((Slot::MAX, Pubkey::default())))
             .collect();
-    let out = verify_shreds(thread_pool, packets, &leader_slots, cache);
-    solana_perf::sigverify::mark_disabled(packets, &out);
+    verify_shreds(thread_pool, packets, &leader_slots, cache);
 }
 
 // Returns pubkey of leaders for shred slots referenced in the packets.

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -18,7 +18,7 @@ use {
             layout::{get_shred, resign_packet},
             wire::is_retransmitter_signed_variant,
         },
-        sigverify_shreds::{LruCache, SlotPubkeys, verify_shreds},
+        sigverify_shreds::{LruCache, SlotPubkeys, par_verify_shreds},
     },
     solana_perf::{
         self,
@@ -202,14 +202,15 @@ fn run_shred_sigverify<const K: usize>(
         let bank_forks = bank_forks.read().unwrap();
         (bank_forks.working_bank(), bank_forks.root_bank())
     };
-    verify_packets(
-        thread_pool,
-        &keypair.pubkey(),
-        &working_bank,
-        leader_schedule_cache,
-        shred_buffer,
-        cache,
-    );
+    thread_pool.install(|| {
+        par_verify_packets(
+            &keypair.pubkey(),
+            &working_bank,
+            leader_schedule_cache,
+            shred_buffer,
+            cache,
+        )
+    });
     stats.num_discards_post += count_discards(shred_buffer);
     // Verify retransmitter's signature, and resign shreds
     // Merkle root as the retransmitter node.
@@ -414,8 +415,7 @@ fn verify_retransmitter_signature(
     }
 }
 
-fn verify_packets(
-    thread_pool: &ThreadPool,
+fn par_verify_packets(
     self_pubkey: &Pubkey,
     working_bank: &Bank,
     leader_schedule_cache: &LeaderScheduleCache,
@@ -427,7 +427,7 @@ fn verify_packets(
             .filter_map(|(slot, pubkey)| Some((slot, pubkey?)))
             .chain(std::iter::once((Slot::MAX, Pubkey::default())))
             .collect();
-    verify_shreds(thread_pool, packets, &leader_slots, cache);
+    par_verify_shreds(packets, &leader_slots, cache);
 }
 
 // Returns pubkey of leaders for shred slots referenced in the packets.
@@ -663,14 +663,15 @@ mod tests {
             .into_iter()
             .map(PacketBatch::from)
             .collect::<Vec<_>>();
-        verify_packets(
-            &thread_pool,
-            &Pubkey::new_unique(), // self_pubkey
-            &working_bank,
-            &leader_schedule_cache,
-            &mut batches,
-            &cache,
-        );
+        thread_pool.install(|| {
+            par_verify_packets(
+                &Pubkey::new_unique(), // self_pubkey
+                &working_bank,
+                &leader_schedule_cache,
+                &mut batches,
+                &cache,
+            )
+        });
         assert!(!batches[0].get(0).unwrap().meta().discard());
         assert!(batches[0].get(1).unwrap().meta().discard());
     }


### PR DESCRIPTION
#### Problem

This PR is on top of https://github.com/anza-xyz/agave/pull/14771
Also I want to extract turbine refactorings into it's own PR, leaving only the last commit.

#### Summary of Changes

Tested on one DC cluster with 10 nodes, the loads was created by 4KB txs (~4.4k tps which is determined by 20MB block size limit). There is no difference metric-wise with/without cache. But in profile it disappears, of course.
