### PR TITLE
Order equal-priority transactions by arrival

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
+++ b/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs
@@ -1,6 +1,5 @@
 use {
     super::{
-        transaction_priority_id::TransactionPriorityId,
         transaction_state::TransactionState,
         transaction_state_container::{
             StateContainer, TransactionViewState, TransactionViewStateContainer,
@@ -484,8 +483,7 @@ impl TransactionViewReceiveAndBuffer {
             return;
         }
 
-        let transaction_id = container.insert_map_only(state);
-        let priority_id = TransactionPriorityId::new(priority, transaction_id);
+        let priority_id = container.insert_map_only(state);
 
         // A validated nonce transaction is higher priority than any queued
         // conflict. Evict that conflict only after all ingress checks passed.

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -1138,10 +1138,10 @@ mod tests {
             .send(to_banking_packet_batch(&txs))
             .unwrap();
 
-        // Priority Expectation:
-        // Thread 0: [3, 1]
+        // Transactions 1, 2, and 3 have equal priority and are scheduled FIFO.
+        // Thread 0: [1, 3]
         // Thread 1: [2, 0]
-        let t0_expected = [3, 1]
+        let t0_expected = [1, 3]
             .into_iter()
             .map(|i| txs[i].message().hash())
             .collect_vec();

--- a/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_priority_id.rs
@@ -1,15 +1,35 @@
-use crate::banking_stage::scheduler_messages::TransactionId;
+use {crate::banking_stage::scheduler_messages::TransactionId, std::cmp::Ordering};
 
 /// A unique identifier tied with priority ordering for a transaction/packet:
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TransactionPriorityId {
     pub(crate) priority: u64,
+    pub(crate) arrival_order: u64,
     pub(crate) id: TransactionId,
 }
 
 impl TransactionPriorityId {
-    pub(crate) fn new(priority: u64, id: TransactionId) -> Self {
-        Self { priority, id }
+    pub(crate) fn new(priority: u64, arrival_order: u64, id: TransactionId) -> Self {
+        Self {
+            priority,
+            arrival_order,
+            id,
+        }
+    }
+}
+
+impl Ord for TransactionPriorityId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.priority
+            .cmp(&other.priority)
+            .then_with(|| other.arrival_order.cmp(&self.arrival_order))
+            .then_with(|| other.id.cmp(&self.id))
+    }
+}
+
+impl PartialOrd for TransactionPriorityId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -21,28 +41,38 @@ mod tests {
     fn test_transaction_priority_id_ordering() {
         // Higher priority first
         {
-            let id1 = TransactionPriorityId::new(1, 1);
-            let id2 = TransactionPriorityId::new(2, 1);
+            let id1 = TransactionPriorityId::new(1, 0, 1);
+            let id2 = TransactionPriorityId::new(2, 1, 2);
             assert!(id1 < id2);
             assert!(id1 <= id2);
             assert!(id2 > id1);
             assert!(id2 >= id1);
         }
 
-        // Equal priority then compare by id
+        // Equal priority then compare by arrival order, oldest first
         {
-            let id1 = TransactionPriorityId::new(1, 1);
-            let id2 = TransactionPriorityId::new(1, 2);
-            assert!(id1 < id2);
-            assert!(id1 <= id2);
-            assert!(id2 > id1);
-            assert!(id2 >= id1);
+            let id1 = TransactionPriorityId::new(1, 0, 2);
+            let id2 = TransactionPriorityId::new(1, 1, 1);
+            assert!(id1 > id2);
+            assert!(id1 >= id2);
+            assert!(id2 < id1);
+            assert!(id2 <= id1);
         }
 
-        // Equal priority and id
+        // Equal priority and arrival order then compare by id, lowest first
         {
-            let id1 = TransactionPriorityId::new(1, 1);
-            let id2 = TransactionPriorityId::new(1, 1);
+            let id1 = TransactionPriorityId::new(1, 0, 1);
+            let id2 = TransactionPriorityId::new(1, 0, 2);
+            assert!(id1 > id2);
+            assert!(id1 >= id2);
+            assert!(id2 < id1);
+            assert!(id2 <= id1);
+        }
+
+        // Equal priority, arrival order, and id
+        {
+            let id1 = TransactionPriorityId::new(1, 0, 1);
+            let id2 = TransactionPriorityId::new(1, 0, 1);
             assert_eq!(id1, id2);
             assert!(id1 >= id2);
             assert!(id1 <= id2);

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -18,6 +18,8 @@ pub(crate) struct TransactionState<Tx> {
     max_age: MaxAge,
     /// Priority of the transaction.
     priority: u64,
+    /// Order in which the transaction entered the scheduler's container.
+    arrival_order: u64,
     /// Estimated cost of the transaction.
     cost: u64,
     /// Nonce address, if this is a validated nonce transaction.
@@ -31,6 +33,7 @@ impl<Tx> TransactionState<Tx> {
             transaction: Some(transaction),
             max_age,
             priority,
+            arrival_order: 0,
             cost,
             nonce_address: None,
         }
@@ -41,6 +44,14 @@ impl<Tx> TransactionState<Tx> {
     /// The priority is used to order transactions for processing.
     pub(crate) fn priority(&self) -> u64 {
         self.priority
+    }
+
+    pub(crate) fn arrival_order(&self) -> u64 {
+        self.arrival_order
+    }
+
+    pub(crate) fn set_arrival_order(&mut self, arrival_order: u64) {
+        self.arrival_order = arrival_order;
     }
 
     /// Return the cost of the transaction.

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -44,6 +44,7 @@ pub(crate) struct TransactionStateContainer<Tx: StaticTransactionWithMeta> {
     capacity: usize,
     priority_queue: BTreeSet<TransactionPriorityId>,
     id_to_transaction_state: Slab<TransactionState<Tx>>,
+    next_arrival_order: u64,
     held_transactions: Vec<TransactionPriorityId>,
     nonces_in_use: HashMap<Pubkey, TransactionPriorityId, PubkeyHasherBuilder>,
 }
@@ -81,7 +82,11 @@ pub(crate) trait StateContainer<Tx: StaticTransactionWithMeta> {
         let transaction_state = self
             .get_mut_transaction_state(transaction_id)
             .expect("transaction must exist");
-        let priority_id = TransactionPriorityId::new(transaction_state.priority(), transaction_id);
+        let priority_id = TransactionPriorityId::new(
+            transaction_state.priority(),
+            transaction_state.arrival_order(),
+            transaction_id,
+        );
         transaction_state.retry_transaction(transaction);
 
         if immediately_retryable {
@@ -141,6 +146,7 @@ impl<Tx: StaticTransactionWithMeta> StateContainer<Tx> for TransactionStateConta
             capacity,
             priority_queue: BTreeSet::new(),
             id_to_transaction_state: Slab::with_capacity(capacity + EXTRA_CAPACITY),
+            next_arrival_order: 0,
             held_transactions: Vec::with_capacity(capacity),
             nonces_in_use: HashMap::with_hasher(PubkeyHasherBuilder::default()),
         }
@@ -264,12 +270,19 @@ impl<Tx: StaticTransactionWithMeta> StateContainer<Tx> for TransactionStateConta
 
 impl<Tx: StaticTransactionWithMeta> TransactionStateContainer<Tx> {
     /// Insert into the map, but NOT into the priority queue.
-    /// Returns the id of the inserted transaction.
-    pub(crate) fn insert_map_only(&mut self, state: TransactionState<Tx>) -> TransactionId {
+    /// Returns the priority id of the inserted transaction.
+    pub(crate) fn insert_map_only(
+        &mut self,
+        mut state: TransactionState<Tx>,
+    ) -> TransactionPriorityId {
+        let arrival_order = self.next_arrival_order;
+        self.next_arrival_order = self.next_arrival_order.wrapping_add(1);
+        state.set_arrival_order(arrival_order);
+        let priority = state.priority();
         let entry = self.get_vacant_map_entry();
         let transaction_id = entry.key();
         entry.insert(state);
-        transaction_id
+        TransactionPriorityId::new(priority, arrival_order, transaction_id)
     }
 
     /// Insert a new transaction into the container's queues and maps.
@@ -282,9 +295,8 @@ impl<Tx: StaticTransactionWithMeta> TransactionStateContainer<Tx> {
         priority: u64,
         cost: u64,
     ) -> bool {
-        let transaction_id =
+        let priority_id =
             self.insert_map_only(TransactionState::new(transaction, max_age, priority, cost));
-        let priority_id = TransactionPriorityId::new(priority, transaction_id);
 
         self.push_ids_into_queue(std::iter::once(priority_id)) > 0
     }
@@ -296,7 +308,7 @@ impl<Tx: StaticTransactionWithMeta> TransactionStateContainer<Tx> {
 
     fn remove_state(&mut self, id: TransactionId) -> TransactionPriorityId {
         let state = self.id_to_transaction_state.remove(id);
-        let priority_id = TransactionPriorityId::new(state.priority(), id);
+        let priority_id = TransactionPriorityId::new(state.priority(), state.arrival_order(), id);
 
         if let Some(nonce_address) = state.nonce_address()
             && let Entry::Occupied(entry) = self.nonces_in_use.entry(*nonce_address)
@@ -391,6 +403,61 @@ mod tests {
     }
 
     #[test]
+    fn test_equal_priority_transactions_are_fifo_across_slab_reuse() {
+        let mut container = TransactionStateContainer::with_capacity(2);
+        let mut priority_ids = Vec::new();
+
+        for _ in 0..2 {
+            let (transaction, max_age, priority, cost) = test_transaction(1);
+            let priority_id = container.insert_map_only(TransactionState::new(
+                transaction,
+                max_age,
+                priority,
+                cost,
+            ));
+            container.push_ids_into_queue(std::iter::once(priority_id));
+            priority_ids.push(priority_id);
+        }
+
+        let removed = priority_ids[1];
+        container.remove_by_id(removed.id);
+
+        let (transaction, max_age, priority, cost) = test_transaction(1);
+        let priority_id =
+            container.insert_map_only(TransactionState::new(transaction, max_age, priority, cost));
+        assert_eq!(priority_id.id, removed.id);
+        container.push_ids_into_queue(std::iter::once(priority_id));
+
+        assert_eq!(container.pop().unwrap(), priority_ids[0]);
+        assert_eq!(container.pop().unwrap(), priority_id);
+    }
+
+    #[test]
+    fn test_equal_priority_capacity_drops_newest_transaction() {
+        let mut container = TransactionStateContainer::with_capacity(2);
+        let mut priority_ids = Vec::new();
+
+        for expected_drops in [0, 0, 1] {
+            let (transaction, max_age, priority, cost) = test_transaction(1);
+            let priority_id = container.insert_map_only(TransactionState::new(
+                transaction,
+                max_age,
+                priority,
+                cost,
+            ));
+            assert_eq!(
+                container.push_ids_into_queue(std::iter::once(priority_id)),
+                expected_drops,
+            );
+            priority_ids.push(priority_id);
+        }
+
+        assert!(container.get_transaction(priority_ids[2].id).is_none());
+        assert_eq!(container.pop().unwrap(), priority_ids[0]);
+        assert_eq!(container.pop().unwrap(), priority_ids[1]);
+    }
+
+    #[test]
     fn test_get_mut_transaction_state() {
         let mut container = TransactionStateContainer::with_capacity(5);
         push_to_container(&mut container, 5);
@@ -435,8 +502,7 @@ mod tests {
             let (transaction, _max_age, priority, cost) = test_transaction(priority);
             let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
             let data = Bytes::copy_from_slice(packet.data(..).unwrap());
-            let id = container.insert_map_only(packet_parser(data, priority, cost));
-            let priority_id = TransactionPriorityId::new(priority, id);
+            let priority_id = container.insert_map_only(packet_parser(data, priority, cost));
             assert_eq!(
                 container.push_ids_into_queue(std::iter::once(priority_id)),
                 0
@@ -448,8 +514,7 @@ mod tests {
             let (transaction, _max_age, priority, cost) = test_transaction(priority);
             let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
             let data = Bytes::copy_from_slice(packet.data(..).unwrap());
-            let id = container.insert_map_only(packet_parser(data, priority, cost));
-            let priority_id = TransactionPriorityId::new(priority, id);
+            let priority_id = container.insert_map_only(packet_parser(data, priority, cost));
             assert_eq!(
                 container.push_ids_into_queue(std::iter::once(priority_id)),
                 1,
@@ -466,8 +531,7 @@ mod tests {
         let (transaction, _max_age, priority, cost) = test_transaction(priority);
         let packet = Packet::from_data(None, transaction.to_versioned_transaction()).unwrap();
         let data = Bytes::copy_from_slice(packet.data(..).unwrap());
-        let id = container.insert_map_only(packet_parser(data, priority, cost));
-        let priority_id = TransactionPriorityId::new(priority, id);
+        let priority_id = container.insert_map_only(packet_parser(data, priority, cost));
         assert_eq!(
             container.push_ids_into_queue(std::iter::once(priority_id)),
             1


### PR DESCRIPTION
#### Problem

Transactions with the same priority are currently ordered using their slab ID. Slab IDs are internal storage indexes that get reused, so they do not provide a meaningful or stable ordering between otherwise equal-priority transactions. This adds some randomness to transaction inclusion. That variation can encourage users to submit the same-nonce transaction through multiple transaction sending services, since a later submission may beat an earlier one. As a result, a slower service can appear competitive despite providing no actual benefit.

#### Summary of Changes

Add a increasing submission order to transactions when they first enter the scheduler container. Transactions with equal priority are now processed FIFO based on that order instead of their slab ID.
