### PR TITLE
ci: remove redundant tree command in dependabot-pr.yml

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -67,8 +67,6 @@ jobs:
 
           cargo anza-xtask update-crate --package "$CRATE_NAME" --from "$OLD_VERSION" --to "$NEW_VERSION"
 
-          ./scripts/cargo-for-all-lock-files.sh tree
-
       - name: push
         run: |
           if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
#### Problem

we updated the command order in https://github.com/anza-xyz/agave/pull/14794 to get it more stable. with that ordering, the tree command becomes redundant because lock files have already been updated by the first command. the second toml minimum version bump shouldn't make any difference to the lock

#### Summary of Changes

remove the tree command