### PR TITLE
rpc: don't sort the full mint account set in getTokenLargestAccounts

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2099,7 +2099,8 @@ impl JsonRpcRequestProcessor {
                 mint_owner,
                 mint,
                 vec![],
-                true,
+                // Don't sort here: the heap below handles sorting
+                false,
             )
             .await?
         {


### PR DESCRIPTION
#### Problem

`getTokenLargestAccounts` passes `sort_results=true` to `get_filtered_spl_token_accounts_by_mint`, which address-sorts every token account for the mint. The top-`NUM_LARGEST_ACCOUNTS` selection that follows uses a bounded `BinaryHeap` keyed by `(amount, address)` and emits its own sorted output, so that address sort is wasted work. It scales with the number of accounts for the mint, and on a high-cardinality mint it ties up an RPC blocking worker for the duration.

#### Summary of Changes

Pass `sort_results=false`. The response is unchanged, since the heap determines the final order; only the redundant full-set sort is removed.
