### PR TITLE
Caches node staked status

### DIFF
--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -5,6 +5,7 @@
 //! - newly constructed certificates and standstill refreshes are queued for broadcast;
 //! - pending intrawindow `SafeToNotar` blocks are repaired and rechecked;
 
+pub(crate) mod staked_status;
 mod stats;
 
 use {
@@ -14,6 +15,7 @@ use {
             ConsensusPool,
             parent_ready_tracker::{BlockProductionParent, ParentReady},
         },
+        consensus_pool_service::staked_status::StakedStatus,
         event::{LeaderWindowInfo, RepairEvent, RepairEventSender, VotorEvent, VotorEventSender},
         voting_service::BLSOp,
         votor::ExitOnDrop,
@@ -98,6 +100,7 @@ pub(crate) struct ConsensusPoolContext {
     pub(crate) bls_sender: Sender<BLSOp>,
     pub(crate) event_sender: VotorEventSender,
     pub(crate) repair_event_sender: RepairEventSender,
+    pub(crate) staked_status: StakedStatus,
 
     /// Used to communicate the highest finalization cert the pool has observed to the block creation loop.
     pub(crate) highest_finalized: Arc<RwLock<Option<ValidatedBlockFinalizationCert>>>,
@@ -187,14 +190,13 @@ impl ConsensusPoolService {
         }
     }
 
-    fn maybe_update_root_and_send_new_certificates(
+    fn maybe_update_root(
         ctx: &ConsensusPoolContext,
         consensus_pool: &mut ConsensusPool,
         new_finalized_slot: Option<Slot>,
-        new_certificates_to_send: Vec<Arc<Certificate>>,
         standstill_timer: &mut Instant,
         stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), &'static str> {
+    ) {
         // If we have a new finalized slot, update the root and send new certificates
         if new_finalized_slot.is_some() {
             // Reset standstill timer
@@ -207,59 +209,48 @@ impl ConsensusPoolService {
         let bank = ctx.sharable_banks.root();
         consensus_pool.maybe_prune(bank.slot());
         stats.prune_old_state_called += 1;
-        // Send new certificates to peers
-        Self::send_certificates(
-            ctx,
-            BLSOp::PushCertificates {
-                certificates: new_certificates_to_send,
-            },
-            stats,
-        )
     }
 
-    fn send_certificates(
-        ctx: &ConsensusPoolContext,
-        op: BLSOp,
+    fn send_certs(
+        ctx: &mut ConsensusPoolContext,
+        certificates: Vec<Arc<Certificate>>,
         stats: &mut ConsensusPoolServiceStats,
     ) -> Result<(), &'static str> {
-        let num_certs = Self::num_certificates(&op);
+        let num_certs = certificates.len();
+        let op = BLSOp::PushCertificates { certificates };
+        Self::enqueue_certificates(ctx, op, num_certs, stats)
+    }
+
+    fn refresh_certs(
+        ctx: &mut ConsensusPoolContext,
+        certificates: Vec<Arc<Certificate>>,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), &'static str> {
+        let num_certs = certificates.len();
+        let op = BLSOp::RefreshCertificates { certificates };
+        Self::enqueue_certificates(ctx, op, num_certs, stats)
+    }
+
+    fn enqueue_certificates(
+        ctx: &mut ConsensusPoolContext,
+        op: BLSOp,
+        num_certs: usize,
+        stats: &mut ConsensusPoolServiceStats,
+    ) -> Result<(), &'static str> {
         if num_certs == 0 {
             return Ok(());
         }
         // If we are not a staked identity (hot spare / RPC / new validator / failed VAT)
         // we should not send out the certificate. A2A quic only accepts connections
         // from staked identities
-        if !Self::is_current_identity_staked(ctx) {
+        if !ctx
+            .staked_status
+            .is_staked(&ctx.sharable_banks.root(), &ctx.cluster_info)
+        {
             stats.certificates_skipped_unstaked += num_certs;
             return Ok(());
         }
-        Self::enqueue_certificates(ctx, op, stats)
-    }
-
-    fn is_current_identity_staked(ctx: &ConsensusPoolContext) -> bool {
-        let root_bank = ctx.sharable_banks.root();
-        root_bank
-            .epoch_staked_nodes(root_bank.epoch())
-            .expect("Root bank retains epoch_stakes for its own epoch")
-            .get(&ctx.cluster_info.id())
-            .is_some_and(|stake| *stake > 0)
-    }
-
-    fn num_certificates(op: &BLSOp) -> usize {
-        match op {
-            BLSOp::PushCertificates { certificates }
-            | BLSOp::RefreshCertificates { certificates } => certificates.len(),
-            _ => unreachable!("expected a certificate BLSOp"),
-        }
-    }
-
-    fn enqueue_certificates(
-        ctx: &ConsensusPoolContext,
-        op: BLSOp,
-        stats: &mut ConsensusPoolServiceStats,
-    ) -> Result<(), &'static str> {
         let channel_name = "bls_sender";
-        let num_certs = Self::num_certificates(&op);
         match ctx.bls_sender.try_send(op) {
             Ok(()) => {
                 stats.certificates_sent += num_certs;
@@ -332,13 +323,7 @@ impl ConsensusPoolService {
                 }
                 stats.standstill = true;
                 standstill_timer = Instant::now();
-                Self::send_certificates(
-                    ctx,
-                    BLSOp::RefreshCertificates {
-                        certificates: consensus_pool.get_certs_for_standstill(),
-                    },
-                    stats,
-                )?;
+                Self::refresh_certs(ctx, consensus_pool.get_certs_for_standstill(), stats)?;
             }
 
             // Process pending safe-to-notar blocks for intrawindow slots
@@ -573,15 +558,18 @@ impl ConsensusPoolService {
         };
 
         let mut own_votes_received = 0u64;
+        let mut finalized_slot = None;
+        let mut certs_to_send = vec![];
+        let receiver = ctx.own_votes_receiver.clone();
         for msg in std::iter::once(first).chain(
-            ctx.own_votes_receiver
+            receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
             own_votes_received = own_votes_received.saturating_add(1);
             let pool_msg = PoolMessage::Votes(vec![PoolVote::Own(msg)]);
             let root_bank = ctx.sharable_banks.root();
-            let (new_finalized_slot, new_certificates_to_send) = Self::add_pool_msg(
+            let (new_finalized_slot, mut new_certs_to_send) = Self::add_pool_msg(
                 &root_bank,
                 &ctx.cluster_info.id(),
                 pool_msg,
@@ -589,15 +577,13 @@ impl ConsensusPoolService {
                 events,
                 stats,
             );
-            Self::maybe_update_root_and_send_new_certificates(
-                ctx,
-                consensus_pool,
-                new_finalized_slot,
-                new_certificates_to_send,
-                standstill_timer,
-                stats,
-            )?;
+            certs_to_send.append(&mut new_certs_to_send);
+            if new_finalized_slot.is_some() {
+                finalized_slot = new_finalized_slot;
+            }
         }
+        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::send_certs(ctx, certs_to_send, stats)?;
         stats.own_votes_received += own_votes_received;
         if own_votes_received >= MAX_MESSAGES_PER_RECEIVE {
             stats.own_message_receive_limit_reached += 1;
@@ -618,15 +604,18 @@ impl ConsensusPoolService {
         };
 
         let mut footer_certs_received = 0u64;
+        let mut finalized_slot = None;
+        let mut certs_to_send = vec![];
+        let receiver = ctx.footer_certs_receiver.clone();
         for certs in std::iter::once(first).chain(
-            ctx.footer_certs_receiver
+            receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
             footer_certs_received = footer_certs_received.saturating_add(1);
             let pool_msg = PoolMessage::Certificates(certs.to_vec());
             let root_bank = ctx.sharable_banks.root();
-            let (new_finalized_slot, new_certificates_to_send) = Self::add_pool_msg(
+            let (new_finalized_slot, mut new_certs_to_send) = Self::add_pool_msg(
                 &root_bank,
                 &ctx.cluster_info.id(),
                 pool_msg,
@@ -634,15 +623,13 @@ impl ConsensusPoolService {
                 events,
                 stats,
             );
-            Self::maybe_update_root_and_send_new_certificates(
-                ctx,
-                consensus_pool,
-                new_finalized_slot,
-                new_certificates_to_send,
-                standstill_timer,
-                stats,
-            )?;
+            certs_to_send.append(&mut new_certs_to_send);
+            if new_finalized_slot.is_some() {
+                finalized_slot = new_finalized_slot;
+            }
         }
+        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::send_certs(ctx, certs_to_send, stats)?;
         stats.footer_certs_received += footer_certs_received;
         if footer_certs_received >= MAX_MESSAGES_PER_RECEIVE {
             stats.own_message_receive_limit_reached += 1;
@@ -663,7 +650,10 @@ impl ConsensusPoolService {
         };
 
         let mut msgs_received = 0u64;
-        for batch in std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()) {
+        let mut finalized_slot = None;
+        let mut certs_to_send = vec![];
+        let receiver = ctx.consensus_message_receiver.clone();
+        for batch in std::iter::once(first).chain(receiver.try_iter()) {
             let msg = match batch {
                 SigVerifiedBatch::Votes(votes) => {
                     stats.vote_aggregates_received += votes.len() as u64;
@@ -677,7 +667,7 @@ impl ConsensusPoolService {
                 }
             };
             let root_bank = ctx.sharable_banks.root();
-            let (new_finalized_slot, new_certificates_to_send) = Self::add_pool_msg(
+            let (new_finalized_slot, mut new_certs_to_send) = Self::add_pool_msg(
                 &root_bank,
                 &ctx.cluster_info.id(),
                 msg,
@@ -685,19 +675,17 @@ impl ConsensusPoolService {
                 events,
                 stats,
             );
-            Self::maybe_update_root_and_send_new_certificates(
-                ctx,
-                consensus_pool,
-                new_finalized_slot,
-                new_certificates_to_send,
-                standstill_timer,
-                stats,
-            )?;
+            certs_to_send.append(&mut new_certs_to_send);
+            if new_finalized_slot.is_some() {
+                finalized_slot = new_finalized_slot;
+            }
             if msgs_received >= MAX_MESSAGES_PER_RECEIVE {
                 stats.consensus_message_batch_receive_limit_reached += 1;
                 break;
             }
         }
+        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::send_certs(ctx, certs_to_send, stats)?;
         Ok(())
     }
 
@@ -763,16 +751,16 @@ mod tests {
         std::sync::Arc,
     };
 
-    struct TestContext {
-        consensus_pool: ConsensusPool,
-        ctx: ConsensusPoolContext,
-        bls_receiver: Receiver<BLSOp>,
-        consensus_message_sender: Sender<SigVerifiedBatch>,
-        own_votes_sender: Sender<VoteMessage>,
-        footer_certs_sender: Sender<SmallVec<[Certificate; 2]>>,
-        event_receiver: Receiver<VotorEvent>,
-        _repair_event_receiver: Receiver<RepairEvent>,
-        validator_keypairs: Vec<ValidatorVoteKeypairs>,
+    pub struct TestContext {
+        pub consensus_pool: ConsensusPool,
+        pub ctx: ConsensusPoolContext,
+        pub bls_receiver: Receiver<BLSOp>,
+        pub consensus_message_sender: Sender<SigVerifiedBatch>,
+        pub own_votes_sender: Sender<VoteMessage>,
+        pub footer_certs_sender: Sender<SmallVec<[Certificate; 2]>>,
+        pub event_receiver: Receiver<VotorEvent>,
+        pub _repair_event_receiver: Receiver<RepairEvent>,
+        pub validator_keypairs: Vec<ValidatorVoteKeypairs>,
     }
 
     impl Default for TestContext {
@@ -811,12 +799,13 @@ mod tests {
             let (event_sender, event_receiver) = unbounded();
             let (repair_event_sender, repair_event_receiver) = unbounded();
 
+            let root_bank = sharable_banks.root();
             let ctx = ConsensusPoolContext {
                 exit: Arc::new(AtomicBool::new(false)),
                 validator_exit: Arc::default(),
                 migration_status,
                 generated_cert_types,
-                cluster_info,
+                cluster_info: cluster_info.clone(),
                 blockstore,
                 sharable_banks,
                 leader_schedule_cache,
@@ -828,6 +817,7 @@ mod tests {
                 event_sender,
                 repair_event_sender,
                 highest_finalized: Arc::new(RwLock::new(None)),
+                staked_status: StakedStatus::new(&root_bank, &cluster_info),
             };
             let consensus_pool = ctx.new_consensus_pool();
 
@@ -904,12 +894,16 @@ mod tests {
 
             // Send certificates if any were produced
             if !new_certificates_to_send.is_empty() || new_finalized_slot.is_some() {
-                ConsensusPoolService::maybe_update_root_and_send_new_certificates(
+                ConsensusPoolService::maybe_update_root(
                     &ctx.ctx,
                     &mut ctx.consensus_pool,
                     new_finalized_slot,
-                    new_certificates_to_send,
                     &mut standstill_timer,
+                    &mut stats,
+                );
+                ConsensusPoolService::send_certs(
+                    &mut ctx.ctx,
+                    new_certificates_to_send,
                     &mut stats,
                 )
                 .unwrap();
@@ -963,15 +957,15 @@ mod tests {
 
         let mut standstill_timer = Instant::now();
 
-        ConsensusPoolService::maybe_update_root_and_send_new_certificates(
+        ConsensusPoolService::maybe_update_root(
             &ctx.ctx,
             &mut ctx.consensus_pool,
             new_finalized_slot,
-            new_certificates_to_send,
             &mut standstill_timer,
             &mut stats,
-        )
-        .unwrap();
+        );
+        ConsensusPoolService::send_certs(&mut ctx.ctx, new_certificates_to_send, &mut stats)
+            .unwrap();
 
         // Verify skip certificate was forwarded
         let mut found_skip = false;
@@ -1325,7 +1319,7 @@ mod tests {
 
     #[test]
     fn test_send_certificates() {
-        let ctx = TestContext::default();
+        let mut ctx = TestContext::default();
 
         let certificates = vec![
             Arc::new(Certificate {
@@ -1341,14 +1335,7 @@ mod tests {
         ];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result = ConsensusPoolService::send_certificates(
-            &ctx.ctx,
-            BLSOp::PushCertificates {
-                certificates: certificates.clone(),
-            },
-            &mut stats,
-        );
-        assert!(result.is_ok());
+        ConsensusPoolService::send_certs(&mut ctx.ctx, certificates.clone(), &mut stats).unwrap();
         assert_eq!(stats.certificates_sent.0, 2);
 
         // Verify certificates were received
@@ -1369,7 +1356,7 @@ mod tests {
 
     #[test]
     fn test_send_certificates_refresh() {
-        let ctx = TestContext::default();
+        let mut ctx = TestContext::default();
 
         let certificates = vec![Arc::new(Certificate {
             cert_type: CertificateType::Skip(1),
@@ -1378,14 +1365,8 @@ mod tests {
         })];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        ConsensusPoolService::send_certificates(
-            &ctx.ctx,
-            BLSOp::RefreshCertificates {
-                certificates: certificates.clone(),
-            },
-            &mut stats,
-        )
-        .unwrap();
+        ConsensusPoolService::refresh_certs(&mut ctx.ctx, certificates.clone(), &mut stats)
+            .unwrap();
         assert_eq!(stats.certificates_sent.0, 1);
 
         let BLSOp::RefreshCertificates { certificates } = ctx.bls_receiver.try_recv().unwrap()
@@ -1418,12 +1399,7 @@ mod tests {
         let cluster_info = get_cluster_info(unstaked_identity);
         ctx.ctx.cluster_info = cluster_info;
         let mut stats = ConsensusPoolServiceStats::new();
-        ConsensusPoolService::send_certificates(
-            &ctx.ctx,
-            BLSOp::PushCertificates { certificates },
-            &mut stats,
-        )
-        .unwrap();
+        ConsensusPoolService::send_certs(&mut ctx.ctx, certificates, &mut stats).unwrap();
         assert_eq!(stats.certificates_sent.0, 0);
         assert_eq!(stats.certificates_skipped_unstaked.0, 2);
         assert!(ctx.bls_receiver.try_recv().is_err());
@@ -1431,7 +1407,7 @@ mod tests {
 
     #[test]
     fn test_send_certificates_channel_disconnected() {
-        let ctx = TestContext::default();
+        let mut ctx = TestContext::default();
         drop(ctx.bls_receiver); // Disconnect channel
 
         let certificates = vec![Arc::new(Certificate {
@@ -1441,11 +1417,7 @@ mod tests {
         })];
 
         let mut stats = ConsensusPoolServiceStats::new();
-        let result = ConsensusPoolService::send_certificates(
-            &ctx.ctx,
-            BLSOp::PushCertificates { certificates },
-            &mut stats,
-        );
+        let result = ConsensusPoolService::send_certs(&mut ctx.ctx, certificates, &mut stats);
         result.unwrap_err();
     }
 
@@ -1463,16 +1435,15 @@ mod tests {
         let mut standstill_timer = Instant::now();
 
         // Test with new_finalized_slot = Some
-        let result = ConsensusPoolService::maybe_update_root_and_send_new_certificates(
+        ConsensusPoolService::maybe_update_root(
             &ctx.ctx,
             &mut ctx.consensus_pool,
             Some(5), // new finalized slot
-            certificates,
             &mut standstill_timer,
             &mut stats,
         );
+        ConsensusPoolService::send_certs(&mut ctx.ctx, certificates, &mut stats).unwrap();
 
-        assert!(result.is_ok());
         assert_eq!(stats.new_finalized_slot.0, 1);
         assert_eq!(stats.prune_old_state_called.0, 1);
         assert_eq!(stats.certificates_sent.0, 1);

--- a/votor/src/consensus_pool_service.rs
+++ b/votor/src/consensus_pool_service.rs
@@ -190,7 +190,7 @@ impl ConsensusPoolService {
         }
     }
 
-    fn maybe_update_root(
+    fn handle_new_finalized(
         ctx: &ConsensusPoolContext,
         consensus_pool: &mut ConsensusPool,
         new_finalized_slot: Option<Slot>,
@@ -560,9 +560,8 @@ impl ConsensusPoolService {
         let mut own_votes_received = 0u64;
         let mut finalized_slot = None;
         let mut certs_to_send = vec![];
-        let receiver = ctx.own_votes_receiver.clone();
         for msg in std::iter::once(first).chain(
-            receiver
+            ctx.own_votes_receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
@@ -582,7 +581,7 @@ impl ConsensusPoolService {
                 finalized_slot = new_finalized_slot;
             }
         }
-        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::handle_new_finalized(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
         Self::send_certs(ctx, certs_to_send, stats)?;
         stats.own_votes_received += own_votes_received;
         if own_votes_received >= MAX_MESSAGES_PER_RECEIVE {
@@ -606,9 +605,8 @@ impl ConsensusPoolService {
         let mut footer_certs_received = 0u64;
         let mut finalized_slot = None;
         let mut certs_to_send = vec![];
-        let receiver = ctx.footer_certs_receiver.clone();
         for certs in std::iter::once(first).chain(
-            receiver
+            ctx.footer_certs_receiver
                 .try_iter()
                 .take(ADDITIONAL_MESSAGES_PER_RECEIVE as usize),
         ) {
@@ -628,7 +626,7 @@ impl ConsensusPoolService {
                 finalized_slot = new_finalized_slot;
             }
         }
-        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::handle_new_finalized(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
         Self::send_certs(ctx, certs_to_send, stats)?;
         stats.footer_certs_received += footer_certs_received;
         if footer_certs_received >= MAX_MESSAGES_PER_RECEIVE {
@@ -652,8 +650,7 @@ impl ConsensusPoolService {
         let mut msgs_received = 0u64;
         let mut finalized_slot = None;
         let mut certs_to_send = vec![];
-        let receiver = ctx.consensus_message_receiver.clone();
-        for batch in std::iter::once(first).chain(receiver.try_iter()) {
+        for batch in std::iter::once(first).chain(ctx.consensus_message_receiver.try_iter()) {
             let msg = match batch {
                 SigVerifiedBatch::Votes(votes) => {
                     stats.vote_aggregates_received += votes.len() as u64;
@@ -684,7 +681,7 @@ impl ConsensusPoolService {
                 break;
             }
         }
-        Self::maybe_update_root(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
+        Self::handle_new_finalized(ctx, consensus_pool, finalized_slot, standstill_timer, stats);
         Self::send_certs(ctx, certs_to_send, stats)?;
         Ok(())
     }
@@ -894,7 +891,7 @@ mod tests {
 
             // Send certificates if any were produced
             if !new_certificates_to_send.is_empty() || new_finalized_slot.is_some() {
-                ConsensusPoolService::maybe_update_root(
+                ConsensusPoolService::handle_new_finalized(
                     &ctx.ctx,
                     &mut ctx.consensus_pool,
                     new_finalized_slot,
@@ -957,7 +954,7 @@ mod tests {
 
         let mut standstill_timer = Instant::now();
 
-        ConsensusPoolService::maybe_update_root(
+        ConsensusPoolService::handle_new_finalized(
             &ctx.ctx,
             &mut ctx.consensus_pool,
             new_finalized_slot,
@@ -1435,7 +1432,7 @@ mod tests {
         let mut standstill_timer = Instant::now();
 
         // Test with new_finalized_slot = Some
-        ConsensusPoolService::maybe_update_root(
+        ConsensusPoolService::handle_new_finalized(
             &ctx.ctx,
             &mut ctx.consensus_pool,
             Some(5), // new finalized slot

--- a/votor/src/consensus_pool_service/staked_status.rs
+++ b/votor/src/consensus_pool_service/staked_status.rs
@@ -1,0 +1,80 @@
+use {
+    solana_clock::Epoch, solana_gossip::cluster_info::ClusterInfo, solana_pubkey::Pubkey,
+    solana_runtime::bank::Bank,
+};
+
+pub(crate) struct StakedStatus {
+    epoch: Epoch,
+    identity: Pubkey,
+    is_staked: bool,
+}
+
+impl StakedStatus {
+    pub(crate) fn new(root_bank: &Bank, cluster_info: &ClusterInfo) -> Self {
+        let epoch = root_bank.epoch();
+        let identity = cluster_info.id();
+        let is_staked = root_bank
+            .epoch_staked_nodes(epoch)
+            .expect("Root bank retains epoch_stakes for its own epoch")
+            .get(&identity)
+            .is_some_and(|stake| *stake > 0);
+        Self {
+            epoch,
+            identity,
+            is_staked,
+        }
+    }
+
+    #[must_use]
+    pub(super) fn is_staked(&mut self, root_bank: &Bank, cluster_info: &ClusterInfo) -> bool {
+        let epoch = root_bank.epoch();
+        let identity = cluster_info.id();
+        if self.epoch != epoch || self.identity != identity {
+            *self = Self::new(root_bank, cluster_info);
+        }
+        self.is_staked
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        crate::{consensus_pool_service::tests::TestContext, tests::get_cluster_info},
+        solana_keypair::Keypair,
+    };
+
+    #[test]
+    fn test_staked_status_refreshes_on_identity_change() {
+        let mut ctx = TestContext::default();
+        let root_bank = ctx.ctx.sharable_banks.root();
+
+        let staked_cluster_info =
+            get_cluster_info(ctx.validator_keypairs[1].node_keypair.insecure_clone());
+        assert!(
+            ctx.ctx
+                .staked_status
+                .is_staked(&root_bank, &staked_cluster_info)
+        );
+        assert_eq!(ctx.ctx.staked_status.identity, staked_cluster_info.id());
+
+        let unstaked_cluster_info = get_cluster_info(Keypair::new());
+        assert!(
+            !ctx.ctx
+                .staked_status
+                .is_staked(&root_bank, &unstaked_cluster_info)
+        );
+        assert_eq!(ctx.ctx.staked_status.identity, unstaked_cluster_info.id());
+    }
+
+    #[test]
+    fn test_staked_status_refreshes_on_epoch_change() {
+        let ctx = TestContext::default();
+        let root_bank = ctx.ctx.sharable_banks.root();
+        let mut staked_status = ctx.ctx.staked_status;
+        staked_status.epoch = root_bank.epoch().saturating_add(1);
+        staked_status.is_staked = false;
+
+        assert!(staked_status.is_staked(&root_bank, &ctx.ctx.cluster_info));
+        assert_eq!(staked_status.epoch, root_bank.epoch());
+    }
+}

--- a/votor/src/votor.rs
+++ b/votor/src/votor.rs
@@ -47,7 +47,9 @@ use {
     crate::{
         commitment::CommitmentAggregationData,
         consensus_metrics::ConsensusMetrics,
-        consensus_pool_service::{ConsensusPoolContext, ConsensusPoolService},
+        consensus_pool_service::{
+            ConsensusPoolContext, ConsensusPoolService, staked_status::StakedStatus,
+        },
         event::{
             LatestSwitchRequest, LeaderWindowInfo, RepairEventSender, VotorEventReceiver,
             VotorEventSender,
@@ -269,7 +271,8 @@ impl Votor {
             root_context,
         };
 
-        let epoch_schedule = sharable_banks.root().epoch_schedule().clone();
+        let root_bank = sharable_banks.root();
+        let epoch_schedule = root_bank.epoch_schedule().clone();
 
         let consensus_pool_context = ConsensusPoolContext {
             exit: exit.clone(),
@@ -288,6 +291,7 @@ impl Votor {
             event_sender,
             repair_event_sender,
             highest_finalized,
+            staked_status: StakedStatus::new(&root_bank, &cluster_info),
         };
 
         let metrics = ConsensusMetrics::start_metrics_loop(


### PR DESCRIPTION
#### Problem

Currently, each time a node wants to broadcast a certificate, it checks whether its current identity is staked or not.  This information can only change when an epoch change and when its identity changes.  Doing these look ups each time it sends a cert is wasteful.


#### Summary of Changes

- Introduces `StakedStatus` that caches the whether the node is staked or not and updates it when necessary.
- Some minor clean ups in the functions using this code, in particular, we do more batching of certs to send.


#### Testing

Added tests to ensure that the status is updated if the identity or the epoch changes


Fixes #14777 