### PR TITLE
CI - Uses `replenish_program_cache()` in `SvmTestEnvironment::is_program_blocked()`

### DIFF
--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -354,7 +354,7 @@ impl SvmTestEnvironment<'_> {
         batch_output
     }
 
-    pub fn is_program_blocked(&self, program_id: &Pubkey) -> bool {
+    pub fn is_program_blocked(&self, program_id: &Pubkey, deployment_slot: Slot) -> bool {
         let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
             self.processing_config.account_overrides,
             &self.mock_bank,
@@ -368,8 +368,8 @@ impl SvmTestEnvironment<'_> {
             vec![ProgramToLoad {
                 program_id,
                 loader: ProgramCacheEntryOwner::LoaderV3,
-                deployment_slot: DEPLOYMENT_SLOT,
-                last_modification_slot: DEPLOYMENT_SLOT,
+                deployment_slot,
+                last_modification_slot: deployment_slot,
             }],
             self.processing_environment
                 .program_runtime_environments
@@ -2956,7 +2956,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
 
     // test in same entry as program change
     env.execute();
-    assert!(env.is_program_blocked(&program_id));
+    assert!(env.is_program_blocked(&program_id, 5));
 
     let mut test_entry = SvmTestEntry {
         initial_accounts: env.test_entry.final_accounts.clone(),
@@ -2971,7 +2971,7 @@ fn program_cache_loaderv3_update_tombstone(upgrade_program: bool, invoke_changed
     // test in different entry same slot
     env.test_entry = test_entry;
     env.execute();
-    assert!(env.is_program_blocked(&program_id));
+    assert!(env.is_program_blocked(&program_id, 5));
 }
 
 #[test_case(false; "upgrade::scan_only")]
@@ -3088,7 +3088,7 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
 
     // test in same entry as program change
     env.execute();
-    assert!(env.is_program_blocked(&target));
+    assert!(env.is_program_blocked(&target, 5));
 
     let mut test_entry = SvmTestEntry {
         initial_accounts: env.test_entry.final_accounts.clone(),
@@ -3103,7 +3103,7 @@ fn program_cache_loaderv3_buffer_swap(invoke_changed_program: bool) {
     // test in different entry same slot
     env.test_entry = test_entry;
     env.execute();
-    assert!(env.is_program_blocked(&target));
+    assert!(env.is_program_blocked(&target, 5));
 }
 
 #[test]

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -26,7 +26,8 @@ use {
         execution_budget::{
             MAX_LOADED_ACCOUNTS_DATA_SIZE_BYTES, SVMTransactionExecutionAndFeeBudgetLimits,
         },
-        loaded_programs::ProgramRuntimeEnvironments,
+        loaded_programs::{ProgramCacheForTxBatch, ProgramRuntimeEnvironments, ProgramToLoad},
+        program_cache_entry::ProgramCacheEntryOwner,
     },
     solana_pubkey::Pubkey,
     solana_sdk_ids::{
@@ -35,7 +36,8 @@ use {
     solana_signer::Signer,
     solana_svm::{
         account_loader::{
-            CheckedTransactionDetails, TRANSACTION_ACCOUNT_BASE_SIZE, TransactionCheckResult,
+            AccountLoader, CheckedTransactionDetails, TRANSACTION_ACCOUNT_BASE_SIZE,
+            TransactionCheckResult,
         },
         nonce_info::NonceInfo,
         transaction_execution_result::TransactionExecutionDetails,
@@ -50,6 +52,7 @@ use {
         },
     },
     solana_svm_feature_set::SVMFeatureSet,
+    solana_svm_timings::ExecuteTimings,
     solana_svm_transaction::{
         instruction::SVMInstruction,
         svm_message::{SVMMessage, SVMStaticMessage},
@@ -352,16 +355,31 @@ impl SvmTestEnvironment<'_> {
     }
 
     pub fn is_program_blocked(&self, program_id: &Pubkey) -> bool {
-        let (_, program_cache_entry) = self
-            .batch_processor
-            .global_program_cache
-            .read()
-            .unwrap()
-            .get_flattened_entries_for_tests()
-            .into_iter()
-            .rev()
-            .find(|(key, _)| key == program_id)
-            .unwrap();
+        let account_loader = AccountLoader::new_with_loaded_accounts_capacity(
+            self.processing_config.account_overrides,
+            &self.mock_bank,
+            &self.processing_environment.feature_set,
+            1,
+        );
+        let mut program_cache_for_tx_batch = ProgramCacheForTxBatch::new(EXECUTION_SLOT);
+        let mut execute_timings = ExecuteTimings::default();
+        self.batch_processor.replenish_program_cache(
+            &account_loader,
+            vec![ProgramToLoad {
+                program_id,
+                loader: ProgramCacheEntryOwner::LoaderV3,
+                deployment_slot: DEPLOYMENT_SLOT,
+                last_modification_slot: DEPLOYMENT_SLOT,
+            }],
+            self.processing_environment
+                .program_runtime_environments
+                .get_env_for_execution(),
+            &mut program_cache_for_tx_batch,
+            &mut execute_timings,
+            false, // limit_to_load_programs
+            true,  // increment_usage_counter
+        );
+        let program_cache_entry = program_cache_for_tx_batch.find(program_id).unwrap();
 
         // in the same batch, a new valid loaderv3 program may have a Loaded entry with a later execution slot
         // in a later batch, the same loaderv3 program will have a DelayedVisibility tombstone


### PR DESCRIPTION
#### Problem

Preparation for #14639 as forcing a reload in integration tests will become necessary when the loader uplink to the global program cache is removed.

#### Summary of Changes

Uses `replenish_program_cache()` instead of `get_flattened_entries_for_tests()` in `SvmTestEnvironment::is_program_blocked()`.

#### Testing
The method is used in `program_cache_loaderv3_buffer_swap` and `program_cache_loaderv3_update_tombstone`.