### PR TITLE
conformance(cost): reject oversized transactions

### DIFF
--- a/runtime/src/conformance/cost.rs
+++ b/runtime/src/conformance/cost.rs
@@ -24,7 +24,7 @@ use {
 
 fn runtime_transaction_from_proto(
     proto_tx: &ProtoSanitizedTransaction,
-) -> RuntimeTransaction<SanitizedTransaction> {
+) -> Option<RuntimeTransaction<SanitizedTransaction>> {
     let proto_message = proto_tx
         .message
         .as_ref()
@@ -49,10 +49,9 @@ fn runtime_transaction_from_proto(
 
     let serialized_size =
         bincode::serialized_size(&versioned_tx).expect("failed to compute serialized size");
-    assert!(
-        serialized_size <= PACKET_DATA_SIZE as u64,
-        "transaction exceeds max packet size",
-    );
+    if serialized_size > PACKET_DATA_SIZE as u64 {
+        return None;
+    }
 
     // Dummy loaded addresses, one per ALUT index. Cost tracking only
     // tracks counts, so dummy pubkeys are fine.
@@ -78,14 +77,16 @@ fn runtime_transaction_from_proto(
             .collect(),
     };
 
-    RuntimeTransaction::try_create(
-        versioned_tx,
-        MessageHash::Compute,
-        None,
-        SimpleAddressLoader::Enabled(loaded_addresses),
-        &std::collections::HashSet::new(),
+    Some(
+        RuntimeTransaction::try_create(
+            versioned_tx,
+            MessageHash::Compute,
+            None,
+            SimpleAddressLoader::Enabled(loaded_addresses),
+            &std::collections::HashSet::new(),
+        )
+        .expect("failed to create RuntimeTransaction"),
     )
-    .expect("failed to create RuntimeTransaction")
 }
 
 fn cost_result_to_proto<Tx>(cost: &TransactionCost<'_, Tx>) -> ProtoCostResult
@@ -104,12 +105,12 @@ where
     }
 }
 
-pub fn execute_cost(input: &ProtoCostContext) -> ProtoCostResult {
+pub fn execute_cost(input: &ProtoCostContext) -> Option<ProtoCostResult> {
     let proto_tx = input
         .tx
         .as_ref()
         .expect("ProtoCostContext missing transaction");
-    let runtime_tx = runtime_transaction_from_proto(proto_tx);
+    let runtime_tx = runtime_transaction_from_proto(proto_tx)?;
 
     let feature_set = input
         .features
@@ -128,7 +129,7 @@ pub fn execute_cost(input: &ProtoCostContext) -> ProtoCostResult {
         CostModel::calculate_cost(&runtime_tx, &feature_set)
     };
 
-    cost_result_to_proto(&cost)
+    Some(cost_result_to_proto(&cost))
 }
 
 /// # Safety
@@ -164,7 +165,9 @@ pub unsafe extern "C" fn sol_compat_txn_cost_v1(
         return 0;
     };
 
-    let cost_result = execute_cost(&cost_context);
+    let Some(cost_result) = execute_cost(&cost_context) else {
+        return 0;
+    };
 
     let out_vec = cost_result.encode_to_vec();
     let out_cap = unsafe { *out_psz } as usize;
@@ -291,7 +294,7 @@ mod tests {
     }
 
     fn assert_has_cost(ctx: &ProtoCostContext) -> ProtoCostResult {
-        let result = execute_cost(ctx);
+        let result = execute_cost(ctx).expect("expected a cost result");
         assert!(result.has_cost, "expected has_cost to be true");
         result
     }
@@ -368,12 +371,11 @@ mod tests {
             actual_programs_execution_cost: 0,
             actual_loaded_accounts_data_size_bytes: 0,
         };
-        execute_cost(&ctx);
+        let _ = execute_cost(&ctx);
     }
 
     #[test]
-    #[should_panic(expected = "transaction exceeds max packet size")]
-    fn test_oversized_transaction_panics() {
+    fn test_oversized_transaction_is_rejected() {
         let msg = ProtoTransactionMessage {
             is_legacy: true,
             header: Some(ProtoMessageHeader {
@@ -396,6 +398,6 @@ mod tests {
             signatures: vec![vec![0; 64]],
         };
         let ctx = estimate_context(tx);
-        execute_cost(&ctx);
+        assert!(execute_cost(&ctx).is_none());
     }
 }


### PR DESCRIPTION
#### Problem

The cost conformance harness asserts that a transaction serializes to at most `PACKET_DATA_SIZE`, so a differential fuzzer feeding it a larger transaction aborts the process instead of getting a result. Firedancer's equivalent harness returns no result for the same input, so the two disagree by crashing rather than by disagreeing.

#### Summary of Changes

`runtime_transaction_from_proto` and `execute_cost` now return `Option`, and an oversized transaction returns `None`, which `sol_compat_txn_cost_v1` reports as no result. The other failure paths keep their existing `expect`s, since only the size cap is enforced by network ingress rather than by sanitization.
