### PR TITLE
ledger-tool: Bump max supported transaction version

### DIFF
--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -772,7 +772,7 @@ pub(crate) fn encode_confirmed_block(
         BlockEncodingOptions {
             transaction_details: TransactionDetails::Full,
             show_rewards: true,
-            max_supported_transaction_version: Some(0),
+            max_supported_transaction_version: Some(1),
         },
     )?;
 


### PR DESCRIPTION
#### Problem

Ledger-tool hardcodes the max supported transaction version to `0` in `encode_confirmed_block`, but tx v1 is about to be released.

#### Summary of changes

Bump the version to `1`.

NOTE: I don't know enough about the code to know if this is correct, but it seems like we should bump it.

#### Testing

None, I mainly wanted to get this on your radar with a PR. If it's good, then we can merge. If not, I'll happily take feedback.