### PR TITLE
streamer: fix stake quota overflow in stream throttling

### DIFF
--- a/streamer/src/nonblocking/stream_throttle.rs
+++ b/streamer/src/nonblocking/stream_throttle.rs
@@ -175,9 +175,10 @@ impl StakedStreamLoadEMA {
                 if self.staked_throttling_enabled.load(Ordering::Relaxed) {
                     // 1 is added to `max_unstaked_load_in_throttling_window` to guarantee that staked
                     // clients get at least 1 more number of streams than unstaked connections.
-                    self.max_staked_load_in_throttling_window
-                        .saturating_mul(stake)
-                        .checked_div(total_stake)
+                    u128::from(self.max_staked_load_in_throttling_window)
+                        .saturating_mul(u128::from(stake))
+                        .checked_div(u128::from(total_stake))
+                        .and_then(|capacity| u64::try_from(capacity).ok())
                         .unwrap_or(self.max_unstaked_load_in_throttling_window + 1)
                         .max(self.max_unstaked_load_in_throttling_window + 1)
                 } else {


### PR DESCRIPTION
#### Problem
When the system is saturated (and stream throttling is applied), the staked stream quota is computed as `max_staked_load * stake / total_stake` in `u64`. Since stake is in lamports, the multiplication saturates for peers with more than ~461K SOL (at default settings), capping them at `u64::MAX / total_stake` instead of their proportional share.

This is a regression introduced by 82836bf7f0 ("Don't apply throttling until a configurable load threshold is reached.", #9580). On the positive side, that change got rid of occasional `throttled-stake-stream` events (e.g. 0 events
across all prod nodes in the last 30 days), but it also introduced this overflow.

#### Summary of Changes
- Widen the arithmetic to `u128`.

#### Testing
Tests around the overflow boundary are split out into #14830. They fail without this fix. To be rebased/undrafted once this PR lands.