### PR TITLE
ci: raise the sanity and miri timeouts to 15 minutes

### DIFF
--- a/ci/xtask/src/commands/generate_pipeline.rs
+++ b/ci/xtask/src/commands/generate_pipeline.rs
@@ -74,7 +74,7 @@ fn generate_private_pipeline() -> Result<buildkite::Pipeline> {
         name: String::from("sanity"),
         command: String::from("ci/test-sanity.sh"),
         agents: Some(queue_agents()),
-        timeout_in_minutes: Some(5),
+        timeout_in_minutes: Some(15),
         ..Default::default()
     }));
 
@@ -379,7 +379,7 @@ fn default_sanity_step() -> buildkite::Step {
         name: String::from("sanity"),
         command: String::from("ci/docker-run-default-image.sh ci/test-sanity.sh"),
         agents: Some(queue_agents()),
-        timeout_in_minutes: Some(5),
+        timeout_in_minutes: Some(15),
         ..Default::default()
     })
 }
@@ -456,7 +456,7 @@ fn default_miri_step() -> buildkite::Step {
         name: String::from("miri"),
         command: String::from("ci/docker-run-default-image.sh ci/test-miri.sh"),
         agents: Some(queue_agents()),
-        timeout_in_minutes: Some(5),
+        timeout_in_minutes: Some(15),
         ..Default::default()
     })
 }


### PR DESCRIPTION
#### Problem
The rust-rocksdb git dependency carries rocksdb's full history resulting a fetch of ~200MB This timeouts CI regularly.

#### Summary of Changes
Extend Timeouts
Temporary hack until db history is squashed or expermental cargo is used. 

#### Testing
One of the CI runs for this PR actually would've timedout
```
2026-08-20 14:51:51 PDT Updating git submodule `https://github.com/anza-xyz/rocksdb.git`
2026-08-20 14:57:11 PDT Updating git submodule `https://github.com/google/snappy.git`
```

Note: There are two other possible fix directions, both reduce the time significantly (at least 15x)
1. Squash the history of the vendored version of rocksdb, this shrinks the fetch down to about 15MB
- Downsides: Squashed history. Might be a pain to sync with the main repo
2. Using shallow copy, which also shrinks it down to about 15MB. 
```
2026-08-20 14:58:04 PDT Updating git submodule `https://github.com/anza-xyz/rocksdb.git`
2026-08-20 14:58:05 PDT Updating git submodule `https://github.com/google/snappy.git`
```
- Downsides: It has been supported in cargo nightly for a long time(https://github.com/rust-lang/cargo/issues/13285) , but unclear if/when it will be stabilized as there are downstream issues to resolve. So this would require using the nightly version of rust. The current nightly version used for other purposes (fmt, miri) already supports this option. It also only effects whichever steps are switched to use the nightly cargo

Fixes #
