### PR TITLE
Replace ref_count_storage with slot_list_len_storage

### DIFF
--- a/accounts-db/src/accounts_db/tests/impl.rs
+++ b/accounts-db/src/accounts_db/tests/impl.rs
@@ -184,10 +184,7 @@ fn test_generate_index_for_single_ref_zero_lamport_slot() {
 
     // The zero-lamport account stays alive in the index; its pubkey is added to
     // `uncleaned_pubkeys` for clean to handle
-    let slot_list_len = db.accounts_index.get_and_then(&pubkey, |entry| {
-        (false, entry.unwrap().slot_list_lock_read_len())
-    });
-    assert_eq!(slot_list_len, 1);
+    assert_eq!(db.accounts_index.slot_list_len(&pubkey), 1);
     assert_eq!(
         append_vec.alive_bytes(),
         AppendVec::calculate_stored_size(0),
@@ -917,9 +914,9 @@ fn test_clean_zero_lamport_and_dead_slot() {
     assert_eq!(accounts.alive_account_count_in_slot(1), 0);
 }
 
-// When a dead slot is cleaned, the pubkeys it held are unreffed.
+// When a dead slot is cleaned, its entries are removed from the pubkeys' slot lists.
 #[test]
-fn test_clean_dead_slot_unrefs_reclaimed_pubkeys() {
+fn test_clean_dead_slot_removes_reclaimed_pubkey_entries() {
     let accounts = AccountsDb::new_for_tests_with_config(Vec::new(), DEFAULT_ACCOUNTS_DB_CONFIG);
     let pubkey = Pubkey::new_unique();
     let account = AccountSharedData::new(1, 0, &Pubkey::default());
@@ -931,11 +928,11 @@ fn test_clean_dead_slot_unrefs_reclaimed_pubkeys() {
     accounts.store_for_tests((11, [(&pubkey, &updated_account)].as_slice()));
     accounts.add_root(11);
 
-    // Flush both roots without cleaning, so slot 10's version survives and the ref count reaches 2.
+    // Flush both roots without cleaning, so slot 10's version survives and pubkey's slot list keeps both entries.
     accounts.flush_rooted_accounts_cache_without_clean();
 
-    // Both slots are in pubkey's slot list, each in its own storage, so its ref count is 2.
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey), 2);
+    // Both slots are in pubkey's slot list, each in its own storage, its slot list len is 2
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey), 2);
     assert!(accounts.storage.get_slot_storage_entry(10).is_some());
     assert!(accounts.storage.get_slot_storage_entry(11).is_some());
 
@@ -946,8 +943,8 @@ fn test_clean_dead_slot_unrefs_reclaimed_pubkeys() {
     assert!(accounts.storage.get_slot_storage_entry(10).is_none());
     assert!(accounts.storage.get_slot_storage_entry(11).is_some());
 
-    // pubkey is now in one storage (slot 11), so its ref count is 1.
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey), 1);
+    // pubkey is now in one storage (slot 11), so its slot list has one entry
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey), 1);
 }
 
 #[test]
@@ -1626,9 +1623,9 @@ fn test_clean_multiple_zero_lamport_slots() {
     ));
     accounts.add_root_and_flush_write_cache(2);
 
-    // Both accounts are zero-lamport, so each was deleted from the index at flush (ref count 0).
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 0);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 0);
+    // Both accounts are zero-lamport, so each was deleted from the index at flush.
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 0);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey2), 0);
 
     accounts.clean_accounts_for_tests();
     // Slot 0 is cleared because both of its accounts were reclaimed by the tombstone flushes
@@ -2376,14 +2373,14 @@ fn do_full_clean_refcount(accounts: AccountsDb, store1_first: bool) {
     // B: Test multiple updates to pubkey1 in a single slot/storage
     current_slot += 1;
     assert_eq!(0, accounts.alive_account_count_in_slot(current_slot));
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 1);
     accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
     accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
     accounts.add_root_and_flush_write_cache(current_slot);
     assert_eq!(1, accounts.alive_account_count_in_slot(current_slot));
-    // Since flush was clean was used, the ref count should still be one as the older entry
+    // Since flush with clean was used, the slot list len should still be one as the older entry
     // was marked obsolete
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 1);
     accounts.add_root_and_flush_write_cache(current_slot);
 
     accounts.print_accounts_stats("Post-B pre-clean");
@@ -2395,12 +2392,12 @@ fn do_full_clean_refcount(accounts: AccountsDb, store1_first: bool) {
 
     // C: more updates to trigger clean of previous updates
     current_slot += 1;
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 1);
     accounts.store_for_tests((current_slot, [(&pubkey1, &account3)].as_slice()));
     accounts.store_for_tests((current_slot, [(&pubkey2, &account3)].as_slice()));
     accounts.store_for_tests((current_slot, [(&pubkey3, &account4)].as_slice()));
     accounts.add_root_and_flush_write_cache(current_slot);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 1);
 
     info!("post C");
 
@@ -2429,9 +2426,9 @@ fn do_full_clean_refcount(accounts: AccountsDb, store1_first: bool) {
     assert_eq!(total_accounts, total_accounts_post_clean);
 
     // should clean all 3 pubkeys
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 0);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey2), 0);
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey3), 0);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 0);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey2), 0);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey3), 0);
 }
 
 // Setup 2 scenarios which try to differentiate between pubkey1 being in an
@@ -3028,7 +3025,7 @@ fn test_store_clean_after_shrink() {
     accounts.clean_accounts_for_tests();
 
     accounts.print_accounts_stats("post-clean");
-    assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 0);
+    assert_eq!(accounts.accounts_index.slot_list_len(&pubkey1), 0);
 }
 
 #[test]
@@ -3793,8 +3790,8 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
     // Store into slot 2, which makes all updates from slot 1 outdated.
     // This means slot 1 is a dead slot. Later, slot 1 will be cleaned/purged
     // before it even reaches storage, but this purge of slot 1 should not affect
-    // the refcount of `zero_lamport_account_key` because cached keys do not bump
-    // the refcount in the index. This means clean should *not* remove
+    // `zero_lamport_account_key`'s slot list because cached slots are never in
+    // the index. This means clean should *not* remove
     // `zero_lamport_account_key` from slot 2
     db.store_for_tests((2, &[(&zero_lamport_account_key, &zero_lamport_account)][..]));
     db.add_root(1);
@@ -3805,17 +3802,13 @@ fn test_flush_cache_dont_clean_zero_lamport_account() {
     db.flush_accounts_cache(true, None);
     db.clean_accounts_for_tests();
 
-    // `zero_lamport_account_key` was deleted from the index at flush, so its ref count is 0.
-    // `other_account_key` stays alive in slot 0 with ref count 1.
+    // `zero_lamport_account_key` was deleted from the index at flush, so it has no slot list
+    // entries. `other_account_key` stays alive in slot 0.
     assert_eq!(
-        db.accounts_index
-            .ref_count_from_storage(&zero_lamport_account_key),
+        db.accounts_index.slot_list_len(&zero_lamport_account_key),
         0
     );
-    assert_eq!(
-        db.accounts_index.ref_count_from_storage(&other_account_key),
-        1
-    );
+    assert_eq!(db.accounts_index.slot_list_len(&other_account_key), 1);
 
     // The zero-lamport tombstone written to slot 2 is newer than the latest full snapshot, so
     // clean must retain its storage rather than dropping it.
@@ -4588,10 +4581,10 @@ fn test_shrink_unref() {
     // No stores should exist for slot 0 after clean
     assert_no_storages_at_slot(&db, 0);
 
-    // Ref count for `account_key1` (account removed earlier by shrink)
+    // Slot list len for `account_key1` (account removed earlier by shrink)
     // should be 1, since it was only stored in slot 0 and 1, and slot 0
     // is now dead
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 1);
+    assert_eq!(db.accounts_index.slot_list_len(&account_key1), 1);
 }
 
 #[test]
@@ -4650,10 +4643,10 @@ fn test_clean_drop_dead_storage_handle_zero_lamport_single_ref_accounts() {
     // Assert that after clean, slot 0 is dropped.
     assert!(db.storage.get_slot_storage_entry(0).is_none());
 
-    // account_key1 is a tombstone in slot 1 (ref count 0). Because slot 1 still has one other
+    // account_key1 is a tombstone in slot 1. Because slot 1 still has one other
     // alive account, it is not completely dead, so clean won't drop it. Instead it is a candidate
     // for next round shrinking.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key1), 0);
+    assert_eq!(db.accounts_index.slot_list_len(&account_key1), 0);
     assert_eq!(db.get_and_assert_single_storage(1).num_tombstones(), 1);
     assert!(db.shrink_candidate_slots.lock().unwrap().contains(&1));
 }
@@ -4691,20 +4684,20 @@ fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
     // covered by the full snapshot, account_key3's is not.
     db.set_latest_full_snapshot_slot(1);
 
-    // Clean reclaims the outdated slot 0 entries, unreffing them at reclaim. That leaves
-    // each zero-lamport update as its account's only ref.
+    // Clean reclaims the outdated slot 0 entries, removing them from the slot lists at
+    // reclaim. That leaves each zero-lamport update as its account's only slot list entry.
     db.clean_accounts(Some(3), false);
 
     // The reclaim leaves account_key1 zero-lamport single-ref, so it is tombstoned:
     // removed from the index, and slot 1's storage, now holding only the tombstone and
     // already covered by the full snapshot, is purged in the same pass.
-    assert!(!db.accounts_index.contains(&account_key1));
+    assert_eq!(db.accounts_index.slot_list_len(&account_key1), 0);
     assert_no_storages_at_slot(&db, 1);
 
     // account_key3 is likewise tombstoned, but slot 3 is newer than the full snapshot,
     // so its storage keeps the tombstone for an incremental snapshot to propagate the
     // deletion and is queued for a later clean via dirty_stores rather than shrink.
-    assert!(!db.accounts_index.contains(&account_key3));
+    assert_eq!(db.accounts_index.slot_list_len(&account_key3), 0);
     assert_eq!(db.get_and_assert_single_storage(3).num_tombstones(), 1);
     assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&3));
 
@@ -4729,8 +4722,10 @@ fn test_clean_tombstones_zero_lamport_single_ref_at_reclaim() {
     // No stores should exist for slot 0. Slot 0 stores are cleaned when
     // slot 4 is flushed; the older accounts are marked obsolete.
     assert_no_storages_at_slot(&db, 0);
+    // account_key2 was never tombstoned; its slot 0 entry was reclaimed when slot 4 was
+    // flushed, leaving slot 4 as its only slot list entry.
+    assert_eq!(db.accounts_index.slot_list_len(&account_key2), 1);
     // Store 4 should have a single account.
-    assert_eq!(db.accounts_index.ref_count_from_storage(&account_key2), 1);
     db.get_and_assert_single_storage(4);
 }
 
@@ -5422,11 +5417,8 @@ fn test_purge_alive_unrooted_slots_after_clean() {
     // Simulate adding dirty pubkeys on bank freeze, set root
     accounts.add_root_and_flush_write_cache(slot2);
 
-    // Account is now a tombstone and has a reference count of zero
-    assert_eq!(
-        accounts.accounts_index.ref_count_from_storage(&shared_key),
-        0
-    );
+    // Account is now a tombstone and has no slot list entries
+    assert_eq!(accounts.accounts_index.slot_list_len(&shared_key), 0);
 
     // The later rooted zero-lamport update to 'shared_key' can be purged
     // as there are no rooted ancestors
@@ -5434,11 +5426,8 @@ fn test_purge_alive_unrooted_slots_after_clean() {
     accounts.clean_accounts_for_tests();
     assert!(accounts.contains(&shared_key));
 
-    // Account now has a reference count of zero as it is not contained in any storages
-    assert_eq!(
-        accounts.accounts_index.ref_count_from_storage(&shared_key),
-        0
-    );
+    // Account is no longer in the accounts index, only in the cache index
+    assert_eq!(accounts.accounts_index.slot_list_len(&shared_key), 0);
 
     // Simulate purge_slot() all from AccountsBackgroundService
     accounts.purge_slot(slot1, 0, true);
@@ -6042,7 +6031,7 @@ fn test_shrink_collect_with_obsolete_accounts() {
 
     assert_eq!(shrink_collect.slot, slot);
 
-    // Ensure that the obsolete accounts and accounts to unref are not in the alive list
+    // Ensure that the obsolete accounts and purged accounts are not in the alive list
     assert_eq!(
         shrink_collect
             .alive_accounts
@@ -6191,11 +6180,8 @@ fn test_mark_obsolete_accounts_at_startup_purge_slot() {
     // Verify that slot 1 has been purged
     assert!(accounts_db.storage.get_slot_storage_entry(1).is_none());
 
-    // Verify that the pubkey ref1's count is 1
-    assert_eq!(
-        accounts_db.accounts_index.ref_count_from_storage(&pubkey1),
-        1
-    );
+    // Verify that the pubkey's slot list len is 1
+    assert_eq!(accounts_db.accounts_index.slot_list_len(&pubkey1), 1);
 
     assert_eq!(obsolete_stats.accounts_marked_obsolete, 2);
 }
@@ -6228,15 +6214,9 @@ fn test_mark_obsolete_accounts_at_startup_multiple_bins() {
     // Verify that slot 1 has been purged
     assert!(accounts_db.storage.get_slot_storage_entry(1).is_some());
 
-    // Verify that both pubkeys ref_counts are 1
-    assert_eq!(
-        accounts_db.accounts_index.ref_count_from_storage(&pubkey1),
-        1
-    );
-    assert_eq!(
-        accounts_db.accounts_index.ref_count_from_storage(&pubkey2),
-        1
-    );
+    // Verify that both pubkeys slot list lens are 1
+    assert_eq!(accounts_db.accounts_index.slot_list_len(&pubkey1), 1);
+    assert_eq!(accounts_db.accounts_index.slot_list_len(&pubkey2), 1);
 
     // Ensure that stats were accumulated correctly
     assert_eq!(obsolete_stats.accounts_marked_obsolete, 2);

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -842,12 +842,16 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         map.delete(pubkey, reclaims);
     }
 
-    pub fn ref_count_from_storage(&self, pubkey: &Pubkey) -> RefCount {
+    /// Length of `pubkey`'s slot list, 0 if the pubkey is not in the index
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn slot_list_len(&self, pubkey: &Pubkey) -> usize {
         let map = self.get_bin(pubkey);
         map.get_internal_inner(pubkey, |entry| {
             (
                 false,
-                entry.map(|entry| entry.ref_count()).unwrap_or_default(),
+                entry
+                    .map(|entry| entry.slot_list_lock_read_len())
+                    .unwrap_or_default(),
             )
         })
     }
@@ -1181,7 +1185,7 @@ mod tests {
 
         let ancestors = Ancestors::default();
         assert!(index.contains_with(pubkey, &ancestors));
-        assert_eq!(index.ref_count_from_storage(pubkey), 1);
+        assert_eq!(index.slot_list_len(pubkey), 1);
 
         let mut num = 0;
         index.scan_accounts(
@@ -1204,7 +1208,7 @@ mod tests {
 
         let ancestors = Ancestors::default();
         assert!(index.contains_with(pubkey, &ancestors));
-        assert_eq!(index.ref_count_from_storage(pubkey), 1);
+        assert_eq!(index.slot_list_len(pubkey), 1);
 
         let mut num = 0;
         index.scan_accounts(
@@ -1772,10 +1776,7 @@ mod tests {
         assert!(reclaims.is_empty());
 
         // Slot list should only have a single entry
-        let slot_list_len = index.get_and_then(&key, |entry| {
-            (false, entry.unwrap().slot_list_lock_read_len())
-        });
-        assert_eq!(slot_list_len, 1);
+        assert_eq!(index.slot_list_len(&key), 1);
 
         index.upsert(0, 0, &key, 0, &mut reclaims, UPSERT_RECLAIM_TEST_DEFAULT);
 
@@ -1783,10 +1784,7 @@ mod tests {
         assert!(!reclaims.is_empty());
 
         // Slot list should only have a single entry
-        let slot_list_len = index.get_and_then(&key, |entry| {
-            (false, entry.unwrap().slot_list_lock_read_len())
-        });
-        assert_eq!(slot_list_len, 1);
+        assert_eq!(index.slot_list_len(&key), 1);
     }
 
     #[test]
@@ -1805,7 +1803,7 @@ mod tests {
             &mut gc,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(index.ref_count_from_storage(&key), 1);
+        assert_eq!(index.slot_list_len(&key), 1);
 
         let account_info = 200;
 
@@ -1816,8 +1814,8 @@ mod tests {
             (false, entry.unwrap().slot_list_read_lock().clone_list())
         });
         assert_eq!(slot_list, SlotList::from([(slot, account_info)]));
-        // Replace doesn't change refcounts.
-        assert_eq!(index.ref_count_from_storage(&key), 1);
+        // Replace doesn't change the slot list length.
+        assert_eq!(index.slot_list_len(&key), 1);
     }
 
     #[test]
@@ -1838,7 +1836,7 @@ mod tests {
             &mut gc,
             UpsertReclaim::IgnoreReclaims,
         );
-        assert_eq!(index.ref_count_from_storage(&key), 1);
+        assert_eq!(index.slot_list_len(&key), 1);
 
         index.replace(new_slot, old_slot, &key, account_info);
 
@@ -1846,8 +1844,8 @@ mod tests {
             (false, entry.unwrap().slot_list_read_lock().clone_list())
         });
         assert_eq!(slot_list, SlotList::from([(new_slot, account_info)]));
-        // Moving an entry between slots must not change the ref count.
-        assert_eq!(index.ref_count_from_storage(&key), 1);
+        // Moving an entry between slots must not change the slot list length.
+        assert_eq!(index.slot_list_len(&key), 1);
     }
 
     #[test]
@@ -2008,10 +2006,7 @@ mod tests {
                 UpsertReclaim::IgnoreReclaims,
             );
         }
-        let slot_list_len = index.get_and_then(&key, |entry| {
-            (false, entry.unwrap().slot_list_lock_read_len())
-        });
-        assert_eq!(slot_list_len, reclaim_slot as usize);
+        assert_eq!(index.slot_list_len(&key), reclaim_slot as usize);
 
         // Insert an item newer than the one that we will reclaim old slots on
         index.upsert(
@@ -2022,10 +2017,7 @@ mod tests {
             &mut gc,
             UpsertReclaim::IgnoreReclaims,
         );
-        let slot_list_len = index.get_and_then(&key, |entry| {
-            (false, entry.unwrap().slot_list_lock_read_len())
-        });
-        assert_eq!(slot_list_len, (reclaim_slot + 1) as usize);
+        assert_eq!(index.slot_list_len(&key), (reclaim_slot + 1) as usize);
 
         // Reclaim all older slots
         index.upsert(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9269,11 +9269,11 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     //! 1. A key is written _only_ in an unrooted bank (key1)
     //!     - In this case, key1 should be cleaned up
     //! 2. A key is written in both an unrooted _and_ rooted bank (key3)
-    //!     - In this case, key3's ref-count should be decremented correctly
+    //!     - In this case, key3 should stay in the index
     //! 3. A key with zero lamports is _only_ in an unrooted bank (key4)
     //!     - In this case, key4 should be cleaned up
     //! 4. A key with zero lamports is in both an unrooted _and_ rooted bank (key5)
-    //!     - In this case, key5's ref-count should be decremented correctly
+    //!     - In this case, key5 should be cleaned up
 
     let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
     let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
@@ -9336,45 +9336,11 @@ fn do_test_clean_dropped_unrooted_banks(freeze_bank1: FreezeBank1) {
     drop(bank1);
     bank2.clean_accounts_for_tests();
 
-    let expected_ref_count_for_cleaned_up_keys = 0;
-    let expected_ref_count_for_keys_in_both_slot1_and_slot2 = 1;
-
-    assert_eq!(
-        bank2
-            .rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .ref_count_from_storage(&key1.pubkey()),
-        expected_ref_count_for_cleaned_up_keys,
-    );
-    assert_eq!(
-        bank2
-            .rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .ref_count_from_storage(&key3.pubkey()),
-        expected_ref_count_for_keys_in_both_slot1_and_slot2,
-    );
-    assert_eq!(
-        bank2
-            .rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .ref_count_from_storage(&key4.pubkey()),
-        expected_ref_count_for_cleaned_up_keys,
-    );
-    assert_eq!(
-        bank2
-            .rc
-            .accounts
-            .accounts_db
-            .accounts_index
-            .ref_count_from_storage(&key5.pubkey()),
-        expected_ref_count_for_cleaned_up_keys,
-    );
+    // key1, key4 and key5 are cleaned up; key3 is still alive in rooted slot 2
+    assert!(!bank2.rc.accounts.accounts_db.contains(&key1.pubkey()));
+    assert!(bank2.rc.accounts.accounts_db.contains(&key3.pubkey()));
+    assert!(!bank2.rc.accounts.accounts_db.contains(&key4.pubkey()));
+    assert!(!bank2.rc.accounts.accounts_db.contains(&key5.pubkey()));
     assert_eq!(
         bank2.rc.accounts.accounts_db.alive_account_count_in_slot(1),
         0

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -662,30 +662,30 @@ mod serde_snapshot_tests {
         current_slot += 1;
         assert_eq!(0, accounts.alive_account_count_in_slot(current_slot));
         accounts.add_root_and_flush_write_cache(current_slot - 1);
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+        assert!(accounts.contains(&pubkey1));
         accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
         accounts.store_for_tests((current_slot, [(&pubkey1, &account2)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
         assert_eq!(1, accounts.alive_account_count_in_slot(current_slot));
-        // Ref count is 1 as the older version in the previous slot was marked obsolete
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+        // pubkey1 is still alive; the older version in the previous slot was marked obsolete
+        assert!(accounts.contains(&pubkey1));
 
         // C: Yet more update to trigger lazy clean of step A
         current_slot += 1;
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+        assert!(accounts.contains(&pubkey1));
         accounts.store_for_tests((current_slot, [(&pubkey1, &account3)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+        assert!(accounts.contains(&pubkey1));
         accounts.add_root_and_flush_write_cache(current_slot);
 
         // D: Make pubkey1 0-lamport; also triggers clean of step B
         current_slot += 1;
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 1);
+        assert!(accounts.contains(&pubkey1));
         accounts.store_for_tests((current_slot, [(&pubkey1, &zero_lamport_account)].as_slice()));
         accounts.add_root_and_flush_write_cache(current_slot);
 
-        // Ref count is 0 as the zero lamport account was converted to a tombstone
-        assert_eq!(accounts.accounts_index.ref_count_from_storage(&pubkey1), 0);
+        // The zero lamport account was converted to a tombstone, so pubkey1 is out of the index
+        assert!(!accounts.contains(&pubkey1));
         accounts.add_root(current_slot);
 
         // E: Avoid missing bank hash error

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -582,7 +582,7 @@ mod tests {
         ); // snapshot slot is untouched, so still has all 300 accounts
     }
 
-    /// Purging an account from a filtered storage must decrement its ref count when the
+    /// Purging an account from a filtered storage must remove its slot list entry when the
     /// account is still alive in a later slot.
     #[test]
     fn test_minimize_accounts_db_unrefs_multi_ref_accounts() {
@@ -606,12 +606,7 @@ mod tests {
         // Flush without clean so pubkey_multi keeps both slot list entries
         accounts.flush_rooted_accounts_cache_without_clean();
 
-        assert_eq!(
-            accounts
-                .accounts_index
-                .ref_count_from_storage(&pubkey_multi),
-            2
-        );
+        assert_eq!(accounts.accounts_index.slot_list_len(&pubkey_multi), 2);
 
         let minimized_account_set = DashSet::new();
         minimized_account_set.insert(pubkey_keep);
@@ -622,14 +617,9 @@ mod tests {
         };
         minimizer.minimize_accounts_db();
 
-        // filter_storage purged (pubkey_multi, slot 1) from the index, decrementing its
-        // ref count; the other entry keeps it alive
-        assert_eq!(
-            accounts
-                .accounts_index
-                .ref_count_from_storage(&pubkey_multi),
-            1
-        );
+        // filter_storage purged (pubkey_multi, slot 1) from the index; the slot 2 entry
+        // keeps it alive
+        assert_eq!(accounts.accounts_index.slot_list_len(&pubkey_multi), 1);
     }
 
     /// A dead slot whose storage carries a shrink-produced tombstone must still purge


### PR DESCRIPTION
#### Problem
ref_count_storage is ref_count based, should use slot_list instead as ref_count is going away

#### Summary of Changes
- For runtime tests, switch to using contains, to avoid exposing internals
- Exception for snapshot minimizer, which is specifically looking at slot_list_len
- For accounts_db tests, use slot_list_len

- Next PR is ref_count removal!
#### Testing


Fixes #
