### PR TITLE
Switch add to slot list len based

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1623,9 +1623,9 @@ impl AccountsDb {
                     let mut should_collect_reclaims = false;
                     self.accounts_index.scan(
                         iter::once(&candidate_pubkey),
-                        |_candidate_pubkey, slot_list_and_ref_count| {
+                        |_candidate_pubkey, slot_list| {
                             let mut useless = true;
-                            if let Some((slot_list, _)) = slot_list_and_ref_count {
+                            if let Some(slot_list) = slot_list {
                                 // find the highest rooted slot in the slot list
                                 let index_in_slot_list = self.accounts_index.latest_slot(
                                     None,
@@ -1909,9 +1909,9 @@ impl AccountsDb {
         let mut index_scan_returned_none_count = 0;
         self.accounts_index.scan(
             accounts.iter().map(|account| account.pubkey()),
-            |_pubkey, slots_refs| {
+            |_pubkey, slot_list| {
                 let stored_account = &accounts[index];
-                if let Some((slot_list, _)) = slots_refs {
+                if let Some(slot_list) = slot_list {
                     index_scan_returned_some_count += 1;
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
                         // if the accounts index contains an entry at this slot, then the append vec we're asking about contains this item and thus, it is alive at this slot
@@ -5559,8 +5559,8 @@ impl AccountsDb {
         let mut capitalization_from_duplicates = 0_u128;
         self.accounts_index.scan(
             pubkeys.iter(),
-            |pubkey, slots_refs| {
-                if let Some((slot_list, _ref_count)) = slots_refs
+            |pubkey, slot_list| {
+                if let Some(slot_list) = slot_list
                     && slot_list.len() > 1
                 {
                     // Only the account data len in the highest slot should be used, and the rest are

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -181,10 +181,11 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
     }
     fn add(
         &mut self,
-        _ref_count: RefCount,
+        ref_count: RefCount,
         account: &'a AccountFromStorage,
-        _slot_list: &[(Slot, AccountInfo)],
+        slot_list: &[(Slot, AccountInfo)],
     ) {
+        assert_eq!(ref_count as usize, slot_list.len());
         self.accounts.push(account);
         self.bytes = self.bytes.saturating_add(account.stored_size());
     }
@@ -219,6 +220,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccountsSeparated<'a> {
         account: &'a AccountFromStorage,
         slot_list: &[(Slot, AccountInfo)],
     ) {
+        assert_eq!(ref_count as usize, slot_list.len());
         let other = if ref_count == 1 {
             &mut self.no_duplicates
         } else if slot_list.len() == 1

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -47,7 +47,7 @@ use {
         accounts_hash::{AccountLtHash, AccountsLtHash, ZERO_LAMPORT_ACCOUNT_LT_HASH},
         accounts_index::{
             AccountSecondaryIndexes, AccountsIndex, IndexKey, ReclaimsSlotList,
-            ReclaimsWithNewestSlot, RefCount, ScanFilter, Startup, UpsertReclaim,
+            ReclaimsWithNewestSlot, ScanFilter, Startup, UpsertReclaim,
             in_mem_accounts_index::StartupStats,
         },
         accounts_scan::{ScanConfig, ScanError, ScanGuard, ScanResult, ScanTracker},
@@ -156,12 +156,7 @@ pub(crate) struct AliveAccountsSeparated<'a> {
 pub(crate) trait ShrinkCollector<'a>: Sync + Send {
     fn with_capacity(capacity: usize, slot: Slot) -> Self;
     fn collect(&mut self, other: Self);
-    fn add(
-        &mut self,
-        ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        slot_list: &[(Slot, AccountInfo)],
-    );
+    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]);
     fn len(&self) -> usize;
     fn alive_bytes(&self) -> usize;
     fn alive_accounts(&self) -> &Vec<&'a AccountFromStorage>;
@@ -179,13 +174,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccounts<'a> {
             slot,
         }
     }
-    fn add(
-        &mut self,
-        ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        slot_list: &[(Slot, AccountInfo)],
-    ) {
-        assert_eq!(ref_count as usize, slot_list.len());
+    fn add(&mut self, account: &'a AccountFromStorage, _slot_list: &[(Slot, AccountInfo)]) {
         self.accounts.push(account);
         self.bytes = self.bytes.saturating_add(account.stored_size());
     }
@@ -214,19 +203,14 @@ impl<'a> ShrinkCollector<'a> for AliveAccountsSeparated<'a> {
             not_newest_duplicate: AliveAccounts::with_capacity(0, slot),
         }
     }
-    fn add(
-        &mut self,
-        ref_count: RefCount,
-        account: &'a AccountFromStorage,
-        slot_list: &[(Slot, AccountInfo)],
-    ) {
-        assert_eq!(ref_count as usize, slot_list.len());
-        let other = if ref_count == 1 {
+    fn add(&mut self, account: &'a AccountFromStorage, slot_list: &[(Slot, AccountInfo)]) {
+        assert!(!slot_list.is_empty());
+        let slot = self.no_duplicates.slot;
+        let other = if slot_list.len() == 1 {
             &mut self.no_duplicates
-        } else if slot_list.len() == 1
-            || !slot_list
-                .iter()
-                .any(|(slot_list_slot, _info)| slot_list_slot > &self.not_newest_duplicate.slot)
+        } else if !slot_list
+            .iter()
+            .any(|(slot_list_slot, _info)| slot_list_slot > &slot)
         {
             // this entry is alive but is newer than any other slot in the index
             &mut self.newest_duplicate
@@ -235,7 +219,7 @@ impl<'a> ShrinkCollector<'a> for AliveAccountsSeparated<'a> {
             // We would expect clean to get rid of the entry for THIS slot at some point, but clean hasn't done that yet.
             &mut self.not_newest_duplicate
         };
-        other.add(ref_count, account, slot_list);
+        other.add(account, slot_list);
     }
     fn len(&self) -> usize {
         self.no_duplicates
@@ -1927,7 +1911,7 @@ impl AccountsDb {
             accounts.iter().map(|account| account.pubkey()),
             |_pubkey, slots_refs| {
                 let stored_account = &accounts[index];
-                if let Some((slot_list, ref_count)) = slots_refs {
+                if let Some((slot_list, _)) = slots_refs {
                     index_scan_returned_some_count += 1;
                     let is_alive = slot_list.iter().any(|(slot, _acct_info)| {
                         // if the accounts index contains an entry at this slot, then the append vec we're asking about contains this item and thus, it is alive at this slot
@@ -1936,17 +1920,16 @@ impl AccountsDb {
 
                     // All obsolete and tombstones have been filtered. Account MUST be alive in this slot
                     assert!(is_alive);
-                    alive_accounts.add(ref_count, stored_account, slot_list);
+                    alive_accounts.add(stored_account, slot_list);
                 } else {
                     index_scan_returned_none_count += 1;
-                    // getting None here means the account is 'normal' and was written to disk. This means it must have ref_count=1 and
+                    // getting None here means the account is 'normal' and was written to disk. This means it must have
                     // slot_list.len() = 1. This means it must be alive in this slot. This is by far the most common case.
                     // Note that we could get Some(...) here if the account is in the in mem index because it is hot.
                     // Note this could also mean the account isn't on disk either. That would indicate a bug in accounts db.
                     // Account is alive.
-                    let ref_count = 1;
                     let slot_list = [(slot_to_shrink, AccountInfo::default())];
-                    alive_accounts.add(ref_count, stored_account, &slot_list);
+                    alive_accounts.add(stored_account, &slot_list);
                 }
                 index += 1;
             },

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -478,10 +478,10 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     ///
     /// The `callback` fn takes in 2 arguments:
     ///   - the first an immutable ref of the pubkey,
-    ///   - the second an option of the SlotList and RefCount
+    ///   - the second an option of the SlotList
     pub(crate) fn scan<'a, F, I>(&self, pubkeys: I, mut callback: F, filter: ScanFilter)
     where
-        F: FnMut(&'a Pubkey, Option<(&[SlotListItem<T>], RefCount)>),
+        F: FnMut(&'a Pubkey, Option<&[SlotListItem<T>]>),
         I: Iterator<Item = &'a Pubkey>,
     {
         let mut lock = None;
@@ -497,7 +497,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             let mut internal_callback = |entry: Option<&AccountMapEntry<T>>| {
                 if let Some(locked_entry) = entry {
                     let slot_list = locked_entry.slot_list_read_lock();
-                    callback(pubkey, Some((slot_list.as_ref(), locked_entry.ref_count())));
+                    callback(pubkey, Some(slot_list.as_ref()));
                 } else {
                     callback(pubkey, None);
                 }

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1807,18 +1807,8 @@ mod tests {
                             infos = infos.into_iter().rev().collect();
                         }
 
-                        let original_results = storages
-                            .iter()
-                            .map(|store| db.get_unique_accounts_from_storage(store))
-                            .collect::<Vec<_>>();
                         if two_refs {
-                            original_results.iter().for_each(|results| {
-                                results.stored_accounts.iter().for_each(|account| {
-                                    db.accounts_index.get_and_then(account.pubkey(), |entry| {
-                                        (false, entry.unwrap().addref())
-                                    });
-                                })
-                            });
+                            add_older_ref(&db, &storages);
                         }
 
                         let original_results = storages
@@ -2292,6 +2282,8 @@ mod tests {
         let pk_with_2_refs = account_with_2_refs.pubkey();
         let mut account_with_1_ref = account_shared_data_with_2_refs.clone();
         _ = account_with_1_ref.checked_add_lamports(1);
+        // only pk_with_2_refs is in the storage so far, so only it gets the older entry
+        add_older_ref(&db, &storages);
         append_single_account_with_default_hash(
             &storage,
             &pk_with_1_ref,
@@ -2299,12 +2291,6 @@ mod tests {
             true,
             Some(&db.accounts_index),
         );
-        original_results.iter().for_each(|results| {
-            results.stored_accounts.iter().for_each(|account| {
-                db.accounts_index
-                    .get_and_then(account.pubkey(), |entry| (true, entry.unwrap().addref()));
-            })
-        });
 
         // update to get both accounts in the storage
         let original_results = storages
@@ -3760,21 +3746,13 @@ mod tests {
                 let account = AccountFromStorage::new(offset, &stored_account);
                 let slot = 1;
                 let capacity = 0;
-                for i in 0..4usize {
+                for i in 0..3usize {
                     let mut alive_accounts = AliveAccountsSeparated::with_capacity(capacity, slot);
                     let lamports = 1;
 
                     match i {
                         0 => {
-                            // empty slot list (ignored anyway) because ref_count = 1
-                            let slot_list = vec![];
-                            alive_accounts.add(1, &account, &slot_list);
-                            assert!(!alive_accounts.no_duplicates.accounts.is_empty());
-                            assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
-                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
-                        }
-                        1 => {
-                            // non-empty slot list (but ignored) because slot_list = 1
+                            // single slot list because ref_count = 1
                             let slot_list = vec![(
                                 slot,
                                 AccountInfo::new(
@@ -3782,12 +3760,12 @@ mod tests {
                                     lamports == 0,
                                 ),
                             )];
-                            alive_accounts.add(2, &account, &slot_list);
-                            assert!(alive_accounts.no_duplicates.accounts.is_empty());
+                            alive_accounts.add(1, &account, &slot_list);
+                            assert!(!alive_accounts.no_duplicates.accounts.is_empty());
                             assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
-                            assert!(!alive_accounts.newest_duplicate.accounts.is_empty());
+                            assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
-                        2 => {
+                        1 => {
                             // multiple slot list, this is not the newest, so not_newest_duplicate
                             let slot_list = vec![
                                 (
@@ -3810,7 +3788,7 @@ mod tests {
                             assert!(!alive_accounts.not_newest_duplicate.accounts.is_empty());
                             assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
-                        3 => {
+                        2 => {
                             // multiple slot list, ref_count=2, this is newest
                             let slot_list = vec![
                                 (

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -3752,7 +3752,7 @@ mod tests {
 
                     match i {
                         0 => {
-                            // single slot list because ref_count = 1
+                            // single slot list, so no_duplicates
                             let slot_list = vec![(
                                 slot,
                                 AccountInfo::new(
@@ -3760,7 +3760,7 @@ mod tests {
                                     lamports == 0,
                                 ),
                             )];
-                            alive_accounts.add(1, &account, &slot_list);
+                            alive_accounts.add(&account, &slot_list);
                             assert!(!alive_accounts.no_duplicates.accounts.is_empty());
                             assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
                             assert!(alive_accounts.newest_duplicate.accounts.is_empty());
@@ -3783,13 +3783,13 @@ mod tests {
                                     ),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(&account, &slot_list);
                             assert!(alive_accounts.no_duplicates.accounts.is_empty());
                             assert!(!alive_accounts.not_newest_duplicate.accounts.is_empty());
                             assert!(alive_accounts.newest_duplicate.accounts.is_empty());
                         }
                         2 => {
-                            // multiple slot list, ref_count=2, this is newest
+                            // multiple slot list, this is the newest, so newest_duplicate
                             let slot_list = vec![
                                 (
                                     slot,
@@ -3806,7 +3806,7 @@ mod tests {
                                     ),
                                 ),
                             ];
-                            alive_accounts.add(2, &account, &slot_list);
+                            alive_accounts.add(&account, &slot_list);
                             assert!(alive_accounts.no_duplicates.accounts.is_empty());
                             assert!(alive_accounts.not_newest_duplicate.accounts.is_empty());
                             assert!(!alive_accounts.newest_duplicate.accounts.is_empty());


### PR DESCRIPTION
#### Problem
RefCount is going away, so all shrink add needs to be slot list len based. 

#### Summary of Changes
- First commit fixes any tests that currently have slot_list!=ref_count. has an assert to verify that all tests pass
- Second commit makes the change to add (and removes the previously added assert). 
- Third commit removes ref_count from accounts_scan callback, since it is now unused. 

Can be viewed individually, or separately.

#### Testing


Fixes #
