### PR TITLE
Various cleanups in block creation loop stats

### DIFF
--- a/core/src/block_creation_loop.rs
+++ b/core/src/block_creation_loop.rs
@@ -191,7 +191,6 @@ struct LeaderContext {
 
     // Metrics
     metrics: LoopMetrics,
-    slot_metrics: SlotMetrics,
 
     // Migration information
     genesis_cert_block_marker: GenesisCertBlockMarker,
@@ -322,7 +321,6 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
         reward_certs_requestor,
         banking_stage_sender,
         metrics: LoopMetrics::default(),
-        slot_metrics: SlotMetrics::default(),
         highest_finalized,
         genesis_cert_block_marker,
     };
@@ -411,14 +409,18 @@ fn start_loop(config: BlockCreationLoopConfig, reward_certs_requestor: CertsRequ
             continue;
         }
 
-        if let Err(e) = produce_window(
+        let mut slot_metrics = SlotMetrics::new(start_slot, fast_leader_handover);
+        let res = produce_window(
             fast_leader_handover,
             start_slot,
             end_slot,
             parent_block,
             block_timer,
             &mut ctx,
-        ) {
+            &mut slot_metrics,
+        );
+        slot_metrics.report();
+        if let Err(e) = res {
             // Give up on this leader window
             error!(
                 "{my_pubkey}: Unable to produce window {start_slot}-{end_slot}, skipping window: \
@@ -588,20 +590,19 @@ fn produce_window(
     parent_block: Block,
     mut block_timer: Instant,
     ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
 ) -> Result<(), StartLeaderError> {
     update_leader_window_clock(ctx, start_slot, block_timer);
 
     // Insert the first bank
     let mut working_bank = start_leader_wait_for_parent_replay(
+        ctx,
+        slot_metrics,
         start_slot,
         parent_block.slot,
         Some(parent_block.block_id),
         block_timer,
-        ctx,
     )?;
-    if fast_leader_handover {
-        ctx.slot_metrics.mark_leader_handover_fast();
-    }
 
     let my_pubkey = ctx.my_pubkey;
     let mut window_production_start = Measure::start("window_production");
@@ -617,9 +618,14 @@ fn produce_window(
         let mut bank_completion_measure = Measure::start("bank_completion");
         let optimistic_parent =
             (fast_leader_handover && slot == start_slot).then_some(parent_block);
-        if let Err(e) =
-            record_and_complete_block(ctx, slot, optimistic_parent, &mut block_timer, timeout)
-        {
+        if let Err(e) = record_and_complete_block(
+            ctx,
+            slot_metrics,
+            slot,
+            optimistic_parent,
+            &mut block_timer,
+            timeout,
+        ) {
             if ctx.exit.load(Ordering::Relaxed) {
                 return Ok(());
             }
@@ -630,13 +636,11 @@ fn produce_window(
         }
         assert!(!ctx.poh_recorder.read().unwrap().has_bank());
         bank_completion_measure.stop();
-        ctx.slot_metrics.report();
 
         ctx.metrics.bank_timeout_completion_count += 1;
-        let _ = ctx
-            .metrics
-            .bank_timeout_completion_elapsed_hist
-            .increment(bank_completion_measure.as_us());
+        ctx.metrics
+            .bank_timeout_completion_elapsed
+            .add_sample(bank_completion_measure.as_us());
 
         // Produce our next slot
         slot += 1;
@@ -644,10 +648,22 @@ fn produce_window(
             trace!("{my_pubkey}: finished leader window {start_slot}-{end_slot}");
             break;
         }
+        {
+            let mut swap = SlotMetrics::new(slot, false);
+            std::mem::swap(&mut swap, slot_metrics);
+            swap.report();
+        }
 
         // Although `slot - 1`has been cleared from `poh_recorder`, it might not have finished processing in
         // `replay_stage`, which is why we use `start_leader_retry_replay`
-        working_bank = start_leader_wait_for_parent_replay(slot, slot - 1, None, block_timer, ctx)?;
+        working_bank = start_leader_wait_for_parent_replay(
+            ctx,
+            slot_metrics,
+            slot,
+            slot - 1,
+            None,
+            block_timer,
+        )?;
     }
 
     window_production_start.stop();
@@ -664,6 +680,7 @@ fn produce_window(
 /// - Clear the working bank
 fn record_and_complete_block(
     ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     bank_slot: Slot,
     mut optimistic_parent: Option<Block>,
     block_timer: &mut Instant,
@@ -727,6 +744,7 @@ fn record_and_complete_block(
                 let info = msg.map_err(|_| PohRecorderError::ChannelDisconnected)?;
                 if process_parent_ready(
                     ctx,
+                    slot_metrics,
                     info,
                     bank_slot,
                     &mut optimistic_parent,
@@ -841,6 +859,7 @@ fn record_and_complete_block(
 /// sad leader handover and restart the bank on the ParentReady parent.
 fn process_parent_ready(
     ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     info: LeaderWindowInfo,
     bank_slot: Slot,
     optimistic_parent: &mut Option<Block>,
@@ -858,6 +877,7 @@ fn process_parent_ready(
         if let Some(optimistic_parent_block) = optimistic_parent.take()
             && handle_parent_ready(
                 ctx,
+                slot_metrics,
                 info,
                 optimistic_parent_block,
                 std::mem::take(accumulated_txs),
@@ -933,6 +953,7 @@ fn send_update_parent(
 /// - we clear the bank for the current slot
 fn handle_parent_ready(
     ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     leader_window_info: LeaderWindowInfo,
     optimistic_parent_block: Block,
     mut accumulated_txs: Vec<VersionedTransaction>,
@@ -948,7 +969,7 @@ fn handle_parent_ready(
         "{:?}: Sad leader handover slot optimistic parent = {:?} != {:?} = parent from ParentReady",
         ctx.my_pubkey, optimistic_parent_block, leader_window_info.parent_block
     );
-    ctx.slot_metrics.mark_leader_handover_sad();
+    slot_metrics.leader_handover_sad = true;
 
     // If the optimistic parent doesn't match the one specified in ParentReady, then
     // this resets the block timer to the new parent's timer.
@@ -1001,12 +1022,13 @@ fn handle_parent_ready(
 
     // Create the new bank before re-injecting transactions to avoid racing.
     let new_bank = start_leader_wait_for_parent_replay_with_used_bytes(
+        ctx,
+        slot_metrics,
         slot,
         new_parent_slot,
         Some(new_parent_hash),
         *block_timer,
         entry_bytes_consumed,
-        ctx,
     )
     .map_err(|_| PohRecorderError::ResetBankError(old_parent_slot, new_parent_slot))?;
     update_leader_window_clock(ctx, slot, *block_timer);
@@ -1089,29 +1111,32 @@ fn time_left(block_timer: Instant, timeout: Duration) -> Duration {
 /// Similar to `maybe_start_leader`, however if replay of the parent block is lagging we retry
 /// until either replay finishes or we hit the block timeout.
 fn start_leader_wait_for_parent_replay(
+    ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     slot: Slot,
     parent_slot: Slot,
     parent_hash: Option<Hash>,
     block_timer: Instant,
-    ctx: &mut LeaderContext,
 ) -> Result<Arc<Bank>, StartLeaderError> {
     start_leader_wait_for_parent_replay_with_used_bytes(
+        ctx,
+        slot_metrics,
         slot,
         parent_slot,
         parent_hash,
         block_timer,
         0,
-        ctx,
     )
 }
 
 fn start_leader_wait_for_parent_replay_with_used_bytes(
+    ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     slot: Slot,
     parent_slot: Slot,
     parent_hash: Option<Hash>,
     block_timer: Instant,
     entry_bytes_consumed: u64,
-    ctx: &mut LeaderContext,
 ) -> Result<Arc<Bank>, StartLeaderError> {
     trace!(
         "{}: Attempting to start leader slot {slot} parent {parent_slot}",
@@ -1121,9 +1146,9 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
     let timeout = block_timeout(&ctx.bank_forks.read().unwrap().root_bank(), slot);
     let end_slot = last_of_consecutive_leader_slots(slot);
 
-    let mut slot_delay_start = Measure::start("slot_delay");
+    let mut slot_delay_measure = Measure::start("slot_delay");
     while !time_left(block_timer, timeout).is_zero() {
-        ctx.slot_metrics.attempt_start_leader_count += 1;
+        slot_metrics.attempt_start_leader_count += 1;
 
         // Check if the entire window is skipped.
         let highest_parent_ready_slot = ctx.highest_parent_ready.read().unwrap().0;
@@ -1139,21 +1164,18 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
             ));
         }
 
-        match maybe_start_leader(slot, parent_slot, parent_hash, entry_bytes_consumed, ctx) {
+        match maybe_start_leader(
+            ctx,
+            slot_metrics,
+            slot,
+            parent_slot,
+            parent_hash,
+            entry_bytes_consumed,
+        ) {
             Ok(()) => {
-                slot_delay_start.stop();
-                let _ = ctx
-                    .slot_metrics
-                    .slot_delay_hist
-                    .increment(slot_delay_start.as_us())
-                    .inspect_err(|e| {
-                        error!(
-                            "{}: unable to increment slot delay histogram {e:?}",
-                            ctx.my_pubkey
-                        );
-                    });
+                slot_delay_measure.stop();
+                slot_metrics.slot_delay_us += slot_delay_measure.as_us();
 
-                ctx.slot_metrics.report();
                 return Ok(ctx
                     .poh_recorder
                     .read()
@@ -1174,7 +1196,7 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
                     .unwrap();
 
                 // We wait until either we finish replay of the parent or the block timer finishes
-                let mut wait_start = Measure::start("replay_is_behind");
+                let mut replay_behind_measure = Measure::start("replay_is_behind");
                 let _unused = {
                     let timeout = time_left(block_timer, timeout);
                     ctx.replay_highest_frozen
@@ -1182,18 +1204,8 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
                         .wait_timeout_while(highest_frozen_slot, timeout, |hfs| *hfs < parent_slot)
                         .unwrap()
                 };
-                wait_start.stop();
-                ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
-                let _ = ctx
-                    .slot_metrics
-                    .replay_is_behind_wait_elapsed_hist
-                    .increment(wait_start.as_us())
-                    .inspect_err(|e| {
-                        error!(
-                            "{}: unable to increment replay is behind histogram {e:?}",
-                            ctx.my_pubkey
-                        );
-                    });
+                replay_behind_measure.stop();
+                slot_metrics.replay_is_behind_us += replay_behind_measure.as_us();
             }
             Err(StartLeaderError::ParentBlockIdMismatch {
                 expected, actual, ..
@@ -1202,7 +1214,7 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
                     "{my_pubkey}: Attempting to produce slot {slot}, however parent {parent_slot} \
                      has block id {actual:?}, expected {expected}; waiting for bank switch"
                 );
-                let mut wait_start = Measure::start("parent_block_id_mismatch");
+                let mut replay_behind_measure = Measure::start("parent_block_id_mismatch");
                 let wait_timeout = time_left(block_timer, timeout).min(Duration::from_millis(100));
                 if !wait_timeout.is_zero() {
                     let highest_frozen_slot = ctx
@@ -1216,12 +1228,8 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
                         .wait_timeout(highest_frozen_slot, wait_timeout)
                         .unwrap();
                 }
-                wait_start.stop();
-                ctx.slot_metrics.replay_is_behind_cumulative_wait_elapsed += wait_start.as_us();
-                let _ = ctx
-                    .slot_metrics
-                    .replay_is_behind_wait_elapsed_hist
-                    .increment(wait_start.as_us());
+                replay_behind_measure.stop();
+                slot_metrics.replay_is_behind_us += replay_behind_measure.as_us();
             }
             Err(e) => return Err(e),
         }
@@ -1243,24 +1251,23 @@ fn start_leader_wait_for_parent_replay_with_used_bytes(
 /// - Create a new bank for `slot` with parent `parent_slot`
 /// - Insert into bank_forks and poh recorder
 fn maybe_start_leader(
+    ctx: &mut LeaderContext,
+    slot_metrics: &mut SlotMetrics,
     slot: Slot,
     parent_slot: Slot,
     parent_hash: Option<Hash>,
     entry_bytes_consumed: u64,
-    ctx: &mut LeaderContext,
 ) -> Result<(), StartLeaderError> {
     if ctx.bank_forks.read().unwrap().get(slot).is_some() {
-        ctx.slot_metrics.already_have_bank_count += 1;
+        slot_metrics.already_have_bank_count += 1;
         return Err(StartLeaderError::AlreadyHaveBank(slot));
     }
 
     let Some(parent_bank) = ctx.bank_forks.read().unwrap().get(parent_slot) else {
-        ctx.slot_metrics.replay_is_behind_count += 1;
         return Err(StartLeaderError::ReplayIsBehind(parent_slot, slot));
     };
 
     if !parent_bank.is_frozen() {
-        ctx.slot_metrics.replay_is_behind_count += 1;
         return Err(StartLeaderError::ReplayIsBehind(parent_slot, slot));
     }
 
@@ -1382,7 +1389,6 @@ fn create_and_insert_leader_bank(
 
     // Wakeup banking stage
     ctx.record_receiver.restart(bank_id);
-    ctx.slot_metrics.reset(slot);
 
     info!(
         "{}: new fork:{} parent:{} (leader) root:{}",
@@ -1658,7 +1664,6 @@ mod tests {
             reward_certs_requestor,
             banking_stage_sender,
             metrics: LoopMetrics::default(),
-            slot_metrics: SlotMetrics::default(),
             genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
@@ -1780,7 +1785,6 @@ mod tests {
             reward_certs_requestor,
             banking_stage_sender,
             metrics: LoopMetrics::default(),
-            slot_metrics: SlotMetrics::default(),
             genesis_cert_block_marker,
         };
 
@@ -1858,7 +1862,6 @@ mod tests {
             reward_certs_requestor,
             banking_stage_sender,
             metrics: LoopMetrics::default(),
-            slot_metrics: SlotMetrics::default(),
             genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
@@ -1873,8 +1876,14 @@ mod tests {
             .unwrap();
 
         let start = Instant::now();
-        let result =
-            record_and_complete_block(&mut ctx, 1, None, &mut Instant::now(), Duration::ZERO);
+        let result = record_and_complete_block(
+            &mut ctx,
+            &mut SlotMetrics::new(1, true),
+            1,
+            None,
+            &mut Instant::now(),
+            Duration::ZERO,
+        );
         assert!(matches!(result, Err(PohRecorderError::WindowMovedOn(1))));
         assert!(start.elapsed() < Duration::from_millis(250));
         assert!(!ctx.poh_recorder.read().unwrap().has_bank());
@@ -1996,7 +2005,6 @@ mod tests {
             reward_certs_requestor,
             banking_stage_sender,
             metrics: LoopMetrics::default(),
-            slot_metrics: SlotMetrics::default(),
             genesis_cert_block_marker: test_genesis_cert_block_marker(),
         };
 
@@ -2036,6 +2044,7 @@ mod tests {
         };
         let new_bank = handle_parent_ready(
             &mut ctx,
+            &mut SlotMetrics::new(leader_slot, true),
             parent_ready,
             Block {
                 slot: optimistic_parent_slot,

--- a/core/src/block_creation_loop/stats.rs
+++ b/core/src/block_creation_loop/stats.rs
@@ -1,19 +1,18 @@
 //! Stats about the block creation loop
 use {
-    histogram::Histogram,
+    agave_math_utils::welford_stats::WelfordStats,
     solana_clock::Slot,
     solana_metrics::datapoint_info,
     std::time::{Duration, Instant},
 };
 
-pub(crate) struct LoopMetrics {
-    pub(crate) last_report: Instant,
-    pub(crate) loop_count: u64,
-    pub(crate) bank_timeout_completion_count: u64,
-    pub(crate) skipped_window_behind_parent_ready_count: u64,
-
-    pub(crate) window_production_elapsed: u64,
-    pub(crate) bank_timeout_completion_elapsed_hist: Histogram,
+pub(super) struct LoopMetrics {
+    pub(super) last_report: Instant,
+    pub(super) loop_count: u64,
+    pub(super) bank_timeout_completion_count: u64,
+    pub(super) skipped_window_behind_parent_ready_count: u64,
+    pub(super) window_production_elapsed: u64,
+    pub(super) bank_timeout_completion_elapsed: WelfordStats,
 }
 
 impl Default for LoopMetrics {
@@ -24,76 +23,77 @@ impl Default for LoopMetrics {
             bank_timeout_completion_count: 0,
             skipped_window_behind_parent_ready_count: 0,
             window_production_elapsed: 0,
-            bank_timeout_completion_elapsed_hist: Histogram::default(),
+            bank_timeout_completion_elapsed: WelfordStats::default(),
         }
     }
 }
 
 impl LoopMetrics {
     fn is_empty(&self) -> bool {
-        0 == self.loop_count
-            + self.bank_timeout_completion_count
-            + self.window_production_elapsed
-            + self.skipped_window_behind_parent_ready_count
-            + self.bank_timeout_completion_elapsed_hist.entries()
+        let Self {
+            loop_count,
+            bank_timeout_completion_count,
+            skipped_window_behind_parent_ready_count,
+            window_production_elapsed,
+            bank_timeout_completion_elapsed,
+            last_report: _,
+        } = self;
+        0 == loop_count
+            + bank_timeout_completion_count
+            + skipped_window_behind_parent_ready_count
+            + window_production_elapsed
+            + bank_timeout_completion_elapsed.count()
     }
 
-    pub(crate) fn report(&mut self, report_interval: Duration) {
-        // skip reporting metrics if stats is empty
+    pub(super) fn report(&mut self, report_interval: Duration) {
         if self.is_empty() {
             return;
         }
+        let Self {
+            loop_count,
+            bank_timeout_completion_count,
+            skipped_window_behind_parent_ready_count,
+            window_production_elapsed,
+            bank_timeout_completion_elapsed,
+            last_report,
+        } = self;
 
-        if self.last_report.elapsed() > report_interval {
+        if last_report.elapsed() > report_interval {
             datapoint_info!(
                 "block-creation-loop-metrics",
-                ("loop_count", self.loop_count, i64),
+                ("loop_count", *loop_count, i64),
                 (
                     "bank_timeout_completion_count",
-                    self.bank_timeout_completion_count,
+                    *bank_timeout_completion_count,
                     i64
                 ),
-                (
-                    "window_production_elapsed",
-                    self.window_production_elapsed,
-                    i64
-                ),
+                ("window_production_elapsed", *window_production_elapsed, i64),
                 (
                     "skipped_window_behind_parent_ready_count",
-                    self.skipped_window_behind_parent_ready_count,
-                    i64
-                ),
-                (
-                    "bank_timeout_completion_elapsed_90pct",
-                    self.bank_timeout_completion_elapsed_hist
-                        .percentile(90.0)
-                        .unwrap_or(0),
+                    *skipped_window_behind_parent_ready_count,
                     i64
                 ),
                 (
                     "bank_timeout_completion_elapsed_mean",
-                    self.bank_timeout_completion_elapsed_hist
-                        .mean()
-                        .unwrap_or(0),
-                    i64
-                ),
-                (
-                    "bank_timeout_completion_elapsed_min",
-                    self.bank_timeout_completion_elapsed_hist
-                        .minimum()
-                        .unwrap_or(0),
-                    i64
+                    bank_timeout_completion_elapsed.mean::<u64>(),
+                    Option<i64>
                 ),
                 (
                     "bank_timeout_completion_elapsed_max",
-                    self.bank_timeout_completion_elapsed_hist
-                        .maximum()
-                        .unwrap_or(0),
+                    bank_timeout_completion_elapsed.maximum::<u64>(),
+                    Option<i64>
+                ),
+                (
+                    "bank_timeout_completion_elapsed_stddev",
+                    bank_timeout_completion_elapsed.stddev::<u64>(),
+                    Option<i64>
+                ),
+                (
+                    "bank_timeout_completion_elapsed_count",
+                   bank_timeout_completion_elapsed.count(),
                     i64
                 ),
             );
-
-            // reset metrics
             self.reset();
         }
     }
@@ -104,122 +104,51 @@ impl LoopMetrics {
 }
 
 // Metrics on slots that we attempt to start a leader block for
-#[derive(Default)]
-pub(crate) struct SlotMetrics {
-    pub(crate) slot: Slot,
-    pub(crate) attempt_start_leader_count: u64,
+pub(super) struct SlotMetrics {
+    slot: Slot,
+    pub(super) attempt_start_leader_count: u64,
     /// Indicates we have attempted fast leader handover
-    pub(crate) leader_handover_fast: bool,
+    leader_handover_fast: bool,
     /// Indicates we had to switch parent.
-    pub(crate) leader_handover_sad: bool,
-    pub(crate) replay_is_behind_count: u64,
-    pub(crate) already_have_bank_count: u64,
+    pub(super) leader_handover_sad: bool,
+    pub(super) already_have_bank_count: u64,
 
-    pub(crate) slot_delay_hist: Histogram,
-    pub(crate) replay_is_behind_cumulative_wait_elapsed: u64,
-    pub(crate) replay_is_behind_wait_elapsed_hist: Histogram,
+    pub(super) slot_delay_us: u64,
+    pub(super) replay_is_behind_us: u64,
 }
 
 impl SlotMetrics {
-    pub(crate) fn report(&mut self) {
+    pub(super) fn new(slot: Slot, leader_handover_fast: bool) -> Self {
+        Self {
+            slot,
+            attempt_start_leader_count: 0,
+            leader_handover_fast,
+            leader_handover_sad: false,
+            already_have_bank_count: 0,
+            slot_delay_us: 0,
+            replay_is_behind_us: 0,
+        }
+    }
+
+    pub(super) fn report(self) {
+        let Self {
+            slot,
+            attempt_start_leader_count,
+            leader_handover_fast,
+            leader_handover_sad,
+            already_have_bank_count,
+            slot_delay_us,
+            replay_is_behind_us,
+        } = self;
         datapoint_info!(
             "slot-metrics",
-            ("slot", self.slot, i64),
-            ("attempt_count", self.attempt_start_leader_count, i64),
-            ("leader_handover_fast", self.leader_handover_fast, i64),
-            ("leader_handover_sad", self.leader_handover_sad, i64),
-            ("replay_is_behind_count", self.replay_is_behind_count, i64),
-            ("already_have_bank_count", self.already_have_bank_count, i64),
-            (
-                "slot_delay_90pct",
-                self.slot_delay_hist.percentile(90.0).unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_mean",
-                self.slot_delay_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_min",
-                self.slot_delay_hist.minimum().unwrap_or(0),
-                i64
-            ),
-            (
-                "slot_delay_max",
-                self.slot_delay_hist.maximum().unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_cumulative_wait_elapsed",
-                self.replay_is_behind_cumulative_wait_elapsed,
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_90pct",
-                self.replay_is_behind_wait_elapsed_hist
-                    .percentile(90.0)
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_mean",
-                self.replay_is_behind_wait_elapsed_hist.mean().unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_min",
-                self.replay_is_behind_wait_elapsed_hist
-                    .minimum()
-                    .unwrap_or(0),
-                i64
-            ),
-            (
-                "replay_is_behind_wait_elapsed_max",
-                self.replay_is_behind_wait_elapsed_hist
-                    .maximum()
-                    .unwrap_or(0),
-                i64
-            ),
+            ("slot", slot, i64),
+            ("attempt_count", attempt_start_leader_count, i64),
+            ("leader_handover_fast", leader_handover_fast, i64),
+            ("leader_handover_sad", leader_handover_sad, i64),
+            ("already_have_bank_count", already_have_bank_count, i64),
+            ("slot_delay_us", slot_delay_us, i64),
+            ("replay_is_behind_us", replay_is_behind_us, i64),
         );
-    }
-
-    pub(crate) fn mark_leader_handover_fast(&mut self) {
-        self.leader_handover_fast = true;
-    }
-
-    pub(crate) fn mark_leader_handover_sad(&mut self) {
-        self.leader_handover_sad = true;
-    }
-
-    pub(crate) fn reset(&mut self, slot: Slot) {
-        let same_slot = self.slot == slot;
-        let leader_handover_fast = same_slot && self.leader_handover_fast;
-        let leader_handover_sad = same_slot && self.leader_handover_sad;
-        *self = Self::default();
-        self.leader_handover_fast = leader_handover_fast;
-        self.leader_handover_sad = leader_handover_sad;
-        self.slot = slot;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_slot_metrics_handover() {
-        let mut metrics = SlotMetrics::default();
-        metrics.reset(42);
-        metrics.mark_leader_handover_fast();
-        metrics.mark_leader_handover_sad();
-
-        metrics.reset(42);
-        assert!(metrics.leader_handover_fast);
-        assert!(metrics.leader_handover_sad);
-
-        metrics.reset(43);
-        assert!(!metrics.leader_handover_fast);
-        assert!(!metrics.leader_handover_sad);
     }
 }


### PR DESCRIPTION
#### Problem

There are a few problems in block creation loop stats that make them fragile to use:
- It is using `Histogram` which is not really maintained and we have an alternative: `WelfordStats`
- It is not deconstructing structs which makes it error prone when adding new stats.
- It is unnecessarily exposing some fields and exposing some too much


#### Summary of Changes

Fixes all the above issues


#### Testing

No new tests added